### PR TITLE
fix: install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If this directory does not already exist, the script will create it.
 ## macOS and Linux
 To install Pixi on macOS and Linux, open a terminal and run the following command:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/prefix-dev/pixi/main/install/install.sh | bash
+curl -fsSL https://pixi.sh/install.sh | bash
 # or with brew
 brew install pixi
 ```
@@ -79,7 +79,7 @@ You might need to restart your terminal or source your shell for the changes to 
 To install Pixi on Windows, open a PowerShell terminal (you may need to run it as an administrator) and run the following command:
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/prefix-dev/pixi/main/install/install.ps1 | iex
+iwr -useb https://pixi.sh/install.ps1 | iex
 ```
 The script will inform you once the installation is successful and add the ~/.pixi/bin directory to your PATH, which will allow you to run the pixi command from any location.
 
@@ -89,6 +89,8 @@ The script will inform you once the installation is successful and add the ~/.pi
 To start using `pixi` from a source build run:
 
 ```shell
+cargo install --locked pixi
+# Or to use the the latest `main` branch
 cargo install --locked --git https://github.com/prefix-dev/pixi.git
 ```
 


### PR DESCRIPTION
Updates the installation instructions to use the shorthand/memorable URLs. 

Also added that you can now use `cargo install --locked pixi` since `pixi` is available on crates.io now.