### PR TITLE
fix: Use home dir on windows

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,6 +1,6 @@
 param (
     [string]$PIXI_VERSION = "latest",
-    [string]$PIXI_DIR = "$Env:LocalAppData\pixi\bin"
+    [string]$PIXI_DIR = "$Env:USERPROFILE\.pixi\bin"
 )
 
 # Repository name


### PR DESCRIPTION
Smaller solution than #448 

Decided to keep it simple to also make the documentation simpler. Now it is just the home folder for everything. 