### PR TITLE
Feature/add pixi metadata to env vars

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1,11 +1,17 @@
 metadata:
   content_hash:
-    linux-64: '"72440c4457518de172f627362ef0d41a4ca28fd52e6b117c1f7bea1d846edb29"'
+    linux-64: '"bf69ff0abffd93844b3e6cb5c9da503a52f832f127712416cc081fbfab7b99ee"'
+    osx-arm64: '"bf69ff0abffd93844b3e6cb5c9da503a52f832f127712416cc081fbfab7b99ee"'
+    win-64: '"bf69ff0abffd93844b3e6cb5c9da503a52f832f127712416cc081fbfab7b99ee"'
+    osx-64: '"bf69ff0abffd93844b3e6cb5c9da503a52f832f127712416cc081fbfab7b99ee"'
   channels:
   - url: https://conda.anaconda.org/conda-forge/
     used_env_vars: []
   platforms:
   - linux-64
+  - osx-64
+  - osx-arm64
+  - win-64
   sources: []
   time_metadata: null
   git_metadata: null
@@ -26,82 +32,6 @@ package:
   category: main
   source: null
   build: hd18ef5c_1
-- name: rust
-  version: 1.70.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gcc_impl_linux-64: '*'
-    rust-std-x86_64-unknown-linux-gnu: ==1.70.0 hc1431ca_0
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rust-1.70.0-h70c747d_0.conda
-  hash:
-    md5: 8a2c7746d5ecd02bd24ffef161eb7df4
-    sha256: 760931bd88a481b123266e7fad6c853ce226e40ee15219baa1ff823353d8c44a
-  optional: false
-  category: main
-  source: null
-  build: h70c747d_0
-- name: rust-std-x86_64-unknown-linux-gnu
-  version: 1.70.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.70.0-hc1431ca_0.conda
-  hash:
-    md5: a1047542eaa0926288779f5c513bc675
-    sha256: aa4dff453effbb17ce1057f37151c97ebfb701f439febd9b7d7f856bb1a799f3
-  optional: false
-  category: main
-  source: null
-  build: hc1431ca_0
-- name: libzlib
-  version: 1.2.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2
-  hash:
-    md5: f3f9de449d32ca9b9c66a22863c96f41
-    sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
-  optional: false
-  category: main
-  source: null
-  build: h166bdaf_4
-- name: cxx-compiler
-  version: 1.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gxx: '*'
-    gxx_linux-64: 11.*
-    c-compiler: ==1.5.2 h0b41bf4_0
-  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.5.2-hf52228f_0.conda
-  hash:
-    md5: 6b3b19e359824b97df7145c8c878c8be
-    sha256: c6916082ea28b905dd59d4b6b5b07be413a3a5a814193df43c28101e4d29a7fc
-  optional: false
-  category: main
-  source: null
-  build: hf52228f_0
-- name: c-compiler
-  version: 1.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    binutils: '*'
-    gcc_linux-64: 11.*
-    gcc: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.5.2-h0b41bf4_0.conda
-  hash:
-    md5: 69afb4e35be6366c2c1f9ed7f49bc3e6
-    sha256: fe4c0080648c3448939919ddc49339cd8e250124b69a518e66ef6989794fa58a
-  optional: false
-  category: main
-  source: null
-  build: h0b41bf4_0
 - name: pkg-config
   version: 0.29.2
   manager: conda
@@ -116,39 +46,56 @@ package:
   category: main
   source: null
   build: h36c2ea0_1008
-- name: openssl
-  version: 3.1.1
+- name: cxx-compiler
+  version: 1.5.2
   manager: conda
   platform: linux-64
   dependencies:
-    ca-certificates: '*'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.1-hd590300_1.conda
+    c-compiler: ==1.5.2 h0b41bf4_0
+    gxx: '*'
+    gxx_linux-64: 11.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.5.2-hf52228f_0.conda
   hash:
-    md5: 2e1d7b458ac8f1e3ca4e18b77add6277
-    sha256: 407d655643389bdb49266842a816815c981ae98f3513a6a2059b908b3abb380a
+    md5: 6b3b19e359824b97df7145c8c878c8be
+    sha256: c6916082ea28b905dd59d4b6b5b07be413a3a5a814193df43c28101e4d29a7fc
   optional: false
   category: main
   source: null
-  build: hd590300_1
+  build: hf52228f_0
+- name: c-compiler
+  version: 1.5.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gcc: '*'
+    gcc_linux-64: 11.*
+    binutils: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.5.2-h0b41bf4_0.conda
+  hash:
+    md5: 69afb4e35be6366c2c1f9ed7f49bc3e6
+    sha256: fe4c0080648c3448939919ddc49339cd8e250124b69a518e66ef6989794fa58a
+  optional: false
+  category: main
+  source: null
+  build: h0b41bf4_0
 - name: cmake
   version: 3.26.4
   manager: conda
   platform: linux-64
   dependencies:
+    libuv: '*'
+    libcurl: '>=8.1.0,<9.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libgcc-ng: '>=12'
+    expat: '*'
+    libexpat: '>=2.5.0,<3.0a0'
+    rhash: '*'
+    bzip2: '>=1.0.8,<2.0a0'
+    libstdcxx-ng: '>=12'
+    ncurses: '>=6.3,<7.0a0'
     xz: '>=5.2.6,<6.0a0'
     zlib: '*'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libcurl: '>=8.1.0,<9.0a0'
-    expat: '*'
-    libgcc-ng: '>=12'
-    libexpat: '>=2.5.0,<3.0a0'
-    ncurses: '>=6.3,<7.0a0'
     zstd: '>=1.5.2,<1.6.0a0'
-    libuv: '*'
-    bzip2: '>=1.0.8,<2.0a0'
-    rhash: '*'
   url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.26.4-hcfe8598_0.conda
   hash:
     md5: 1714cf0f0facaeb609a0846e4270aff2
@@ -171,21 +118,6 @@ package:
   category: main
   source: null
   build: h166bdaf_0
-- name: zlib
-  version: 1.2.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libzlib: ==1.2.13 h166bdaf_4
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2
-  hash:
-    md5: 4b11e365c0275b808be78b30f904e295
-    sha256: 282ce274ebe6da1fbd52efbb61bd5a93dec0365b14d64566e6819d1691b75300
-  optional: false
-  category: main
-  source: null
-  build: h166bdaf_4
 - name: libexpat
   version: 2.5.0
   manager: conda
@@ -200,54 +132,288 @@ package:
   category: main
   source: null
   build: hcb278e6_1
+- name: rust
+  version: 1.70.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gcc_impl_linux-64: '*'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libgcc-ng: '>=12'
+    rust-std-x86_64-unknown-linux-gnu: ==1.70.0 hc1431ca_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/rust-1.70.0-h70c747d_0.conda
+  hash:
+    md5: 8a2c7746d5ecd02bd24ffef161eb7df4
+    sha256: 760931bd88a481b123266e7fad6c853ce226e40ee15219baa1ff823353d8c44a
+  optional: false
+  category: main
+  source: null
+  build: h70c747d_0
+- name: rust-std-x86_64-unknown-linux-gnu
+  version: 1.70.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.70.0-hc1431ca_0.conda
+  hash:
+    md5: a1047542eaa0926288779f5c513bc675
+    sha256: aa4dff453effbb17ce1057f37151c97ebfb701f439febd9b7d7f856bb1a799f3
+  optional: false
+  category: main
+  source: null
+  build: hc1431ca_0
+- name: openssl
+  version: 3.1.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ca-certificates: '*'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.1-hd590300_1.conda
+  hash:
+    md5: 2e1d7b458ac8f1e3ca4e18b77add6277
+    sha256: 407d655643389bdb49266842a816815c981ae98f3513a6a2059b908b3abb380a
+  optional: false
+  category: main
+  source: null
+  build: hd590300_1
+- name: libgcc-ng
+  version: 13.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _libgcc_mutex: ==0.1 conda_forge
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+  hash:
+    md5: cd93f779ff018dd85c7544c015c9db3c
+    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
+  optional: false
+  category: main
+  source: null
+  build: he5830b7_0
+- name: _libgcc_mutex
+  version: '0.1'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  hash:
+    md5: d7c89558ba9fa0495403155b64376d81
+    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  optional: false
+  category: main
+  source: null
+  build: conda_forge
 - name: gcc_linux-64
-  version: 11.3.0
+  version: 11.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    gcc_impl_linux-64: 11.3.0.*
-    binutils_linux-64: ==2.39 h5fc0e48_13
+    binutils_linux-64: ==2.40 hbdbef99_0
+    gcc_impl_linux-64: 11.4.0.*
     sysroot_linux-64: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-11.3.0-he6f903b_13.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-11.4.0-hfd045f2_0.conda
   hash:
-    md5: 90a9fa7151e709ba224232ea9bfa4fea
-    sha256: e7f1bf1fb66dbe6fcfa8e87aa218e19f934a76dac694622bd7ce7c4ed7ed4483
+    md5: fbd045cae068fc5afe6e35e36d498167
+    sha256: 9849211de993ee9d905312a16fb879b17f92c5a228b903a9e665140f2fe14a79
   optional: false
   category: main
   source: null
