### PR TITLE
Misc/transition to libsolve rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,13 @@ rattler_conda_types = { default-features = false, git = "https://github.com/mamb
 rattler_networking = { default-features = false, git = "https://github.com/mamba-org/rattler", branch = "main" }
 rattler_repodata_gateway = { default-features = false, git = "https://github.com/mamba-org/rattler", branch = "main", features = ["sparse"] }
 rattler_shell = { default-features = false, git = "https://github.com/mamba-org/rattler", branch = "main", features = ["sysinfo"] }
-rattler_solve = { default-features = false, git = "https://github.com/mamba-org/rattler", branch = "main", features = ["libsolv_c"] }
+rattler_solve = { default-features = false, git = "https://github.com/mamba-org/rattler", branch = "main", features = ["libsolv_rs"] }
 rattler_virtual_packages = { default-features = false, git = "https://github.com/mamba-org/rattler", branch = "main" }
 #rattler = { default-features = false, path="../rattler/crates/rattler" }
 #rattler_conda_types = { default-features = false, path="../rattler/crates/rattler_conda_types" }
 #rattler_repodata_gateway = { default-features = false, path="../rattler/crates/rattler_repodata_gateway", features = ["sparse"] }
 #rattler_shell = { default-features = false, path="../rattler/crates/rattler_shell", features = ["sysinfo"] }
-#rattler_solve = { default-features = false, path="../rattler/crates/rattler_solve" }
+#rattler_solve = { default-features = false, path="../rattler/crates/rattler_solve", features = ["libsolv_rs"] }
 #rattler_virtual_packages = { default-features = false, path="../rattler/crates/rattler_virtual_packages" }
 #rattler_networking = { default-features = false, path="../rattler/crates/rattler_networking" }
 reqwest = { version = "0.11.16", default-features = false }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -11,7 +11,7 @@ use rattler_conda_types::{
     version_spec::VersionOperator, MatchSpec, NamelessMatchSpec, Platform, Version, VersionSpec,
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::{libsolv_c, SolverImpl};
+use rattler_solve::{libsolv_rs, SolverImpl};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -226,7 +226,7 @@ pub fn determine_best_version(
         pinned_packages: vec![],
     };
 
-    let records = libsolv_c::Solver.solve(task)?;
+    let records = libsolv_rs::Solver.solve(task)?;
 
     // Determine the versions of the new packages
     Ok(records

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -15,7 +15,7 @@ use rattler_shell::{
     shell::Shell,
     shell::ShellEnum,
 };
-use rattler_solve::{libsolv_c, SolverImpl};
+use rattler_solve::{libsolv_rs, SolverImpl};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -233,7 +233,7 @@ pub async fn execute(args: Args) -> anyhow::Result<()> {
     };
 
     // Solve it
-    let records = libsolv_c::Solver.solve(task)?;
+    let records = libsolv_rs::Solver.solve(task)?;
 
     // Create the binary environment prefix where we install or update the package
     let bin_prefix = BinEnvDir::create(&package_name).await?;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -26,7 +26,7 @@ use rattler_conda_types::{
 };
 use rattler_networking::AuthenticatedClient;
 use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::{libsolv_c, SolverImpl};
+use rattler_solve::{libsolv_rs, SolverImpl};
 use std::collections::HashMap;
 use std::{
     collections::{HashSet, VecDeque},
@@ -339,7 +339,7 @@ pub async fn update_lock_file(
         };
 
         // Solve the task
-        let records = libsolv_c::Solver.solve(task)?;
+        let records = libsolv_rs::Solver.solve(task)?;
 
         // Update lock file
         let mut locked_packages = LockedPackages::new(platform);


### PR DESCRIPTION
Depends on https://github.com/mamba-org/rattler/pull/260

This removes the requirement to build the c version of `libsolv` which makes building pixi from source easier. And we get the ability to improve and iterate on the solver simpler. 

Thanks @aochagavia for the port!