### PR TITLE
feat: enable use of os certificate store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2683,6 +2684,18 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [features]
 default = ["native-tls"]
 native-tls = ["reqwest/native-tls", "rattler_repodata_gateway/native-tls", "rattler/native-tls"]
-rustls-tls = ["reqwest/rustls-tls", "rattler_repodata_gateway/rustls-tls", "rattler/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls", "reqwest/rustls-tls-native-roots", "rattler_repodata_gateway/rustls-tls", "rattler/rustls-tls"]
 slow_integration_tests = []
 
 [dependencies]


### PR DESCRIPTION
This PR enables the use of the OS certificate store which should make it possible to use pixi behind a corporate firewall.

This might also be a solution for https://github.com/prefix-dev/pixi/issues/291 , if the used certificate is stored in the OS certificate store.

@pavelzw I know you ran into this at some point, would you be able to test this?