### PR TITLE
Add `pixi global list` and `pixi global remove` commands

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -44,7 +44,7 @@ pub struct Args {
     channel: Vec<String>,
 }
 
-struct BinDir(pub PathBuf);
+pub(crate) struct BinDir(pub PathBuf);
 
 impl BinDir {
     /// Create the Binary Executable directory
@@ -109,7 +109,7 @@ impl BinEnvDir {
 }
 
 /// Binary environments are installed in ~/.pixi/envs
-fn bin_env_dir() -> miette::Result<PathBuf> {
+pub(crate) fn bin_env_dir() -> miette::Result<PathBuf> {
     Ok(home_dir()
         .ok_or_else(|| miette::miette!("could not find home directory"))?
         .join(BIN_ENVS_DIR))

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -362,11 +362,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             channel,
         );
 
-        let bin_dir = BinDir::from_existing().await?;
+        let BinDir(bin_dir) = BinDir::from_existing().await?;
         let script_names = scripts
             .into_iter()
             .map(|path| {
-                path.strip_prefix(&bin_dir.0)
+                path.strip_prefix(&bin_dir)
                     .expect("script paths were constructed by joining onto BinDir")
                     .to_string_lossy()
                     .to_string()

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -202,7 +202,7 @@ pub(crate) async fn create_executable_scripts(
         .filter(|relative_path| is_executable(prefix, relative_path));
 
     let mut scripts = Vec::new();
-    let bin_dir = BinDir::create().await?;
+    let BinDir(bin_dir) = BinDir::create().await?;
     for exec in executables {
         let mut script = activation_script.clone();
         shell
@@ -218,7 +218,7 @@ pub(crate) async fn create_executable_scripts(
         let file_name = exec
             .file_stem()
             .ok_or_else(|| miette::miette!("could not get filename from {}", exec.display()))?;
-        let mut executable_script_path = bin_dir.0.join(file_name);
+        let mut executable_script_path = bin_dir.join(file_name);
 
         if cfg!(windows) {
             executable_script_path.set_extension("bat");
@@ -297,8 +297,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let records = libsolv_rs::Solver.solve(task).into_diagnostic()?;
 
     // Create the binary environment prefix where we install or update the package
-    let bin_prefix = BinEnvDir::create(&package_name).await?;
-    let prefix = Prefix::new(bin_prefix.0)?;
+    let BinEnvDir(bin_prefix) = BinEnvDir::create(&package_name).await?;
+    let prefix = Prefix::new(bin_prefix)?;
     let prefix_records = prefix.find_installed_packages(None).await?;
 
     // Create the transaction that we need

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -59,11 +59,11 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
     let mut package_info = vec![];
 
     for package_name in packages {
-        let Ok(bin_env_prefix) = BinEnvDir::from_existing(&package_name).await else {
+        let Ok(BinEnvDir(bin_env_prefix)) = BinEnvDir::from_existing(&package_name).await else {
             print_no_packages_found_message();
             return Ok(());
         };
-        let prefix = Prefix::new(bin_env_prefix.0)?;
+        let prefix = Prefix::new(bin_env_prefix)?;
 
         let Ok(bin_prefix) = BinDir::from_existing().await else {
             print_no_packages_found_message();

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -13,6 +13,7 @@ use crate::prefix::Prefix;
 
 use super::install::{bin_env_dir, BinDir};
 
+/// Lists all packages previously installed into a globally accessible location via `pixi global install`.
 #[derive(Parser, Debug)]
 pub struct Args {}
 

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -29,7 +29,11 @@ impl Display for InstalledPackageInfo {
             .iter()
             .map(|name| format!("[bin] {}", console::style(name).bold()))
             .join("\n     -  ");
-        write!(f, "  -  [package] {}\n     -  {binaries}", console::style(&self.name).bold())
+        write!(
+            f,
+            "  -  [package] {}\n     -  {binaries}",
+            console::style(&self.name).bold()
+        )
     }
 }
 
@@ -54,7 +58,7 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
     let mut package_info = vec![];
 
     for package_name in packages {
-        let Ok(bin_env_prefix) = BinEnvDir::from_existing(&package_name).await else { 
+        let Ok(bin_env_prefix) = BinEnvDir::from_existing(&package_name).await else {
             print_no_packages_found_message();
             return Ok(());
         };

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -1,0 +1,115 @@
+use std::collections::HashSet;
+use std::fmt::Display;
+
+use clap::Parser;
+use itertools::Itertools;
+use miette::IntoDiagnostic;
+use rattler_shell::shell::ShellEnum;
+
+use crate::cli::global::install::{
+    create_activation_script, create_executable_scripts, find_designated_package, BinEnvDir,
+};
+use crate::prefix::Prefix;
+
+use super::install::{bin_env_dir, BinDir};
+
+#[derive(Parser, Debug)]
+pub struct Args {}
+
+#[derive(Debug)]
+struct InstalledPackageInfo {
+    name: String,
+    binaries: Vec<String>,
+}
+
+impl Display for InstalledPackageInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let binaries = self
+            .binaries
+            .iter()
+            .map(|name| format!("[bin] {}", console::style(name).bold()))
+            .join("\n     -  ");
+        write!(f, "  -  [package] {}\n     -  {binaries}", console::style(&self.name).bold())
+    }
+}
+
+fn print_no_packages_found_message() {
+    eprintln!(
+        "{} No globally installed binaries found",
+        console::style("!").yellow().bold()
+    )
+}
+
+pub async fn execute(_args: Args) -> miette::Result<()> {
+    let mut packages = vec![];
+    let mut dir_contents = tokio::fs::read_dir(bin_env_dir()?)
+        .await
+        .into_diagnostic()?;
+    while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
+        if entry.file_type().await.into_diagnostic()?.is_dir() {
+            packages.push(entry.file_name().to_string_lossy().to_string());
+        }
+    }
+
+    let mut package_info = vec![];
+
+    for package_name in packages {
+        let Ok(bin_env_prefix) = BinEnvDir::from_existing(&package_name).await else { 
+            print_no_packages_found_message();
+            return Ok(());
+        };
+        let prefix = Prefix::new(bin_env_prefix.0)?;
+
+        let Ok(bin_prefix) = BinDir::from_existing().await else {
+            print_no_packages_found_message();
+            return Ok(());
+        };
+
+        // Find the installed package in the environment
+        let prefix_package = find_designated_package(&prefix, &package_name).await?;
+
+        // Determine the shell to use for the invocation script
+        let shell: ShellEnum = if cfg!(windows) {
+            rattler_shell::shell::CmdExe.into()
+        } else {
+            rattler_shell::shell::Bash.into()
+        };
+
+        // Do a dry run creation of the executable scripts to figure out what installed paths we have.
+        let activation_script = create_activation_script(&prefix, shell.clone())?;
+        let binaries: Vec<_> =
+            create_executable_scripts(&prefix, &prefix_package, &shell, activation_script, true)
+                .await?
+                .into_iter()
+                .map(|path| {
+                    path.strip_prefix(&bin_prefix.0)
+                        .expect("script paths were constructed by joining onto BinDir")
+                        .to_string_lossy()
+                        .to_string()
+                })
+                // Collecting to a HashSet first is a workaround for issue #317 and can be removed
+                // once that is fixed.
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+
+        package_info.push(InstalledPackageInfo {
+            name: package_name,
+            binaries,
+        });
+    }
+
+    if package_info.is_empty() {
+        print_no_packages_found_message();
+    } else {
+        eprintln!(
+            "Globally installed binary packages:\n{}",
+            package_info
+                .into_iter()
+                .map(|pkg| pkg.to_string())
+                .join("\n")
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -1,10 +1,13 @@
 use clap::Parser;
 mod install;
+mod remove;
 
 #[derive(Debug, Parser)]
 pub enum Command {
     #[clap(alias = "a")]
     Install(install::Args),
+    #[clap(alias = "r")]
+    Remove(remove::Args),
 }
 
 /// Global is the main entry point for the part of pixi that executes on the global(system) level.
@@ -19,6 +22,7 @@ pub struct Args {
 pub async fn execute(cmd: Args) -> miette::Result<()> {
     match cmd.command {
         Command::Install(args) => install::execute(args).await?,
+        Command::Remove(args) => remove::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 mod install;
+mod list;
 mod remove;
 
 #[derive(Debug, Parser)]
@@ -8,6 +9,8 @@ pub enum Command {
     Install(install::Args),
     #[clap(alias = "r")]
     Remove(remove::Args),
+    #[clap(alias = "ls")]
+    List(list::Args),
 }
 
 /// Global is the main entry point for the part of pixi that executes on the global(system) level.
@@ -23,6 +26,7 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
     match cmd.command {
         Command::Install(args) => install::execute(args).await?,
         Command::Remove(args) => remove::execute(args).await?,
+        Command::List(args) => list::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -1,0 +1,111 @@
+use std::collections::HashSet;
+use std::str::FromStr;
+
+use clap::Parser;
+use clap_verbosity_flag::{Level, Verbosity};
+use itertools::Itertools;
+use miette::IntoDiagnostic;
+use rattler_conda_types::MatchSpec;
+use rattler_shell::shell::ShellEnum;
+
+use crate::cli::global::install::{
+    create_activation_script, create_executable_scripts, find_designated_package, BinEnvDir,
+};
+use crate::prefix::Prefix;
+
+#[derive(Parser, Debug)]
+#[clap(arg_required_else_help = true)]
+pub struct Args {
+    /// Specifies the package that is to be removed.
+    package: String,
+    #[command(flatten)]
+    verbose: Verbosity,
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    // Find the MatchSpec we want to install
+    let package_matchspec = MatchSpec::from_str(&args.package).into_diagnostic()?;
+    let package_name = package_matchspec.name.clone().ok_or_else(|| {
+        miette::miette!(
+            "could not find package name in MatchSpec {}",
+            package_matchspec
+        )
+    })?;
+    let bin_prefix = BinEnvDir::from_existing(&package_name).await?;
+    let prefix = Prefix::new(bin_prefix.0.clone())?;
+
+    // Find the installed package in the environment
+    let prefix_package = find_designated_package(&prefix, &package_name).await?;
+
+    // Determine the shell to use for the invocation script
+    let shell: ShellEnum = if cfg!(windows) {
+        rattler_shell::shell::CmdExe.into()
+    } else {
+        rattler_shell::shell::Bash.into()
+    };
+
+    // Construct the reusable activation script for the shell and generate an invocation script
+    // for each executable added by the package to the environment.
+    let activation_script = create_activation_script(&prefix, shell.clone())?;
+    let paths_to_remove: Vec<_> =
+        create_executable_scripts(&prefix, &prefix_package, &shell, activation_script, true)
+            .await?
+            // Collecting to a HashSet first is a workaround for issue #317 and can be removed
+            // once that is fixed.
+            .into_iter()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+    let dirs_to_remove: Vec<_> = vec![bin_prefix.0];
+
+    if args.verbose.log_level().unwrap_or(Level::Error) >= Level::Warn {
+        let whitespace = console::Emoji("  ", "").to_string();
+        let names_to_remove = dirs_to_remove
+            .iter()
+            .map(|dir| dir.to_string_lossy())
+            .chain(paths_to_remove.iter().map(|path| path.to_string_lossy()))
+            .join(&format!("\n{whitespace} -  "));
+
+        eprintln!(
+            "{} Removing the following files and directories:\n{whitespace} -  {names_to_remove}",
+            console::style("!").yellow().bold(),
+        )
+    }
+
+    let mut errors = vec![];
+
+    for file in paths_to_remove {
+        if let Err(e) = tokio::fs::remove_file(&file).await.into_diagnostic() {
+            errors.push((file, e))
+        }
+    }
+
+    for dir in dirs_to_remove {
+        if let Err(e) = tokio::fs::remove_dir_all(&dir).await.into_diagnostic() {
+            errors.push((dir, e))
+        }
+    }
+
+    if errors.is_empty() {
+        eprintln!(
+            "{}Successfully removed global package {}",
+            console::style(console::Emoji("✔ ", "")).green(),
+            console::style(package_name).bold(),
+        );
+    } else {
+        let whitespace = console::Emoji("  ", "").to_string();
+        let error_string = errors
+            .into_iter()
+            .map(|(file, e)| format!("{} (on {})", e, file.to_string_lossy()))
+            .join(&format!("\n{whitespace} -  "));
+        miette::bail!(
+            "got multiple errors trying to remove global package {}:\n{} -  {}",
+            package_name,
+            whitespace,
+            error_string,
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -13,6 +13,7 @@ use crate::cli::global::install::{
 };
 use crate::prefix::Prefix;
 
+/// Removes a package previously installed into a globally accessible location via `pixi global install`.
 #[derive(Parser, Debug)]
 #[clap(arg_required_else_help = true)]
 pub struct Args {
@@ -31,8 +32,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             package_matchspec
         )
     })?;
-    let bin_prefix = BinEnvDir::from_existing(&package_name).await?;
-    let prefix = Prefix::new(bin_prefix.0.clone())?;
+    let BinEnvDir(bin_prefix) = BinEnvDir::from_existing(&package_name).await?;
+    let prefix = Prefix::new(bin_prefix.clone())?;
 
     // Find the installed package in the environment
     let prefix_package = find_designated_package(&prefix, &package_name).await?;
@@ -57,7 +58,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             .into_iter()
             .collect();
 
-    let dirs_to_remove: Vec<_> = vec![bin_prefix.0];
+    let dirs_to_remove: Vec<_> = vec![bin_prefix];
 
     if args.verbose.log_level().unwrap_or(Level::Error) >= Level::Warn {
         let whitespace = console::Emoji("  ", "").to_string();


### PR DESCRIPTION
This fixes #314 and #50 by adding two new global commands `global list` and `global remove` for inspecting and removing the globally installed packages.

In order to avoid having to try to map back the installed binaries to their source packages via parsing the shell scripts or something, the general approach I took here was to add a dry run option to the function that generates the binary scripts, such that we can re-run the script generation on list or remove to see what files would be generated for a given package and thus belong to that package. (This strategy has at least two small flaws: it's not very backwards compatible if pixi decides to change the names of the generated files at some point, and it's not robust to two different packages installing a binary with the same name. The former could perhaps be fixed later by writing some kind of manifest into the env instead that persists the list of generates files? The latter could be fixed by refusing to install two binaries with the same name at install time?)

I didn't see a test harness that can run automated tests of the `global` commands, so I tested manually using the following steps. (Happy to go back and add automated tests if there is such a harness and I just missed it.)

Manual test steps:
```shell
# test an add/remove cycle:
pixi (global_remove_and_list) $ cargo run -- global install starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/pixi global install starship`
✔ Installed package starship 1.16.0 h725e511_0 from conda-forge
  These apps are now globally available:
   -  starship
pixi (global_remove_and_list) $ ls ~/.pixi/bin
starship
pixi (global_remove_and_list) $ ls ~/.pixi/envs
starship
pixi (global_remove_and_list) $ cargo run -- global remove starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/pixi global remove starship`
✔ Successfully removed global package starship
pixi (global_remove_and_list) $ ls ~/.pixi/bin
pixi (global_remove_and_list) $ ls ~/.pixi/envs
pixi (global_remove_and_list) $ cargo run -- global remove starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/pixi global remove starship`
  × could not find environment for package starship

# test an add/remove cycle with `--verbose` for remove:
pixi (global_remove_and_list) $ cargo run -- global install starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/pixi global install starship`
✔ Installed package starship 1.16.0 h725e511_0 from conda-forge
  These apps are now globally available:
   -  starship
pixi (global_remove_and_list) $ ls ~/.pixi/bin
starship
pixi (global_remove_and_list) $ ls ~/.pixi/envs
starship
pixi (global_remove_and_list) $ cargo run -- global remove starship --verbose
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/pixi global remove starship --verbose`
! Removing the following files and directories:
   -  /home/colin/.pixi/envs/starship
   -  /home/colin/.pixi/bin/starship
✔ Successfully removed global package starship
pixi (global_remove_and_list) $ ls ~/.pixi/bin
pixi (global_remove_and_list) $ ls ~/.pixi/envs
pixi (global_remove_and_list) $ cargo run -- global remove starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/pixi global remove starship`
  × could not find environment for package starship

# Test list for both python, which has multiple binaries, and starship, which has one
pixi (global_remove_and_list) $ cargo run -- global list
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/pixi global list`
! No globally installed binaries found
pixi (global_remove_and_list) $ cargo run -- global install python==3.11
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/pixi global install python==3.11`
✔ Installed package python 3.11.0 he550d4f_1_cpython from conda-forge
  These apps are now globally available:
   -  2to3
   -  2to3-3
   -  idle3
   -  idle3
   -  pydoc
   -  pydoc3
   -  pydoc3
   -  python
   -  python3
   -  python3-config
   -  python3
   -  python3
   -  python3
pixi (global_remove_and_list) $ cargo run -- global list
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/pixi global list`
Globally installed binary packages:
  -  [package] python
     -  [bin] idle3
     -  [bin] python
     -  [bin] pydoc3
     -  [bin] python3-config
     -  [bin] 2to3-3
     -  [bin] 2to3
     -  [bin] python3
     -  [bin] pydoc
pixi (global_remove_and_list) $ cargo run -- global install starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/pixi global install starship`
✔ Installed package starship 1.16.0 h725e511_0 from conda-forge
  These apps are now globally available:
   -  starship
pixi (global_remove_and_list) $ cargo run -- global list
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/pixi global list`
Globally installed binary packages:
  -  [package] python
     -  [bin] 2to3-3
     -  [bin] python3
     -  [bin] pydoc
     -  [bin] python
     -  [bin] 2to3
     -  [bin] idle3
     -  [bin] pydoc3
     -  [bin] python3-config
  -  [package] starship
     -  [bin] starship
pixi (global_remove_and_list) $ cargo run -- global remove python --verbose
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/pixi global remove python --verbose`
! Removing the following files and directories:
   -  /home/colin/.pixi/envs/python
   -  /home/colin/.pixi/bin/pydoc3
   -  /home/colin/.pixi/bin/python3-config
   -  /home/colin/.pixi/bin/pydoc
   -  /home/colin/.pixi/bin/python3
   -  /home/colin/.pixi/bin/idle3
   -  /home/colin/.pixi/bin/2to3-3
   -  /home/colin/.pixi/bin/python
   -  /home/colin/.pixi/bin/2to3
✔ Successfully removed global package python
pixi (global_remove_and_list) $ cargo run -- global list
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/pixi global list`
Globally installed binary packages:
  -  [package] starship
     -  [bin] starship
pixi (global_remove_and_list) $ cargo run -- global remove starship
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/pixi global remove starship`
✔ Successfully removed global package starship
pixi (global_remove_and_list) $ cargo run -- global list
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/pixi global list`
! No globally installed binaries found
```