### PR TITLE
fix: detect shell for autocompletion

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -37,7 +37,7 @@ enum Command {
 
 fn completion(args: CompletionCommand) -> Result<(), Error> {
     clap_complete::generate(
-        args.shell.unwrap_or(Shell::Bash),
+        args.shell.or(Shell::from_env()).unwrap_or(Shell::Bash),
         &mut Args::command(),
         "pixi",
         &mut std::io::stdout(),


### PR DESCRIPTION
Detect the current shell from the environment if not specified on the command line.

Fix #90 