### PR TITLE
bump: rip to fix sdist issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "rattler_installs_packages"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#65c7ac5483140d759807ca04b4bfabb573cac134"
+source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#66cd42a21ff8dbeb41ad9ab9ea59db5f268621dc"
 dependencies = [
  "async-trait",
  "async_http_range_reader",

--- a/src/lock_file/python.rs
+++ b/src/lock_file/python.rs
@@ -8,7 +8,7 @@ use pep508_rs::{MarkerEnvironment, StringVersion};
 use rattler_conda_types::{PackageRecord, Platform, RepoDataRecord, Version, VersionWithSource};
 use rip::{
     tags::{WheelTag, WheelTags},
-    PinnedPackage,
+    PinnedPackage, SDistResolution,
 };
 use std::collections::HashMap;
 use std::{str::FromStr, vec};
@@ -72,6 +72,10 @@ pub async fn resolve_pypi_dependencies<'p>(
             .map(|p| (p.name.clone(), p))
             .collect(),
         HashMap::default(),
+        &rip::ResolveOptions {
+            // TODO: Change this once we fully support sdists.
+            sdist_resolution: SDistResolution::OnlyWheels,
+        },
     )
     .await?;
 


### PR DESCRIPTION
Bump RIP to fix the sdist issues we had. Only wheels are allowed for pixi atm.