### PR TITLE
Add additional information in info, closes #193 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .idea
+.vscode
 .test-projects
 __pycache__
 **/**/.pixi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pixi"
 version = "0.0.7"
 dependencies = [
+ "chrono",
  "clap",
  "clap-verbosity-flag",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rustls-tls = ["reqwest/rustls-tls", "rattler_repodata_gateway/rustls-tls", "ratt
 slow_integration_tests = []
 
 [dependencies]
+chrono = "0.4.26"
 clap = { version = "4.3.16", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context"] }
 clap-verbosity-flag = "2.0.1"
 clap_complete = "4.3.2"

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -1,9 +1,16 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use miette::IntoDiagnostic;
 use rattler_networking::{Authentication, AuthenticationStorage};
 
 fn default_authentication_storage() -> AuthenticationStorage {
-    AuthenticationStorage::new("rattler", &dirs::home_dir().unwrap().join(".rattler"))
+    AuthenticationStorage::new("rattler", &get_default_auth_store_location())
+}
+
+// moved into seperate function to access from info command
+pub fn get_default_auth_store_location() -> PathBuf {
+    dirs::home_dir().unwrap().join(".rattler")
 }
 
 #[derive(Parser, Debug)]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -41,7 +41,7 @@ impl SpecType {
 }
 
 /// A project represented by a pixi.toml file.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Project {
     root: PathBuf,
     source: String,


### PR DESCRIPTION
Add additonal information in info command
global: 
- cache dir size
- auth store location 

project: 
- dependency count
- cache size 
- lock file last updated
- target platforms

also reformats the output of tasks and adds help string in info command