### PR TITLE
docs: change commands to tasks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,23 +45,29 @@ pixi install --manifest-path ~/myproject
 ```
 
 ### Run commands in the environment
-The `run` commands first checks if the environment is ready to use. When you didn't run `pixi install` the run command will do that for you. The custom commands defined in the `pixi.toml` are also available through the run command.
+The `run` commands first checks if the environment is ready to use.
+When you didn't run `pixi install` the run command will do that for you.
+The custom tasks defined in the `pixi.toml` are also available through the run command.
 
-The run command will search for the given executable and run that in the pixi environment.
+**NOTE:** In `pixi` the [`deno_task_shell`](https://deno.land/manual@v1.35.0/tools/task_runner#task-runner) is the underlying runner of the run command.
+Checkout their [documentation](https://deno.land/manual@v1.35.0/tools/task_runner#task-runner) for the syntax and available commands.
+This is done so that the run commands can be run across all platforms.
 
-You cannot run `pixi run source setup.bash` as `source` is a shell commando and not an executable.
-
-You cannot run `pixi run echo hello_world && echo hello` as the shell will split it up in `pixi run echo hello_world` and `echo hello`.
+You cannot run `pixi run source setup.bash` as `source` is not available in the `deno_task_shell` commandos and not an executable.
 
 ```bash
 pixi run python
 pixi run cowpy "Hey pixi user"
 pixi run --manifest-path ~/myproject python
-# If you have specified a custom command in the pixi.toml you can run it with run aswell
+# If you have specified a custom task in the pixi.toml you can run it with run as well
 pixi run build
 ```
 
 ### Create a task from a command
+**NOTE:** In `pixi` the [`deno_task_shell`](https://deno.land/manual@v1.35.0/tools/task_runner#task-runner) is the underlying runner of the tasks.
+Checkout their [documentation](https://deno.land/manual@v1.35.0/tools/task_runner#task-runner) for the syntax and available commands.
+This is done so that the tasks defined can be run across all platforms.
+
 If you want to make a shorthand for a specific command you can add a task for it
 ```bash
 pixi task add cow cowpy "Hello User"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -62,7 +62,7 @@ authors = ["John Doe <john@prefix.dev>"]      # Gets the information from you cu
 channels = ["conda-forge"]                    # Defaults to conda-forge, add in vector style more channels if needed.
 platforms = ["linux-64"]                      # Defaults to the platform you are currently on but add the platform you want to support as needed.
 
-[commands]
+[tasks]
 
 [dependencies]
 ```
@@ -171,27 +171,27 @@ This overwrites the generic python dependency specified in the dependencies bloc
 As a rule the target specific dependencies take precedence over generic ones
 in the order that they are specified, so should multiple targets match the last specification is used.
 
-## The `commands` part
-In addition to managing dependencies, `pixi` aims to provide a user-friendly interface that simplifies the execution of repetitive, complex commands.
-The commands section in your `pixi` configuration serves this purpose.
-Here, you can specify any commands that you frequently use in your project's environment.
+## The `tasks` part
+In addition to managing dependencies, `pixi` aims to provide a user-friendly interface that simplifies the execution of repetitive, complex tasks.
+The tasks section in your `pixi` configuration serves this purpose.
+Here, you can specify any tasks that you frequently use in your project's environment.
 
 Here are a few examples:
 ```toml
-[commands]
+[tasks]
 build = "cargo build --release"
 test = {cmd = "pytest /tests", depends_on=["build"]}
 
-[commands.check]
+[tasks.check]
 cmd = "ruff check path/to/code/*.py"
 ```
-With these commands specified in the configuration, you can easily execute them using `pixi run`:
+With these tasks specified in the configuration, you can easily execute them using `pixi run`:
 ```shell
 pixi run build
 pixi run test
 pixi run check
 ```
-This commands feature makes it straightforward and efficient to execute commonly-used commands, further enhancing `pixi` as a versatile tool for project management.
+This tasks feature makes it straightforward and efficient to execute commonly-used tasks, further enhancing `pixi` as a versatile tool for project management.
 
 The `depends_on` will run the specified command in there to be run before the command itself.
 So in the example `build` will be run before `test`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -172,6 +172,10 @@ As a rule the target specific dependencies take precedence over generic ones
 in the order that they are specified, so should multiple targets match the last specification is used.
 
 ## The `tasks` part
+**NOTE:** In `pixi` the [`deno_task_shell`](https://deno.land/manual@v1.35.0/tools/task_runner#task-runner) is the underlying runner of the tasks.
+Checkout their [documentation](https://deno.land/manual@v1.35.0/tools/task_runner#task-runner) for the syntax and available commands.
+This is done so that the tasks defined can be run across all platforms.
+
 In addition to managing dependencies, `pixi` aims to provide a user-friendly interface that simplifies the execution of repetitive, complex tasks.
 The tasks section in your `pixi` configuration serves this purpose.
 Here, you can specify any tasks that you frequently use in your project's environment.


### PR DESCRIPTION
Update `[commands]` references in documentation to `[tasks]` 