### PR TITLE
feat: allow forcing or disabling colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1129,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -1360,7 +1380,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1386,7 +1406,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
@@ -1831,7 +1851,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -2038,6 +2058,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "pixi"
 version = "0.0.7"
 dependencies = [
+ "atty",
  "chrono",
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rustls-tls = ["reqwest/rustls-tls", "rattler_repodata_gateway/rustls-tls", "ratt
 slow_integration_tests = []
 
 [dependencies]
+atty = "0.2"
 chrono = "0.4.26"
 clap = { version = "4.3.16", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context"] }
 clap-verbosity-flag = "2.0.1"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -115,6 +115,10 @@ pub async fn execute() -> miette::Result<()> {
         )
     }))?;
 
+    // Enable disable colors for the colors crate
+    console::set_colors_enabled(use_colors);
+    console::set_colors_enabled_stderr(use_colors);
+
     let level_filter = match args.verbose.log_level_filter() {
         clap_verbosity_flag::LevelFilter::Off => LevelFilter::OFF,
         clap_verbosity_flag::LevelFilter::Error => LevelFilter::ERROR,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,10 @@ struct Args {
     /// (-v for verbose, -vv for debug, -vvv for trace, -q for quiet)
     #[command(flatten)]
     verbose: Verbosity,
+
+    /// Whether the log needs to be colored.
+    #[clap(long, default_value = "auto", global = true)]
+    color: ColorOutput,
 }
 
 /// Generates a completion script for a shell.
@@ -100,6 +104,16 @@ fn completion(args: CompletionCommand) -> miette::Result<()> {
 
 pub async fn execute() -> miette::Result<()> {
     let args = Args::parse();
+    let use_colors = use_color_output(&args);
+
+    // Setup the default miette handler based on whether or not we want colors or not.
+    miette::set_hook(Box::new(move |_| {
+        Box::new(
+            miette::MietteHandlerOpts::default()
+                .color(use_colors)
+                .build(),
+        )
+    }))?;
 
     let level_filter = match args.verbose.log_level_filter() {
         clap_verbosity_flag::LevelFilter::Off => LevelFilter::OFF,
@@ -121,6 +135,7 @@ pub async fn execute() -> miette::Result<()> {
 
     // Setup the tracing subscriber
     tracing_subscriber::fmt()
+        .with_ansi(use_colors)
         .with_env_filter(env_filter)
         .with_writer(IndicatifWriter::new(progress::global_multi_progress()))
         .without_time()
@@ -146,5 +161,32 @@ pub async fn execute_command(command: Command) -> miette::Result<()> {
         Command::Task(cmd) => task::execute(cmd),
         Command::Info(cmd) => info::execute(cmd).await,
         Command::Upload(cmd) => upload::execute(cmd).await,
+    }
+}
+
+/// Whether to use colored log format.
+/// Option `Auto` enables color output only if the logging is done to a terminal and  `NO_COLOR`
+/// environment variable is not set.
+#[derive(clap::ValueEnum, Debug, Clone, Default)]
+pub enum ColorOutput {
+    Always,
+    Never,
+
+    #[default]
+    Auto,
+}
+
+/// Returns true if the output is considered to be a terminal.
+fn is_terminal() -> bool {
+    // Crate `atty` provides a platform-independent way of checking whether the output is a tty.
+    atty::is(atty::Stream::Stderr)
+}
+
+/// Returns true if the log outputs should be colored or not.
+fn use_color_output(args: &Args) -> bool {
+    match args.color {
+        ColorOutput::Always => true,
+        ColorOutput::Never => false,
+        ColorOutput::Auto => std::env::var_os("NO_COLOR").is_none() && is_terminal(),
     }
 }


### PR DESCRIPTION
Allow control over whether colors are used in the output.

`--color auto`: default behavior. Will use colors if on a terminal and the env variable `NO_COLOR` is not set.
`--color never`: never use colors.
`--color always`: force using colors regardless of the environment.