### PR TITLE
test: run serially

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.2",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2547,7 @@ dependencies = [
  "serde_json",
  "serde_spanned",
  "serde_with",
+ "serial_test",
  "signal-hook",
  "spdx",
  "strsim",
@@ -3503,6 +3517,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures 0.3.29",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ signal-hook = "0.3.17"
 [dev-dependencies]
 rattler_digest = "0.12.0"
 serde_json = "1.0.107"
+serial_test = "2.0.0"
 tokio = { version = "1.32.0", features = ["rt"] }
 toml = "0.8.1"
 

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -4,11 +4,13 @@ use crate::common::builders::string_from_iter;
 use crate::common::package_database::{Package, PackageDatabase};
 use common::{LockFileExt, PixiControl};
 use pixi::cli::run;
+use serial_test::serial;
 use tempfile::TempDir;
 
 /// Should add a python version to the environment and lock file that matches the specified version
 /// and run it
 #[tokio::test]
+#[serial]
 #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn install_run_python() {
     let pixi = PixiControl::new().unwrap();
@@ -43,6 +45,7 @@ async fn install_run_python() {
 /// version `2` is available. This is because `bar` was previously locked to version `1` and it is
 /// still a valid solution to keep using version `1` of bar.
 #[tokio::test]
+#[serial]
 async fn test_incremental_lock_file() {
     let mut package_database = PackageDatabase::default();
 
@@ -106,6 +109,7 @@ async fn test_incremental_lock_file() {
 
 /// Test the `pixi install --locked` functionality.
 #[tokio::test]
+#[serial]
 #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn install_locked() {
     let pixi = PixiControl::new().unwrap();
@@ -136,6 +140,7 @@ async fn install_locked() {
 
 /// Test `pixi install/run --frozen` functionality
 #[tokio::test]
+#[serial]
 #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn install_frozen() {
     let pixi = PixiControl::new().unwrap();


### PR DESCRIPTION
This ensures that tests that install things are run in serial. Hopefully that fixes the flaky CI. In the future we should properly fix this though...