### PR TITLE
Add trailing newline to pixi.toml and .gitignore

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -34,10 +34,12 @@ platforms = ["{{ platform }}"]
 [tasks]
 
 [dependencies]
+
 "#;
 
 const GITIGNORE_TEMPLATE: &str = r#"# pixi environments
 .pixi
+
 "#;
 
 pub async fn execute(args: Args) -> miette::Result<()> {


### PR DESCRIPTION
Closes #214 

https://docs.rs/minijinja/latest/minijinja/syntax/index.html#trailing-newlines

> MiniJinja, like Jinja2, will remove one trailing newline from the end of the file automatically on parsing. This lets templates produce a consistent output no matter if the editor adds a trailing newline or not. If one wants a trailing newline an extra newline can be added or the code rendering it adds it manually.