### PR TITLE
fix: lto with flags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,7 +89,7 @@ jobs:
           - { name: "Windows-x86_64", target: x86_64-pc-windows-msvc,     os: windows-latest, rustflags: -C target-feature=+crt-static }
     env:
       BUILD_CMD: cargo # The build and test command to use if not overwritten
-      RUSTFLAGS: ${{ matrix.rustflags || '' }} -D warnings
+      RUSTFLAGS: ${{ matrix.job.rustflags || '' }} -D warnings
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,6 +161,13 @@ jobs:
           unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/v[0-9].* ]]; then IS_RELEASE='true' ; fi
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
 
+      - name: Set release specific compilation flags
+        if: steps.is-release.outputs.IS_RELEASE
+        shell: bash
+        run: |
+          echo "CARGO_PROFILE_RELEASE_LTO=true" >> $GITHUB_ENV
+          echo "CARGO_PROFILE_RELEASE_STRIP=true" >> $GITHUB_ENV
+
       - name: Set build options
         id: build-options
         shell: bash
@@ -171,25 +178,14 @@ jobs:
             *) CARGO_BUILD_OPTIONS=""  ;;
           esac
 
-          if [[ '${{ steps.is-release.outputs.IS_RELEASE }}' == 'true' ]]; then
-            CARGO_BUILD_OPTIONS="${CARGO_BUILD_OPTIONS} --profile=release-lto"
-            BUILD_TARGET_FOLDER="release-lto"
-          else
-            CARGO_BUILD_OPTIONS="${CARGO_BUILD_OPTIONS} --release"
-            BUILD_TARGET_FOLDER="release"
-          fi
-
-          echo "BUILD_TARGET_FOLDER=${BUILD_TARGET_FOLDER}" >> $GITHUB_OUTPUT
           echo "CARGO_BUILD_OPTIONS=${CARGO_BUILD_OPTIONS}" >> $GITHUB_OUTPUT
 
       - name: Build
         uses: actions-rs/cargo@v1
-        env:
-          BUILD_PROFILE: ${{ steps.is-release.outputs.IS_RELEASE && '--profile release-lto' || '--release' }}
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: build
-          args: --locked --target=${{ matrix.job.target }} ${{ steps.build-options.outputs.CARGO_BUILD_OPTIONS}}
+          args: --locked --release --target=${{ matrix.job.target }} ${{ steps.build-options.outputs.CARGO_BUILD_OPTIONS}}
 
       - name: Set binary name & path
         id: bin
@@ -202,9 +198,8 @@ jobs:
           esac;
 
           # Setup paths
-          BUILD_TARGET_FOLDER="${{ steps.build-options.outputs.BUILD_TARGET_FOLDER }}"
           BIN_NAME="${{ needs.crate_metadata.outputs.name }}${EXE_SUFFIX}"
-          BIN_PATH="target/${{ matrix.job.target }}/${BUILD_TARGET_FOLDER}/${BIN_NAME}"
+          BIN_PATH="target/${{ matrix.job.target }}/release/${BIN_NAME}"
 
           # Let subsequent steps know where to find the binary
           echo "BIN_PATH=${BIN_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,7 +76,7 @@ jobs:
   build:
     name: ${{ matrix.job.name }}
     runs-on: ${{ matrix.job.os }}
-    needs: [crate_metadata, clippy]
+    needs: [ crate_metadata, clippy ]
     strategy:
       fail-fast: false
       matrix:
@@ -86,10 +86,7 @@ jobs:
           - { name: "macOS-x86_64",   target: x86_64-apple-darwin,        os: macOS-latest }
           - { name: "macOS-aarch64",  target: aarch64-apple-darwin,       os: macOS-latest, skip-tests: true }
 
-          - { name: "Windows-x86_64", target: x86_64-pc-windows-msvc,     os: windows-latest }
-        include:
-          - os: windows-latest
-            rustflags: -C target-feature=+crt-static
+          - { name: "Windows-x86_64", target: x86_64-pc-windows-msvc,     os: windows-latest, rustflags: -C target-feature=+crt-static }
     env:
       BUILD_CMD: cargo # The build and test command to use if not overwritten
       RUSTFLAGS: ${{ matrix.rustflags || '' }} -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,3 @@ toml_edit = { version = "0.19.10", features = ["serde"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.4.0"
-
-[profile.release-lto]
-inherits = "release"
-lto = true
-strip = true


### PR DESCRIPTION
The Wix installer requires that the binary is placed in the `release` folder but when running in release its placed in the `release-lto` folder. This is because for releases we use a different profile. I changed the code around so that instead of using another profile the flags for `lto` and `strip` are injected with environment variables.