### PR TITLE
Feature/target specific tasks

### DIFF
--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -195,7 +195,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let project_info = project.map(|p| ProjectInfo {
         manifest_path: p.root().to_path_buf().join("pixi.toml"),
-        tasks: p.manifest.tasks.keys().cloned().collect(),
+        tasks: p
+            .tasks(Some(Platform::current()))
+            .into_keys()
+            .map(|k| k.to_string())
+            .collect(),
         package_count: dependency_count(&p).ok(),
         environment_size,
         last_updated: last_updated(p.lock_file_path()).ok(),

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -16,6 +16,10 @@ pub struct Args {
     /// Channels to use in the project.
     #[arg(short, long = "channel", id = "channel")]
     pub channels: Vec<String>,
+
+    /// Platforms that the project supports.
+    #[arg(short, long = "platform", id = "platform")]
+    pub platforms: Vec<String>,
 }
 
 /// The pixi.toml template
@@ -29,7 +33,7 @@ description = "Add a short description here"
 authors = ["{{ author[0] }} <{{ author[1] }}>"]
 {%- endif %}
 channels = ["{{ channels|join("\", \"") }}"]
-platforms = ["{{ platform }}"]
+platforms = ["{{ platforms|join("\", \"") }}"]
 
 [tasks]
 
@@ -73,7 +77,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     } else {
         args.channels
     };
