### PR TITLE
fix: #77

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml_edit",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ shlex = "1.1.0"
 tempfile = "3.5.0"
 tokio = { version = "1.27.0", features = ["macros", "rt-multi-thread"] }
 toml_edit = { version = "0.19.8", features = ["serde"] }
+tracing = "0.1.37"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Checks the consistency of the lock file. If a dependency references a package that doesn't exist the lock file is also discarded. If a package exists that is not referenced by a dependency the lock file is also discarded.