### PR TITLE
fix: noarch is the only channel that must exist

### DIFF
--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -74,7 +74,7 @@ pub async fn fetch_sparse_repodata(
                 &repodata_cache,
                 download_client,
                 progress_bar.clone(),
-                platform == Platform::NoArch,
+                platform != Platform::NoArch,
             )
             .await;
 


### PR DESCRIPTION
Only noarch should be required, the other subdirs might be missing.