### PR TITLE
fix: add --locked to install instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,7 +87,7 @@ tested with cargo.
 To start using `pixi` from a source build run:
 
 ```shell
-cargo install --git https://github.com/prefix-dev/pixi.git
+cargo install --locked --git https://github.com/prefix-dev/pixi.git
 ```
 
 or when you want to make changes use:


### PR DESCRIPTION
We installing using `cargo install` it is important to use the lock file from the repository. By default, this is not the case but by adding `--locked` it is. 

Fix #96 