### PR TITLE
Fix pypi dependencies parsing errors

### DIFF
--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -47,7 +47,10 @@ pub fn lock_file_up_to_date(project: &Project, lock_file: &CondaLock) -> miette:
     let platforms = project.platforms();
 
     // TODO: Add support for python dependencies
-    if !project.pypi_dependencies().is_empty() {
+    if project
+        .pypi_dependencies()
+        .is_some_and(|deps| !deps.is_empty())
+    {
         tracing::warn!("Checking if a lock-file is up to date with `pypi-dependencies` in the mix is not yet implemented.");
         return Ok(false);
     }

--- a/src/project/manifest.rs
+++ b/src/project/manifest.rs
@@ -1,4 +1,4 @@
-use crate::project::python::PypiDependencies;
+use crate::project::python::PyPiRequirement;
 use crate::project::SpecType;
 use crate::utils::spanned::PixiSpanned;
 use crate::{consts, task::Task};
@@ -70,7 +70,7 @@ pub struct ProjectManifest {
 
     /// Optional python requirements
     #[serde(default, rename = "pypi-dependencies")]
-    pub pypi_dependencies: PypiDependencies,
+    pub pypi_dependencies: Option<IndexMap<rip::PackageName, PyPiRequirement>>,
 }
 
 impl ProjectManifest {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -20,7 +20,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::project::python::PypiDependencies;
+use crate::project::python::PyPiRequirement;
 use crate::{
     consts::{self, PROJECT_MANIFEST},
     default_client,
@@ -332,7 +332,11 @@ impl Project {
         )?;
 
         // Notify the user that pypi-dependencies are still experimental
-        if !manifest.pypi_dependencies.is_empty() {
+        if manifest
+            .pypi_dependencies
+            .as_ref()
+            .map_or(false, |deps| !deps.is_empty())
+        {
             tracing::warn!("ALPHA feature enabled!\n\nIt looks like your project contains `[pypi-dependencies]`. This feature is currently still in an ALPHA state!\n\nYou may encounter bugs or weird behavior. Please report any and all issues you encounter on our github repository:\n\n\thttps://github.com/prefix-dev/pixi.\n");
         }
 
@@ -447,8 +451,8 @@ impl Project {
         Ok(dependencies)
     }
 
-    pub fn pypi_dependencies(&self) -> &PypiDependencies {
-        &self.manifest.pypi_dependencies
+    pub fn pypi_dependencies(&self) -> Option<&IndexMap<rip::PackageName, PyPiRequirement>> {
+        self.manifest.pypi_dependencies.as_ref()
     }
 
     /// Returns the Python index URLs to use for this project.

--- a/src/project/python.rs
+++ b/src/project/python.rs
@@ -1,4 +1,3 @@
-use indexmap::IndexMap;
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::VersionOrUrl;
 use serde::de::{Error, MapAccess, Visitor};
@@ -16,7 +15,7 @@ pub struct PyPiRequirement {
 /// The type of parse error that occurred when parsing match spec.
 #[derive(Debug, Clone, Error)]
 pub enum ParsePyPiRequirementError {
-    #[error("invalid PEP440")]
+    #[error("invalid PEP440: https://peps.python.org/pep-0440/")]
     Pep440Error(#[from] pep440_rs::Pep440Error),
 }
 
@@ -43,35 +42,15 @@ impl FromStr for PyPiRequirement {
     }
 }
 
-/// Represents a set of python dependencies on which a project can depend. The dependencies are
-/// formatted using a custom version specifier.
-#[derive(Default, Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct PypiDependencies {
-    #[serde(flatten)]
-    requirements: IndexMap<rip::PackageName, PyPiRequirement>,
-}
-
-impl PypiDependencies {
-    /// Returns `true` if no requirements have been specified
-    pub fn is_empty(&self) -> bool {
-        self.requirements.is_empty()
-    }
-
+impl PyPiRequirement {
     /// Returns the requirements as [`pep508_rs::Requirement`]s.
-    pub fn as_pep508(&self) -> Vec<pep508_rs::Requirement> {
-        self.requirements
-            .iter()
-            .map(|(name, req)| {
-                let version = req.version.clone().map(VersionOrUrl::VersionSpecifier);
-
-                pep508_rs::Requirement {
-                    name: name.as_str().to_string(),
-                    extras: req.extras.clone(),
-                    version_or_url: version,
-                    marker: None,
-                }
-            })
-            .collect()
+    pub fn as_pep508(&self, name: &rip::PackageName) -> pep508_rs::Requirement {
+        pep508_rs::Requirement {
+            name: name.as_str().to_string(),
+            extras: self.extras.clone(),
+            version_or_url: self.version.clone().map(VersionOrUrl::VersionSpecifier),
+            marker: None,
+        }
     }
 }
 impl<'de> Deserialize<'de> for PyPiRequirement {
@@ -117,93 +96,83 @@ impl<'de> Deserialize<'de> for PyPiRequirement {
 #[cfg(test)]
 mod test {
     use super::*;
+    use indexmap::IndexMap;
 
     #[test]
     fn test_only_version() {
-        let requirement: PypiDependencies = toml_edit::de::from_str(r#"foo = ">=3.12""#).unwrap();
+        let requirement: IndexMap<rip::PackageName, PyPiRequirement> =
+            toml_edit::de::from_str(r#"foo = ">=3.12""#).unwrap();
         assert_eq!(
-            requirement,
-            PypiDependencies {
-                requirements: IndexMap::from([(
-                    rip::PackageName::from_str("foo").unwrap(),
-                    PyPiRequirement {
-                        version: Some(VersionSpecifiers::from_str(">=3.12").unwrap()),
-                        extras: None
-                    }
-                ),])
+            requirement.first().unwrap().0,
+            &rip::PackageName::from_str("foo").unwrap()
+        );
+        assert_eq!(
+            requirement.first().unwrap().1,
+            &PyPiRequirement {
+                version: Some(VersionSpecifiers::from_str(">=3.12").unwrap()),
+                extras: None
             }
         );
-        let requirement: PypiDependencies = toml_edit::de::from_str(r#"foo = "==3.12.0""#).unwrap();
+        let requirement: IndexMap<rip::PackageName, PyPiRequirement> =
+            toml_edit::de::from_str(r#"foo = "==3.12.0""#).unwrap();
         assert_eq!(
-            requirement,
-            PypiDependencies {
-                requirements: IndexMap::from([(
-                    rip::PackageName::from_str("foo").unwrap(),
-                    PyPiRequirement {
-                        version: Some(VersionSpecifiers::from_str("==3.12.0").unwrap()),
-                        extras: None
-                    }
-                ),])
+            requirement.first().unwrap().1,
+            &PyPiRequirement {
+                version: Some(VersionSpecifiers::from_str("==3.12.0").unwrap()),
+                extras: None
             }
         );
-        let requirement: PypiDependencies = toml_edit::de::from_str(r#"foo = "~=2.1.3""#).unwrap();
+
+        let requirement: IndexMap<rip::PackageName, PyPiRequirement> =
+            toml_edit::de::from_str(r#"foo = "~=2.1.3""#).unwrap();
         assert_eq!(
-            requirement,
-            PypiDependencies {
-                requirements: IndexMap::from([(
-                    rip::PackageName::from_str("foo").unwrap(),
-                    PyPiRequirement {
-                        version: Some(VersionSpecifiers::from_str("~=2.1.3").unwrap()),
-                        extras: None
-                    }
-                ),])
+            requirement.first().unwrap().1,
+            &PyPiRequirement {
+                version: Some(VersionSpecifiers::from_str("~=2.1.3").unwrap()),
+                extras: None
             }
         );
-        let requirement: PypiDependencies = toml_edit::de::from_str(r#"foo = "*""#).unwrap();
+
+        let requirement: IndexMap<rip::PackageName, PyPiRequirement> =
+            toml_edit::de::from_str(r#"foo = "*""#).unwrap();
         assert_eq!(
-            requirement,
-            PypiDependencies {
-                requirements: IndexMap::from([(
-                    rip::PackageName::from_str("foo").unwrap(),
-                    PyPiRequirement {
-                        version: None,
-                        extras: None
-                    }
-                ),])
+            requirement.first().unwrap().1,
+            &PyPiRequirement {
+                version: None,
+                extras: None
             }
         );
     }
 
     #[test]
     fn test_extended() {
-        let requirement: PypiDependencies =
-            toml::de::from_str(r#"foo = { version=">=3.12", extras = ["bar"] }"#).unwrap();
+        let requirement: IndexMap<rip::PackageName, PyPiRequirement> =
+            toml_edit::de::from_str(r#"foo = { version=">=3.12", extras = ["bar"] }"#).unwrap();
         assert_eq!(
-            requirement,
-            PypiDependencies {
-                requirements: IndexMap::from([(
-                    rip::PackageName::from_str("foo").unwrap(),
-                    PyPiRequirement {
-                        version: Some(VersionSpecifiers::from_str(">=3.12").unwrap()),
-                        extras: Some(vec!("bar".to_string()))
-                    }
-                ),])
+            requirement.first().unwrap().0,
+            &rip::PackageName::from_str("foo").unwrap()
+        );
+        assert_eq!(
+            requirement.first().unwrap().1,
+            &PyPiRequirement {
+                version: Some(VersionSpecifiers::from_str(">=3.12").unwrap()),
+                extras: Some(vec!("bar".to_string()))
             }
         );
 
-        let requirement: PypiDependencies =
-            toml::de::from_str(r#"bar = { version=">=3.12,<3.13.0", extras = ["bar", "foo"] }"#)
-                .unwrap();
+        let requirement: IndexMap<rip::PackageName, PyPiRequirement> = toml_edit::de::from_str(
+            r#"bar = { version=">=3.12,<3.13.0", extras = ["bar", "foo"] }"#,
+        )
+        .unwrap();
         assert_eq!(
-            requirement,
-            PypiDependencies {
-                requirements: IndexMap::from([(
-                    rip::PackageName::from_str("bar").unwrap(),
-                    PyPiRequirement {
-                        version: Some(VersionSpecifiers::from_str(">=3.12,<3.13.0").unwrap()),
-                        extras: Some(vec!("bar".to_string(), "foo".to_string()))
-                    }
-                ),])
+            requirement.first().unwrap().0,
+            &rip::PackageName::from_str("bar").unwrap()
+        );
+        assert_eq!(
+            requirement.first().unwrap().1,
+            &PyPiRequirement {
+                version: Some(VersionSpecifiers::from_str(">=3.12,<3.13.0").unwrap()),
+                extras: Some(vec!("bar".to_string(), "foo".to_string()))
             }
         );
     }

--- a/src/project/snapshots/pixi__project__manifest__test__activation_scripts.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__activation_scripts.snap
@@ -1,6 +1,5 @@
 ---
 source: src/project/manifest.rs
-assertion_line: 481
 expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"parsing should succeed!\")"
 ---
 ProjectManifest {
@@ -97,7 +96,5 @@ ProjectManifest {
             ),
         },
     ),
-    pypi_dependencies: PypiDependencies {
-        requirements: {},
-    },
+    pypi_dependencies: None,
 }

--- a/src/project/snapshots/pixi__project__manifest__test__dependency_types.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__dependency_types.snap
@@ -1,6 +1,5 @@
 ---
 source: src/project/manifest.rs
-assertion_line: 442
 expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"parsing should succeed!\")"
 ---
 ProjectManifest {
@@ -95,7 +94,5 @@ ProjectManifest {
     ),
     target: {},
     activation: None,
-    pypi_dependencies: PypiDependencies {
-        requirements: {},
-    },
+    pypi_dependencies: None,
 }

--- a/src/project/snapshots/pixi__project__manifest__test__mapped_dependencies.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__mapped_dependencies.snap
@@ -1,6 +1,5 @@
 ---
 source: src/project/manifest.rs
-assertion_line: 421
 expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"parsing should succeed!\")"
 ---
 ProjectManifest {
@@ -89,7 +88,5 @@ ProjectManifest {
     build_dependencies: None,
     target: {},
     activation: None,
-    pypi_dependencies: PypiDependencies {
-        requirements: {},
-    },
+    pypi_dependencies: None,
 }

--- a/src/project/snapshots/pixi__project__manifest__test__python_dependencies.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__python_dependencies.snap
@@ -42,8 +42,8 @@ ProjectManifest {
     build_dependencies: None,
     target: {},
     activation: None,
-    pypi_dependencies: PypiDependencies {
-        requirements: {
+    pypi_dependencies: Some(
+        {
             PackageName {
                 source: "foo",
                 normalized: "foo",
@@ -101,5 +101,5 @@ ProjectManifest {
                 ),
             },
         },
-    },
+    ),
 }

--- a/src/project/snapshots/pixi__project__manifest__test__target_specific.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__target_specific.snap
@@ -1,6 +1,5 @@
 ---
 source: src/project/manifest.rs
-assertion_line: 406
 expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"parsing should succeed!\")"
 ---
 ProjectManifest {
@@ -112,7 +111,5 @@ ProjectManifest {
         },
     },
     activation: None,
-    pypi_dependencies: PypiDependencies {
-        requirements: {},
-    },
+    pypi_dependencies: None,
 }

--- a/src/project/snapshots/pixi__project__manifest__test__target_specific_tasks.snap
+++ b/src/project/snapshots/pixi__project__manifest__test__target_specific_tasks.snap
@@ -1,6 +1,5 @@
 ---
 source: src/project/manifest.rs
-assertion_line: 502
 expression: "toml_edit::de::from_str::<ProjectManifest>(&contents).expect(\"parsing should succeed!\")"
 ---
 ProjectManifest {
@@ -84,7 +83,5 @@ ProjectManifest {
         },
     },
     activation: None,
-    pypi_dependencies: PypiDependencies {
-        requirements: {},
-    },
+    pypi_dependencies: None,
 }


### PR DESCRIPTION
Going from:
```
  × failed to parse pixi.toml from /home/rarts/development/pixi/examples/pypi
  ╰─▶ failed to parse project manifest
    ╭─[pixi.toml:14:1]
 14 │     
 15 │ ╭─▶ [pypi-dependencies]
 16 │ │   pyboy = "==1.6.6"
 17 │ │   tensorflow = "==2.14.0"
 18 │ │   flask = ""
 19 │ ├─▶ black = "~=23.10"
    · ╰──── invalid PEP440
    ╰────


```

To:
```
  × failed to parse pixi.toml from /home/rarts/development/pixi/examples/pypi
  ╰─▶ failed to parse project manifest
    ╭─[pixi.toml:17:1]
 17 │ tensorflow = "==2.14.0"
 18 │ flask = ""
    ·         ─┬
    ·          ╰── invalid PEP440: https://peps.python.org/pep-0440/
 19 │ black = "~=23.10"
    ╰────

```
