### PR TITLE
bump: 0.5.0-dev and rattler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +925,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2013,7 +2031,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "atty",
  "chrono",
@@ -2172,6 +2190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,8 +2228,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e492d94b0548647590f56a2c2b88cd2f07df4b70fba43e215db3271046b5d580"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2245,8 +2268,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eaff6d30e6e75d9496592670244f3f4b7e8e6fec33ab75f05d6092e69f724e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "chrono",
  "fxhash",
@@ -2275,8 +2297,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881d6040b07c00070386bc7d98f21b71474a0b7847fa5b32a7c5a0a01d028f8f"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "blake2",
  "digest",
@@ -2289,22 +2310,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "rattler_libsolv_rs"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6402ac62d587024ece8abb8ec2834d893942b7bea579661d9e785f915aaaa9c"
-dependencies = [
- "elsa",
- "itertools",
- "petgraph",
- "tracing",
-]
-
-[[package]]
 name = "rattler_macros"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cd618d7645bf1afdf3aecb62a47ebb10b7179ecc1f26e007a81e6637fee8b9"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -2313,8 +2321,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8689ecbc1bc29e0821d902f1b7a7ed0c30ad8af855635947f1f66e78c7d1e9cb"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2333,8 +2340,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac355b64f27277c17cc5f293f8de3905596e92716f66ba46a8fc4cf1af7635ba"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2357,8 +2363,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e208f6677fbfff530fcd98847946361d723414240ac22f3641b5e3e45b59adfd"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2396,8 +2401,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5537efd8f7414aba4a8af963d7319e61cd444c66547a091b8d6cbafcd6b92a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.0.0",
@@ -2414,8 +2418,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972e93abc50a7e226310555daab464460fb20c7bbdd62bece06c454bdcec41ae"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2423,7 +2426,7 @@ dependencies = [
  "itertools",
  "rattler_conda_types",
  "rattler_digest",
- "rattler_libsolv_rs",
+ "resolvo",
  "serde",
  "tempfile",
  "thiserror",
@@ -2434,8 +2437,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76e860582a7249dce80347fcff798c62bc53df88db9ccc52839066ed898dda4"
+source = "git+https://github.com/mamba-org/rattler?branch=main#d61936ed47e7f2e1bfdecc6229624bf6839dda8d"
 dependencies = [
  "cfg-if",
  "libloading",
@@ -2588,6 +2590,19 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "resolvo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dab30801b54723f1949c6453a35db09c89e2ce7e052dc63e715f32fb40e427c"
+dependencies = [
+ "bitvec",
+ "elsa",
+ "itertools",
+ "petgraph",
+ "tracing",
 ]
 
 [[package]]
@@ -3129,6 +3144,12 @@ dependencies = [
  "rayon",
  "winapi",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -3863,6 +3884,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi"
-version = "0.4.0"
+version = "0.5.0-dev"
 description = "A package management and workflow tool"
 edition = "2021"
 authors = ["pixi contributors <hi@prefix.dev>"]
@@ -41,7 +41,7 @@ rattler_digest = { version = "0.9.0", default-features = false }
 rattler_networking = { version = "0.9.0", default-features = false }
 rattler_repodata_gateway = { version = "0.9.0", default-features = false, features = ["sparse"] }
 rattler_shell = { version = "0.9.0", default-features = false, features = ["sysinfo"] }
-rattler_solve = { version = "0.9.0", default-features = false, features = ["libsolv_rs"] }
+rattler_solve = { version = "0.9.0", default-features = false, features = ["resolvo"] }
 rattler_virtual_packages = { version = "0.9.0", default-features = false }
 reqwest = { version = "0.11.20", default-features = false }
 serde = "1.0.188"
@@ -71,14 +71,14 @@ tokio = { version = "1.32.0", features = ["rt"] }
 toml = "0.7.6"
 
 [patch.crates-io]
-#rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
 
 #rattler = { path = "../rattler/crates/rattler" }
 #rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -17,7 +17,7 @@ use rattler_conda_types::{
     MatchSpec, NamelessMatchSpec, Platform, StrictVersion, Version, VersionSpec,
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::{libsolv_rs, SolverImpl};
+use rattler_solve::{resolvo, SolverImpl};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -305,7 +305,7 @@ pub fn determine_best_version(
         pinned_packages: vec![],
     };
 
-    let records = libsolv_rs::Solver.solve(task).into_diagnostic()?;
+    let records = resolvo::Solver.solve(task).into_diagnostic()?;
 
     // Determine the versions of the new packages
     Ok(records

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -16,7 +16,7 @@ use rattler_shell::{
     shell::Shell,
     shell::ShellEnum,
 };
-use rattler_solve::{libsolv_rs, SolverImpl};
+use rattler_solve::{resolvo, SolverImpl};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -329,7 +329,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     // Solve it
-    let records = libsolv_rs::Solver.solve(task).into_diagnostic()?;
+    let records = resolvo::Solver.solve(task).into_diagnostic()?;
 
     // Create the binary environment prefix where we install or update the package
     let BinEnvDir(bin_prefix) = BinEnvDir::create(&package_name).await?;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -24,7 +24,7 @@ use rattler_conda_types::{
 };
 use rattler_networking::AuthenticatedClient;
 use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::{libsolv_rs, SolverImpl};
+use rattler_solve::{resolvo, SolverImpl};
 use std::collections::HashMap;
 use std::{
     collections::{HashSet, VecDeque},
@@ -352,7 +352,7 @@ pub async fn update_lock_file(
         };
 
         // Solve the task
-        let records = libsolv_rs::Solver.solve(task).into_diagnostic()?;
+        let records = resolvo::Solver.solve(task).into_diagnostic()?;
 
         // Update lock file
         let mut locked_packages = LockedPackages::new(platform);

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -129,7 +129,7 @@ async fn fetch_repo_data_records_with_progress(
     let result = fetch::fetch_repo_data(
         channel.platform_url(platform),
         client,
-        repodata_cache,
+        repodata_cache.to_path_buf(),
         Default::default(),
         Some(Box::new(move |fetch::DownloadProgress { total, bytes }| {
             download_progress_progress_bar.set_length(total.unwrap_or(bytes));


### PR DESCRIPTION
Bumps rattler to use the latest `main` branch and bumps pixi to `0.5.0-dev` to indicate that the latest version is a not the latest released one.