### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ If this directory does not already exist, the script will create it.
 To install Pixi on macOS and Linux, open a terminal and run the following command:
 ```bash
 curl -fsSL https://pixi.sh/install.sh | bash
+# or
+curl -fsSL https://raw.githubusercontent.com/prefix-dev/pixi/main/install/install.sh | bash
 # or with brew
 brew install pixi
 ```


### PR DESCRIPTION
The domain "pixi.sh" seems to be blocked by my organization. So, the curl command didn't work for me. Adding a fallback source to curl with a github raw link to the install.sh file in the repo, in case the first one doesn't work.