### PR TITLE
Add missing newline to end of script

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -171,7 +171,7 @@ async fn create_executable_scripts(
             executable_script_path.set_extension("bat");
         };
 
-        tokio::fs::write(&executable_script_path, script).await?;
+        tokio::fs::write(&executable_script_path, format!("{}\n", script)).await?;
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
Scripts being text files should end with a newline character, both by convention and to make it play nice with the `cat` command.

I'm not experienced in Rust, so I'm not sure if this is the most appropriate place to add the newline character.