### PR TITLE
Feature/specify project path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,11 +148,14 @@ Commands:
   add         Adds a dependency to the project
   run         Runs command in project
   global      Global is the main entry point for the part of pixi that executes on the global(system) level
+  install     Install the dependencies of the project
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -v, --verbose...  More output per occurrence
+  -q, --quiet...    Less output per occurrence
+  -h, --help        Print help
+  -V, --version     Print version
 ```
 
 ## Creating a pixi project

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,23 +11,23 @@ Except for very low level drivers like Cuda and platform libraries.
 
 Examples of such installations, which automatically fetch the tools from the `conda-forge` channel, are:
 ```shell
-pixi install starship
-pixi install ruff
+pixi global install starship
+pixi global install ruff
 ```
 After running the above commands (and adding the binary folder to your path) the tools are directly available from the command line.
 
 If you wish to install packages from a different channel, the `--channel` or `-c` option can be used:
 ```shell
-pixi install --channel conda-forge --channel bioconda trackplot
+pixi global install --channel conda-forge --channel bioconda trackplot
 # Or in a more concise form
-pixi install -c conda-forge -c bioconda trackplot
+pixi global install -c conda-forge -c bioconda trackplot
 ```
 
 The `install` command in pixi can take a matchspec, providing you with the flexibility to specify the exact version of a package you want to install.
 You can fine-tune the version down to the build:
 ```shell
-pixi install python=3.9.*
-pixi install "python [version="3.11.0", build_number=1]"
-pixi install "python [version="3.11.0", build=he550d4f_1_cpython]"
-pixi install python=3.11.0=h10a6764_1_cpython
+pixi global install python=3.9.*
+pixi global install "python [version="3.11.0", build_number=1]"
+pixi global install "python [version="3.11.0", build=he550d4f_1_cpython]"
+pixi global install python=3.11.0=h10a6764_1_cpython
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,7 +3,7 @@ The central philosophy of pixi revolves around maintaining a separate conda envi
 The `pixi` tool achieves this by organizing environments and installations within unique directories.
 
 When you use pixi to install a standalone tool, for example `cowpy`, it creates a distinct structure in your home directory.
-To illustrate, running the command `pixi install cowpy` would yield the following directory structure:
+To illustrate, running the command `pixi global install cowpy` would yield the following directory structure:
 ```shell
 $HOME
 └── .pixi

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -12,6 +12,7 @@ use rattler_conda_types::{
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{LibsolvRepoData, SolverBackend};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 /// Adds a dependency to the project
 #[derive(Parser, Debug)]
@@ -34,11 +35,15 @@ pub struct Args {
     ///
     /// - `pixi add python pytest`: This will add both `python` and `pytest` to the project's dependencies.
     specs: Vec<MatchSpec>,
+
+    /// The path to the pixi project
+    #[arg(long)]
+    project_path: Option<PathBuf>,
 }
 
 pub async fn execute(args: Args) -> anyhow::Result<()> {
     // Determine the location and metadata of the current project
-    let mut project = Project::discover()?;
+    let mut project = Project::discover(args.project_path)?;
 
     // Split the specs into package name and version specifier
     let new_specs = args

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,0 +1,24 @@
+use crate::environment::get_up_to_date_prefix;
+use crate::Project;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Install all the dependencies
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The path to a pixi project
+    #[arg(long)]
+    project_path: Option<PathBuf>,
+}
+
+pub async fn execute(args: Args) -> anyhow::Result<()> {
+    let project = Project::discover(args.project_path)?;
+    get_up_to_date_prefix(&project).await?;
+    // Emit success
+    eprintln!(
+        "{}Project in {} is ready to use!",
+        console::style(console::Emoji("✔ ", "")).green(),
+        project.root().display()
+    );
+    Ok(())
+}

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -3,7 +3,7 @@ use crate::Project;
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Install all the dependencies
+/// Install the dependencies of the project
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The path to a pixi project

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -21,10 +21,14 @@ use rattler_shell::{
 pub struct Args {
     /// The command you want to run in the projects environment.
     command: Vec<String>,
+
+    /// The path to the pixi project
+    #[arg(long)]
+    project_path: Option<PathBuf>,
 }
 
 pub async fn execute(args: Args) -> anyhow::Result<()> {
-    let project = Project::discover()?;
+    let project = Project::discover(args.project_path)?;
 
     // Get the script to execute from the command line.
     let (command_name, command) = args

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -28,8 +28,8 @@ pub struct Project {
 impl Project {
     /// Discovers the project manifest file in the current directory or any of the parent
     /// directories.
-    pub fn discover() -> anyhow::Result<Self> {
-        let project_toml = match find_project_root() {
+    pub fn discover(project_path: Option<PathBuf>) -> anyhow::Result<Self> {
+        let project_toml = match find_project_root(project_path) {
             Some(root) => root.join(consts::PROJECT_MANIFEST),
             None => anyhow::bail!("could not find {}", consts::PROJECT_MANIFEST),
         };
@@ -220,9 +220,9 @@ impl Project {
 
 /// Iterates over the current directory and all its parent directories and returns the first
 /// directory path that contains the [`consts::PROJECT_MANIFEST`].
-pub fn find_project_root() -> Option<PathBuf> {
-    let current_dir = env::current_dir().ok()?;
-    std::iter::successors(Some(current_dir.as_path()), |prev| prev.parent())
+pub fn find_project_root(project_path: Option<PathBuf>) -> Option<PathBuf> {
+    let search_path = project_path.unwrap_or(env::current_dir().ok()?);
+    std::iter::successors(Some(search_path.as_path()), |prev| prev.parent())
         .find(|dir| dir.join(consts::PROJECT_MANIFEST).is_file())
         .map(Path::to_path_buf)
 }


### PR DESCRIPTION
This removes the `pixi` command as a functional tool and add `pixi install` for initializing the environment. 
This decision is made as it aligns with [`yarn`](https://yarnpkg.com/getting-started/usage#installing-all-the-dependencies) and [`poetry`](https://python-poetry.org/docs/cli/#install)

This also adds the `--project-path` argument to specify which project you want to use. This is useful for ci and testing scripts. It is different from any other tool as we're not able to find a suiting alternative. Lots of tools use `-C` or `--cwd` which changes the current working directory but that is not what we wanted. 