### PR TITLE
Set linguist attributes for `pixi.lock`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pixi.lock linguist-generated linguist-language=YAML

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-pixi.lock linguist-generated linguist-language=YAML
+pixi.lock linguist-language=YAML

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -4,7 +4,10 @@ use miette::IntoDiagnostic;
 use minijinja::{context, Environment};
 use rattler_conda_types::Platform;
 use std::io::{Error, ErrorKind};
-use std::{fs, path::{Path, PathBuf}};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 /// Creates a new project
 #[derive(Parser, Debug)]
@@ -103,7 +106,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // create a .gitattributes if one is missing
     if !gitattributes_path.is_file() {
-        write_contextless_file(&env, gitattributes_path, "gitattributes.txt", GITATTRIBUTES_TEMPLATE)?;
+        write_contextless_file(
+            &env,
+            gitattributes_path,
+            "gitattributes.txt",
+            GITATTRIBUTES_TEMPLATE,
+        )?;
     }
 
     // Emit success
@@ -136,10 +144,13 @@ fn get_dir(path: PathBuf) -> Result<PathBuf, Error> {
     }
 }
 
-fn write_contextless_file<P: AsRef<Path>>(env: &Environment, path: P, name: &str, template: &str) -> miette::Result<()> {
-        let rv = env
-        .render_named_str(name, template, ())
-        .into_diagnostic()?;
+fn write_contextless_file<P: AsRef<Path>>(
+    env: &Environment,
+    path: P,
+    name: &str,
+    template: &str,
+) -> miette::Result<()> {
+    let rv = env.render_named_str(name, template, ()).into_diagnostic()?;
     fs::write(&path, rv).into_diagnostic()?;
     Ok(())
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -42,8 +42,8 @@ const GITIGNORE_TEMPLATE: &str = r#"# pixi environments
 
 "#;
 
-const GITATTRIBUTES_TEMPLATE: &str = r#"# GitHub syntax highlighting and stats
-pixi.lock linguist-generated linguist-language=YAML
+const GITATTRIBUTES_TEMPLATE: &str = r#"# GitHub syntax highlighting
+pixi.lock linguist-language=YAML
 
 "#;
 


### PR DESCRIPTION
Just stumbled on this project and figured I'd add this small nice-to-have.

This applies syntax highlighting in the GitHub web interface, and treats it as a generated file.

In the future, you might want to contribute to [github-linguist](https://github.com/github-linguist/linguist) so that GitHub has proper support for this filename, but, for now, a [quick search](https://github.com/search?q=path%3Apixi.lock&type=code) shows that this file probably won't meet the popularity requirement.