-  build: he6f903b_13
+  build: hfd045f2_0
+- name: gcc_impl_linux-64
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-devel_linux-64: ==11.4.0 h922705a_0
+    sysroot_linux-64: '*'
+    libsanitizer: ==11.4.0 h4dcbe23_0
+    libstdcxx-ng: '>=11.4.0'
+    libgomp: '>=11.4.0'
+    binutils_impl_linux-64: '>=2.39'
+    libgcc-ng: '>=11.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-11.4.0-h7aa1c59_0.conda
+  hash:
+    md5: 858ee47d842ee80e9777c7f558aedf13
+    sha256: e6b566c101a0baa403ec429962c9f8bea925d3f76b148d2a9f8044c331c8d7e8
+  optional: false
+  category: main
+  source: null
+  build: h7aa1c59_0
 - name: binutils_linux-64
-  version: '2.39'
+  version: '2.40'
   manager: conda
   platform: linux-64
   dependencies:
-    binutils_impl_linux-64: 2.39.*
+    binutils_impl_linux-64: 2.40.*
     sysroot_linux-64: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.39-h5fc0e48_13.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_0.conda
   hash:
-    md5: 7f25a524665e4e2f8a5f86522f8d0e31
-    sha256: 9ccdc61d461dc174f6d5af33064bf58ebcbccb7cf3d62eee0e584c7e4764e828
+    md5: 8dd723ef0716b6d102d57bbacbe92b22
+    sha256: 3ea4b9915086f5cfdd52c236734a1e64c88ea57a3cde6138209dc23291cb761e
   optional: false
   category: main
   source: null
-  build: h5fc0e48_13
+  build: hbdbef99_0
+- name: libgcc-devel_linux-64
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-11.4.0-h922705a_0.conda
+  hash:
+    md5: 4b2b4bbd3b68a5fd72e648ea70208a97
+    sha256: ef5f23785ac2aa61ee47838334bd80538a60dd23d31207bbcacbfa86a5a50d13
+  optional: false
+  category: main
+  source: null
+  build: h922705a_0
+- name: libgomp
+  version: 13.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    _libgcc_mutex: ==0.1 conda_forge
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+  hash:
+    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
+    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
+  optional: false
+  category: main
+  source: null
+  build: he5830b7_0
+- name: libsanitizer
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=11.4.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-11.4.0-h4dcbe23_0.conda
+  hash:
+    md5: 62790b01a5710ee704f48b01f64f4743
+    sha256: e6eeee9515ea1d272eb087387646a0c08d1cdabfdf228740f337a9ddb249ec78
+  optional: false
+  category: main
+  source: null
+  build: h4dcbe23_0
+- name: binutils_impl_linux-64
+  version: '2.40'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ld_impl_linux-64: ==2.40 h41732ed_0
+    sysroot_linux-64: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+  hash:
+    md5: 33084421a8c0af6aef1b439707f7662a
+    sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
+  optional: false
+  category: main
+  source: null
+  build: hf600244_0
 - name: gxx_linux-64
-  version: 11.3.0
+  version: 11.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    gcc_linux-64: ==11.3.0 he6f903b_13
-    binutils_linux-64: ==2.39 h5fc0e48_13
-    gxx_impl_linux-64: 11.3.0.*
     sysroot_linux-64: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-11.3.0-hc203a17_13.conda
+    gxx_impl_linux-64: 11.4.0.*
+    binutils_linux-64: ==2.40 hbdbef99_0
+    gcc_linux-64: ==11.4.0 hfd045f2_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-11.4.0-hfc1ae95_0.conda
   hash:
-    md5: c22e035729c5d224dd875274c92a0522
-    sha256: 10e3bed089705caa1700933ad745dba4fe2fc7d92e70ea0b9dc7140158c5d9d2
+    md5: 72e4a2fb33a16877df88ee4ecee4cfca
+    sha256: f648ea1003c443ea3732911d196b1273753803e13bea6318c364b8071880882b
   optional: false
   category: main
   source: null
-  build: hc203a17_13
+  build: hfc1ae95_0
+- name: ld_impl_linux-64
+  version: '2.40'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  hash:
+    md5: 7aca3059a1729aa76c597603f10b0dd3
+    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  optional: false
+  category: main
+  source: null
+  build: h41732ed_0
+- name: gxx_impl_linux-64
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gcc_impl_linux-64: ==11.4.0 h7aa1c59_0
+    sysroot_linux-64: '*'
+    libstdcxx-devel_linux-64: ==11.4.0 h922705a_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-11.4.0-h7aa1c59_0.conda
+  hash:
+    md5: 0a7a65ae7f95053773f6b88e2b0fc9ab
+    sha256: d50cea15462631e16b2e577a7889ab5c3c6e743b79b165af4edd32b37541da27
+  optional: false
+  category: main
+  source: null
+  build: h7aa1c59_0
+- name: gcc
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gcc_impl_linux-64: 11.4.0.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-11.4.0-h7baecda_0.conda
+  hash:
+    md5: 0881eb2796f204edcbf76997fbab7f41
+    sha256: ea78efdae9f9e4f4def3ecf902295c2c35a32761964f0742d35bfd178ba4c85f
+  optional: false
+  category: main
+  source: null
+  build: h7baecda_0
+- name: libstdcxx-devel_linux-64
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-11.4.0-h922705a_0.conda
+  hash:
+    md5: f6ab69b69e09f83024d1d79a72700c5a
+    sha256: 2064befcc62da09e0fb945aa342b74de87165d5267585a361d54277ac3e8c64a
+  optional: false
+  category: main
+  source: null
+  build: h922705a_0
+- name: gxx
+  version: 11.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    gcc: 11.4.0.*
+    gxx_impl_linux-64: 11.4.0.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-11.4.0-h7baecda_0.conda
+  hash:
+    md5: c85109c5edb7ebfe732caf7348ef4296
+    sha256: 85f2652d5700abdf46ba7d07ac7a2437106294d731d0deea1770e1669b17f8aa
+  optional: false
+  category: main
+  source: null
+  build: h7baecda_0
+- name: binutils
+  version: '2.40'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    binutils_impl_linux-64: '>=2.40,<2.41.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+  hash:
+    md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
+    sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
+  optional: false
+  category: main
+  source: null
+  build: hdd6e379_0
 - name: sysroot_linux-64
   version: '2.12'
   manager: conda
@@ -275,159 +441,26 @@ package:
   category: main
   source: null
   build: he073ed8_15
-- name: binutils_impl_linux-64
-  version: '2.39'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ld_impl_linux-64: ==2.39 hcc3a1bd_1
-    sysroot_linux-64: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.39-he00db2b_1.conda
-  hash:
-    md5: 3d726e8b51a1f5bfd66892a2b7d9db2d
-    sha256: 69a7c32141475dab43de2f19b7a67c14596cbb357cdb5891ff866918f8f65a2e
-  optional: false
-  category: main
-  source: null
-  build: he00db2b_1
-- name: ld_impl_linux-64
-  version: '2.39'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.39-hcc3a1bd_1.conda
-  hash:
-    md5: 737be0d34c22d24432049ab7a3214de4
-    sha256: 3e7f203e33ea497b6e468279cc5fdef7d556473c25e7466b35fd672940392469
-  optional: false
-  category: main
-  source: null
-  build: hcc3a1bd_1
-- name: gcc_impl_linux-64
-  version: 11.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-devel_linux-64: ==11.3.0 h210ce93_19
-    libsanitizer: ==11.3.0 h239ccf8_19
-    binutils_impl_linux-64: '>=2.39'
-    libgcc-ng: '>=11.3.0'
-    libgomp: '>=11.3.0'
-    sysroot_linux-64: '*'
-    libstdcxx-ng: '>=11.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-11.3.0-hab1b70f_19.tar.bz2
-  hash:
-    md5: 89ac16d36e66ccb9ca5d34c9217e5799
-    sha256: 51c6e39148c9da4a9889d34f0daebdf961ca93f032b1e86f621a67ecff2bd915
-  optional: false
-  category: main
-  source: null
-  build: hab1b70f_19
-- name: libgcc-devel_linux-64
-  version: 11.3.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-11.3.0-h210ce93_19.tar.bz2
-  hash:
-    md5: 9b7bdb0b42ce4e4670d32bfe0532b56a
-    sha256: 70b2c370cc616304f732eeb4014825390dbee044ecbc3875e968b0ea01bd7503
-  optional: false
-  category: main
-  source: null
-  build: h210ce93_19
-- name: libsanitizer
-  version: 11.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=11.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-11.3.0-h239ccf8_19.tar.bz2
-  hash:
-    md5: d17fd55aed84ab6592c5419b6600501c
-    sha256: 5e53a50c9b5fd04790f4cc63aa74cd6172151246248438b9bc154392ebe0bd17
-  optional: false
-  category: main
-  source: null
-  build: h239ccf8_19
-- name: gxx_impl_linux-64
-  version: 11.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    sysroot_linux-64: '*'
-    libstdcxx-devel_linux-64: ==11.3.0 h210ce93_19
-    gcc_impl_linux-64: ==11.3.0 hab1b70f_19
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-11.3.0-hab1b70f_19.tar.bz2
-  hash:
-    md5: b73564a352e64bb5f2c9bfd3cd6dd127
-    sha256: b86a4d15050c8ad5b8a4273c55f468847d891ceb08f3702408c3a0e921a5b5ea
-  optional: false
-  category: main
-  source: null
-  build: hab1b70f_19
-- name: libstdcxx-devel_linux-64
-  version: 11.3.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-11.3.0-h210ce93_19.tar.bz2
-  hash:
-    md5: 8aee006c0662f551f3acef9a7077a5b9
-    sha256: abfcbf3a0f770be88eefebf84ae3a901da9e933799c9eecf3e9b06f34b00a0a5
-  optional: false
-  category: main
-  source: null
-  build: h210ce93_19
-- name: libgcc-ng
+- name: libstdcxx-ng
   version: 13.1.0
   manager: conda
   platform: linux-64
