### PR TITLE
feat: use solver to find latest version

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,9 +1,16 @@
-use crate::environment::{load_lock_file, update_lock_file};
-use crate::project::Project;
+use crate::{
+    environment::{load_lock_file, update_lock_file},
+    project::Project,
+};
+use anyhow::Context;
 use clap::Parser;
-use rattler_conda_types::{version_spec::VersionOperator, MatchSpec, Version, VersionSpec};
+use itertools::Itertools;
+use rattler_conda_types::{
+    version_spec::VersionOperator, MatchSpec, NamelessMatchSpec, Platform, Version, VersionSpec,
+};
+use rattler_repodata_gateway::sparse::SparseRepoData;
+use rattler_solve::{LibsolvRepoData, SolverBackend};
 use std::collections::HashMap;
-use std::ops::Deref;
 
 /// Adds a dependency to the project
 #[derive(Parser, Debug)]
@@ -11,64 +18,88 @@ pub struct Args {
     specs: Vec<MatchSpec>,
 }
 
-pub async fn execute(mut args: Args) -> anyhow::Result<()> {
+pub async fn execute(args: Args) -> anyhow::Result<()> {
     // Determine the location and metadata of the current project
     let mut project = Project::discover()?;
 
-    // Check if there are specs that do not specify an explicit version
+    // Split the specs into package name and version specifier
+    let new_specs = args
+        .specs
+        .into_iter()
+        .map(|spec| match &spec.name {
+            Some(name) => Ok((name.clone(), spec.into())),
+            None => Err(anyhow::anyhow!("missing package name for spec '{spec}'")),
+        })
+        .collect::<anyhow::Result<HashMap<String, NamelessMatchSpec>>>()?;
+
+    // Get the current specs
+    let current_specs = project.dependencies()?;
+
+    // Fetch the repodata for the project
     let sparse_repo_data = project.fetch_sparse_repodata().await?;
 
-    // Add all the specs to the project
-    for spec in args.specs.iter_mut() {
-        // Get the name of the package to add
-        let name = spec
-            .name
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("glob packages are not supported"))?;
+    // Determine the best version per platform
+    let mut best_versions = HashMap::new();
+    for platform in project.platforms()? {
+        // Solve the environment with the new specs added
+        let solved_versions =
+            match determine_best_version(&new_specs, &current_specs, &sparse_repo_data, platform) {
+                Ok(versions) => versions,
+                Err(err) => {
+                    return Err(err).context(anyhow::anyhow!(
+                        "could not determine any available versions for {} on {platform}. Either the package could not be found or version constraints on other dependencies result in a conflict.",
+                        new_specs.keys().join(", ")
+                    ))
+                }
+            };
 
-        // If no version is specified, determine the latest version and use that version
-        if spec.version.is_none() {
-            // Find the version that is supported by all non-noarch platforms.
-            let all_package_records = sparse_repo_data
-                .iter()
-                .map(|repodata| repodata.load_records(name))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .flatten();
-
-            let max_versions =
-                all_package_records.fold(HashMap::<String, Version>::new(), |mut init, record| {
-                    init.entry(record.package_record.subdir.clone())
-                        .and_modify(|version| {
-                            if version.deref().lt(&record.package_record.version) {
-                                *version = record.package_record.version.clone()
-                            }
-                        })
-                        .or_insert(record.package_record.version.clone());
-                    init
-                });
-
-            spec.version = max_versions
-                .into_values()
-                .min()
-                .map(|version| VersionSpec::Operator(VersionOperator::StartsWith, version))
+        // Determine the minimum compatible constraining version.
+        for (name, version) in solved_versions {
+            match best_versions.get_mut(&name) {
+                Some(prev) => {
+                    if &*prev > &version {
+                        *prev = version
+                    }
+                }
+                None => {
+                    best_versions.insert(name, version);
+                }
+            }
         }
-
-        project.add_dependency(spec)?;
     }
 
-    // Update the lock file
+    // Update the specs passed on the command line with the best available versions.
+    let mut added_specs = Vec::new();
+    for (name, spec) in new_specs {
+        let best_version = best_versions
+            .get(&name)
+            .cloned()
+            .expect("a version must have been previously selected");
+        let updated_spec = if spec.version.is_none() {
+            let mut updated_spec = spec.clone();
+            updated_spec.version = Some(VersionSpec::Operator(
+                VersionOperator::StartsWith,
+                best_version,
+            ));
+            updated_spec
+        } else {
+            spec
+        };
+        let spec = MatchSpec::from_nameless(updated_spec, Some(name));
+        project.add_dependency(&spec)?;
+        added_specs.push(spec);
+    }
+
+    // Update the lock file and write to disk
     update_lock_file(
         &project,
         load_lock_file(&project).await?,
         Some(sparse_repo_data),
     )
     .await?;
-
-    // Save the project to disk
     project.save()?;
 
-    for spec in args.specs {
+    for spec in added_specs {
         eprintln!(
             "{}Added {}",
             console::style(console::Emoji("✔ ", "")).green(),
@@ -77,4 +108,59 @@ pub async fn execute(mut args: Args) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Given several specs determines the highest installable version for them.
+pub fn determine_best_version(
+    new_specs: &HashMap<String, NamelessMatchSpec>,
+    current_specs: &HashMap<String, NamelessMatchSpec>,
+    sparse_repo_data: &Vec<SparseRepoData>,
+    platform: Platform,
+) -> anyhow::Result<HashMap<String, Version>> {
+    // Extract the package names from all the dependencies
+    let package_names = new_specs
+        .keys()
+        .chain(current_specs.keys())
+        .cloned()
+        .collect_vec();
+
+    // Get the repodata for the current platform and for NoArch
+    let platform_sparse_repo_data = sparse_repo_data.iter().filter(|sparse| {
+        sparse.subdir() == platform.as_str() || sparse.subdir() == Platform::NoArch.as_str()
+    });
+
+    // Load only records we need for this platform
+    let available_packages = SparseRepoData::load_records_recursive(
+        platform_sparse_repo_data,
+        package_names.iter().cloned(),
+    )?;
+
+    // Construct a solver task to start solving.
+    let task = rattler_solve::SolverTask {
+        specs: new_specs
+            .iter()
+            .chain(current_specs.iter())
+            .map(|(name, spec)| MatchSpec::from_nameless(spec.clone(), Some(name.clone())))
+            .collect(),
+
+        available_packages: available_packages
+            .iter()
+            .map(|records| LibsolvRepoData::from_records(records)),
+
+        // TODO: Add the information from the current lock file here.
+        pinned_packages: vec![],
+
+        // TODO: All these things.
+        locked_packages: vec![],
+        virtual_packages: vec![],
+    };
+
+    let records = rattler_solve::LibsolvBackend.solve(task)?;
+
+    // Determine the versions of the new packages
+    Ok(records
+        .into_iter()
+        .filter(|record| new_specs.contains_key(&record.package_record.name))
+        .map(|record| (record.package_record.name, record.package_record.version))
+        .collect())
 }


### PR DESCRIPTION
Fixes #30 

Previously:

```
> pax add boa
✔ Added boa 0.6.2.*
> pax add python
error: unsolvable
```

(actually a bit weird already because the latest version is 0.14.0)

With this PR:

```
> pax add boa
✔ Added boa 0.14.0.*
> pax add python
✔ Added python 3.10.11.*
```

In the future it would be much better if we had much better solver error messages. Now it can be a bit confusing that adding a dependency is not possible.