-    let platform = Platform::current();
+    let platforms = if args.platforms.is_empty() {
+        vec![Platform::current().to_string()]
+    } else {
+        args.platforms
+    };
 
     let rv = env
         .render_named_str(
@@ -84,7 +92,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 version,
                 author,
                 channels,
-                platform
+                platforms
             },
         )
         .unwrap();

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -29,9 +29,13 @@ pub enum Operation {
 pub struct RemoveArgs {
     /// Task names to remove
     pub names: Vec<String>,
+
+    /// The platform for which the task should be removed
+    #[arg(long, short)]
+    pub platform: Option<Platform>,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(arg_required_else_help = true)]
 pub struct AddArgs {
     /// Task name
@@ -45,9 +49,13 @@ pub struct AddArgs {
     #[clap(long)]
     #[clap(num_args = 1..)]
     pub depends_on: Option<Vec<String>>,
+
+    /// The platform for which the task should be added
+    #[arg(long, short)]
+    pub platform: Option<Platform>,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(arg_required_else_help = true)]
 pub struct AliasArgs {
     /// Alias name
@@ -56,6 +64,10 @@ pub struct AliasArgs {
     /// Depends on these tasks to execute
     #[clap(required = true, num_args = 1..)]
     pub depends_on: Vec<String>,
+
+    /// The platform for which the alias should be added
+    #[arg(long, short)]
+    pub platform: Option<Platform>,
 }
 
 impl From<AddArgs> for Task {
@@ -106,9 +118,9 @@ pub fn execute(args: Args) -> miette::Result<()> {
     let mut project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
     match args.operation {
         Operation::Add(args) => {
-            let name = args.name.clone();
-            let task: Task = args.into();
-            project.add_task(&name, task.clone())?;
+            let name = &args.name;
+            let task: Task = args.clone().into();
+            project.add_task(name, task.clone(), args.platform)?;
             eprintln!(
                 "{}Added task {}: {}",
                 console::style(console::Emoji("✔ ", "+")).green(),
@@ -119,7 +131,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
         Operation::Remove(args) => {
             let mut to_remove = Vec::new();
             for name in args.names.iter() {
-                if project.task_opt(name).is_none() {
+                if !project.task_names(args.platform).iter().any(|n| *n == name) {
                     eprintln!(
                         "{}Task {} does not exist",
                         console::style(console::Emoji("❌ ", "X")).red(),
@@ -155,9 +167,9 @@ pub fn execute(args: Args) -> miette::Result<()> {
             }
         }
         Operation::Alias(args) => {
-            let name = args.alias.clone();
-            let task: Task = args.into();
-            project.add_task(&name, task.clone())?;
+            let name = &args.alias;
+            let task: Task = args.clone().into();
+            project.add_task(name, task.clone(), args.platform)?;
             eprintln!(
                 "{} Added alias {}: {}",
                 console::style("@").blue(),
@@ -166,7 +178,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
             );
         }
         Operation::List => {
-            let tasks = project.task_names(Platform::current());
+            let tasks = project.task_names(Some(Platform::current()));
             if tasks.is_empty() {
                 eprintln!("No tasks found",);
             } else {

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -2,6 +2,7 @@ use crate::task::{Alias, CmdArgs, Execute, Task};
 use crate::Project;
 use clap::Parser;
 use itertools::Itertools;
+use rattler_conda_types::Platform;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -127,7 +128,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
                     continue;
                 }
                 // Check if task has dependencies
-                let depends_on = project.task_depends_on(name);
+                let depends_on = project.task_names_depending_on(name);
                 if !depends_on.is_empty() && !args.names.contains(name) {
                     eprintln!(
                         "{}: {}",
@@ -165,7 +166,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
             );
         }
         Operation::List => {
-            let tasks = project.tasks();
+            let tasks = project.task_names(Platform::current());
             if tasks.is_empty() {
                 eprintln!("No tasks found",);
             } else {

--- a/src/project/manifest.rs
+++ b/src/project/manifest.rs
@@ -196,6 +196,10 @@ pub struct TargetMetadata {
     /// Additional information to activate an environment.
     #[serde(default)]
     pub activation: Option<Activation>,
+
+    /// Target specific tasks to run in the environment
+    #[serde(default)]
+    pub tasks: HashMap<String, Task>,
 }
 
 /// Describes the contents of the `[package]` section of the project manifest.
@@ -449,6 +453,27 @@ mod test {
 
             [target.linux-64.activation]
             scripts = [".pixi/install/setup.sh", "test"]
+            "#
+        );
+
+        assert_debug_snapshot!(
+            toml_edit::de::from_str::<ProjectManifest>(&contents).expect("parsing should succeed!")
+        );
+    }
+
+    #[test]
+    fn test_target_specific_tasks() {
+        let contents = format!(
+            r#"
+            {PROJECT_BOILERPLATE}
+            [tasks]
+            test = "test multi"
+
+            [target.win-64.tasks]
+            test = "test win"
+
+            [target.linux-64.tasks]
+            test = "test linux"
             "#
         );
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -952,8 +952,6 @@ mod tests {
             manifest,
         };
 
-        let win_tasks = project.tasks(Platform::Win64);
-
         assert_debug_snapshot!(project.tasks(Platform::Osx64));
         assert_debug_snapshot!(project.tasks(Platform::Win64));
         assert_debug_snapshot!(project.tasks(Platform::Linux64));

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -121,7 +121,7 @@ impl Project {
             })
     }
 
-    /// Get all tasks defined in the project for the specified platform
+    /// Returns all tasks defined in the project for the given platform
     pub fn task_names(&self, platform: Platform) -> Vec<&String> {
         let mut all_tasks = HashSet::new();
 
@@ -135,6 +135,7 @@ impl Project {
         Vec::from_iter(all_tasks)
     }
 
+    /// Returns a hashmap of the tasks that should run on the given platform.
     pub fn tasks(&self, platform: Platform) -> HashMap<&str, &Task> {
         let mut all_tasks = HashMap::default();
 
@@ -149,7 +150,7 @@ impl Project {
         all_tasks
     }
 
-    /// Find task dependencies
+    /// Returns names of the tasks that depend on the given task.
     pub fn task_names_depending_on(&self, name: impl AsRef<str>) -> Vec<&str> {
         let mut tasks = self.tasks(Platform::current());
         let task = tasks.remove(name.as_ref());

--- a/src/project/snapshots/pixi__project__manifest__test__target_specific.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__target_specific.snap
@@ -71,6 +71,7 @@ ProjectManifest {
             host_dependencies: None,
             build_dependencies: None,
             activation: None,
+            tasks: {},
         },
         PixiSpanned {
             span: Some(
@@ -104,6 +105,7 @@ ProjectManifest {
             host_dependencies: None,
             build_dependencies: None,
             activation: None,
+            tasks: {},
         },
     },
     activation: None,

--- a/src/project/snapshots/pixi__project__manifest__test__target_specific_tasks.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__target_specific_tasks.snap
@@ -25,7 +25,11 @@ ProjectManifest {
         repository: None,
         documentation: None,
     },
-    tasks: {},
+    tasks: {
+        "test": Plain(
+            "test multi",
+        ),
+    },
     system_requirements: SystemRequirements {
         windows: None,
         unix: None,
@@ -41,7 +45,7 @@ ProjectManifest {
     target: {
         PixiSpanned {
             span: Some(
-                228..234,
+                206..212,
             ),
             value: Platform(
                 Win64,
@@ -50,20 +54,16 @@ ProjectManifest {
             dependencies: {},
             host_dependencies: None,
             build_dependencies: None,
-            activation: Some(
-                Activation {
-                    scripts: Some(
-                        [
-                            ".pixi/install/setup.ps1",
-                        ],
-                    ),
-                },
-            ),
-            tasks: {},
+            activation: None,
+            tasks: {
+                "test": Plain(
+                    "test win",
+                ),
+            },
         },
         PixiSpanned {
             span: Some(
-                318..326,
+                271..279,
             ),
             value: Platform(
                 Linux64,
@@ -72,26 +72,13 @@ ProjectManifest {
             dependencies: {},
             host_dependencies: None,
             build_dependencies: None,
-            activation: Some(
-                Activation {
-                    scripts: Some(
-                        [
-                            ".pixi/install/setup.sh",
-                            "test",
-                        ],
-                    ),
-                },
-            ),
-            tasks: {},
+            activation: None,
+            tasks: {
+                "test": Plain(
+                    "test linux",
+                ),
+            },
         },
     },
-    activation: Some(
-        Activation {
-            scripts: Some(
-                [
-                    ".pixi/install/setup.sh",
-                ],
-            ),
-        },
-    ),
+    activation: None,
 }

--- a/src/project/snapshots/pixi__project__tests__target_specific_tasks-2.snap
+++ b/src/project/snapshots/pixi__project__tests__target_specific_tasks-2.snap
@@ -1,0 +1,9 @@
+---
+source: src/project/mod.rs
+expression: "project.tasks(Platform::Win64)"
+---
+{
+    "test": Plain(
+        "test win",
+    ),
+}

--- a/src/project/snapshots/pixi__project__tests__target_specific_tasks-3.snap
+++ b/src/project/snapshots/pixi__project__tests__target_specific_tasks-3.snap
@@ -1,0 +1,9 @@
+---
+source: src/project/mod.rs
+expression: "project.tasks(Platform::Linux64)"
+---
+{
+    "test": Plain(
+        "test linux",
+    ),
+}

--- a/src/project/snapshots/pixi__project__tests__target_specific_tasks.snap
+++ b/src/project/snapshots/pixi__project__tests__target_specific_tasks.snap
@@ -1,0 +1,9 @@
+---
+source: src/project/mod.rs
+expression: "project.tasks(Platform::Osx64)"
+---
+{
+    "test": Plain(
+        "test multi",
+    ),
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -129,6 +129,19 @@ impl PixiControl {
             args: init::Args {
                 path: self.project_path().to_path_buf(),
                 channels: Vec::new(),
+                platforms: Vec::new(),
+            },
+        }
+    }
+
+    /// Initialize pixi project inside a temporary directory. Returns a [`InitBuilder`]. To execute
+    /// the command and await the result call `.await` on the return value.
+    pub fn init_with_platforms(&self, platforms: Vec<String>) -> InitBuilder {
+        InitBuilder {
+            args: init::Args {
+                path: self.project_path().to_path_buf(),
+                channels: Vec::new(),
+                platforms,
             },
         }
     }
@@ -215,7 +228,7 @@ impl TasksControl<'_> {
             manifest_path: Some(self.pixi.manifest_path()),
             operation: task::Operation::Remove(task::RemoveArgs {
                 names: vec![name.to_string()],
-                platform: platform,
+                platform,
             }),
         })
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -193,32 +193,39 @@ pub struct TasksControl<'a> {
 
 impl TasksControl<'_> {
     /// Add a task
-    pub fn add(&self, name: impl ToString) -> TaskAddBuilder {
+    pub fn add(&self, name: impl ToString, platform: Option<Platform>) -> TaskAddBuilder {
         TaskAddBuilder {
             manifest_path: Some(self.pixi.manifest_path()),
             args: AddArgs {
                 name: name.to_string(),
                 commands: vec![],
                 depends_on: None,
+                platform: platform,
             },
         }
     }
 
     /// Remove a task
-    pub async fn remove(&self, name: impl ToString) -> miette::Result<()> {
+    pub async fn remove(
+        &self,
+        name: impl ToString,
+        platform: Option<Platform>,
+    ) -> miette::Result<()> {
         task::execute(task::Args {
             manifest_path: Some(self.pixi.manifest_path()),
             operation: task::Operation::Remove(task::RemoveArgs {
                 names: vec![name.to_string()],
+                platform: platform,
             }),
         })
     }
 
     /// Alias one or multiple tasks
-    pub fn alias(&self, name: impl ToString) -> TaskAliasBuilder {
+    pub fn alias(&self, name: impl ToString, platform: Option<Platform>) -> TaskAliasBuilder {
         TaskAliasBuilder {
             manifest_path: Some(self.pixi.manifest_path()),
             args: AliasArgs {
+                platform: platform,
                 alias: name.to_string(),
                 depends_on: vec![],
             },

--- a/tests/task_tests.rs
+++ b/tests/task_tests.rs
@@ -10,7 +10,7 @@ pub async fn add_remove_task() {
 
     // Simple task
     pixi.tasks()
-        .add("test")
+        .add("test", None)
         .with_commands(["echo hello"])
         .execute()
         .unwrap();
@@ -20,7 +20,7 @@ pub async fn add_remove_task() {
     assert!(matches!(task, Task::Plain(s) if s == "echo hello"));
 
     // Remove the task
-    pixi.tasks().remove("test").await.unwrap();
+    pixi.tasks().remove("test", None).await.unwrap();
     assert_eq!(pixi.project().unwrap().manifest.tasks.len(), 0);
 }
 
@@ -31,12 +31,12 @@ pub async fn add_command_types() {
 
     // Add a command with dependencies
     pixi.tasks()
-        .add("test")
+        .add("test", None)
         .with_commands(["echo hello"])
         .execute()
         .unwrap();
     pixi.tasks()
-        .add("test2")
+        .add("test2", None)
         .with_commands(["echo hello", "echo bonjour"])
         .with_depends_on(["test"])
         .execute()
@@ -49,7 +49,7 @@ pub async fn add_command_types() {
 
     // Create an alias
     pixi.tasks()
-        .alias("testing")
+        .alias("testing", None)
         .with_depends_on(["test"])
         .execute()
         .unwrap();


### PR DESCRIPTION
Adding the ability to add target (platform) specific tasks. The idea is that a task is cross platform by definition but sometimes you need extra parameters on different platforms for instance:

```
[tasks]
build = {cmd="colcon build --build-base .pixi/build --install-base .pixi/install"}
test = {cmd="colcon test --build-base .pixi/build --install-base .pixi/install"}

[target.win-64.tasks]
build = {cmd="colcon build --merge-install --build-base .pixi/build --install-base .pixi/install"}
test = {cmd="colcon test --merge-install --build-base .pixi/build --install-base .pixi/install"}
```

This pr allows for that. 

closes https://github.com/prefix-dev/pixi/issues/192