### PR TITLE
refactor to install command and add manifest path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,10 +137,10 @@ And then restart the shell or source the shell config file.
 The cli looks as follows:
 
 ```bash
-➜ pixi -h
+➜ pixi
 A package management and workflow tool
 
-Usage: pixi [COMMAND]
+Usage: pixi [OPTIONS] <COMMAND>
 
 Commands:
   completion  Generates a completion script for a shell
@@ -148,6 +148,8 @@ Commands:
   add         Adds a dependency to the project
   run         Runs command in project
   global      Global is the main entry point for the part of pixi that executes on the global(system) level
+  auth        Login to prefix.dev or anaconda.org servers to access private channels
+  install     Install all dependencies
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -155,6 +157,7 @@ Options:
   -q, --quiet...    Less output per occurrence
   -h, --help        Print help
   -V, --version     Print version
+
 ```
 
 ## Creating a pixi project

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -37,8 +37,6 @@ pub struct Args {
     specs: Vec<MatchSpec>,
 
     /// The path to a projects manifest path. Default is `pixi.toml`.
-    ///
-    /// The pixi.toml is searched for in the current dir or lower in the directory tree.
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -36,7 +36,7 @@ pub struct Args {
     /// - `pixi add python pytest`: This will add both `python` and `pytest` to the project's dependencies.
     specs: Vec<MatchSpec>,
 
-    /// The path to a projects manifest path. Default is `pixi.toml`.
+    /// The path to 'pixi.toml'
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -7,8 +7,6 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The path to a projects manifest path. Default is `pixi.toml`.
-    ///
-    /// The pixi.toml is searched for in the current dir or lower in the directory tree.
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,0 +1,31 @@
+use crate::environment::get_up_to_date_prefix;
+use crate::Project;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Install all dependencies
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The path to a projects manifest path. Default is `pixi.toml`.
+    ///
+    /// The pixi.toml is searched for in the current dir or lower in the directory tree.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+}
+
+pub async fn execute(args: Args) -> anyhow::Result<()> {
+    let project = match args.manifest_path {
+        Some(path) => Project::load(path.as_path())?,
+        None => Project::discover()?,
+    };
+
+    get_up_to_date_prefix(&project).await?;
+
+    // Emit success
+    eprintln!(
+        "{}Project in {} is ready to use!",
+        console::style(console::Emoji("✔ ", "")).green(),
+        project.root().display()
+    );
+    Ok(())
+}

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 /// Install all dependencies
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to a projects manifest path. Default is `pixi.toml`.
+    /// The path to 'pixi.toml'
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,8 +3,7 @@ use clap::{CommandFactory, Parser};
 use clap_complete::Shell;
 use clap_verbosity_flag::Verbosity;
 
-use crate::Project;
-use crate::{environment::get_up_to_date_prefix, progress};
+use crate::progress;
 use anyhow::Error;
 use tracing_subscriber::{filter::LevelFilter, util::SubscriberInitExt, EnvFilter};
 
@@ -12,13 +11,15 @@ mod add;
 mod auth;
 mod global;
 mod init;
+mod install;
 mod run;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
+#[clap(arg_required_else_help = true)]
 struct Args {
     #[command(subcommand)]
-    command: Option<Command>,
+    command: Command,
 
     /// The verbosity level
     /// (-v for verbose, -vv for debug, -vvv for trace, -q for quiet)
@@ -45,6 +46,7 @@ enum Command {
     #[clap(alias = "g")]
     Global(global::Args),
     Auth(auth::Args),
+    Install(install::Args),
 }
 
 fn completion(args: CompletionCommand) -> Result<(), Error> {
@@ -55,20 +57,6 @@ fn completion(args: CompletionCommand) -> Result<(), Error> {
         &mut std::io::stdout(),
     );
 
-    Ok(())
-}
-
-/// Run the project initialization when there is a manifest available.
-/// This is run when only running `pixi`, which aligns with yarns implementation.
-async fn default() -> Result<(), Error> {
-    let project = Project::discover()?;
-    get_up_to_date_prefix(&project).await?;
-    // Emit success
-    eprintln!(
-        "{}Project in {} is ready to use!",
-        console::style(console::Emoji("✔ ", "")).green(),
-        project.root().display()
-    );
     Ok(())
 }
 
@@ -99,12 +87,12 @@ pub async fn execute() -> anyhow::Result<()> {
         .try_init()?;
 
     match args.command {
-        Some(Command::Completion(cmd)) => completion(cmd),
-        Some(Command::Init(cmd)) => init::execute(cmd).await,
-        Some(Command::Add(cmd)) => add::execute(cmd).await,
-        Some(Command::Run(cmd)) => run::execute(cmd).await,
-        Some(Command::Global(cmd)) => global::execute(cmd).await,
-        Some(Command::Auth(cmd)) => auth::execute(cmd).await,
-        None => default().await,
+        Command::Completion(cmd) => completion(cmd),
+        Command::Init(cmd) => init::execute(cmd).await,
+        Command::Add(cmd) => add::execute(cmd).await,
+        Command::Run(cmd) => run::execute(cmd).await,
+        Command::Global(cmd) => global::execute(cmd).await,
+        Command::Auth(cmd) => auth::execute(cmd).await,
+        Command::Install(cmd) => install::execute(cmd).await,
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -23,8 +23,6 @@ pub struct Args {
     command: Vec<String>,
 
     /// The path to a projects manifest path. Default is `pixi.toml`.
-    ///
-    /// The pixi.toml is searched for in the current dir or lower in the directory tree.
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -21,10 +21,19 @@ use rattler_shell::{
 pub struct Args {
     /// The command you want to run in the projects environment.
     command: Vec<String>,
+
+    /// The path to a projects manifest path. Default is `pixi.toml`.
+    ///
+    /// The pixi.toml is searched for in the current dir or lower in the directory tree.
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
 }
 
 pub async fn execute(args: Args) -> anyhow::Result<()> {
-    let project = Project::discover()?;
+    let project = match args.manifest_path {
+        Some(path) => Project::load(path.as_path())?,
+        None => Project::discover()?,
+    };
 
     // Get the script to execute from the command line.
     let (command_name, command) = args

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -22,7 +22,7 @@ pub struct Args {
     /// The command you want to run in the projects environment.
     command: Vec<String>,
 
-    /// The path to a projects manifest path. Default is `pixi.toml`.
+    /// The path to 'pixi.toml'
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 }


### PR DESCRIPTION
This PR does two things
- Refactors `pixi` to give the help command and `pixi install` will prepare the environment + lockfile
- Adds the `--manifest-path` option to `run`, `add` and `install`.