### PR TITLE
feat: improve cli output

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,6 +1,9 @@
-use indicatif::{HumanBytes, MultiProgress, ProgressDrawTarget, ProgressState};
+use std::borrow::Cow;
+use indicatif::{HumanBytes, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressState};
 use once_cell::sync::Lazy;
 use std::fmt::Write;
+use std::future::Future;
+use std::time::Duration;
 
 /// Returns a global instance of [`indicatif::MultiProgress`].
 ///
@@ -19,7 +22,7 @@ pub fn global_multi_progress() -> MultiProgress {
 /// Returns the style to use for a progressbar that is currently in progress.
 pub fn default_bytes_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
-        .template("{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:40!.bright.yellow/dim.white}] {bytes:>8} @ {smoothed_bytes_per_sec:8}").unwrap()
+        .template("    {prefix:20!} [{elapsed_precise}] [{bar:40!.bright.yellow/dim.white}] {bytes:>8} @ {smoothed_bytes_per_sec:8}").unwrap()
         .progress_chars("━━╾─")
         .with_key(
             "smoothed_bytes_per_sec",
@@ -35,14 +38,14 @@ pub fn default_bytes_style() -> indicatif::ProgressStyle {
 /// Returns the style to use for a progressbar that is currently in progress.
 pub fn default_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
-        .template("{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:40!.bright.yellow/dim.white}] {pos:>7}/{len:7}").unwrap()
+        .template("    {prefix:20!} [{elapsed_precise}] [{bar:40!.bright.yellow/dim.white}] {pos:>7}/{len:7}").unwrap()
         .progress_chars("━━╾─")
 }
 
 /// Returns the style to use for a progressbar that is in Deserializing state.
 pub fn deserializing_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
-        .template("{spinner:.green} {prefix:20!} [{elapsed_precise}] {wide_msg}")
+        .template("    {prefix:20!} [{elapsed_precise}] {wide_msg}")
         .unwrap()
         .progress_chars("━━╾─")
 }
@@ -51,7 +54,7 @@ pub fn deserializing_progress_style() -> indicatif::ProgressStyle {
 pub fn finished_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
         .template(&format!(
-            "{} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
+            "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
             console::style(console::Emoji("✔", " ")).green()
         ))
         .unwrap()
@@ -62,18 +65,18 @@ pub fn finished_progress_style() -> indicatif::ProgressStyle {
 pub fn errored_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
         .template(&format!(
-            "{} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.red}}",
+            "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.red}}",
             console::style(console::Emoji("❌", " ")).red()
         ))
         .unwrap()
         .progress_chars("━━╾─")
 }
 
-// /// Returns the style to use for a progressbar that is indeterminate and simply shows a spinner.
-// pub fn long_running_progress_style() -> indicatif::ProgressStyle {
-//     ProgressStyle::with_template("{spinner:.green} {msg}").unwrap()
-// }
-//
+/// Returns the style to use for a progressbar that is indeterminate and simply shows a spinner.
+pub fn long_running_progress_style() -> indicatif::ProgressStyle {
+    indicatif::ProgressStyle::with_template("{spinner:.green} {msg}").unwrap()
+}
+
 // /// Displays a spinner with the given message while running the specified function to completion.
 // pub fn wrap_in_progress<T, F: FnOnce() -> T>(msg: impl Into<Cow<'static, str>>, func: F) -> T {
 //     let pb = global_multi_progress().add(ProgressBar::new_spinner());
@@ -84,3 +87,14 @@ pub fn errored_progress_style() -> indicatif::ProgressStyle {
 //     pb.finish_and_clear();
 //     result
 // }
+
+/// Displays a spinner with the given message while running the specified function to completion.
+pub async fn await_in_progress<T, F: Future<Output=T>>(msg: impl Into<Cow<'static, str>>, future: F) -> T {
+    let pb = global_multi_progress().add(ProgressBar::new_spinner());
+    pb.enable_steady_tick(Duration::from_millis(100));
+    pb.set_style(long_running_progress_style());
+    pb.set_message(msg);
+    let result = future.await;
+    pb.finish_and_clear();
+    result
+}


### PR DESCRIPTION
This "improves" the CLI output by removing progress bars from the terminal if they completed successfully. I like this style much better because most of the time a user doesn't need any of this success state information and it just clutters the screen.

Previously:

![image](https://github.com/prefix-dev/pax/assets/4995967/ece83000-7a1d-4805-95a5-6c2094f84518)

Current output (note that progress bars are still shown when there is something going on, they are just removed if everything succeeded):

![image](https://github.com/prefix-dev/pax/assets/4995967/e8cc226a-8a74-4036-b56b-10f6907bcb22)