### PR TITLE
feat: add --locked and --frozen to getting an up-to-date prefix

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -59,10 +59,14 @@ Which gets generated on `pixi add` or when you manually change the `pixi.toml` f
 #### Options
 
 - `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
+- `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile.
+- `--locked`: only install if lockfile is up-to-date. Conflicts with `--frozen`.
 
 ```shell
 pixi install
 pixi install --manifest-path ~/myproject/pixi.toml
+pixi install --frozen
+pixi install --locked
 ```
 
 ## `run`
@@ -76,11 +80,15 @@ You cannot run `pixi run source setup.bash` as `source` is not available in the 
 #### Options
 
 - `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
+- `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile.
+- `--locked`: only install if lockfile is up-to-date. Conflicts with `--frozen`.
 
 ```shell
 pixi run python
 pixi run cowpy "Hey pixi user"
 pixi run --manifest-path ~/myproject/pixi.toml python
+pixi run --frozen python
+pixi run --locked python
 # If you have specified a custom task in the pixi.toml you can run it with run as well
 pixi run build
 ```
@@ -158,11 +166,17 @@ To exit the pixi shell, simply run `exit`.
 #### Options
 
 - `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
+- `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile.
+- `--locked`: only install if lockfile is up-to-date. Conflicts with `--frozen`.
 
 ```shell
 pixi shell
 exit
 pixi shell --manifest-path ~/myproject/pixi.toml
+exit
+pixi shell --frozen
+exit
+pixi shell --locked
 exit
 ```
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -9,12 +9,20 @@ pub struct Args {
     /// The path to 'pixi.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
+
+    /// Require pixi.lock is up-to-date
+    #[clap(long, conflicts_with = "frozen")]
+    pub locked: bool,
+
+    /// Don't check if pixi.lock is up-to-date, install as lockfile states
+    #[clap(long, conflicts_with = "locked")]
+    pub frozen: bool,
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
 
-    get_up_to_date_prefix(&project).await?;
+    get_up_to_date_prefix(&project, args.frozen, args.locked).await?;
 
     // Emit success
     eprintln!(

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -134,7 +134,11 @@ async fn start_unix_shell<T: Shell + Copy>(
 /// function as if the environment has been activated. This method runs the activation scripts from
 /// the environment and stores the environment variables it added, finally it adds environment
 /// variables from the project.
-pub async fn get_shell_env(project: &Project, frozen: bool, locked: bool) -> miette::Result<HashMap<String, String>> {
+pub async fn get_shell_env(
+    project: &Project,
+    frozen: bool,
+    locked: bool,
+) -> miette::Result<HashMap<String, String>> {
     // Get the prefix which we can then activate.
     let prefix = get_up_to_date_prefix(project, frozen, locked).await?;
 

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -103,3 +103,68 @@ async fn test_incremental_lock_file() {
         "expected `bar` to remain locked to version 1."
     );
 }
+
+/// Test the `pixi install --locked` functionality.
+#[tokio::test]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+async fn install_locked() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+    // Add and update lockfile with this version of python
+    pixi.add("python==3.10.0").await.unwrap();
+
+    // Add new version of python only to the manifest
+    pixi.add("python==3.11.0")
+        .without_lockfile_update()
+        .await
+        .unwrap();
+
+    assert!(pixi.install().with_locked().await.is_err(), "should error when installing with locked but there is a mismatch in the dependencies and the lockfile.");
+
+    // Check if it didn't accidentally update the lockfile
+    let lock = pixi.lock_file().await.unwrap();
+    assert!(lock.contains_matchspec("python==3.10.0"));
+
+    // After an install with lockfile update the locked install should succeed.
+    pixi.install().await.unwrap();
+    pixi.install().with_locked().await.unwrap();
+
+    // Check if lock has python version updated
+    let lock = pixi.lock_file().await.unwrap();
+    assert!(lock.contains_matchspec("python==3.11.0"));
+}
+
+/// Test `pixi install/run --frozen` functionality
+#[tokio::test]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+async fn install_frozen() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+    // Add and update lockfile with this version of python
+    pixi.add("python==3.10.0").await.unwrap();
+
+    // Add new version of python only to the manifest
+    pixi.add("python==3.11.0")
+        .without_lockfile_update()
+        .await
+        .unwrap();
+
+    pixi.install().with_frozen().await.unwrap();
+
+    // Check if it didn't accidentally update the lockfile
+    let lock = pixi.lock_file().await.unwrap();
+    assert!(lock.contains_matchspec("python==3.10.0"));
+
+    // Check if running with frozen doesn't suddenly install the latest update.
+    let result = pixi
+        .run(run::Args {
+            frozen: true,
+            task: string_from_iter(["python", "--version"]),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout.trim(), "Python 3.10.0");
+    assert!(result.stderr.is_empty());
+}

--- a/tests/task_tests.rs
+++ b/tests/task_tests.rs
@@ -94,6 +94,8 @@ async fn test_alias() {
         .run(Args {
             task: vec!["helloworld".to_string()],
             manifest_path: None,
+            locked: false,
+            frozen: false,
         })
         .await
         .unwrap();


### PR DESCRIPTION
Closes #349 

Add the `--frozen` and `--locked` like how cargo does it. 

Allow users to force CI to not touch the lock file. 