### PR TITLE
feat: Add completion evaluation to the activation of the shell on install

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -44,6 +44,9 @@ try {
     } else {
         Write-Output "$PIXI_DIR is already in PATH`n"
     }
+
+    # Add the completion script to teh activation of the shell.
+    Add-Content -Path $PROFILE -Value 'Invoke-Expression (&pixi completion --shell powershell)'
 } catch {
     Write-Host "Error: '$DOWNLOAD_URL' is not available or failed to download"
     exit 1

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -45,7 +45,7 @@ try {
         Write-Output "$PIXI_DIR is already in PATH`n"
     }
 
-    # Add the completion script to teh activation of the shell.
+    # Add the completion script to the activation of the shell.
     Add-Content -Path $PROFILE -Value 'Invoke-Expression (&pixi completion --shell powershell)'
 } catch {
     Write-Host "Error: '$DOWNLOAD_URL' is not available or failed to download"

--- a/install/install.sh
+++ b/install/install.sh
@@ -82,15 +82,24 @@ case "$(basename "$SHELL")" in
         fi
         LINE="export PATH=\$PATH:${INSTALL_DIR}"
         update_shell $BASH_FILE "$LINE"
+
+        LINE='eval "$(pixi completion --shell bash)"'
+        update_shell $BASH_FILE "$LINE"
         ;;
 
     fish)
         LINE="fish_add_path ${INSTALL_DIR}"
         update_shell ~/.config/fish/config.fish "$LINE"
+
+        LINE='pixi completion --shell fish | source'
+        update_shell ~/.config/fish/config.fish "$LINE"
         ;;
 
     zsh)
         LINE="export PATH=\$PATH:${INSTALL_DIR}"
+        update_shell ~/.zshrc "$LINE"
+
+        LINE='eval "$(pixi completion --shell zsh)"'
         update_shell ~/.zshrc "$LINE"
         ;;
 


### PR DESCRIPTION
This adds the `pixi completion` command to the activation of a shell on installation. This should make the initial setup easier. 

Related to #292 