-  dependencies:
-    _openmp_mutex: '>=4.5'
-    _libgcc_mutex: ==0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
-  hash:
-    md5: cd93f779ff018dd85c7544c015c9db3c
-    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
-  optional: false
-  category: main
-  source: null
-  build: he5830b7_0
-- name: _libgcc_mutex
-  version: '0.1'
-  manager: conda
-  platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
   hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+    md5: 067bcc23164642f4c226da631f2a2e1d
+    sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
   optional: false
   category: main
   source: null
-  build: conda_forge
-- name: libgomp
-  version: 13.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
-  hash:
-    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
-    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
-  optional: false
-  category: main
-  source: null
-  build: he5830b7_0
+  build: hfd8a6a1_0
 - name: _openmp_mutex
   version: '4.5'
   manager: conda
   platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
     libgomp: '>=7.5.0'
+    _libgcc_mutex: ==0.1 conda_forge
   url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
     md5: 73aaf86a425cc6e73fcf236a5a46396d
@@ -436,34 +469,35 @@ package:
   category: main
   source: null
   build: 2_gnu
-- name: ca-certificates
-  version: 2023.5.7
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.5.7-hbcca054_0.conda
-  hash:
-    md5: f5c65075fc34438d5b456c7f3f5ab695
-    sha256: 0cf1bb3d0bfc5519b60af2c360fa4888fb838e1476b1e0f65b9dbc48b45c7345
-  optional: false
-  category: main
-  source: null
-  build: hbcca054_0
-- name: gxx
-  version: 11.3.0
+- name: zlib
+  version: 1.2.13
   manager: conda
   platform: linux-64
   dependencies:
-    gxx_impl_linux-64: 11.3.0.*
-    gcc: 11.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gxx-11.3.0-h02d0930_13.conda
+    libzlib: ==1.2.13 hd590300_5
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
   hash:
-    md5: b8882bac01c133f6f8ac86193c6c00a7
-    sha256: c1eac89bd8ea8456aaae2353724bd3aef59fb3216f6eb343c1c279a23155d8b0
+    md5: 68c34ec6149623be41a1933ab996a209
+    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
   optional: false
   category: main
   source: null
-  build: h02d0930_13
+  build: hd590300_5
+- name: libzlib
+  version: 1.2.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  hash:
+    md5: f36c115f1ee199da648e0597ec2047ad
+    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  optional: false
+  category: main
+  source: null
+  build: hd590300_5
 - name: bzip2
   version: 1.0.8
   manager: conda
@@ -483,8 +517,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
     libexpat: ==2.5.0 hcb278e6_1
+    libgcc-ng: '>=12'
   url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
   hash:
     md5: 8b9b5aca60558d02ddaa09d599e55920
@@ -535,30 +569,17 @@ package:
   category: main
   source: null
   build: h166bdaf_0
-- name: libstdcxx-ng
-  version: 13.1.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
-  hash:
-    md5: 067bcc23164642f4c226da631f2a2e1d
-    sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
-  optional: false
-  category: main
-  source: null
-  build: hfd8a6a1_0
 - name: libcurl
   version: 8.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    openssl: '>=3.1.0,<4.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-    krb5: '>=1.20.1,<1.21.0a0'
     libssh2: '>=1.10.0,<2.0a0'
-    libgcc-ng: '>=12'
+    zstd: '>=1.5.2,<1.6.0a0'
     libnghttp2: '>=1.52.0,<2.0a0'
+    openssl: '>=3.1.0,<4.0a0'
+    krb5: '>=1.20.1,<1.21.0a0'
+    libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.1.2-h409715c_0.conda
   hash:
@@ -573,11 +594,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    keyutils: '>=1.6.1,<2.0a0'
     openssl: '>=3.0.7,<4.0a0'
     libedit: '>=3.1.20191231,<4.0a0'
+    libgcc-ng: '>=12'
+    keyutils: '>=1.6.1,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-h81ceb04_0.conda
   hash:
     md5: 89a41adce7106749573d883b2f657d78
@@ -591,12 +612,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.18.1,<2.0a0'
     libstdcxx-ng: '>=12'
+    c-ares: '>=1.18.1,<2.0a0'
     libev: '>=4.33,<4.34.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.0.8,<4.0a0'
     libgcc-ng: '>=12'
+    openssl: '>=3.0.8,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.52.0-h61bc06f_0.conda
   hash:
     md5: 613955a50485812985c059e7b269f42e
@@ -624,8 +645,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
   url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda
   hash:
@@ -635,6 +656,19 @@ package:
   category: main
   source: null
   build: h3eb15da_6
+- name: ca-certificates
+  version: 2023.5.7
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.5.7-hbcca054_0.conda
+  hash:
+    md5: f5c65075fc34438d5b456c7f3f5ab695
+    sha256: 0cf1bb3d0bfc5519b60af2c360fa4888fb838e1476b1e0f65b9dbc48b45c7345
+  optional: false
+  category: main
+  source: null
+  build: hbcca054_0
 - name: c-ares
   version: 1.19.1
   manager: conda
@@ -663,42 +697,14 @@ package:
   category: main
   source: null
   build: h516909a_1
-- name: gcc
-  version: 11.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    gcc_impl_linux-64: 11.3.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gcc-11.3.0-h02d0930_13.conda
-  hash:
-    md5: ead4470a123fb664e358d02a333676ba
-    sha256: d2d1a23d1245a9a585c02553ddb160c66303ab7785040036da6b2497209d5bcf
-  optional: false
-  category: main
-  source: null
-  build: h02d0930_13
-- name: binutils
-  version: '2.39'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    binutils_impl_linux-64: '>=2.39,<2.40.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.39-hdd6e379_1.conda
-  hash:
-    md5: 1276c18b0a562739185dbf5bd14b57b2
-    sha256: 8edbd5a01feaf22053d7c02e7d5066a3b35b265deee0a5ad3f69054289bbbd7e
-  optional: false
-  category: main
-  source: null
-  build: hdd6e379_1
 - name: libssh2
   version: 1.11.0
   manager: conda
   platform: linux-64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
+    openssl: '>=3.1.1,<4.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   hash:
     md5: 1f5a58e686b13bcfde88b93f547d23fe
@@ -722,4 +728,1805 @@ package:
   category: main
   source: null
   build: he28a2e2_2
