### PR TITLE
feat: add version and color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "pixi"
 version = "0.0.2"
+description = "A package management and workflow tool"
 edition = "2021"
+authors = ["pixi contributors <hi@prefix.dev>"]
+homepage = "https://github.com/prefix-dev/pixi"
+repository = "https://github.com/prefix-dev/pixi"
+license = "BSD-3-Clause"
+readme = "docs/README.md"
 
 [features]
 default = ["native-tls"]
@@ -10,7 +16,7 @@ rustls-tls = ["reqwest/rustls-tls", "rattler_repodata_gateway/rustls-tls", "ratt
 
 [dependencies]
 anyhow = "1.0.70"
-clap = { version = "4.2.4", default-features = false, features = ["derive", "usage", "wrap_help", "std"] }
+clap = { version = "4.2.4", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context"] }
 clap_complete = "4.2.1"
 console = { version = "0.15.5", features = ["windows-console-colors"] }
 dirs = "5.0.1"

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,7 +140,7 @@ The cli looks as follows:
 ➜ pixi -h
 A package management and workflow tool
 
-Usage: pixi.exe [COMMAND]
+Usage: pixi [COMMAND]
 
 Commands:
   completion  Generates a completion script for a shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,9 @@ The cli looks as follows:
 
 ```bash
 ➜ pixi -h
-Usage: pixi [COMMAND]
+A package management and workflow tool
+
+Usage: pixi.exe [COMMAND]
 
 Commands:
   completion  Generates a completion script for a shell
@@ -149,7 +151,8 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 ## Creating a pixi project

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ mod install;
 mod run;
 
 #[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
 struct Args {
     #[command(subcommand)]
     command: Option<Command>,


### PR DESCRIPTION
Adds `--version`, usage, about, and stuff to `Cargo.toml`.

```
A package management and workflow tool

Usage: pixi.exe [COMMAND]

Commands:
  completion  Generates a completion script for a shell
  init        Creates a new project
  add         Adds a dependency to the project
  run         Runs command in project
  install     Installs the defined package in a global accessible location
  help        Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

Fixes #92 