### PR TITLE
feat: Add the current working directory in tasks

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -111,8 +111,16 @@ If you want to make a shorthand for a specific command you can add a task for it
 
 Add a task to the `pixi.toml`, use `--depends-on` to add tasks you want to run before this task, e.g. build before an execute task.
 
+#### Options
+- `--platform`: the platform for which this task should be added.
+- `--depends-on`: the task it depends on to be run before the one your adding.
+- `--cwd`: the working directory for the task relative to the root of the project.
+
 ```shell
 pixi task add cow cowpy "Hello User"
+pixi task add tls ls --cwd tests
+pixi task add test cargo t --depends-on build
+pixi task add build-osx "METAL=1 cargo build" --platform osx-64
 ```
 
 This adds the following to the `pixi.toml`:
@@ -120,6 +128,11 @@ This adds the following to the `pixi.toml`:
 ```toml
 [tasks]
 cow = "cowpy \"Hello User\""
+tls = { cmd = "ls", cwd = "tests" }
+test = { cmd = "cargo t", depends_on = ["build"] }
+
+[target.osx-64.tasks]
+build-osx = "METAL=1 cargo build"
 ```
 
 Which you can then run with the `run` command:

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -53,6 +53,10 @@ pub struct AddArgs {
     /// The platform for which the task should be added
     #[arg(long, short)]
     pub platform: Option<Platform>,
+
+    /// The working directory relative to the root of the project
+    #[arg(long)]
+    pub cwd: Option<PathBuf>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -88,12 +92,13 @@ impl From<AddArgs> for Task {
 
         // Depending on whether the task should have depends_on or not we create a Plain or complex
         // command.
-        if depends_on.is_empty() {
+        if depends_on.is_empty() && value.cwd.is_none() {
             Self::Plain(cmd_args)
         } else {
             Self::Execute(Execute {
                 cmd: CmdArgs::Single(cmd_args),
                 depends_on,
+                cwd: value.cwd,
             })
         }
     }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -72,6 +72,9 @@ fn task_as_toml(task: Task) -> Item {
                     Value::Array(Array::from_iter(process.depends_on.into_iter())),
                 );
             }
+            if let Some(cwd) = process.cwd {
+                table.insert("cwd", cwd.to_string_lossy().to_string().into());
+            }
             Item::Value(Value::InlineTable(table))
         }
         Task::Alias(alias) => {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use serde_with::{formats::PreferMany, serde_as, OneOrMany};
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
 
 /// Represents different types of scripts
 #[derive(Debug, Clone, Deserialize)]
@@ -72,6 +73,15 @@ impl Task {
             Task::Alias(_) => None,
         }
     }
+
+    /// Returns the working directory for the task to run in.
+    pub fn working_directory(&self) -> Option<&Path> {
+        match self {
+            Task::Plain(_) => None,
+            Task::Execute(t) => t.cwd.as_deref(),
+            Task::Alias(_) => None,
+        }
+    }
 }
 
 /// A command script executes a single command from the environment
@@ -86,6 +96,9 @@ pub struct Execute {
     #[serde(default)]
     #[serde_as(deserialize_as = "OneOrMany<_, PreferMany>")]
     pub depends_on: Vec<String>,
+
+    /// The working directory for the command relative to the root of the project.
+    pub cwd: Option<PathBuf>,
 }
 
 impl From<Execute> for Task {

--- a/tests/common/builders.rs
+++ b/tests/common/builders.rs
@@ -149,6 +149,12 @@ impl TaskAddBuilder {
         self
     }
 
+    /// With this working directory
+    pub fn with_cwd(mut self, cwd: PathBuf) -> Self {
+        self.args.cwd = Some(cwd);
+        self
+    }
+
     /// Execute the CLI command
     pub fn execute(self) -> miette::Result<()> {
         task::execute(task::Args {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -238,6 +238,7 @@ impl TasksControl<'_> {
                 commands: vec![],
                 depends_on: None,
                 platform,
+                cwd: None,
             },
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -188,9 +188,11 @@ impl PixiControl {
 
         let mut result = RunOutput::default();
         while let Some((command, args)) = tasks.pop_back() {
+            let cwd = run::select_cwd(command.working_directory(), &project)?;
             let script = create_script(command, args).await;
             if let Ok(script) = script {
-                let output = execute_script_with_output(script, &project, &task_env, None).await;
+                let output =
+                    execute_script_with_output(script, cwd.as_path(), &task_env, None).await;
                 result.stdout.push_str(&output.stdout);
                 result.stderr.push_str(&output.stderr);
                 result.exit_code = output.exit_code;

--- a/tests/task_tests.rs
+++ b/tests/task_tests.rs
@@ -2,6 +2,8 @@ use crate::common::PixiControl;
 use pixi::cli::run::Args;
 use pixi::task::{CmdArgs, Task};
 use rattler_conda_types::Platform;
+use std::fs;
+use std::path::PathBuf;
 
 mod common;
 
@@ -141,4 +143,51 @@ pub async fn add_remove_target_specific_task() {
             .len(),
         0
     );
+}
+
+#[tokio::test]
+async fn test_cwd() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().without_channels().await.unwrap();
+
+    // Create test dir
+    fs::create_dir(pixi.project_path().join("test")).unwrap();
+
+    pixi.tasks()
+        .add("pwd-test", None)
+        .with_commands(["pwd"])
+        .with_cwd(PathBuf::from("test"))
+        .execute()
+        .unwrap();
+
+    let result = pixi
+        .run(Args {
+            task: vec!["pwd-test".to_string()],
+            manifest_path: None,
+            locked: false,
+            frozen: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.stdout.contains("test"));
+
+    // Test that an unknown cwd gives an error
+    pixi.tasks()
+        .add("unknown-cwd", None)
+        .with_commands(["pwd"])
+        .with_cwd(PathBuf::from("tests"))
+        .execute()
+        .unwrap();
+
+    assert!(pixi
+        .run(Args {
+            task: vec!["unknown-cwd".to_string()],
+            manifest_path: None,
+            locked: false,
+            frozen: false,
+        })
+        .await
+        .is_err());
 }


### PR DESCRIPTION
This feature also fixes the fact that `pixi run` always runs in the root of the project.
Now only the pixi tasks are run in the root of the project (unless specified differently), while the `pixi run` will run in the `env::current_dir()` .

closes #376