### PR TITLE
Let `PIXI_BIN_PATH` use backslashes

### DIFF
--- a/install/windows/main.wxs
+++ b/install/windows/main.wxs
@@ -129,7 +129,7 @@
                             <Environment
                                 Id='PIXI_BIN_PATH'
                                 Name='PATH'
-                                Value='%UserProfile%/.pixi/bin'
+                                Value='%UserProfile%\.pixi\bin'
                                 Permanent='no'
                                 Part='last'
                                 Action='set'


### PR DESCRIPTION
I've had problems related to his path entry.
Changing it to backslashes resolved them.

I am not 100% sure that the forward slashes were the reason.
However,  using backslashes on Windows is probably a good idea in general.
