### PR TITLE
Missing word in getting_started.mdx

### DIFF
--- a/docs/getting_started.mdx
+++ b/docs/getting_started.mdx
@@ -45,7 +45,7 @@ You can also put this run command in a **task**.
 pixi task add hello python hello_world.py
 ```
 
-After adding the task, you can the task using its name.
+After adding the task, you can run the task using its name.
 
 ```shell
 pixi run hello


### PR DESCRIPTION
The word `run` was missing in the task section