+- name: make
+  version: '4.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/make-4.3-he57ea6c_1.tar.bz2
+  hash:
+    md5: 1939d04ef89e38fde652ee8c669e092f
+    sha256: a011e3e1c4caec821eb4213d0a0154d39e5f81a44d2e8bafe6f84e7840c3909e
+  optional: false
+  category: main
+  source: null
+  build: he57ea6c_1
+- name: pkg-config
+  version: 0.29.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libglib: '>=2.70.2,<3.0a0'
+    libiconv: '>=1.16,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2
+  hash:
+    md5: 8d173d52214679033079d1b0582075aa
+    sha256: e59e69111709d097f9938e72ba19811ec1ef36aababdbed77bd7c767f15639e0
+  optional: false
+  category: main
+  source: null
+  build: hab62308_1008
+- name: cxx-compiler
+  version: 1.5.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    clangxx_osx-arm64: 14.*
+    c-compiler: ==1.5.2 h5008568_0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.5.2-hffc8910_0.conda
+  hash:
+    md5: 3dd2dd956573a59e32711e2e08bb5d8b
+    sha256: 84f23671f8b18aeabcfd4b5315383442c3bdff3c9194b85c30ec5690d14e721a
+  optional: false
+  category: main
+  source: null
+  build: hffc8910_0
+- name: c-compiler
+  version: 1.5.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ld64: '>=530'
+    llvm-openmp: '*'
+    clang_osx-arm64: 14.*
+    cctools: '>=949.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.5.2-h5008568_0.conda
+  hash:
+    md5: 56a88306583601d05b6eeded173d73d9
+    sha256: 54fabbef178e857a639a9c7a302cdab072ca5c2b94052ac939a7ebcf9dad32e4
+  optional: false
+  category: main
+  source: null
+  build: h5008568_0
+- name: cmake
+  version: 3.26.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libuv: '*'
+    libcurl: '>=8.1.0,<9.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    rhash: '*'
+    expat: '*'
+    libexpat: '>=2.5.0,<3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libcxx: '>=15.0.7'
+    ncurses: '>=6.3,<7.0a0'
+    zlib: '*'
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.26.4-hc0af03a_0.conda
+  hash:
+    md5: 84c170713e88c74f45fd87ce2a065cd3
+    sha256: cba596b6bba58e347bd8be51fce82583f16c5707f6c98b22a7e7ba1ecdb09783
+  optional: false
+  category: main
+  source: null
+  build: hc0af03a_0
+- name: xz
+  version: 5.2.6
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  hash:
+    md5: 39c6b54e94014701dd157f4f576ed211
+    sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  optional: false
+  category: main
+  source: null
+  build: h57fd34a_0
+- name: libexpat
+  version: 2.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  hash:
+    md5: 5a097ad3d17e42c148c9566280481317
+    sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+  optional: false
+  category: main
+  source: null
+  build: hb7217d7_1
+- name: rust
+  version: 1.70.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    rust-std-aarch64-apple-darwin: ==1.70.0 hf1a8007_0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.70.0-h4ff7c5d_0.conda
+  hash:
+    md5: fdd46a8698d3ae4590206f34ad5251ae
+    sha256: 63b73cf3137cd2d982412ad871e032db02af932eae464a3bdb5d63604e5ef069
+  optional: false
+  category: main
+  source: null
+  build: h4ff7c5d_0
+- name: rust-std-aarch64-apple-darwin
+  version: 1.70.0
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.70.0-hf1a8007_0.conda
+  hash:
+    md5: f944a8695fcfea2739488fc67d5653c5
+    sha256: fbeee19b13f8bffe84d5a60e26a77b762693930f741ebea64a2b1c7ffa348cb8
+  optional: false
+  category: main
+  source: null
+  build: hf1a8007_0
+- name: openssl
+  version: 3.1.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ca-certificates: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.1-h53f4e23_1.conda
+  hash:
+    md5: 7451b96ed28b5fd02f0df32689327755
+    sha256: 898aac8f8753385e9cd378d539364647d1deb9396032b7c1fd8f0f08107e020b
+  optional: false
+  category: main
+  source: null
+  build: h53f4e23_1
+- name: clang_osx-arm64
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ld64_osx-arm64: '*'
+    cctools_osx-arm64: '*'
+    clang: 14.0.6.*
+    compiler-rt: 14.0.6.*
+    llvm-tools: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-14.0.6-h15773ab_6.conda
+  hash:
+    md5: d8f3900d91a67bc95856b297b1fbd4ae
+    sha256: 4b9c93f2a13c8329db93c6acd3cdb6a4bace7848357943e3f2f8097153e71262
+  optional: false
+  category: main
+  source: null
+  build: h15773ab_6
+- name: compiler-rt
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    clangxx: 14.0.6.*
+    clang: 14.0.6.*
+    compiler-rt_osx-arm64: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-14.0.6-h30b49de_0.tar.bz2
+  hash:
+    md5: b88a5457fa7def557e5902046ab56b6e
+    sha256: 266578ae49450e6b4a778b454f8e7fd988676dd9146bb186093066ab1589ba06
+  optional: false
+  category: main
+  source: null
+  build: h30b49de_0
+- name: compiler-rt_osx-arm64
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    clangxx: 14.0.6.*
+    clang: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-14.0.6-h48302dc_0.tar.bz2
+  hash:
+    md5: ebcb473032038866101b70f9f270a9a2
+    sha256: f9f63e8779ff31368cc92ee668308c8e7e974f68457f62148c5663aa0136a42d
+  optional: false
+  category: main
+  source: null
+  build: h48302dc_0
+- name: clangxx_osx-arm64
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '>=14.0.6'
+    clang_osx-arm64: ==14.0.6 h15773ab_6
+    clangxx: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-14.0.6-he29aa18_6.conda
+  hash:
+    md5: 7a6be3e4c92a1cedf333f44d77fd732f
+    sha256: 175291d3e349829dc1f03d598815f70b11e978b9e286828c88b9d08a74eb1927
+  optional: false
+  category: main
+  source: null
+  build: he29aa18_6
+- name: llvm-openmp
+  version: 16.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-16.0.5-h1c12783_0.conda
+  hash:
+    md5: ca737da88c0732ccce43b67611516c80
+    sha256: 8fa97c774bd670d5322b5e891d14f1fbe65704c6b2ca6964302e753b81b4d383
+  optional: false
+  category: main
+  source: null
+  build: h1c12783_0
+- name: ca-certificates
+  version: 2023.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.5.7-hf0a4a13_0.conda
+  hash:
+    md5: a8387be82224743cf849fb907790b91a
+    sha256: 27214b54d1cb9a92455689e20d0007a0ff9ace99b853867d53a05a04c24bdae5
+  optional: false
+  category: main
+  source: null
+  build: hf0a4a13_0
+- name: libglib
+  version: 2.76.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gettext: '>=0.21.1,<1.0a0'
+    libcxx: '>=15.0.7'
+    pcre2: '>=10.40,<10.41.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.76.3-h24e9cb9_0.conda
+  hash:
+    md5: 30b160e9e8ca46b28491ca85eab61dce
+    sha256: 5b31f80d89224fbfbd0c46b313f6a8d3c43f20f2ae57613cd25d46524a3ca23d
+  optional: false
+  category: main
+  source: null
+  build: h24e9cb9_0
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+  hash:
+    md5: 686f9c755574aa221f29fbcf36a67265
+    sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
+  optional: false
+  category: main
+  source: null
+  build: he4db4b2_0
+- name: gettext
+  version: 0.21.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+  hash:
+    md5: 63d2ff6fddfa74e5458488fd311bf635
+    sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
+  optional: false
+  category: main
+  source: null
+  build: h0186832_0
+- name: pcre2
+  version: '10.40'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libzlib: '>=1.2.12,<1.3.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
+  hash:
+    md5: 721b7288270bafc83586b0f01c2a67f2
+    sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
+  optional: false
+  category: main
+  source: null
+  build: hb34f9b4_0
+- name: expat
+  version: 2.5.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libexpat: ==2.5.0 hb7217d7_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+  hash:
+    md5: 624fa0dd6fdeaa650b71a62296fdfedf
+    sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
+  optional: false
+  category: main
+  source: null
+  build: hb7217d7_1
+- name: libcurl
+  version: 8.1.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libssh2: '>=1.10.0,<2.0a0'
+    libnghttp2: '>=1.52.0,<2.0a0'
+    openssl: '>=3.1.0,<4.0a0'
+    krb5: '>=1.20.1,<1.21.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.1.2-h912dcd9_0.conda
+  hash:
+    md5: af01aa21cd4bb0cf519cda6bcec83fc5
+    sha256: 5d5bbc7a6eb363b2df85c5df32d34295346fc8b4d9e3754bbaf2af3e80422fab
+  optional: false
+  category: main
+  source: null
+  build: h912dcd9_0
+- name: krb5
+  version: 1.20.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libedit: '>=3.1.20191231,<4.0a0'
+    libcxx: '>=14.0.6'
+    openssl: '>=3.0.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.20.1-h69eda48_0.conda
+  hash:
+    md5: a85db53e45b1173f270fc998dd40ec03
+    sha256: 80094682db47468befef8e14a8a2ccc82cf71d6cf23bfa5d25c4de1df56e3067
+  optional: false
+  category: main
+  source: null
+  build: h69eda48_0
+- name: libnghttp2
+  version: 1.52.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=14.0.6'
+    c-ares: '>=1.18.1,<2.0a0'
+    libev: '>=4.33,<4.34.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.0.8,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.52.0-hae82a92_0.conda
+  hash:
+    md5: 1d319e95a0216f801293626a00337712
+    sha256: 1a3944d6295dcbecdf6489ce8a05fe416ad401727c901ec390e9200a351bdb10
+  optional: false
+  category: main
+  source: null
+  build: hae82a92_0
+- name: libedit
+  version: 3.1.20191231
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ncurses: '>=6.2,<7.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+  hash:
+    md5: 30e4362988a2623e9eb34337b83e01f9
+    sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
+  optional: false
+  category: main
+  source: null
+  build: hc8eb9b7_2
+- name: libcxx
+  version: 16.0.5
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.5-h4653b0c_0.conda
+  hash:
+    md5: d36fb4372ff02b2d1596366ee1d984bc
+    sha256: 14452e6dab03eb5260101cca926b4b96764f28726e5965067d0ba0101949e9e4
+  optional: false
+  category: main
+  source: null
+  build: h4653b0c_0
+- name: libuv
+  version: 1.44.2
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.44.2-he4db4b2_0.tar.bz2
+  hash:
+    md5: 9ec5d69871f50066aca03d0611507396
+    sha256: 287e905d9e28cd868033c98cb5871377c1fdaa9c4985195ea59023aaff1ebdbf
+  optional: false
+  category: main
+  source: null
+  build: he4db4b2_0
+- name: ncurses
+  version: '6.4'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+  hash:
+    md5: 318337fb9d0c53ba635efb7888242373
+    sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
+  optional: false
+  category: main
+  source: null
+  build: h7ea286d_0
+- name: rhash
+  version: 1.4.3
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.3-he4db4b2_0.tar.bz2
+  hash:
+    md5: e45421ad669d2e9bf56b7af7be0111e0
+    sha256: 404182eee6bc4da134cf1ce32ddf055d1a80bf14702bc9978de04f5eb2ecbf86
+  optional: false
+  category: main
+  source: null
+  build: he4db4b2_0
+- name: zlib
+  version: 1.2.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libzlib: ==1.2.13 h53f4e23_5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  hash:
+    md5: a08383f223b10b71492d27566fafbf6c
+    sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  optional: false
+  category: main
+  source: null
+  build: h53f4e23_5
+- name: libzlib
+  version: 1.2.13
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  hash:
+    md5: 1a47f5236db2e06a320ffa0392f81bd8
+    sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  optional: false
+  category: main
+  source: null
+  build: h53f4e23_5
+- name: zstd
+  version: 1.5.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-hf913c23_6.conda
+  hash:
+    md5: 8f346953ef63bf5fb482488a659adcf3
+    sha256: 018989ba028e76abc332c246002e8f5975ff123c68f6116a30da8009b14ea88d
+  optional: false
+  category: main
+  source: null
+  build: hf913c23_6
+- name: clangxx
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    clang: ==14.0.6 hce30654_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-14.0.6-default_h610c423_1.conda
+  hash:
+    md5: a9b37a157fdc4a3584aa7f5fb69d3a1a
+    sha256: abf47478baa7c0d183b43150ca600630dd5ce6762890e0bca925e05bd3247c6b
+  optional: false
+  category: main
+  source: null
+  build: default_h610c423_1
+- name: clang
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    clang-14: ==14.0.6 default_h5dc8d65_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-14.0.6-hce30654_1.conda
+  hash:
+    md5: 74394af220230cb88970984c086d2cba
+    sha256: da28397f5ab383d9cdcc0d3ed9b3e51a6b2a73edbb1867e13120e2f137eeb69e
+  optional: false
+  category: main
+  source: null
+  build: hce30654_1
+- name: clang-14
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libclang-cpp14: ==14.0.6 default_h5dc8d65_1
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-14-14.0.6-default_h5dc8d65_1.conda
+  hash:
+    md5: aafcdf5d9f0b5a00540469242d7ab67b
+    sha256: b674c9ff31b9bbf225b6c62e0b8a2ca45fe70ef78ad5ca22a79f6c8e41f37306
+  optional: false
+  category: main
+  source: null
+  build: default_h5dc8d65_1
+- name: libclang-cpp14
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp14-14.0.6-default_h5dc8d65_1.conda
+  hash:
+    md5: 7caa562f3551c16cd82d0147640091f8
+    sha256: 9cb083dae695cda715e280c2cadd08b625ecc5842f99fb575901990b0e60bf7c
+  optional: false
+  category: main
+  source: null
+  build: default_h5dc8d65_1
+- name: libllvm14
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hd1a9a77_3.conda
+  hash:
+    md5: 51d95b4036d6f7695b7dee38ea1792a6
+    sha256: 905f9084737336c4232c25698e0ac16f23f3d9f541647c9874e8392cbcf9e9cd
+  optional: false
+  category: main
+  source: null
+  build: hd1a9a77_3
+- name: llvm-tools
+  version: 14.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libllvm14: ==14.0.6 hd1a9a77_3
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-14.0.6-hd1a9a77_3.conda
+  hash:
+    md5: 6d7a2cdecb10729faa86a4e6d861adf6
+    sha256: b04e204fd03b7910bac32e76423dcfd855f3e2367a59a8e218ccbd102bba512c
+  optional: false
+  category: main
+  source: null
+  build: hd1a9a77_3
+- name: cctools_osx-arm64
+  version: 973.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ld64_osx-arm64: '>=609,<610.0a0'
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '*'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    sigtool: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-hef52d2f_13.conda
+  hash:
+    md5: ec8f13409a2be66371f6d1022ce4fe9a
+    sha256: 1fbb33b31de5a1a31f7658cdb540f76aaf43f52c81e53f83761486820f653610
+  optional: false
+  category: main
+  source: null
+  build: hef52d2f_13
+- name: cctools
+  version: 973.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    ld64: ==609 h619f069_13
+    cctools_osx-arm64: ==973.0.1 hef52d2f_13
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hcbb26d4_13.conda
+  hash:
+    md5: 0f89fe3819b672b09d7e6cadc8932cea
+    sha256: a7c66e9d8a353e5996dc63dc1f179a7dda40a4133d056dcbca90855b9157e199
+  optional: false
+  category: main
+  source: null
+  build: hcbb26d4_13
+- name: ld64
+  version: '609'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ld64_osx-arm64: ==609 h7167370_13
+    libllvm14: '>=14.0.6,<14.1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h619f069_13.conda
+  hash:
+    md5: c771ebc91a8088d5078332c83758e774
+    sha256: f39fdd5b8bfacc811d812370c26b5bd7a95551c130775664ed7eb259c509c9da
+  optional: false
+  category: main
+  source: null
+  build: h619f069_13
+- name: ld64_osx-arm64
+  version: '609'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    tapi: '>=1100.0.11,<1101.0a0'
+    libcxx: '*'
+    sigtool: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-h7167370_13.conda
+  hash:
+    md5: 95b0f14e103c5a2c27f5d53609e60643
+    sha256: baed60a74f3fa1e3158240ca0562fecb9398e7568d4b6126e494771323995b5c
+  optional: false
+  category: main
+  source: null
+  build: h7167370_13
+- name: tapi
+  version: 1100.0.11
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libcxx: '>=11.0.0.a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+  hash:
+    md5: d83362e7d0513f35f454bc50b0ca591d
+    sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
+  optional: false
+  category: main
+  source: null
+  build: he4954df_0
+- name: c-ares
+  version: 1.19.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.19.1-hb547adb_0.conda
+  hash:
+    md5: e7fc7430440d255e3a9c7e5a52f7b294
+    sha256: fc9d0fcfb30c20c0032b294120b6ba9c01078ddb372c34dd491214c598aecc06
+  optional: false
+  category: main
+  source: null
+  build: hb547adb_0
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+  hash:
+    md5: 566dbf70fe79eacdb3c3d3d195a27f55
+    sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
+  optional: false
+  category: main
+  source: null
+  build: h642e427_1
+- name: libffi
+  version: 3.4.2
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  hash:
+    md5: 086914b672be056eb70fd4285b6783b6
+    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  optional: false
+  category: main
+  source: null
+  build: h3422bc3_5
+- name: libssh2
+  version: 1.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+  hash:
+    md5: 029f7dc931a3b626b94823bc77830b01
+    sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
+  optional: false
+  category: main
+  source: null
+  build: h7a5bd25_0
+- name: sigtool
+  version: 0.1.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    openssl: '>=3.0.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+  hash:
+    md5: 4a2cac04f86a4540b8c9b8d8f597848f
+    sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
+  optional: false
+  category: main
+  source: null
+  build: h44b9a77_0
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+  hash:
+    md5: fc76ace7b94fb1f694988ab1b14dd248
+    sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+  optional: false
+  category: main
+  source: null
+  build: h3422bc3_4
+- name: make
+  version: '4.3'
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/make-4.3-h3d2af85_1.tar.bz2
+  hash:
+    md5: c3be283d3d278c379b50137a2a17f869
+    sha256: f31b00c710df71f2f75c641272ecb1f9bd1e15a5a77510055120641215487fbb
+  optional: false
+  category: main
+  source: null
+  build: h3d2af85_1
+- name: m2w64-gcc-libs
+  version: 5.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-libwinpthread-git: '*'
+    msys2-conda-epoch: '>=20160418'
+    m2w64-gcc-libs-core: '*'
+    m2w64-gcc-libgfortran: '*'
+    m2w64-gmp: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  hash:
+    md5: fe759119b8b3bfa720b8762c6fdc35de
+    sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  optional: false
+  category: main
+  source: null
+  build: '7'
+- name: m2w64-gcc-libgfortran
+  version: 5.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    m2w64-gcc-libs-core: '*'
+    msys2-conda-epoch: '>=20160418'
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  hash:
+    md5: 066552ac6b907ec6d72c0ddab29050dc
+    sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  optional: false
+  category: main
+  source: null
+  build: '6'
+- name: m2w64-gcc-libs-core
+  version: 5.3.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    msys2-conda-epoch: '>=20160418'
+    m2w64-gmp: '*'
+    m2w64-libwinpthread-git: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  hash:
+    md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+    sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  optional: false
+  category: main
+  source: null
+  build: '7'
+- name: m2w64-gmp
+  version: 6.1.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    msys2-conda-epoch: '>=20160418'
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  hash:
+    md5: 53a1c73e1e3d185516d7e3af177596d9
+    sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  optional: false
+  category: main
+  source: null
+  build: '2'
+- name: m2w64-libwinpthread-git
+  version: 5.0.0.4634.697f757
+  manager: conda
+  platform: win-64
+  dependencies:
+    msys2-conda-epoch: '>=20160418'
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  hash:
+    md5: 774130a326dee16f1ceb05cc687ee4f0
+    sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  optional: false
+  category: main
+  source: null
+  build: '2'
+- name: msys2-conda-epoch
+  version: '20160418'
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  hash:
+    md5: b0309b72560df66f71a9d5e34a5efdfa
+    sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  optional: false
+  category: main
+  source: null
+  build: '1'
+- name: pkg-config
+  version: 0.29.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    libglib: '>=2.64.6,<3.0a0'
+    vc: '>=14.1,<15.0a0'
+    vs2015_runtime: '>=14.16.27012'
+  url: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
+  hash:
+    md5: 8ff5bccb4dc5d153e79b068e0bb301c5
+    sha256: f2f64c4774eea3b789c9568452d8cd776bdcf7e2cda0f24bfa9dbcbd7fbb9f6f
+  optional: false
+  category: main
+  source: null
+  build: h2bf4dc2_1008
+- name: cxx-compiler
+  version: 1.5.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    vs2019_win-64: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/cxx-compiler-1.5.2-h91493d7_0.conda
+  hash:
+    md5: 96a8cc05d246f92e122e0affa390cba6
+    sha256: 2f8178bc97fff699ae54dd90b96ffa980ec148136e18fe3351a13741a55cc755
+  optional: false
+  category: main
+  source: null
+  build: h91493d7_0
+- name: cmake
+  version: 3.26.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc14_runtime: '>=14.29.30139'
+    vs2015_runtime: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.26.4-h1537add_0.conda
+  hash:
+    md5: d208c156437ff251e83a1061fa082064
+    sha256: c114c7fb3de04329620b715c0677d6dc943954be3877ee5a232ef0dc09f202d9
+  optional: false
+  category: main
+  source: null
+  build: h1537add_0
+- name: rust
+  version: 1.70.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    rust-std-x86_64-pc-windows-msvc: ==1.70.0 h69312b4_0
+  url: https://conda.anaconda.org/conda-forge/win-64/rust-1.70.0-hf8d6059_0.conda
+  hash:
+    md5: 01f0a71fd67b9763d72cf4540f2f6a88
+    sha256: 2f6b6ed05abea7cc3b985fa4d177271bd4bcc4decb9aab1128e0f5a8c627270a
+  optional: false
+  category: main
+  source: null
+  build: hf8d6059_0
+- name: rust-std-x86_64-pc-windows-msvc
+  version: 1.70.0
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.70.0-h69312b4_0.conda
+  hash:
+    md5: e9409f3ce67330c30b1f1ea231cc76ec
+    sha256: 390cd31b1cdece82696b979e110471785fffe6b21ad366a4da36f2b36b595211
+  optional: false
+  category: main
+  source: null
+  build: h69312b4_0
+- name: openssl
+  version: 3.1.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    ca-certificates: '*'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.1-hcfcfb64_1.conda
+  hash:
+    md5: 1d913a5de46c6b2f7e4cfbd26b106b8b
+    sha256: 4424486fb9a2aeaba912a8dd8a5b5cdb6fcd65d7708fd854e3ea27449bb352a3
+  optional: false
+  category: main
+  source: null
+  build: hcfcfb64_1
+- name: ucrt
+  version: 10.0.22621.0
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+  hash:
+    md5: 72608f6cd3e5898229c3ea16deb1ac43
+    sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+  optional: false
+  category: main
+  source: null
+  build: h57928b3_0
+- name: vc14_runtime
+  version: 14.34.31931
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.34.31931-h5081d32_16.conda
+  hash:
+    md5: 22125178654c6a8a393f9743d585704b
+    sha256: 1161f4848e1c0663897a6324fbc4ff13dafd11650b42c9864428da73593dda95
+  optional: false
+  category: main
+  source: null
+  build: h5081d32_16
+- name: vs2015_runtime
+  version: 14.34.31931
+  manager: conda
+  platform: win-64
+  dependencies:
+    vc14_runtime: '>=14.34.31931'
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.34.31931-hed1258a_16.conda
+  hash:
+    md5: 0374eae69b6dbfb27c3dc27167109eb4
+    sha256: 25d852887a501ca8cb6753a4f3dae1549fa49592d51aec1a230b1f0c85fe4297
+  optional: false
+  category: main
+  source: null
+  build: hed1258a_16
+- name: ca-certificates
+  version: 2023.5.7
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.5.7-h56e8100_0.conda
+  hash:
+    md5: 604212634bd8c4d6f20d44b946e8eedb
+    sha256: d0488a3e7a86cc11f8c847a7c12a5f1fb8567f05646faae78944807862f9d167
+  optional: false
+  category: main
+  source: null
+  build: h56e8100_0
+- name: vs2019_win-64
+  version: 19.29.30139
+  manager: conda
+  platform: win-64
+  dependencies:
+    vswhere: '*'
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2019_win-64-19.29.30139-he1865b1_16.conda
+  hash:
+    md5: 7c6cbe2f27602899828f42b04b66adc2
+    sha256: b8f579a806a32cfcbeb4b4a3460c888486319aa346c040ceac1af1da55dff90f
+  optional: false
+  category: main
+  source: null
+  build: he1865b1_16
+- name: libglib
+  version: 2.76.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    pcre2: '>=10.40,<10.41.0a0'
+    libffi: '>=3.4,<4.0a0'
+    vc: '>=14.2,<15'
+    libiconv: '>=1.17,<2.0a0'
+    ucrt: '>=10.0.20348.0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.76.3-he8f3873_0.conda
+  hash:
+    md5: 4695e6acaf4790170161048d56cb51fc
+    sha256: 170d42dcf0c73f5846dfb0c4a241c065cd9830c644d98042f076f25c309e7571
+  optional: false
+  category: main
+  source: null
+  build: he8f3873_0
+- name: gettext
+  version: 0.21.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    libiconv: '>=1.17,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+  hash:
+    md5: 299d4fd6798a45337042ff5a48219e5f
+    sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
+  optional: false
+  category: main
+  source: null
+  build: h5728263_0
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: win-64
+  dependencies:
+    vc: '>=14.1,<15'
+    vs2015_runtime: '>=14.16.27033'
+  url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+  hash:
+    md5: 050119977a86e4856f0416e2edcf81bb
+    sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
+  optional: false
+  category: main
+  source: null
+  build: h8ffe710_0
+- name: pcre2
+  version: '10.40'
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libzlib: '>=1.2.12,<1.3.0a0'
+    vc: '>=14.2,<15'
+    vs2015_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
+  hash:
+    md5: 2519de0d9620dc2bc7e19caf6867136d
+    sha256: 5833c63548e4fae91da6d77739eab7dc9bf6542e43f105826b23c01bfdd9cb57
+  optional: false
+  category: main
+  source: null
+  build: h17e33f8_0
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: win-64
+  dependencies:
+    vc: '>=14.1,<15.0a0'
+    vs2015_runtime: '>=14.16.27012'
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+  hash:
+    md5: 7c03c66026944073040cb19a4f3ec3c9
+    sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+  optional: false
+  category: main
+  source: null
+  build: h8ffe710_4
+- name: libzlib
+  version: 1.2.13
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+  hash:
+    md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+    sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+  optional: false
+  category: main
+  source: null
+  build: hcfcfb64_5
+- name: vswhere
+  version: 3.1.4
+  manager: conda
+  platform: win-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+  hash:
+    md5: b1d1d6a1f874d8c93a57b5efece52f03
+    sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
+  optional: false
+  category: main
+  source: null
+  build: h57928b3_0
+- name: libffi
+  version: 3.4.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    vc: '>=14.1,<15.0a0'
+    vs2015_runtime: '>=14.16.27012'
+  url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+  hash:
+    md5: 2c96d1b6915b408893f9472569dee135
+    sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+  optional: false
+  category: main
+  source: null
+  build: h8ffe710_5
+- name: vc
+  version: '14.3'
+  manager: conda
+  platform: win-64
+  dependencies:
+    vc14_runtime: '>=14.32.31332'
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hb25d44b_16.conda
+  hash:
+    md5: ea326b37e3bd6d2616988e09f3a9396c
+    sha256: 29bc108d66150ca75cab937f844f4ac4a836beb6ea3ee167d03c611444bb2a82
+  optional: false
+  category: main
+  source: null
+  build: hb25d44b_16
+- name: make
+  version: '4.3'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/make-4.3-h22f3db7_1.tar.bz2
+  hash:
+    md5: ac4a1dd58e6d821c518ae0011e8592b7
+    sha256: adef15126b518548b69ecaef24e22f88fa0a6358bd3c11e791af214f7344983b
+  optional: false
+  category: main
+  source: null
+  build: h22f3db7_1
+- name: pkg-config
+  version: 0.29.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libiconv: '>=1.16,<2.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-ha3d46e9_1008.tar.bz2
+  hash:
+    md5: 352bc6fb446a7ca608c61b33c1d5eb98
+    sha256: f60d1c03c7d10e8926e767981872fdd6002d2094925df598a53c58261524c151
+  optional: false
+  category: main
+  source: null
+  build: ha3d46e9_1008
+- name: cxx-compiler
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    c-compiler: ==1.5.2 hbf74d83_0
+    clangxx_osx-64: 14.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.5.2-hb8565cd_0.conda
+  hash:
+    md5: 349ae14723b98f76ea0fcb8e532b2ead
+    sha256: 91193c9029594d102217457ce8b4fe1cfd4a1e13e652451e94f851e91b45a147
+  optional: false
+  category: main
+  source: null
+  build: hb8565cd_0
+- name: c-compiler
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ld64: '>=530'
+    llvm-openmp: '*'
+    clang_osx-64: 14.*
+    cctools: '>=949.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.5.2-hbf74d83_0.conda
+  hash:
+    md5: c1413ef5a20d658923e12dd3b566d8f3
+    sha256: 0f97b6cc2215f0789ffa2781eb8a6304efaf5c4592c4c619d6e0a63c23f2b877
+  optional: false
+  category: main
+  source: null
+  build: hbf74d83_0
+- name: cmake
+  version: 3.26.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libuv: '*'
+    libcurl: '>=8.1.0,<9.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    rhash: '*'
+    expat: '*'
+    libexpat: '>=2.5.0,<3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libcxx: '>=15.0.7'
+    ncurses: '>=6.3,<7.0a0'
+    zlib: '*'
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.26.4-hf40c264_0.conda
+  hash:
+    md5: 24d42ac02d1968f731740c14e30d72b9
+    sha256: a13eb9e0a7f6b46c1035af0830324ba458315ed973022a21e0473f5d5090bfc9
+  optional: false
+  category: main
+  source: null
+  build: hf40c264_0
+- name: xz
+  version: 5.2.6
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+  hash:
+    md5: a72f9d4ea13d55d745ff1ed594747f10
+    sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+  optional: false
+  category: main
+  source: null
+  build: h775f41a_0
+- name: libexpat
+  version: 2.5.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  hash:
+    md5: 6c81cb022780ee33435cca0127dd43c9
+    sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+  optional: false
+  category: main
+  source: null
+  build: hf0c8a7f_1
+- name: rust
+  version: 1.70.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    rust-std-x86_64-apple-darwin: ==1.70.0 h059895a_0
+  url: https://conda.anaconda.org/conda-forge/osx-64/rust-1.70.0-h7e1429e_0.conda
+  hash:
+    md5: 4d7fc39af3d6bee1aa5a0f639f09d882
+    sha256: a059f07840dd24d7604ceb7cb15a0f526a2beec84237090248181556a11ae15b
+  optional: false
+  category: main
+  source: null
+  build: h7e1429e_0
+- name: rust-std-x86_64-apple-darwin
+  version: 1.70.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.70.0-h059895a_0.conda
+  hash:
+    md5: 622ce95657da30109767978868cf47f3
+    sha256: 90d71918fe1944e540370d4c8ac508cc3c367d6a5d5f39420be61e7fb03e7cf2
+  optional: false
+  category: main
+  source: null
+  build: h059895a_0
+- name: openssl
+  version: 3.1.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ca-certificates: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.1-h8a1eda9_1.conda
+  hash:
+    md5: c7822d6ee74e34af1fd74365cfd18983
+    sha256: 67855f92bf50f24cbbc44879864d7a040b1f351e95b599cfcf4cc49b2cc3fd08
+  optional: false
+  category: main
+  source: null
+  build: h8a1eda9_1
+- name: clang_osx-64
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ld64_osx-64: '*'
+    cctools_osx-64: '*'
+    clang: 14.0.6.*
+    compiler-rt: 14.0.6.*
+    llvm-tools: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-14.0.6-h3113cd8_6.conda
+  hash:
+    md5: 1b191288877fac1564184b28ce07de84
+    sha256: 26092a2c8f9d87c1113e3a20cf0700df4df388c58eba04fabe33fafc0e62190d
+  optional: false
+  category: main
+  source: null
+  build: h3113cd8_6
+- name: compiler-rt
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    clangxx: 14.0.6.*
+    clang: 14.0.6.*
+    compiler-rt_osx-64: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-14.0.6-h613da45_0.tar.bz2
+  hash:
+    md5: b44e0625319f9933e584dc3b96f5baf7
+    sha256: 2dea3b5efea587329320c70a335fa5666c3a814e70e76464734b90a40b70e8a8
+  optional: false
+  category: main
+  source: null
+  build: h613da45_0
+- name: compiler-rt_osx-64
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    clangxx: 14.0.6.*
+    clang: 14.0.6.*
+  url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-14.0.6-hab78ec2_0.tar.bz2
+  hash:
+    md5: 4fdde3f4ed31722a1c811723f5db82f0
+    sha256: a8351d6a47a8a2cd8267862d36ad5a06f16955c68111140b8b147ee126433712
+  optional: false
+  category: main
+  source: null
+  build: hab78ec2_0
+- name: clangxx_osx-64
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '>=14.0.6'
+    clangxx: 14.0.6.*
+    clang_osx-64: ==14.0.6 h3113cd8_6
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-14.0.6-h6f97653_6.conda
+  hash:
+    md5: 3989d08f74e7d987e94d9003cea30080
+    sha256: 185f9ccec322cfee2303ba0129ad37c0803492e535978f9e5432e23973004d50
+  optional: false
+  category: main
+  source: null
+  build: h6f97653_6
+- name: llvm-openmp
+  version: 16.0.5
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-16.0.5-hff08bdf_0.conda
+  hash:
+    md5: af8df1a61e8137e3479b0f71d5bd0a49
+    sha256: 8615505724d8e4e86fc036de3aad73382bf33028f305c279cee28f10c8448291
+  optional: false
+  category: main
+  source: null
+  build: hff08bdf_0
+- name: libcxx
+  version: 16.0.5
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.5-hd57cbcb_0.conda
+  hash:
+    md5: d34eed0a4fb993f0d934db6394ba23ef
+    sha256: 1661ffd4e62593aed05da9ee1f7b1905711d8374a25b187e61cb7e55823440df
+  optional: false
+  category: main
+  source: null
+  build: hd57cbcb_0
+- name: clangxx
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    clang: ==14.0.6 h694c41f_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-14.0.6-default_hdb78580_1.conda
+  hash:
+    md5: cc2ac1c5c838cb0edd65258da7c38294
+    sha256: 6c5ed5942dc9627926741e001a042f2a8dc31e221c0a7e4bcbbe35cd0e6681b8
+  optional: false
+  category: main
+  source: null
+  build: default_hdb78580_1
+- name: clang
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    clang-14: ==14.0.6 default_hdb78580_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-14.0.6-h694c41f_1.conda
+  hash:
+    md5: 1305da4c85c7eaa2e90fa14efc35f591
+    sha256: f757328f9924d93b09aa16423160b6ebbe28dac7508cce76d50795db4d1d39c9
+  optional: false
+  category: main
+  source: null
+  build: h694c41f_1
+- name: clang-14
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libclang-cpp14: ==14.0.6 default_hdb78580_1
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/clang-14-14.0.6-default_hdb78580_1.conda
+  hash:
+    md5: ce19ccaee311132f299ffd0eec9c4581
+    sha256: a8ef6982c0da903e31215425219693a45e39b47189018cf479b03290764793cd
+  optional: false
+  category: main
+  source: null
+  build: default_hdb78580_1
+- name: libclang-cpp14
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    libcxx: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp14-14.0.6-default_hdb78580_1.conda
+  hash:
+    md5: 9a235664bf087994aa3acc1a60614964
+    sha256: 5720d4662bd032a1dc07d0ae1368fa5e454c938545bdd93f78dacd25b9f597d3
+  optional: false
+  category: main
+  source: null
+  build: default_hdb78580_1
+- name: libllvm14
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-hc8e404f_3.conda
+  hash:
+    md5: a6433d7252b49c2195f8aa70ad898104
+    sha256: 2469a23d25e2d6b782aa06621f234009f0e401bbf81b479c535809975605596c
+  optional: false
+  category: main
+  source: null
+  build: hc8e404f_3
+- name: llvm-tools
+  version: 14.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: ==14.0.6 hc8e404f_3
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-14.0.6-hc8e404f_3.conda
+  hash:
+    md5: 3bebd091daab84c54f91205bb4d4a9c3
+    sha256: f766574fc90d624ee2ed44824726a5f02eb9f90090659c353f125c1488edb271
+  optional: false
+  category: main
+  source: null
+  build: hc8e404f_3
+- name: zlib
+  version: 1.2.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: ==1.2.13 h8a1eda9_5
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+  hash:
+    md5: 75a8a98b1c4671c5d2897975731da42d
+    sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
+  optional: false
+  category: main
+  source: null
+  build: h8a1eda9_5
+- name: libzlib
+  version: 1.2.13
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+  hash:
+    md5: 4a3ad23f6e16f99c04e166767193d700
+    sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+  optional: false
+  category: main
+  source: null
+  build: h8a1eda9_5
+- name: expat
+  version: 2.5.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libexpat: ==2.5.0 hf0c8a7f_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+  hash:
+    md5: e12630038077877cbb6c7851e139c17c
+    sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
+  optional: false
+  category: main
+  source: null
+  build: hf0c8a7f_1
+- name: libuv
+  version: 1.44.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.44.2-hac89ed1_0.tar.bz2
+  hash:
+    md5: 958fa9add5701462a6c91e3774425ea1
+    sha256: c9f8e0884c1557ad886b4389688f8005a655392bd8b90007b0bab463193bfd3a
+  optional: false
+  category: main
+  source: null
+  build: hac89ed1_0
+- name: ncurses
+  version: '6.4'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
+  hash:
+    md5: c3dbae2411164d9b02c69090a9a91857
+    sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
+  optional: false
+  category: main
+  source: null
+  build: hf0c8a7f_0
+- name: rhash
+  version: 1.4.3
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.3-hac89ed1_0.tar.bz2
+  hash:
+    md5: 503cbfbbda92c68b918adb8f8c13afaa
+    sha256: 39ea9d1e6736d710bf9b56d6ce262c82064946ffada5e4c9459121a51e442381
+  optional: false
+  category: main
+  source: null
+  build: hac89ed1_0
+- name: libcurl
+  version: 8.1.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libssh2: '>=1.10.0,<2.0a0'
+    libnghttp2: '>=1.52.0,<2.0a0'
+    openssl: '>=3.1.0,<4.0a0'
+    krb5: '>=1.20.1,<1.21.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.1.2-hbee3ae8_0.conda
+  hash:
+    md5: d51e337da844262f9033c9a26452520f
+    sha256: 2f81bb06377779ea1abe373a2a89289fb440751ad6f68f947ec0f3b1e4399968
+  optional: false
+  category: main
+  source: null
+  build: hbee3ae8_0
+- name: krb5
+  version: 1.20.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libedit: '>=3.1.20191231,<4.0a0'
+    libcxx: '>=14.0.6'
+    openssl: '>=3.0.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.20.1-h049b76e_0.conda
+  hash:
+    md5: db11fa2968ef0837288fe2d7f5b77a50
+    sha256: 41cfbf4c5cdb4a32eb5319943113d7ef1edb894ea0a5464233e510b59450c824
+  optional: false
+  category: main
+  source: null
+  build: h049b76e_0
+- name: libnghttp2
+  version: 1.52.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=14.0.6'
+    c-ares: '>=1.18.1,<2.0a0'
+    libev: '>=4.33,<4.34.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.0.8,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.52.0-he2ab024_0.conda
+  hash:
+    md5: 12ac7d100bf260263e30a019517f42a2
+    sha256: 093e4f3f62b3b07befa403e84a1f550cffe3b3961e435d42a75284f44be5f68a
+  optional: false
+  category: main
+  source: null
+  build: he2ab024_0
+- name: zstd
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    libcxx: '>=14.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.2-hbc0c0cd_6.conda
+  hash:
+    md5: 40a188783d3c425bdccc9ae9104acbb8
+    sha256: f845dafb0b488703ce81e25b6f27ed909ee9061b730c172e6b084fcf7156231f
+  optional: false
+  category: main
+  source: null
+  build: hbc0c0cd_6
+- name: libiconv
+  version: '1.17'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+  hash:
+    md5: 691d103d11180486154af49c037b7ed9
+    sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
+  optional: false
+  category: main
+  source: null
+  build: hac89ed1_0
+- name: ca-certificates
+  version: 2023.5.7
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.5.7-h8857fd0_0.conda
+  hash:
+    md5: b704e4b79ba0d887c4870b7b09d6a4df
+    sha256: a06c9c788de81da3a3868ac56781680cc1fc50a0b5a545d4453818975c141b2c
+  optional: false
+  category: main
+  source: null
+  build: h8857fd0_0
+- name: c-ares
+  version: 1.19.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.19.1-h0dc2134_0.conda
+  hash:
+    md5: b3e62631b4e1b9801477523ce1d6f355
+    sha256: 1de09d540facc3833e3f0a280ae987859f310f535726eff66d6f4a66045bd32c
+  optional: false
+  category: main
+  source: null
+  build: h0dc2134_0
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+  hash:
+    md5: 79dc2be110b2a3d1e97ec21f691c50ad
+    sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
+  optional: false
+  category: main
+  source: null
+  build: haf1e3a3_1
+- name: cctools_osx-64
+  version: 973.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    ld64_osx-64: '>=609,<610.0a0'
+    libcxx: '*'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    sigtool: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-hcc6d90d_13.conda
+  hash:
+    md5: 76e5fa849e2042cd657d9eec96095680
+    sha256: 468bc6d052fd57928049fa05efc42e2a197026cf817942de833f9f526fdc39c0
+  optional: false
+  category: main
+  source: null
+  build: hcc6d90d_13
+- name: cctools
+  version: 973.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cctools_osx-64: ==973.0.1 hcc6d90d_13
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    ld64: ==609 hc6ad406_13
+  url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h76f1dac_13.conda
+  hash:
+    md5: 802cae917abdc5a7cdfa699ff02da42d
+    sha256: f36d2b5eccd494f0ade668bd1a63e09b78427d0abb8066c6041e8776d9582114
+  optional: false
+  category: main
+  source: null
+  build: h76f1dac_13
+- name: ld64
+  version: '609'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    ld64_osx-64: ==609 hfd63004_13
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-hc6ad406_13.conda
+  hash:
+    md5: 5d7676eee44dfa3e48bf21700e044aa9
+    sha256: cc7d0de073179de57763c5cf9ee7c2bc9855d362c13245427cccbd517fe794fe
+  optional: false
+  category: main
+  source: null
+  build: hc6ad406_13
+- name: ld64_osx-64
+  version: '609'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libllvm14: '>=14.0.6,<14.1.0a0'
+    tapi: '>=1100.0.11,<1101.0a0'
+    libcxx: '*'
+    sigtool: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-hfd63004_13.conda
+  hash:
+    md5: 58fcda6a84fb42f51c6c2d6d175b435d
+    sha256: 97c752c2b4518c394adf6db1538d8dff233a4a3072964fb4d834f3993f988e43
+  optional: false
+  category: main
+  source: null
+  build: hfd63004_13
+- name: libssh2
+  version: 1.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  hash:
+    md5: ca3a72efba692c59a90d4b9fc0dfe774
+    sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  optional: false
+  category: main
+  source: null
+  build: hd019ec5_0
+- name: sigtool
+  version: 0.1.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    openssl: '>=3.0.0,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+  hash:
+    md5: fbfb84b9de9a6939cb165c02c69b1865
+    sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
+  optional: false
+  category: main
+  source: null
+  build: h88f4db0_0
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+  hash:
+    md5: 37edc4e6304ca87316e160f5ca0bd1b5
+    sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+  optional: false
+  category: main
+  source: null
+  build: h0d85af4_4
+- name: tapi
+  version: 1100.0.11
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libcxx: '>=10.0.0.a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+  hash:
+    md5: f9ff42ccf809a21ba6f8607f8de36108
+    sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
+  optional: false
+  category: main
+  source: null
+  build: h9ce4665_0
+- name: libedit
+  version: 3.1.20191231
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ncurses: '>=6.2,<7.0.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+  hash:
+    md5: 6016a8a1d0e63cac3de2c352cd40208b
+    sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
+  optional: false
+  category: main
+  source: null
+  build: h0678c8f_2
 version: 1

