### PR TITLE
feat: remove the sync command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,6 @@ use anyhow::Error;
 mod add;
 mod init;
 mod run;
-mod sync;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -28,7 +27,6 @@ enum Command {
     Completion(CompletionCommand),
     Init(init::Args),
     Add(add::Args),
-    Sync(sync::Args),
     Run(run::Args),
 }
 
@@ -51,7 +49,6 @@ pub async fn execute() -> anyhow::Result<()> {
         Command::Completion(cmd) => completion(cmd),
         Command::Init(cmd) => init::execute(cmd).await,
         Command::Add(cmd) => add::execute(cmd).await,
-        Command::Sync(cmd) => sync::execute(cmd).await,
         Command::Run(cmd) => run::execute(cmd).await,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod prefix;
 mod progress;
 mod project;
 mod repodata;
+mod environment;
 
 pub use project::Project;
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use tokio::task::JoinHandle;
 
 /// Points to a directory that serves as a Conda prefix.
+#[derive(Debug, Clone)]
 pub struct Prefix {
     root: PathBuf,
 }


### PR DESCRIPTION
Removes the sync command. 

* The lockfile is updated when the `add` command is invoked.
* The lockfile and environment are (potentially) updated when invoking the `run` command.

If you need an up-to-date environment in an a command simply use:

```rust
let project = Project::discover()?;
let prefix = get_up_to_date_prefix(&project).await?;
```