### PR TITLE
[wip] implement "detaching" from shell to start a background process [skip ci]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "daemonize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,6 +2049,7 @@ dependencies = [
  "clap-verbosity-flag",
  "clap_complete",
  "console",
+ "daemonize",
  "deno_task_shell",
  "dirs",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.4.5", default-features = false, features = ["derive", "usa
 clap-verbosity-flag = "2.0.1"
 clap_complete = "4.4.2"
 console = { version = "0.15.7", features = ["windows-console-colors"] }
+daemonize = "0.5.0"
 deno_task_shell = "0.13.2"
 # deno_task_shell = { path = "../deno_task_shell" }
 dirs = "5.0.1"

--- a/examples/jupyterlab/pixi.lock
+++ b/examples/jupyterlab/pixi.lock
@@ -41,8 +41,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgomp: '>=7.5.0'
     _libgcc_mutex: ==0.1 conda_forge
+    libgomp: '>=7.5.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
     md5: 73aaf86a425cc6e73fcf236a5a46396d
@@ -60,15 +60,15 @@ package:
   size: 23621
   timestamp: 1650670423406
 - name: alsa-lib
-  version: 1.2.9
+  version: 1.2.10
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.9-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
   hash:
-    md5: a0c6f0e7e1a467f5678f94dea18c8aa7
-    sha256: f177627acdfcead15a28f4a07fcda6a1e26b83f053eaa1efa7cce01c0a3b09a8
+    md5: 75dae9a4201732aa78a530b826ee5fe0
+    sha256: 51147922bad9d3176e780eb26f748f380cd3184896a9f9125d8ac64fe330158b
   optional: false
   category: main
   build: hd590300_0
@@ -77,22 +77,21 @@ package:
   build_number: 0
   license: LGPL-2.1-or-later
   license_family: GPL
-  size: 546752
-  timestamp: 1683210393229
+  size: 554938
+  timestamp: 1693607226431
 - name: anyio
-  version: 3.7.1
+  version: 4.0.0
   manager: conda
   platform: linux-64
   dependencies:
     exceptiongroup: '*'
-    python: '>=3.7'
-    typing_extensions: '*'
     idna: '>=2.8'
+    python: '>=3.8'
     sniffio: '>=1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b517e7a6f0790337906c055aa97ca49
-    sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
+    md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+    sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -100,26 +99,25 @@ package:
   subdir: linux-64
   build_number: 0
   constrains:
-  - trio >=0.16,<0.22
+  - trio >=0.22
   license: MIT
   license_family: MIT
   noarch: python
-  size: 96707
-  timestamp: 1688651250785
+  size: 98958
+  timestamp: 1693488730301
 - name: anyio
-  version: 3.7.1
+  version: 4.0.0
   manager: conda
   platform: osx-64
   dependencies:
     exceptiongroup: '*'
-    python: '>=3.7'
-    typing_extensions: '*'
     idna: '>=2.8'
+    python: '>=3.8'
     sniffio: '>=1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b517e7a6f0790337906c055aa97ca49
-    sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
+    md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+    sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -127,26 +125,25 @@ package:
   subdir: osx-64
   build_number: 0
   constrains:
-  - trio >=0.16,<0.22
+  - trio >=0.22
   license: MIT
   license_family: MIT
   noarch: python
-  size: 96707
-  timestamp: 1688651250785
+  size: 98958
+  timestamp: 1693488730301
 - name: anyio
-  version: 3.7.1
+  version: 4.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     exceptiongroup: '*'
-    python: '>=3.7'
-    typing_extensions: '*'
     idna: '>=2.8'
+    python: '>=3.8'
     sniffio: '>=1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b517e7a6f0790337906c055aa97ca49
-    sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
+    md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+    sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -154,26 +151,25 @@ package:
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - trio >=0.16,<0.22
+  - trio >=0.22
   license: MIT
   license_family: MIT
   noarch: python
-  size: 96707
-  timestamp: 1688651250785
+  size: 98958
+  timestamp: 1693488730301
 - name: anyio
-  version: 3.7.1
+  version: 4.0.0
   manager: conda
   platform: win-64
   dependencies:
     exceptiongroup: '*'
-    python: '>=3.7'
-    typing_extensions: '*'
     idna: '>=2.8'
+    python: '>=3.8'
     sniffio: '>=1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 7b517e7a6f0790337906c055aa97ca49
-    sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
+    md5: 3c4e99d3ae4ec033d4dd99fb5220e540
+    sha256: 64125775b2e724db5c72e431dd180495d5d509d0a2d1228a122e6af9f1b60e33
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -181,12 +177,12 @@ package:
   subdir: win-64
   build_number: 0
   constrains:
-  - trio >=0.16,<0.22
+  - trio >=0.22
   license: MIT
   license_family: MIT
   noarch: python
-  size: 96707
-  timestamp: 1688651250785
+  size: 98958
+  timestamp: 1693488730301
 - name: appnope
   version: 0.1.3
   manager: conda
@@ -230,17 +226,17 @@ package:
   size: 8095
   timestamp: 1649077760928
 - name: argon2-cffi
-  version: 21.3.0
+  version: 23.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-    flit-core: '>=3.4,<4'
     argon2-cffi-bindings: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.7'
+    typing-extensions: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a0b402db58f73aaab8ee0ca1025a362e
-    sha256: 3a53cfd674641d9ff9901f5d4e1cc5e9a3ce9bb8b6a7dca826db840c2e39bc23
+    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -252,20 +248,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15708
-  timestamp: 1640817831095
+  size: 18602
+  timestamp: 1692818472638
 - name: argon2-cffi
-  version: 21.3.0
+  version: 23.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-    flit-core: '>=3.4,<4'
     argon2-cffi-bindings: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.7'
+    typing-extensions: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a0b402db58f73aaab8ee0ca1025a362e
-    sha256: 3a53cfd674641d9ff9901f5d4e1cc5e9a3ce9bb8b6a7dca826db840c2e39bc23
+    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -277,20 +273,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15708
-  timestamp: 1640817831095
+  size: 18602
+  timestamp: 1692818472638
 - name: argon2-cffi
-  version: 21.3.0
+  version: 23.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-    flit-core: '>=3.4,<4'
     argon2-cffi-bindings: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.7'
+    typing-extensions: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a0b402db58f73aaab8ee0ca1025a362e
-    sha256: 3a53cfd674641d9ff9901f5d4e1cc5e9a3ce9bb8b6a7dca826db840c2e39bc23
+    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -302,20 +298,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15708
-  timestamp: 1640817831095
+  size: 18602
+  timestamp: 1692818472638
 - name: argon2-cffi
-  version: 21.3.0
+  version: 23.1.0
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-    flit-core: '>=3.4,<4'
     argon2-cffi-bindings: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.7'
+    typing-extensions: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a0b402db58f73aaab8ee0ca1025a362e
-    sha256: 3a53cfd674641d9ff9901f5d4e1cc5e9a3ce9bb8b6a7dca826db840c2e39bc23
+    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
+    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -327,111 +323,112 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15708
-  timestamp: 1640817831095
+  size: 18602
+  timestamp: 1692818472638
 - name: argon2-cffi-bindings
   version: 21.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
     cffi: '>=1.0.1'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311hd4cff14_3.tar.bz2
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h459d7ec_4.conda
   hash:
-    md5: 5159e874f65ac382773d2b534a1d7b80
-    sha256: a79e7600c22552782850f5734b89bb7eb0bba15999c68d58706e32d86f5380e8
+    md5: de5b16869a430949b02161b04b844a30
+    sha256: 104194af519b4e667aa5341068b94b521a791aaaa05ec0091f8f0bdba43a60ac
   optional: false
   category: main
-  build: py311hd4cff14_3
+  build: py311h459d7ec_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   license: MIT
   license_family: MIT
-  size: 36285
-  timestamp: 1666850986696
+  size: 34955
+  timestamp: 1695386703660
 - name: argon2-cffi-bindings
   version: 21.2.0
   manager: conda
   platform: osx-64
   dependencies:
+    cffi: '>=1.0.1'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    cffi: '>=1.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h5547dcb_3.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h2725bcf_4.conda
   hash:
-    md5: c09459e349fa61afc352f473766de109
-    sha256: ec3cf8f2091e4add30482728917fddc9c5c1fa4e53c68c0ebcac8f043ad3cf11
+    md5: e2aba0ad0f533ee73f9d4330d2e32549
+    sha256: be27659496bcb660fc9c3f5f74128a7bb090336897e9c7cfbcc55ae66f13b8d8
   optional: false
   category: main
-  build: py311h5547dcb_3
+  build: py311h2725bcf_4
   arch: x86_64
   subdir: osx-64
-  build_number: 3
+  build_number: 4
   license: MIT
   license_family: MIT
-  size: 33973
-  timestamp: 1666851121728
+  size: 32542
+  timestamp: 1695386887016
 - name: argon2-cffi-bindings
   version: 21.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    cffi: '>=1.0.1'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    cffi: '>=1.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311he2be06e_3.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311heffc1b2_4.conda
   hash:
-    md5: 268c0ecc4ad9f4d47f69785a6254334c
-    sha256: eab9a2bfad356f0055edadc2048406004e1d46107176986f6df59cf5dfeb81ac
+    md5: e9a56c22ca1215ed3a7b6a9e8c4e6f07
+    sha256: b9ab23e4f0d615432949d4b93723bd04b3c4aef725aa03b1e993903265c1b975
   optional: false
   category: main
-  build: py311he2be06e_3
+  build: py311heffc1b2_4
   arch: aarch64
   subdir: osx-arm64
-  build_number: 3
+  build_number: 4
   license: MIT
   license_family: MIT
-  size: 34526
-  timestamp: 1666851140553
+  size: 34126
+  timestamp: 1695386994453
 - name: argon2-cffi-bindings
   version: 21.2.0
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
+    cffi: '>=1.0.1'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    cffi: '>=1.0.1'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_3.tar.bz2
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_4.conda
   hash:
-    md5: c321cd825b72a2073dfb3f92ce1507fb
-    sha256: 641dd4b9d7714d28a2dbc3f80e9f3503acabd5706454d54e8c04578035cb22e7
+    md5: e95c947541bf1cb821ea4a6bf7d5794c
+    sha256: 0b8eb99e7ac6b409abbb5f3b9733f883865ff4314e85146380f072f6f6234929
   optional: false
   category: main
-  build: py311ha68e1ae_3
+  build: py311ha68e1ae_4
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 4
   license: MIT
   license_family: MIT
-  size: 36208
-  timestamp: 1666851014828
-- name: asttokens
-  version: 2.2.1
+  size: 34687
+  timestamp: 1695387285415
+- name: arrow
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-    six: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    python-dateutil: '>=2.7.0'
+    types-python-dateutil: '>=2.8.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bf7f54dd0f25c3f06ecb82a07341841a
-    sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    md5: b77d8c2313158e6e461ca0efb1c2c508
+    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -441,19 +438,20 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 27831
-  timestamp: 1670264089059
-- name: asttokens
-  version: 2.2.1
+  size: 100096
+  timestamp: 1696129131844
+- name: arrow
+  version: 1.3.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.5'
-    six: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    python-dateutil: '>=2.7.0'
+    types-python-dateutil: '>=2.8.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bf7f54dd0f25c3f06ecb82a07341841a
-    sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    md5: b77d8c2313158e6e461ca0efb1c2c508
+    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -463,19 +461,20 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 27831
-  timestamp: 1670264089059
-- name: asttokens
-  version: 2.2.1
+  size: 100096
+  timestamp: 1696129131844
+- name: arrow
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
-    six: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    python-dateutil: '>=2.7.0'
+    types-python-dateutil: '>=2.8.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bf7f54dd0f25c3f06ecb82a07341841a
-    sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    md5: b77d8c2313158e6e461ca0efb1c2c508
+    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -485,19 +484,20 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 27831
-  timestamp: 1670264089059
-- name: asttokens
-  version: 2.2.1
+  size: 100096
+  timestamp: 1696129131844
+- name: arrow
+  version: 1.3.0
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.5'
-    six: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    python-dateutil: '>=2.7.0'
+    types-python-dateutil: '>=2.8.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: bf7f54dd0f25c3f06ecb82a07341841a
-    sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    md5: b77d8c2313158e6e461ca0efb1c2c508
+    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -507,19 +507,107 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 27831
-  timestamp: 1670264089059
-- name: async-lru
-  version: 2.0.3
+  size: 100096
+  timestamp: 1696129131844
+- name: asttokens
+  version: 2.4.0
   manager: conda
   platform: linux-64
   dependencies:
-    typing_extensions: '>=4.0.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.5'
+    six: '>=1.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a3d2d43b74e042567cc4b5e328534885
-    sha256: 673d57dd2c7acb5b1685f8ddeb992d246fcdd658f2c7bba9b4ea3c023bacaf93
+    md5: 056f04e51dd63337e8d7c425c18c86f1
+    sha256: e7e91e3fa26abe502be690371893f205d87a82c225668ea6e9a1ba26870388ee
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 28819
+  timestamp: 1694046538391
+- name: asttokens
+  version: 2.4.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.5'
+    six: '>=1.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 056f04e51dd63337e8d7c425c18c86f1
+    sha256: e7e91e3fa26abe502be690371893f205d87a82c225668ea6e9a1ba26870388ee
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 28819
+  timestamp: 1694046538391
+- name: asttokens
+  version: 2.4.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.5'
+    six: '>=1.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 056f04e51dd63337e8d7c425c18c86f1
+    sha256: e7e91e3fa26abe502be690371893f205d87a82c225668ea6e9a1ba26870388ee
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 28819
+  timestamp: 1694046538391
+- name: asttokens
+  version: 2.4.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.5'
+    six: '>=1.12.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 056f04e51dd63337e8d7c425c18c86f1
+    sha256: e7e91e3fa26abe502be690371893f205d87a82c225668ea6e9a1ba26870388ee
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 28819
+  timestamp: 1694046538391
+- name: async-lru
+  version: 2.0.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -529,19 +617,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15181
-  timestamp: 1688997384351
+  size: 15342
+  timestamp: 1690563152778
 - name: async-lru
-  version: 2.0.3
+  version: 2.0.4
   manager: conda
   platform: osx-64
   dependencies:
-    typing_extensions: '>=4.0.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.3-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: a3d2d43b74e042567cc4b5e328534885
-    sha256: 673d57dd2c7acb5b1685f8ddeb992d246fcdd658f2c7bba9b4ea3c023bacaf93
+    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -551,19 +639,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15181
-  timestamp: 1688997384351
+  size: 15342
+  timestamp: 1690563152778
 - name: async-lru
-  version: 2.0.3
+  version: 2.0.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: '>=4.0.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.3-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: a3d2d43b74e042567cc4b5e328534885
-    sha256: 673d57dd2c7acb5b1685f8ddeb992d246fcdd658f2c7bba9b4ea3c023bacaf93
+    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -573,19 +661,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15181
-  timestamp: 1688997384351
+  size: 15342
+  timestamp: 1690563152778
 - name: async-lru
-  version: 2.0.3
+  version: 2.0.4
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: '>=4.0.0'
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.3-pyhd8ed1ab_0.conda
+    typing_extensions: '>=4.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: a3d2d43b74e042567cc4b5e328534885
-    sha256: 673d57dd2c7acb5b1685f8ddeb992d246fcdd658f2c7bba9b4ea3c023bacaf93
+    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
+    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -595,8 +683,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 15181
-  timestamp: 1688997384351
+  size: 15342
+  timestamp: 1690563152778
 - name: attr
   version: 2.5.1
   manager: conda
@@ -962,9 +1050,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
     backports: '*'
+    python: '>=3.6'
+    setuptools: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
   hash:
     md5: 6b1b907661838a75d067a22f87996b2e
@@ -985,9 +1073,9 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
     backports: '*'
+    python: '>=3.6'
+    setuptools: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
   hash:
     md5: 6b1b907661838a75d067a22f87996b2e
@@ -1008,9 +1096,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
     backports: '*'
+    python: '>=3.6'
+    setuptools: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
   hash:
     md5: 6b1b907661838a75d067a22f87996b2e
@@ -1031,9 +1119,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
     backports: '*'
+    python: '>=3.6'
+    setuptools: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
   hash:
     md5: 6b1b907661838a75d067a22f87996b2e
@@ -1138,19 +1226,19 @@ package:
   size: 115011
   timestamp: 1680888259061
 - name: bleach
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
-    webencodings: '*'
     packaging: '*'
+    python: '>=3.6'
+    setuptools: '*'
     six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+    webencodings: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d48b143d01385872a88ef8417e96c30e
-    sha256: 59da02f550ec546f9375fa309bc7712f50b478bad67b99fbebbb5b57ee3a67d3
+    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1160,22 +1248,22 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 130677
-  timestamp: 1674535450476
+  size: 131220
+  timestamp: 1696630354218
 - name: bleach
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
-    webencodings: '*'
     packaging: '*'
+    python: '>=3.6'
+    setuptools: '*'
     six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+    webencodings: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d48b143d01385872a88ef8417e96c30e
-    sha256: 59da02f550ec546f9375fa309bc7712f50b478bad67b99fbebbb5b57ee3a67d3
+    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1185,22 +1273,22 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 130677
-  timestamp: 1674535450476
+  size: 131220
+  timestamp: 1696630354218
 - name: bleach
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
-    webencodings: '*'
     packaging: '*'
+    python: '>=3.6'
+    setuptools: '*'
     six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+    webencodings: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d48b143d01385872a88ef8417e96c30e
-    sha256: 59da02f550ec546f9375fa309bc7712f50b478bad67b99fbebbb5b57ee3a67d3
+    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1210,22 +1298,22 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 130677
-  timestamp: 1674535450476
+  size: 131220
+  timestamp: 1696630354218
 - name: bleach
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: '*'
-    python: '>=3.6'
-    webencodings: '*'
     packaging: '*'
+    python: '>=3.6'
+    setuptools: '*'
     six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.0.0-pyhd8ed1ab_0.conda
+    webencodings: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d48b143d01385872a88ef8417e96c30e
-    sha256: 59da02f550ec546f9375fa309bc7712f50b478bad67b99fbebbb5b57ee3a67d3
+    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
+    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1235,287 +1323,287 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 130677
-  timestamp: 1674535450476
+  size: 131220
+  timestamp: 1696630354218
 - name: brotli
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libbrotlienc: ==1.0.9 h166bdaf_9
-    brotli-bin: ==1.0.9 h166bdaf_9
+    brotli-bin: ==1.1.0 hd590300_1
+    libbrotlidec: ==1.1.0 hd590300_1
+    libbrotlienc: ==1.1.0 hd590300_1
     libgcc-ng: '>=12'
-    libbrotlidec: ==1.0.9 h166bdaf_9
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
   hash:
-    md5: 4601544b4982ba1861fa9b9c607b2c06
-    sha256: 2357d205931912def55df0dc53573361156b27856f9bf359d464da162812ec1f
+    md5: f27a24d46e3ea7b70a1f98e50c62508f
+    sha256: f2d918d351edd06c55a6c2d84b488fe392f85ea018ff227daac07db22b408f6b
   optional: false
   category: main
-  build: h166bdaf_9
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 20065
-  timestamp: 1687884291946
+  size: 19383
+  timestamp: 1695990069230
 - name: brotli
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    brotli-bin: ==1.0.9 hb7f2c08_9
-    libbrotlienc: ==1.0.9 hb7f2c08_9
-    libbrotlidec: ==1.0.9 hb7f2c08_9
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_9.conda
+    brotli-bin: ==1.1.0 h0dc2134_1
+    libbrotlidec: ==1.1.0 h0dc2134_1
+    libbrotlienc: ==1.1.0 h0dc2134_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
   hash:
-    md5: 53cff90f0cea22e13e5b791f0e5a8e7d
-    sha256: eb425d4075f90d90bf9de5c2e8f88fe783d70177fcdfd3d3da5ef48e444ca148
+    md5: 9272dd3b19c4e8212f8542cefd5c3d67
+    sha256: 4bf66d450be5d3f9ebe029b50f818d088b1ef9666b1f19e90c85479c77bbdcde
   optional: false
   category: main
-  build: hb7f2c08_9
+  build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 20237
-  timestamp: 1687884767757
+  size: 19530
+  timestamp: 1695990310168
 - name: brotli
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    brotli-bin: ==1.0.9 h1a8c8d9_9
-    libbrotlienc: ==1.0.9 h1a8c8d9_9
-    libbrotlidec: ==1.0.9 h1a8c8d9_9
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_9.conda
+    brotli-bin: ==1.1.0 hb547adb_1
+    libbrotlidec: ==1.1.0 hb547adb_1
+    libbrotlienc: ==1.1.0 hb547adb_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
   hash:
-    md5: 856692dff5e450c269465e3256e1277b
-    sha256: 92c3062dd7e593a502c2f8d12e9ccca7ae1ef0363eb0b12faa47e1bb4fae42c7
+    md5: a33aa58d448cbc054f887e39dd1dfaea
+    sha256: 62d1587deab752fcee07adc371eb20fcadc09f72c0c85399c22b637ca858020f
   optional: false
   category: main
-  build: h1a8c8d9_9
+  build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 20228
-  timestamp: 1687884815549
+  size: 19506
+  timestamp: 1695990588610
 - name: brotli
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: win-64
   dependencies:
+    brotli-bin: ==1.1.0 hcfcfb64_1
+    libbrotlidec: ==1.1.0 hcfcfb64_1
+    libbrotlienc: ==1.1.0 hcfcfb64_1
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    libbrotlienc: ==1.0.9 hcfcfb64_9
-    brotli-bin: ==1.0.9 hcfcfb64_9
     vc14_runtime: '>=14.29.30139'
-    libbrotlidec: ==1.0.9 hcfcfb64_9
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-1.0.9-hcfcfb64_9.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
   hash:
-    md5: 5275e2634840f6d156934a16b7c0c813
-    sha256: 7bfc2b4002463dd69d140ab1b46bb36987581252d19af08b5eb9611e339cd7a3
+    md5: f47f6db2528e38321fb00ae31674c133
+    sha256: b927c95121c5f3d82fe084730281739fb04621afebf2d9f05711a0f42d27e326
   optional: false
   category: main
-  build: hcfcfb64_9
+  build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 20278
-  timestamp: 1687886707104
+  size: 19772
+  timestamp: 1695990547936
 - name: brotli-bin
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libbrotlienc: ==1.0.9 h166bdaf_9
+    libbrotlidec: ==1.1.0 hd590300_1
+    libbrotlienc: ==1.1.0 hd590300_1
     libgcc-ng: '>=12'
-    libbrotlidec: ==1.0.9 h166bdaf_9
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
   hash:
-    md5: d47dee1856d9cb955b8076eeff304a5b
-    sha256: 1c128f136a59ee2fa47d7fbd9b6fc8afa8460d340e4ae0e6f5419ebbd7539a10
+    md5: 39f910d205726805a958da408ca194ba
+    sha256: a641abfbaec54f454c8434061fffa7fdaa9c695e8a5a400ed96b4f07c0c00677
   optional: false
   category: main
-  build: h166bdaf_9
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 20361
-  timestamp: 1687884277426
+  size: 18980
+  timestamp: 1695990054140
 - name: brotli-bin
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    libbrotlienc: ==1.0.9 hb7f2c08_9
-    libbrotlidec: ==1.0.9 hb7f2c08_9
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_9.conda
+    libbrotlidec: ==1.1.0 h0dc2134_1
+    libbrotlienc: ==1.1.0 h0dc2134_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
   hash:
-    md5: 72c526f7ffa265473e6c75fd90605e52
-    sha256: 98c257aee9b60dc91a86fc486b19192eebfe9ec7929b4efff99b6fb643f85b05
+    md5: ece565c215adcc47fc1db4e651ee094b
+    sha256: 7ca3cfb4c5df314ed481301335387ab2b2ee651e2c74fbb15bacc795c664a5f1
   optional: false
   category: main
-  build: hb7f2c08_9
+  build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 17977
-  timestamp: 1687884724119
+  size: 16660
+  timestamp: 1695990286737
 - name: brotli-bin
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libbrotlienc: ==1.0.9 h1a8c8d9_9
-    libbrotlidec: ==1.0.9 h1a8c8d9_9
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_9.conda
+    libbrotlidec: ==1.1.0 hb547adb_1
+    libbrotlienc: ==1.1.0 hb547adb_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
   hash:
-    md5: 19ad562adca69541e67613022b41df5b
-    sha256: 4731892fb855f5993129515c5b63b36d049cc64e70611c6afa8f64aae5f51323
+    md5: 990d04f8c017b1b77103f9a7730a5f12
+    sha256: 8fbfc2834606292016f2faffac67deea4c5cdbc21a61169f0b355e1600105a24
   optional: false
   category: main
-  build: h1a8c8d9_9
+  build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 18182
-  timestamp: 1687884787034
+  size: 17001
+  timestamp: 1695990551239
 - name: brotli-bin
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: win-64
   dependencies:
+    libbrotlidec: ==1.1.0 hcfcfb64_1
+    libbrotlienc: ==1.1.0 hcfcfb64_1
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    libbrotlienc: ==1.0.9 hcfcfb64_9
     vc14_runtime: '>=14.29.30139'
-    libbrotlidec: ==1.0.9 hcfcfb64_9
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.0.9-hcfcfb64_9.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
   hash:
-    md5: ba8ae6c24cf47da3fb73270e4f119f08
-    sha256: 08c1431f7b4946a568d8f44d452a9358a841eaa58dd64dee66d8ac7bf1092673
+    md5: 0105229d7c5fabaa840043a86c10ec64
+    sha256: 4fbcb8f94acc97b2b04adbc64e304acd7c06fa0cf01953527bddae46091cc942
   optional: false
   category: main
-  build: hcfcfb64_9
+  build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 22498
-  timestamp: 1687886681486
+  size: 20885
+  timestamp: 1695990517506
 - name: brotli-python
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.0.9-py311ha362b79_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
   hash:
-    md5: ced5340f5dc6cff43a80deac8d0e398f
-    sha256: e2c0a391839914a1b3611b661ebd1736dd747f43a4611254d9333d9db3163ec7
+    md5: cce9e7c3f1c307f2a5fb08a2922d6164
+    sha256: 559093679e9fdb6061b7b80ca0f9a31fe6ffc213f1dae65bc5c82e2cd1a94107
   optional: false
   category: main
-  build: py311ha362b79_9
+  build: py311hb755f60_1
   arch: x86_64
   subdir: linux-64
-  build_number: 9
+  build_number: 1
   constrains:
-  - libbrotlicommon 1.0.9 h166bdaf_9
+  - libbrotlicommon 1.1.0 hd590300_1
   license: MIT
   license_family: MIT
-  size: 327121
-  timestamp: 1687884370597
+  size: 351340
+  timestamp: 1695990160360
 - name: brotli-python
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies:
+    libcxx: '>=15.0.7'
     python: '>=3.11,<3.12.0a0'
-    libcxx: '>=14.0.6'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.0.9-py311h814d153_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
   hash:
-    md5: 034ddcc806d421524fbc46778447e87c
-    sha256: 0d49fcc6eddfc5d87844419b9de4267a83e870331102bf01ca41e404e4374293
+    md5: 546fdccabb90492fbaf2da4ffb78f352
+    sha256: 0f5e0a7de58006f349220365e32db521a1fe494c37ee455e5ecf05b8fe567dcc
   optional: false
   category: main
-  build: py311h814d153_9
+  build: py311hdf8f085_1
   arch: x86_64
   subdir: osx-64
-  build_number: 9
+  build_number: 1
   constrains:
-  - libbrotlicommon 1.0.9 hb7f2c08_9
+  - libbrotlicommon 1.1.0 h0dc2134_1
   license: MIT
   license_family: MIT
-  size: 351794
-  timestamp: 1687885468850
+  size: 366864
+  timestamp: 1695990449997
 - name: brotli-python
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    libcxx: '>=15.0.7'
     python: '>=3.11,<3.12.0a0 *_cpython'
-    libcxx: '>=14.0.6'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py311ha397e9f_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311ha891d26_1.conda
   hash:
-    md5: 34c36b315dc70cde887ea8c3991b994d
-    sha256: a0f54181606c26b754567feac9d0595b7d5de5d199aa15129dcfa3eed10ef3b7
+    md5: 5e802b015e33447d1283d599d21f052b
+    sha256: 2d78c79ccf2c17236c52ef217a4c34b762eb7908a6903d94439f787aac1c8f4b
   optional: false
   category: main
-  build: py311ha397e9f_9
+  build: py311ha891d26_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 9
+  build_number: 1
   constrains:
-  - libbrotlicommon 1.0.9 h1a8c8d9_9
+  - libbrotlicommon 1.1.0 hb547adb_1
   license: MIT
   license_family: MIT
-  size: 325107
-  timestamp: 1687885049582
+  size: 343332
+  timestamp: 1695991223439
 - name: brotli-python
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.0.9-py311h12c1d0e_9.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
   hash:
-    md5: e3f916714f59b88acb5d3c9d83b6f44a
-    sha256: 69733919c0f46b8f2caf4d1301dcc9be7019e01d99b6dc713aff0859760c42a5
+    md5: 42fbf4e947c17ea605e6a4d7f526669a
+    sha256: 5390e1e5e8e159d4893ecbfd2c08ca75ef51bdce1a4a44ff4ee9e2d596004aac
   optional: false
   category: main
-  build: py311h12c1d0e_9
+  build: py311h12c1d0e_1
   arch: x86_64
   subdir: win-64
-  build_number: 9
+  build_number: 1
   constrains:
-  - libbrotlicommon 1.0.9 hcfcfb64_9
+  - libbrotlicommon 1.1.0 hcfcfb64_1
   license: MIT
   license_family: MIT
-  size: 308792
-  timestamp: 1687886791753
+  size: 322086
+  timestamp: 1695990976742
 - name: bzip2
   version: 1.0.8
   manager: conda
@@ -1596,14 +1684,14 @@ package:
   size: 152247
   timestamp: 1606605223049
 - name: ca-certificates
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.5.7-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
   hash:
-    md5: f5c65075fc34438d5b456c7f3f5ab695
-    sha256: 0cf1bb3d0bfc5519b60af2c360fa4888fb838e1476b1e0f65b9dbc48b45c7345
+    md5: a73ecd2988327ad4c8f2c331482917f2
+    sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
   optional: false
   category: main
   build: hbcca054_0
@@ -1611,17 +1699,17 @@ package:
   subdir: linux-64
   build_number: 0
   license: ISC
-  size: 148360
-  timestamp: 1683451720318
+  size: 149515
+  timestamp: 1690026108541
 - name: ca-certificates
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.5.7-h8857fd0_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
   hash:
-    md5: b704e4b79ba0d887c4870b7b09d6a4df
-    sha256: a06c9c788de81da3a3868ac56781680cc1fc50a0b5a545d4453818975c141b2c
+    md5: bf2c54c18997bf3542af074c10191771
+    sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
   optional: false
   category: main
   build: h8857fd0_0
@@ -1629,17 +1717,17 @@ package:
   subdir: osx-64
   build_number: 0
   license: ISC
-  size: 148522
-  timestamp: 1683451939937
+  size: 149911
+  timestamp: 1690026363769
 - name: ca-certificates
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.5.7-hf0a4a13_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
   hash:
-    md5: a8387be82224743cf849fb907790b91a
-    sha256: 27214b54d1cb9a92455689e20d0007a0ff9ace99b853867d53a05a04c24bdae5
+    md5: e1b99ac4dbcee71a71682996f67f7965
+    sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
   optional: false
   category: main
   build: hf0a4a13_0
@@ -1647,17 +1735,17 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: ISC
-  size: 148524
-  timestamp: 1683451885269
+  size: 149918
+  timestamp: 1690026385821
 - name: ca-certificates
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.5.7-h56e8100_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
   hash:
-    md5: 604212634bd8c4d6f20d44b946e8eedb
-    sha256: d0488a3e7a86cc11f8c847a7c12a5f1fb8567f05646faae78944807862f9d167
+    md5: b1c2327b36f1a25d96f2039b0d3e3739
+    sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
   optional: false
   category: main
   build: h56e8100_0
@@ -1665,52 +1753,220 @@ package:
   subdir: win-64
   build_number: 0
   license: ISC
-  size: 148581
-  timestamp: 1683451822049
+  size: 150013
+  timestamp: 1690026269050
+- name: cached-property
+  version: 1.5.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cached_property: '>=1.5.2,<1.5.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  hash:
+    md5: 9b347a7ec10940d3f7941ff6c460b551
+    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  optional: false
+  category: main
+  build: hd8ed1ab_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 4134
+  timestamp: 1615209571450
+- name: cached-property
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cached_property: '>=1.5.2,<1.5.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  hash:
+    md5: 9b347a7ec10940d3f7941ff6c460b551
+    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  optional: false
+  category: main
+  build: hd8ed1ab_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 4134
+  timestamp: 1615209571450
+- name: cached-property
+  version: 1.5.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cached_property: '>=1.5.2,<1.5.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  hash:
+    md5: 9b347a7ec10940d3f7941ff6c460b551
+    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  optional: false
+  category: main
+  build: hd8ed1ab_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 4134
+  timestamp: 1615209571450
+- name: cached-property
+  version: 1.5.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    cached_property: '>=1.5.2,<1.5.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
+  hash:
+    md5: 9b347a7ec10940d3f7941ff6c460b551
+    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
+  optional: false
+  category: main
+  build: hd8ed1ab_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 4134
+  timestamp: 1615209571450
+- name: cached_property
+  version: 1.5.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  hash:
+    md5: 576d629e47797577ab0f1b351297ef4a
+    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  optional: false
+  category: main
+  build: pyha770c72_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 11065
+  timestamp: 1615209567874
+- name: cached_property
+  version: 1.5.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  hash:
+    md5: 576d629e47797577ab0f1b351297ef4a
+    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  optional: false
+  category: main
+  build: pyha770c72_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 11065
+  timestamp: 1615209567874
+- name: cached_property
+  version: 1.5.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  hash:
+    md5: 576d629e47797577ab0f1b351297ef4a
+    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  optional: false
+  category: main
+  build: pyha770c72_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 11065
+  timestamp: 1615209567874
+- name: cached_property
+  version: 1.5.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
+  hash:
+    md5: 576d629e47797577ab0f1b351297ef4a
+    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
+  optional: false
+  category: main
+  build: pyha770c72_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 11065
+  timestamp: 1615209567874
 - name: cairo
   version: 1.16.0
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-libxrender: '*'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libgcc-ng: '>=12'
-    xorg-libsm: '*'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    icu: '>=72.1,<73.0a0'
-    libglib: '>=2.76.2,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    xorg-libice: '*'
-    zlib: '*'
     fontconfig: '>=2.14.2,<3.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
     fonts-conda-ecosystem: '*'
-    xorg-libx11: '>=1.8.4,<2.0a0'
+    freetype: '>=2.12.1,<3.0a0'
+    icu: '>=73.2,<74.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.76.4,<3.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     pixman: '>=0.40.0,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-hbbf8b49_1016.conda
+    xorg-libice: '>=1.1.1,<2.0a0'
+    xorg-libsm: '>=1.2.4,<2.0a0'
+    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+    zlib: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-h0c91306_1017.conda
   hash:
-    md5: c1dd96500b9b1a75e9e511931f415cbc
-    sha256: 1fffecc684c26e0f1aed6d9857ad0f2abfe3a849977f718ad82366c68c7a9a36
+    md5: 3db543896d34fc6804ddfb9239dcb125
+    sha256: e8218419ba02e49b1b33365f139622ed23c93c089ebbcef99ac1c6d05a07f247
   optional: false
   category: main
-  build: hbbf8b49_1016
+  build: h0c91306_1017
   arch: x86_64
   subdir: linux-64
-  build_number: 1016
+  build_number: 1017
   license: LGPL-2.1-only or MPL-1.1
-  size: 1107996
-  timestamp: 1684639348133
+  size: 1106759
+  timestamp: 1692960387046
 - name: certifi
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d1b71c942b8421285934dad1d891ebc
-    sha256: f839a6e04d94069f90dd85337ea9108f058dc76771bb469a413f32bb1ba0b256
+    md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+    sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1719,18 +1975,18 @@ package:
   build_number: 0
   license: ISC
   noarch: python
-  size: 152383
-  timestamp: 1683450391501
+  size: 153791
+  timestamp: 1690024617757
 - name: certifi
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d1b71c942b8421285934dad1d891ebc
-    sha256: f839a6e04d94069f90dd85337ea9108f058dc76771bb469a413f32bb1ba0b256
+    md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+    sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1739,18 +1995,18 @@ package:
   build_number: 0
   license: ISC
   noarch: python
-  size: 152383
-  timestamp: 1683450391501
+  size: 153791
+  timestamp: 1690024617757
 - name: certifi
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d1b71c942b8421285934dad1d891ebc
-    sha256: f839a6e04d94069f90dd85337ea9108f058dc76771bb469a413f32bb1ba0b256
+    md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+    sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1759,18 +2015,18 @@ package:
   build_number: 0
   license: ISC
   noarch: python
-  size: 152383
-  timestamp: 1683450391501
+  size: 153791
+  timestamp: 1690024617757
 - name: certifi
-  version: 2023.5.7
+  version: 2023.7.22
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.5.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 5d1b71c942b8421285934dad1d891ebc
-    sha256: f839a6e04d94069f90dd85337ea9108f058dc76771bb469a413f32bb1ba0b256
+    md5: 7f3dbc9179b4dde7da98dfb151d0ad22
+    sha256: db66e31866ff4250c190788769e3a8a1709237c3e9c38d7143aae95ab75fcb31
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1779,113 +2035,113 @@ package:
   build_number: 0
   license: ISC
   noarch: python
-  size: 152383
-  timestamp: 1683450391501
+  size: 153791
+  timestamp: 1690024617757
 - name: cffi
-  version: 1.15.1
+  version: 1.16.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    pycparser: '*'
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.15.1-py311h409f033_3.conda
+    pycparser: '*'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py311hb3a22ac_0.conda
   hash:
-    md5: 9025d0786dbbe4bc91fd8e85502decce
-    sha256: 7161bcdf1a304f76e88a05ed435c03ee92864ee5e8f4c938e35b089b3861b5a7
+    md5: b3469563ac5e808b0cd92810d0697043
+    sha256: b71c94528ca0c35133da4b7ef69b51a0b55eeee570376057f3d2ad60c3ab1444
   optional: false
   category: main
-  build: py311h409f033_3
+  build: py311hb3a22ac_0
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 295516
-  timestamp: 1671179478348
+  size: 300207
+  timestamp: 1696001873452
 - name: cffi
-  version: 1.15.1
+  version: 1.16.0
   manager: conda
   platform: osx-64
   dependencies:
+    libffi: '>=3.4,<4.0a0'
+    pycparser: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    pycparser: '*'
-    libffi: '>=3.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.15.1-py311ha86e640_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
   hash:
-    md5: 5967be4da33261eada7cc79593f71088
-    sha256: 436a99652d9b13ed4b945f05740b50c79447b581aa400f69607f56c4960b806d
+    md5: 15d07b82223cac96af629e5e747ba27a
+    sha256: 1f13a5fa7f310fdbd27f5eddceb9e62cfb10012c58a58c923dd6f51fa979748a
   optional: false
   category: main
-  build: py311ha86e640_3
+  build: py311hc0b63fd_0
   arch: x86_64
   subdir: osx-64
-  build_number: 3
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 280535
-  timestamp: 1671179829333
+  size: 289932
+  timestamp: 1696002096156
 - name: cffi
-  version: 1.15.1
+  version: 1.16.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    libffi: '>=3.4,<4.0a0'
+    pycparser: '*'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    pycparser: '*'
-    libffi: '>=3.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py311hae827db_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py311h4a08483_0.conda
   hash:
-    md5: bb7a416f8871a6cf6ddec76450d6cf7b
-    sha256: 28bf7f7c1ded35d270660183990056b6192e3fe06eaebb1043fd4b97ccea2b98
+    md5: cbdde0484a47b40e6ce2a4e5aaeb48d7
+    sha256: 9430416328fe2a28e206e703de771817064c8613a79a6a21fe7107f6a783104c
   optional: false
   category: main
-  build: py311hae827db_3
+  build: py311h4a08483_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 3
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 278614
-  timestamp: 1671179791632
+  size: 292511
+  timestamp: 1696002194472
 - name: cffi
-  version: 1.15.1
+  version: 1.16.0
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
+    pycparser: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    pycparser: '*'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.15.1-py311h7d9ee11_3.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
   hash:
-    md5: a8524727eb956b4741e25a64af79edb8
-    sha256: 49ce08187365f97c67476d504411de0a17e69b972ab6b80521d01dc80dd657e6
+    md5: d109d6e767c4890ea32880b8bfa4a3b6
+    sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
   optional: false
   category: main
-  build: py311h7d9ee11_3
+  build: py311ha68e1ae_0
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 292953
-  timestamp: 1671179769667
+  size: 297043
+  timestamp: 1696002186279
 - name: charset-normalizer
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 313516e9a4b08b12dfb1e1cd390a96e3
-    sha256: 0666a95fbbd2299008162e2126c009191e5953d1cad1878bf9f4d8d634af1dd4
+    md5: fef8ef5f0a54546b9efee39468229917
+    sha256: 3407cd21af7e85aeb9499c377e7db25d2bbb9cbaf2f47d92626b3471dca65b4c
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1895,18 +2151,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 45686
-  timestamp: 1688813585878
+  size: 46237
+  timestamp: 1696431275563
 - name: charset-normalizer
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 313516e9a4b08b12dfb1e1cd390a96e3
-    sha256: 0666a95fbbd2299008162e2126c009191e5953d1cad1878bf9f4d8d634af1dd4
+    md5: fef8ef5f0a54546b9efee39468229917
+    sha256: 3407cd21af7e85aeb9499c377e7db25d2bbb9cbaf2f47d92626b3471dca65b4c
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1916,18 +2172,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 45686
-  timestamp: 1688813585878
+  size: 46237
+  timestamp: 1696431275563
 - name: charset-normalizer
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 313516e9a4b08b12dfb1e1cd390a96e3
-    sha256: 0666a95fbbd2299008162e2126c009191e5953d1cad1878bf9f4d8d634af1dd4
+    md5: fef8ef5f0a54546b9efee39468229917
+    sha256: 3407cd21af7e85aeb9499c377e7db25d2bbb9cbaf2f47d92626b3471dca65b4c
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1937,18 +2193,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 45686
-  timestamp: 1688813585878
+  size: 46237
+  timestamp: 1696431275563
 - name: charset-normalizer
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 313516e9a4b08b12dfb1e1cd390a96e3
-    sha256: 0666a95fbbd2299008162e2126c009191e5953d1cad1878bf9f4d8d634af1dd4
+    md5: fef8ef5f0a54546b9efee39468229917
+    sha256: 3407cd21af7e85aeb9499c377e7db25d2bbb9cbaf2f47d92626b3471dca65b4c
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -1958,8 +2214,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 45686
-  timestamp: 1688813585878
+  size: 46237
+  timestamp: 1696431275563
 - name: colorama
   version: 0.4.6
   manager: conda
@@ -1982,16 +2238,16 @@ package:
   size: 25170
   timestamp: 1666700778190
 - name: comm
-  version: 0.1.3
+  version: 0.1.4
   manager: conda
   platform: linux-64
   dependencies:
-    traitlets: '>=5.3'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 168ae0f82cdf7505048e81054c7354e4
-    sha256: 657e0a513c8705dc542c54c4c5234e813b7f4e2f412688796d611e83ddf132ea
+    md5: c8eaca39e2b6abae1fc96acc929ae939
+    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2001,19 +2257,19 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 11480
-  timestamp: 1679481450658
+  size: 11682
+  timestamp: 1691045097208
 - name: comm
-  version: 0.1.3
+  version: 0.1.4
   manager: conda
   platform: osx-64
   dependencies:
-    traitlets: '>=5.3'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 168ae0f82cdf7505048e81054c7354e4
-    sha256: 657e0a513c8705dc542c54c4c5234e813b7f4e2f412688796d611e83ddf132ea
+    md5: c8eaca39e2b6abae1fc96acc929ae939
+    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2023,19 +2279,19 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 11480
-  timestamp: 1679481450658
+  size: 11682
+  timestamp: 1691045097208
 - name: comm
-  version: 0.1.3
+  version: 0.1.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    traitlets: '>=5.3'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 168ae0f82cdf7505048e81054c7354e4
-    sha256: 657e0a513c8705dc542c54c4c5234e813b7f4e2f412688796d611e83ddf132ea
+    md5: c8eaca39e2b6abae1fc96acc929ae939
+    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2045,19 +2301,19 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 11480
-  timestamp: 1679481450658
+  size: 11682
+  timestamp: 1691045097208
 - name: comm
-  version: 0.1.3
+  version: 0.1.4
   manager: conda
   platform: win-64
   dependencies:
-    traitlets: '>=5.3'
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.3-pyhd8ed1ab_0.conda
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 168ae0f82cdf7505048e81054c7354e4
-    sha256: 657e0a513c8705dc542c54c4c5234e813b7f4e2f412688796d611e83ddf132ea
+    md5: c8eaca39e2b6abae1fc96acc929ae939
+    sha256: 11057745946a95ee7cc4c98900a60c7362266a4cb28bc97d96cd88e3056eb701
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2067,113 +2323,113 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 11480
-  timestamp: 1679481450658
+  size: 11682
+  timestamp: 1691045097208
 - name: contourpy
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    numpy: '>=1.16'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
+    numpy: '>=1.16'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.0-py311h9547e67_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.1.1-py311h9547e67_1.conda
   hash:
-    md5: daf3f23397ab2265d0cdfa339f3627ba
-    sha256: a4bfb068ccce9be161f8f0af98613fa9d0f3b7f0a5e526dea063dc42fb8a3a04
+    md5: 52d3de443952d33c5cee6b24b172ce96
+    sha256: dbc70ddc7ce3e764b22e9ebc14e635268b2d9e8b0abe32a19f46def110eb8f47
   optional: false
   category: main
-  build: py311h9547e67_0
+  build: py311h9547e67_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 230852
-  timestamp: 1686733988401
+  size: 234891
+  timestamp: 1695554431837
 - name: contourpy
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: osx-64
   dependencies:
-    numpy: '>=1.16'
     libcxx: '>=15.0.7'
+    numpy: '>=1.16'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.0-py311h5fe6e05_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.1.1-py311h5fe6e05_1.conda
   hash:
-    md5: 1969042c846644a15c25ea78f487459c
-    sha256: a4ea7bf689d1e20775094931c86190c64eb8b3cedc00bf4ff2596872c5963d0a
+    md5: a8e5f688e3249e1dea90b4dd4eede1a7
+    sha256: 7a2d0dcd69098d87455268a2b46cbec46a97de7090048f7ac8cadaae3d21a60e
   optional: false
   category: main
-  build: py311h5fe6e05_0
+  build: py311h5fe6e05_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 225625
-  timestamp: 1686734338502
+  size: 229250
+  timestamp: 1695554561690
 - name: contourpy
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    numpy: '>=1.16'
     libcxx: '>=15.0.7'
+    numpy: '>=1.16'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.0-py311he4fd1f5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.1.1-py311he4fd1f5_1.conda
   hash:
-    md5: 03634a2747d92b95126d493a8f2cbd8f
-    sha256: 37cdb9dc731a5782047056290feb9db1bd2aee5028537b27d1afab40e9d83161
+    md5: 14a8e6c8088ec971aa1a35dfd846797b
+    sha256: 6fa58b8451707ec4261fdec6c48d4e65addbd168f3c5073c8bdd757db1e2005c
   optional: false
   category: main
-  build: py311he4fd1f5_0
+  build: py311he4fd1f5_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 224881
-  timestamp: 1686734353495
+  size: 228551
+  timestamp: 1695554685850
 - name: contourpy
-  version: 1.1.0
+  version: 1.1.1
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     numpy: '>=1.16'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.0-py311h005e61a_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.1.1-py311h005e61a_1.conda
   hash:
-    md5: 86659e75f43068aacce35f3d93e9d80e
-    sha256: 36d98060fef7b77c71545365ff52afd10f29b18478a1332b7aa5b6f0357f4cef
+    md5: 12947dd3b9884bf165cb53cf93c69799
+    sha256: 75f9c46aed36f51a63dd85e9696692bbcd3b5282ef7df84003f081179e6a4d8e
   optional: false
   category: main
-  build: py311h005e61a_0
+  build: py311h005e61a_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 182954
-  timestamp: 1686734495403
+  size: 185671
+  timestamp: 1695554665873
 - name: cycler
-  version: 0.11.0
+  version: 0.12.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a50559fad0affdbb33729a68669ca1cb
-    sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2181,20 +2437,19 @@ package:
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 10307
-  timestamp: 1635519555262
+  size: 13458
+  timestamp: 1696677888423
 - name: cycler
-  version: 0.11.0
+  version: 0.12.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a50559fad0affdbb33729a68669ca1cb
-    sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2202,20 +2457,19 @@ package:
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 10307
-  timestamp: 1635519555262
+  size: 13458
+  timestamp: 1696677888423
 - name: cycler
-  version: 0.11.0
+  version: 0.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a50559fad0affdbb33729a68669ca1cb
-    sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2223,20 +2477,19 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 10307
-  timestamp: 1635519555262
+  size: 13458
+  timestamp: 1696677888423
 - name: cycler
-  version: 0.11.0
+  version: 0.12.1
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a50559fad0affdbb33729a68669ca1cb
-    sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2244,18 +2497,17 @@ package:
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 10307
-  timestamp: 1635519555262
+  size: 13458
+  timestamp: 1696677888423
 - name: dbus
   version: 1.13.6
   manager: conda
   platform: linux-64
   dependencies:
-    libglib: '>=2.70.2,<3.0a0'
-    libgcc-ng: '>=9.4.0'
     expat: '>=2.4.2,<3.0a0'
+    libgcc-ng: '>=9.4.0'
+    libglib: '>=2.70.2,<3.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
   hash:
     md5: ecfff944ba3960ecb334b9a2663d708d
@@ -2271,96 +2523,96 @@ package:
   size: 618596
   timestamp: 1640112124844
 - name: debugpy
-  version: 1.6.7
+  version: 1.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    libstdcxx-ng: '>=12'
-    python_abi: 3.11.* *_cp311
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.6.7-py311hcafe171_0.conda
+    libstdcxx-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py311hb755f60_1.conda
   hash:
-    md5: f4c810ad9d791c8df5ad900ed74b085b
-    sha256: d9efff4affb277ae72d537d1d4e8d5f9204919b953813b13ac6f428d8efa93cf
+    md5: 2c241533b8eafe8028442d46ef41eb13
+    sha256: f18492ebfaea54bbbeaec0ae207851f711ff589f60f2cc9b8a689f88b2442171
   optional: false
   category: main
-  build: py311hcafe171_0
+  build: py311hb755f60_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 2298861
-  timestamp: 1680755612259
+  size: 3001696
+  timestamp: 1695534493087
 - name: debugpy
-  version: 1.6.7
+  version: 1.8.0
   manager: conda
   platform: osx-64
   dependencies:
+    libcxx: '>=15.0.7'
     python: '>=3.11,<3.12.0a0'
-    libcxx: '>=14.0.6'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.6.7-py311h814d153_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py311hdf8f085_1.conda
   hash:
-    md5: c27802860b87fe024c9b6276205a56b5
-    sha256: d6097236ed8720606c17685d759bb6010331cc4bee835921f586917b1d5ec564
+    md5: 7f20ef8a63be62d1bcdaa8136ec09647
+    sha256: 93e94c9077b13f3dde47794bb6ca02f9c3174c794edf889158306a54764a075c
   optional: false
   category: main
-  build: py311h814d153_0
+  build: py311hdf8f085_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 2244926
-  timestamp: 1680756034707
+  size: 2939392
+  timestamp: 1695534639423
 - name: debugpy
-  version: 1.6.7
+  version: 1.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
+    libcxx: '>=15.0.7'
     python: '>=3.11,<3.12.0a0 *_cpython'
-    libcxx: '>=14.0.6'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.6.7-py311ha397e9f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py311ha891d26_1.conda
   hash:
-    md5: 28d404816181a50fa74b8cc6c8fd5ca0
-    sha256: e0b01eece2a1155d1b5a34dfde53829c5cb96b96179cff9a9bedb8d1f0d34e9e
+    md5: 575b875f1e7901213e9a0f44db9deccc
+    sha256: a7c3b4abf2d3d5256be7e891e76c86dd52e3893e9495d468e3c95e82932b9d7b
   optional: false
   category: main
-  build: py311ha397e9f_0
+  build: py311ha891d26_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 2273997
-  timestamp: 1680756057837
+  size: 2957693
+  timestamp: 1695534717336
 - name: debugpy
-  version: 1.6.7
+  version: 1.8.0
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.6.7-py311h12c1d0e_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py311h12c1d0e_1.conda
   hash:
-    md5: b056c7299be929b711016d2f4e48d303
-    sha256: 7e3dc2ea1f4f2bd90572c0aa5466b80d0debbc24b17f2ac778324fd56d80ce8f
+    md5: 8f521f35a7544cbf058b24e11561d53a
+    sha256: df14ab3bfa7864fedda2d45b16057792ad29dd607f0ff9a86b3e9cfbd0c41332
   optional: false
   category: main
-  build: py311h12c1d0e_0
+  build: py311h12c1d0e_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 3268456
-  timestamp: 1680756242290
+  size: 3870801
+  timestamp: 1695534773660
 - name: decorator
   version: 5.1.1
   manager: conda
@@ -2614,15 +2866,15 @@ package:
   size: 9199
   timestamp: 1643888357950
 - name: exceptiongroup
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: de4cb3384374e1411f0454edcf546cdb
-    sha256: 7b23ea0169fa6e7c3a0867d96d9eacd312759f83e5d83ad0fcc93e85379c16ae
+    md5: e6518222753f519e911e83136d2158d9
+    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2632,18 +2884,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 19043
-  timestamp: 1688381208754
+  size: 19262
+  timestamp: 1692026296517
 - name: exceptiongroup
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: de4cb3384374e1411f0454edcf546cdb
-    sha256: 7b23ea0169fa6e7c3a0867d96d9eacd312759f83e5d83ad0fcc93e85379c16ae
+    md5: e6518222753f519e911e83136d2158d9
+    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2653,18 +2905,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 19043
-  timestamp: 1688381208754
+  size: 19262
+  timestamp: 1692026296517
 - name: exceptiongroup
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: de4cb3384374e1411f0454edcf546cdb
-    sha256: 7b23ea0169fa6e7c3a0867d96d9eacd312759f83e5d83ad0fcc93e85379c16ae
+    md5: e6518222753f519e911e83136d2158d9
+    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2674,18 +2926,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 19043
-  timestamp: 1688381208754
+  size: 19262
+  timestamp: 1692026296517
 - name: exceptiongroup
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
   hash:
-    md5: de4cb3384374e1411f0454edcf546cdb
-    sha256: 7b23ea0169fa6e7c3a0867d96d9eacd312759f83e5d83ad0fcc93e85379c16ae
+    md5: e6518222753f519e911e83136d2158d9
+    sha256: c28f715e049fe0f09785660bcbffa175ffb438720e5bc5a60d56d4b08364b315
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -2695,8 +2947,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 19043
-  timestamp: 1688381208754
+  size: 19262
+  timestamp: 1692026296517
 - name: executing
   version: 1.2.0
   manager: conda
@@ -2802,90 +3054,6 @@ package:
   license_family: MIT
   size: 136778
   timestamp: 1680190541750
-- name: flit-core
-  version: 3.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e8cfceef004266b259604c3faa2a0191
-    sha256: a2ef503739ac22bf2a5d91c6a7b0f6a4413a56fbdb9b84f8f70427b9e37fbb69
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 49072
-  timestamp: 1684084485822
-- name: flit-core
-  version: 3.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e8cfceef004266b259604c3faa2a0191
-    sha256: a2ef503739ac22bf2a5d91c6a7b0f6a4413a56fbdb9b84f8f70427b9e37fbb69
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 49072
-  timestamp: 1684084485822
-- name: flit-core
-  version: 3.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e8cfceef004266b259604c3faa2a0191
-    sha256: a2ef503739ac22bf2a5d91c6a7b0f6a4413a56fbdb9b84f8f70427b9e37fbb69
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 49072
-  timestamp: 1684084485822
-- name: flit-core
-  version: 3.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e8cfceef004266b259604c3faa2a0191
-    sha256: a2ef503739ac22bf2a5d91c6a7b0f6a4413a56fbdb9b84f8f70427b9e37fbb69
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 49072
-  timestamp: 1684084485822
 - name: font-ttf-dejavu-sans-mono
   version: '2.37'
   manager: conda
@@ -2971,11 +3139,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    expat: '>=2.5.0,<3.0a0'
+    freetype: '>=2.12.1,<3.0a0'
     libgcc-ng: '>=12'
     libuuid: '>=2.32.1,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    expat: '>=2.5.0,<3.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
   hash:
     md5: 0f69b688f52ff6da70bccb7ff7001d1d
@@ -3016,10 +3184,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    font-ttf-ubuntu: '*'
-    font-ttf-inconsolata: '*'
     font-ttf-dejavu-sans-mono: '*'
+    font-ttf-inconsolata: '*'
     font-ttf-source-code-pro: '*'
+    font-ttf-ubuntu: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
@@ -3036,19 +3204,19 @@ package:
   size: 4102
   timestamp: 1566932280397
 - name: fonttools
-  version: 4.41.0
+  version: 4.43.1
   manager: conda
   platform: linux-64
   dependencies:
     brotli: '*'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
     libgcc-ng: '>=12'
     munkres: '*'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.41.0-py311h459d7ec_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.43.1-py311h459d7ec_0.conda
   hash:
-    md5: dbe23d19ab7f05bb08dd7d1838dc5547
-    sha256: b19ddba30d7a2d30d6099f5d711afa6015fe4c347990c1673ea4419644a11f8e
+    md5: ac995b680de3bdce2531c553b27dfe7e
+    sha256: 6bb6d8f3316b8a6ea0701db9985cde6a7b59587be723182700e838d5474a354a
   optional: false
   category: main
   build: py311h459d7ec_0
@@ -3057,70 +3225,70 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2660010
-  timestamp: 1689196945209
+  size: 2760186
+  timestamp: 1696601464671
 - name: fonttools
-  version: 4.41.0
+  version: 4.43.1
   manager: conda
   platform: osx-64
   dependencies:
     brotli: '*'
+    munkres: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    munkres: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.41.0-py311h2725bcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.43.1-py311he705e18_0.conda
   hash:
-    md5: d7dfcb70d2b0dfe07c4c7ed05cc91af1
-    sha256: 4634238fe410e3a63023c4a009c170c3474b623c753c445fb9c6e59d403bcf90
+    md5: 08a64b9eafc59720c1732a689e64f59c
+    sha256: 6fe82a512c3fa204a50367522e78a62a71df6b6729924793ebe644a8600d852a
   optional: false
   category: main
-  build: py311h2725bcf_0
+  build: py311he705e18_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2598099
-  timestamp: 1689197203441
+  size: 2647724
+  timestamp: 1696601655817
 - name: fonttools
-  version: 4.41.0
+  version: 4.43.1
   manager: conda
   platform: osx-arm64
   dependencies:
     brotli: '*'
+    munkres: '*'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    munkres: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.41.0-py311heffc1b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.43.1-py311h05b510d_0.conda
   hash:
-    md5: b78ad080c72b9768d99756122789f8dc
-    sha256: 37f3e9c143c937dda1dea2d63a4bcfc7cb26998b9a587f9d80982b8ace1fa57c
+    md5: b2fa21c160775e62af06d2db79dfc42d
+    sha256: 0c30de5f545b2b5a38d5239260d796d457bae77bb114c07ed2154a764d76e0c2
   optional: false
   category: main
-  build: py311heffc1b2_0
+  build: py311h05b510d_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2615621
-  timestamp: 1689197201339
+  size: 2682609
+  timestamp: 1696601722810
 - name: fonttools
-  version: 4.41.0
+  version: 4.43.1
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
+    brotli: '*'
+    munkres: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    vc14_runtime: '>=14.29.30139'
-    brotli: '*'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    munkres: '*'
-  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.41.0-py311ha68e1ae_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.43.1-py311ha68e1ae_0.conda
   hash:
-    md5: 2e91511d0cae514d376f028c5335db91
-    sha256: 861c1acdfb231d457841b072fc3ae6454f1b90b48684dc1a7312e7791b435a8a
+    md5: 64bb0eec43927cff8b5973ca4d81a1cc
+    sha256: 4947f9c3851bcc9aad42230abbfdf657d6f5ddd5238396bcd794cebfbac228ad
   optional: false
   category: main
   build: py311ha68e1ae_0
@@ -3129,69 +3297,157 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2297977
-  timestamp: 1689197302718
+  size: 2366967
+  timestamp: 1696601840517
+- name: fqdn
+  version: 1.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cached-property: '>=1.3.0'
+    python: '>=2.7,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 642d35437078749ef23a5dca2c9bb1f3
+    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 14395
+  timestamp: 1638810388635
+- name: fqdn
+  version: 1.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    cached-property: '>=1.3.0'
+    python: '>=2.7,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 642d35437078749ef23a5dca2c9bb1f3
+    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 14395
+  timestamp: 1638810388635
+- name: fqdn
+  version: 1.5.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cached-property: '>=1.3.0'
+    python: '>=2.7,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 642d35437078749ef23a5dca2c9bb1f3
+    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 14395
+  timestamp: 1638810388635
+- name: fqdn
+  version: 1.5.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    cached-property: '>=1.3.0'
+    python: '>=2.7,<4'
+  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 642d35437078749ef23a5dca2c9bb1f3
+    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MPL-2.0
+  license_family: MOZILLA
+  noarch: python
+  size: 14395
+  timestamp: 1638810388635
 - name: freetype
   version: 2.12.1
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
     libpng: '>=1.6.39,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-hca18f0e_1.conda
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   hash:
-    md5: e1232042de76d24539a436d37597eb06
-    sha256: 1eb913727b54e9aa63c6d9a1177db4e2894cee97c5f26910a2b61899d5ac904f
+    md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+    sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   optional: false
   category: main
-  build: hca18f0e_1
+  build: h267a509_2
   arch: x86_64
   subdir: linux-64
-  build_number: 1
-  license: GPL-2.0-only and LicenseRef-FreeType
-  size: 625655
-  timestamp: 1669232824158
+  build_number: 2
+  license: GPL-2.0-only OR FTL
+  size: 634972
+  timestamp: 1694615932610
 - name: freetype
   version: 2.12.1
   manager: conda
   platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     libpng: '>=1.6.39,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h3f81eb7_1.conda
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
   hash:
-    md5: 852224ea3e8991a8342228eab274840e
-    sha256: 0aea2b93d0da8bf022501857de93f2fc0e362fabcd83c4579be8d8f5bc3e17cb
+    md5: 25152fce119320c980e5470e64834b50
+    sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
   optional: false
   category: main
-  build: h3f81eb7_1
+  build: h60636b9_2
   arch: x86_64
   subdir: osx-64
-  build_number: 1
-  license: GPL-2.0-only and LicenseRef-FreeType
-  size: 599569
-  timestamp: 1669233263749
+  build_number: 2
+  license: GPL-2.0-only OR FTL
+  size: 599300
+  timestamp: 1694616137838
 - name: freetype
   version: 2.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     libpng: '>=1.6.39,<1.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hd633e50_1.conda
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
   hash:
-    md5: 33ea6326e26d1da25eb8dfa768195b82
-    sha256: 9f20ac782386cca6295cf02a07bbc6aedc4739330dc9caba242630602a9ab7f4
+    md5: e6085e516a3e304ce41a8ee08b9b89ad
+    sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
   optional: false
   category: main
-  build: hd633e50_1
+  build: hadb7bae_2
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
-  license: GPL-2.0-only and LicenseRef-FreeType
-  size: 572579
-  timestamp: 1669233072570
+  build_number: 2
+  license: GPL-2.0-only OR FTL
+  size: 596430
+  timestamp: 1694616332835
 - name: freetype
   version: 2.12.1
   manager: conda
@@ -3199,21 +3455,22 @@ package:
   dependencies:
     libpng: '>=1.6.39,<1.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
-  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-h546665d_1.conda
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
   hash:
-    md5: 1b513009cd012591f3fdc9e03a74ec0a
-    sha256: fe027235660d9dfe7889c350a51e96bc0134c3f408827a4c58c4b0557409984c
+    md5: 3761b23693f768dc75a8fd0a73ca053f
+    sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
   optional: false
   category: main
-  build: h546665d_1
+  build: hdaf720e_2
   arch: x86_64
   subdir: win-64
-  build_number: 1
-  license: GPL-2.0-only and LicenseRef-FreeType
-  size: 497412
-  timestamp: 1669233360876
+  build_number: 2
+  license: GPL-2.0-only OR FTL
+  size: 510306
+  timestamp: 1694616398888
 - name: gettext
   version: 0.21.1
   manager: conda
@@ -3253,21 +3510,21 @@ package:
   size: 5579416
   timestamp: 1665676022441
 - name: glib
-  version: 2.76.4
+  version: 2.78.0
   manager: conda
   platform: linux-64
   dependencies:
-    glib-tools: ==2.76.4 hfc55251_0
-    python: '*'
     gettext: '>=0.21.1,<1.0a0'
-    libstdcxx-ng: '>=12'
-    libglib: ==2.76.4 hebfc3b9_0
-    libzlib: '>=1.2.13,<1.3.0a0'
+    glib-tools: ==2.78.0 hfc55251_0
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.76.4-hfc55251_0.conda
+    libglib: ==2.78.0 hebfc3b9_0
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    python: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.0-hfc55251_0.conda
   hash:
-    md5: dbcec5fd9c6c8be24b23575048755a59
-    sha256: 85de9ec71a143e9b86e381e865341f2d706387f3d3facaf935d4598b6dfa7229
+    md5: 2f55a36b549f51a7e0c2b1e3c3f0ccd4
+    sha256: b7fd5ef9aee4205e14105dc9f79b3de326af091c0253e1e52d3e4ee0d960851d
   optional: false
   category: main
   build: hfc55251_0
@@ -3275,25 +3532,25 @@ package:
   subdir: linux-64
   build_number: 0
   license: LGPL-2.1-or-later
-  size: 482405
-  timestamp: 1688694735795
+  size: 490912
+  timestamp: 1694381302237
 - name: glib
-  version: 2.76.4
+  version: 2.78.0
   manager: conda
   platform: win-64
   dependencies:
-    glib-tools: ==2.76.4 h12be248_0
-    python: '*'
-    libglib: ==2.76.4 he8f3873_0
+    gettext: '>=0.21.1,<1.0a0'
+    glib-tools: ==2.78.0 h12be248_0
+    libglib: ==2.78.0 he8f3873_0
     libzlib: '>=1.2.13,<1.3.0a0'
+    python: '*'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-    ucrt: '>=10.0.20348.0'
-    gettext: '>=0.21.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.76.4-h12be248_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.0-h12be248_0.conda
   hash:
-    md5: 4d7ae53ee4b7e08f3fbd1d3a7efd4812
-    sha256: 96457df6c2cb42ec32c25a135ca1232e740f21fe20216e54024df9274f5ae4ad
+    md5: 1ed98e4da48693079f2fe83298c5b0ac
+    sha256: a9860e833d1ac9e2e87e5a0ae6863c819d893dac90aa1f6df9c06ab312d80170
   optional: false
   category: main
   build: h12be248_0
@@ -3301,21 +3558,21 @@ package:
   subdir: win-64
   build_number: 0
   license: LGPL-2.1-or-later
-  size: 499494
-  timestamp: 1688695170322
+  size: 509622
+  timestamp: 1694381620175
 - name: glib-tools
-  version: 2.76.4
+  version: 2.78.0
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx-ng: '>=12'
-    libglib: ==2.76.4 hebfc3b9_0
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.76.4-hfc55251_0.conda
+    libglib: ==2.78.0 hebfc3b9_0
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.0-hfc55251_0.conda
   hash:
-    md5: 76ac435b8668f636a39fcb155c3543fd
-    sha256: 6940a5d60d1fd8a14e8597e1e65e1a6e3a811368f279d4a2ab66ed73a2c26b31
+    md5: e10134de3558dd95abda6987b5548f4f
+    sha256: 991803ca90e6ba54568ff1bcb8a02f69a9beb8a09988d257fc21e1bbb3557d8c
   optional: false
   category: main
   build: hfc55251_0
@@ -3323,22 +3580,22 @@ package:
   subdir: linux-64
   build_number: 0
   license: LGPL-2.1-or-later
-  size: 111429
-  timestamp: 1688694701485
+  size: 112222
+  timestamp: 1694381266818
 - name: glib-tools
-  version: 2.76.4
+  version: 2.78.0
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    libglib: ==2.76.4 he8f3873_0
+    libglib: ==2.78.0 he8f3873_0
     libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.76.4-h12be248_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.0-h12be248_0.conda
   hash:
-    md5: 88237d3ddd338164196043cb7e927246
-    sha256: f90981fd787047c1b355bdaa9a981a5822152d3121f696d532ed29d51acc1507
+    md5: 466538fb59949a3c015b55671dc7e52c
+    sha256: 0781647629fdb9c88a2b1dc22bb845645d3365693f104374c7d9139bc59bd0ce
   optional: false
   category: main
   build: h12be248_0
@@ -3346,8 +3603,8 @@ package:
   subdir: win-64
   build_number: 0
   license: LGPL-2.1-or-later
-  size: 145910
-  timestamp: 1688695112953
+  size: 145796
+  timestamp: 1694381570560
 - name: gmp
   version: 6.2.1
   manager: conda
@@ -3411,12 +3668,12 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
     gmp: '>=6.2.1,<7.0a0'
-    mpfr: '>=4.1.0,<5.0a0'
     libgcc-ng: '>=12'
     mpc: '>=1.2.1,<2.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.1.2-py311h6a5fa03_1.tar.bz2
   hash:
     md5: 3515bd4a3d92bbd3cc2d25aac335e34d
@@ -3436,11 +3693,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    mpfr: '>=4.1.0,<5.0a0'
     gmp: '>=6.2.1,<7.0a0'
     mpc: '>=1.2.1,<2.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-64/gmpy2-2.1.2-py311hc5b4402_1.tar.bz2
   hash:
     md5: 658d2cc5cfce328fe85ab46259250e03
@@ -3460,11 +3717,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-    mpfr: '>=4.1.0,<5.0a0'
     gmp: '>=6.2.1,<7.0a0'
     mpc: '>=1.2.1,<2.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
+    python: '>=3.11,<3.12.0a0 *_cpython'
+    python_abi: 3.11.* *_cp311
   url: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.2-py311h2ba9262_1.tar.bz2
   hash:
     md5: b8f9e2ef835066ec723b6297d260cbe6
@@ -3500,181 +3757,181 @@ package:
   size: 104701
   timestamp: 1604365484436
 - name: gst-plugins-base
-  version: 1.22.4
+  version: 1.22.6
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    alsa-lib: '>=1.2.9,<1.2.10.0a0'
-    libgcc-ng: '>=12'
-    libexpat: '>=2.5.0,<3.0a0'
-    gstreamer: ==1.22.4 h98fc4e7_1
+    __glibc: '>=2.17,<3.0.a0'
+    alsa-lib: '>=1.2.10,<1.2.11.0a0'
     gettext: '>=0.21.1,<1.0a0'
-    xorg-libxau: '>=1.0.11,<2.0a0'
+    gstreamer: ==1.22.6 h98fc4e7_2
+    libexpat: '>=2.5.0,<3.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.78.0,<3.0a0'
+    libogg: '>=1.3.4,<1.4.0a0'
     libopus: '>=1.3.1,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    libglib: '>=2.76.3,<3.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libstdcxx-ng: '>=12'
     libvorbis: '>=1.3.7,<1.4.0a0'
     libxcb: '>=1.15,<1.16.0a0'
-    libstdcxx-ng: '>=12'
-    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     xorg-libx11: '>=1.8.6,<2.0a0'
-    libogg: '>=1.3.4,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.4-hf7dbed1_1.conda
+    xorg-libxau: '>=1.0.11,<2.0a0'
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.6-h8e1006c_2.conda
   hash:
-    md5: ae590378e58f11642bbdf8effd1d315d
-    sha256: d999811b95cb424fd23365c0e80897ab33768fb2c3457e01a641cf6ad4b5a0a7
+    md5: 3d8e98279bad55287f2ef9047996f33c
+    sha256: 07e71ef8ad4d1516695132ed142ef6bc6393243fee54f950aa0944561f2f277f
   optional: false
   category: main
-  build: hf7dbed1_1
+  build: h8e1006c_2
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2706989
-  timestamp: 1688582306867
+  size: 2704605
+  timestamp: 1696222053755
 - name: gst-plugins-base
-  version: 1.22.4
+  version: 1.22.6
   manager: conda
   platform: win-64
   dependencies:
-    libglib: '>=2.76.3,<3.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    gstreamer: ==1.22.6 hb4038d2_2
+    libglib: '>=2.78.0,<3.0a0'
+    libogg: '>=1.3.4,<1.4.0a0'
     libvorbis: '>=1.3.7,<1.4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    vc: '>=14.2,<15'
     ucrt: '>=10.0.20348.0'
-    gstreamer: ==1.22.4 hb4038d2_1
-    gettext: '>=0.21.1,<1.0a0'
+    vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-    libogg: '>=1.3.4,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.4-h001b923_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.6-h001b923_2.conda
   hash:
-    md5: ce797dd3d60901f6260e84e84674c829
-    sha256: 796b63de19fa87c76583e0253e02796937d635d98701976390494589b5109d54
+    md5: 20e57b894392cb792cdf5c501b35a8f6
+    sha256: 34816d0335e796ea3610022756b3b0832f5699007adc2819a08e068120dd3a8f
   optional: false
   category: main
-  build: h001b923_1
+  build: h001b923_2
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2034245
-  timestamp: 1688582747778
+  size: 2032915
+  timestamp: 1696222439891
 - name: gstreamer
-  version: 1.22.4
+  version: 1.22.6
   manager: conda
   platform: linux-64
   dependencies:
-    glib: '>=2.76.3,<3.0a0'
-    gettext: '>=0.21.1,<1.0a0'
     __glibc: '>=2.17,<3.0.a0'
-    libglib: '>=2.76.3,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
+    gettext: '>=0.21.1,<1.0a0'
+    glib: '>=2.78.0,<3.0a0'
     libgcc-ng: '>=12'
+    libglib: '>=2.78.0,<3.0a0'
+    libiconv: '>=1.17,<2.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.4-h98fc4e7_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.6-h98fc4e7_2.conda
   hash:
-    md5: 7f203906e390f70687a7df985c573c89
-    sha256: 105d612e5d5872b3be4bfbff3bcd5a674d3a83a7427dd52287f06a09bc844578
+    md5: 1c95f7c612f9121353c4ef764678113e
+    sha256: 5578119cec4e86b7b607678781026ebe1170cb851b4f784c49b09bed1c92566c
   optional: false
   category: main
-  build: h98fc4e7_1
+  build: h98fc4e7_2
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1977219
-  timestamp: 1688582155623
+  size: 1972133
+  timestamp: 1696221935494
 - name: gstreamer
-  version: 1.22.4
+  version: 1.22.6
   manager: conda
   platform: win-64
   dependencies:
-    glib: '>=2.76.3,<3.0a0'
-    ucrt: '>=10.0.20348.0'
     gettext: '>=0.21.1,<1.0a0'
-    libglib: '>=2.76.3,<3.0a0'
+    glib: '>=2.78.0,<3.0a0'
+    libglib: '>=2.78.0,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.4-hb4038d2_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.6-hb4038d2_2.conda
   hash:
-    md5: 42f53931331420f6b748f91ef356a558
-    sha256: 5f9e74b2114872ed0ababbeaf5915a59729d1cc993a453de7584eaece1ddab91
+    md5: e6d2009457a1e5d9653fd06873a7a367
+    sha256: 08600f04d220a43f0ef5c383bb586cdd05ec482aceadb397fcd43a233b946144
   optional: false
   category: main
-  build: hb4038d2_1
+  build: hb4038d2_2
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1936654
-  timestamp: 1688582544317
+  size: 1939400
+  timestamp: 1696222270363
 - name: harfbuzz
-  version: 7.3.0
+  version: 8.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    libglib: '>=2.76.2,<3.0a0'
-    icu: '>=72.1,<73.0a0'
-    libstdcxx-ng: '>=12'
-    graphite2: '*'
     cairo: '>=1.16.0,<2.0a0'
     freetype: '>=2.12.1,<3.0a0'
+    graphite2: '*'
+    icu: '>=73.2,<74.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-7.3.0-hdb3a94d_0.conda
+    libglib: '>=2.78.0,<3.0a0'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
   hash:
-    md5: 765bc76c0dfaf24ff9d8a2935b2510df
-    sha256: 9d99416e9d4a01ea0915f65ea7fac71dee11916de115fbd0325c0cb82e0b63f8
+    md5: 98db5f8813f45e2b29766aff0e4a499c
+    sha256: 5ca6585e6a4348bcbe214d57f5d6f560d15d23a6650770a2909475848b214edb
   optional: false
   category: main
-  build: hdb3a94d_0
+  build: h3d44ed6_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1438931
-  timestamp: 1683684067694
+  size: 1526592
+  timestamp: 1695089914042
 - name: icu
-  version: '72.1'
+  version: '73.2'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-72.1-hcb278e6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
   hash:
-    md5: 7c8d20d847bb45f56bd941578fcfa146
-    sha256: e44cc00eec068e7f7a6dd117ba17bf5d57658729b7b841945546f82505138292
+    md5: cc47e1facc155f91abd89b11e48e72ff
+    sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
   optional: false
   category: main
-  build: hcb278e6_0
+  build: h59595ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 11994866
-  timestamp: 1679314345076
+  size: 12089150
+  timestamp: 1692900650789
 - name: icu
-  version: '72.1'
+  version: '73.2'
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/icu-72.1-h63175ca_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
   hash:
-    md5: a108731562663d787066bd17c9595114
-    sha256: 06ceff1f021f4a540a6b5c8a037b79b3d98757b1f9659a4b08ad352912b8ef2e
+    md5: 0f47d9e3192d9e09ae300da0d28e0f56
+    sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
   optional: false
   category: main
   build: h63175ca_0
@@ -3683,8 +3940,8 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 13209837
-  timestamp: 1679314799856
+  size: 13422193
+  timestamp: 1692901469029
 - name: idna
   version: '3.4'
   manager: conda
@@ -3942,407 +4199,411 @@ package:
   size: 9428
   timestamp: 1688754660209
 - name: importlib_resources
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.0.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a08b6be5bf18b9d2a927d3457750f82e
-    sha256: 94c1b2831c0f908ae56212d9aeb9c9173051d307682b4fedfd88fef774b0b8f7
+    md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+    sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   constrains:
-  - importlib-resources >=6.0.0,<6.0.1.0a0
+  - importlib-resources >=6.1.0,<6.1.1.0a0
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 27728
-  timestamp: 1689017819532
+  size: 30024
+  timestamp: 1695414932459
 - name: importlib_resources
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.0.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a08b6be5bf18b9d2a927d3457750f82e
-    sha256: 94c1b2831c0f908ae56212d9aeb9c9173051d307682b4fedfd88fef774b0b8f7
+    md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+    sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   constrains:
-  - importlib-resources >=6.0.0,<6.0.1.0a0
+  - importlib-resources >=6.1.0,<6.1.1.0a0
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 27728
-  timestamp: 1689017819532
+  size: 30024
+  timestamp: 1695414932459
 - name: importlib_resources
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.0.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a08b6be5bf18b9d2a927d3457750f82e
-    sha256: 94c1b2831c0f908ae56212d9aeb9c9173051d307682b4fedfd88fef774b0b8f7
+    md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+    sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   constrains:
-  - importlib-resources >=6.0.0,<6.0.1.0a0
+  - importlib-resources >=6.1.0,<6.1.1.0a0
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 27728
-  timestamp: 1689017819532
+  size: 30024
+  timestamp: 1695414932459
 - name: importlib_resources
-  version: 6.0.0
+  version: 6.1.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
     zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.0.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a08b6be5bf18b9d2a927d3457750f82e
-    sha256: 94c1b2831c0f908ae56212d9aeb9c9173051d307682b4fedfd88fef774b0b8f7
+    md5: 48b0d98e0c0ec810d3ccc2a0926c8c0e
+    sha256: adab6da633ec3b642f036ab5c1196c3e2db0e8db57fb0c7fc9a8e06e29fa9bdc
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   constrains:
-  - importlib-resources >=6.0.0,<6.0.1.0a0
+  - importlib-resources >=6.1.0,<6.1.1.0a0
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 27728
-  timestamp: 1689017819532
+  size: 30024
+  timestamp: 1695414932459
 - name: intel-openmp
-  version: 2023.1.0
+  version: 2023.2.0
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.1.0-h57928b3_46319.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50496.conda
   hash:
-    md5: dbc4636f419722fbf3ab6501377228ba
-    sha256: b3006690844eedbb51030e71778767acc9967f4148b6f335ba3fddf8aa42aa5b
+    md5: 519f9c42672f1e8a334ec9471e93f4fe
+    sha256: 38367c264bace64d6f939c1170cda3aba2eb0fb2300570c16a8c63aff9ca8031
   optional: false
   category: main
-  build: h57928b3_46319
+  build: h57928b3_50496
   arch: x86_64
   subdir: win-64
-  build_number: 46319
+  build_number: 50496
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
-  size: 2571975
-  timestamp: 1681819121435
+  size: 2520627
+  timestamp: 1695994411378
 - name: ipykernel
-  version: 6.24.0
+  version: 6.25.2
   manager: conda
   platform: linux-64
   dependencies:
-    packaging: '*'
-    comm: '>=0.1.1'
-    python: '>=3.8'
     __linux: '*'
-    traitlets: '>=5.4.0'
-    ipython: '>=7.23.1'
-    psutil: '*'
-    matplotlib-inline: '>=0.1'
-    pyzmq: '>=20'
-    nest-asyncio: '*'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.1'
-    jupyter_client: '>=6.1.12'
+    comm: '>=0.1.1'
     debugpy: '>=1.6.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.24.0-pyh71e2992_0.conda
+    ipython: '>=7.23.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    matplotlib-inline: '>=0.1'
+    nest-asyncio: '*'
+    packaging: '*'
+    psutil: '*'
+    python: '>=3.8'
+    pyzmq: '>=20'
+    tornado: '>=6.1'
+    traitlets: '>=5.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.25.2-pyh2140261_0.conda
   hash:
-    md5: cfafc9387c32a43a1b6d63633489cbc9
-    sha256: db2b0e1ad21c95b0b803a2c6208229a4954727cb1d006b46eacb0aa242633218
+    md5: 226f2032ec491cc6e9ce66072660e4f6
+    sha256: 30316b79a8b2777ad6120c724440ae8a260c6b61eeb3edffbe0380e87c26c4b9
   optional: false
   category: main
-  build: pyh71e2992_0
+  build: pyh2140261_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 113414
-  timestamp: 1688404925379
+  size: 113964
+  timestamp: 1693880440518
 - name: ipykernel
-  version: 6.24.0
+  version: 6.25.2
   manager: conda
   platform: osx-64
   dependencies:
-    packaging: '*'
+    __osx: '*'
     appnope: '*'
     comm: '>=0.1.1'
-    python: '>=3.8'
-    __osx: '*'
-    traitlets: '>=5.4.0'
-    matplotlib-inline: '>=0.1'
-    pyzmq: '>=20'
-    jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
-    psutil: '*'
-    nest-asyncio: '*'
-    tornado: '>=6.1'
     debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.24.0-pyh5fb750a_0.conda
+    jupyter_core: '>=4.12,!=5.0.*'
+    matplotlib-inline: '>=0.1'
+    nest-asyncio: '*'
+    packaging: '*'
+    psutil: '*'
+    python: '>=3.8'
+    pyzmq: '>=20'
+    tornado: '>=6.1'
+    traitlets: '>=5.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.25.2-pyh1050b4e_0.conda
   hash:
-    md5: 2a8ffa559d393fea47237b9d23ddf74f
-    sha256: e1342176c31a1da7579f6b837c5c809960c82bc8a47d2593d7af9f457e061dd9
+    md5: a643e6f6c33ed821664f2a69f6e4e89f
+    sha256: f99ab5cbbe2f349ff2f7842ee1ab710e15b27d6140e8b1356098bbbba2e6370c
   optional: false
   category: main
-  build: pyh5fb750a_0
+  build: pyh1050b4e_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 114238
-  timestamp: 1688739663223
+  size: 115240
+  timestamp: 1693880672936
 - name: ipykernel
-  version: 6.24.0
+  version: 6.25.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    packaging: '*'
+    __osx: '*'
     appnope: '*'
     comm: '>=0.1.1'
-    python: '>=3.8'
-    __osx: '*'
-    traitlets: '>=5.4.0'
-    matplotlib-inline: '>=0.1'
-    pyzmq: '>=20'
-    jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
-    psutil: '*'
-    nest-asyncio: '*'
-    tornado: '>=6.1'
     debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
     jupyter_client: '>=6.1.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.24.0-pyh5fb750a_0.conda
+    jupyter_core: '>=4.12,!=5.0.*'
+    matplotlib-inline: '>=0.1'
+    nest-asyncio: '*'
+    packaging: '*'
+    psutil: '*'
+    python: '>=3.8'
+    pyzmq: '>=20'
+    tornado: '>=6.1'
+    traitlets: '>=5.4.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.25.2-pyh1050b4e_0.conda
   hash:
-    md5: 2a8ffa559d393fea47237b9d23ddf74f
-    sha256: e1342176c31a1da7579f6b837c5c809960c82bc8a47d2593d7af9f457e061dd9
+    md5: a643e6f6c33ed821664f2a69f6e4e89f
+    sha256: f99ab5cbbe2f349ff2f7842ee1ab710e15b27d6140e8b1356098bbbba2e6370c
   optional: false
   category: main
-  build: pyh5fb750a_0
+  build: pyh1050b4e_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 114238
-  timestamp: 1688739663223
+  size: 115240
+  timestamp: 1693880672936
 - name: ipykernel
-  version: 6.24.0
+  version: 6.25.2
   manager: conda
   platform: win-64
   dependencies:
-    packaging: '*'
+    __win: '*'
     comm: '>=0.1.1'
+    debugpy: '>=1.6.5'
+    ipython: '>=7.23.1'
+    jupyter_client: '>=6.1.12'
+    jupyter_core: '>=4.12,!=5.0.*'
+    matplotlib-inline: '>=0.1'
+    nest-asyncio: '*'
+    packaging: '*'
+    psutil: '*'
     python: '>=3.8'
+    pyzmq: '>=20'
     tornado: '>=6.1'
     traitlets: '>=5.4.0'
-    ipython: '>=7.23.1'
-    psutil: '*'
-    matplotlib-inline: '>=0.1'
-    pyzmq: '>=20'
-    nest-asyncio: '*'
-    jupyter_core: '>=4.12,!=5.0.*'
-    __win: '*'
-    jupyter_client: '>=6.1.12'
-    debugpy: '>=1.6.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.24.0-pyh6817e22_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.25.2-pyh60829e3_0.conda
   hash:
-    md5: b5cd11cf19c739548e968c12e020c54d
-    sha256: 646543978553c78c62b8a4515d0b1cdf1a7c42ae603aa0475e78fb2347233c52
+    md5: 387f16a39a2e57bff9de9bc0216baa09
+    sha256: 8531e04e585db4fb95ba5152e7f6af0fa9be0b3e68a8c9e335e4a3585222db2c
   optional: false
   category: main
-  build: pyh6817e22_0
+  build: pyh60829e3_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 113466
-  timestamp: 1688405130214
+  size: 115123
+  timestamp: 1693880680681
 - name: ipython
-  version: 8.14.0
+  version: 8.16.1
   manager: conda
   platform: linux-64
   dependencies:
-    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
-    python: '>=3.9'
-    pickleshare: '*'
-    jedi: '>=0.16'
-    decorator: '*'
-    traitlets: '>=5'
-    matplotlib-inline: '*'
-    stack_data: '*'
-    pygments: '>=2.4.0'
-    typing_extensions: '*'
-    pexpect: '>4.3'
-    backcall: '*'
     __linux: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyh41d4057_0.conda
+    backcall: '*'
+    decorator: '*'
+    exceptiongroup: '*'
+    jedi: '>=0.16'
+    matplotlib-inline: '*'
+    pexpect: '>4.3'
+    pickleshare: '*'
+    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
+    pygments: '>=2.4.0'
+    python: '>=3.9'
+    stack_data: '*'
+    traitlets: '>=5'
+    typing_extensions: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.16.1-pyh0d859eb_0.conda
   hash:
-    md5: 0a0b0d8177c4a209017b356439292db8
-    sha256: 25f1e5d78f7f063b3e32b939fed1e4d797df12f384c949902a325e6539315f96
+    md5: 7e52cb0dbf01b90365bfe433ec8bd3c0
+    sha256: 2dc119746ddac02cb01644ae7c7ac54a296366e2edf0d178f50f833113aaf94a
   optional: false
   category: main
-  build: pyh41d4057_0
+  build: pyh0d859eb_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 583448
-  timestamp: 1685727878658
+  size: 590501
+  timestamp: 1696264206857
 - name: ipython
-  version: 8.14.0
+  version: 8.16.1
   manager: conda
   platform: osx-64
   dependencies:
-    appnope: '*'
-    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
-    jedi: '>=0.16'
     __osx: '*'
+    appnope: '*'
+    backcall: '*'
     decorator: '*'
-    pickleshare: '*'
+    exceptiongroup: '*'
+    jedi: '>=0.16'
     matplotlib-inline: '*'
-    python: '>=3.9'
+    pexpect: '>4.3'
+    pickleshare: '*'
+    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
     pygments: '>=2.4.0'
+    python: '>=3.9'
     stack_data: '*'
     traitlets: '>=5'
     typing_extensions: '*'
-    pexpect: '>4.3'
-    backcall: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyhd1c38e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.16.1-pyh31c8845_0.conda
   hash:
-    md5: f56fab4cea853c2248105b6cd7d79bf0
-    sha256: ea7524cd33c18c5c0d01e48e0089f339e7e8f1c3a6a8d2416c46b3d50d509894
+    md5: 531bac092414642fdead7a511357485a
+    sha256: 77cfbc15ee2ad8976009a6880bb1f7c716db44e23594fba7c9c382135e02eb03
   optional: false
   category: main
-  build: pyhd1c38e8_0
+  build: pyh31c8845_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 585154
-  timestamp: 1685728306650
+  size: 593043
+  timestamp: 1696264534473
 - name: ipython
-  version: 8.14.0
+  version: 8.16.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    appnope: '*'
-    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
-    jedi: '>=0.16'
     __osx: '*'
+    appnope: '*'
+    backcall: '*'
     decorator: '*'
-    pickleshare: '*'
+    exceptiongroup: '*'
+    jedi: '>=0.16'
     matplotlib-inline: '*'
-    python: '>=3.9'
+    pexpect: '>4.3'
+    pickleshare: '*'
+    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
     pygments: '>=2.4.0'
+    python: '>=3.9'
     stack_data: '*'
     traitlets: '>=5'
     typing_extensions: '*'
-    pexpect: '>4.3'
-    backcall: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyhd1c38e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.16.1-pyh31c8845_0.conda
   hash:
-    md5: f56fab4cea853c2248105b6cd7d79bf0
-    sha256: ea7524cd33c18c5c0d01e48e0089f339e7e8f1c3a6a8d2416c46b3d50d509894
+    md5: 531bac092414642fdead7a511357485a
+    sha256: 77cfbc15ee2ad8976009a6880bb1f7c716db44e23594fba7c9c382135e02eb03
   optional: false
   category: main
-  build: pyhd1c38e8_0
+  build: pyh31c8845_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 585154
-  timestamp: 1685728306650
+  size: 593043
+  timestamp: 1696264534473
 - name: ipython
-  version: 8.14.0
+  version: 8.16.1
   manager: conda
   platform: win-64
   dependencies:
-    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
-    python: '>=3.9'
-    pickleshare: '*'
-    jedi: '>=0.16'
-    decorator: '*'
+    __win: '*'
+    backcall: '*'
     colorama: '*'
+    decorator: '*'
+    exceptiongroup: '*'
+    jedi: '>=0.16'
     matplotlib-inline: '*'
-    stack_data: '*'
+    pickleshare: '*'
+    prompt_toolkit: '>=3.0.30,<3.1.0,!=3.0.37'
     pygments: '>=2.4.0'
+    python: '>=3.9'
+    stack_data: '*'
     traitlets: '>=5'
     typing_extensions: '*'
-    __win: '*'
-    backcall: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.14.0-pyh08f2357_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.16.1-pyh5737063_0.conda
   hash:
-    md5: 1fc684c1de5475383790ada5627c5430
-    sha256: 16a409828a1efc95b2d74f6080782ab8f7fdae2c33dde8d2f795e172d9c379a3
+    md5: 1f0a208b45d0bf8d1cf09d2f2b549ab5
+    sha256: 9a09600613147838d6bd027d22078abc13e83300a53192b465e8deb1ef0eeb22
   optional: false
   category: main
-  build: pyh08f2357_0
+  build: pyh5737063_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 583510
-  timestamp: 1685728341837
+  size: 590588
+  timestamp: 1696264618038
 - name: ipywidgets
-  version: 8.0.7
+  version: 8.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    jupyterlab_widgets: '>=3.0.7,<3.1.0'
-    python: '>=3.7'
-    ipykernel: '>=4.5.1'
+    comm: '>=0.1.3'
     ipython: '>=6.1.0'
+    jupyterlab_widgets: '>=3.0.9,<3.1.0'
+    python: '>=3.7'
     traitlets: '>=4.3.1'
-    widgetsnbextension: '>=4.0.7,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.0.7-pyhd8ed1ab_0.conda
+    widgetsnbextension: '>=4.0.9,<4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b0f4e8fe2a303e472674eae0340bdad
-    sha256: 3b17ad90294f0684fca9191f1e696e9b4f03a652d5e588b6ff0feb5647fcf116
+    md5: 2605fae5ee27100e5f10037baebf4d41
+    sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4352,23 +4613,23 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 111959
-  timestamp: 1688489764194
+  size: 114155
+  timestamp: 1694607285777
 - name: ipywidgets
-  version: 8.0.7
+  version: 8.1.1
   manager: conda
   platform: osx-64
   dependencies:
-    jupyterlab_widgets: '>=3.0.7,<3.1.0'
-    python: '>=3.7'
-    ipykernel: '>=4.5.1'
+    comm: '>=0.1.3'
     ipython: '>=6.1.0'
+    jupyterlab_widgets: '>=3.0.9,<3.1.0'
+    python: '>=3.7'
     traitlets: '>=4.3.1'
-    widgetsnbextension: '>=4.0.7,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.0.7-pyhd8ed1ab_0.conda
+    widgetsnbextension: '>=4.0.9,<4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b0f4e8fe2a303e472674eae0340bdad
-    sha256: 3b17ad90294f0684fca9191f1e696e9b4f03a652d5e588b6ff0feb5647fcf116
+    md5: 2605fae5ee27100e5f10037baebf4d41
+    sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4378,23 +4639,23 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 111959
-  timestamp: 1688489764194
+  size: 114155
+  timestamp: 1694607285777
 - name: ipywidgets
-  version: 8.0.7
+  version: 8.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    jupyterlab_widgets: '>=3.0.7,<3.1.0'
-    python: '>=3.7'
-    ipykernel: '>=4.5.1'
+    comm: '>=0.1.3'
     ipython: '>=6.1.0'
+    jupyterlab_widgets: '>=3.0.9,<3.1.0'
+    python: '>=3.7'
     traitlets: '>=4.3.1'
-    widgetsnbextension: '>=4.0.7,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.0.7-pyhd8ed1ab_0.conda
+    widgetsnbextension: '>=4.0.9,<4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b0f4e8fe2a303e472674eae0340bdad
-    sha256: 3b17ad90294f0684fca9191f1e696e9b4f03a652d5e588b6ff0feb5647fcf116
+    md5: 2605fae5ee27100e5f10037baebf4d41
+    sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4404,23 +4665,23 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 111959
-  timestamp: 1688489764194
+  size: 114155
+  timestamp: 1694607285777
 - name: ipywidgets
-  version: 8.0.7
+  version: 8.1.1
   manager: conda
   platform: win-64
   dependencies:
-    jupyterlab_widgets: '>=3.0.7,<3.1.0'
-    python: '>=3.7'
-    ipykernel: '>=4.5.1'
+    comm: '>=0.1.3'
     ipython: '>=6.1.0'
+    jupyterlab_widgets: '>=3.0.9,<3.1.0'
+    python: '>=3.7'
     traitlets: '>=4.3.1'
-    widgetsnbextension: '>=4.0.7,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.0.7-pyhd8ed1ab_0.conda
+    widgetsnbextension: '>=4.0.9,<4.1.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b0f4e8fe2a303e472674eae0340bdad
-    sha256: 3b17ad90294f0684fca9191f1e696e9b4f03a652d5e588b6ff0feb5647fcf116
+    md5: 2605fae5ee27100e5f10037baebf4d41
+    sha256: 8136defec115396ba992273a77f814d74eeafd9cc099f5430d109c60785a7f02
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4430,19 +4691,19 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 111959
-  timestamp: 1688489764194
-- name: jedi
-  version: 0.18.2
+  size: 114155
+  timestamp: 1694607285777
+- name: isoduration
+  version: 20.11.0
   manager: conda
   platform: linux-64
   dependencies:
-    parso: '>=0.8.0,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+    arrow: '>=0.15.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-    sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    md5: 4cb68948e0b8429534380243d063a27a
+    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4452,19 +4713,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 804409
-  timestamp: 1669134434500
-- name: jedi
-  version: 0.18.2
+  size: 17189
+  timestamp: 1638811664194
+- name: isoduration
+  version: 20.11.0
   manager: conda
   platform: osx-64
   dependencies:
-    parso: '>=0.8.0,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+    arrow: '>=0.15.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-    sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    md5: 4cb68948e0b8429534380243d063a27a
+    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4474,19 +4735,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 804409
-  timestamp: 1669134434500
-- name: jedi
-  version: 0.18.2
+  size: 17189
+  timestamp: 1638811664194
+- name: isoduration
+  version: 20.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    parso: '>=0.8.0,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+    arrow: '>=0.15.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-    sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    md5: 4cb68948e0b8429534380243d063a27a
+    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4496,19 +4757,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 804409
-  timestamp: 1669134434500
-- name: jedi
-  version: 0.18.2
+  size: 17189
+  timestamp: 1638811664194
+- name: isoduration
+  version: 20.11.0
   manager: conda
   platform: win-64
   dependencies:
-    parso: '>=0.8.0,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda
+    arrow: '>=0.15.0'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
   hash:
-    md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-    sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    md5: 4cb68948e0b8429534380243d063a27a
+    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -4518,15 +4779,103 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 804409
-  timestamp: 1669134434500
+  size: 17189
+  timestamp: 1638811664194
+- name: jedi
+  version: 0.19.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 81a3be0b2023e1ea8555781f0ad904a2
+    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 841312
+  timestamp: 1696326218364
+- name: jedi
+  version: 0.19.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 81a3be0b2023e1ea8555781f0ad904a2
+    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 841312
+  timestamp: 1696326218364
+- name: jedi
+  version: 0.19.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 81a3be0b2023e1ea8555781f0ad904a2
+    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 841312
+  timestamp: 1696326218364
+- name: jedi
+  version: 0.19.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    parso: '>=0.8.3,<0.9.0'
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 81a3be0b2023e1ea8555781f0ad904a2
+    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 841312
+  timestamp: 1696326218364
 - name: jinja2
   version: 3.1.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
@@ -4547,8 +4896,8 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
@@ -4569,8 +4918,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
@@ -4591,8 +4940,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     markupsafe: '>=2.0'
+    python: '>=3.7'
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
@@ -4609,93 +4958,93 @@ package:
   size: 101443
   timestamp: 1654302514195
 - name: joblib
-  version: 1.3.0
+  version: 1.3.2
   manager: conda
   platform: linux-64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.0-pyhd8ed1ab_1.conda
+    setuptools: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: fb4caf6da228ccc487350eade569abae
-    sha256: e759642a5d7940b428deb7fc39707101f67de4e3ab46bea7fdc07443e4576f7d
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 221166
-  timestamp: 1688155428746
+  size: 221200
+  timestamp: 1691577306309
 - name: joblib
-  version: 1.3.0
+  version: 1.3.2
   manager: conda
   platform: osx-64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.0-pyhd8ed1ab_1.conda
+    setuptools: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: fb4caf6da228ccc487350eade569abae
-    sha256: e759642a5d7940b428deb7fc39707101f67de4e3ab46bea7fdc07443e4576f7d
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 221166
-  timestamp: 1688155428746
+  size: 221200
+  timestamp: 1691577306309
 - name: joblib
-  version: 1.3.0
+  version: 1.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.0-pyhd8ed1ab_1.conda
+    setuptools: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: fb4caf6da228ccc487350eade569abae
-    sha256: e759642a5d7940b428deb7fc39707101f67de4e3ab46bea7fdc07443e4576f7d
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 221166
-  timestamp: 1688155428746
+  size: 221200
+  timestamp: 1691577306309
 - name: joblib
-  version: 1.3.0
+  version: 1.3.2
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.0-pyhd8ed1ab_1.conda
+    setuptools: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: fb4caf6da228ccc487350eade569abae
-    sha256: e759642a5d7940b428deb7fc39707101f67de4e3ab46bea7fdc07443e4576f7d
+    md5: 4da50d410f553db77e62ab62ffaa1abc
+    sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 221166
-  timestamp: 1688155428746
+  size: 221200
+  timestamp: 1691577306309
 - name: json5
   version: 0.9.14
   manager: conda
@@ -4780,419 +5129,623 @@ package:
   noarch: python
   size: 25003
   timestamp: 1688248468479
-- name: jsonschema
-  version: 4.18.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jsonschema-specifications: '>=2023.3.6'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.18.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 66f117feaf02e29f1b71c500cc0848cb
-    sha256: 4aa27035e88d27aa6d269f718b4e9a335e0d444e3c6b245dfc6c6065a3d79806
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 69929
-  timestamp: 1689278415484
-- name: jsonschema
-  version: 4.18.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    jsonschema-specifications: '>=2023.3.6'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.18.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 66f117feaf02e29f1b71c500cc0848cb
-    sha256: 4aa27035e88d27aa6d269f718b4e9a335e0d444e3c6b245dfc6c6065a3d79806
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 69929
-  timestamp: 1689278415484
-- name: jsonschema
-  version: 4.18.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    jsonschema-specifications: '>=2023.3.6'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.18.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 66f117feaf02e29f1b71c500cc0848cb
-    sha256: 4aa27035e88d27aa6d269f718b4e9a335e0d444e3c6b245dfc6c6065a3d79806
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 69929
-  timestamp: 1689278415484
-- name: jsonschema
-  version: 4.18.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    jsonschema-specifications: '>=2023.3.6'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.18.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 66f117feaf02e29f1b71c500cc0848cb
-    sha256: 4aa27035e88d27aa6d269f718b4e9a335e0d444e3c6b245dfc6c6065a3d79806
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 69929
-  timestamp: 1689278415484
-- name: jsonschema-specifications
-  version: 2023.6.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1c5c9ad5e7885a4c99d516fa4c791b4
-    sha256: 21cf2f9075afdb430aa0929319d8ea2148771d0de6b68000f5f3236ec5109c4f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15360
-  timestamp: 1687705110007
-- name: jsonschema-specifications
-  version: 2023.6.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1c5c9ad5e7885a4c99d516fa4c791b4
-    sha256: 21cf2f9075afdb430aa0929319d8ea2148771d0de6b68000f5f3236ec5109c4f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15360
-  timestamp: 1687705110007
-- name: jsonschema-specifications
-  version: 2023.6.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1c5c9ad5e7885a4c99d516fa4c791b4
-    sha256: 21cf2f9075afdb430aa0929319d8ea2148771d0de6b68000f5f3236ec5109c4f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15360
-  timestamp: 1687705110007
-- name: jsonschema-specifications
-  version: 2023.6.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f1c5c9ad5e7885a4c99d516fa4c791b4
-    sha256: 21cf2f9075afdb430aa0929319d8ea2148771d0de6b68000f5f3236ec5109c4f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15360
-  timestamp: 1687705110007
-- name: jupyter-lsp
-  version: 2.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
-    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52525
-  timestamp: 1685453825227
-- name: jupyter-lsp
-  version: 2.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
-    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52525
-  timestamp: 1685453825227
-- name: jupyter-lsp
-  version: 2.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
-    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52525
-  timestamp: 1685453825227
-- name: jupyter-lsp
-  version: 2.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
-    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 52525
-  timestamp: 1685453825227
-- name: jupyter_client
-  version: 8.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pyzmq: '>=23.0'
-    python: '>=3.8'
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python-dateutil: '>=2.8.2'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1d018ee4ab13217e2544f795eb0a6798
-    sha256: 7dc74a032daefbdcf4d6d661616dfdc8649e5cf9db58258afe91cc09ea0cf402
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 104407
-  timestamp: 1687701169103
-- name: jupyter_client
-  version: 8.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pyzmq: '>=23.0'
-    python: '>=3.8'
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python-dateutil: '>=2.8.2'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1d018ee4ab13217e2544f795eb0a6798
-    sha256: 7dc74a032daefbdcf4d6d661616dfdc8649e5cf9db58258afe91cc09ea0cf402
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 104407
-  timestamp: 1687701169103
-- name: jupyter_client
-  version: 8.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pyzmq: '>=23.0'
-    python: '>=3.8'
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python-dateutil: '>=2.8.2'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1d018ee4ab13217e2544f795eb0a6798
-    sha256: 7dc74a032daefbdcf4d6d661616dfdc8649e5cf9db58258afe91cc09ea0cf402
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 104407
-  timestamp: 1687701169103
-- name: jupyter_client
-  version: 8.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    pyzmq: '>=23.0'
-    python: '>=3.8'
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python-dateutil: '>=2.8.2'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1d018ee4ab13217e2544f795eb0a6798
-    sha256: 7dc74a032daefbdcf4d6d661616dfdc8649e5cf9db58258afe91cc09ea0cf402
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 104407
-  timestamp: 1687701169103
-- name: jupyter_core
-  version: 5.3.1
+- name: jsonpointer
+  version: '2.4'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    platformdirs: '>=2.5'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.3.1-py311h38be061_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py311h38be061_3.conda
   hash:
-    md5: 0cf8259b01ede82c76007996f73f89ed
-    sha256: d8d4d662b5a645d7937fb1fbbac3820ea82097acf26fd57f5990a5ced17aad54
+    md5: 41d52d822edf991bf0e6b08c1921a8ec
+    sha256: 976f7bf3c3a49c3066f36b67c12ae06b31542e53b843bb4362f31c9e449c6c46
+  optional: false
+  category: main
+  build: py311h38be061_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18389
+  timestamp: 1695397377176
+- name: jsonpointer
+  version: '2.4'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py311h6eed73b_3.conda
+  hash:
+    md5: ed1c23d0e55abd27d8b9e31c58105140
+    sha256: b0ba738e1dbf3b69558557cd1e63310364e045b8c8e7f73fdce7e71928b5f22a
+  optional: false
+  category: main
+  build: py311h6eed73b_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18557
+  timestamp: 1695397765266
+- name: jsonpointer
+  version: '2.4'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.11,<3.12.0a0 *_cpython'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py311h267d04e_3.conda
+  hash:
+    md5: b6008a5b9180e58a235f5e45432dfe2e
+    sha256: 807d6c44f3e34139bfd25db4409381a6ce37fad2902c58f10fa7e1c30a64333d
+  optional: false
+  category: main
+  build: py311h267d04e_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18841
+  timestamp: 1695397944650
+- name: jsonpointer
+  version: '2.4'
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py311h1ea47a8_3.conda
+  hash:
+    md5: db8fc59f9215e668e602f769d0bf67bb
+    sha256: 13042586b08e8caa60615e7c42d05601f9421e8bda5df932e3ef9d2401bf2435
+  optional: false
+  category: main
+  build: py311h1ea47a8_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 34654
+  timestamp: 1695397742357
+- name: jsonschema
+  version: 4.19.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    jsonschema-specifications: '>=2023.3.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 78aff5d2af74e6537c1ca73017f01f4f
+    sha256: b4e50e1d53b984a467e79b7ba69cc408d14e3a2002cad4eaf7798e20268cff2d
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 71078
+  timestamp: 1695229168542
+- name: jsonschema
+  version: 4.19.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    jsonschema-specifications: '>=2023.3.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 78aff5d2af74e6537c1ca73017f01f4f
+    sha256: b4e50e1d53b984a467e79b7ba69cc408d14e3a2002cad4eaf7798e20268cff2d
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 71078
+  timestamp: 1695229168542
+- name: jsonschema
+  version: 4.19.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    jsonschema-specifications: '>=2023.3.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 78aff5d2af74e6537c1ca73017f01f4f
+    sha256: b4e50e1d53b984a467e79b7ba69cc408d14e3a2002cad4eaf7798e20268cff2d
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 71078
+  timestamp: 1695229168542
+- name: jsonschema
+  version: 4.19.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    attrs: '>=22.2.0'
+    importlib_resources: '>=1.4.0'
+    jsonschema-specifications: '>=2023.3.6'
+    pkgutil-resolve-name: '>=1.3.10'
+    python: '>=3.8'
+    referencing: '>=0.28.4'
+    rpds-py: '>=0.7.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 78aff5d2af74e6537c1ca73017f01f4f
+    sha256: b4e50e1d53b984a467e79b7ba69cc408d14e3a2002cad4eaf7798e20268cff2d
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 71078
+  timestamp: 1695229168542
+- name: jsonschema-specifications
+  version: 2023.7.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib_resources: '>=1.4.0'
+    python: '>=3.8'
+    referencing: '>=0.25.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15296
+  timestamp: 1689701341221
+- name: jsonschema-specifications
+  version: 2023.7.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib_resources: '>=1.4.0'
+    python: '>=3.8'
+    referencing: '>=0.25.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15296
+  timestamp: 1689701341221
+- name: jsonschema-specifications
+  version: 2023.7.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    importlib_resources: '>=1.4.0'
+    python: '>=3.8'
+    referencing: '>=0.25.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15296
+  timestamp: 1689701341221
+- name: jsonschema-specifications
+  version: 2023.7.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    importlib_resources: '>=1.4.0'
+    python: '>=3.8'
+    referencing: '>=0.25.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15296
+  timestamp: 1689701341221
+- name: jsonschema-with-format-nongpl
+  version: 4.19.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    fqdn: '*'
+    idna: '*'
+    isoduration: '*'
+    jsonpointer: '>1.13'
+    jsonschema: '>=4.19.1,<4.19.2.0a0'
+    python: '*'
+    rfc3339-validator: '*'
+    rfc3986-validator: '>0.1.0'
+    uri-template: '*'
+    webcolors: '>=1.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: daca0665e6fe8a376e48b9f0b5865326
+    sha256: af65a8783a89c03ac8437a1d95ee5ac2e50e92d3af231cec515292fe296aff8e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7367
+  timestamp: 1695229193334
+- name: jsonschema-with-format-nongpl
+  version: 4.19.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    fqdn: '*'
+    idna: '*'
+    isoduration: '*'
+    jsonpointer: '>1.13'
+    jsonschema: '>=4.19.1,<4.19.2.0a0'
+    python: '*'
+    rfc3339-validator: '*'
+    rfc3986-validator: '>0.1.0'
+    uri-template: '*'
+    webcolors: '>=1.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: daca0665e6fe8a376e48b9f0b5865326
+    sha256: af65a8783a89c03ac8437a1d95ee5ac2e50e92d3af231cec515292fe296aff8e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7367
+  timestamp: 1695229193334
+- name: jsonschema-with-format-nongpl
+  version: 4.19.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    fqdn: '*'
+    idna: '*'
+    isoduration: '*'
+    jsonpointer: '>1.13'
+    jsonschema: '>=4.19.1,<4.19.2.0a0'
+    python: '*'
+    rfc3339-validator: '*'
+    rfc3986-validator: '>0.1.0'
+    uri-template: '*'
+    webcolors: '>=1.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: daca0665e6fe8a376e48b9f0b5865326
+    sha256: af65a8783a89c03ac8437a1d95ee5ac2e50e92d3af231cec515292fe296aff8e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7367
+  timestamp: 1695229193334
+- name: jsonschema-with-format-nongpl
+  version: 4.19.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    fqdn: '*'
+    idna: '*'
+    isoduration: '*'
+    jsonpointer: '>1.13'
+    jsonschema: '>=4.19.1,<4.19.2.0a0'
+    python: '*'
+    rfc3339-validator: '*'
+    rfc3986-validator: '>0.1.0'
+    uri-template: '*'
+    webcolors: '>=1.11'
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: daca0665e6fe8a376e48b9f0b5865326
+    sha256: af65a8783a89c03ac8437a1d95ee5ac2e50e92d3af231cec515292fe296aff8e
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7367
+  timestamp: 1695229193334
+- name: jupyter-lsp
+  version: 2.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.1.2'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
+    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 52525
+  timestamp: 1685453825227
+- name: jupyter-lsp
+  version: 2.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.1.2'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
+    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 52525
+  timestamp: 1685453825227
+- name: jupyter-lsp
+  version: 2.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.1.2'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
+    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 52525
+  timestamp: 1685453825227
+- name: jupyter-lsp
+  version: 2.2.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    importlib-metadata: '>=4.8.3'
+    jupyter_server: '>=1.1.2'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38589f4104d11f2a59ff01a9f4e3bfb3
+    sha256: 16fc7b40024adece716ba7227e5c123a2deccc13f946a10d9a3270493908d11c
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 52525
+  timestamp: 1685453825227
+- name: jupyter_client
+  version: 8.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b7cc0981484fcb6390e6d341e55618b3
+    sha256: f8b679e90056271abd9bbb2233198159de60777fe4c06818757552bf5be48fe8
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 105112
+  timestamp: 1693317650877
+- name: jupyter_client
+  version: 8.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b7cc0981484fcb6390e6d341e55618b3
+    sha256: f8b679e90056271abd9bbb2233198159de60777fe4c06818757552bf5be48fe8
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 105112
+  timestamp: 1693317650877
+- name: jupyter_client
+  version: 8.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b7cc0981484fcb6390e6d341e55618b3
+    sha256: f8b679e90056271abd9bbb2233198159de60777fe4c06818757552bf5be48fe8
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 105112
+  timestamp: 1693317650877
+- name: jupyter_client
+  version: 8.3.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    importlib_metadata: '>=4.8.3'
+    jupyter_core: '>=4.12,!=5.0.*'
+    python: '>=3.8'
+    python-dateutil: '>=2.8.2'
+    pyzmq: '>=23.0'
+    tornado: '>=6.2'
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: b7cc0981484fcb6390e6d341e55618b3
+    sha256: f8b679e90056271abd9bbb2233198159de60777fe4c06818757552bf5be48fe8
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 105112
+  timestamp: 1693317650877
+- name: jupyter_core
+  version: 5.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    platformdirs: '>=2.5'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    traitlets: '>=5.3'
+  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.3.2-py311h38be061_0.conda
+  hash:
+    md5: 4e4341e940c0dfa1038c1a2d11fd8c3e
+    sha256: 189435dc967fb5a83f7855abadc6ea503a7f242cbbb1d21c8785b375cfe967ae
   optional: false
   category: main
   build: py311h38be061_0
@@ -5201,21 +5754,21 @@ package:
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 116010
-  timestamp: 1686775882769
+  size: 93583
+  timestamp: 1695828240384
 - name: jupyter_core
-  version: 5.3.1
+  version: 5.3.2
   manager: conda
   platform: osx-64
   dependencies:
+    platformdirs: '>=2.5'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    platformdirs: '>=2.5'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.3.1-py311h6eed73b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.3.2-py311h6eed73b_0.conda
   hash:
-    md5: 2d45628b123595054093ff65996b98ae
-    sha256: 90045f63ca46c1cd66c55e7a3fce41f9719c82ec30cedc608d368fbde67b9265
+    md5: 32b2a44c7686c1dc850e4dd44f16b2d8
+    sha256: 4d4d786062f2e247754e104dc7047e0c3d0a72042d44363d2243471828fbd564
   optional: false
   category: main
   build: py311h6eed73b_0
@@ -5224,21 +5777,21 @@ package:
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 116941
-  timestamp: 1686776188528
+  size: 93386
+  timestamp: 1695828613961
 - name: jupyter_core
-  version: 5.3.1
+  version: 5.3.2
   manager: conda
   platform: osx-arm64
   dependencies:
+    platformdirs: '>=2.5'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    platformdirs: '>=2.5'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.3.1-py311h267d04e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.3.2-py311h267d04e_0.conda
   hash:
-    md5: 6ccf01fec31c032910fae668deb036ea
-    sha256: ab2177a18473e4fe78ee75a40952d8b487c04a1dfec53dc657940a9ae85c66ff
+    md5: 9bf1a837d985dfb1be9a97c7b54a5673
+    sha256: 8b22c8321b2cb3120e2da2fd8d711fcc9f80c2ddc50c5eef63937ec8cdeef43f
   optional: false
   category: main
   build: py311h267d04e_0
@@ -5247,22 +5800,22 @@ package:
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 117070
-  timestamp: 1686776273651
+  size: 93871
+  timestamp: 1695828600427
 - name: jupyter_core
-  version: 5.3.1
+  version: 5.3.2
   manager: conda
   platform: win-64
   dependencies:
+    platformdirs: '>=2.5'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
     pywin32: '>=300'
-    platformdirs: '>=2.5'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.3.1-py311h1ea47a8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.3.2-py311h1ea47a8_0.conda
   hash:
-    md5: 6754e6f5ead86225c8c78825ff0398c9
-    sha256: 049eeb389e8caa3c61c26c1458d905335d4fc4d0af7a7af2cadcaeb537e8edce
+    md5: 5debad8642e6d852a2d190b20bbc4e97
+    sha256: c8d3602c26781eea2d73509e9ee3cb37eec8030e30380cfda27ad20f31fe8a6f
   optional: false
   category: main
   build: py311h1ea47a8_0
@@ -5271,272 +5824,276 @@ package:
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 133217
-  timestamp: 1686776376996
+  size: 110237
+  timestamp: 1695828826662
 - name: jupyter_events
-  version: 0.6.3
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
-    rfc3986-validator: '>=0.1.1'
-    python: '>=3.7'
-    pyyaml: '>=5.3'
-    jsonschema: '>=3.2'
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
     python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
+    referencing: '*'
     rfc3339-validator: '*'
+    rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.7.0-pyhd8ed1ab_2.conda
   hash:
-    md5: d98c5196ab6ffeb0c2feca2912801353
-    sha256: 16f73833537e05384d3eef27e62edb31de344d6d26666e1a465c1819014f2655
+    md5: 088f0493279a7f7eebd514df47d65851
+    sha256: df230c068714f71c2b00fd3acee7e5c3ae128a5c23279d146827fdba55977823
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_2
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 2
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 76889
-  timestamp: 1673559924440
+  size: 21381
+  timestamp: 1691506087003
 - name: jupyter_events
-  version: 0.6.3
+  version: 0.7.0
   manager: conda
   platform: osx-64
   dependencies:
-    rfc3986-validator: '>=0.1.1'
-    python: '>=3.7'
-    pyyaml: '>=5.3'
-    jsonschema: '>=3.2'
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
     python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
+    referencing: '*'
     rfc3339-validator: '*'
+    rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.7.0-pyhd8ed1ab_2.conda
   hash:
-    md5: d98c5196ab6ffeb0c2feca2912801353
-    sha256: 16f73833537e05384d3eef27e62edb31de344d6d26666e1a465c1819014f2655
+    md5: 088f0493279a7f7eebd514df47d65851
+    sha256: df230c068714f71c2b00fd3acee7e5c3ae128a5c23279d146827fdba55977823
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_2
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 2
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 76889
-  timestamp: 1673559924440
+  size: 21381
+  timestamp: 1691506087003
 - name: jupyter_events
-  version: 0.6.3
+  version: 0.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    rfc3986-validator: '>=0.1.1'
-    python: '>=3.7'
-    pyyaml: '>=5.3'
-    jsonschema: '>=3.2'
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
     python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
+    referencing: '*'
     rfc3339-validator: '*'
+    rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.7.0-pyhd8ed1ab_2.conda
   hash:
-    md5: d98c5196ab6ffeb0c2feca2912801353
-    sha256: 16f73833537e05384d3eef27e62edb31de344d6d26666e1a465c1819014f2655
+    md5: 088f0493279a7f7eebd514df47d65851
+    sha256: df230c068714f71c2b00fd3acee7e5c3ae128a5c23279d146827fdba55977823
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_2
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 2
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 76889
-  timestamp: 1673559924440
+  size: 21381
+  timestamp: 1691506087003
 - name: jupyter_events
-  version: 0.6.3
+  version: 0.7.0
   manager: conda
   platform: win-64
   dependencies:
-    rfc3986-validator: '>=0.1.1'
-    python: '>=3.7'
-    pyyaml: '>=5.3'
-    jsonschema: '>=3.2'
+    jsonschema-with-format-nongpl: '>=4.18.0'
+    python: '>=3.8'
     python-json-logger: '>=2.0.4'
+    pyyaml: '>=5.3'
+    referencing: '*'
     rfc3339-validator: '*'
+    rfc3986-validator: '>=0.1.1'
     traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.7.0-pyhd8ed1ab_2.conda
   hash:
-    md5: d98c5196ab6ffeb0c2feca2912801353
-    sha256: 16f73833537e05384d3eef27e62edb31de344d6d26666e1a465c1819014f2655
+    md5: 088f0493279a7f7eebd514df47d65851
+    sha256: df230c068714f71c2b00fd3acee7e5c3ae128a5c23279d146827fdba55977823
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_2
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 2
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 76889
-  timestamp: 1673559924440
+  size: 21381
+  timestamp: 1691506087003
 - name: jupyter_server
-  version: 2.7.0
+  version: 2.7.3
   manager: conda
   platform: linux-64
   dependencies:
-    jupyter_server_terminals: '*'
-    jupyter_events: '>=0.4.0'
-    python: '>=3.8'
-    websocket-client: '*'
-    traitlets: '>=5.6.0'
+    anyio: '>=3.1.0'
     argon2-cffi: '*'
-    pyzmq: '>=24'
-    nbformat: '>=5.3.0'
-    jupyter_core: '>=4.12,!=5.0.*'
-    prometheus_client: '*'
-    anyio: '>=3.1.0,<4'
-    overrides: '*'
-    terminado: '>=0.8.3'
     jinja2: '*'
-    send2trash: '*'
-    nbconvert-core: '>=6.4.4'
-    tornado: '>=6.2.0'
     jupyter_client: '>=7.4.4'
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.6.0'
+    jupyter_server_terminals: '*'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: '*'
     packaging: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.0-pyhd8ed1ab_0.conda
+    prometheus_client: '*'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 7488cd1f4d35a2af96faa765b7e5b2f0
-    sha256: 132bfa3eef62231e53b59d93358f818a97c5e7939670bfdd821b7146a0094e43
+    md5: 0123f934221b023ddc7443e85cac9023
+    sha256: 47913d8bda9f0cd5cf2a2d27039436a55a74eec51f1ad2b374a88fbf99fd46b3
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 314908
-  timestamp: 1687870149534
+  size: 317533
+  timestamp: 1695664995482
 - name: jupyter_server
-  version: 2.7.0
+  version: 2.7.3
   manager: conda
   platform: osx-64
   dependencies:
-    jupyter_server_terminals: '*'
-    jupyter_events: '>=0.4.0'
-    python: '>=3.8'
-    websocket-client: '*'
-    traitlets: '>=5.6.0'
+    anyio: '>=3.1.0'
     argon2-cffi: '*'
-    pyzmq: '>=24'
-    nbformat: '>=5.3.0'
-    jupyter_core: '>=4.12,!=5.0.*'
-    prometheus_client: '*'
-    anyio: '>=3.1.0,<4'
-    overrides: '*'
-    terminado: '>=0.8.3'
     jinja2: '*'
-    send2trash: '*'
-    nbconvert-core: '>=6.4.4'
-    tornado: '>=6.2.0'
-    packaging: '*'
     jupyter_client: '>=7.4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.0-pyhd8ed1ab_0.conda
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.6.0'
+    jupyter_server_terminals: '*'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: '*'
+    packaging: '*'
+    prometheus_client: '*'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 7488cd1f4d35a2af96faa765b7e5b2f0
-    sha256: 132bfa3eef62231e53b59d93358f818a97c5e7939670bfdd821b7146a0094e43
+    md5: 0123f934221b023ddc7443e85cac9023
+    sha256: 47913d8bda9f0cd5cf2a2d27039436a55a74eec51f1ad2b374a88fbf99fd46b3
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 314908
-  timestamp: 1687870149534
+  size: 317533
+  timestamp: 1695664995482
 - name: jupyter_server
-  version: 2.7.0
+  version: 2.7.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    jupyter_server_terminals: '*'
-    jupyter_events: '>=0.4.0'
-    python: '>=3.8'
-    websocket-client: '*'
-    traitlets: '>=5.6.0'
+    anyio: '>=3.1.0'
     argon2-cffi: '*'
-    pyzmq: '>=24'
-    nbformat: '>=5.3.0'
-    jupyter_core: '>=4.12,!=5.0.*'
-    prometheus_client: '*'
-    anyio: '>=3.1.0,<4'
-    overrides: '*'
-    terminado: '>=0.8.3'
     jinja2: '*'
-    send2trash: '*'
-    nbconvert-core: '>=6.4.4'
-    tornado: '>=6.2.0'
-    packaging: '*'
     jupyter_client: '>=7.4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.0-pyhd8ed1ab_0.conda
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.6.0'
+    jupyter_server_terminals: '*'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: '*'
+    packaging: '*'
+    prometheus_client: '*'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 7488cd1f4d35a2af96faa765b7e5b2f0
-    sha256: 132bfa3eef62231e53b59d93358f818a97c5e7939670bfdd821b7146a0094e43
+    md5: 0123f934221b023ddc7443e85cac9023
+    sha256: 47913d8bda9f0cd5cf2a2d27039436a55a74eec51f1ad2b374a88fbf99fd46b3
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 314908
-  timestamp: 1687870149534
+  size: 317533
+  timestamp: 1695664995482
 - name: jupyter_server
-  version: 2.7.0
+  version: 2.7.3
   manager: conda
   platform: win-64
   dependencies:
-    jupyter_server_terminals: '*'
-    jupyter_events: '>=0.4.0'
-    python: '>=3.8'
-    websocket-client: '*'
-    traitlets: '>=5.6.0'
+    anyio: '>=3.1.0'
     argon2-cffi: '*'
-    pyzmq: '>=24'
-    nbformat: '>=5.3.0'
-    jupyter_core: '>=4.12,!=5.0.*'
-    prometheus_client: '*'
-    anyio: '>=3.1.0,<4'
-    overrides: '*'
-    terminado: '>=0.8.3'
     jinja2: '*'
-    send2trash: '*'
-    nbconvert-core: '>=6.4.4'
-    tornado: '>=6.2.0'
-    packaging: '*'
     jupyter_client: '>=7.4.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.0-pyhd8ed1ab_0.conda
+    jupyter_core: '>=4.12,!=5.0.*'
+    jupyter_events: '>=0.6.0'
+    jupyter_server_terminals: '*'
+    nbconvert-core: '>=6.4.4'
+    nbformat: '>=5.3.0'
+    overrides: '*'
+    packaging: '*'
+    prometheus_client: '*'
+    python: '>=3.8'
+    pyzmq: '>=24'
+    send2trash: '>=1.8.2'
+    terminado: '>=0.8.3'
+    tornado: '>=6.2.0'
+    traitlets: '>=5.6.0'
+    websocket-client: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 7488cd1f4d35a2af96faa765b7e5b2f0
-    sha256: 132bfa3eef62231e53b59d93358f818a97c5e7939670bfdd821b7146a0094e43
+    md5: 0123f934221b023ddc7443e85cac9023
+    sha256: 47913d8bda9f0cd5cf2a2d27039436a55a74eec51f1ad2b374a88fbf99fd46b3
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 314908
-  timestamp: 1687870149534
+  size: 317533
+  timestamp: 1695664995482
 - name: jupyter_server_terminals
   version: 0.4.4
   manager: conda
@@ -5626,29 +6183,29 @@ package:
   size: 18974
   timestamp: 1673491600853
 - name: jupyterlab
-  version: 4.0.3
+  version: 4.0.6
   manager: conda
   platform: linux-64
   dependencies:
     async-lru: '>=1.0.0'
-    python: '>=3.8'
-    ipykernel: '*'
-    traitlets: '*'
-    importlib_resources: '>=1.4'
-    jupyter_core: '*'
-    jupyterlab_server: '>=2.19.0,<3'
-    jupyter-lsp: '>=2.0.0'
-    tomli: '*'
-    jinja2: '>=3.0.3'
     importlib_metadata: '>=4.8.3'
-    notebook-shim: '>=0.2'
+    importlib_resources: '>=1.4'
+    ipykernel: '*'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: '*'
     jupyter_server: '>=2.4.0,<3'
+    jupyterlab_server: '>=2.19.0,<3'
+    notebook-shim: '>=0.2'
     packaging: '*'
+    python: '>=3.8'
+    tomli: '*'
     tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.3-pyhd8ed1ab_0.conda
+    traitlets: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c861cae50ac4cbc6d573a947f67a2d0c
-    sha256: 57b15a0503b0c261e6dbafd1cfb40089ea994ca08c6b89bf43d37a53b3c28b4e
+    md5: 80bb1cc3b540790cb5afecd73c2d4d1f
+    sha256: 5eb157e0ec794c0d4b100e9b11efefcc8d8b50b6c298539df31ab79ff9fbe446
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -5658,32 +6215,32 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5526898
-  timestamp: 1689253558379
+  size: 5673099
+  timestamp: 1694728366705
 - name: jupyterlab
-  version: 4.0.3
+  version: 4.0.6
   manager: conda
   platform: osx-64
   dependencies:
     async-lru: '>=1.0.0'
-    python: '>=3.8'
-    ipykernel: '*'
-    traitlets: '*'
-    importlib_resources: '>=1.4'
-    jupyter_core: '*'
-    jupyterlab_server: '>=2.19.0,<3'
-    jupyter-lsp: '>=2.0.0'
-    tomli: '*'
-    jinja2: '>=3.0.3'
     importlib_metadata: '>=4.8.3'
-    notebook-shim: '>=0.2'
-    tornado: '>=6.2.0'
-    packaging: '*'
+    importlib_resources: '>=1.4'
+    ipykernel: '*'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: '*'
     jupyter_server: '>=2.4.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.3-pyhd8ed1ab_0.conda
+    jupyterlab_server: '>=2.19.0,<3'
+    notebook-shim: '>=0.2'
+    packaging: '*'
+    python: '>=3.8'
+    tomli: '*'
+    tornado: '>=6.2.0'
+    traitlets: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c861cae50ac4cbc6d573a947f67a2d0c
-    sha256: 57b15a0503b0c261e6dbafd1cfb40089ea994ca08c6b89bf43d37a53b3c28b4e
+    md5: 80bb1cc3b540790cb5afecd73c2d4d1f
+    sha256: 5eb157e0ec794c0d4b100e9b11efefcc8d8b50b6c298539df31ab79ff9fbe446
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -5693,32 +6250,32 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5526898
-  timestamp: 1689253558379
+  size: 5673099
+  timestamp: 1694728366705
 - name: jupyterlab
-  version: 4.0.3
+  version: 4.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
     async-lru: '>=1.0.0'
-    python: '>=3.8'
-    ipykernel: '*'
-    traitlets: '*'
-    importlib_resources: '>=1.4'
-    jupyter_core: '*'
-    jupyterlab_server: '>=2.19.0,<3'
-    jupyter-lsp: '>=2.0.0'
-    tomli: '*'
-    jinja2: '>=3.0.3'
     importlib_metadata: '>=4.8.3'
-    notebook-shim: '>=0.2'
-    tornado: '>=6.2.0'
-    packaging: '*'
+    importlib_resources: '>=1.4'
+    ipykernel: '*'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: '*'
     jupyter_server: '>=2.4.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.3-pyhd8ed1ab_0.conda
+    jupyterlab_server: '>=2.19.0,<3'
+    notebook-shim: '>=0.2'
+    packaging: '*'
+    python: '>=3.8'
+    tomli: '*'
+    tornado: '>=6.2.0'
+    traitlets: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c861cae50ac4cbc6d573a947f67a2d0c
-    sha256: 57b15a0503b0c261e6dbafd1cfb40089ea994ca08c6b89bf43d37a53b3c28b4e
+    md5: 80bb1cc3b540790cb5afecd73c2d4d1f
+    sha256: 5eb157e0ec794c0d4b100e9b11efefcc8d8b50b6c298539df31ab79ff9fbe446
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -5728,32 +6285,32 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5526898
-  timestamp: 1689253558379
+  size: 5673099
+  timestamp: 1694728366705
 - name: jupyterlab
-  version: 4.0.3
+  version: 4.0.6
   manager: conda
   platform: win-64
   dependencies:
     async-lru: '>=1.0.0'
-    python: '>=3.8'
-    ipykernel: '*'
-    traitlets: '*'
-    importlib_resources: '>=1.4'
-    jupyter_core: '*'
-    jupyterlab_server: '>=2.19.0,<3'
-    jupyter-lsp: '>=2.0.0'
-    tomli: '*'
-    jinja2: '>=3.0.3'
     importlib_metadata: '>=4.8.3'
-    notebook-shim: '>=0.2'
-    tornado: '>=6.2.0'
-    packaging: '*'
+    importlib_resources: '>=1.4'
+    ipykernel: '*'
+    jinja2: '>=3.0.3'
+    jupyter-lsp: '>=2.0.0'
+    jupyter_core: '*'
     jupyter_server: '>=2.4.0,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.3-pyhd8ed1ab_0.conda
+    jupyterlab_server: '>=2.19.0,<3'
+    notebook-shim: '>=0.2'
+    packaging: '*'
+    python: '>=3.8'
+    tomli: '*'
+    tornado: '>=6.2.0'
+    traitlets: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.6-pyhd8ed1ab_0.conda
   hash:
-    md5: c861cae50ac4cbc6d573a947f67a2d0c
-    sha256: 57b15a0503b0c261e6dbafd1cfb40089ea994ca08c6b89bf43d37a53b3c28b4e
+    md5: 80bb1cc3b540790cb5afecd73c2d4d1f
+    sha256: 5eb157e0ec794c0d4b100e9b11efefcc8d8b50b6c298539df31ab79ff9fbe446
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -5763,8 +6320,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5526898
-  timestamp: 1689253558379
+  size: 5673099
+  timestamp: 1694728366705
 - name: jupyterlab_pygments
   version: 0.2.2
   manager: conda
@@ -5854,131 +6411,23 @@ package:
   size: 17410
   timestamp: 1649936689608
 - name: jupyterlab_server
-  version: 2.23.0
+  version: 2.25.0
   manager: conda
   platform: linux-64
   dependencies:
-    importlib-metadata: '>=4.8.3'
-    python: '>=3.7'
-    requests: '>=2.28'
     babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
     jinja2: '>=3.0.3'
-    jsonschema: '>=4.17.3'
+    json5: '>=0.9.0'
+    jsonschema: '>=4.18'
     jupyter_server: '>=1.21,<3'
     packaging: '>=21.3'
-    json5: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.23.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    requests: '>=2.31'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 942aa06b962c7e507884c6fbeb4d1f7d
-    sha256: 4f19476ef5d4cc712bc0323f36fb06ef5b1a24abcaec4fd87e5efc12ef9d6073
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 60158
-  timestamp: 1686660302432
-- name: jupyterlab_server
-  version: 2.23.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    python: '>=3.7'
-    requests: '>=2.28'
-    babel: '>=2.10'
-    jinja2: '>=3.0.3'
-    jsonschema: '>=4.17.3'
-    jupyter_server: '>=1.21,<3'
-    packaging: '>=21.3'
-    json5: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 942aa06b962c7e507884c6fbeb4d1f7d
-    sha256: 4f19476ef5d4cc712bc0323f36fb06ef5b1a24abcaec4fd87e5efc12ef9d6073
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 60158
-  timestamp: 1686660302432
-- name: jupyterlab_server
-  version: 2.23.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    python: '>=3.7'
-    requests: '>=2.28'
-    babel: '>=2.10'
-    jinja2: '>=3.0.3'
-    jsonschema: '>=4.17.3'
-    jupyter_server: '>=1.21,<3'
-    packaging: '>=21.3'
-    json5: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 942aa06b962c7e507884c6fbeb4d1f7d
-    sha256: 4f19476ef5d4cc712bc0323f36fb06ef5b1a24abcaec4fd87e5efc12ef9d6073
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 60158
-  timestamp: 1686660302432
-- name: jupyterlab_server
-  version: 2.23.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    python: '>=3.7'
-    requests: '>=2.28'
-    babel: '>=2.10'
-    jinja2: '>=3.0.3'
-    jsonschema: '>=4.17.3'
-    jupyter_server: '>=1.21,<3'
-    packaging: '>=21.3'
-    json5: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.23.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 942aa06b962c7e507884c6fbeb4d1f7d
-    sha256: 4f19476ef5d4cc712bc0323f36fb06ef5b1a24abcaec4fd87e5efc12ef9d6073
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 60158
-  timestamp: 1686660302432
-- name: jupyterlab_widgets
-  version: 3.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2bc3ca2f7387af385dd06706b4fb2d35
-    sha256: 0781ed7a4f35ff1309e95381c40c8d8f96263ca4260a72baaafda87c975a972a
+    md5: a52834fa7e3d12abc5efdf06b2097a05
+    sha256: 608a878d08e0f4f51dd9a61eaead7c0e22d07f48aad06e3e2f6d6f1d0a929746
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -5986,22 +6435,138 @@ package:
   subdir: linux-64
   build_number: 0
   constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 48289
+  timestamp: 1694532412609
+- name: jupyterlab_server
+  version: 2.25.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
+    json5: '>=0.9.0'
+    jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a52834fa7e3d12abc5efdf06b2097a05
+    sha256: 608a878d08e0f4f51dd9a61eaead7c0e22d07f48aad06e3e2f6d6f1d0a929746
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 48289
+  timestamp: 1694532412609
+- name: jupyterlab_server
+  version: 2.25.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
+    json5: '>=0.9.0'
+    jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a52834fa7e3d12abc5efdf06b2097a05
+    sha256: 608a878d08e0f4f51dd9a61eaead7c0e22d07f48aad06e3e2f6d6f1d0a929746
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 48289
+  timestamp: 1694532412609
+- name: jupyterlab_server
+  version: 2.25.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    babel: '>=2.10'
+    importlib-metadata: '>=4.8.3'
+    jinja2: '>=3.0.3'
+    json5: '>=0.9.0'
+    jsonschema: '>=4.18'
+    jupyter_server: '>=1.21,<3'
+    packaging: '>=21.3'
+    python: '>=3.8'
+    requests: '>=2.31'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: a52834fa7e3d12abc5efdf06b2097a05
+    sha256: 608a878d08e0f4f51dd9a61eaead7c0e22d07f48aad06e3e2f6d6f1d0a929746
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 48289
+  timestamp: 1694532412609
+- name: jupyterlab_widgets
+  version: 3.0.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
+    sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
   - jupyterlab >=3,<5
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 186893
-  timestamp: 1688489587808
+  size: 186821
+  timestamp: 1694598854365
 - name: jupyterlab_widgets
-  version: 3.0.8
+  version: 3.0.9
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 2bc3ca2f7387af385dd06706b4fb2d35
-    sha256: 0781ed7a4f35ff1309e95381c40c8d8f96263ca4260a72baaafda87c975a972a
+    md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
+    sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -6013,18 +6578,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 186893
-  timestamp: 1688489587808
+  size: 186821
+  timestamp: 1694598854365
 - name: jupyterlab_widgets
-  version: 3.0.8
+  version: 3.0.9
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 2bc3ca2f7387af385dd06706b4fb2d35
-    sha256: 0781ed7a4f35ff1309e95381c40c8d8f96263ca4260a72baaafda87c975a972a
+    md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
+    sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -6036,18 +6601,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 186893
-  timestamp: 1688489587808
+  size: 186821
+  timestamp: 1694598854365
 - name: jupyterlab_widgets
-  version: 3.0.8
+  version: 3.0.9
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.8-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
   hash:
-    md5: 2bc3ca2f7387af385dd06706b4fb2d35
-    sha256: 0781ed7a4f35ff1309e95381c40c8d8f96263ca4260a72baaafda87c975a972a
+    md5: 8370e0a9dc443f9b45a23fd30e7a6b3b
+    sha256: ec66991d2175f7b1f35973d6c4f56ad9a49666f77acf1037d72f3bc6e37224f3
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -6059,8 +6624,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 186893
-  timestamp: 1688489587808
+  size: 186821
+  timestamp: 1694598854365
 - name: keyutils
   version: 1.6.1
   manager: conda
@@ -6081,86 +6646,86 @@ package:
   size: 117831
   timestamp: 1646151697040
 - name: kiwisolver
-  version: 1.4.4
+  version: 1.4.5
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    libstdcxx-ng: '>=12'
-    python_abi: 3.11.* *_cp311
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.4-py311h4dd048b_1.tar.bz2
+    libstdcxx-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py311h9547e67_1.conda
   hash:
-    md5: 46d451f575392c01dc193069bd89766d
-    sha256: b0d014c8d26e6c88deb9c0e0084387827e48fc83c5ca696b27a88f6683192ef7
+    md5: 2c65bdf442b0d37aad080c8a4e0d452f
+    sha256: 723b0894d2d2b05a38f9c5a285d5a0a5baa27235ceab6531dbf262ba7c6955c1
   optional: false
   category: main
-  build: py311h4dd048b_1
+  build: py311h9547e67_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 77388
-  timestamp: 1666805880436
+  size: 73273
+  timestamp: 1695380140676
 - name: kiwisolver
-  version: 1.4.4
+  version: 1.4.5
   manager: conda
   platform: osx-64
   dependencies:
+    libcxx: '>=15.0.7'
     python: '>=3.11,<3.12.0a0'
-    libcxx: '>=14.0.4'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.4-py311hd2070f0_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py311h5fe6e05_1.conda
   hash:
-    md5: 5219e72a43e53e8f6af4fdf76a0f90ef
-    sha256: 49f91463ed78c6f4e31ddd12a9fe46b4d8ea85a7480620c1a39fd64971764654
+    md5: 24305b23f7995de72bbd53b7c01242a2
+    sha256: 586a4d0a17e6cfd9f8fdee56106d263ee40ca156832774d6e899f82ad68ac8d0
   optional: false
   category: main
-  build: py311hd2070f0_1
+  build: py311h5fe6e05_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 64753
-  timestamp: 1666806012673
+  size: 60694
+  timestamp: 1695380246398
 - name: kiwisolver
-  version: 1.4.4
+  version: 1.4.5
   manager: conda
   platform: osx-arm64
   dependencies:
+    libcxx: '>=15.0.7'
     python: '>=3.11,<3.12.0a0 *_cpython'
-    libcxx: '>=14.0.4'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.4-py311hd6ee22a_1.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py311he4fd1f5_1.conda
   hash:
-    md5: aea430ca7df231e9d17dba5dc7ba52b5
-    sha256: 9bfa08cc2cac4458537ec7dbf78fdd30379cf46a236d586117e803aecf707671
+    md5: 4c871d65040b8c7bbb914df7f8f11492
+    sha256: 907af50734789d47b3e8b2148dde763699dc746c64e5849baf6bd720c8cd0235
   optional: false
   category: main
-  build: py311hd6ee22a_1
+  build: py311he4fd1f5_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 62973
-  timestamp: 1666806157641
+  size: 61946
+  timestamp: 1695380538042
 - name: kiwisolver
-  version: 1.4.4
+  version: 1.4.5
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.4-py311h005e61a_1.tar.bz2
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py311h005e61a_1.conda
   hash:
-    md5: 564530d9dd01d102b5ec76c34381f3b7
-    sha256: 08cb19253d863d311f4b2d6f30a0a770ab0ce6365b238f3c5272c1fc6f6d5e5c
+    md5: de0b3f37405f8386ac8be18fdc06ff92
+    sha256: 8fdd1bff75c24ac6a2a13be4db1c9abcfa39ab50b81539e8bd01131141df271a
   optional: false
   category: main
   build: py311h005e61a_1
@@ -6169,45 +6734,45 @@ package:
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 59565
-  timestamp: 1666806285110
+  size: 55822
+  timestamp: 1695380386563
 - name: krb5
-  version: 1.20.1
+  version: 1.21.2
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.0.7,<4.0a0'
+    keyutils: '>=1.6.1,<2.0a0'
     libedit: '>=3.1.20191231,<4.0a0'
     libgcc-ng: '>=12'
-    keyutils: '>=1.6.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-h81ceb04_0.conda
+    libstdcxx-ng: '>=12'
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
   hash:
-    md5: 89a41adce7106749573d883b2f657d78
-    sha256: 51a346807ce981e1450eb04c3566415b05eed705bc9e6c98c198ec62367b7c62
+    md5: cd95826dbd331ed1be26bdf401432844
+    sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
   optional: false
   category: main
-  build: h81ceb04_0
+  build: h659d440_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1329877
-  timestamp: 1671091750695
+  size: 1371181
+  timestamp: 1692097755782
 - name: krb5
-  version: 1.20.1
+  version: 1.21.2
   manager: conda
   platform: win-64
   dependencies:
+    openssl: '>=3.1.2,<4.0a0'
     ucrt: '>=10.0.20348.0'
-    openssl: '>=3.0.7,<4.0a0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.20.1-heb0366b_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
   hash:
-    md5: a07b05ee8f451ab15698397185efe989
-    sha256: 429edc4fa9e2420c55cdbd9febb154d2358bf662735efda4372f62142ff310cd
+    md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+    sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
   optional: false
   category: main
   build: heb0366b_0
@@ -6216,8 +6781,8 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 717332
-  timestamp: 1671092419752
+  size: 710894
+  timestamp: 1692098129546
 - name: lame
   version: '3.100'
   manager: conda
@@ -6243,89 +6808,89 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-haa2dc70_1.conda
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-h7f713cb_2.conda
   hash:
-    md5: 980d8aca0bc23ca73fa8caa3e7c84c28
-    sha256: 0d88e0e7f8dbf8f01788e21dd63dd49b89433ce7dfd10f53839441396f6481cd
+    md5: 9ab79924a3760f85a799f21bc99bd655
+    sha256: 9125833b3019bf29c4a20295665e7bc912de581086a53693f10709fae409a3b2
   optional: false
   category: main
-  build: haa2dc70_1
+  build: h7f713cb_2
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: MIT
   license_family: MIT
-  size: 242147
-  timestamp: 1678213367786
+  size: 240620
+  timestamp: 1694650174930
 - name: lcms2
   version: '2.15'
   manager: conda
   platform: osx-64
   dependencies:
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-h2dcdeff_1.conda
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
   hash:
-    md5: f1df9b0c2d9fbe985e62f4b24773a9e4
-    sha256: 5154e12ea600a0008ddb76a02e3f6edb373bf8c3eef47f7dd052d66b8d2fc35a
+    md5: 8059507d52f477fbd4b81841e085e25b
+    sha256: b2234f24e3b0030762430ec3414410119d1129804a95ef65af50ad36cabd9bd5
   optional: false
   category: main
-  build: h2dcdeff_1
+  build: hd6ba6f3_3
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 227656
-  timestamp: 1678213605937
+  size: 224895
+  timestamp: 1695969874291
 - name: lcms2
   version: '2.15'
   manager: conda
   platform: osx-arm64
   dependencies:
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hd835a16_1.conda
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
   hash:
-    md5: 945a7b2d3fecee7299855bc0257f6f33
-    sha256: e15f3ac072a19e3ce5ff04c171b7f931e6a6c0bf3c394329b72cfb6cc69fbdbd
+    md5: bbaac531169fed3e09ae31aff80aa069
+    sha256: 3d07ba04602617c3084b302c8a6fa30b2e4b20511180f45992b289c312298018
   optional: false
   category: main
-  build: hd835a16_1
+  build: hf2736f0_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 206190
-  timestamp: 1678213721993
+  size: 215466
+  timestamp: 1695969888308
 - name: lcms2
   version: '2.15'
   manager: conda
   platform: win-64
   dependencies:
     libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.0,<4.6.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h3e3b177_1.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-he9d350c_2.conda
   hash:
-    md5: a76c36ad1b4b87f038d67890122d08ec
-    sha256: 24179aae324bcfa65ec983a389c5e048bd6b174f63afedf4cdd654da78cf9558
+    md5: c09e28411768ba590c7f4d729dd4e3eb
+    sha256: 78630759c1ee298611a34f70fd721b315d72932eabbcd1a7d45b985bf43987d2
   optional: false
   category: main
-  build: h3e3b177_1
+  build: he9d350c_2
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: MIT
   license_family: MIT
-  size: 499079
-  timestamp: 1678213836010
+  size: 498034
+  timestamp: 1694650655672
 - name: ld_impl_linux-64
   version: '2.40'
   manager: conda
@@ -6434,583 +6999,583 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.23,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-17_linux64_openblas.conda
+    libopenblas: '>=0.3.24,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-18_linux64_openblas.conda
   hash:
-    md5: 57fb44770b1bc832fb2dbefa1bd502de
-    sha256: 5a9dfeb9ede4b7ac136ac8c0b589309f8aba5ce79d14ca64ad8bffb3876eb04b
+    md5: bcddbb497582ece559465b9cd11042e7
+    sha256: 92142c12eb42172365c96c865be8f164a2653649b28b23bded0e658f8d5d0815
   optional: false
   category: main
-  build: 17_linux64_openblas
+  build: 18_linux64_openblas
   arch: x86_64
   subdir: linux-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_linux64_openblas
-  - libcblas 3.9.0 17_linux64_openblas
+  - liblapacke 3.9.0 18_linux64_openblas
+  - libcblas 3.9.0 18_linux64_openblas
+  - liblapack 3.9.0 18_linux64_openblas
   - blas * openblas
-  - liblapack 3.9.0 17_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14473
-  timestamp: 1685930788591
+  size: 14545
+  timestamp: 1693951361891
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    libopenblas: '>=0.3.23,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-17_osx64_openblas.conda
+    libopenblas: '>=0.3.24,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-18_osx64_openblas.conda
   hash:
-    md5: 65299527582e2449b05d27fcf8352125
-    sha256: d2439e4f7bbe0814128d080a01f8435875cc423543184ca0096087308631d73e
+    md5: 6461cded280f7a46ebef0f1b687d4883
+    sha256: 6df6e9c008a1a68493c8c394e6dcdd51cfeb7e51f91c0699a596f62f4d9d8995
   optional: false
   category: main
-  build: 17_osx64_openblas
+  build: 18_osx64_openblas
   arch: x86_64
   subdir: osx-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_osx64_openblas
-  - libcblas 3.9.0 17_osx64_openblas
   - blas * openblas
-  - liblapack 3.9.0 17_osx64_openblas
+  - libcblas 3.9.0 18_osx64_openblas
+  - liblapacke 3.9.0 18_osx64_openblas
+  - liblapack 3.9.0 18_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14710
-  timestamp: 1685930987689
+  size: 14765
+  timestamp: 1693951714123
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libopenblas: '>=0.3.23,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-17_osxarm64_openblas.conda
+    libopenblas: '>=0.3.24,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-18_osxarm64_openblas.conda
   hash:
-    md5: 2597bd39632ec57ef3f5ac14865dca09
-    sha256: 76c68d59491b449b7608fb5e4a86f3c292c01cf487ce47288a22fc7001a6b150
+    md5: 928d0c0b57e342a8629f5f5e001ee0d0
+    sha256: efef2710d5309124e200dccb883cdd66531f3f4dcb4af2eb4b7b1e5cf1bac57d
   optional: false
   category: main
-  build: 17_osxarm64_openblas
+  build: 18_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
-  build_number: 17
+  build_number: 18
   constrains:
-  - libcblas 3.9.0 17_osxarm64_openblas
-  - liblapacke 3.9.0 17_osxarm64_openblas
+  - liblapack 3.9.0 18_osxarm64_openblas
+  - liblapacke 3.9.0 18_osxarm64_openblas
   - blas * openblas
-  - liblapack 3.9.0 17_osxarm64_openblas
+  - libcblas 3.9.0 18_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14715
-  timestamp: 1685931044178
+  size: 14859
+  timestamp: 1693951888126
 - name: libblas
   version: 3.9.0
   manager: conda
   platform: win-64
   dependencies:
     mkl: ==2022.1.0 h6a75c08_874
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-17_win64_mkl.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-18_win64_mkl.conda
   hash:
-    md5: 9e42ac6b256b96bfaa19f829c25940e8
-    sha256: 56c5394e80c429acfee53a075e3d1b6ccd8c294510084cd6a2a4b7d8cc80abfb
+    md5: b241da5b7a888f72bb3c3e82747334f4
+    sha256: 5aef8d69197108f3c320a5d4ad4d19ab9c809cdbbf731c7ab988c227de42d6b5
   optional: false
   category: main
-  build: 17_win64_mkl
+  build: 18_win64_mkl
   arch: x86_64
   subdir: win-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - libcblas 3.9.0 17_win64_mkl
-  - liblapack 3.9.0 17_win64_mkl
-  - liblapacke 3.9.0 17_win64_mkl
+  - liblapacke 3.9.0 18_win64_mkl
   - blas * mkl
+  - libcblas 3.9.0 18_win64_mkl
+  - liblapack 3.9.0 18_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 3655884
-  timestamp: 1685931194813
+  size: 3656012
+  timestamp: 1693952074690
 - name: libbrotlicommon
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
   hash:
-    md5: 61641e239f96eae2b8492dc7e755828c
-    sha256: fc57c0876695c5b4ab7173438580c1d7eaa7dccaf14cb6467ca9e0e97abe0cf0
+    md5: aec6c91c7371c26392a06708a73c70e5
+    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
   optional: false
   category: main
-  build: h166bdaf_9
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 71065
-  timestamp: 1687884232329
+  size: 69403
+  timestamp: 1695990007212
 - name: libbrotlicommon
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
   hash:
-    md5: ee1ee8c79c3426229ad03290573be552
-    sha256: 1718e037a7ea9a1730b9f5285898528676794e2aaf5590149d239febab9a9b36
+    md5: 9e6c31441c9aa24e41ace40d6151aab6
+    sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
   optional: false
   category: main
-  build: hb7f2c08_9
+  build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 69588
-  timestamp: 1687884586401
+  size: 67476
+  timestamp: 1695990207321
 - name: libbrotlicommon
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
   hash:
-    md5: 82354022c67480c61419b6e47377af89
-    sha256: 53f4a6cc4f5795adf33fda00b86a0e91513c534ae44859754e9c07954d3a7148
+    md5: cd68f024df0304be41d29a9088162b02
+    sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
   optional: false
   category: main
-  build: h1a8c8d9_9
+  build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 70285
-  timestamp: 1687884697998
+  size: 68579
+  timestamp: 1695990426128
 - name: libbrotlicommon
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.0.9-hcfcfb64_9.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
   hash:
-    md5: 5e0f7bd6f1d0747abd5da59cffb6f533
-    sha256: adef98f4013859c111da28ff1f66c2c65e90213fe8bac78b7fc83a15e26bc955
+    md5: f77f319fb82980166569e1280d5b2864
+    sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
   optional: false
   category: main
-  build: hcfcfb64_9
+  build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 72530
-  timestamp: 1687886570242
+  size: 70598
+  timestamp: 1695990405143
 - name: libbrotlidec
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libbrotlicommon: ==1.0.9 h166bdaf_9
+    libbrotlicommon: ==1.1.0 hd590300_1
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
   hash:
-    md5: 081aa22f4581c08e4372b0b6c2f8478e
-    sha256: 564f301430c3c61bc5e149e74157ec181ed2a758befc89f7c38466d515a0f614
+    md5: f07002e225d7a60a694d42a7bf5ff53f
+    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
   optional: false
   category: main
-  build: h166bdaf_9
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 32567
-  timestamp: 1687884247423
+  size: 32775
+  timestamp: 1695990022788
 - name: libbrotlidec
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    libbrotlicommon: ==1.0.9 hb7f2c08_9
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_9.conda
+    libbrotlicommon: ==1.1.0 h0dc2134_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
   hash:
-    md5: 4043ef9fe42e178785e0e1853b79bdf9
-    sha256: 3892d88f778ddcda5c2bb7d066082fc7b785dcc84ffe448c65f21cbadd856e2c
+    md5: 9ee0bab91b2ca579e10353738be36063
+    sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
   optional: false
   category: main
-  build: hb7f2c08_9
+  build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 31929
-  timestamp: 1687884624094
+  size: 30327
+  timestamp: 1695990232422
 - name: libbrotlidec
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libbrotlicommon: ==1.0.9 h1a8c8d9_9
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_9.conda
+    libbrotlicommon: ==1.1.0 hb547adb_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
   hash:
-    md5: af03c66e8cb688221bdc9e2b0faaa2bf
-    sha256: 2de613dcccbbe40f90a256784ab23f7292aaa0985642ca35496cb9c177d8220b
+    md5: ee1a519335cc10d0ec7e097602058c0a
+    sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
   optional: false
   category: main
-  build: h1a8c8d9_9
+  build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 29129
-  timestamp: 1687884725821
+  size: 28928
+  timestamp: 1695990463780
 - name: libbrotlidec
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: win-64
   dependencies:
+    libbrotlicommon: ==1.1.0 hcfcfb64_1
     ucrt: '>=10.0.20348.0'
-    libbrotlicommon: ==1.0.9 hcfcfb64_9
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.0.9-hcfcfb64_9.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
   hash:
-    md5: 4c502e4846bdc22b944ab9aa5a55a58f
-    sha256: 12880edf7865c7acb72c8501ef71874a65ee5c7960c19cf21883390bc02860bb
+    md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+    sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
   optional: false
   category: main
-  build: hcfcfb64_9
+  build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 32397
-  timestamp: 1687886606813
+  size: 32788
+  timestamp: 1695990443165
 - name: libbrotlienc
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    libbrotlicommon: ==1.0.9 h166bdaf_9
+    libbrotlicommon: ==1.1.0 hd590300_1
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
   hash:
-    md5: 1f0a03af852a9659ed2bf08f2f1704fd
-    sha256: d27bc2562ea3f3b2bfd777f074f1cac6bfa4a737233dad288cd87c4634a9bb3a
+    md5: 5fc11c6020d421960607d821310fcd4d
+    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
   optional: false
   category: main
-  build: h166bdaf_9
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 265202
-  timestamp: 1687884262352
+  size: 282523
+  timestamp: 1695990038302
 - name: libbrotlienc
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-64
   dependencies:
-    libbrotlicommon: ==1.0.9 hb7f2c08_9
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_9.conda
+    libbrotlicommon: ==1.1.0 h0dc2134_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
   hash:
-    md5: b64d4dcc70aa141db7fccbf13bad81e1
-    sha256: c099c964277ee7ea98cf6ba1bfe07078e662b86ed999da3fcf9eaf7d7d242e86
+    md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+    sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
   optional: false
   category: main
-  build: hb7f2c08_9
+  build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 279086
-  timestamp: 1687884674212
+  size: 299092
+  timestamp: 1695990259225
 - name: libbrotlienc
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libbrotlicommon: ==1.0.9 h1a8c8d9_9
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_9.conda
+    libbrotlicommon: ==1.1.0 hb547adb_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
   hash:
-    md5: 8231f81e72b1113eb2ed8d2586c82691
-    sha256: 37e766c0b87d06637bdfc68e072c227ce2dac82b81d26b5f9ac57fb948e2e2b7
+    md5: d7e077f326a98b2cc60087eaff7c730b
+    sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
   optional: false
   category: main
-  build: h1a8c8d9_9
+  build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 263314
-  timestamp: 1687884758242
+  size: 280943
+  timestamp: 1695990509392
 - name: libbrotlienc
-  version: 1.0.9
+  version: 1.1.0
   manager: conda
   platform: win-64
   dependencies:
+    libbrotlicommon: ==1.1.0 hcfcfb64_1
     ucrt: '>=10.0.20348.0'
-    libbrotlicommon: ==1.0.9 hcfcfb64_9
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.0.9-hcfcfb64_9.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
   hash:
-    md5: 19029748649ae0d48871d7012918efef
-    sha256: d8b1ee384d368aa72f7806f771a470e9676149c57f0d12876aff6e45079745c1
+    md5: 71e890a0b361fd58743a13f77e1506b7
+    sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
   optional: false
   category: main
-  build: hcfcfb64_9
+  build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
-  build_number: 9
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 235953
-  timestamp: 1687886643790
+  size: 246515
+  timestamp: 1695990479484
 - name: libcap
-  version: '2.67'
+  version: '2.69'
   manager: conda
   platform: linux-64
   dependencies:
     attr: '>=2.5.1,<2.6.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.67-he9d0100_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
   hash:
-    md5: d05556c80caffff164d17bdea0105a1a
-    sha256: 4dcf2290b9b90ad2654fbfff52e9c1d49885ce71f0bb853520e2b9d54809605b
+    md5: 25cb5999faa414e5ccb2c1388f62d3d5
+    sha256: 942f9564b4228609f017b6617425d29a74c43b8a030e12239fa4458e5cb6323c
   optional: false
   category: main
-  build: he9d0100_0
+  build: h0f662aa_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 99032
-  timestamp: 1675412183349
+  size: 100582
+  timestamp: 1684162447012
 - name: libcblas
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    libblas: ==3.9.0 17_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-17_linux64_openblas.conda
+    libblas: ==3.9.0 18_linux64_openblas
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-18_linux64_openblas.conda
   hash:
-    md5: 7ef0969b00fe3d6eef56a8151d3afb29
-    sha256: 535bc0a6bc7641090b1bdd00a001bb6c4ac43bce2a11f238bc6676252f53eb3f
+    md5: 93dd9ab275ad888ed8113953769af78c
+    sha256: b5a3eac5a1e14ad7054a19249afeee6536ab8c9fb6d6ddc26e277f5c3b1acce4
   optional: false
   category: main
-  build: 17_linux64_openblas
+  build: 18_linux64_openblas
   arch: x86_64
   subdir: linux-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_linux64_openblas
+  - liblapacke 3.9.0 18_linux64_openblas
+  - liblapack 3.9.0 18_linux64_openblas
   - blas * openblas
-  - liblapack 3.9.0 17_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14401
-  timestamp: 1685930800770
+  size: 14455
+  timestamp: 1693951371996
 - name: libcblas
   version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    libblas: ==3.9.0 17_osx64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-17_osx64_openblas.conda
+    libblas: ==3.9.0 18_osx64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-18_osx64_openblas.conda
   hash:
-    md5: 380151ca00704172b242a63701b7bf8a
-    sha256: 5c85941b55a8e897e11188ab66900eb3d83c87f6bdd0b88856733f8510fa4c91
+    md5: b359d4c7d91ff6bf5442604d06538985
+    sha256: 7e8d8bc42c2c21d75b2121cfee0842bd0cf5500e6306c964bea4a9fafd3abba5
   optional: false
   category: main
-  build: 17_osx64_openblas
+  build: 18_osx64_openblas
   arch: x86_64
   subdir: osx-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_osx64_openblas
   - blas * openblas
-  - liblapack 3.9.0 17_osx64_openblas
+  - liblapacke 3.9.0 18_osx64_openblas
+  - liblapack 3.9.0 18_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14614
-  timestamp: 1685931005294
+  size: 14699
+  timestamp: 1693951732651
 - name: libcblas
   version: 3.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 17_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-17_osxarm64_openblas.conda
+    libblas: ==3.9.0 18_osxarm64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-18_osxarm64_openblas.conda
   hash:
-    md5: cf6f9ca46e3db6b2437024df14046b48
-    sha256: d5828db3a507790582815aaf44d54ed6bb07dfce4fd25f92e34b2eb31378a372
+    md5: ee0108105d7181f1c6f8c4269883ff3b
+    sha256: d01e63f9b02b3b45283319341662b2fc5e5598019ba3bceb131b0f79c6962ca8
   optional: false
   category: main
-  build: 17_osxarm64_openblas
+  build: 18_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_osxarm64_openblas
+  - liblapack 3.9.0 18_osxarm64_openblas
+  - liblapacke 3.9.0 18_osxarm64_openblas
   - blas * openblas
-  - liblapack 3.9.0 17_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14629
-  timestamp: 1685931056087
+  size: 14733
+  timestamp: 1693951904664
 - name: libcblas
   version: 3.9.0
   manager: conda
   platform: win-64
   dependencies:
-    libblas: ==3.9.0 17_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-17_win64_mkl.conda
+    libblas: ==3.9.0 18_win64_mkl
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-18_win64_mkl.conda
   hash:
-    md5: 768b2c3be666ecf9e62f939ea919f819
-    sha256: 5b9914c3b95d947a613a9b6d3c1c1515257a61e7838a1f2484927f0c9fe23063
+    md5: fb0b514194c14342a97dfe31a41d60fc
+    sha256: d5f60ed6508b3889a77caf5ff2b66203714e45ec4eea6e5cdb12fe6e8ef2bbdb
   optional: false
   category: main
-  build: 17_win64_mkl
+  build: 18_win64_mkl
   arch: x86_64
   subdir: win-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapack 3.9.0 17_win64_mkl
-  - liblapacke 3.9.0 17_win64_mkl
+  - liblapacke 3.9.0 18_win64_mkl
   - blas * mkl
+  - liblapack 3.9.0 18_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 3655926
-  timestamp: 1685931229487
+  size: 3655770
+  timestamp: 1693952109193
 - name: libclang
   version: 15.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libstdcxx-ng: '>=12'
-    libclang13: ==15.0.7 default_h9986a30_2
+    libclang13: ==15.0.7 default_h9986a30_3
     libgcc-ng: '>=12'
     libllvm15: '>=15.0.7,<15.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_2.conda
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_3.conda
   hash:
-    md5: 1a4fe5162abe4a19b5a9dedf158a0ff9
-    sha256: 9fd064ed59a07ed096fe3c641752be5279f6696bc8b25da0ca4e41fb92758a5b
+    md5: 0922208521c0463e690bbaebba7eb551
+    sha256: c2b0c8dd675e30d86bad410679f258820bc36723fbadffc13c2f60249be91815
   optional: false
   category: main
-  build: default_h7634d5b_2
+  build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 133475
-  timestamp: 1684408546949
+  size: 133162
+  timestamp: 1690549855318
 - name: libclang
   version: 15.0.7
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc14_runtime: '>=14.29.30139'
-    libclang13: ==15.0.7 default_h77d9078_2
+    libclang13: ==15.0.7 default_h77d9078_3
     libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h77d9078_2.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h77d9078_3.conda
   hash:
-    md5: 70188b1b3e0b1716405adab9050894d1
-    sha256: af265f9358565c650ec3f09557d47c6ced441164d10cd500b74651513f61be46
+    md5: 71c8b6249c9e9e18b3aec705e95c1040
+    sha256: d54ad3cc60469f3c885cef45acd7216bab9d941dec8f37e75ece48b9baba145b
   optional: false
   category: main
-  build: default_h77d9078_2
+  build: default_h77d9078_3
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 148161
-  timestamp: 1684447688680
+  size: 147881
+  timestamp: 1690553583920
 - name: libclang13
   version: 15.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
     libllvm15: '>=15.0.7,<15.1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_2.conda
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_3.conda
   hash:
-    md5: 907344cee64101d44d806bbe0fccb01d
-    sha256: d9f9fb5622489d7e5c3237a4a6a46db20ead3c6bafb7277de1a25278db59b863
+    md5: 1720df000b48e31842500323cb7be18c
+    sha256: df1221a9a05b9bb3bd9b43c08a7e2fe57a0e15a0010ef26065f7ed7666083f45
   optional: false
   category: main
-  build: default_h9986a30_2
+  build: default_h9986a30_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 9594391
-  timestamp: 1684408496977
+  size: 9557507
+  timestamp: 1690549793486
 - name: libclang13
   version: 15.0.7
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h77d9078_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h77d9078_3.conda
   hash:
-    md5: c2e1def32a19610ac26db453501760b6
-    sha256: 0be9e57f50f33c813df6e1ad65b8bf8ccf1c23f734785236146b56b9078e7c7b
+    md5: ba26634d038b91466bb4242c8b5e0cfa
+    sha256: 9cff68d1bd3b1b956133f9f5f35d475014402f3f4e7956047bf3a70f2107f11c
   optional: false
   category: main
-  build: default_h77d9078_2
+  build: default_h77d9078_3
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 21913050
-  timestamp: 1684447290621
+  size: 21900199
+  timestamp: 1690553341399
 - name: libcups
   version: 2.3.3
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx-ng: '>=12'
-    krb5: '>=1.20.1,<1.21.0a0'
+    krb5: '>=1.21.1,<1.22.0a0'
     libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h36d4200_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   hash:
-    md5: c9f4416a34bc91e0eb029f912c68f81f
-    sha256: 0ccd610207807f53328f137b2adc99c413f8e1dcd1302f0325412796a94eaaf7
+    md5: d4529f4dff3057982a7617c7ac58fde3
+    sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
   optional: false
   category: main
-  build: h36d4200_3
+  build: h4637d8d_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   license: Apache-2.0
   license_family: Apache
-  size: 4519779
-  timestamp: 1671148111233
+  size: 4519402
+  timestamp: 1689195353551
 - name: libcxx
   version: 16.0.6
   manager: conda
@@ -7050,75 +7615,75 @@ package:
   size: 1160232
   timestamp: 1686896993785
 - name: libdeflate
-  version: '1.18'
+  version: '1.19'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.18-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
   hash:
-    md5: 6aa9c9de5542ecb07fdda9ca626252d8
-    sha256: 949d84ceea543802c1e085b2aa58f1d6cb5dd8cec5a9abaaf4e8ac65d6094b3a
+    md5: 1635570038840ee3f9c71d22aa5b8b6d
+    sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
   optional: false
   category: main
-  build: h0b41bf4_0
+  build: hd590300_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 65177
-  timestamp: 1679647333950
+  size: 67080
+  timestamp: 1694922285678
 - name: libdeflate
-  version: '1.18'
+  version: '1.19'
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.18-hac1461d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
   hash:
-    md5: 3d131584456b277ce0871e6481fde49b
-    sha256: b985178bc45f83259c99026d988448277e17171801945769396e2577ce59778c
+    md5: 6a45f543c2beb40023df5ee7e3cedfbd
+    sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
   optional: false
   category: main
-  build: hac1461d_0
+  build: ha4e1b8e_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 67061
-  timestamp: 1679647698096
+  size: 68962
+  timestamp: 1694922440450
 - name: libdeflate
-  version: '1.18'
+  version: '1.19'
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.18-h1a8c8d9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
   hash:
-    md5: 73ebca3d8666fcfcf28abd74b39b99eb
-    sha256: a7ef4fd6ca62619397af4f434e69b96dfbc2c4e13080475719a8371bfd73834a
+    md5: f8c1eb0e99e90b55965c6558578537cc
+    sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
   optional: false
   category: main
-  build: h1a8c8d9_0
+  build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 48428
-  timestamp: 1679647544992
+  size: 52841
+  timestamp: 1694924330786
 - name: libdeflate
-  version: '1.18'
+  version: '1.19'
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.18-hcfcfb64_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
   hash:
-    md5: 493acc14c556ef6f1d13ba00b099c679
-    sha256: 9a9a1a6e47777c9bf6086d88f6567ed3fc32d4f849b3d42b51bbf0b9fa4727f7
+    md5: 002b1b723b44dbd286b9e3708762433c
+    sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
   optional: false
   category: main
   build: hcfcfb64_0
@@ -7127,15 +7692,15 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 152345
-  timestamp: 1679647873728
+  size: 153203
+  timestamp: 1694922596415
 - name: libedit
   version: 3.1.20191231
   manager: conda
   platform: linux-64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
     libgcc-ng: '>=7.5.0'
+    ncurses: '>=6.2,<7.0.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   hash:
     md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
@@ -7341,9 +7906,9 @@ package:
   platform: linux-64
   dependencies:
     gettext: '>=0.21.1,<1.0a0'
-    libstdcxx-ng: '>=12'
     libgcc-ng: '>=12'
     libogg: '>=1.3.4,<1.4.0a0'
+    libstdcxx-ng: '>=12'
   url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
   hash:
     md5: ee48bf17cc83a00f59ca1494d5646869
@@ -7359,28 +7924,28 @@ package:
   size: 394383
   timestamp: 1687765514062
 - name: libgcc-ng
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: ==0.1 conda_forge
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
   hash:
-    md5: cd93f779ff018dd85c7544c015c9db3c
-    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
+    md5: c28003b0be0494f9a7664389146716ff
+    sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
   optional: false
   category: main
-  build: he5830b7_0
+  build: h807b86a_2
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 2
   constrains:
-  - libgomp 13.1.0 he5830b7_0
+  - libgomp 13.2.0 h807b86a_2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 776294
-  timestamp: 1685816209343
+  size: 771133
+  timestamp: 1695219384393
 - name: libgcrypt
   version: 1.10.1
   manager: conda
@@ -7407,142 +7972,143 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libgfortran5: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-11_3_0_h97931a8_31.conda
+    libgfortran5: ==13.2.0 h2873a65_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
   hash:
-    md5: 97451338600bd9c5b535eb224ef6c471
-    sha256: 55d3c81ce8cd931260c3cb8c85868e36223d2bd0d5e2f35a79503810ee172769
+    md5: b55fd11ab6318a6e67ac191309701d5a
+    sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
   optional: false
   category: main
-  build: 11_3_0_h97931a8_31
+  build: 13_2_0_h97931a8_1
   arch: x86_64
   subdir: osx-64
-  build_number: 31
+  build_number: 1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 160084
-  timestamp: 1678485362631
+  size: 109855
+  timestamp: 1694165674845
 - name: libgfortran
   version: 5.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libgfortran5: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-12_2_0_hd922786_31.conda
+    libgfortran5: ==13.2.0 hf226fd6_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
   hash:
-    md5: dfc3dff1ce831c8e821f19d5d218825a
-    sha256: 1abde945c2c7377aec9f2f648d9cc1fcb5f818a1e0caf53f8188b1182cbc1332
+    md5: 1ad37a5c60c250bb2b4a9f75563e181c
+    sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
   optional: false
   category: main
-  build: 12_2_0_hd922786_31
+  build: 13_2_0_hd922786_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 31
+  build_number: 1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 160260
-  timestamp: 1678488316051
+  size: 110095
+  timestamp: 1694172198016
 - name: libgfortran-ng
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran5: ==13.1.0 h15d22d2_0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.1.0-h69a702a_0.conda
+    libgfortran5: ==13.2.0 ha4646dd_2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
   hash:
-    md5: 506dc07710dd5b0ba63cbf134897fc10
-    sha256: 429e1d8a3e70b632df5b876e3fc322a56f769756693daa07114c46fa5098684e
+    md5: e75a75a6eaf6f318dae2631158c46575
+    sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
   optional: false
   category: main
-  build: h69a702a_0
+  build: h69a702a_2
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23182
-  timestamp: 1685816194244
+  size: 23722
+  timestamp: 1695219642066
 - name: libgfortran5
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.1.0-h15d22d2_0.conda
+  dependencies:
+    libgcc-ng: '>=13.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
   hash:
-    md5: afb656a334c409dd9805508af1c89c7a
-    sha256: a06235f4c4b85b463d9b8a73c9e10c1b5b4105f8a0ea8ac1f2f5f64edac3dfe7
+    md5: 78fdab09d9138851dde2b5fe2a11019e
+    sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
   optional: false
   category: main
-  build: h15d22d2_0
+  build: ha4646dd_2
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 2
   constrains:
-  - libgfortran-ng 13.1.0
+  - libgfortran-ng 13.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1437388
-  timestamp: 1685816112374
+  size: 1441830
+  timestamp: 1695219403435
 - name: libgfortran5
-  version: 12.2.0
+  version: 13.2.0
   manager: conda
   platform: osx-64
   dependencies:
     llvm-openmp: '>=8.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-12.2.0-he409387_31.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
   hash:
-    md5: 5a544130e584b1f204ac896ff071d5b3
-    sha256: 42ae06bbb3cf7f7c3194482894f4287fad7bc39214d1a0dbf0c43f8efb8d3c1a
+    md5: 3af564516b5163cd8cc08820413854bc
+    sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
   optional: false
   category: main
-  build: he409387_31
+  build: h2873a65_1
   arch: x86_64
   subdir: osx-64
-  build_number: 31
+  build_number: 1
   constrains:
-  - libgfortran 5.0.0 *_31
+  - libgfortran 5.0.0 13_2_0_*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1600291
-  timestamp: 1678485061597
+  size: 1571764
+  timestamp: 1694165583047
 - name: libgfortran5
-  version: 12.2.0
+  version: 13.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
     llvm-openmp: '>=8.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-12.2.0-h0eea778_31.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
   hash:
-    md5: 244a7665228221cc951d5126b8bc1465
-    sha256: 375b6ebafffcc1b0e377559b5ba7cb723634a88b77513ad158982d98ff98c32b
+    md5: 4480d71b98c87faafab132d33e23135e
+    sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
   optional: false
   category: main
-  build: h0eea778_31
+  build: hf226fd6_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 31
+  build_number: 1
   constrains:
-  - libgfortran 5.0.0 *_31
+  - libgfortran 5.0.0 13_2_0_*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1049187
-  timestamp: 1678488257002
+  size: 995733
+  timestamp: 1694172076009
 - name: libglib
-  version: 2.76.4
+  version: 2.78.0
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     gettext: '>=0.21.1,<1.0a0'
-    libstdcxx-ng: '>=12'
-    pcre2: '>=10.40,<10.41.0a0'
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.76.4-hebfc3b9_0.conda
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pcre2: '>=10.40,<10.41.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.0-hebfc3b9_0.conda
   hash:
-    md5: c6f951789c888f7bbd2dd6858eab69de
-    sha256: e909b5e648d1ace172aac2ddf9d755f72429b134155a9b07156acb58a77ceee1
+    md5: e618003da3547216310088478e475945
+    sha256: 96ec4dc5e38f434aa5862cb46d74923cce1445de3cd0b9d61e3e63102b163af6
   optional: false
   category: main
   build: hebfc3b9_0
@@ -7550,27 +8116,27 @@ package:
   subdir: linux-64
   build_number: 0
   constrains:
-  - glib 2.76.4 *_0
+  - glib 2.78.0 *_0
   license: LGPL-2.1-or-later
-  size: 2689038
-  timestamp: 1688694661996
+  size: 2701539
+  timestamp: 1694381226310
 - name: libglib
-  version: 2.76.4
+  version: 2.78.0
   manager: conda
   platform: win-64
   dependencies:
-    pcre2: '>=10.40,<10.41.0a0'
-    libffi: '>=3.4,<4.0a0'
-    vc: '>=14.2,<15'
-    libiconv: '>=1.17,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    libzlib: '>=1.2.13,<1.3.0a0'
     gettext: '>=0.21.1,<1.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    pcre2: '>=10.40,<10.41.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.76.4-he8f3873_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.0-he8f3873_0.conda
   hash:
-    md5: 8c3f24acdc0403eeb3fb42ab75e8a659
-    sha256: 4d7b96d0ed8b46df5ccd5de7e726c1ed81c9dc4526460e7608d9dbdbb8ac18f5
+    md5: 25f5b3502a82ac425c72c3bc0efbecb5
+    sha256: 1417a309e40a2fae41e18170a74bface2ab67fb0d6905caeb34f91c6840edacc
   optional: false
   category: main
   build: he8f3873_0
@@ -7578,38 +8144,38 @@ package:
   subdir: win-64
   build_number: 0
   constrains:
-  - glib 2.76.4 *_0
+  - glib 2.78.0 *_0
   license: LGPL-2.1-or-later
-  size: 2612308
-  timestamp: 1688695049371
+  size: 2637097
+  timestamp: 1694381512139
 - name: libgomp
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: ==0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
   hash:
-    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
-    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
+    md5: e2042154faafe61969556f28bade94b9
+    sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
   optional: false
   category: main
-  build: he5830b7_0
+  build: h807b86a_2
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 419184
-  timestamp: 1685816132543
+  size: 421133
+  timestamp: 1695219303065
 - name: libgpg-error
   version: '1.47'
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx-ng: '>=12'
     gettext: '>=0.21.1,<1.0a0'
     libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
   url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
   hash:
     md5: c2097d0b46367996f09b4e8e4920384a
@@ -7625,29 +8191,29 @@ package:
   size: 260794
   timestamp: 1686979818648
 - name: libhwloc
-  version: 2.9.1
+  version: 2.9.3
   manager: conda
   platform: win-64
   dependencies:
-    libxml2: '>=2.11.4,<2.12.0a0'
-    ucrt: '>=10.0.20348.0'
+    libxml2: '>=2.11.5,<2.12.0a0'
     pthreads-win32: '*'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.1-nocuda_h15da153_6.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
   hash:
-    md5: 95b1bd8df3033d08ae5125ed69d71194
-    sha256: dbb221db2ca66075fc12976c55db511dd88433c4db91ed20da59ffada2f6e6bb
+    md5: 87da045f6d26ce9fe20ad76a18f6a18a
+    sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
   optional: false
   category: main
-  build: nocuda_h15da153_6
+  build: default_haede6df_1009
   arch: x86_64
   subdir: win-64
-  build_number: 6
+  build_number: 1009
   license: BSD-3-Clause
   license_family: BSD
-  size: 2537812
-  timestamp: 1686174051116
+  size: 2578462
+  timestamp: 1694533393675
 - name: libiconv
   version: '1.17'
   manager: conda
@@ -7693,61 +8259,61 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-2.1.5.1-h0b41bf4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-2.1.5.1-hd590300_1.conda
   hash:
-    md5: 1edd9e67bdb90d78cea97733ff6b54e6
-    sha256: b19de7bda34eac4fa931be11fa8d7640cdf1441dfd51c91786586a4a4c64c92f
+    md5: 323e90742f0f48fc22bea908735f55e6
+    sha256: 0ef7378818c6d5b407692d02556c32e2f6af31c7542bca5160d0b92a59427fb5
   optional: false
   category: main
-  build: h0b41bf4_0
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   constrains:
   - jpeg <0.0.0a
-  license: IJG, modified 3-clause BSD and zlib
-  size: 490511
-  timestamp: 1678127836526
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 496449
+  timestamp: 1694566464059
 - name: libjpeg-turbo
-  version: 2.1.5.1
+  version: 3.0.0
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-2.1.5.1-hb7f2c08_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
   hash:
-    md5: d7309a152b9b79799063b8bb47e34a3a
-    sha256: 38288e83201639983d3e158a1e8f638334298a0ca3a59dbb188651c874fd6077
+    md5: 72507f8e3961bc968af17435060b6dd6
+    sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
   optional: false
   category: main
-  build: hb7f2c08_0
+  build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   constrains:
   - jpeg <0.0.0a
-  license: IJG, modified 3-clause BSD and zlib
-  size: 458439
-  timestamp: 1678127987545
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 579748
+  timestamp: 1694475265912
 - name: libjpeg-turbo
-  version: 2.1.5.1
+  version: 3.0.0
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-2.1.5.1-h1a8c8d9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
   hash:
-    md5: cd9d6c05ca2e993429a90496ab7e1b99
-    sha256: bda32077e0024630b2348dc1eabc21246b999ece3789e45e6f778c378ec77f08
+    md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
+    sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
   optional: false
   category: main
-  build: h1a8c8d9_0
+  build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   constrains:
   - jpeg <0.0.0a
-  license: IJG, modified 3-clause BSD and zlib
-  size: 426518
-  timestamp: 1678128003762
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 547541
+  timestamp: 1694475104253
 - name: libjpeg-turbo
   version: 2.1.5.1
   manager: conda
@@ -7755,162 +8321,162 @@ package:
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-2.1.5.1-hcfcfb64_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-2.1.5.1-hcfcfb64_1.conda
   hash:
-    md5: f2fad2ae9f1365e343e4329fdb1e9d63
-    sha256: 42a874448d060b59f9b5c900b260c992df9543da55c2ac9537b442450d6e6497
+    md5: 9503c6648d5692f1f26aabca7156f809
+    sha256: 27e49e07f2129cd39c1c34ac882a0e89f55d597d54c35fab362bcd0a37b532a2
   optional: false
   category: main
-  build: hcfcfb64_0
+  build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   constrains:
   - jpeg <0.0.0a
-  license: IJG, modified 3-clause BSD and zlib
-  size: 688076
-  timestamp: 1678128177975
+  license: IJG AND BSD-3-Clause AND Zlib
+  size: 688116
+  timestamp: 1694566907689
 - name: liblapack
   version: 3.9.0
   manager: conda
   platform: linux-64
   dependencies:
-    libblas: ==3.9.0 17_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-17_linux64_openblas.conda
+    libblas: ==3.9.0 18_linux64_openblas
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-18_linux64_openblas.conda
   hash:
-    md5: a2103882c46492e26500fcb56c03de8b
-    sha256: 45128394d2f4d4caf949c1b02bff1cace3ef2e33762dbe8f0edec7701a16aaa9
+    md5: a1244707531e5b143c420c70573c8ec5
+    sha256: 7b59c9bf8399b34818d36c7bbd30cd447649fe4ff2136d3102bb67da0af67a3a
   optional: false
   category: main
-  build: 17_linux64_openblas
+  build: 18_linux64_openblas
   arch: x86_64
   subdir: linux-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_linux64_openblas
-  - libcblas 3.9.0 17_linux64_openblas
+  - liblapacke 3.9.0 18_linux64_openblas
+  - libcblas 3.9.0 18_linux64_openblas
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14408
-  timestamp: 1685930812931
+  size: 14482
+  timestamp: 1693951382004
 - name: liblapack
   version: 3.9.0
   manager: conda
   platform: osx-64
   dependencies:
-    libblas: ==3.9.0 17_osx64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-17_osx64_openblas.conda
+    libblas: ==3.9.0 18_osx64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-18_osx64_openblas.conda
   hash:
-    md5: 6ab83532872bf3659613638589dd10af
-    sha256: 7ce76f3e9578b62fbd88c094f343c1b09ec3466afccfc08347d31742e6831e97
+    md5: e3e4572494c68a638faea31e7b72ec56
+    sha256: 2a297c50fdd566f8a1685ca3da2d3fc3e8b33806240b20ce9e1dc3a739cd48ff
   optional: false
   category: main
-  build: 17_osx64_openblas
+  build: 18_osx64_openblas
   arch: x86_64
   subdir: osx-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - liblapacke 3.9.0 17_osx64_openblas
-  - libcblas 3.9.0 17_osx64_openblas
   - blas * openblas
+  - libcblas 3.9.0 18_osx64_openblas
+  - liblapacke 3.9.0 18_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14619
-  timestamp: 1685931022827
+  size: 14676
+  timestamp: 1693951751596
 - name: liblapack
   version: 3.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 17_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-17_osxarm64_openblas.conda
+    libblas: ==3.9.0 18_osxarm64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-18_osxarm64_openblas.conda
   hash:
-    md5: d93cc56c1467a5bcf6a4c9c0be469114
-    sha256: 7e32d178639c5bcaac4b654438aa364eec8a42f108bc592dda8e52a432b0cdb4
+    md5: 92cd5c16ed732ac6c439145aa21ec7c5
+    sha256: 8e19b14ba16d286d889e3d1c78aaa3344e4c6dff50a21b54ee00ee88a95bb2e9
   optional: false
   category: main
-  build: 17_osxarm64_openblas
+  build: 18_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
-  build_number: 17
+  build_number: 18
   constrains:
-  - libcblas 3.9.0 17_osxarm64_openblas
-  - liblapacke 3.9.0 17_osxarm64_openblas
+  - liblapacke 3.9.0 18_osxarm64_openblas
   - blas * openblas
+  - libcblas 3.9.0 18_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14640
-  timestamp: 1685931066631
+  size: 14767
+  timestamp: 1693951919599
 - name: liblapack
   version: 3.9.0
   manager: conda
   platform: win-64
   dependencies:
-    libblas: ==3.9.0 17_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-17_win64_mkl.conda
+    libblas: ==3.9.0 18_win64_mkl
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-18_win64_mkl.conda
   hash:
-    md5: 278121fe8f0d65d496998aa290f36322
-    sha256: 68922a63d92a414af06b208136c9304be179c6fc911e8636430b0e15c0a9aa3b
+    md5: 82117ef735a916ace2df6f2de4df4824
+    sha256: f90d96695938659fad4dd47d92dbeebff4a3824979bfb1aac33c8287a83e9d23
   optional: false
   category: main
-  build: 17_win64_mkl
+  build: 18_win64_mkl
   arch: x86_64
   subdir: win-64
-  build_number: 17
+  build_number: 18
   constrains:
-  - libcblas 3.9.0 17_win64_mkl
-  - liblapacke 3.9.0 17_win64_mkl
+  - liblapacke 3.9.0 18_win64_mkl
   - blas * mkl
+  - libcblas 3.9.0 18_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 3655939
-  timestamp: 1685931263174
+  size: 3655780
+  timestamp: 1693952143445
 - name: libllvm15
   version: 15.0.7
   manager: conda
   platform: linux-64
   dependencies:
-    libxml2: '>=2.11.3,<2.12.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxml2: '>=2.11.4,<2.12.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
   hash:
-    md5: 5c0a511fa7d223d8661fefcf77b2a877
-    sha256: c9438d40c00a70a1bd959cd133ffb2416e0528edfaefd8a25a73024da9aba5c1
+    md5: 9efe82d44b76a7529a1d702e5a37752e
+    sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
   optional: false
   category: main
-  build: h5cf9203_2
+  build: h5cf9203_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 33311743
-  timestamp: 1684388312978
+  size: 33333655
+  timestamp: 1690527825436
 - name: libnsl
   version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-h7f98852_0.tar.bz2
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-hd590300_1.conda
   hash:
-    md5: 39b1328babf85c7c3a61636d9cd50206
-    sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
+    md5: 854e3e1623b39777140f199c5f9ab952
+    sha256: c0a0c0abc1c17983168c3239d79a62d53c424bc5dd1764dbcd0fa953d6fce5e0
   optional: false
   category: main
-  build: h7f98852_0
+  build: hd590300_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: GPL-2.0-only
+  build_number: 1
+  license: LGPL-2.1-only
   license_family: GPL
-  size: 31236
-  timestamp: 1633040059627
+  size: 33210
+  timestamp: 1695799598317
 - name: libogg
   version: 1.3.4
   manager: conda
@@ -7953,77 +8519,77 @@ package:
   size: 35187
   timestamp: 1610382533961
 - name: libopenblas
-  version: 0.3.23
+  version: 0.3.24
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran-ng: '*'
     libgcc-ng: '>=12'
-    libgfortran5: '>=11.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.23-pthreads_h80387f5_0.conda
+    libgfortran-ng: '*'
+    libgfortran5: '>=12.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
   hash:
-    md5: 9c5ea51ccb8ffae7d06c645869d24ce6
-    sha256: 00aee12d04979d024c7f9cabccff5f5db2852c934397ec863a4abde3e09d5a79
+    md5: 6e4ef6ca28655124dcde9bd500e44c32
+    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
   optional: false
   category: main
-  build: pthreads_h80387f5_0
+  build: pthreads_h413a1c8_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   constrains:
-  - openblas >=0.3.23,<0.3.24.0a0
+  - openblas >=0.3.24,<0.3.25.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5406072
-  timestamp: 1681398290679
+  size: 5492091
+  timestamp: 1693785223074
 - name: libopenblas
-  version: 0.3.23
+  version: 0.3.24
   manager: conda
   platform: osx-64
   dependencies:
     libgfortran: 5.*
-    libgfortran5: '>=11.3.0'
-    llvm-openmp: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.23-openmp_h429af6e_0.conda
+    libgfortran5: '>=12.3.0'
+    llvm-openmp: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
   hash:
-    md5: 7000a828e29608e4f57e662b5502d2c9
-    sha256: fb1ba347e07145807fb1688c78b115d5eb2f4775d9eb6d991d49cb88eef174b7
+    md5: 077718837dd06cf0c3089070108869f6
+    sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
   optional: false
   category: main
-  build: openmp_h429af6e_0
+  build: openmp_h48a4ad5_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   constrains:
-  - openblas >=0.3.23,<0.3.24.0a0
+  - openblas >=0.3.24,<0.3.25.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6018665
-  timestamp: 1681400118468
+  size: 6157393
+  timestamp: 1693785988209
 - name: libopenblas
-  version: 0.3.23
+  version: 0.3.24
   manager: conda
   platform: osx-arm64
   dependencies:
     libgfortran: 5.*
-    libgfortran5: '>=11.3.0'
-    llvm-openmp: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.23-openmp_hc731615_0.conda
+    libgfortran5: '>=12.3.0'
+    llvm-openmp: '>=15.0.7'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
   hash:
-    md5: a40b73e171a91527c79fb1c8b10e3312
-    sha256: 7f88475228d306962493a3f1c52637187695f7c9716a68a75e24a8aa910be69a
+    md5: aacb05989f358affe1bafd4ea7294db4
+    sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
   optional: false
   category: main
-  build: openmp_hc731615_0
+  build: openmp_hd76b1f2_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - openblas >=0.3.23,<0.3.24.0a0
+  - openblas >=0.3.24,<0.3.25.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2732539
-  timestamp: 1681398430140
+  size: 2849225
+  timestamp: 1693784744674
 - name: libopus
   version: 1.3.1
   manager: conda
@@ -8049,8 +8615,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
   hash:
     md5: e1c890aebdebbfbf87e2c917187b4416
@@ -8107,8 +8673,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vs2015_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
@@ -8125,54 +8691,54 @@ package:
   size: 343883
   timestamp: 1669076173145
 - name: libpq
-  version: '15.3'
+  version: '15.4'
   manager: conda
   platform: linux-64
   dependencies:
-    openssl: '>=3.1.0,<4.0a0'
-    krb5: '>=1.20.1,<1.21.0a0'
+    krb5: '>=1.21.2,<1.22.0a0'
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-15.3-hbcd7760_1.conda
+    openssl: '>=3.1.3,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-15.4-hfc447b1_2.conda
   hash:
-    md5: 8afb2a97d256ffde95b91a6283bc598c
-    sha256: 96031c853d1a8b32c50c04b791aa199508ab1f0fa879ab7fcce175ee24620f78
+    md5: 4a180ab68881a86be49858c9baf4581d
+    sha256: f537ad28c083585e7c40e8a05f6febad8b9e649a48a1f2f497add3fc0947800b
   optional: false
   category: main
-  build: hbcd7760_1
+  build: hfc447b1_2
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: PostgreSQL
-  size: 2530642
-  timestamp: 1684451981378
+  size: 2538743
+  timestamp: 1696003959107
 - name: libsndfile
-  version: 1.2.0
+  version: 1.2.2
   manager: conda
   platform: linux-64
   dependencies:
     lame: '>=3.100,<3.101.0a0'
-    libflac: '>=1.4.2,<1.5.0a0'
-    libvorbis: '>=1.3.7,<1.4.0a0'
+    libflac: '>=1.4.3,<1.5.0a0'
     libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libopus: '>=1.3.1,<2.0a0'
-    mpg123: '>=1.31.1,<1.32.0a0'
     libogg: '>=1.3.4,<1.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.0-hb75c966_0.conda
+    libopus: '>=1.3.1,<2.0a0'
+    libstdcxx-ng: '>=12'
+    libvorbis: '>=1.3.7,<1.4.0a0'
+    mpg123: '>=1.32.1,<1.33.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
   hash:
-    md5: c648d19cd9c8625898d5d370414de7c7
-    sha256: 52ab2460d626d1cc95092daa4f7191f84d4950aeb9925484135f96af6b6391d8
+    md5: ef1910918dd895516a769ed36b5b3a4e
+    sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
   optional: false
   category: main
-  build: hb75c966_0
+  build: hc60ed4a_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 350153
-  timestamp: 1672054525440
+  size: 354372
+  timestamp: 1695747735668
 - name: libsodium
   version: 1.0.18
   manager: conda
@@ -8249,16 +8815,16 @@ package:
   size: 713431
   timestamp: 1605135918736
 - name: libsqlite
-  version: 3.42.0
+  version: 3.43.0
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.42.0-h2797004_0.conda
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.0-h2797004_0.conda
   hash:
-    md5: fdaae20a1cf7cd62130a0973190a31b7
-    sha256: 72e958870f49174ebc0ddcd4129e9a9f48de815f20aa3b553f136b514f29bb3a
+    md5: 903fa782a9067d5934210df6d79220f6
+    sha256: e715fab7ec6b3f3df2a5962ef372ff0f871d215fe819482dcd80357999513652
   optional: false
   category: main
   build: h2797004_0
@@ -8266,18 +8832,18 @@ package:
   subdir: linux-64
   build_number: 0
   license: Unlicense
-  size: 828910
-  timestamp: 1684264791037
+  size: 840871
+  timestamp: 1692911324643
 - name: libsqlite
-  version: 3.42.0
+  version: 3.43.0
   manager: conda
   platform: osx-64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.42.0-h58db7d2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.0-h58db7d2_0.conda
   hash:
-    md5: a7d3b44b7b0c9901ac7813b7a0462893
-    sha256: 182689f4b1a5ed638cd615c7774e1a9974842bc127c59173f1d25e31a8795eef
+    md5: e2195038e85e49e26fbeb7efc0ad38c4
+    sha256: 3c3e06284c3426126901891675d09e181c651b2db01df9884da2613015e3fbac
   optional: false
   category: main
   build: h58db7d2_0
@@ -8285,18 +8851,18 @@ package:
   subdir: osx-64
   build_number: 0
   license: Unlicense
-  size: 878744
-  timestamp: 1684265213849
+  size: 891003
+  timestamp: 1692911591798
 - name: libsqlite
-  version: 3.42.0
+  version: 3.43.0
   manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.42.0-hb31c410_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.0-hb31c410_0.conda
   hash:
-    md5: 6ae1bbf3ae393a45a75685072fffbe8d
-    sha256: 120913cf0fb694546fbaf95dff211ac5c1e3e91bc69c73350891a05dc106355f
+    md5: 060a9948665e56a38060a1ed3ebc553a
+    sha256: ddc90cc7a33563cd1f2b179a4964d144c221f9148634c006fd83ec9e1c667907
   optional: false
   category: main
   build: hb31c410_0
@@ -8304,20 +8870,20 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: Unlicense
-  size: 822883
-  timestamp: 1684265273102
+  size: 834286
+  timestamp: 1692911796861
 - name: libsqlite
-  version: 3.42.0
+  version: 3.43.0
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.42.0-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.0-hcfcfb64_0.conda
   hash:
-    md5: 9a71d93deb99cc09d8939d5235b5909a
-    sha256: 70bc1fdb72de847807355c13144666d4f151894f9b141ee559f5d243bdf577e2
+    md5: 16c6f482e70cb3da41d0bee5d49c6bf3
+    sha256: d79128a279c8e8b4afeef5cfe9d4302a2fd65b1af3973732d92a7cc396d5332f
   optional: false
   category: main
   build: hcfcfb64_0
@@ -8325,158 +8891,158 @@ package:
   subdir: win-64
   build_number: 0
   license: Unlicense
-  size: 839797
-  timestamp: 1684265312954
+  size: 846526
+  timestamp: 1692911612959
 - name: libstdcxx-ng
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
   hash:
-    md5: 067bcc23164642f4c226da631f2a2e1d
-    sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
+    md5: 9172c297304f2a20134fc56c97fbe229
+    sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
   optional: false
   category: main
-  build: hfd8a6a1_0
+  build: h7e041cc_2
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 2
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3847887
-  timestamp: 1685816251278
+  size: 3842773
+  timestamp: 1695219454837
 - name: libsystemd0
-  version: '253'
+  version: '254'
   manager: conda
   platform: linux-64
   dependencies:
-    libgcrypt: '>=1.10.1,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    libcap: '>=2.67,<2.68.0a0'
     __glibc: '>=2.17,<3.0.a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+    libcap: '>=2.69,<2.70.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-253-h8c4010b_1.conda
+    libgcrypt: '>=1.10.1,<2.0a0'
+    lz4-c: '>=1.9.3,<1.10.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.2,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-254-h3516f8a_0.conda
   hash:
-    md5: 9176b1e2cb8beca37a7510b0e801e38f
-    sha256: 13f5db46b7ded028f5b53fd5373e27a47789b9a655b52a92c4b324099602f29a
+    md5: df4b1cd0c91b4234fb02b5701a4cdddc
+    sha256: e4732b9bc6acbdd3308cd0abd0860c9ea44e37127cd78acb797c996c20e4f42f
   optional: false
   category: main
-  build: h8c4010b_1
+  build: h3516f8a_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: LGPL-2.1-or-later
+  size: 400372
+  timestamp: 1690575436367
+- name: libtiff
+  version: 4.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    lerc: '>=4.0.0,<5.0a0'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libgcc-ng: '>=12'
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libstdcxx-ng: '>=12'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h29866fb_1.conda
+  hash:
+    md5: 4e9afd30f4ccb2f98645e51005f82236
+    sha256: 16f70e3170b9acb5b5a9e7fe60fd9b1104c946e165a48882ebf38ecb7978e980
+  optional: false
+  category: main
+  build: h29866fb_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
-  license: LGPL-2.1-or-later
-  size: 380557
-  timestamp: 1677532757148
-- name: libtiff
-  version: 4.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libdeflate: '>=1.18,<1.19.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libgcc-ng: '>=12'
-    libwebp-base: '>=1.3.0,<2.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    libstdcxx-ng: '>=12'
-    lerc: '>=4.0.0,<5.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.1-h8b53f26_0.conda
-  hash:
-    md5: 8ad377fb60abab446a9f02c62b3c2190
-    sha256: 920943ad46869938bd070ccd4c0117594e07538bc6b27b75462594c67b6f215d
-  optional: false
-  category: main
-  build: h8b53f26_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: HPND
-  size: 418155
-  timestamp: 1686756728978
+  size: 277480
+  timestamp: 1694958140034
 - name: libtiff
-  version: 4.5.1
+  version: 4.6.0
   manager: conda
   platform: osx-64
   dependencies:
-    libdeflate: '>=1.18,<1.19.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libwebp-base: '>=1.3.0,<2.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    libcxx: '>=15.0.7'
     lerc: '>=4.0.0,<5.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.5.1-hf955e92_0.conda
+    libcxx: '>=15.0.7'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
   hash:
-    md5: 56523ed556e3a44c0fd55bcf17045892
-    sha256: 0526690c890b53419e6bbbe17dfc456789897ce9d7d79db3c4ea6568848bf6d0
+    md5: 2ca10a325063e000ad6d2a5900061e0d
+    sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
   optional: false
   category: main
-  build: hf955e92_0
+  build: h684deea_2
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 2
   license: HPND
-  size: 394629
-  timestamp: 1686757046182
+  size: 266501
+  timestamp: 1695661828714
 - name: libtiff
-  version: 4.5.1
+  version: 4.6.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libdeflate: '>=1.18,<1.19.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libwebp-base: '>=1.3.0,<2.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    libcxx: '>=15.0.7'
     lerc: '>=4.0.0,<5.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.1-h23a1a89_0.conda
+    libcxx: '>=15.0.7'
+    libdeflate: '>=1.19,<1.20.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
   hash:
-    md5: 3bea2e090bd67b6eb1f34d645c2028a1
-    sha256: ebb67ac0970b249786cb37a94be41744032fbb68b5536f661a70581a649d381e
+    md5: 596d6d949bab9a75a492d451f521f457
+    sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
   optional: false
   category: main
-  build: h23a1a89_0
+  build: ha8a6c65_2
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 2
   license: HPND
-  size: 364553
-  timestamp: 1686757144896
+  size: 246265
+  timestamp: 1695661829324
 - name: libtiff
-  version: 4.5.1
+  version: 4.6.0
   manager: conda
   platform: win-64
   dependencies:
-    libdeflate: '>=1.18,<1.19.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    vc14_runtime: '>=14.29.30139'
-    vc: '>=14.2,<15'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    ucrt: '>=10.0.20348.0'
-    xz: '>=5.2.6,<6.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.5.1-h6c8260b_0.conda
+    libdeflate: '>=1.19,<1.20.0a0'
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+    xz: '>=5.2.6,<6.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h4554b19_1.conda
   hash:
-    md5: cc46fe88f82f9c98bd6858b3f6efb4e0
-    sha256: 688e813d61e0d5dff284ef95c53b5c0acf950bbc1df97def4a4a33bbf1bb2fab
+    md5: 84150e18ed7ebd287fb9e3446a13fa8d
+    sha256: c1a31d00654d5e21f276d6280226188142120d7f8ab5d64d6dfadab2b4015098
   optional: false
   category: main
-  build: h6c8260b_0
+  build: h4554b19_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: HPND
-  size: 954786
-  timestamp: 1686757228686
+  size: 784271
+  timestamp: 1694958528287
 - name: libuuid
   version: 2.38.1
   manager: conda
@@ -8503,8 +9069,8 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=9.3.0'
-    libstdcxx-ng: '>=9.3.0'
     libogg: '>=1.3.4,<1.4.0a0'
+    libstdcxx-ng: '>=9.3.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
   hash:
     md5: 309dec04b70a3cc0f1e84a4013683bc0
@@ -8524,9 +9090,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
+    libogg: '>=1.3.4,<1.4.0a0'
     vc: '>=14.1,<15.0a0'
     vs2015_runtime: '>=14.16.27012'
-    libogg: '>=1.3.4,<1.4.0a0'
   url: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
   hash:
     md5: e1a22282de0169c93e4ffe6ce6acc212
@@ -8542,15 +9108,15 @@ package:
   size: 273721
   timestamp: 1610610022421
 - name: libwebp-base
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.1-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
   hash:
-    md5: 82bf6f63eb15ef719b556b63feec3a77
-    sha256: 66658d5cdcf89169e284488d280b6ce693c98c0319d7eabebcedac0929140a73
+    md5: 30de3fd9b3b602f7473f30e684eeea8c
+    sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
   optional: false
   category: main
   build: hd590300_0
@@ -8558,20 +9124,20 @@ package:
   subdir: linux-64
   build_number: 0
   constrains:
-  - libwebp 1.3.1
+  - libwebp 1.3.2
   license: BSD-3-Clause
   license_family: BSD
-  size: 399938
-  timestamp: 1688046983701
+  size: 401830
+  timestamp: 1694709121323
 - name: libwebp-base
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.1-h0dc2134_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
   hash:
-    md5: a25a41b5be3fed4b671a58b998dcf89b
-    sha256: ff0fb385d85dae7c4ba61d28990c32f2f2686b14e503dfb956a0c076e30d59e6
+    md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+    sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
   optional: false
   category: main
   build: h0dc2134_0
@@ -8579,20 +9145,20 @@ package:
   subdir: osx-64
   build_number: 0
   constrains:
-  - libwebp 1.3.1
+  - libwebp 1.3.2
   license: BSD-3-Clause
   license_family: BSD
-  size: 346358
-  timestamp: 1688047185328
+  size: 346599
+  timestamp: 1694709233836
 - name: libwebp-base
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.1-hb547adb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
   hash:
-    md5: 538e751abad9d7ee1bbb5630c679c44d
-    sha256: eee31a8b2bb5c0b1f950ed334f19f399bac0b0b8830dbe39d6f3b84e3aee21bf
+    md5: 85dbc11098cdbe4244cd73f29a3ab795
+    sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
   optional: false
   category: main
   build: hb547adb_0
@@ -8600,23 +9166,23 @@ package:
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - libwebp 1.3.1
+  - libwebp 1.3.2
   license: BSD-3-Clause
   license_family: BSD
-  size: 274105
-  timestamp: 1688047313680
+  size: 273844
+  timestamp: 1694709510635
 - name: libwebp-base
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.1-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
   hash:
-    md5: f89e765213cac556a8ed72ba8c1b5071
-    sha256: 1652438917a14bf67c1dc5a94a431f45fece7837c016a7144979a50924faa1b7
+    md5: dcde8820959e64378d4e06147ffecfdd
+    sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
   optional: false
   category: main
   build: hcfcfb64_0
@@ -8624,20 +9190,20 @@ package:
   subdir: win-64
   build_number: 0
   constrains:
-  - libwebp 1.3.1
+  - libwebp 1.3.2
   license: BSD-3-Clause
   license_family: BSD
-  size: 268638
-  timestamp: 1688047352914
+  size: 268870
+  timestamp: 1694709461733
 - name: libxcb
   version: '1.15'
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-libxau: '*'
-    xorg-libxdmcp: '*'
     libgcc-ng: '>=12'
     pthread-stubs: '*'
+    xorg-libxau: '*'
+    xorg-libxdmcp: '*'
   url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
   hash:
     md5: 33277193f5b92bad9fdd230eb700929c
@@ -8657,8 +9223,8 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    xorg-libxau: '*'
     pthread-stubs: '*'
+    xorg-libxau: '*'
     xorg-libxdmcp: '*'
   url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
   hash:
@@ -8679,8 +9245,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    xorg-libxau: '*'
     pthread-stubs: '*'
+    xorg-libxau: '*'
     xorg-libxdmcp: '*'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
   hash:
@@ -8701,10 +9267,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    xorg-libxau: '*'
-    m2w64-gcc-libs-core: '*'
     m2w64-gcc-libs: '*'
+    m2w64-gcc-libs-core: '*'
     pthread-stubs: '*'
+    xorg-libxau: '*'
     xorg-libxdmcp: '*'
   url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
   hash:
@@ -8725,10 +9291,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libstdcxx-ng: '>=12'
     libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+    libxml2: '>=2.11.4,<2.12.0a0'
     xkeyboard-config: '*'
   url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.5.0-h5d7e998_3.conda
   hash:
@@ -8745,53 +9311,53 @@ package:
   size: 560725
   timestamp: 1684639184662
 - name: libxml2
-  version: 2.11.4
+  version: 2.11.5
   manager: conda
   platform: linux-64
   dependencies:
-    xz: '>=5.2.6,<6.0a0'
-    icu: '>=72.1,<73.0a0'
-    libiconv: '>=1.17,<2.0a0'
+    icu: '>=73.2,<74.0a0'
     libgcc-ng: '>=12'
+    libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.4-h0d562d8_0.conda
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
   hash:
-    md5: e46fad17d5fb57316b956f88dca765e4
-    sha256: bc7fa8590c15ffdea5101075ce02de09441c9f378ac1d05e26510d12d25d7099
+    md5: f3858448893839820d4bcfb14ad3ecdf
+    sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
   optional: false
   category: main
-  build: h0d562d8_0
+  build: h232c23b_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 704128
-  timestamp: 1684627162618
+  size: 705542
+  timestamp: 1692960341690
 - name: libxml2
-  version: 2.11.4
+  version: 2.11.5
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    libzlib: '>=1.2.13,<1.3.0a0'
     libiconv: '>=1.17,<2.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.4-hc3477c8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
   hash:
-    md5: 586627982a63815637f871a6360fe3f9
-    sha256: d9d2210436ac28d1a15de08468202a944135d17da3b37fd82c0e90a36ce8ef72
+    md5: 27974f880a010b1441093d9f737a949f
+    sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
   optional: false
   category: main
-  build: hc3477c8_0
+  build: hc3477c8_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 1700060
-  timestamp: 1684627377126
+  size: 1600640
+  timestamp: 1692960798126
 - name: libzlib
   version: 1.2.13
   manager: conda
@@ -8881,14 +9447,14 @@ package:
   size: 55800
   timestamp: 1686575452215
 - name: llvm-openmp
-  version: 16.0.6
+  version: 17.0.2
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-16.0.6-hff08bdf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.2-hff08bdf_0.conda
   hash:
-    md5: 39a5227d906f75102bf8586741690128
-    sha256: 0fbcf1c9e15dbb22d337063550ebcadbeb96b2a012e633f80255c8c720e4f832
+    md5: fe9a7b6676832e214e7b135b611592bc
+    sha256: c251012a7504b67907bd22efa1df13ac88a4f3bce2d83850665b465125b43e18
   optional: false
   category: main
   build: hff08bdf_0
@@ -8896,20 +9462,20 @@ package:
   subdir: osx-64
   build_number: 0
   constrains:
-  - openmp 16.0.6|16.0.6.*
+  - openmp 17.0.2|17.0.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 295823
-  timestamp: 1686865427800
+  size: 304623
+  timestamp: 1696555642332
 - name: llvm-openmp
-  version: 16.0.6
+  version: 17.0.2
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-16.0.6-h1c12783_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.2-h1c12783_0.conda
   hash:
-    md5: 52e5730888439f7f55fd4f83905581b4
-    sha256: f5cbb852853a7a931716d55e39515876f61fefd0cb4e055f286adc2dc3bc9d2a
+    md5: cc2d5e802daf2135a1eaa5983ee47827
+    sha256: 4bbe783de0fafa9e05b0af28c8afbfde5b9525acd65e8f387562c5e80f5ec4bd
   optional: false
   category: main
   build: h1c12783_0
@@ -8917,11 +9483,11 @@ package:
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - openmp 16.0.6|16.0.6.*
+  - openmp 17.0.2|17.0.2.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 268740
-  timestamp: 1686865657336
+  size: 275849
+  timestamp: 1696555855843
 - name: lz4-c
   version: 1.9.4
   manager: conda
@@ -8949,7 +9515,7 @@ package:
   platform: win-64
   dependencies:
     m2w64-gcc-libs-core: '*'
-    msys2-conda-epoch: '>=20160418'
+    msys2-conda-epoch: ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
   hash:
     md5: 066552ac6b907ec6d72c0ddab29050dc
@@ -8968,11 +9534,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    m2w64-libwinpthread-git: '*'
-    msys2-conda-epoch: '>=20160418'
-    m2w64-gcc-libs-core: '*'
     m2w64-gcc-libgfortran: '*'
+    m2w64-gcc-libs-core: '*'
     m2w64-gmp: '*'
+    m2w64-libwinpthread-git: '*'
+    msys2-conda-epoch: ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
   hash:
     md5: fe759119b8b3bfa720b8762c6fdc35de
@@ -8991,9 +9557,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    msys2-conda-epoch: '>=20160418'
     m2w64-gmp: '*'
     m2w64-libwinpthread-git: '*'
+    msys2-conda-epoch: ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
   hash:
     md5: 4289d80fb4d272f1f3b56cfe87ac90bd
@@ -9012,7 +9578,7 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    msys2-conda-epoch: '>=20160418'
+    msys2-conda-epoch: ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
   hash:
     md5: 53a1c73e1e3d185516d7e3af177596d9
@@ -9031,7 +9597,7 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    msys2-conda-epoch: '>=20160418'
+    msys2-conda-epoch: ==20160418
   url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
   hash:
     md5: 774130a326dee16f1ceb05cc687ee4f0
@@ -9050,25 +9616,25 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
     libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
   hash:
-    md5: 9904dc4adb5d547cb21e136f98cb24b0
-    sha256: 747b00706156b61d48565710f38cdb382e22f7db03e5b429532a2d5d5917c313
+    md5: 71120b5155a0c500826cf81536721a15
+    sha256: e1a9930f35e39bf65bc293e24160b83ebf9f800f02749f65358e1c04882ee6b0
   optional: false
   category: main
-  build: py311h459d7ec_0
+  build: py311h459d7ec_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 26975
-  timestamp: 1685769213443
+  size: 27174
+  timestamp: 1695367575909
 - name: markupsafe
   version: 2.1.3
   manager: conda
@@ -9076,22 +9642,22 @@ package:
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_1.conda
   hash:
-    md5: 65b70928fcc2a81891ad1a8a6a7b085a
-    sha256: 93dbcca2a1a1c0ee1dbd60b578a66b650da2b166845ccf9ec54eed948ae42e47
+    md5: 52ee86f482b552e547e2b1d6c01adf55
+    sha256: 5a8f8caa89eeba6ea6e9e96d3e7c109b675bc3c6ed4b109b8931757da2411d48
   optional: false
   category: main
-  build: py311h2725bcf_0
+  build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 25795
-  timestamp: 1685769434455
+  size: 25917
+  timestamp: 1695367980802
 - name: markupsafe
   version: 2.1.3
   manager: conda
@@ -9099,85 +9665,85 @@ package:
   dependencies:
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_1.conda
   hash:
-    md5: 64767fbeb9e55231662b75405f9e01e4
-    sha256: 3d8fc172185c479b9df33259300bd204e40f13d958c030249cd35952709d61bf
+    md5: 5a7b68cb9eea46bea31aaf2d11d0dd2f
+    sha256: 307c1e3b2e4a2a992a6c94975910adff88cc523e2c9a41e81b2d506d8c9e7359
   optional: false
   category: main
-  build: py311heffc1b2_0
+  build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 26729
-  timestamp: 1685769407109
+  size: 26764
+  timestamp: 1695368008221
 - name: markupsafe
   version: 2.1.3
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_1.conda
   hash:
-    md5: db2c2f72a83bdc5b70947964e1ddc8bb
-    sha256: 53093042d6223531559fab2096eed85abee39d9386df9d7d42f9398e40017f04
+    md5: bc93b9d445824cfce3933b5dcc1087b4
+    sha256: 435c4c2df8d98cd49d8332d22b6f4847fc4b594500f0cdf0f9437274c668642b
   optional: false
   category: main
-  build: py311ha68e1ae_0
+  build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 29453
-  timestamp: 1685769449108
+  size: 29466
+  timestamp: 1695367841578
 - name: matplotlib
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    matplotlib-base: '>=3.7.2,<3.7.3.0a0'
+    matplotlib-base: '>=3.8.0,<3.8.1.0a0'
+    pyqt: '>=5.10'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    pyqt: '>=5.10'
     tornado: '>=5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.7.2-py311h38be061_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.8.0-py311h38be061_1.conda
   hash:
-    md5: c056ffab165096669389e5a4eea4dc4d
-    sha256: dcf20650b3561fa0294264cf388c8027cd0707039312692f70997d7b84f7c6dc
+    md5: 6a2cd22264c8a61c8a571bb6e524775f
+    sha256: 2e6a73ecbcb3a7027fc672d28cc22375bff9089621534cf1712678511e53ac8f
   optional: false
   category: main
-  build: py311h38be061_0
+  build: py311h38be061_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: LicenseRef-PSF-2.0 and CC0-1.0
+  build_number: 1
+  license: PSF-2.0
   license_family: PSF
-  size: 8427
-  timestamp: 1688685179235
+  size: 8456
+  timestamp: 1695329104595
 - name: matplotlib
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    matplotlib-base: '>=3.7.2,<3.7.3.0a0'
+    matplotlib-base: '>=3.8.0,<3.8.1.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
     tornado: '>=5'
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.7.2-py311h6eed73b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.8.0-py311h6eed73b_0.conda
   hash:
-    md5: e32f9e5a192246ee550157ac8ffca102
-    sha256: 02876fb351fba127c217adb001c15540150e9bfdcab74ad9aee0cdadd9d74f2b
+    md5: 51d122b38289e4112c7175d55cfd27a1
+    sha256: 51402de23eaa2674807858be31a13edd3a52fa342011428e1295790f9406d54f
   optional: false
   category: main
   build: py311h6eed73b_0
@@ -9186,114 +9752,114 @@ package:
   build_number: 0
   license: LicenseRef-PSF-2.0 and CC0-1.0
   license_family: PSF
-  size: 8469
-  timestamp: 1688685389939
+  size: 8566
+  timestamp: 1695080981156
 - name: matplotlib
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    matplotlib-base: '>=3.7.2,<3.7.3.0a0'
+    matplotlib-base: '>=3.8.0,<3.8.1.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
     tornado: '>=5'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.7.2-py311ha1ab1f8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.8.0-py311ha1ab1f8_1.conda
   hash:
-    md5: 39e4bb6ea39391959d04772e1b8dd66a
-    sha256: 70b564f56be04b4f4e7d3ebf05af78052d56a163e49df716f5fe24cb65886ca2
+    md5: 2676eb8e3309757b94ac426f7c49ae70
+    sha256: 60688ca76c85f37567d1f4c246696bf5a08b118664b90c557978099f15dc37cc
   optional: false
   category: main
-  build: py311ha1ab1f8_0
+  build: py311ha1ab1f8_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: LicenseRef-PSF-2.0 and CC0-1.0
+  build_number: 1
+  license: PSF-2.0
   license_family: PSF
-  size: 8532
-  timestamp: 1688685970697
+  size: 8618
+  timestamp: 1695333177276
 - name: matplotlib
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: win-64
   dependencies:
-    matplotlib-base: '>=3.7.2,<3.7.3.0a0'
+    matplotlib-base: '>=3.8.0,<3.8.1.0a0'
+    pyqt: '>=5.10'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    pyqt: '>=5.10'
     tornado: '>=5'
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.7.2-py311h1ea47a8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.8.0-py311h1ea47a8_1.conda
   hash:
-    md5: d95553771cdf9d4c03545d80138724b9
-    sha256: 897ddd85034d366a95210fb6ac7e90ba4a697a199df13e1d23d77888fcc99626
+    md5: 58587d3aa73615391356293dc8e7479a
+    sha256: 204d4445e13f7765a5341dd0a86c901d20b7ef8d01b3413e195a82f2f490ba6b
   optional: false
   category: main
-  build: py311h1ea47a8_0
+  build: py311h1ea47a8_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
-  license: LicenseRef-PSF-2.0 and CC0-1.0
+  build_number: 1
+  license: PSF-2.0
   license_family: PSF
-  size: 8804
-  timestamp: 1688685589685
+  size: 8862
+  timestamp: 1695329615942
 - name: matplotlib-base
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    cycler: '>=0.10'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    kiwisolver: '>=1.0.1'
-    pyparsing: '>=2.3.1,<3.1'
-    libgcc-ng: '>=12'
-    python-dateutil: '>=2.7'
     certifi: '>=2020.6.20'
     contourpy: '>=1.0.1'
+    cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
-    numpy: '>=1.23.5,<2.0a0'
+    kiwisolver: '>=1.0.1'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    pillow: '>=6.2.0'
-    tk: '>=8.6.12,<8.7.0a0'
+    numpy: '>=1.23.5,<2.0a0'
     packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.7.2-py311h54ef318_0.conda
+    pillow: '>=6.2.0'
+    pyparsing: '>=2.3.1'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.7'
+    python_abi: 3.11.* *_cp311
+    tk: '>=8.6.12,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.0-py311h54ef318_1.conda
   hash:
-    md5: 2631a9e423855fb586c05f8a5ee8b177
-    sha256: 9029779788461098618aa9b3ef01dc61d8561686abb97a7ddf310d89b68365e6
+    md5: 20d79e2fe53b49b399f3d36977b05abb
+    sha256: dc66351c4d8250a318ece2d98837fda48adc5e62227ad1283468a9d982d280e7
   optional: false
   category: main
-  build: py311h54ef318_0
+  build: py311h54ef318_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: LicenseRef-PSF-2.0 and CC0-1.0
+  build_number: 1
+  license: PSF-2.0
   license_family: PSF
-  size: 7710042
-  timestamp: 1688685154053
+  size: 7861835
+  timestamp: 1695329078332
 - name: matplotlib-base
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    cycler: '>=0.10'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    kiwisolver: '>=1.0.1'
     __osx: '>=10.12'
-    pyparsing: '>=2.3.1,<3.1'
-    python-dateutil: '>=2.7'
     certifi: '>=2020.6.20'
     contourpy: '>=1.0.1'
+    cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
-    numpy: '>=1.23.5,<2.0a0'
+    kiwisolver: '>=1.0.1'
     libcxx: '>=15.0.7'
-    pillow: '>=6.2.0'
+    numpy: '>=1.23.5,<2.0a0'
     packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.7.2-py311haff9b01_0.conda
+    pillow: '>=6.2.0'
+    pyparsing: '>=2.3.1'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.7'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.0-py311haff9b01_0.conda
   hash:
-    md5: bd9520e9015e70f3de839ce48c9061ea
-    sha256: 2264ee0dbb0bac37d9fe36867f06eb0169fdeb158696cd41d83c4b0bdc503541
+    md5: 390e0db0f04fabd7330fa626c398b16f
+    sha256: cb2711d7a9d34a5954939737a38ebcb4916279c0a49d7cd7272d2e28b2b94b97
   optional: false
   category: main
   build: py311haff9b01_0
@@ -9302,83 +9868,83 @@ package:
   build_number: 0
   license: LicenseRef-PSF-2.0 and CC0-1.0
   license_family: PSF
-  size: 7634454
-  timestamp: 1688685352615
+  size: 7915262
+  timestamp: 1695080924547
 - name: matplotlib-base
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    cycler: '>=0.10'
     certifi: '>=2020.6.20'
     contourpy: '>=1.0.1'
+    cycler: '>=0.10'
     fonttools: '>=4.22.0'
-    kiwisolver: '>=1.0.1'
     freetype: '>=2.12.1,<3.0a0'
-    pyparsing: '>=2.3.1,<3.1'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-    numpy: '>=1.23.5,<2.0a0'
+    kiwisolver: '>=1.0.1'
     libcxx: '>=15.0.7'
-    pillow: '>=6.2.0'
-    python-dateutil: '>=2.7'
+    numpy: '>=1.23.5,<2.0a0'
     packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.7.2-py311h3bc9839_0.conda
+    pillow: '>=6.2.0'
+    pyparsing: '>=2.3.1'
+    python: '>=3.11,<3.12.0a0 *_cpython'
+    python-dateutil: '>=2.7'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.0-py311h3bc9839_1.conda
   hash:
-    md5: af0a2c33d9c11ddd939b9b29b56e8b7b
-    sha256: 714f202f17d2085714a318ba1aadb2120ad2e83b74608621b4cdba4845c3267c
+    md5: 6a29506521cea5e724d3015e0fd0ce07
+    sha256: 14f64e6fdeb18733b92704a919dbf60c0fe1e13f559e69caad2af673da5bee5a
   optional: false
   category: main
-  build: py311h3bc9839_0
+  build: py311h3bc9839_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: LicenseRef-PSF-2.0 and CC0-1.0
+  build_number: 1
+  license: PSF-2.0
   license_family: PSF
-  size: 7735429
-  timestamp: 1688685916369
+  size: 7794166
+  timestamp: 1695332828721
 - name: matplotlib-base
-  version: 3.7.2
+  version: 3.8.0
   manager: conda
   platform: win-64
   dependencies:
-    cycler: '>=0.10'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    kiwisolver: '>=1.0.1'
-    pyparsing: '>=2.3.1,<3.1'
-    vc14_runtime: '>=14.29.30139'
-    ucrt: '>=10.0.20348.0'
-    python-dateutil: '>=2.7'
     certifi: '>=2020.6.20'
     contourpy: '>=1.0.1'
+    cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
-    vc: '>=14.2,<15'
+    kiwisolver: '>=1.0.1'
     numpy: '>=1.23.5,<2.0a0'
-    pillow: '>=6.2.0'
     packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.7.2-py311h6e989c2_0.conda
+    pillow: '>=6.2.0'
+    pyparsing: '>=2.3.1'
+    python: '>=3.11,<3.12.0a0'
+    python-dateutil: '>=2.7'
+    python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.0-py311h6e989c2_1.conda
   hash:
-    md5: 9fc9898bc66347cb1d843999610f28ea
-    sha256: b8bba431f040e6c753e95a9f4c6362153c731c5fee168367452adc81b4ad97d1
+    md5: d28013e1333ec4007b3c4dec8aa81d03
+    sha256: 7585de7efa8229056df1a7883ff30322e30193941e61c0f5bc134d8bf7f9b7df
   optional: false
   category: main
-  build: py311h6e989c2_0
+  build: py311h6e989c2_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
-  license: LicenseRef-PSF-2.0 and CC0-1.0
+  build_number: 1
+  license: PSF-2.0
   license_family: PSF
-  size: 7550581
-  timestamp: 1688685542172
+  size: 7767944
+  timestamp: 1695329576374
 - name: matplotlib-inline
   version: 0.1.6
   manager: conda
   platform: linux-64
   dependencies:
-    traitlets: '*'
     python: '>=3.6'
+    traitlets: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21613793fcc81d944c76c9f2864a7de
@@ -9399,8 +9965,8 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    traitlets: '*'
     python: '>=3.6'
+    traitlets: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21613793fcc81d944c76c9f2864a7de
@@ -9421,8 +9987,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    traitlets: '*'
     python: '>=3.6'
+    traitlets: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21613793fcc81d944c76c9f2864a7de
@@ -9443,8 +10009,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    traitlets: '*'
     python: '>=3.6'
+    traitlets: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: b21613793fcc81d944c76c9f2864a7de
@@ -9461,15 +10027,15 @@ package:
   size: 12273
   timestamp: 1660814913405
 - name: mistune
-  version: 3.0.0
+  version: 3.0.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c7d0ea64c37752ecbe6da458aee662d2
-    sha256: 0f913186537ce2c8df3440a934a1dbe9faefe6ab5df44fc48cb854c0704abb60
+    md5: 1dad8397c94e4de97a70de552a7dcf49
+    sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -9479,18 +10045,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 66117
-  timestamp: 1686313772742
+  size: 66169
+  timestamp: 1692116828443
 - name: mistune
-  version: 3.0.0
+  version: 3.0.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c7d0ea64c37752ecbe6da458aee662d2
-    sha256: 0f913186537ce2c8df3440a934a1dbe9faefe6ab5df44fc48cb854c0704abb60
+    md5: 1dad8397c94e4de97a70de552a7dcf49
+    sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -9500,18 +10066,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 66117
-  timestamp: 1686313772742
+  size: 66169
+  timestamp: 1692116828443
 - name: mistune
-  version: 3.0.0
+  version: 3.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c7d0ea64c37752ecbe6da458aee662d2
-    sha256: 0f913186537ce2c8df3440a934a1dbe9faefe6ab5df44fc48cb854c0704abb60
+    md5: 1dad8397c94e4de97a70de552a7dcf49
+    sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -9521,18 +10087,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 66117
-  timestamp: 1686313772742
+  size: 66169
+  timestamp: 1692116828443
 - name: mistune
-  version: 3.0.0
+  version: 3.0.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
   hash:
-    md5: c7d0ea64c37752ecbe6da458aee662d2
-    sha256: 0f913186537ce2c8df3440a934a1dbe9faefe6ab5df44fc48cb854c0704abb60
+    md5: 1dad8397c94e4de97a70de552a7dcf49
+    sha256: 0b4558d3afb64e23b66f5279b704de76ebeb6b4eebbf913d65fbd4ba7d9acc2f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -9542,8 +10108,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 66117
-  timestamp: 1686313772742
+  size: 66169
+  timestamp: 1692116828443
 - name: mkl
   version: 2022.1.0
   manager: conda
@@ -9570,9 +10136,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    mpfr: '>=4.1.0,<5.0a0'
-    libgcc-ng: '>=12'
     gmp: '>=6.2.1,<7.0a0'
+    libgcc-ng: '>=12'
+    mpfr: '>=4.1.0,<5.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.3.1-hfe3b2da_0.conda
   hash:
     md5: 289c71e83dc0daa7d4c81f04180778ca
@@ -9592,8 +10158,8 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    mpfr: '>=4.1.0,<5.0a0'
     gmp: '>=6.2.1,<7.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h81bd1dd_0.conda
   hash:
     md5: c752c0eb6c250919559172c011e5f65b
@@ -9613,8 +10179,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    mpfr: '>=4.1.0,<5.0a0'
     gmp: '>=6.2.1,<7.0a0'
+    mpfr: '>=4.1.0,<5.0a0'
   url: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h91ba8db_0.conda
   hash:
     md5: 362af269d860ae49580f8f032a68b0df
@@ -9634,8 +10200,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
     gmp: '>=6.2.1,<7.0a0'
+    libgcc-ng: '>=12'
   url: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.0-hb012696_0.conda
   hash:
     md5: 14d87bdff2cbd3b1179a29fb316ed743
@@ -9691,26 +10257,26 @@ package:
   size: 343909
   timestamp: 1678380200136
 - name: mpg123
-  version: 1.31.3
+  version: 1.32.3
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.31.3-hcb278e6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.3-h59595ed_0.conda
   hash:
-    md5: 141a126675b6d1a4eabb111a4a353898
-    sha256: 7e4a64329595c0cbfc770585827b72a63d224606324dff5b399467486dc68344
+    md5: bdadff838d5437aea83607ced8b37f75
+    sha256: f02b8ed16b3a488938b5f9453d19ea315ce6ed0d46cc389ecfaa28f2a4c3cb16
   optional: false
   category: main
-  build: hcb278e6_0
+  build: h59595ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: LGPL-2.1-only
   license_family: LGPL
-  size: 485496
-  timestamp: 1679317436814
+  size: 491969
+  timestamp: 1696265613952
 - name: mpmath
   version: 1.3.0
   manager: conda
@@ -9901,54 +10467,54 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_2.conda
+    openssl: '>=3.1.2,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_4.conda
   hash:
-    md5: a55ff0ed12efd86cf3a3dfb750adb950
-    sha256: edc73f41509b41b2c907c82443a5c44fd44219012cdbf15042d93d16affe91ab
+    md5: f6f0ac5665849afc0716213a6cff224d
+    sha256: 1c7d001454cb13832eb4fb7abe89af56aaf968cb4aa1735d6523ab560312dd5e
   optional: false
   category: main
-  build: hf1915f5_2
+  build: hf1915f5_4
   arch: x86_64
   subdir: linux-64
-  build_number: 2
-  size: 755127
-  timestamp: 1689438270632
+  build_number: 4
+  size: 766601
+  timestamp: 1694343358341
 - name: mysql-libs
   version: 8.0.33
   manager: conda
   platform: linux-64
   dependencies:
-    zstd: '>=1.5.2,<1.6.0a0'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
-    mysql-common: ==8.0.33 hf1915f5_2
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_2.conda
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    mysql-common: ==8.0.33 hf1915f5_4
+    openssl: '>=3.1.2,<4.0a0'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_4.conda
   hash:
-    md5: b2f09078f50b9e859aca3f0dc1cc8b7e
-    sha256: f4d396571cbaee6074063d4f46fb6f37b70caed68376cd5af14b9c2f2a90926b
+    md5: db7f2c877209ac620fcd1c3ce7407cf0
+    sha256: b558c3a1a0db7d351f8899ebe6f5c6d096b5a6b5e772d0b2dd2d0961aa7cdcaa
   optional: false
   category: main
-  build: hca2cd23_2
+  build: hca2cd23_4
   arch: x86_64
   subdir: linux-64
-  build_number: 2
-  size: 1531512
-  timestamp: 1689438349037
+  build_number: 4
+  size: 1532122
+  timestamp: 1694343456055
 - name: nbclient
   version: 0.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    nbformat: '>=5.1'
+    jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
     python: '>=3.8'
     traitlets: '>=5.4'
-    jupyter_client: '>=6.1.12'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
   hash:
     md5: e78da91cf428faaf05701ce8cc8f2f9b
@@ -9969,11 +10535,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    nbformat: '>=5.1'
+    jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
     python: '>=3.8'
     traitlets: '>=5.4'
-    jupyter_client: '>=6.1.12'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
   hash:
     md5: e78da91cf428faaf05701ce8cc8f2f9b
@@ -9994,11 +10560,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    nbformat: '>=5.1'
+    jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
     python: '>=3.8'
     traitlets: '>=5.4'
-    jupyter_client: '>=6.1.12'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
   hash:
     md5: e78da91cf428faaf05701ce8cc8f2f9b
@@ -10019,11 +10585,11 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    nbformat: '>=5.1'
+    jupyter_client: '>=6.1.12'
     jupyter_core: '>=4.12,!=5.0.*'
+    nbformat: '>=5.1'
     python: '>=3.8'
     traitlets: '>=5.4'
-    jupyter_client: '>=6.1.12'
   url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
   hash:
     md5: e78da91cf428faaf05701ce8cc8f2f9b
@@ -10040,31 +10606,31 @@ package:
   size: 64852
   timestamp: 1684791049212
 - name: nbconvert-core
-  version: 7.6.0
+  version: 7.9.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
+    beautifulsoup4: '*'
+    bleach: '*'
+    defusedxml: '*'
+    entrypoints: '>=0.2.2'
+    jinja2: '>=3.0'
+    jupyter_core: '>=4.7'
+    jupyterlab_pygments: '*'
+    markupsafe: '>=2.0'
+    mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: '*'
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
     tinycss2: '*'
     traitlets: '>=5.0'
-    mistune: '>=2.0.3,<4'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    pandocfilters: '>=1.4.1'
-    markupsafe: '>=2.0'
-    nbformat: '>=5.1'
-    nbclient: '>=0.5.0'
-    defusedxml: '*'
-    jupyterlab_pygments: '*'
-    jinja2: '>=3.0'
-    bleach: '*'
-    pygments: '>=2.4.1'
-    beautifulsoup4: '*'
-    packaging: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 879782bde4bbdb4c7b5d4054504a20d5
-    sha256: cebfc8c620bdc950e92f72562d281fc57d696497e30bef5bc9e517be757b1c2f
+    md5: 01e4314c780ca73759c694ce3ece281f
+    sha256: 2c85cf290cffb72b1fe7d24c22ad6bf89873bf0f562c9c51907dfb6c00f2d4dd
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10072,40 +10638,39 @@ package:
   subdir: linux-64
   build_number: 0
   constrains:
+  - nbconvert =7.9.2=*_0
   - pandoc >=2.14.2,<4.0.0
-  - pyppeteer >=1,<1.1
-  - nbconvert =7.6.0=*_0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 211896
-  timestamp: 1687202318318
+  size: 187699
+  timestamp: 1696472907887
 - name: nbconvert-core
-  version: 7.6.0
+  version: 7.9.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
+    beautifulsoup4: '*'
+    bleach: '*'
+    defusedxml: '*'
+    entrypoints: '>=0.2.2'
+    jinja2: '>=3.0'
+    jupyter_core: '>=4.7'
+    jupyterlab_pygments: '*'
+    markupsafe: '>=2.0'
+    mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: '*'
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
     tinycss2: '*'
     traitlets: '>=5.0'
-    mistune: '>=2.0.3,<4'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    pandocfilters: '>=1.4.1'
-    markupsafe: '>=2.0'
-    nbformat: '>=5.1'
-    nbclient: '>=0.5.0'
-    defusedxml: '*'
-    jupyterlab_pygments: '*'
-    jinja2: '>=3.0'
-    bleach: '*'
-    pygments: '>=2.4.1'
-    beautifulsoup4: '*'
-    packaging: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 879782bde4bbdb4c7b5d4054504a20d5
-    sha256: cebfc8c620bdc950e92f72562d281fc57d696497e30bef5bc9e517be757b1c2f
+    md5: 01e4314c780ca73759c694ce3ece281f
+    sha256: 2c85cf290cffb72b1fe7d24c22ad6bf89873bf0f562c9c51907dfb6c00f2d4dd
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10113,40 +10678,39 @@ package:
   subdir: osx-64
   build_number: 0
   constrains:
+  - nbconvert =7.9.2=*_0
   - pandoc >=2.14.2,<4.0.0
-  - pyppeteer >=1,<1.1
-  - nbconvert =7.6.0=*_0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 211896
-  timestamp: 1687202318318
+  size: 187699
+  timestamp: 1696472907887
 - name: nbconvert-core
-  version: 7.6.0
+  version: 7.9.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+    beautifulsoup4: '*'
+    bleach: '*'
+    defusedxml: '*'
+    entrypoints: '>=0.2.2'
+    jinja2: '>=3.0'
+    jupyter_core: '>=4.7'
+    jupyterlab_pygments: '*'
+    markupsafe: '>=2.0'
+    mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: '*'
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
     tinycss2: '*'
     traitlets: '>=5.0'
-    mistune: '>=2.0.3,<4'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    pandocfilters: '>=1.4.1'
-    markupsafe: '>=2.0'
-    nbformat: '>=5.1'
-    nbclient: '>=0.5.0'
-    defusedxml: '*'
-    jupyterlab_pygments: '*'
-    jinja2: '>=3.0'
-    bleach: '*'
-    pygments: '>=2.4.1'
-    beautifulsoup4: '*'
-    packaging: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 879782bde4bbdb4c7b5d4054504a20d5
-    sha256: cebfc8c620bdc950e92f72562d281fc57d696497e30bef5bc9e517be757b1c2f
+    md5: 01e4314c780ca73759c694ce3ece281f
+    sha256: 2c85cf290cffb72b1fe7d24c22ad6bf89873bf0f562c9c51907dfb6c00f2d4dd
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10154,40 +10718,39 @@ package:
   subdir: osx-arm64
   build_number: 0
   constrains:
+  - nbconvert =7.9.2=*_0
   - pandoc >=2.14.2,<4.0.0
-  - pyppeteer >=1,<1.1
-  - nbconvert =7.6.0=*_0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 211896
-  timestamp: 1687202318318
+  size: 187699
+  timestamp: 1696472907887
 - name: nbconvert-core
-  version: 7.6.0
+  version: 7.9.2
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
+    beautifulsoup4: '*'
+    bleach: '*'
+    defusedxml: '*'
+    entrypoints: '>=0.2.2'
+    jinja2: '>=3.0'
+    jupyter_core: '>=4.7'
+    jupyterlab_pygments: '*'
+    markupsafe: '>=2.0'
+    mistune: '>=2.0.3,<4'
+    nbclient: '>=0.5.0'
+    nbformat: '>=5.1'
+    packaging: '*'
+    pandocfilters: '>=1.4.1'
+    pygments: '>=2.4.1'
+    python: '>=3.8'
     tinycss2: '*'
     traitlets: '>=5.0'
-    mistune: '>=2.0.3,<4'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    pandocfilters: '>=1.4.1'
-    markupsafe: '>=2.0'
-    nbformat: '>=5.1'
-    nbclient: '>=0.5.0'
-    defusedxml: '*'
-    jupyterlab_pygments: '*'
-    jinja2: '>=3.0'
-    bleach: '*'
-    pygments: '>=2.4.1'
-    beautifulsoup4: '*'
-    packaging: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 879782bde4bbdb4c7b5d4054504a20d5
-    sha256: cebfc8c620bdc950e92f72562d281fc57d696497e30bef5bc9e517be757b1c2f
+    md5: 01e4314c780ca73759c694ce3ece281f
+    sha256: 2c85cf290cffb72b1fe7d24c22ad6bf89873bf0f562c9c51907dfb6c00f2d4dd
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10195,28 +10758,27 @@ package:
   subdir: win-64
   build_number: 0
   constrains:
+  - nbconvert =7.9.2=*_0
   - pandoc >=2.14.2,<4.0.0
-  - pyppeteer >=1,<1.1
-  - nbconvert =7.6.0=*_0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 211896
-  timestamp: 1687202318318
+  size: 187699
+  timestamp: 1696472907887
 - name: nbformat
-  version: 5.9.1
+  version: 5.9.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '*'
     jsonschema: '>=2.6'
-    traitlets: '>=5.1'
+    jupyter_core: '*'
+    python: '>=3.8'
     python-fastjsonschema: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.1-pyhd8ed1ab_0.conda
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ec35d84fc1775215061517eb4660693
-    sha256: d8b1ad3c219b39e5e325785606853ff1cd334769228490ac977b85aa95e94ba0
+    md5: 61ba076de6530d9301a0053b02f093d2
+    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10226,22 +10788,22 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 100756
-  timestamp: 1688996406957
+  size: 100446
+  timestamp: 1690815009867
 - name: nbformat
-  version: 5.9.1
+  version: 5.9.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '*'
     jsonschema: '>=2.6'
-    traitlets: '>=5.1'
+    jupyter_core: '*'
+    python: '>=3.8'
     python-fastjsonschema: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.1-pyhd8ed1ab_0.conda
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ec35d84fc1775215061517eb4660693
-    sha256: d8b1ad3c219b39e5e325785606853ff1cd334769228490ac977b85aa95e94ba0
+    md5: 61ba076de6530d9301a0053b02f093d2
+    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10251,22 +10813,22 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 100756
-  timestamp: 1688996406957
+  size: 100446
+  timestamp: 1690815009867
 - name: nbformat
-  version: 5.9.1
+  version: 5.9.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '*'
     jsonschema: '>=2.6'
-    traitlets: '>=5.1'
+    jupyter_core: '*'
+    python: '>=3.8'
     python-fastjsonschema: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.1-pyhd8ed1ab_0.conda
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ec35d84fc1775215061517eb4660693
-    sha256: d8b1ad3c219b39e5e325785606853ff1cd334769228490ac977b85aa95e94ba0
+    md5: 61ba076de6530d9301a0053b02f093d2
+    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10276,22 +10838,22 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 100756
-  timestamp: 1688996406957
+  size: 100446
+  timestamp: 1690815009867
 - name: nbformat
-  version: 5.9.1
+  version: 5.9.2
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.8'
-    jupyter_core: '*'
     jsonschema: '>=2.6'
-    traitlets: '>=5.1'
+    jupyter_core: '*'
+    python: '>=3.8'
     python-fastjsonschema: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.1-pyhd8ed1ab_0.conda
+    traitlets: '>=5.1'
+  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ec35d84fc1775215061517eb4660693
-    sha256: d8b1ad3c219b39e5e325785606853ff1cd334769228490ac977b85aa95e94ba0
+    md5: 61ba076de6530d9301a0053b02f093d2
+    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10301,8 +10863,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 100756
-  timestamp: 1688996406957
+  size: 100446
+  timestamp: 1690815009867
 - name: ncurses
   version: '6.4'
   manager: conda
@@ -10552,46 +11114,46 @@ package:
   size: 226848
   timestamp: 1669784948267
 - name: nss
-  version: '3.89'
+  version: '3.94'
   manager: conda
   platform: linux-64
   dependencies:
-    libstdcxx-ng: '>=12'
     __glibc: '>=2.17,<3.0.a0'
-    nspr: '>=4.35,<5.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libsqlite: '>=3.40.0,<4.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.89-he45b914_0.conda
+    libsqlite: '>=3.43.0,<4.0a0'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    nspr: '>=4.35,<5.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.94-h1d7d5a4_0.conda
   hash:
-    md5: 2745719a58eeaab6657256a3f142f099
-    sha256: 6d512e4a7ffae4fed9feac2cb2037398c78ade47e5358fc79ac3e58494de0cad
+    md5: 7caef74bbfa730e014b20f0852068509
+    sha256: c9b7910fc554c6550905b9150f4c8230e973ca63f41b42f2c18a49e8aa458e78
   optional: false
   category: main
-  build: he45b914_0
+  build: h1d7d5a4_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 1959876
-  timestamp: 1678488155403
+  size: 2003539
+  timestamp: 1696290024389
 - name: numpy
-  version: 1.25.1
+  version: 1.25.2
   manager: conda
   platform: linux-64
   dependencies:
+    libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.25.1-py311h64a7726_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.25.2-py311h64a7726_0.conda
   hash:
-    md5: b32456e3b3b4d375860ce12163f20122
-    sha256: 5bd888cb62082dab048203adc5eec719379bf90ead5600856d75f3fbbf3cfb71
+    md5: 71fd6f1734a0fa64d8f852ae7156ec45
+    sha256: 2e74d2f11d85e0a796a14b63702c7a963244795c52f92ea98b6f2c0d7620c065
   optional: false
   category: main
   build: py311h64a7726_0
@@ -10602,23 +11164,23 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7874056
-  timestamp: 1688887437651
+  size: 8139293
+  timestamp: 1691056686685
 - name: numpy
-  version: 1.25.1
+  version: 1.25.2
   manager: conda
   platform: osx-64
   dependencies:
+    libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=15.0.7'
     liblapack: '>=3.9.0,<4.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libblas: '>=3.9.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.25.1-py311hc44ba51_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.25.2-py311hc44ba51_0.conda
   hash:
-    md5: 95e5dd71ab35f956a278ab4560c2f58e
-    sha256: 2ab3166ab8afb75acf5ba2972ead86a8da55b574a7f3dfb4605b4c82eec9b4d8
+    md5: e45d265a53efa94a8e8e94392fab71e0
+    sha256: b3736fb30fcec4d7f9e038c09d3c0051101bbd524de30e9f7bc6cc28622e2882
   optional: false
   category: main
   build: py311hc44ba51_0
@@ -10629,23 +11191,23 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7622341
-  timestamp: 1688887653186
+  size: 7633130
+  timestamp: 1691057195991
 - name: numpy
-  version: 1.25.1
+  version: 1.25.2
   manager: conda
   platform: osx-arm64
   dependencies:
+    libblas: '>=3.9.0,<4.0a0'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=15.0.7'
     liblapack: '>=3.9.0,<4.0a0'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    libblas: '>=3.9.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.25.1-py311hb8f3215_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.25.2-py311hb8f3215_0.conda
   hash:
-    md5: d846aa51d3965c982033451bd9c4b969
-    sha256: 46b651c5b445f29f355ee9d26a212177e7948d8a922e0cdf6a87f4da471f7edc
+    md5: ef2d971fb4efed85728e541cf5dcc33b
+    sha256: 3948ae03666f0d46fe8e6dda192627fec33232132eee40d3e495b1e22918bb2a
   optional: false
   category: main
   build: py311hb8f3215_0
@@ -10656,25 +11218,25 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6785721
-  timestamp: 1688887742911
+  size: 6874451
+  timestamp: 1691057647865
 - name: numpy
-  version: 1.25.1
+  version: 1.25.2
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
     libblas: '>=3.9.0,<4.0a0'
-    vc: '>=14.2,<15'
-    ucrt: '>=10.0.20348.0'
     libcblas: '>=3.9.0,<4.0a0'
     liblapack: '>=3.9.0,<4.0a0'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.25.1-py311h0b4df5a_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.25.2-py311h0b4df5a_0.conda
   hash:
-    md5: 7ef5a38d3f927eb0086df4e9074241ec
-    sha256: 718715c8c9775521dd53095a747248603306117b65de2bf3f12e22835dbbd276
+    md5: bbd73574ddf7fd559008f352877baa15
+    sha256: b3571b560e2e6736a08d1c053e4910d281759f9dffd31cd76de85fba490c92b6
   optional: false
   category: main
   build: py311h0b4df5a_0
@@ -10685,206 +11247,206 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7173192
-  timestamp: 1688887650995
+  size: 7319662
+  timestamp: 1691057290250
 - name: openjpeg
   version: 2.5.0
   manager: conda
   platform: linux-64
   dependencies:
-    libtiff: '>=4.5.0,<4.6.0a0'
+    libgcc-ng: '>=12'
+    libpng: '>=1.6.39,<1.7.0a0'
     libstdcxx-ng: '>=12'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
   hash:
-    md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
-    sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
+    md5: 128c25b7fe6a25286a48f3a6a9b5b6f3
+    sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
   optional: false
   category: main
-  build: hfec8fc6_2
+  build: h488ebb8_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: BSD-2-Clause
   license_family: BSD
-  size: 352022
-  timestamp: 1671435172657
+  size: 356698
+  timestamp: 1694708325417
 - name: openjpeg
   version: 2.5.0
   manager: conda
   platform: osx-64
   dependencies:
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libcxx: '>=14.0.6'
+    libcxx: '>=15.0.7'
     libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-h13ac156_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
   hash:
-    md5: 299a29af9ac9f550ad459d655739280b
-    sha256: 2375eafbd5241d8249fb467e2a8e190646e8798c33059c72efa60f197cdf4944
+    md5: 40a36f8e9a6fdf6a78c6428ee6c44188
+    sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
   optional: false
   category: main
-  build: h13ac156_2
+  build: ha4da562_3
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 3
   license: BSD-2-Clause
   license_family: BSD
-  size: 329555
-  timestamp: 1671435389
+  size: 335643
+  timestamp: 1694708811338
 - name: openjpeg
   version: 2.5.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libtiff: '>=4.5.0,<4.6.0a0'
-    libcxx: '>=14.0.6'
+    libcxx: '>=15.0.7'
     libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
   hash:
-    md5: c3e184f0810a4614863569488b1ac709
-    sha256: 2bb159e385e633a08cc164f50b4e39fa465b85f54c376a5c20aa15f57ef407b3
+    md5: 4127dd217a010d9c6cbefdaae07d9f19
+    sha256: a6998c0da4643a84dc7c0b3a9e5137db258619ea922317bb7d9ae64f54b4a9ed
   optional: false
   category: main
-  build: hbc2ba62_2
+  build: h4c1507b_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 3
   license: BSD-2-Clause
   license_family: BSD
-  size: 307087
-  timestamp: 1671435439914
+  size: 323335
+  timestamp: 1694708748389
 - name: openjpeg
   version: 2.5.0
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    libtiff: '>=4.5.0,<4.6.0a0'
     libpng: '>=1.6.39,<1.7.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-ha2aaf27_2.conda
-  hash:
-    md5: db0490689232e8e38c312281df6f31a2
-    sha256: 1fb72db47e9b1cdb4980a1fd031e31fad2c6a4a632fc602e7d6fa74f4f491608
-  optional: false
-  category: main
-  build: ha2aaf27_2
-  arch: x86_64
-  subdir: win-64
-  build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 237111
-  timestamp: 1671435754860
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ca-certificates: '*'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.1-hd590300_1.conda
-  hash:
-    md5: 2e1d7b458ac8f1e3ca4e18b77add6277
-    sha256: 407d655643389bdb49266842a816815c981ae98f3513a6a2059b908b3abb380a
-  optional: false
-  category: main
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2642411
-  timestamp: 1685517327134
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    ca-certificates: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.1-h8a1eda9_1.conda
-  hash:
-    md5: c7822d6ee74e34af1fd74365cfd18983
-    sha256: 67855f92bf50f24cbbc44879864d7a040b1f351e95b599cfcf4cc49b2cc3fd08
-  optional: false
-  category: main
-  build: h8a1eda9_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2326872
-  timestamp: 1685518213128
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    ca-certificates: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.1-h53f4e23_1.conda
-  hash:
-    md5: 7451b96ed28b5fd02f0df32689327755
-    sha256: 898aac8f8753385e9cd378d539364647d1deb9396032b7c1fd8f0f08107e020b
-  optional: false
-  category: main
-  build: h53f4e23_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2223980
-  timestamp: 1685517736396
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
     ucrt: '>=10.0.20348.0'
-    ca-certificates: '*'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.1-hcfcfb64_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
   hash:
-    md5: 1d913a5de46c6b2f7e4cfbd26b106b8b
-    sha256: 4424486fb9a2aeaba912a8dd8a5b5cdb6fcd65d7708fd854e3ea27449bb352a3
+    md5: 45a9628a04efb6fc326fff0a8f47b799
+    sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
   optional: false
   category: main
-  build: hcfcfb64_1
+  build: h3d672ee_3
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 3
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 236847
+  timestamp: 1694708878963
+- name: openssl
+  version: 3.1.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ca-certificates: '*'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.3-hd590300_0.conda
+  hash:
+    md5: 7bb88ce04c8deb9f7d763ae04a1da72f
+    sha256: f4e35f506c7e8ab7dfdc47255b0d5aa8ce0c99028ae0affafd274333042c4f70
+  optional: false
+  category: main
+  build: hd590300_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 7415451
-  timestamp: 1685519134254
+  size: 2642850
+  timestamp: 1695158025027
+- name: openssl
+  version: 3.1.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    ca-certificates: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.3-h8a1eda9_0.conda
+  hash:
+    md5: 26f9b58f905547e658e9587f8e8cfe43
+    sha256: 69731ce62d4b68e538af559747da53f837ae0bbca519b38f2eea28680eb9e8d1
+  optional: false
+  category: main
+  build: h8a1eda9_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2329752
+  timestamp: 1695158667922
+- name: openssl
+  version: 3.1.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    ca-certificates: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.3-h53f4e23_0.conda
+  hash:
+    md5: 40d01d3f39589f54b618ddd28a5a48cb
+    sha256: d9af6208610d4985322b8eade79215f1ded6e2a2b41b0a885714b971a36a5bae
+  optional: false
+  category: main
+  build: h53f4e23_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2225422
+  timestamp: 1695158154709
+- name: openssl
+  version: 3.1.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    ca-certificates: '*'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.3-hcfcfb64_0.conda
+  hash:
+    md5: 16b2c80ad196f18acd31b588ef28cb9a
+    sha256: 6a6b20aa2b9f32d94f8d2c352b7635b5e8b9fb7ffad823bf2ce88dc8ef61ffc8
+  optional: false
+  category: main
+  build: hcfcfb64_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 7427366
+  timestamp: 1695218580613
 - name: overrides
-  version: 7.3.1
+  version: 7.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
     typing_utils: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a5745ced46e69aa9754053ba061974ab
-    sha256: f4d8d05292714fc8dcd3a01c57a2ad41eab88a51e7608b70ae041f2b92de16a4
+    md5: 4625b7b01d7f4ac9c96300a5515acfaa
+    sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10894,19 +11456,19 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 25464
-  timestamp: 1666057928209
+  size: 29976
+  timestamp: 1691338962381
 - name: overrides
-  version: 7.3.1
+  version: 7.4.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
     typing_utils: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a5745ced46e69aa9754053ba061974ab
-    sha256: f4d8d05292714fc8dcd3a01c57a2ad41eab88a51e7608b70ae041f2b92de16a4
+    md5: 4625b7b01d7f4ac9c96300a5515acfaa
+    sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10916,19 +11478,19 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 25464
-  timestamp: 1666057928209
+  size: 29976
+  timestamp: 1691338962381
 - name: overrides
-  version: 7.3.1
+  version: 7.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
     typing_utils: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a5745ced46e69aa9754053ba061974ab
-    sha256: f4d8d05292714fc8dcd3a01c57a2ad41eab88a51e7608b70ae041f2b92de16a4
+    md5: 4625b7b01d7f4ac9c96300a5515acfaa
+    sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10938,19 +11500,19 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 25464
-  timestamp: 1666057928209
+  size: 29976
+  timestamp: 1691338962381
 - name: overrides
-  version: 7.3.1
+  version: 7.4.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
     typing_utils: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.3.1-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a5745ced46e69aa9754053ba061974ab
-    sha256: f4d8d05292714fc8dcd3a01c57a2ad41eab88a51e7608b70ae041f2b92de16a4
+    md5: 4625b7b01d7f4ac9c96300a5515acfaa
+    sha256: 29db8c3b521d261bf71897ba3cfbebc81cd61e581b30fcb984b5a713f02fe1ff
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10960,18 +11522,18 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 25464
-  timestamp: 1666057928209
+  size: 29976
+  timestamp: 1691338962381
 - name: packaging
-  version: '23.1'
+  version: '23.2'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 91cda59e66e1e4afe9476f8ef98f5c30
-    sha256: ded536a96a00d45a693dbc2971bb688248324dadd129eddda2100e177583d768
+    md5: 79002079284aa895f883c6b7f3f88fd6
+    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -10981,18 +11543,18 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 46098
-  timestamp: 1681337144376
+  size: 49452
+  timestamp: 1696202521121
 - name: packaging
-  version: '23.1'
+  version: '23.2'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 91cda59e66e1e4afe9476f8ef98f5c30
-    sha256: ded536a96a00d45a693dbc2971bb688248324dadd129eddda2100e177583d768
+    md5: 79002079284aa895f883c6b7f3f88fd6
+    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11002,18 +11564,18 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 46098
-  timestamp: 1681337144376
+  size: 49452
+  timestamp: 1696202521121
 - name: packaging
-  version: '23.1'
+  version: '23.2'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 91cda59e66e1e4afe9476f8ef98f5c30
-    sha256: ded536a96a00d45a693dbc2971bb688248324dadd129eddda2100e177583d768
+    md5: 79002079284aa895f883c6b7f3f88fd6
+    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11023,18 +11585,18 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 46098
-  timestamp: 1681337144376
+  size: 49452
+  timestamp: 1696202521121
 - name: packaging
-  version: '23.1'
+  version: '23.2'
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 91cda59e66e1e4afe9476f8ef98f5c30
-    sha256: ded536a96a00d45a693dbc2971bb688248324dadd129eddda2100e177583d768
+    md5: 79002079284aa895f883c6b7f3f88fd6
+    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11044,8 +11606,8 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 46098
-  timestamp: 1681337144376
+  size: 49452
+  timestamp: 1696202521121
 - name: pandocfilters
   version: 1.5.0
   manager: conda
@@ -11219,9 +11781,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.12,<1.3.0a0'
     bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
+    libzlib: '>=1.2.12,<1.3.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
   hash:
     md5: 69e2c796349cd9b273890bee0febfe1b
@@ -11241,9 +11803,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     bzip2: '>=1.0.8,<2.0a0'
     libzlib: '>=1.2.12,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vs2015_runtime: '>=14.29.30139'
   url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
@@ -11265,8 +11827,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '*'
     ptyprocess: '>=0.5'
+    python: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
   hash:
     md5: 330448ce4403cc74990ac07c555942a1
@@ -11286,8 +11848,8 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '*'
     ptyprocess: '>=0.5'
+    python: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
   hash:
     md5: 330448ce4403cc74990ac07c555942a1
@@ -11307,8 +11869,8 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '*'
     ptyprocess: '>=0.5'
+    python: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
   hash:
     md5: 330448ce4403cc74990ac07c555942a1
@@ -11408,137 +11970,137 @@ package:
   size: 9332
   timestamp: 1602536313357
 - name: pillow
-  version: 10.0.0
+  version: 10.0.1
   manager: conda
   platform: linux-64
   dependencies:
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.15,<3.0a0'
+    libgcc-ng: '>=12'
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    openjpeg: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libgcc-ng: '>=12'
-    libwebp-base: '>=1.3.1,<2.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.1,<4.6.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    lcms2: '>=2.15,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
     tk: '>=8.6.12,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.0-py311h0b84326_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.1-py311h8aef010_1.conda
   hash:
-    md5: 4b24acdc1fbbae9da03147e7d2cf8c8a
-    sha256: 20b0a2fcdc5fee405fe3ef8d18f737863c58a5209ebf0211dec1f820c2c640c2
+    md5: 4d66ee2081a7cd444ff6f30d95873eef
+    sha256: 42f21344c2fb7ee614243a632e261580408b24003d83cf34548661c2973a368a
   optional: false
   category: main
-  build: py311h0b84326_0
+  build: py311h8aef010_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: LicenseRef-PIL
-  size: 46719790
-  timestamp: 1688256024359
+  build_number: 1
+  license: HPND
+  size: 46908609
+  timestamp: 1695247484014
 - name: pillow
-  version: 10.0.0
+  version: 10.0.1
   manager: conda
   platform: osx-64
   dependencies:
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.15,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    openjpeg: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libwebp-base: '>=1.3.1,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.1,<4.6.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    lcms2: '>=2.15,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.0.0-py311h7cb0e2d_0.conda
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.0.1-py311h0beca62_2.conda
   hash:
-    md5: 042cee47581520be03136d16e8cc0969
-    sha256: 9feff2b191925d441b6634340cce5b553522c7a381aafacd7928b9428314a55a
+    md5: c2912bd99208de316137d9848f5bda18
+    sha256: 8579d38f93038280d9c6c3c70692ad25fea188dde0132c8c0d0d3908d2e5cd1d
   optional: false
   category: main
-  build: py311h7cb0e2d_0
+  build: py311h0beca62_2
   arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: LicenseRef-PIL
-  size: 45576114
-  timestamp: 1688256382019
+  build_number: 2
+  license: HPND
+  size: 46492736
+  timestamp: 1696149683597
 - name: pillow
-  version: 10.0.0
+  version: 10.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.15,<3.0a0'
+    libjpeg-turbo: '>=3.0.0,<4.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    openjpeg: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libwebp-base: '>=1.3.1,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.1,<4.6.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    lcms2: '>=2.15,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.0.0-py311h095fde6_0.conda
+    tk: '>=8.6.13,<8.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.0.1-py311h8dc27b9_2.conda
   hash:
-    md5: f77cb382a8b3224b9f44b029ca39ed8c
-    sha256: c88a0d19842d5ef5a2cc1325c4de88798f295982dd56edb7e180f616e4420306
+    md5: 912bf3b31f7babc60d016704f395cb39
+    sha256: dda84e48316f957ea9ca4830c6e85a92effa74e6430ee651a6cc68cee64fa68a
   optional: false
   category: main
-  build: py311h095fde6_0
+  build: py311h8dc27b9_2
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: LicenseRef-PIL
-  size: 45961944
-  timestamp: 1688256289209
+  build_number: 2
+  license: HPND
+  size: 45619857
+  timestamp: 1696149767795
 - name: pillow
-  version: 10.0.0
+  version: 10.0.1
   manager: conda
   platform: win-64
   dependencies:
+    freetype: '>=2.12.1,<3.0a0'
+    lcms2: '>=2.15,<3.0a0'
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libtiff: '>=4.6.0,<4.7.0a0'
+    libwebp-base: '>=1.3.2,<2.0a0'
+    libxcb: '>=1.15,<1.16.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openjpeg: '>=2.5.0,<3.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    openjpeg: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libwebp-base: '>=1.3.1,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libtiff: '>=4.5.1,<4.6.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    lcms2: '>=2.15,<3.0a0'
     tk: '>=8.6.12,<8.7.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.0.0-py311hde623f7_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.0.1-py311hd926f49_1.conda
   hash:
-    md5: 217a6fc0df385c9a929144549f26b124
-    sha256: 3771fa4cd26b5654dcb9e12a65a624be87836e002900a0d6b98c93870b75aa02
+    md5: d6eafb14d0f3096f4809929efb2b4f39
+    sha256: 4cf3b45a9877c3d05fc882fe8f74c7290c3c92bd098ca5a93f248ac7ee749efb
   optional: false
   category: main
-  build: py311hde623f7_0
+  build: py311hd926f49_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
-  license: LicenseRef-PIL
-  size: 46076579
-  timestamp: 1688256328666
+  build_number: 1
+  license: HPND
+  size: 46840201
+  timestamp: 1695247874191
 - name: pip
-  version: '23.2'
+  version: 23.2.1
   manager: conda
   platform: linux-64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
+    setuptools: '*'
     wheel: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: fb90dfe13ce16c0a3374e3d34e3291c5
-    sha256: 31e71fc25dbc411c1595661c8eb2c2491e71895ce6954ea2d0e9a585d39eed57
+    md5: e2783aa3f9235225eec92f9081c5b801
+    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11548,20 +12110,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 1382461
-  timestamp: 1689420484743
+  size: 1386212
+  timestamp: 1690024763393
 - name: pip
-  version: '23.2'
+  version: 23.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
+    setuptools: '*'
     wheel: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: fb90dfe13ce16c0a3374e3d34e3291c5
-    sha256: 31e71fc25dbc411c1595661c8eb2c2491e71895ce6954ea2d0e9a585d39eed57
+    md5: e2783aa3f9235225eec92f9081c5b801
+    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11571,20 +12133,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 1382461
-  timestamp: 1689420484743
+  size: 1386212
+  timestamp: 1690024763393
 - name: pip
-  version: '23.2'
+  version: 23.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
+    setuptools: '*'
     wheel: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: fb90dfe13ce16c0a3374e3d34e3291c5
-    sha256: 31e71fc25dbc411c1595661c8eb2c2491e71895ce6954ea2d0e9a585d39eed57
+    md5: e2783aa3f9235225eec92f9081c5b801
+    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11594,20 +12156,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 1382461
-  timestamp: 1689420484743
+  size: 1386212
+  timestamp: 1690024763393
 - name: pip
-  version: '23.2'
+  version: 23.2.1
   manager: conda
   platform: win-64
   dependencies:
-    setuptools: '*'
     python: '>=3.7'
+    setuptools: '*'
     wheel: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: fb90dfe13ce16c0a3374e3d34e3291c5
-    sha256: 31e71fc25dbc411c1595661c8eb2c2491e71895ce6954ea2d0e9a585d39eed57
+    md5: e2783aa3f9235225eec92f9081c5b801
+    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11617,119 +12179,120 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 1382461
-  timestamp: 1689420484743
+  size: 1386212
+  timestamp: 1690024763393
 - name: pixman
-  version: 0.40.0
+  version: 0.42.2
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.40.0-h36c2ea0_0.tar.bz2
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
   hash:
-    md5: 660e72c82f2e75a6b3fe6a6e75c79f19
-    sha256: 6a0630fff84b5a683af6185a6c67adc8bdfa2043047fcb251add0d352ef60e79
+    md5: 700edd63ccd5fc66b70b1c028cea9a68
+    sha256: ae917851474eb3b08812b02c9e945d040808523ec53f828aa74a90b0cdf15f57
   optional: false
   category: main
-  build: h36c2ea0_0
+  build: h59595ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 642520
-  timestamp: 1604342437426
+  size: 385309
+  timestamp: 1695736061006
 - name: pkgutil-resolve-name
   version: 1.3.10
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: 89e3c7cdde7d3aaa2aee933b604dd07f
-    sha256: 7d055ffc8a02bf781a89d069db3454b453605cdaff300b82cedcc7133283e47e
+    md5: 405678b942f2481cecdb3e010f4925d9
+    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: BSD-4-Clause
+  build_number: 1
+  license: MIT AND PSF-2.0
   noarch: python
-  size: 8717
-  timestamp: 1633982101415
+  size: 10778
+  timestamp: 1694617398467
 - name: pkgutil-resolve-name
   version: 1.3.10
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: 89e3c7cdde7d3aaa2aee933b604dd07f
-    sha256: 7d055ffc8a02bf781a89d069db3454b453605cdaff300b82cedcc7133283e47e
+    md5: 405678b942f2481cecdb3e010f4925d9
+    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
-  license: BSD-4-Clause
+  build_number: 1
+  license: MIT AND PSF-2.0
   noarch: python
-  size: 8717
-  timestamp: 1633982101415
+  size: 10778
+  timestamp: 1694617398467
 - name: pkgutil-resolve-name
   version: 1.3.10
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: 89e3c7cdde7d3aaa2aee933b604dd07f
-    sha256: 7d055ffc8a02bf781a89d069db3454b453605cdaff300b82cedcc7133283e47e
+    md5: 405678b942f2481cecdb3e010f4925d9
+    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: BSD-4-Clause
+  build_number: 1
+  license: MIT AND PSF-2.0
   noarch: python
-  size: 8717
-  timestamp: 1633982101415
+  size: 10778
+  timestamp: 1694617398467
 - name: pkgutil-resolve-name
   version: 1.3.10
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
   hash:
-    md5: 89e3c7cdde7d3aaa2aee933b604dd07f
-    sha256: 7d055ffc8a02bf781a89d069db3454b453605cdaff300b82cedcc7133283e47e
+    md5: 405678b942f2481cecdb3e010f4925d9
+    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
-  license: BSD-4-Clause
+  build_number: 1
+  license: MIT AND PSF-2.0
   noarch: python
-  size: 8717
-  timestamp: 1633982101415
+  size: 10778
+  timestamp: 1694617398467
 - name: platformdirs
-  version: 3.9.1
+  version: 3.11.0
   manager: conda
   platform: linux-64
   dependencies:
-    typing-extensions: '>=4.6.3'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.9.1-pyhd8ed1ab_0.conda
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 044e7a1e0ad42c4e67110bd078150a63
-    sha256: 885611bd528abaf3e31bc0bfaad3a619cfe89db61d886b53c2a9ec9ff50edebe
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11737,20 +12300,21 @@ package:
   subdir: linux-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
-  size: 19506
-  timestamp: 1689538790293
+  size: 19985
+  timestamp: 1696272419779
 - name: platformdirs
-  version: 3.9.1
+  version: 3.11.0
   manager: conda
   platform: osx-64
   dependencies:
-    typing-extensions: '>=4.6.3'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.9.1-pyhd8ed1ab_0.conda
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 044e7a1e0ad42c4e67110bd078150a63
-    sha256: 885611bd528abaf3e31bc0bfaad3a619cfe89db61d886b53c2a9ec9ff50edebe
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11758,20 +12322,21 @@ package:
   subdir: osx-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
-  size: 19506
-  timestamp: 1689538790293
+  size: 19985
+  timestamp: 1696272419779
 - name: platformdirs
-  version: 3.9.1
+  version: 3.11.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing-extensions: '>=4.6.3'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.9.1-pyhd8ed1ab_0.conda
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 044e7a1e0ad42c4e67110bd078150a63
-    sha256: 885611bd528abaf3e31bc0bfaad3a619cfe89db61d886b53c2a9ec9ff50edebe
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11779,20 +12344,21 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
-  size: 19506
-  timestamp: 1689538790293
+  size: 19985
+  timestamp: 1696272419779
 - name: platformdirs
-  version: 3.9.1
+  version: 3.11.0
   manager: conda
   platform: win-64
   dependencies:
-    typing-extensions: '>=4.6.3'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.9.1-pyhd8ed1ab_0.conda
+    typing-extensions: '>=4.6.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 044e7a1e0ad42c4e67110bd078150a63
-    sha256: 885611bd528abaf3e31bc0bfaad3a619cfe89db61d886b53c2a9ec9ff50edebe
+    md5: 8f567c0a74aa44cf732f15773b4083b0
+    sha256: b3d809ff5a18ee8514bba8bc05a23b4cdf1758090a18a2cf742af38aed405144
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -11800,9 +12366,10 @@ package:
   subdir: win-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
-  size: 19506
-  timestamp: 1689538790293
+  size: 19985
+  timestamp: 1696272419779
 - name: ply
   version: '3.11'
   manager: conda
@@ -11845,102 +12412,6 @@ package:
   noarch: python
   size: 44837
   timestamp: 1530963184592
-- name: pooch
-  version: 1.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    requests: '>=2.19.0'
-    platformdirs: '>=2.5.0'
-    packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
-  hash:
-    md5: 5936894aade8240c867d292aa0d980c6
-    sha256: 64e4d633803df2e36fd141d9bf269568fbe179a313248e1dac4d364c02debdef
-  optional: false
-  category: main
-  build: pyha770c72_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 50857
-  timestamp: 1679580483278
-- name: pooch
-  version: 1.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    requests: '>=2.19.0'
-    platformdirs: '>=2.5.0'
-    packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
-  hash:
-    md5: 5936894aade8240c867d292aa0d980c6
-    sha256: 64e4d633803df2e36fd141d9bf269568fbe179a313248e1dac4d364c02debdef
-  optional: false
-  category: main
-  build: pyha770c72_3
-  arch: x86_64
-  subdir: osx-64
-  build_number: 3
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 50857
-  timestamp: 1679580483278
-- name: pooch
-  version: 1.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    requests: '>=2.19.0'
-    platformdirs: '>=2.5.0'
-    packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
-  hash:
-    md5: 5936894aade8240c867d292aa0d980c6
-    sha256: 64e4d633803df2e36fd141d9bf269568fbe179a313248e1dac4d364c02debdef
-  optional: false
-  category: main
-  build: pyha770c72_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 50857
-  timestamp: 1679580483278
-- name: pooch
-  version: 1.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    requests: '>=2.19.0'
-    platformdirs: '>=2.5.0'
-    packaging: '>=20.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
-  hash:
-    md5: 5936894aade8240c867d292aa0d980c6
-    sha256: 64e4d633803df2e36fd141d9bf269568fbe179a313248e1dac4d364c02debdef
-  optional: false
-  category: main
-  build: pyha770c72_3
-  arch: x86_64
-  subdir: win-64
-  build_number: 3
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 50857
-  timestamp: 1679580483278
 - name: prometheus_client
   version: 0.17.1
   manager: conda
@@ -12210,23 +12681,23 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
     libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h2582759_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
   hash:
-    md5: a90f8e278c1cd7064b2713e6b7db87e6
-    sha256: aa5b377f1555a09ba702d9ac9d0d0585d74cbaf8897e45e5cfa4c464732a6493
+    md5: 490d7fa8675afd1aa6f1b2332d156a45
+    sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
   optional: false
   category: main
-  build: py311h2582759_0
+  build: py311h459d7ec_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 499297
-  timestamp: 1681775150105
+  size: 498698
+  timestamp: 1695367306421
 - name: psutil
   version: 5.9.5
   manager: conda
@@ -12234,20 +12705,20 @@ package:
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h5547dcb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
   hash:
-    md5: d9b4565309f4f992b42bd99031044642
-    sha256: 0c7a402b0b2085b9e77c741ae14a386318c24dea62e12d29385843a6e8ae00a9
+    md5: 16221cd0488a32152a6b3f1a301ccf19
+    sha256: 2eee900e0e5a103cff0159cdd81d401b67ccfb919be6cd868fc34c22dab981f1
   optional: false
   category: main
-  build: py311h5547dcb_0
+  build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 505985
-  timestamp: 1681775450320
+  size: 506611
+  timestamp: 1695367402674
 - name: psutil
   version: 5.9.5
   manager: conda
@@ -12255,44 +12726,44 @@ package:
   dependencies:
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311he2be06e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
   hash:
-    md5: 757782088ac8e0ffc5eb68ae61bf62f9
-    sha256: 0ecdf61a7314171f8abcaa75f2f0d5443c5fe66c0eb146d38428cfb479279888
+    md5: a40123b40642b8b08b3830a3f6bc7fd9
+    sha256: a12a525d3bcaed04e0885b2bd00f4f626c80c19d7c0ae8bb7cf7121aefb39e52
   optional: false
   category: main
-  build: py311he2be06e_0
+  build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 507121
-  timestamp: 1681775539087
+  size: 506971
+  timestamp: 1695367619126
 - name: psutil
   version: 5.9.5
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
   hash:
-    md5: f1a1eecd1bb4f431df5b9b6d8a152efd
-    sha256: b7c3ea83142689ffc6029bb745f6a4836818f1b1c1ba9e9f9ba3a9498f4a3cd4
+    md5: f64b2d9577e753fea9662dae11339ac2
+    sha256: e5c09eee9902e0c56d89f88210009b34d819d241ac5b7dde38266324a85fde51
   optional: false
   category: main
-  build: py311ha68e1ae_0
+  build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 515116
-  timestamp: 1681775399789
+  size: 516106
+  timestamp: 1695367685028
 - name: pthread-stubs
   version: '0.4'
   manager: conda
@@ -12455,27 +12926,27 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libsystemd0: '>=253'
-    libsndfile: '>=1.2.0,<1.3.0a0'
-    libglib: '>=2.76.3,<3.0a0'
-    libgcc-ng: '>=12'
     dbus: '>=1.13.6,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_4.conda
+    libgcc-ng: '>=12'
+    libglib: '>=2.76.4,<3.0a0'
+    libsndfile: '>=1.2.2,<1.3.0a0'
+    libsystemd0: '>=254'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
   hash:
-    md5: 8f349ca16d30950aa00870484d9d30c4
-    sha256: efd5ca5d5b0e55d25b8b2085449618f9777a07a89958c1d557d44f53eff061fe
+    md5: ac902ff3c1c6d750dd0dfc93a974ab74
+    sha256: 9981c70893d95c8cac02e7edd1a9af87f2c8745b772d529f08b7f9dafbe98606
   optional: false
   category: main
-  build: hb77b528_4
+  build: hb77b528_5
   arch: x86_64
   subdir: linux-64
-  build_number: 4
+  build_number: 5
   constrains:
-  - pulseaudio 16.1 *_4
+  - pulseaudio 16.1 *_5
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 750852
-  timestamp: 1685466483507
+  size: 754844
+  timestamp: 1693928953742
 - name: pure_eval
   version: 0.2.2
   manager: conda
@@ -12645,15 +13116,15 @@ package:
   size: 102747
   timestamp: 1636257201998
 - name: pygments
-  version: 2.15.1
+  version: 2.16.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d316679235612869eba305aa7d41d9bf
-    sha256: 1bddeb54863c77ed5613b535a3e06a3a16b55786301a5e28c9bf011656bda686
+    md5: 40e5cb18165466773619e5c963f00a7b
+    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12663,18 +13134,18 @@ package:
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 840719
-  timestamp: 1681904335148
+  size: 853439
+  timestamp: 1691408777841
 - name: pygments
-  version: 2.15.1
+  version: 2.16.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d316679235612869eba305aa7d41d9bf
-    sha256: 1bddeb54863c77ed5613b535a3e06a3a16b55786301a5e28c9bf011656bda686
+    md5: 40e5cb18165466773619e5c963f00a7b
+    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12684,18 +13155,18 @@ package:
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 840719
-  timestamp: 1681904335148
+  size: 853439
+  timestamp: 1691408777841
 - name: pygments
-  version: 2.15.1
+  version: 2.16.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d316679235612869eba305aa7d41d9bf
-    sha256: 1bddeb54863c77ed5613b535a3e06a3a16b55786301a5e28c9bf011656bda686
+    md5: 40e5cb18165466773619e5c963f00a7b
+    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12705,18 +13176,18 @@ package:
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 840719
-  timestamp: 1681904335148
+  size: 853439
+  timestamp: 1691408777841
 - name: pygments
-  version: 2.15.1
+  version: 2.16.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d316679235612869eba305aa7d41d9bf
-    sha256: 1bddeb54863c77ed5613b535a3e06a3a16b55786301a5e28c9bf011656bda686
+    md5: 40e5cb18165466773619e5c963f00a7b
+    sha256: 3f0f0fadc6084960ec8cc00a32a03529c562ffea3b527eb73b1653183daad389
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12726,21 +13197,21 @@ package:
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 840719
-  timestamp: 1681904335148
+  size: 853439
+  timestamp: 1691408777841
 - name: pyobjc-core
-  version: '9.2'
+  version: '10.0'
   manager: conda
   platform: osx-64
   dependencies:
-    setuptools: '*'
+    libffi: '>=3.4,<4.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libffi: '>=3.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-9.2-py311hf110eff_0.conda
+    setuptools: '*'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py311hf110eff_0.conda
   hash:
-    md5: 460e6d2c254ec4aa4299cd9bffa3b7f8
-    sha256: 17fec1464116ce95acc1967941df0f11e0ebd61097eb98b1b8548cbb828fc25f
+    md5: d26705887703d13c655a6098516e06e2
+    sha256: 031b8c48866f1f97a4a12d6a3ea0dc94cb6a735918871460b26f4779f5a01125
   optional: false
   category: main
   build: py311hf110eff_0
@@ -12749,21 +13220,21 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 463112
-  timestamp: 1686129884971
+  size: 465753
+  timestamp: 1695560684232
 - name: pyobjc-core
-  version: '9.2'
+  version: '10.0'
   manager: conda
   platform: osx-arm64
   dependencies:
+    libffi: '>=3.4,<4.0a0'
+    python: '>=3.11,<3.12.0a0 *_cpython'
+    python_abi: 3.11.* *_cp311
     setuptools: '*'
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-    libffi: '>=3.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-9.2-py311hb702dc4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py311hb702dc4_0.conda
   hash:
-    md5: 7cb2cc0921cb5f91ed432acb562cb8b7
-    sha256: d112c78b0da5558ab761bcddd332c36dbb5203f855eb89eea9b3af1e4142ad84
+    md5: 5c441ab09e2d9faf6e875ea9c446b445
+    sha256: d3bb68f8da77bffad5fa690d2cc1aeb0be0608ed0b6e08a96d8fc3613f2e7135
   optional: false
   category: main
   build: py311hb702dc4_0
@@ -12772,64 +13243,64 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 469492
-  timestamp: 1686129987702
+  size: 473740
+  timestamp: 1695560759149
 - name: pyobjc-framework-cocoa
-  version: '9.2'
+  version: '10.0'
   manager: conda
   platform: osx-64
   dependencies:
-    pyobjc-core: 9.2.*
+    libffi: '>=3.4,<4.0a0'
+    pyobjc-core: 10.0.*
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libffi: '>=3.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-9.2-py311hf110eff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py311hf110eff_1.conda
   hash:
-    md5: 6ba4637fa1ed0a1e829b1f278c12274a
-    sha256: 307a3152d67152a1d63a48ec80de1b97c42e9bb7b5975d5af4bbe0cca638c4d5
+    md5: 8fb67274a648901045368717d6221aed
+    sha256: 54530c1b3bfc361e027adbd8f9d9a23e7c102c7f58c04a169da1457f82975724
   optional: false
   category: main
-  build: py311hf110eff_0
+  build: py311hf110eff_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 370409
-  timestamp: 1686136375922
+  size: 369966
+  timestamp: 1695716863742
 - name: pyobjc-framework-cocoa
-  version: '9.2'
+  version: '10.0'
   manager: conda
   platform: osx-arm64
   dependencies:
-    pyobjc-core: 9.2.*
+    libffi: '>=3.4,<4.0a0'
+    pyobjc-core: 10.0.*
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    libffi: '>=3.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-9.2-py311hb702dc4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py311hb702dc4_1.conda
   hash:
-    md5: 0e3f993caf313797b913dc21b5c42824
-    sha256: 1d2362008a30fcb9e83f2b7918f3a46b05a1796aa6275f775478d63a7a5493de
+    md5: ee9430e4e9b69a6270c966bb7439c9a0
+    sha256: 31a7542b8ced5cb3bc236be0b5777dab4bc0e57fbfc5423e9d0ae09ce8eae16c
   optional: false
   category: main
-  build: py311hb702dc4_0
+  build: py311hb702dc4_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 374505
-  timestamp: 1686136553569
+  size: 374853
+  timestamp: 1695717128436
 - name: pyparsing
-  version: 3.0.9
+  version: 3.1.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e8fbc1b54b25f4b08281467bc13b70cc
-    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12839,18 +13310,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 81321
-  timestamp: 1652235496915
+  size: 89521
+  timestamp: 1690737983548
 - name: pyparsing
-  version: 3.0.9
+  version: 3.1.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e8fbc1b54b25f4b08281467bc13b70cc
-    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12860,18 +13331,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 81321
-  timestamp: 1652235496915
+  size: 89521
+  timestamp: 1690737983548
 - name: pyparsing
-  version: 3.0.9
+  version: 3.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e8fbc1b54b25f4b08281467bc13b70cc
-    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12881,18 +13352,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 81321
-  timestamp: 1652235496915
+  size: 89521
+  timestamp: 1690737983548
 - name: pyparsing
-  version: 3.0.9
+  version: 3.1.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: e8fbc1b54b25f4b08281467bc13b70cc
-    sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
+    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -12902,114 +13373,114 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 81321
-  timestamp: 1652235496915
+  size: 89521
+  timestamp: 1690737983548
 - name: pyqt
-  version: 5.15.7
+  version: 5.15.9
   manager: conda
   platform: linux-64
   dependencies:
-    pyqt5-sip: ==12.11.0 py311hcafe171_3
-    python: '>=3.11,<3.12.0a0'
-    libstdcxx-ng: '>=12'
-    python_abi: 3.11.* *_cp311
-    sip: '>=6.7.5,<6.8.0a0'
     libgcc-ng: '>=12'
-    qt-main: '>=5.15.6,<5.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.7-py311ha74522f_3.conda
+    libstdcxx-ng: '>=12'
+    pyqt5-sip: ==12.12.2 py311hb755f60_5
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    qt-main: '>=5.15.8,<5.16.0a0'
+    sip: '>=6.7.11,<6.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py311hf0fb5b6_5.conda
   hash:
-    md5: ad6dd0bed0cdf5f2d4eb2b989d6253b3
-    sha256: 9996afe90cee977de34f57597469c07d36e2834246e2962ac6de764506aec363
+    md5: ec7e45bc76d9d0b69a74a2075932b8e8
+    sha256: 74fcdb8772c7eaf654b32922f77d9a8a1350b3446111c69a32ba4d15be74905a
   optional: false
   category: main
-  build: py311ha74522f_3
+  build: py311hf0fb5b6_5
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 5263906
-  timestamp: 1674670321115
+  size: 5315719
+  timestamp: 1695420475603
 - name: pyqt
-  version: 5.15.7
+  version: 5.15.9
   manager: conda
   platform: win-64
   dependencies:
-    pyqt5-sip: ==12.11.0 py311h12c1d0e_3
+    pyqt5-sip: ==12.12.2 py311h12c1d0e_5
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    vc: '>=14.2,<15'
-    qt-main: '>=5.15.6,<5.16.0a0'
-    sip: '>=6.7.5,<6.8.0a0'
+    qt-main: '>=5.15.8,<5.16.0a0'
+    sip: '>=6.7.11,<6.8.0a0'
     ucrt: '>=10.0.20348.0'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.7-py311h125bc19_3.conda
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py311h125bc19_5.conda
   hash:
-    md5: 97c5f8ce920c1fd0c088e5bc0fd6acd7
-    sha256: 104e6dc3bcd951d12b4e2f1e96bc2813fa9ed07f361609b242583228a521c8d0
+    md5: 29d36acae7ccbcb1f0ec4a39841b3197
+    sha256: 4608b9caafc4fa16d887f5af08e1bafe95f4cb07596ca8f5af184bf5de8f2c4c
   optional: false
   category: main
-  build: py311h125bc19_3
+  build: py311h125bc19_5
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 3906132
-  timestamp: 1674669379771
+  size: 3906427
+  timestamp: 1695422270104
 - name: pyqt5-sip
-  version: 12.11.0
+  version: 12.12.2
   manager: conda
   platform: linux-64
   dependencies:
-    sip: '*'
-    python: '>=3.11,<3.12.0a0'
-    libstdcxx-ng: '>=12'
-    python_abi: 3.11.* *_cp311
-    toml: '*'
-    packaging: '*'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.11.0-py311hcafe171_3.conda
+    libstdcxx-ng: '>=12'
+    packaging: '*'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    sip: '*'
+    toml: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py311hb755f60_5.conda
   hash:
-    md5: 0d79df2a96f6572fed2883374400b235
-    sha256: 8936990e56c28df783b527a60de09a52f58eebc05bcdeaee01e0bc8df992bd75
+    md5: e4d262cc3600e70b505a6761d29f6207
+    sha256: cf6936273d92e5213b085bfd9ce1a37defb46b317b6ee991f2712bf4a25b8456
   optional: false
   category: main
-  build: py311hcafe171_3
+  build: py311hb755f60_5
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 85231
-  timestamp: 1674667131394
+  size: 85162
+  timestamp: 1695418076285
 - name: pyqt5-sip
-  version: 12.11.0
+  version: 12.12.2
   manager: conda
   platform: win-64
   dependencies:
+    packaging: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    toml: '*'
-    vc: '>=14.2,<15'
     sip: '*'
+    toml: '*'
     ucrt: '>=10.0.20348.0'
-    packaging: '*'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.11.0-py311h12c1d0e_3.conda
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py311h12c1d0e_5.conda
   hash:
-    md5: d12ec4e620d50e110dfb1c2c9ff698c3
-    sha256: 16526f22073ad3ad5d5c9f4d791a260943414d108a6dc7556276e2594a58fcd0
+    md5: 1b53a20f311bd99a1e55b31b7219106f
+    sha256: 7130493794e4c65f4e78258619a6ef9d022ba9f9b0f61e70d2973d9bc5f10e11
   optional: false
   category: main
-  build: py311h12c1d0e_3
+  build: py311h12c1d0e_5
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 79390
-  timestamp: 1674667106842
+  size: 79724
+  timestamp: 1695418442619
 - name: pysocks
   version: 1.7.1
   manager: conda
@@ -13081,9 +13552,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    win_inet_pton: '*'
     __win: '*'
     python: '>=3.8'
+    win_inet_pton: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
   hash:
     md5: 56cd9fe388baac0e90c7149cfac95b60
@@ -13100,29 +13571,29 @@ package:
   size: 19348
   timestamp: 1661605138291
 - name: python
-  version: 3.11.4
+  version: 3.11.6
   manager: conda
   platform: linux-64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.5.0,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libnsl: '>=2.0.0,<2.1.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
+    libsqlite: '>=3.43.0,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-    ld_impl_linux-64: '>=2.36.1'
+    openssl: '>=3.1.3,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
     tzdata: '*'
-    libffi: '>=3.4,<4.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.4-hab00c5b_0_cpython.conda
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
   hash:
-    md5: 1c628861a2a126b9fc9363ca1b7d014e
-    sha256: 04422f10d5bcb251fd254d6a9b0659dcde55e900d48cca159cb1fef637b0050c
+    md5: b0dfbe2fcbfdb097d321bfd50ecddab1
+    sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
   optional: false
   category: main
   build: hab00c5b_0_cpython
@@ -13132,28 +13603,28 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 30679695
-  timestamp: 1686421868353
+  size: 30720625
+  timestamp: 1696331287478
 - name: python
-  version: 3.11.4
+  version: 3.11.6
   manager: conda
   platform: osx-64
   dependencies:
-    tzdata: '*'
-    openssl: '>=3.1.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libsqlite: '>=3.43.0,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.4-h30d4d87_0_cpython.conda
+    openssl: '>=3.1.3,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: '*'
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
   hash:
-    md5: e40b3075f85db0184d5f61d17c580ef7
-    sha256: d2c00c7b1a616ad309afd864db6a7be33935710a68a7572509526495346655dc
+    md5: 4d66c5fc01e9be526afe5d828d4de24d
+    sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
   optional: false
   category: main
   build: h30d4d87_0_cpython
@@ -13163,28 +13634,28 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 15324849
-  timestamp: 1686421760912
+  size: 15393521
+  timestamp: 1696330855485
 - name: python
-  version: 3.11.4
+  version: 3.11.6
   manager: conda
   platform: osx-arm64
   dependencies:
-    tzdata: '*'
-    openssl: '>=3.1.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libsqlite: '>=3.43.0,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.4-h47c9636_0_cpython.conda
+    openssl: '>=3.1.3,<4.0a0'
+    readline: '>=8.2,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: '*'
+    xz: '>=5.2.6,<6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
   hash:
-    md5: b790b3cac8db7bdf2aaced9460bdbce4
-    sha256: 7865a28f7ec5c453cd8d3e7f539e02028ba5aa2aa33ccaa9915ba2654ae03ab2
+    md5: 2271df1db9534f5cac7c2d0820c3359d
+    sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
   optional: false
   category: main
   build: h47c9636_0_cpython
@@ -13194,29 +13665,29 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 14666250
-  timestamp: 1686420844311
+  size: 14626958
+  timestamp: 1696329727433
 - name: python
-  version: 3.11.4
+  version: 3.11.6
   manager: conda
   platform: win-64
   dependencies:
-    tzdata: '*'
-    openssl: '>=3.1.1,<4.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
     bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libffi: '>=3.4,<4.0a0'
+    libsqlite: '>=3.43.0,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.3,<4.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: '*'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.4-h2628c8c_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
   hash:
-    md5: 3187a32fba79e835f099ecea054026f4
-    sha256: d43fa70a3549fea27d3993f79ba2584ec6d6fe2aaf6e5890847f974e89a744e0
+    md5: 80b761856b20383615a3fe8b1b13eef8
+    sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
   optional: false
   category: main
   build: h2628c8c_0_cpython
@@ -13226,8 +13697,8 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 18116100
-  timestamp: 1686420267149
+  size: 18121128
+  timestamp: 1696329396864
 - name: python-dateutil
   version: 2.8.2
   manager: conda
@@ -13317,15 +13788,15 @@ package:
   size: 245987
   timestamp: 1626286448716
 - name: python-fastjsonschema
-  version: 2.17.1
+  version: 2.18.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
   hash:
-    md5: dd4f393d857e9283eef2442234bd05e3
-    sha256: b7a8b9b2310b3ee74ba99eef9692e477bb8bddf110eff45784dee7d81a693455
+    md5: 305141cff54af2f90e089d868fffce28
+    sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13335,18 +13806,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 225777
-  timestamp: 1684761393896
+  size: 226030
+  timestamp: 1696171963080
 - name: python-fastjsonschema
-  version: 2.17.1
+  version: 2.18.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
   hash:
-    md5: dd4f393d857e9283eef2442234bd05e3
-    sha256: b7a8b9b2310b3ee74ba99eef9692e477bb8bddf110eff45784dee7d81a693455
+    md5: 305141cff54af2f90e089d868fffce28
+    sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13356,18 +13827,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 225777
-  timestamp: 1684761393896
+  size: 226030
+  timestamp: 1696171963080
 - name: python-fastjsonschema
-  version: 2.17.1
+  version: 2.18.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
   hash:
-    md5: dd4f393d857e9283eef2442234bd05e3
-    sha256: b7a8b9b2310b3ee74ba99eef9692e477bb8bddf110eff45784dee7d81a693455
+    md5: 305141cff54af2f90e089d868fffce28
+    sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13377,18 +13848,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 225777
-  timestamp: 1684761393896
+  size: 226030
+  timestamp: 1696171963080
 - name: python-fastjsonschema
-  version: 2.17.1
+  version: 2.18.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.17.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
   hash:
-    md5: dd4f393d857e9283eef2442234bd05e3
-    sha256: b7a8b9b2310b3ee74ba99eef9692e477bb8bddf110eff45784dee7d81a693455
+    md5: 305141cff54af2f90e089d868fffce28
+    sha256: 3fb1af1ac7525072c46e111bc4e96ddf971f792ab049ca3aa25dbebbaffb6f7d
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13398,8 +13869,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 225777
-  timestamp: 1684761393896
+  size: 226030
+  timestamp: 1696171963080
 - name: python-json-logger
   version: 2.0.7
   manager: conda
@@ -13489,95 +13960,95 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-3_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
   hash:
-    md5: c2e2630ddb68cf52eec74dc7dfab20b5
-    sha256: 2966a87dcb0b11fad28f9fe8216bfa4071115776b47ffc7547492fed176e1a1f
+    md5: d786502c97404c94d7d58d258a445a65
+    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
   optional: false
   category: main
-  build: 3_cp311
+  build: 4_cp311
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 5682
-  timestamp: 1669071702664
+  size: 6385
+  timestamp: 1695147338551
 - name: python_abi
   version: '3.11'
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-3_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
   hash:
-    md5: 5e0a069a585445333868d2c6651c3b3f
-    sha256: 145edb385d464227aca8ce963b9e22f5f36cacac9085eb38f574961ebc69684e
+    md5: fef7a52f0eca6bae9e8e2e255bc86394
+    sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
   optional: false
   category: main
-  build: 3_cp311
+  build: 4_cp311
   arch: x86_64
   subdir: osx-64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 5766
-  timestamp: 1669071853731
+  size: 6478
+  timestamp: 1695147518012
 - name: python_abi
   version: '3.11'
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-3_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
   hash:
-    md5: e1586496f8acd1c9293019ab14dbde9d
-    sha256: cd2bad56c398e77b7f559314c29dd54e9eeb842896ff1de5078ed3192e5e14a6
+    md5: 8d3751bc73d3bbb66f216fa2331d5649
+    sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
   optional: false
   category: main
-  build: 3_cp311
+  build: 4_cp311
   arch: aarch64
   subdir: osx-arm64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 5768
-  timestamp: 1669071844807
+  size: 6492
+  timestamp: 1695147509940
 - name: python_abi
   version: '3.11'
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-3_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
   hash:
-    md5: fd1634ba85cfea9376e1fc02d6f592e9
-    sha256: e042841d13274354d651a69a4f2589e9b46fd23b416368c9821bf3c6676f19d7
+    md5: 70513332c71b56eace4ee6441e66c012
+    sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
   optional: false
   category: main
-  build: 3_cp311
+  build: 4_cp311
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6124
-  timestamp: 1669071848353
+  size: 6755
+  timestamp: 1695147711935
 - name: pytz
-  version: '2023.3'
+  version: 2023.3.post1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3076b483092a435832603243567bc31
-    sha256: e4999484f21763ca4b8f92c95b22cb6d1edc1b61d0a2bb073ee2bd11f39401b9
+    md5: c93346b446cd08c169d843ae5fc0da97
+    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13587,18 +14058,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 186506
-  timestamp: 1680088891597
+  size: 187454
+  timestamp: 1693930444432
 - name: pytz
-  version: '2023.3'
+  version: 2023.3.post1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3076b483092a435832603243567bc31
-    sha256: e4999484f21763ca4b8f92c95b22cb6d1edc1b61d0a2bb073ee2bd11f39401b9
+    md5: c93346b446cd08c169d843ae5fc0da97
+    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13608,18 +14079,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 186506
-  timestamp: 1680088891597
+  size: 187454
+  timestamp: 1693930444432
 - name: pytz
-  version: '2023.3'
+  version: 2023.3.post1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3076b483092a435832603243567bc31
-    sha256: e4999484f21763ca4b8f92c95b22cb6d1edc1b61d0a2bb073ee2bd11f39401b9
+    md5: c93346b446cd08c169d843ae5fc0da97
+    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13629,18 +14100,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 186506
-  timestamp: 1680088891597
+  size: 187454
+  timestamp: 1693930444432
 - name: pytz
-  version: '2023.3'
+  version: 2023.3.post1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3076b483092a435832603243567bc31
-    sha256: e4999484f21763ca4b8f92c95b22cb6d1edc1b61d0a2bb073ee2bd11f39401b9
+    md5: c93346b446cd08c169d843ae5fc0da97
+    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -13650,22 +14121,22 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 186506
-  timestamp: 1680088891597
+  size: 187454
+  timestamp: 1693930444432
 - name: pywin32
-  version: '304'
+  version: '306'
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-304-py311h12c1d0e_2.tar.bz2
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py311h12c1d0e_2.conda
   hash:
-    md5: 20a2d8e73b0be8e27ca4096d4f3a7053
-    sha256: cdefd0688f776940bcc74fd981328a5d45e734006538dca6d686f8d21051c753
+    md5: 25df0fc55722ea1a94494f41302e2d1c
+    sha256: 79d942817bdaf384602113e5fcb9158dc45cae4044bed308918a5db97f141fdb
   optional: false
   category: main
   build: py311h12c1d0e_2
@@ -13674,23 +14145,23 @@ package:
   build_number: 2
   license: PSF-2.0
   license_family: PSF
-  size: 9916058
-  timestamp: 1666985027367
+  size: 6124285
+  timestamp: 1695974706892
 - name: pywinpty
-  version: 2.0.11
+  version: 2.0.12
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     winpty: '*'
-  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.11-py311h12c1d0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py311h12c1d0e_0.conda
   hash:
-    md5: dd979ef7f5a96b0a607dbfe6d5028fef
-    sha256: 1488484432698d098a2850e3522197b7123f2a8d50a66fa759297a5618725dfa
+    md5: 6561b01d9a25270af769d3defd007cc5
+    sha256: 611a59e4b078054ca8cf49e6fd18509345e5d3b1fc79d464dfe584d35a93e933
   optional: false
   category: main
   build: py311h12c1d0e_0
@@ -13699,303 +14170,303 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 216655
-  timestamp: 1689415115511
+  size: 220505
+  timestamp: 1696657577118
 - name: pyyaml
-  version: '6.0'
+  version: 6.0.1
   manager: conda
   platform: linux-64
   dependencies:
+    libgcc-ng: '>=12'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    libgcc-ng: '>=12'
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0-py311hd4cff14_5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py311h459d7ec_1.conda
   hash:
-    md5: da8769492e423103c59f469f4f17f8d9
-    sha256: 47b22be55c6f60f0e93b5e6887e02b98025bb13eeb390d84c68102f63f22413d
+    md5: 52719a74ad130de8fb5d047dc91f247a
+    sha256: 28729ef1ffa7f6f9dfd54345a47c7faac5d34296d66a2b9891fb147f4efe1348
   optional: false
   category: main
-  build: py311hd4cff14_5
+  build: py311h459d7ec_1
   arch: x86_64
   subdir: linux-64
-  build_number: 5
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 206972
-  timestamp: 1666772511542
+  size: 200626
+  timestamp: 1695373818537
 - name: pyyaml
-  version: '6.0'
+  version: 6.0.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0-py311h5547dcb_5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py311h2725bcf_1.conda
   hash:
-    md5: 8d1e456914ce961119b07f396187a564
-    sha256: 1598d451064c39979ac61e821eab3997b03e53eaa61070c450ca05e3ebcc23da
+    md5: 9283f991b5e5856a99f8aabba9927df5
+    sha256: 8ce2ba443414170a2570514d0ce6d03625a847e91af9763d48dc58c338e6f7f3
   optional: false
   category: main
-  build: py311h5547dcb_5
+  build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
-  build_number: 5
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 197877
-  timestamp: 1666772814869
+  size: 188606
+  timestamp: 1695373840022
 - name: pyyaml
-  version: '6.0'
+  version: 6.0.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0-py311he2be06e_5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py311heffc1b2_1.conda
   hash:
-    md5: bd3b5db42251cb399567fa21cea3faf6
-    sha256: b5bff9942f942dbd9caea8258c39f625ea00e48d8854ff8b7c38e9d642de1882
+    md5: d310bfbb8230b9175c0cbc10189ad804
+    sha256: b155f5c27f0e2951256774628c4b91fdeee3267018eef29897a74e3d1316c8b0
   optional: false
   category: main
-  build: py311he2be06e_5
+  build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 5
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 193122
-  timestamp: 1666773008211
+  size: 187795
+  timestamp: 1695373829282
 - name: pyyaml
-  version: '6.0'
+  version: 6.0.1
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+    vc14_runtime: '>=14.29.30139'
     yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0-py311ha68e1ae_5.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py311ha68e1ae_1.conda
   hash:
-    md5: 0c97d59d54eb52e170224b3de6ade906
-    sha256: b97ad8513a22204707dc9ef506f7eca70dc9027cb09e26f559ca560d8b21ae14
+    md5: 2b4128962cd665153e946f2a88667a3b
+    sha256: 4fb0770fc70381a8ab3ced33413ad9dc5e82d4c535b593edd580113ce8760298
   optional: false
   category: main
-  build: py311ha68e1ae_5
+  build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
-  build_number: 5
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 181077
-  timestamp: 1666772842384
+  size: 175469
+  timestamp: 1695374086205
 - name: pyzmq
-  version: 25.1.0
+  version: 25.1.1
   manager: conda
   platform: linux-64
   dependencies:
-    zeromq: '>=4.3.4,<4.4.0a0'
-    python: '>=3.11,<3.12.0a0'
-    libstdcxx-ng: '>=12'
-    python_abi: 3.11.* *_cp311
     libgcc-ng: '>=12'
     libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.0-py311h75c88c4_0.conda
+    libstdcxx-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    zeromq: '>=4.3.4,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py311h75c88c4_1.conda
   hash:
-    md5: db94a7a9e865fbfde8c023b6e8958bb2
-    sha256: cca843be2a970bbadf2268b3d8527910d528d5fe40de53a5cd646d903c70d289
+    md5: b858421f6a3052950c33aecd44a905cb
+    sha256: 846612e248330bfa579c71b837d2c82a2b3755c1b982dd647f5bcb0047f58f9f
   optional: false
   category: main
-  build: py311h75c88c4_0
+  build: py311h75c88c4_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 529341
-  timestamp: 1685519432001
+  size: 539168
+  timestamp: 1695384485238
 - name: pyzmq
-  version: 25.1.0
+  version: 25.1.1
   manager: conda
   platform: osx-64
   dependencies:
-    zeromq: '>=4.3.4,<4.4.0a0'
-    python: '>=3.11,<3.12.0a0'
     libcxx: '>=15.0.7'
-    python_abi: 3.11.* *_cp311
     libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.0-py311h5dacc12_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    zeromq: '>=4.3.4,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py311h5dacc12_1.conda
   hash:
-    md5: 1f65b37886e7cb8476d48ea8bb9d19c0
-    sha256: bef526f79f533f544e1486b8cc1a50af340248afdbc4e6b0de8349d85dbd5cc8
+    md5: f7199b493d4a542d7344e1f9eb5bc476
+    sha256: d556deedd05013eafc5d8df2ef94b81d7f3fd655574698de78a17093b29e0a55
   optional: false
   category: main
-  build: py311h5dacc12_0
+  build: py311h5dacc12_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 498701
-  timestamp: 1685519609247
+  size: 499664
+  timestamp: 1695384610282
 - name: pyzmq
-  version: 25.1.0
+  version: 25.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    zeromq: '>=4.3.4,<4.4.0a0'
-    python: '>=3.11,<3.12.0a0 *_cpython'
     libcxx: '>=15.0.7'
-    python_abi: 3.11.* *_cp311
     libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.0-py311hb1af645_0.conda
+    python: '>=3.11,<3.12.0a0 *_cpython'
+    python_abi: 3.11.* *_cp311
+    zeromq: '>=4.3.4,<4.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py311hb1af645_1.conda
   hash:
-    md5: d318bf7187261258ab18b5197c57714a
-    sha256: 4b94f875f15a225ba56ad3752373382cf07ba1509fd11a85d8de5c1e62850f23
+    md5: 805fa87be04adc49c3d04cbf266f4552
+    sha256: d4ce1a1e201c3db2fbda54799ead8be1a40c870060ebd34889cba5998414947a
   optional: false
   category: main
-  build: py311hb1af645_0
+  build: py311hb1af645_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 507129
-  timestamp: 1685519898208
+  size: 511702
+  timestamp: 1695384959247
 - name: pyzmq
-  version: 25.1.0
+  version: 25.1.1
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
+    libsodium: '>=1.0.18,<1.0.19.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zeromq: '>=4.3.4,<4.3.5.0a0'
-    vc: '>=14.2,<15'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.0-py311h7b3f143_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py311h7b3f143_1.conda
   hash:
-    md5: b690f6e1878ccc98e96a33658867e8e1
-    sha256: ac0f68359c7accb28b438d8a0f7b7e8827ac66d6b5f7dbe80e6570d376b235e2
+    md5: e3d0dd062963011239017d79be3ecdaa
+    sha256: 7412e89a3574d4fb476a3fe1c5f0356f1748d9a0fa611c6301e637456571588c
   optional: false
   category: main
-  build: py311h7b3f143_0
+  build: py311h7b3f143_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 479976
-  timestamp: 1685519861662
+  size: 490355
+  timestamp: 1695384729154
 - name: qt-main
   version: 5.15.8
   manager: conda
   platform: linux-64
   dependencies:
-    libxml2: '>=2.11.4,<2.12.0a0'
-    nspr: '>=4.35,<5.0a0'
-    xcb-util-renderutil: '>=0.3.9,<0.4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    mysql-libs: '>=8.0.33,<8.1.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    libxkbcommon: '>=1.5.0,<2.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-    nss: '>=3.89,<4.0a0'
-    xcb-util-keysyms: '>=0.4.0,<0.5.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libclang: '>=15.0.7,<16.0a0'
-    fonts-conda-ecosystem: '*'
-    xcb-util-image: '>=0.4.0,<0.5.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    xcb-util-wm: '>=0.4.1,<0.5.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    alsa-lib: '>=1.2.9,<1.2.10.0a0'
-    libgcc-ng: '>=12'
-    libcups: '>=2.3.3,<2.4.0a0'
-    gstreamer: '>=1.22.4,<1.23.0a0'
-    xorg-xf86vidmodeproto: '*'
-    harfbuzz: '>=7.3.0,<8.0a0'
-    pulseaudio-client: '>=16.1,<16.2.0a0'
-    dbus: '>=1.13.6,<2.0a0'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    xcb-util: '>=0.4.0,<0.5.0a0'
-    icu: '>=72.1,<73.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-    libglib: '>=2.76.3,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    gst-plugins-base: '>=1.22.4,<1.23.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
     __glibc: '>=2.17,<3.0.a0'
-    libpq: '>=15.3,<16.0a0'
+    alsa-lib: '>=1.2.10,<1.2.11.0a0'
+    dbus: '>=1.13.6,<2.0a0'
+    fontconfig: '>=2.14.2,<3.0a0'
+    fonts-conda-ecosystem: '*'
+    freetype: '>=2.12.1,<3.0a0'
+    gst-plugins-base: '>=1.22.5,<1.23.0a0'
+    gstreamer: '>=1.22.5,<1.23.0a0'
+    harfbuzz: '>=8.2.0,<9.0a0'
+    icu: '>=73.2,<74.0a0'
+    krb5: '>=1.21.2,<1.22.0a0'
+    libclang: '>=15.0.7,<16.0a0'
     libclang13: '>=15.0.7'
-    krb5: '>=1.20.1,<1.21.0a0'
+    libcups: '>=2.3.3,<2.4.0a0'
+    libevent: '>=2.1.12,<2.1.13.0a0'
+    libexpat: '>=2.5.0,<3.0a0'
+    libgcc-ng: '>=12'
+    libglib: '>=2.78.0,<3.0a0'
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libpq: '>=15.4,<16.0a0'
+    libsqlite: '>=3.43.0,<4.0a0'
+    libstdcxx-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
+    libxkbcommon: '>=1.5.0,<2.0a0'
+    libxml2: '>=2.11.5,<2.12.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    mysql-libs: '>=8.0.33,<8.1.0a0'
+    nspr: '>=4.35,<5.0a0'
+    nss: '>=3.92,<4.0a0'
+    openssl: '>=3.1.2,<4.0a0'
+    pulseaudio-client: '>=16.1,<16.2.0a0'
+    xcb-util: '>=0.4.0,<0.5.0a0'
+    xcb-util-image: '>=0.4.0,<0.5.0a0'
+    xcb-util-keysyms: '>=0.4.0,<0.5.0a0'
+    xcb-util-renderutil: '>=0.3.9,<0.4.0a0'
+    xcb-util-wm: '>=0.4.1,<0.5.0a0'
+    xorg-libice: '>=1.1.1,<2.0a0'
+    xorg-libsm: '>=1.2.4,<2.0a0'
     xorg-libx11: '>=1.8.6,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-hf9e2b05_14.conda
+    xorg-libxext: '>=1.3.4,<2.0a0'
+    xorg-xf86vidmodeproto: '*'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-hc47bfe8_16.conda
   hash:
-    md5: d8d4389bd97e0d604150c09d9894a711
-    sha256: 6e35d43e91d4fd838ad26df8e2f6880c5e8707d1a2f630a35b57ab992a2416a8
+    md5: a8dd2dfcd570e3965c73be6c5e03e74f
+    sha256: 18dc29e725b620ec857368b40f07c41fd360b6c4071f83b67112eabfc087e8f1
   optional: false
   category: main
-  build: hf9e2b05_14
+  build: hc47bfe8_16
   arch: x86_64
   subdir: linux-64
-  build_number: 14
+  build_number: 16
   constrains:
   - qt 5.15.8
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 61260870
-  timestamp: 1687874786721
+  size: 60757140
+  timestamp: 1694504368390
 - name: qt-main
   version: 5.15.8
   manager: conda
   platform: win-64
   dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    vc14_runtime: '>=14.29.30139'
-    ucrt: '>=10.0.20348.0'
-    gstreamer: '>=1.22.4,<1.23.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
-    icu: '>=72.1,<73.0a0'
-    libglib: '>=2.76.3,<3.0a0'
-    vc: '>=14.2,<15'
-    gst-plugins-base: '>=1.22.4,<1.23.0a0'
-    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    gst-plugins-base: '>=1.22.5,<1.23.0a0'
+    gstreamer: '>=1.22.5,<1.23.0a0'
+    icu: '>=73.2,<74.0a0'
+    krb5: '>=1.21.2,<1.22.0a0'
     libclang: '>=15.0.7,<16.0a0'
-    krb5: '>=1.20.1,<1.21.0a0'
     libclang13: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h2c8576c_14.conda
+    libglib: '>=2.78.0,<3.0a0'
+    libjpeg-turbo: '>=2.1.5.1,<3.0a0'
+    libpng: '>=1.6.39,<1.7.0a0'
+    libsqlite: '>=3.43.0,<4.0a0'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.1.2,<4.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-he5a7383_16.conda
   hash:
-    md5: 1f5da14a40e9fa12912f1b2c0954a999
-    sha256: 4571f4e194fc3ac7eab4b1f2656fa71beb4b5059cdc2bb3cc5d2c45452d02f04
+    md5: b67cbf30e1c1c0dcb314e2705f088bc2
+    sha256: be746aad17335729eabc029a552c09e6afdcef1d6da14b8daa343cf306fae2b9
   optional: false
   category: main
-  build: h2c8576c_14
+  build: he5a7383_16
   arch: x86_64
   subdir: win-64
-  build_number: 14
+  build_number: 16
   constrains:
   - qt 5.15.8
   license: LGPL-3.0-only
   license_family: LGPL
-  size: 60530287
-  timestamp: 1687905731279
+  size: 60176423
+  timestamp: 1694508254767
 - name: readline
   version: '8.2'
   manager: conda
   platform: linux-64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
     libgcc-ng: '>=12'
+    ncurses: '>=6.3,<7.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   hash:
     md5: 47d31b792659ce70f470b5c82fdfb7a4
@@ -14051,17 +14522,17 @@ package:
   size: 250351
   timestamp: 1679532511311
 - name: referencing
-  version: 0.29.1
+  version: 0.30.2
   manager: conda
   platform: linux-64
   dependencies:
     attrs: '>=22.2.0'
     python: '>=3.8'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.29.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
   hash:
-    md5: ec2794be57ba0a88e8e0277d51d58361
-    sha256: 82529d844a0a8e099a11e38558ae8d0466be3b4e6b8a69538cc3631afced1c09
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14071,20 +14542,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 26671
-  timestamp: 1688649224092
+  size: 38061
+  timestamp: 1691337409918
 - name: referencing
-  version: 0.29.1
+  version: 0.30.2
   manager: conda
   platform: osx-64
   dependencies:
     attrs: '>=22.2.0'
     python: '>=3.8'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.29.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
   hash:
-    md5: ec2794be57ba0a88e8e0277d51d58361
-    sha256: 82529d844a0a8e099a11e38558ae8d0466be3b4e6b8a69538cc3631afced1c09
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14094,20 +14565,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 26671
-  timestamp: 1688649224092
+  size: 38061
+  timestamp: 1691337409918
 - name: referencing
-  version: 0.29.1
+  version: 0.30.2
   manager: conda
   platform: osx-arm64
   dependencies:
     attrs: '>=22.2.0'
     python: '>=3.8'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.29.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
   hash:
-    md5: ec2794be57ba0a88e8e0277d51d58361
-    sha256: 82529d844a0a8e099a11e38558ae8d0466be3b4e6b8a69538cc3631afced1c09
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14117,20 +14588,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 26671
-  timestamp: 1688649224092
+  size: 38061
+  timestamp: 1691337409918
 - name: referencing
-  version: 0.29.1
+  version: 0.30.2
   manager: conda
   platform: win-64
   dependencies:
     attrs: '>=22.2.0'
     python: '>=3.8'
     rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.29.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
   hash:
-    md5: ec2794be57ba0a88e8e0277d51d58361
-    sha256: 82529d844a0a8e099a11e38558ae8d0466be3b4e6b8a69538cc3631afced1c09
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14140,18 +14611,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 26671
-  timestamp: 1688649224092
+  size: 38061
+  timestamp: 1691337409918
 - name: requests
   version: 2.31.0
   manager: conda
   platform: linux-64
   dependencies:
     certifi: '>=2017.4.17'
-    python: '>=3.7'
     charset-normalizer: '>=2,<4'
-    urllib3: '>=1.21.1,<3'
     idna: '>=2.5,<4'
+    python: '>=3.7'
+    urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
   hash:
     md5: a30144e4156cdbb236f99ebb49828f8b
@@ -14175,10 +14646,10 @@ package:
   platform: osx-64
   dependencies:
     certifi: '>=2017.4.17'
-    python: '>=3.7'
     charset-normalizer: '>=2,<4'
-    urllib3: '>=1.21.1,<3'
     idna: '>=2.5,<4'
+    python: '>=3.7'
+    urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
   hash:
     md5: a30144e4156cdbb236f99ebb49828f8b
@@ -14202,10 +14673,10 @@ package:
   platform: osx-arm64
   dependencies:
     certifi: '>=2017.4.17'
-    python: '>=3.7'
     charset-normalizer: '>=2,<4'
-    urllib3: '>=1.21.1,<3'
     idna: '>=2.5,<4'
+    python: '>=3.7'
+    urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
   hash:
     md5: a30144e4156cdbb236f99ebb49828f8b
@@ -14229,10 +14700,10 @@ package:
   platform: win-64
   dependencies:
     certifi: '>=2017.4.17'
-    python: '>=3.7'
     charset-normalizer: '>=2,<4'
-    urllib3: '>=1.21.1,<3'
     idna: '>=2.5,<4'
+    python: '>=3.7'
+    urllib3: '>=1.21.1,<3'
   url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
   hash:
     md5: a30144e4156cdbb236f99ebb49828f8b
@@ -14423,17 +14894,17 @@ package:
   size: 7818
   timestamp: 1598024297745
 - name: rpds-py
-  version: 0.8.10
+  version: 0.10.4
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
     libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.8.10-py311h46250e7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.4-py311h46250e7_0.conda
   hash:
-    md5: 5bd237a92bd798254624f0efa0b14c17
-    sha256: d59f7ed52eb1e8e24faa9e2214c5ee3c03b0c1feb4b567a9fd3b9fc74bcec1be
+    md5: fd2b9bb72eeb3d90187a6d77c46a228e
+    sha256: 4d5de050159eb36c28349bd6e2904a30e1c30cfb8041db95eeb35478de222250
   optional: false
   category: main
   build: py311h46250e7_0
@@ -14442,64 +14913,64 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 931844
-  timestamp: 1688996844392
+  size: 993693
+  timestamp: 1696517634291
 - name: rpds-py
-  version: 0.8.10
+  version: 0.10.4
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.8.10-py311h299eb51_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.4-py311h5e0f0e4_0.conda
   hash:
-    md5: 5a6811ccc05ef19432be0e588a8f866f
-    sha256: fd8ea5e3afd26814dcd8872ba563b2db4e7ada7af195561c71aa47f24485921b
+    md5: e4b956773e591f3e897c13e5d08e2799
+    sha256: 8c101955235616f2c04b89d50779417026e36c2ff2042887eb1cac68fe8276cf
   optional: false
   category: main
-  build: py311h299eb51_0
+  build: py311h5e0f0e4_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 270572
-  timestamp: 1688997285684
+  size: 284931
+  timestamp: 1696517865230
 - name: rpds-py
-  version: 0.8.10
+  version: 0.10.4
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.8.10-py311h0563b04_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.10.4-py311h94f323b_0.conda
   hash:
-    md5: d1c690fbc6631191b0393808a3767c36
-    sha256: ef2efb51cc59c01db325efefb5178fecfaae417f482e10a4f1346c01b3407038
+    md5: c62e1c0759bf45fe0af5c4b4006b5b39
+    sha256: 05234e773398f9b80b7dedd00ca620f0724fa427235f620c67b0da7a31b41afb
   optional: false
   category: main
-  build: py311h0563b04_0
+  build: py311h94f323b_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 273472
-  timestamp: 1688997464718
+  size: 288004
+  timestamp: 1696517860317
 - name: rpds-py
-  version: 0.8.10
+  version: 0.10.4
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.8.10-py311hc37eb10_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.4-py311hc37eb10_0.conda
   hash:
-    md5: bb990d748ebaf568692062ea428a8d0e
-    sha256: 7b539ffc6d5efd9f7a069dd6c9930dee5f0a3ce9270304c04e9ca793fc3b7625
+    md5: 963141fe1302a135417df472015283d2
+    sha256: cde05c5bb7a03adf7ee111c5f4e8955087e50330b85c651cdd545241f317e565
   optional: false
   category: main
   build: py311hc37eb10_0
@@ -14508,244 +14979,240 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 182581
-  timestamp: 1688997571614
+  size: 186807
+  timestamp: 1696518055121
 - name: scikit-learn
-  version: 1.3.0
+  version: 1.3.1
   manager: conda
   platform: linux-64
   dependencies:
+    _openmp_mutex: '>=4.5'
+    joblib: '>=1.1.1'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    _openmp_mutex: '>=4.5'
-    threadpoolctl: '>=2.0.0'
     scipy: '*'
-    libgcc-ng: '>=12'
-    numpy: '>=1.23.5,<2.0a0'
-    joblib: '>=1.1.1'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.3.0-py311hc009520_0.conda
+    threadpoolctl: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.3.1-py311hc009520_1.conda
   hash:
-    md5: 847797c4a9c0c3363ffcfe7571dedfee
-    sha256: 6e467edc8cf65dfd2ae787dae7818dc0c800c2bfd65fce80c87899594e469eb4
+    md5: 0f06a0c10766b511c62050f9aed88b24
+    sha256: 5d8111c6429df7b3fd4f5b1c06b0210c0b2d44717ebb002d17e34fe21de2f9ce
   optional: false
   category: main
-  build: py311hc009520_0
+  build: py311hc009520_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 9615286
-  timestamp: 1688116966605
+  size: 9573691
+  timestamp: 1696575248513
 - name: scikit-learn
-  version: 1.3.0
+  version: 1.3.1
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.9'
+    joblib: '>=1.1.1'
+    libcxx: '>=16.0.6'
+    llvm-openmp: '>=16.0.6'
+    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    threadpoolctl: '>=2.0.0'
     scipy: '*'
-    numpy: '>=1.23.5,<2.0a0'
-    llvm-openmp: '>=15.0.7'
-    joblib: '>=1.1.1'
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.3.0-py311h83feae1_0.conda
+    threadpoolctl: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.3.1-py311h66081b9_1.conda
   hash:
-    md5: 8d80191552e7bd6d92ab85367d498c03
-    sha256: dbf3ec3b3e6eb9c22a41477c55c52386de428ec95df0ef0a40a9f60a6639c81f
+    md5: d4f5fabfaa9b000f30e0de5c5d42b8d6
+    sha256: 0c9c86ea9bdd1e3c3f2c076e44cc900f43c37f97e857f293487748a35d48ae85
   optional: false
   category: main
-  build: py311h83feae1_0
+  build: py311h66081b9_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 8831660
-  timestamp: 1688117306817
+  size: 8824302
+  timestamp: 1696575696464
 - name: scikit-learn
-  version: 1.3.0
+  version: 1.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
+    __osx: '>=10.9'
+    joblib: '>=1.1.1'
+    libcxx: '>=16.0.6'
+    llvm-openmp: '>=16.0.6'
+    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-    threadpoolctl: '>=2.0.0'
     scipy: '*'
-    numpy: '>=1.23.5,<2.0a0'
-    llvm-openmp: '>=15.0.7'
-    joblib: '>=1.1.1'
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.3.0-py311hf0b18b8_0.conda
+    threadpoolctl: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.3.1-py311ha25ca4d_1.conda
   hash:
-    md5: 59c1392eb93becd012ce77e939fad1e4
-    sha256: 670bbe87fbf47c96c54b24d1620a5eedca325dc2a10eaac0d7677874275a1923
+    md5: 4d60bf52a2cf510bfd2e6799cdfad562
+    sha256: d3770dfd3f59a7daa79cdfa660a0e8a480df036b81894f10a237e30c358093a6
   optional: false
   category: main
-  build: py311hf0b18b8_0
+  build: py311ha25ca4d_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 8971112
-  timestamp: 1688117364837
+  size: 8797649
+  timestamp: 1696575782557
 - name: scikit-learn
-  version: 1.3.0
+  version: 1.3.1
   manager: conda
   platform: win-64
   dependencies:
+    joblib: '>=1.1.1'
+    numpy: '>=1.23.5,<2.0a0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    threadpoolctl: '>=2.0.0'
     scipy: '*'
+    threadpoolctl: '>=2.0.0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-    ucrt: '>=10.0.20348.0'
-    numpy: '>=1.23.5,<2.0a0'
-    joblib: '>=1.1.1'
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.3.0-py311h142b183_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.3.1-py311h142b183_1.conda
   hash:
-    md5: ab4a48b21b718dca0d1dc71d0374359d
-    sha256: 17518fe43bc3aa428cf240083f67db1cf687b76d5ba0c17f6e530ef82f5adaa7
+    md5: 3d404996b0f7e1117a980e7f0a22acdf
+    sha256: 962c68afe6e90d9480cf38a8e15c5452fb15adeae144aab1575c080aaf55af64
   optional: false
   category: main
-  build: py311h142b183_0
+  build: py311h142b183_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 8308703
-  timestamp: 1688117347403
+  size: 8291853
+  timestamp: 1696575890648
 - name: scipy
-  version: 1.11.1
+  version: 1.11.3
   manager: conda
   platform: linux-64
   dependencies:
-    libgfortran-ng: '*'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
     libblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    pooch: '*'
     libcblas: '>=3.9.0,<4.0a0'
+    libgcc-ng: '>=12'
+    libgfortran-ng: '*'
     libgfortran5: '>=12.3.0'
     liblapack: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
     numpy: '>=1.23.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.1-py311h64a7726_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py311h64a7726_1.conda
   hash:
-    md5: 356da36102fc1eeb8a81e6d79e53bc7e
-    sha256: 7e2859efd5a5a1d3a943284635ed3504e23bc8eb71532c979401b7131eb31993
+    md5: e4b4d3b764e2d029477d0db88248a8b5
+    sha256: 13ea70afe49a3c92fb9b82a6efcfa23a05ca8f24ec2dff22597d651e0e2b4767
   optional: false
   category: main
-  build: py311h64a7726_0
+  build: py311h64a7726_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 15944954
-  timestamp: 1687996440333
+  size: 16002963
+  timestamp: 1696468652023
 - name: scipy
-  version: 1.11.1
+  version: 1.11.3
   manager: conda
   platform: osx-64
   dependencies:
-    libgfortran: 5.*
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
     libblas: '>=3.9.0,<4.0a0'
-    pooch: '*'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=15.0.7'
-    libgfortran5: '>=12.2.0'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
     liblapack: '>=3.9.0,<4.0a0'
     numpy: '>=1.23.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.1-py311h16c3c4d_0.conda
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py311h16c3c4d_1.conda
   hash:
-    md5: 3492280f8227a6070eb1ee8c84ab5827
-    sha256: a96e241e89f9c18694d56c077edbff344c003990e41a135ce3c54cc5dca8168b
+    md5: 77164acef9bc09545bd3324a8f986be5
+    sha256: 78270d60ea00482b4f64a4b2d5d4e432f48125f6b76780e2094c8363ad48b611
   optional: false
   category: main
-  build: py311h16c3c4d_0
+  build: py311h16c3c4d_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 16143327
-  timestamp: 1687996895625
+  size: 16243071
+  timestamp: 1696469112175
 - name: scipy
-  version: 1.11.1
+  version: 1.11.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libgfortran: 5.*
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
     libblas: '>=3.9.0,<4.0a0'
-    pooch: '*'
     libcblas: '>=3.9.0,<4.0a0'
     libcxx: '>=15.0.7'
-    libgfortran5: '>=12.2.0'
+    libgfortran: 5.*
+    libgfortran5: '>=13.2.0'
     liblapack: '>=3.9.0,<4.0a0'
     numpy: '>=1.23.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.1-py311h93d07a4_0.conda
+    python: '>=3.11,<3.12.0a0 *_cpython'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py311h93d07a4_1.conda
   hash:
-    md5: a62203d2445e563437b3d80327dee0eb
-    sha256: f9b3fcc7c6d87d6603a7d7d6698c7ae8a0172b73241f2f13d16551a135643c84
+    md5: 1c687552b288a801a7851166f2494768
+    sha256: 6347f47c02eef02afe1e5534c88269f73b2da28cdff8c826b210e529b8bd1f07
   optional: false
   category: main
-  build: py311h93d07a4_0
+  build: py311h93d07a4_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 14968676
-  timestamp: 1687997669337
+  size: 15110473
+  timestamp: 1696469388055
 - name: scipy
-  version: 1.11.1
+  version: 1.11.3
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    m2w64-gcc-libs: '*'
     libblas: '>=3.9.0,<4.0a0'
-    pooch: '*'
-    ucrt: '>=10.0.20348.0'
     libcblas: '>=3.9.0,<4.0a0'
     liblapack: '>=3.9.0,<4.0a0'
     numpy: '>=1.23.5,<2.0a0'
-    m2w64-gcc-libs-core: '*'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.1-py311h37ff6ca_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py311h0b4df5a_1.conda
   hash:
-    md5: 03a41a6a8d6878d311eb6c1e8e1edee2
-    sha256: 4b01f790d0257cf696063d756ff6d890834ac64881e1df2aacec238d22477471
+    md5: 67910f5db4ee7b8bbf39250c167d3a34
+    sha256: 1fc5493e5c6706c3e1a925090478f1c8306f493602cb8a4d935de8aa361be36c
   optional: false
   category: main
-  build: py311h37ff6ca_0
+  build: py311h0b4df5a_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 19142412
-  timestamp: 1687997884419
+  size: 14873188
+  timestamp: 1696469599650
 - name: send2trash
   version: 1.8.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
     __linux: '*'
+    python: '>=3.6'
   url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
   hash:
     md5: ada5a17adcd10be4fc7e37e4166ba0e2
@@ -14831,15 +15298,15 @@ package:
   size: 23279
   timestamp: 1682601755260
 - name: setuptools
-  version: 68.0.0
+  version: 68.2.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5a7739d0f57ee64133c9d32e6507c46d
-    sha256: 083a0913f5b56644051f31ac40b4eeea762a88c00aa12437817191b85a753cec
+    md5: fc2166155db840c634a1291a5c35a709
+    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14849,18 +15316,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 463712
-  timestamp: 1687527994911
+  size: 464399
+  timestamp: 1694548452441
 - name: setuptools
-  version: 68.0.0
+  version: 68.2.2
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5a7739d0f57ee64133c9d32e6507c46d
-    sha256: 083a0913f5b56644051f31ac40b4eeea762a88c00aa12437817191b85a753cec
+    md5: fc2166155db840c634a1291a5c35a709
+    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14870,18 +15337,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 463712
-  timestamp: 1687527994911
+  size: 464399
+  timestamp: 1694548452441
 - name: setuptools
-  version: 68.0.0
+  version: 68.2.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5a7739d0f57ee64133c9d32e6507c46d
-    sha256: 083a0913f5b56644051f31ac40b4eeea762a88c00aa12437817191b85a753cec
+    md5: fc2166155db840c634a1291a5c35a709
+    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14891,18 +15358,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 463712
-  timestamp: 1687527994911
+  size: 464399
+  timestamp: 1694548452441
 - name: setuptools
-  version: 68.0.0
+  version: 68.2.2
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 5a7739d0f57ee64133c9d32e6507c46d
-    sha256: 083a0913f5b56644051f31ac40b4eeea762a88c00aa12437817191b85a753cec
+    md5: fc2166155db840c634a1291a5c35a709
+    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -14912,61 +15379,61 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 463712
-  timestamp: 1687527994911
+  size: 464399
+  timestamp: 1694548452441
 - name: sip
-  version: 6.7.9
+  version: 6.7.11
   manager: conda
   platform: linux-64
   dependencies:
-    tomli: '*'
-    ply: '*'
+    libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
+    packaging: '*'
+    ply: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    packaging: '*'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.9-py311hb755f60_0.conda
+    tomli: '*'
+  url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.11-py311hb755f60_1.conda
   hash:
-    md5: 2b5430f2f1651f460c852e1fdd549184
-    sha256: 050c75f887d9fe8da043d6c40f527cf5a340cf927c5589d7a2cb21a2309921a8
+    md5: e09eb6aad3607fb6f2c071a2c6a26e1d
+    sha256: 04c7f567a2c1d4d07ae070986732bd587746fd833b7b61e7457f5e28f246da15
   optional: false
   category: main
-  build: py311hb755f60_0
+  build: py311hb755f60_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: GPL-3.0-only
   license_family: GPL
-  size: 582706
-  timestamp: 1681995145803
+  size: 584377
+  timestamp: 1695399432479
 - name: sip
-  version: 6.7.9
+  version: 6.7.11
   manager: conda
   platform: win-64
   dependencies:
+    packaging: '*'
+    ply: '*'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-    vc: '>=14.2,<15'
     tomli: '*'
     ucrt: '>=10.0.20348.0'
-    ply: '*'
-    packaging: '*'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.9-py311h12c1d0e_0.conda
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.11-py311h12c1d0e_1.conda
   hash:
-    md5: c86fd164bb1294fc556201ee8a19f706
-    sha256: 5ac6d14c397a1cbdae164f38c96fcb284404d72e78934f61ed09b24a70444599
+    md5: 03bd6b708f8c46e2195f7c3b0238ed71
+    sha256: 165f6f9a4026b60a2d058859c6462f233ec169eae6a819cffaa5e66e81926094
   optional: false
   category: main
-  build: py311h12c1d0e_0
+  build: py311h12c1d0e_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: GPL-3.0-only
   license_family: GPL
-  size: 594451
-  timestamp: 1681995504906
+  size: 595502
+  timestamp: 1695399971382
 - name: six
   version: 1.16.0
   manager: conda
@@ -15136,98 +15603,98 @@ package:
   size: 14358
   timestamp: 1662051357638
 - name: soupsieve
-  version: 2.3.2.post1
+  version: '2.5'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
   hash:
-    md5: 146f4541d643d48fc8a75cacf69f03ae
-    sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
   noarch: python
-  size: 34736
-  timestamp: 1658207688981
+  size: 36754
+  timestamp: 1693929424267
 - name: soupsieve
-  version: 2.3.2.post1
+  version: '2.5'
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
   hash:
-    md5: 146f4541d643d48fc8a75cacf69f03ae
-    sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
   noarch: python
-  size: 34736
-  timestamp: 1658207688981
+  size: 36754
+  timestamp: 1693929424267
 - name: soupsieve
-  version: 2.3.2.post1
+  version: '2.5'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
   hash:
-    md5: 146f4541d643d48fc8a75cacf69f03ae
-    sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
   noarch: python
-  size: 34736
-  timestamp: 1658207688981
+  size: 36754
+  timestamp: 1693929424267
 - name: soupsieve
-  version: 2.3.2.post1
+  version: '2.5'
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
   hash:
-    md5: 146f4541d643d48fc8a75cacf69f03ae
-    sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    md5: 3f144b2c34f8cb5a9abd9ed23a39c561
+    sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   optional: false
   category: main
-  build: pyhd8ed1ab_0
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
   noarch: python
-  size: 34736
-  timestamp: 1658207688981
+  size: 36754
+  timestamp: 1693929424267
 - name: stack_data
   version: 0.6.2
   manager: conda
   platform: linux-64
   dependencies:
-    executing: '*'
-    python: '>=3.5'
-    pure_eval: '*'
     asttokens: '*'
+    executing: '*'
+    pure_eval: '*'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: e7df0fdd404616638df5ece6e69ba7af
@@ -15248,10 +15715,10 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    executing: '*'
-    python: '>=3.5'
-    pure_eval: '*'
     asttokens: '*'
+    executing: '*'
+    pure_eval: '*'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: e7df0fdd404616638df5ece6e69ba7af
@@ -15272,10 +15739,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    executing: '*'
-    python: '>=3.5'
-    pure_eval: '*'
     asttokens: '*'
+    executing: '*'
+    pure_eval: '*'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: e7df0fdd404616638df5ece6e69ba7af
@@ -15296,10 +15763,10 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    executing: '*'
-    python: '>=3.5'
-    pure_eval: '*'
     asttokens: '*'
+    executing: '*'
+    pure_eval: '*'
+    python: '>=3.5'
   url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
   hash:
     md5: e7df0fdd404616638df5ece6e69ba7af
@@ -15320,10 +15787,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    __unix: '*'
+    gmpy2: '>=2.0.8'
     mpmath: '>=0.19'
     python: '>=3.8'
-    gmpy2: '>=2.0.8'
-    __unix: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
   hash:
     md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
@@ -15344,10 +15811,10 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
+    __unix: '*'
+    gmpy2: '>=2.0.8'
     mpmath: '>=0.19'
     python: '>=3.8'
-    gmpy2: '>=2.0.8'
-    __unix: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
   hash:
     md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
@@ -15368,10 +15835,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
+    __unix: '*'
+    gmpy2: '>=2.0.8'
     mpmath: '>=0.19'
     python: '>=3.8'
-    gmpy2: '>=2.0.8'
-    __unix: '*'
   url: https://conda.anaconda.org/conda-forge/noarch/sympy-1.12-pypyh9d50eac_103.conda
   hash:
     md5: 2f7d6347d7acf6edf1ac7f2189f44c8f
@@ -15410,37 +15877,37 @@ package:
   size: 4243034
   timestamp: 1684180691391
 - name: tbb
-  version: 2021.9.0
+  version: 2021.10.0
   manager: conda
   platform: win-64
   dependencies:
+    libhwloc: '>=2.9.3,<2.9.4.0a0'
     ucrt: '>=10.0.20348.0'
-    libhwloc: '>=2.9.1,<2.9.2.0a0'
     vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.9.0-h91493d7_0.conda
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_1.conda
   hash:
-    md5: 6aa3f1becefeaa00a4d2a79b2a478aee
-    sha256: bf9a0f71aa9234776fc5d940464f47b760e5b4907c6c4f7eb0273221fe1b834c
+    md5: 57ea1be8408c5a9a737648b5f919e725
+    sha256: 492c57a480ad283e467c0bdfc8ea55eaf20c4c7e73340a0c1b200a077c9ba2d9
   optional: false
   category: main
-  build: h91493d7_0
+  build: h91493d7_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: APACHE
-  size: 154736
-  timestamp: 1681487156667
+  size: 156524
+  timestamp: 1695626239415
 - name: terminado
   version: 0.17.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-    ptyprocess: '*'
-    tornado: '>=6.1.0'
     __linux: '*'
+    ptyprocess: '*'
+    python: '>=3.7'
+    tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
   hash:
     md5: 3788984d535770cad699efaeb6cb3037
@@ -15461,9 +15928,9 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-    ptyprocess: '*'
     __osx: '*'
+    ptyprocess: '*'
+    python: '>=3.7'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
   hash:
@@ -15485,9 +15952,9 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    ptyprocess: '*'
     __osx: '*'
+    ptyprocess: '*'
+    python: '>=3.7'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
   hash:
@@ -15509,8 +15976,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
     __win: '*'
+    python: '>=3.7'
     pywinpty: '>=1.1.0'
     tornado: '>=6.1.0'
   url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
@@ -15701,311 +16168,312 @@ package:
   size: 23235
   timestamp: 1666100385187
 - name: tk
-  version: 8.6.12
+  version: 8.6.13
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.11,<1.3.0a0'
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2
-  hash:
-    md5: 5b8c42eb62e9fc961af70bdd6a26e168
-    sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
-  optional: false
-  category: main
-  build: h27826a3_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: TCL
-  license_family: BSD
-  size: 3456292
-  timestamp: 1645033615058
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libzlib: '>=1.2.11,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2
-  hash:
-    md5: 8e9480d9c47061db2ed1b4ecce519a7f
-    sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
-  optional: false
-  category: main
-  build: h5dbffcc_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: TCL
-  license_family: BSD
-  size: 3531016
-  timestamp: 1645032719565
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libzlib: '>=1.2.11,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2
-  hash:
-    md5: 2cb3d18eac154109107f093860bd545f
-    sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
-  optional: false
-  category: main
-  build: he1e0b03_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: TCL
-  license_family: BSD
-  size: 3382710
-  timestamp: 1645032642101
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: win-64
-  dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.12-h8ffe710_0.tar.bz2
-  hash:
-    md5: c69a5047cc9291ae40afd4a1ad6f0c0f
-    sha256: 087795090a99a1d397ef1ed80b4a01fabfb0122efb141562c168e3c0a76edba6
-  optional: false
-  category: main
-  build: h8ffe710_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: TCL
-  license_family: BSD
-  size: 3681762
-  timestamp: 1645033031535
-- name: toml
-  version: 0.10.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f832c45a477c78bebd107098db465095
-    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 18433
-  timestamp: 1604308660817
-- name: toml
-  version: 0.10.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f832c45a477c78bebd107098db465095
-    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 18433
-  timestamp: 1604308660817
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15940
-  timestamp: 1644342331069
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15940
-  timestamp: 1644342331069
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15940
-  timestamp: 1644342331069
-- name: tomli
-  version: 2.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15940
-  timestamp: 1644342331069
-- name: tornado
-  version: 6.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
     libgcc-ng: '>=12'
-    python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.2-py311h459d7ec_0.conda
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
   hash:
-    md5: 12b1c374ee90a1aa11ea921858394dc8
-    sha256: 962ba2e8eb49e38c4f8a31ca2b4e0fbf342b30bb514b4bfe12727d7a396051c2
+    md5: 513336054f884f95d9fd925748f41ef3
+    sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
   optional: false
   category: main
-  build: py311h459d7ec_0
+  build: h2797004_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
+  license: TCL
+  license_family: BSD
+  size: 3290187
+  timestamp: 1695506262576
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+  hash:
+    md5: 0c25eedcc888b6d765948ab62a18c03e
+    sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
+  optional: false
+  category: main
+  build: hef22860_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: TCL
+  license_family: BSD
+  size: 3273909
+  timestamp: 1695506576288
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+  hash:
+    md5: aa913a828b65f30ee3aba9c59bb0b514
+    sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
+  optional: false
+  category: main
+  build: hb31c410_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: TCL
+  license_family: BSD
+  size: 3223549
+  timestamp: 1695506653047
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: win-64
+  dependencies:
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+  hash:
+    md5: 74405f2ccbb40af409fee1a71ce70dc6
+    sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
+  optional: false
+  category: main
+  build: hcfcfb64_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: TCL
+  license_family: BSD
+  size: 3478482
+  timestamp: 1695506766462
+- name: toml
+  version: 0.10.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: f832c45a477c78bebd107098db465095
+    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 18433
+  timestamp: 1604308660817
+- name: toml
+  version: 0.10.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: f832c45a477c78bebd107098db465095
+    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 18433
+  timestamp: 1604308660817
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15940
+  timestamp: 1644342331069
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15940
+  timestamp: 1644342331069
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15940
+  timestamp: 1644342331069
+- name: tomli
+  version: 2.0.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: 5844808ffab9ebdb694585b50ba02a96
+    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 15940
+  timestamp: 1644342331069
+- name: tornado
+  version: 6.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    python: '>=3.11,<3.12.0a0'
+    python_abi: 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py311h459d7ec_1.conda
+  hash:
+    md5: a700fcb5cedd3e72d0c75d095c7a6eda
+    sha256: 3f0640415c6f50c6b31b5ce41a870ac48c130fda8921aae11afea84c54a6ba84
+  optional: false
+  category: main
+  build: py311h459d7ec_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 842105
-  timestamp: 1684150341108
+  size: 843714
+  timestamp: 1695373626426
 - name: tornado
-  version: 6.3.2
+  version: 6.3.3
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.2-py311h2725bcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py311h2725bcf_1.conda
   hash:
-    md5: 276fe4341e39dcd9d9d33ca18140d2e7
-    sha256: da54e182c99e46225348192b63fc8d0d02a7fc5d405f4548828cf627705b8bc3
+    md5: daf5f053a40c2b0b8f86b605e302b7a4
+    sha256: e3e4c12236b0a59e6568a9dc839116776eda408ca12bc0ad4e7a9dba4d66912f
   optional: false
   category: main
-  build: py311h2725bcf_0
+  build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 842594
-  timestamp: 1684150681154
+  size: 843855
+  timestamp: 1695373925218
 - name: tornado
-  version: 6.3.2
+  version: 6.3.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.11,<3.12.0a0 *_cpython'
     python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.2-py311heffc1b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py311heffc1b2_1.conda
   hash:
-    md5: 81e2c084528c79eb5bfd72ac575a87d1
-    sha256: c944be4e34ed3c949273a95397a85a12d7b3a395e44d11332b29129c9eca51ee
+    md5: a3a94203d225faec0d6bd000ea30b0a1
+    sha256: 65e96fcaa2fad8013fdfd1c7cbdc4684b253541c10091fa7acd55b4a3daa87e6
   optional: false
   category: main
-  build: py311heffc1b2_0
+  build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 840900
-  timestamp: 1684150717610
+  size: 843751
+  timestamp: 1695373818353
 - name: tornado
-  version: 6.3.2
+  version: 6.3.3
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     python: '>=3.11,<3.12.0a0'
     python_abi: 3.11.* *_cp311
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.2-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py311ha68e1ae_1.conda
   hash:
-    md5: e2a6c106c1cff7e884d93351cdee3c3e
-    sha256: 861842b01e24ec66b73909027cd081e47c567710f2ecb06402dcc387c22b24ef
+    md5: ec581b55f82fd6a4a96770c74d48e456
+    sha256: 669091a38b2cb226198a6018a2784d4a4b55eb6416b14a4521a84882e02f47be
   optional: false
   category: main
-  build: py311ha68e1ae_0
+  build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 842217
-  timestamp: 1684150633803
+  size: 845683
+  timestamp: 1695374005077
 - name: traitlets
-  version: 5.9.0
+  version: 5.11.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d0b4f5c87cd35ac3fb3d47b223263a64
-    sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    md5: bd3f90f7551e1cffb1f402880eb2cef1
+    sha256: 81f2675ebc2bd6016c304770c81812aab8947953b0f0cca766077b127cc7e8f1
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16015,18 +16483,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 98443
-  timestamp: 1675110676323
+  size: 108843
+  timestamp: 1696377842098
 - name: traitlets
-  version: 5.9.0
+  version: 5.11.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d0b4f5c87cd35ac3fb3d47b223263a64
-    sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    md5: bd3f90f7551e1cffb1f402880eb2cef1
+    sha256: 81f2675ebc2bd6016c304770c81812aab8947953b0f0cca766077b127cc7e8f1
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16036,18 +16504,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 98443
-  timestamp: 1675110676323
+  size: 108843
+  timestamp: 1696377842098
 - name: traitlets
-  version: 5.9.0
+  version: 5.11.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d0b4f5c87cd35ac3fb3d47b223263a64
-    sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    md5: bd3f90f7551e1cffb1f402880eb2cef1
+    sha256: 81f2675ebc2bd6016c304770c81812aab8947953b0f0cca766077b127cc7e8f1
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16057,18 +16525,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 98443
-  timestamp: 1675110676323
+  size: 108843
+  timestamp: 1696377842098
 - name: traitlets
-  version: 5.9.0
+  version: 5.11.2
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.11.2-pyhd8ed1ab_0.conda
   hash:
-    md5: d0b4f5c87cd35ac3fb3d47b223263a64
-    sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    md5: bd3f90f7551e1cffb1f402880eb2cef1
+    sha256: 81f2675ebc2bd6016c304770c81812aab8947953b0f0cca766077b127cc7e8f1
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16078,18 +16546,98 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 98443
-  timestamp: 1675110676323
-- name: typing-extensions
-  version: 4.7.1
+  size: 108843
+  timestamp: 1696377842098
+- name: types-python-dateutil
+  version: 2.8.19.14
   manager: conda
   platform: linux-64
   dependencies:
-    typing_extensions: ==4.7.1 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.7.1-hd8ed1ab_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
   hash:
-    md5: f96688577f1faa58096d06a45136afa2
-    sha256: d5d19b8f5b275240c19616a46d67ec57250b3720ba88200da8c732c3fcbfc21d
+    md5: 4df15c51a543e806d439490b862be1c6
+    sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0 AND MIT
+  noarch: python
+  size: 21474
+  timestamp: 1689883066161
+- name: types-python-dateutil
+  version: 2.8.19.14
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4df15c51a543e806d439490b862be1c6
+    sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0 AND MIT
+  noarch: python
+  size: 21474
+  timestamp: 1689883066161
+- name: types-python-dateutil
+  version: 2.8.19.14
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4df15c51a543e806d439490b862be1c6
+    sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0 AND MIT
+  noarch: python
+  size: 21474
+  timestamp: 1689883066161
+- name: types-python-dateutil
+  version: 2.8.19.14
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4df15c51a543e806d439490b862be1c6
+    sha256: 7b0129c72d371fa7a06ed5dd1d701844c20d03bb4641a38a88a982b347d087e2
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0 AND MIT
+  noarch: python
+  size: 21474
+  timestamp: 1689883066161
+- name: typing-extensions
+  version: 4.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    typing_extensions: ==4.8.0 pyha770c72_0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
+  hash:
+    md5: 384462e63262a527bda564fa2d9126c0
+    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   optional: false
   category: main
   build: hd8ed1ab_0
@@ -16099,18 +16647,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 10080
-  timestamp: 1688315729011
+  size: 10104
+  timestamp: 1695040958008
 - name: typing-extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    typing_extensions: ==4.7.1 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.7.1-hd8ed1ab_0.conda
+    typing_extensions: ==4.8.0 pyha770c72_0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
-    md5: f96688577f1faa58096d06a45136afa2
-    sha256: d5d19b8f5b275240c19616a46d67ec57250b3720ba88200da8c732c3fcbfc21d
+    md5: 384462e63262a527bda564fa2d9126c0
+    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   optional: false
   category: main
   build: hd8ed1ab_0
@@ -16120,18 +16668,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 10080
-  timestamp: 1688315729011
+  size: 10104
+  timestamp: 1695040958008
 - name: typing-extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    typing_extensions: ==4.7.1 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.7.1-hd8ed1ab_0.conda
+    typing_extensions: ==4.8.0 pyha770c72_0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
-    md5: f96688577f1faa58096d06a45136afa2
-    sha256: d5d19b8f5b275240c19616a46d67ec57250b3720ba88200da8c732c3fcbfc21d
+    md5: 384462e63262a527bda564fa2d9126c0
+    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   optional: false
   category: main
   build: hd8ed1ab_0
@@ -16141,18 +16689,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 10080
-  timestamp: 1688315729011
+  size: 10104
+  timestamp: 1695040958008
 - name: typing-extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: win-64
   dependencies:
-    typing_extensions: ==4.7.1 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.7.1-hd8ed1ab_0.conda
+    typing_extensions: ==4.8.0 pyha770c72_0
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.8.0-hd8ed1ab_0.conda
   hash:
-    md5: f96688577f1faa58096d06a45136afa2
-    sha256: d5d19b8f5b275240c19616a46d67ec57250b3720ba88200da8c732c3fcbfc21d
+    md5: 384462e63262a527bda564fa2d9126c0
+    sha256: d6e1dddd0c372218ef15912383d351ac8c73465cbf16238017f0269813cafe2d
   optional: false
   category: main
   build: hd8ed1ab_0
@@ -16162,18 +16710,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 10080
-  timestamp: 1688315729011
+  size: 10104
+  timestamp: 1695040958008
 - name: typing_extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.7.1-pyha770c72_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
-    md5: c39d6a09fe819de4951c2642629d9115
-    sha256: 6edd6d5be690be492712cb747b6d62707f0d0c34ef56eefc796d91e5a03187d1
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   optional: false
   category: main
   build: pyha770c72_0
@@ -16183,18 +16731,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 36321
-  timestamp: 1688315719627
+  size: 35108
+  timestamp: 1695040948828
 - name: typing_extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.7.1-pyha770c72_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
-    md5: c39d6a09fe819de4951c2642629d9115
-    sha256: 6edd6d5be690be492712cb747b6d62707f0d0c34ef56eefc796d91e5a03187d1
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   optional: false
   category: main
   build: pyha770c72_0
@@ -16204,18 +16752,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 36321
-  timestamp: 1688315719627
+  size: 35108
+  timestamp: 1695040948828
 - name: typing_extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.7.1-pyha770c72_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
-    md5: c39d6a09fe819de4951c2642629d9115
-    sha256: 6edd6d5be690be492712cb747b6d62707f0d0c34ef56eefc796d91e5a03187d1
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   optional: false
   category: main
   build: pyha770c72_0
@@ -16225,18 +16773,18 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 36321
-  timestamp: 1688315719627
+  size: 35108
+  timestamp: 1695040948828
 - name: typing_extensions
-  version: 4.7.1
+  version: 4.8.0
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.7.1-pyha770c72_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
   hash:
-    md5: c39d6a09fe819de4951c2642629d9115
-    sha256: 6edd6d5be690be492712cb747b6d62707f0d0c34ef56eefc796d91e5a03187d1
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
   optional: false
   category: main
   build: pyha770c72_0
@@ -16246,8 +16794,8 @@ package:
   license: PSF-2.0
   license_family: PSF
   noarch: python
-  size: 36321
-  timestamp: 1688315719627
+  size: 35108
+  timestamp: 1695040948828
 - name: typing_utils
   version: 0.1.0
   manager: conda
@@ -16429,98 +16977,182 @@ package:
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- name: urllib3
-  version: 2.0.3
+- name: uri-template
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-    brotli-python: '>=1.0.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 89efeecbb24c62e2f1ed0b8ca959ec69
-    sha256: 60b64b483b2c662f946837043d95c1a5d90948464a834403b0e3bce373a96a1e
+    md5: 0944dc65cb4a9b5b68522c3bb585d41c
+    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98152
-  timestamp: 1688005881308
-- name: urllib3
-  version: 2.0.3
+  size: 23999
+  timestamp: 1688655976471
+- name: uri-template
+  version: 1.3.0
   manager: conda
   platform: osx-64
   dependencies:
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-    brotli-python: '>=1.0.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 89efeecbb24c62e2f1ed0b8ca959ec69
-    sha256: 60b64b483b2c662f946837043d95c1a5d90948464a834403b0e3bce373a96a1e
+    md5: 0944dc65cb4a9b5b68522c3bb585d41c
+    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98152
-  timestamp: 1688005881308
-- name: urllib3
-  version: 2.0.3
+  size: 23999
+  timestamp: 1688655976471
+- name: uri-template
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-    brotli-python: '>=1.0.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 89efeecbb24c62e2f1ed0b8ca959ec69
-    sha256: 60b64b483b2c662f946837043d95c1a5d90948464a834403b0e3bce373a96a1e
+    md5: 0944dc65cb4a9b5b68522c3bb585d41c
+    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98152
-  timestamp: 1688005881308
-- name: urllib3
-  version: 2.0.3
+  size: 23999
+  timestamp: 1688655976471
+- name: uri-template
+  version: 1.3.0
   manager: conda
   platform: win-64
   dependencies:
-    pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-    brotli-python: '>=1.0.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 89efeecbb24c62e2f1ed0b8ca959ec69
-    sha256: 60b64b483b2c662f946837043d95c1a5d90948464a834403b0e3bce373a96a1e
+    md5: 0944dc65cb4a9b5b68522c3bb585d41c
+    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   optional: false
   category: main
-  build: pyhd8ed1ab_1
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98152
-  timestamp: 1688005881308
+  size: 23999
+  timestamp: 1688655976471
+- name: urllib3
+  version: 2.0.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5f8944ff9ab24a292511c83dce33dea
+    sha256: b93db71eb710ae712f1dcb7fb9ea28d03b75841ec42510f7d578956ba6fb6dd5
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 98389
+  timestamp: 1696434518554
+- name: urllib3
+  version: 2.0.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5f8944ff9ab24a292511c83dce33dea
+    sha256: b93db71eb710ae712f1dcb7fb9ea28d03b75841ec42510f7d578956ba6fb6dd5
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 98389
+  timestamp: 1696434518554
+- name: urllib3
+  version: 2.0.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5f8944ff9ab24a292511c83dce33dea
+    sha256: b93db71eb710ae712f1dcb7fb9ea28d03b75841ec42510f7d578956ba6fb6dd5
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 98389
+  timestamp: 1696434518554
+- name: urllib3
+  version: 2.0.6
+  manager: conda
+  platform: win-64
+  dependencies:
+    brotli-python: '>=1.0.9'
+    pysocks: '>=1.5.6,<2.0,!=1.5.7'
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.6-pyhd8ed1ab_0.conda
+  hash:
+    md5: d5f8944ff9ab24a292511c83dce33dea
+    sha256: b93db71eb710ae712f1dcb7fb9ea28d03b75841ec42510f7d578956ba6fb6dd5
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 98389
+  timestamp: 1696434518554
 - name: vc
   version: '14.3'
   manager: conda
@@ -16549,13 +17181,13 @@ package:
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hfdfe4a8_17.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
   hash:
-    md5: 91c1ecaf3996889532fc0456178b1058
-    sha256: e76986c555647347a0185e646ef65625dabed60da255f6b30367df8bd6dc6cd8
+    md5: d0de20f2f3fc806a81b44fcdd941aaf7
+    sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
   optional: false
   category: main
-  build: hfdfe4a8_17
+  build: hdcecf7f_17
   arch: x86_64
   subdir: win-64
   build_number: 17
@@ -16563,8 +17195,8 @@ package:
   - vs2015_runtime 14.36.32532.* *_17
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
-  size: 740599
-  timestamp: 1688020615962
+  size: 739437
+  timestamp: 1694292382336
 - name: vs2015_runtime
   version: 14.36.32532
   manager: conda
@@ -16586,16 +17218,16 @@ package:
   size: 17207
   timestamp: 1688020635322
 - name: wcwidth
-  version: 0.2.6
+  version: 0.2.8
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
     backports.functools_lru_cache: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 078979d33523cb477bd1916ce41aacc9
-    sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    md5: 367386d2575a0e62412448eda1012efd
+    sha256: e3b6d2041b4d175a1437dccc71b4ef2e53111dfcc64b219fef4bed379e6ef236
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16605,19 +17237,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 29133
-  timestamp: 1673864747518
+  size: 30291
+  timestamp: 1696255331126
 - name: wcwidth
-  version: 0.2.6
+  version: 0.2.8
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
     backports.functools_lru_cache: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 078979d33523cb477bd1916ce41aacc9
-    sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    md5: 367386d2575a0e62412448eda1012efd
+    sha256: e3b6d2041b4d175a1437dccc71b4ef2e53111dfcc64b219fef4bed379e6ef236
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16627,19 +17259,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 29133
-  timestamp: 1673864747518
+  size: 30291
+  timestamp: 1696255331126
 - name: wcwidth
-  version: 0.2.6
+  version: 0.2.8
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
     backports.functools_lru_cache: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 078979d33523cb477bd1916ce41aacc9
-    sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    md5: 367386d2575a0e62412448eda1012efd
+    sha256: e3b6d2041b4d175a1437dccc71b4ef2e53111dfcc64b219fef4bed379e6ef236
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16649,19 +17281,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 29133
-  timestamp: 1673864747518
+  size: 30291
+  timestamp: 1696255331126
 - name: wcwidth
-  version: 0.2.6
+  version: 0.2.8
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
     backports.functools_lru_cache: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.8-pyhd8ed1ab_0.conda
   hash:
-    md5: 078979d33523cb477bd1916ce41aacc9
-    sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    md5: 367386d2575a0e62412448eda1012efd
+    sha256: e3b6d2041b4d175a1437dccc71b4ef2e53111dfcc64b219fef4bed379e6ef236
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16671,270 +17303,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 29133
-  timestamp: 1673864747518
-- name: webencodings
-  version: 0.5.1
+  size: 30291
+  timestamp: 1696255331126
+- name: webcolors
+  version: '1.13'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 3563be4c5611a44210d9ba0c16113136
-    sha256: 302f4f4bd1ad00c0be1426ecf6bb01db59cfd8aff3de0cf1596526dca1a6b70e
-  optional: false
-  category: main
-  build: py_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD 3-Clause
-  license_family: BSD
-  noarch: python
-  size: 11901
-  timestamp: 1535427077373
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
-  hash:
-    md5: 3563be4c5611a44210d9ba0c16113136
-    sha256: 302f4f4bd1ad00c0be1426ecf6bb01db59cfd8aff3de0cf1596526dca1a6b70e
-  optional: false
-  category: main
-  build: py_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: BSD 3-Clause
-  license_family: BSD
-  noarch: python
-  size: 11901
-  timestamp: 1535427077373
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
-  hash:
-    md5: 3563be4c5611a44210d9ba0c16113136
-    sha256: 302f4f4bd1ad00c0be1426ecf6bb01db59cfd8aff3de0cf1596526dca1a6b70e
-  optional: false
-  category: main
-  build: py_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: BSD 3-Clause
-  license_family: BSD
-  noarch: python
-  size: 11901
-  timestamp: 1535427077373
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '*'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
-  hash:
-    md5: 3563be4c5611a44210d9ba0c16113136
-    sha256: 302f4f4bd1ad00c0be1426ecf6bb01db59cfd8aff3de0cf1596526dca1a6b70e
-  optional: false
-  category: main
-  build: py_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: BSD 3-Clause
-  license_family: BSD
-  noarch: python
-  size: 11901
-  timestamp: 1535427077373
-- name: websocket-client
-  version: 1.6.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c34d9325a609381a0b0e8a5b4f325147
-    sha256: c71cb65ac49692adb33735f3114b99a96c0c5140db1d56cf4ccef4fe92ea9a4c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 45578
-  timestamp: 1687789305648
-- name: websocket-client
-  version: 1.6.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c34d9325a609381a0b0e8a5b4f325147
-    sha256: c71cb65ac49692adb33735f3114b99a96c0c5140db1d56cf4ccef4fe92ea9a4c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 45578
-  timestamp: 1687789305648
-- name: websocket-client
-  version: 1.6.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c34d9325a609381a0b0e8a5b4f325147
-    sha256: c71cb65ac49692adb33735f3114b99a96c0c5140db1d56cf4ccef4fe92ea9a4c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 45578
-  timestamp: 1687789305648
-- name: websocket-client
-  version: 1.6.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: c34d9325a609381a0b0e8a5b4f325147
-    sha256: c71cb65ac49692adb33735f3114b99a96c0c5140db1d56cf4ccef4fe92ea9a4c
-  optional: false
-  category: main
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 45578
-  timestamp: 1687789305648
-- name: wheel
-  version: 0.40.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c95fac682453aeffa12db7ae5a721bec
-    sha256: e91cbb3c0ad9a9507dd030f5493831cb52da120329e0d0793711e8300a36db22
-  optional: false
-  category: main
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57087
-  timestamp: 1689463253871
-- name: wheel
-  version: 0.40.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c95fac682453aeffa12db7ae5a721bec
-    sha256: e91cbb3c0ad9a9507dd030f5493831cb52da120329e0d0793711e8300a36db22
-  optional: false
-  category: main
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: osx-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57087
-  timestamp: 1689463253871
-- name: wheel
-  version: 0.40.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c95fac682453aeffa12db7ae5a721bec
-    sha256: e91cbb3c0ad9a9507dd030f5493831cb52da120329e0d0793711e8300a36db22
-  optional: false
-  category: main
-  build: pyhd8ed1ab_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57087
-  timestamp: 1689463253871
-- name: wheel
-  version: 0.40.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.40.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: c95fac682453aeffa12db7ae5a721bec
-    sha256: e91cbb3c0ad9a9507dd030f5493831cb52da120329e0d0793711e8300a36db22
-  optional: false
-  category: main
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: win-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57087
-  timestamp: 1689463253871
-- name: widgetsnbextension
-  version: 4.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.8-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e9ebddf0b93d0fb203d0906b8052c4f
-    sha256: a73d34f8169e206bccfb356c093ff5ced803b953bbcc1480ed27976f97598d68
+    md5: 166212fe82dad8735550030488a01d03
+    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16944,18 +17324,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1071462
-  timestamp: 1688504576796
-- name: widgetsnbextension
-  version: 4.0.8
+  size: 18186
+  timestamp: 1679900907305
+- name: webcolors
+  version: '1.13'
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.8-pyhd8ed1ab_0.conda
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 2e9ebddf0b93d0fb203d0906b8052c4f
-    sha256: a73d34f8169e206bccfb356c093ff5ced803b953bbcc1480ed27976f97598d68
+    md5: 166212fe82dad8735550030488a01d03
+    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16965,18 +17345,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1071462
-  timestamp: 1688504576796
-- name: widgetsnbextension
-  version: 4.0.8
+  size: 18186
+  timestamp: 1679900907305
+- name: webcolors
+  version: '1.13'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.8-pyhd8ed1ab_0.conda
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 2e9ebddf0b93d0fb203d0906b8052c4f
-    sha256: a73d34f8169e206bccfb356c093ff5ced803b953bbcc1480ed27976f97598d68
+    md5: 166212fe82dad8735550030488a01d03
+    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -16986,18 +17366,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1071462
-  timestamp: 1688504576796
-- name: widgetsnbextension
-  version: 4.0.8
+  size: 18186
+  timestamp: 1679900907305
+- name: webcolors
+  version: '1.13'
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.8-pyhd8ed1ab_0.conda
+    python: '>=3.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
   hash:
-    md5: 2e9ebddf0b93d0fb203d0906b8052c4f
-    sha256: a73d34f8169e206bccfb356c093ff5ced803b953bbcc1480ed27976f97598d68
+    md5: 166212fe82dad8735550030488a01d03
+    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -17007,8 +17387,344 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1071462
-  timestamp: 1688504576796
+  size: 18186
+  timestamp: 1679900907305
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  optional: false
+  category: main
+  build: pyhd8ed1ab_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 15600
+  timestamp: 1694681458271
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  optional: false
+  category: main
+  build: pyhd8ed1ab_2
+  arch: x86_64
+  subdir: osx-64
+  build_number: 2
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 15600
+  timestamp: 1694681458271
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  optional: false
+  category: main
+  build: pyhd8ed1ab_2
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 2
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 15600
+  timestamp: 1694681458271
+- name: webencodings
+  version: 0.5.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=2.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
+  hash:
+    md5: daf5160ff9cde3a468556965329085b9
+    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
+  optional: false
+  category: main
+  build: pyhd8ed1ab_2
+  arch: x86_64
+  subdir: win-64
+  build_number: 2
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 15600
+  timestamp: 1694681458271
+- name: websocket-client
+  version: 1.6.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38563b419c06ed97458d081df36beec0
+    sha256: 6b7dbfc6b5b1ac8d5d90b963802c12fbd1ea7c3e515b91928c7945c343aae979
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: APACHE
+  noarch: python
+  size: 45801
+  timestamp: 1694440537593
+- name: websocket-client
+  version: 1.6.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38563b419c06ed97458d081df36beec0
+    sha256: 6b7dbfc6b5b1ac8d5d90b963802c12fbd1ea7c3e515b91928c7945c343aae979
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: APACHE
+  noarch: python
+  size: 45801
+  timestamp: 1694440537593
+- name: websocket-client
+  version: 1.6.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38563b419c06ed97458d081df36beec0
+    sha256: 6b7dbfc6b5b1ac8d5d90b963802c12fbd1ea7c3e515b91928c7945c343aae979
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: APACHE
+  noarch: python
+  size: 45801
+  timestamp: 1694440537593
+- name: websocket-client
+  version: 1.6.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 38563b419c06ed97458d081df36beec0
+    sha256: 6b7dbfc6b5b1ac8d5d90b963802c12fbd1ea7c3e515b91928c7945c343aae979
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: APACHE
+  noarch: python
+  size: 45801
+  timestamp: 1694440537593
+- name: wheel
+  version: 0.41.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
+    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 57488
+  timestamp: 1692700760369
+- name: wheel
+  version: 0.41.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
+    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 57488
+  timestamp: 1692700760369
+- name: wheel
+  version: 0.41.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
+    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 57488
+  timestamp: 1692700760369
+- name: wheel
+  version: 0.41.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
+    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 57488
+  timestamp: 1692700760369
+- name: widgetsnbextension
+  version: 4.0.9
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 82617d07b2f5f5a96296d3c19684b37a
+    sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 885957
+  timestamp: 1694598840024
+- name: widgetsnbextension
+  version: 4.0.9
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 82617d07b2f5f5a96296d3c19684b37a
+    sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 885957
+  timestamp: 1694598840024
+- name: widgetsnbextension
+  version: 4.0.9
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 82617d07b2f5f5a96296d3c19684b37a
+    sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 885957
+  timestamp: 1694598840024
+- name: widgetsnbextension
+  version: 4.0.9
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
+  hash:
+    md5: 82617d07b2f5f5a96296d3c19684b37a
+    sha256: 35dd47b3c117cd759ac46da0b69064bebccd94862e795615ee65dbbe3e6cd86b
+  optional: false
+  category: main
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: python
+  size: 885957
+  timestamp: 1694598840024
 - name: win_inet_pton
   version: 1.1.0
   manager: conda
@@ -17053,8 +17769,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
     libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
   hash:
     md5: 9bfac7ccd94d54fd21a0501296d60424
@@ -17074,8 +17790,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
     libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
     xcb-util: '>=0.4.0,<0.5.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
   hash:
@@ -17096,8 +17812,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
     libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
   hash:
     md5: 632413adcd8bc16b515cab87a2932913
@@ -17117,8 +17833,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
     libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
   hash:
     md5: e995b155d938b6779da6ace6c6b13816
@@ -17138,8 +17854,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libxcb: '>=1.15,<1.16.0a0'
     libgcc-ng: '>=12'
+    libxcb: '>=1.15,<1.16.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
   hash:
     md5: 90108a432fb5c6150ccfee3f03388656
@@ -17155,16 +17871,16 @@ package:
   size: 52114
   timestamp: 1684679248466
 - name: xkeyboard-config
-  version: '2.39'
+  version: '2.40'
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-libx11: '>=1.8.5,<2.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.39-hd590300_0.conda
+    xorg-libx11: '>=1.8.6,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.40-hd590300_0.conda
   hash:
-    md5: d88c7fc8a11858fb14761832e4da1954
-    sha256: 364dd7781383336d701bf3f2e10662079b30094b5a9d2a679edeeea9d11cf059
+    md5: 07c15d846a2e4d673da22cbd85fdb6d2
+    sha256: a01fcb9c3346ee08aa24b3900a08896f2e8f80c891378a57d71764e16bbd6141
   optional: false
   category: main
   build: hd590300_0
@@ -17173,8 +17889,8 @@ package:
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 880593
-  timestamp: 1686533532648
+  size: 895713
+  timestamp: 1696647097478
 - name: xorg-kbproto
   version: 1.0.7
   manager: conda
@@ -17220,9 +17936,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-libice: '>=1.1.1,<2.0a0'
     libgcc-ng: '>=12'
     libuuid: '>=2.38.1,<3.0a0'
+    xorg-libice: '>=1.1.1,<2.0a0'
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
   hash:
     md5: 93ee23f12bc2e684548181256edd2cf6
@@ -17242,11 +17958,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-xproto: '*'
+    libgcc-ng: '>=12'
     libxcb: '>=1.15,<1.16.0a0'
     xorg-kbproto: '*'
     xorg-xextproto: '>=7.3.0,<8.0a0'
-    libgcc-ng: '>=12'
+    xorg-xproto: '*'
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.6-h8ee46fc_0.conda
   hash:
     md5: 7590b76c3d11d21caa44f3fc38ac584a
@@ -17324,8 +18040,8 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    m2w64-gcc-libs-core: '*'
     m2w64-gcc-libs: '*'
+    m2w64-gcc-libs-core: '*'
   url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
   hash:
     md5: c46ba8712093cb0114404ae8a7582e1a
@@ -17423,8 +18139,8 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-libx11: '>=1.7.2,<2.0a0'
     libgcc-ng: '>=12'
+    xorg-libx11: '>=1.7.2,<2.0a0'
     xorg-xextproto: '*'
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
   hash:
@@ -17445,9 +18161,9 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    xorg-renderproto: '*'
-    xorg-libx11: '>=1.8.6,<2.0a0'
     libgcc-ng: '>=12'
+    xorg-libx11: '>=1.8.6,<2.0a0'
+    xorg-renderproto: '*'
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
   hash:
     md5: ed67c36f215b310412b2af935bf3e530
@@ -17702,8 +18418,8 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=9.4.0'
-    libstdcxx-ng: '>=9.4.0'
     libsodium: '>=1.0.18,<1.0.19.0a0'
+    libstdcxx-ng: '>=9.4.0'
   url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.4-h9c3ff4c_1.tar.bz2
   hash:
     md5: 21743a8d2ea0c8cfbbf8fe489b0347df
@@ -17765,9 +18481,9 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    vs2015_runtime: '>=14.16.27012'
-    vc: '>=14.1,<15.0a0'
     libsodium: '>=1.0.18,<1.0.19.0a0'
+    vc: '>=14.1,<15.0a0'
+    vs2015_runtime: '>=14.16.27012'
   url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.4-h0e60522_1.tar.bz2
   hash:
     md5: e1aff0583dda5fb917eb3d2c1025aa80
@@ -17783,15 +18499,15 @@ package:
   size: 9355377
   timestamp: 1629968018045
 - name: zipp
-  version: 3.16.2
+  version: 3.17.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2da0451b54c4563c32490cb1b7cf68a1
-    sha256: 16d72127e150a3d5cbdc0b82c4069ef5be135c64bc99e71e7928507910669b41
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -17801,18 +18517,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18783
-  timestamp: 1689374602448
+  size: 18954
+  timestamp: 1695255262261
 - name: zipp
-  version: 3.16.2
+  version: 3.17.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2da0451b54c4563c32490cb1b7cf68a1
-    sha256: 16d72127e150a3d5cbdc0b82c4069ef5be135c64bc99e71e7928507910669b41
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -17822,18 +18538,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18783
-  timestamp: 1689374602448
+  size: 18954
+  timestamp: 1695255262261
 - name: zipp
-  version: 3.16.2
+  version: 3.17.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2da0451b54c4563c32490cb1b7cf68a1
-    sha256: 16d72127e150a3d5cbdc0b82c4069ef5be135c64bc99e71e7928507910669b41
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -17843,18 +18559,18 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18783
-  timestamp: 1689374602448
+  size: 18954
+  timestamp: 1695255262261
 - name: zipp
-  version: 3.16.2
+  version: 3.17.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2da0451b54c4563c32490cb1b7cf68a1
-    sha256: 16d72127e150a3d5cbdc0b82c4069ef5be135c64bc99e71e7928507910669b41
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   optional: false
   category: main
   build: pyhd8ed1ab_0
@@ -17864,15 +18580,15 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18783
-  timestamp: 1689374602448
+  size: 18954
+  timestamp: 1695255262261
 - name: zlib
   version: 1.2.13
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: ==1.2.13 hd590300_5
     libgcc-ng: '>=12'
+    libzlib: ==1.2.13 hd590300_5
   url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
   hash:
     md5: 68c34ec6149623be41a1933ab996a209
@@ -17888,88 +18604,88 @@ package:
   size: 92825
   timestamp: 1686575231103
 - name: zstd
-  version: 1.5.2
+  version: 1.5.5
   manager: conda
   platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-hfc55251_7.conda
+    libzlib: '>=1.2.13,<1.3.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
   hash:
-    md5: 32ae18eb2a687912fc9e92a501c0a11b
-    sha256: a7f7e765dfb7af5265a38080e46f18cb07cfeecf81fe28fad23c4538e7d521c3
+    md5: 04b88013080254850d6c01ed54810589
+    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
   optional: false
   category: main
-  build: hfc55251_7
+  build: hfc55251_0
   arch: x86_64
   subdir: linux-64
-  build_number: 7
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 431126
-  timestamp: 1688721787223
+  size: 545199
+  timestamp: 1693151163452
 - name: zstd
-  version: 1.5.2
+  version: 1.5.5
   manager: conda
   platform: osx-64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.2-h829000d_7.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
   hash:
-    md5: b274ec4dbf15a6e20900e397610567a0
-    sha256: 8d6768da7c3170693c0649188e7575474046f8610d8074903cf84e403e3411e8
+    md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+    sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
   optional: false
   category: main
-  build: h829000d_7
+  build: h829000d_0
   arch: x86_64
   subdir: osx-64
-  build_number: 7
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 405881
-  timestamp: 1688722093601
+  size: 499383
+  timestamp: 1693151312586
 - name: zstd
-  version: 1.5.2
+  version: 1.5.5
   manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-h4f39d0f_7.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
   hash:
-    md5: ac4a17e2fb251cbf3bce3aec64668ef2
-    sha256: d51d2225da473689dcb5d633f3b60ab60beff74d29a380142da4b684db98dd56
+    md5: 5b212cfb7f9d71d603ad891879dc7933
+    sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
   optional: false
   category: main
-  build: h4f39d0f_7
+  build: h4f39d0f_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 7
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 317319
-  timestamp: 1688722265582
+  size: 400508
+  timestamp: 1693151393180
 - name: zstd
-  version: 1.5.2
+  version: 1.5.5
   manager: conda
   platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
     libzlib: '>=1.2.13,<1.3.0a0'
+    ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.2-h12be248_7.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
   hash:
-    md5: f3c3879d8cda1c5a6885435dd48a470e
-    sha256: 33e8fb73dee10740f00d4a450ad2d7f6d90692ca781480fa18fa70fd417d53ad
+    md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+    sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
   optional: false
   category: main
-  build: h12be248_7
+  build: h12be248_0
   arch: x86_64
   subdir: win-64
-  build_number: 7
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 289661
-  timestamp: 1688722138074
+  size: 343428
+  timestamp: 1693151615801
 version: 1

--- a/examples/jupyterlab/pixi.toml
+++ b/examples/jupyterlab/pixi.toml
@@ -8,6 +8,7 @@ platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
 
 [tasks]
 start = "jupyter lab"
+test = "echo 'No tests yet' > test.txt"
 
 [dependencies]
 jupyterlab = "4.*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 use pixi::cli;
 
-#[tokio::main]
-pub async fn main() {
-    if let Err(err) = cli::execute().await {
+pub fn main() {
+    if let Err(err) = cli::execute() {
         eprintln!("{err:?}");
         std::process::exit(1);
     }


### PR DESCRIPTION
This uses the daemonize crate to detach the process and effectively `daemonize` it. 
That is kinda cool for long-running processes (e.g. if I run jupyterlab).

There is one big issue: for some reason, creating the activation subprocess does not seem to work and I haven't figured out why yet.

Other TODOs:

- [ ] store PID file in `.pixi` folder
- [ ] list running tasks
- [ ] kill running tasks
- [ ] look at stdout of running tasks