--- a/pixi.toml
+++ b/pixi.toml
@@ -4,7 +4,7 @@ version = "0.0.2"
 description = "Package manamgent made easy!"
 authors = ["Wolf Vollprecht <wolf@prefix.dev>", "Bas Zalmstra <bas@prefix.dev>", "Tim de Jager <tim@prefix.dev>", "Ruben Arts <ruben@prefix.dev>"]
 channels = ["conda-forge"]
-platforms = ["linux-64"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
 [commands]
 build = "cargo build --release"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -202,21 +202,21 @@ fn add_metadata_as_env_vars(
     project: &Project,
 ) -> anyhow::Result<()> {
     // Setting a base prefix for the pixi package
-    let prefix: String = "PIXI_PACKAGE_".to_string();
+    const PREFIX: &str = "PIXI_PACKAGE_";
 
     shell.set_env_var(
         script,
-        &(prefix.clone() + "ROOT"),
+        &format!("{PREFIX}ROOT"),
         &(project.root().to_string_lossy()),
     )?;
     shell.set_env_var(
         script,
-        &(prefix.clone() + "MANIFEST"),
+        &format!("{PREFIX}MANIFEST"),
         &(project.manifest_path().to_string_lossy()),
     )?;
     shell.set_env_var(
         script,
-        &(prefix.clone() + "PLATFORMS"),
+        &format!("{PREFIX}PLATFORMS"),
         &(project
             .platforms()
             .unwrap()
@@ -225,8 +225,8 @@ fn add_metadata_as_env_vars(
             .collect::<Vec<&str>>()
             .join(",")),
     )?;
-    shell.set_env_var(script, &(prefix.clone() + "NAME"), project.name()?)?;
-    shell.set_env_var(script, &(prefix + "VERSION"), project.version()?)?;
+    shell.set_env_var(script, &format!("{PREFIX}NAME"), project.name()?)?;
+    shell.set_env_var(script, &format!("{PREFIX}VERSION"), project.version()?)?;
 
     Ok(())
 }


### PR DESCRIPTION
Will add the following env  vars to the run environment:
```bash
PIXI_PACKAGE_VERSION=0.0.2
PIXI_PACKAGE_PLATFORMS=linux-64,win-64,osx-64,osx-arm64
PIXI_PACKAGE_NAME=pixi
PIXI_PACKAGE_MANIFEST=/home/rarts/development/pixi/pixi.toml
PIXI_PACKAGE_ROOT=/home/rarts/development/pixi
```
You can test it with:
```
pixi run env | grep PIXI
```

closes #78 