### PR TITLE
misc: make version an optional field in the config.

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -15,7 +15,6 @@ The minimally required information in the `project` table is:
 ```toml
 [project]
 name = "project-name"
-version = "0.1.0"
 authors = ["John Doe <j.doe@prefix.dev>"]
 channels = ["conda-forge"]
 platforms = ["linux-64"]
@@ -28,7 +27,7 @@ The name of the project.
 name = "project-name"
 ```
 
-### `version`
+### `version` (optional)
 The version of the project.
 This should be a valid version based on the conda Version Spec.
 See the [version documentation](https://docs.rs/rattler_conda_types/latest/rattler_conda_types/struct.Version.html), for an explanation what is allowed in a Version Spec.

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -27,7 +27,12 @@ pub fn get_metadata_env(project: &Project) -> HashMap<String, String> {
         ),
         (
             format!("{ENV_PREFIX}VERSION"),
-            project.version().to_string(),
+            project
+                .version()
+                .as_ref()
+                .map_or("NO_VERSION_SPECIFIED".to_string(), |version| {
+                    version.to_string()
+                }),
         ),
         ("PIXI_PROMPT".to_string(), format!("({}) ", project.name())),
     ])

--- a/src/project/manifest.rs
+++ b/src/project/manifest.rs
@@ -213,8 +213,8 @@ pub struct ProjectMetadata {
     pub name: String,
 
     /// The version of the project
-    #[serde_as(as = "DisplayFromStr")]
-    pub version: Version,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub version: Option<Version>,
 
     /// An optional project description
     pub description: Option<String>,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -440,7 +440,7 @@ impl Project {
     }
 
     /// Returns the version of the project
-    pub fn version(&self) -> &Version {
+    pub fn version(&self) -> &Option<Version> {
         &self.manifest.project.version
     }
 
@@ -809,7 +809,10 @@ mod tests {
         let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
 
         assert_eq!(project.name(), "pixi");
-        assert_eq!(project.version(), &Version::from_str("0.0.2").unwrap());
+        assert_eq!(
+            project.version().as_ref().unwrap(),
+            &Version::from_str("0.0.2").unwrap()
+        );
         assert_eq!(
             project.channels(),
             [Channel::from_name(

--- a/src/project/snapshots/pixi__project__manifest__test__activation_scripts.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__activation_scripts.snap
@@ -5,10 +5,12 @@ expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"pars
 ProjectManifest {
     project: ProjectMetadata {
         name: "foo",
-        version: Version {
-            version: [[0], [0], [1], [0]],
-            local: [],
-        },
+        version: Some(
+            Version {
+                version: [[0], [0], [1], [0]],
+                local: [],
+            },
+        ),
         description: None,
         authors: [],
         channels: [],

--- a/src/project/snapshots/pixi__project__manifest__test__dependency_types.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__dependency_types.snap
@@ -5,10 +5,12 @@ expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"pars
 ProjectManifest {
     project: ProjectMetadata {
         name: "foo",
-        version: Version {
-            version: [[0], [0], [1], [0]],
-            local: [],
-        },
+        version: Some(
+            Version {
+                version: [[0], [0], [1], [0]],
+                local: [],
+            },
+        ),
         description: None,
         authors: [],
         channels: [],

--- a/src/project/snapshots/pixi__project__manifest__test__target_specific.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__target_specific.snap
@@ -5,10 +5,12 @@ expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"pars
 ProjectManifest {
     project: ProjectMetadata {
         name: "foo",
-        version: Version {
-            version: [[0], [0], [1], [0]],
-            local: [],
-        },
+        version: Some(
+            Version {
+                version: [[0], [0], [1], [0]],
+                local: [],
+            },
+        ),
         description: None,
         authors: [],
         channels: [],

--- a/src/project/snapshots/pixi__project__manifest__test__target_specific_tasks.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__target_specific_tasks.snap
@@ -5,10 +5,12 @@ expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"pars
 ProjectManifest {
     project: ProjectMetadata {
         name: "foo",
-        version: Version {
-            version: [[0], [0], [1], [0]],
-            local: [],
-        },
+        version: Some(
+            Version {
+                version: [[0], [0], [1], [0]],
+                local: [],
+            },
+        ),
         description: None,
         authors: [],
         channels: [],

--- a/tests/init_tests.rs
+++ b/tests/init_tests.rs
@@ -24,7 +24,10 @@ async fn init_creates_project_manifest() {
             .as_ref(),
         "project name should match the directory name"
     );
-    assert_eq!(project.version(), &Version::from_str("0.1.0").unwrap());
+    assert_eq!(
+        project.version().as_ref().unwrap(),
+        &Version::from_str("0.1.0").unwrap()
+    );
 }
 
 /// Tests that when initializing an empty project with a custom channel it is actually used.


### PR DESCRIPTION
closes #399 

Version is only needed when building so making it an optional. Keeping it in the templates as of right now. 