### PR TITLE
fix: path behavior for run

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -68,7 +68,7 @@ pub async fn create_command(args: Args) -> anyhow::Result<RunScriptCommand> {
 
     let activator_result = activator.activation(ActivationVariables {
         // Get the current PATH variable
-        path: std::env::var_os("PATH").map(|path_var| std::env::split_paths(&path_var).collect()),
+        path: Default::default(),
 
         // Start from an empty prefix
         conda_prefix: None,

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -27,7 +27,7 @@ pub async fn execute(args: Args) -> anyhow::Result<()> {
 
     let activator_result = activator.activation(ActivationVariables {
         // Get the current PATH variable
-        path: std::env::var_os("PATH").map(|path_var| std::env::split_paths(&path_var).collect()),
+        path: Default::default(),
 
         // Start from an empty prefix
         conda_prefix: None,


### PR DESCRIPTION
Don't manually prepend the path anymore