### PR TITLE
rename `install` to `global add`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -147,7 +147,7 @@ Commands:
   init        Creates a new project
   add         Adds a dependency to the project
   run         Runs command in project
-  install     Installs the defined package in a global accessible location
+  global      Global is the main entry point for the part of pixi that executes on the global(system) level
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -183,7 +183,7 @@ You can also globally install conda packages into their own environment.
 This behavior is similar to [`pipx`](https://github.com/pypa/pipx).
 
 ```bash
-pixi install cowpy
+pixi global add cowpy
 ```
 
 For more examples

--- a/src/cli/global/add.rs
+++ b/src/cli/global/add.rs
@@ -36,7 +36,7 @@ pub struct Args {
     ///
     /// When specifying a channel, it is common that the selected channel also
     /// depends on the `conda-forge` channel.
-    /// For example: `pixi install --channel conda-forge --channel bioconda`.
+    /// For example: `pixi global add --channel conda-forge --channel bioconda`.
     ///
     /// By default, if no channel is provided, `conda-forge` is used.
     #[clap(short, long, default_values = ["conda-forge"])]

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+mod add;
+
+#[derive(Debug, Parser)]
+pub enum Command {
+    #[clap(alias = "a")]
+    Add(add::Args),
+}
+
+/// Global is the main entry point for the part of pixi that executes on the global(system) level.
+///
+/// It does not touch your system but in comparison to the normal pixi workflow which focuses on project level actions this will work on your system level.
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+pub async fn execute(cmd: Args) -> anyhow::Result<()> {
+    match cmd.command {
+        Command::Add(args) => add::execute(args).await?,
+    };
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,8 +6,8 @@ use crate::Project;
 use anyhow::Error;
 
 mod add;
+mod global;
 mod init;
-mod install;
 mod run;
 
 #[derive(Parser, Debug)]
@@ -29,11 +29,12 @@ pub struct CompletionCommand {
 enum Command {
     Completion(CompletionCommand),
     Init(init::Args),
+    #[clap(alias = "a")]
     Add(add::Args),
     #[clap(alias = "r")]
     Run(run::Args),
-    #[clap(alias = "i")]
-    Install(install::Args),
+    #[clap(alias = "g")]
+    Global(global::Args),
 }
 
 fn completion(args: CompletionCommand) -> Result<(), Error> {
@@ -69,7 +70,7 @@ pub async fn execute() -> anyhow::Result<()> {
         Some(Command::Init(cmd)) => init::execute(cmd).await,
         Some(Command::Add(cmd)) => add::execute(cmd).await,
         Some(Command::Run(cmd)) => run::execute(cmd).await,
-        Some(Command::Install(cmd)) => install::execute(cmd).await,
+        Some(Command::Global(cmd)) => global::execute(cmd).await,
         None => default().await,
     }
 }


### PR DESCRIPTION
This changes 
```
pixi install cowpy
```
to 
```
pixi global add cowpy
# or
pixi g a cowpy
```