### PR TITLE
feat: implement lock-file satisfiability with pypi dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "rattler_installs_packages"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#30aa1505c7f3ea1600d616b0c95fe1ca6229b18f"
+source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#2d7694d00e79daf9a8764af668cbe55e67b26dc6"
 dependencies = [
  "async-trait",
  "async_http_range_reader",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9338790e78aa95a416786ec8389546c4b6a1dfc3dc36071ed9518a9413a542eb"
+
+[[package]]
 name = "async-process"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +2469,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+ "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+ "unicase",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +2559,7 @@ dependencies = [
 name = "pixi"
 version = "0.7.1-dev"
 dependencies = [
+ "async-once-cell",
  "atty",
  "chrono",
  "clap",
@@ -2533,7 +2584,7 @@ dependencies = [
  "pep508_rs",
  "rattler",
  "rattler_conda_types",
- "rattler_digest 0.12.0",
+ "rattler_digest 0.12.3",
  "rattler_installs_packages",
  "rattler_lock",
  "rattler_networking",
@@ -2674,6 +2725,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "purl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d153044e55fb5c0a6f0f0f974c3335d15a842263ba4b208d2656120fe530a5ab"
+dependencies = [
+ "hex",
+ "percent-encoding",
+ "phf",
+ "serde",
+ "smartstring",
+ "thiserror",
+ "unicase",
+]
+
+[[package]]
 name = "pyproject-toml"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,9 +2808,8 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9536d239746f35977a554914f6ff5ca3eef4136d7760e60d8acc9aefa4bfda03"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "anyhow",
  "async-compression 0.4.4",
@@ -2762,7 +2827,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "rattler_conda_types",
- "rattler_digest 0.12.0",
+ "rattler_digest 0.12.3",
  "rattler_networking",
  "rattler_package_streaming",
  "regex",
@@ -2783,9 +2848,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc52b94ac685c83537162befed0ab7514f764a5ee5d277f530342eb335f56ea"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "chrono",
  "fxhash",
@@ -2795,7 +2859,8 @@ dependencies = [
  "itertools",
  "lazy-regex",
  "nom",
- "rattler_digest 0.12.0",
+ "purl",
+ "rattler_digest 0.12.3",
  "rattler_macros",
  "regex",
  "serde",
@@ -2827,9 +2892,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450a6b3b1faf486f1b9389f06abe08dacd2fb7fe5a40fd9562769debb34cfa42"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "blake2",
  "digest",
@@ -2844,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "rattler_installs_packages"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#66cd42a21ff8dbeb41ad9ab9ea59db5f268621dc"
+source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#2b31e8f51585cdef24b42161e93828ee43183941"
 dependencies = [
  "async-trait",
  "async_http_range_reader",
@@ -2896,9 +2960,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb186d821105f7a974d179db2215aacbfd70898ff7e736cf8e9ecada8889ab11"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "chrono",
  "fxhash",
@@ -2906,7 +2969,7 @@ dependencies = [
  "pep440_rs",
  "pep508_rs",
  "rattler_conda_types",
- "rattler_digest 0.12.0",
+ "rattler_digest 0.12.3",
  "serde",
  "serde-json-python-formatter",
  "serde_json",
@@ -2918,9 +2981,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24448132cde45c82bc2a1067ea9ff03ee410adc298775843b905d86570b05d43"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "quote",
  "syn 2.0.39",
@@ -2928,13 +2990,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f63becf3b45003ef2a033753599c9667c1a0374fcbee15cb7baef64aa74dbd6"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "anyhow",
  "dirs",
  "getrandom",
+ "itertools",
  "keyring",
  "lazy_static",
  "libc",
@@ -2944,20 +3006,20 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3408e3e140f040a9e67438749c8857bc48927ac1d4d86b049b75f91d60312bc"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "bzip2",
  "chrono",
  "futures-util",
  "itertools",
  "rattler_conda_types",
- "rattler_digest 0.12.0",
+ "rattler_digest 0.12.3",
  "rattler_networking",
  "reqwest",
  "serde_json",
@@ -2972,9 +3034,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308293d0577edd89e2815573ea4537c4604f5916c36dcd838dbfdce2d57f5788"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "anyhow",
  "async-compression 0.4.4",
@@ -2993,7 +3054,7 @@ dependencies = [
  "ouroboros",
  "pin-project-lite",
  "rattler_conda_types",
- "rattler_digest 0.12.0",
+ "rattler_digest 0.12.3",
  "rattler_networking",
  "reqwest",
  "serde",
@@ -3011,9 +3072,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4e9396c35302b611e9fa72b1d2261ab49b4ede56b020f77a7dd3ad6d785fa2"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.1.0",
@@ -3029,16 +3089,15 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447056088888f7fd2048129b0dcf34249a84e5cec28387d642817a8ceee3a00c"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "anyhow",
  "chrono",
  "hex",
  "itertools",
  "rattler_conda_types",
- "rattler_digest 0.12.0",
+ "rattler_digest 0.12.3",
  "resolvo",
  "serde",
  "tempfile",
@@ -3049,9 +3108,8 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b844fcc49253aceb4ce2af0cfea1839535d1bc0cbcf996b8020e753f820ba338"
+version = "0.12.3"
+source = "git+https://github.com/mamba-org/rattler?branch=main#807efbf9663b2fb91358f68c47d9dcb306eb6007"
 dependencies = [
  "cfg-if",
  "libloading",
@@ -3607,6 +3665,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,6 +3686,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
 ]
 
 [[package]]
@@ -4186,6 +4261,15 @@ checksum = "ce65604324d3cce9b966701489fbd0cf318cb1f7bd9dd07ac9a4ee6fb791930d"
 dependencies = [
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "rattler_installs_packages"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#2b31e8f51585cdef24b42161e93828ee43183941"
+source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#30aa1505c7f3ea1600d616b0c95fe1ca6229b18f"
 dependencies = [
  "async-trait",
  "async_http_range_reader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rustls-tls = ["reqwest/rustls-tls", "reqwest/rustls-tls-native-roots", "rattler_
 slow_integration_tests = []
 
 [dependencies]
+async-once-cell = "0.5.3"
 atty = "0.2"
 chrono = "0.4.31"
 clap = { version = "4.4.5", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context"] }
@@ -38,15 +39,14 @@ once_cell = "1.18.0"
 pep440_rs = "0.3.12"
 pep508_rs = { version = "0.2.3", features = ["modern"] }
 rattler = { version = "0.12.0", default-features = false }
-rattler_conda_types = { version = "0.12.0", default-features = false }
-rattler_digest = { version = "0.12.0", default-features = false }
-rattler_lock = { version = "0.12.0", default-features = false }
-rattler_networking = { version = "0.12.0", default-features = false }
-rattler_repodata_gateway = { version = "0.12.0", default-features = false, features = ["sparse"] }
-rattler_shell = { version = "0.12.0", default-features = false, features = ["sysinfo"] }
-rattler_solve = { version = "0.12.0", default-features = false, features = ["resolvo"] }
-rattler_virtual_packages = { version = "0.12.0", default-features = false }
-#rip = { package = "rattler_installs_packages", path = "../rattler_installs_packages/crates/rattler_installs_packages", default-features = false, features = ["resolvo"] }
+rattler_conda_types = { version = "0.12.3", default-features = false }
+rattler_digest = { version = "0.12.3", default-features = false }
+rattler_lock = { version = "0.12.3", default-features = false }
+rattler_networking = { version = "0.12.3", default-features = false }
+rattler_repodata_gateway = { version = "0.12.3", default-features = false, features = ["sparse"] }
+rattler_shell = { version = "0.12.3", default-features = false, features = ["sysinfo"] }
+rattler_solve = { version = "0.12.3", default-features = false, features = ["resolvo"] }
+rattler_virtual_packages = { version = "0.12.3", default-features = false }
 regex = "1.9.5"
 reqwest = { version = "0.11.20", default-features = false }
 rip = { package = "rattler_installs_packages", git = "https://github.com/prefix-dev/rattler_installs_packages", branch = "main", default-features = false, features = ["resolvo"] }
@@ -78,14 +78,15 @@ tokio = { version = "1.32.0", features = ["rt"] }
 toml = "0.8.1"
 
 [patch.crates-io]
-#rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-#rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_lock = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
 
 #rattler = { path = "../rattler/crates/rattler" }
 #rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }

--- a/examples/flask-hello-world/pixi.lock
+++ b/examples/flask-hello-world/pixi.lock
@@ -1,3 +1,4 @@
+version: 2
 metadata:
   content_hash:
     linux-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
@@ -18,17 +19,16 @@ metadata:
   inputs_metadata: null
   custom_metadata: null
 package:
-- name: _libgcc_mutex
+- platform: linux-64
+  name: _libgcc_mutex
   version: '0.1'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   hash:
     md5: d7c89558ba9fa0495403155b64376d81
     sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  optional: false
-  category: main
   build: conda_forge
   arch: x86_64
   subdir: linux-64
@@ -36,19 +36,18 @@ package:
   license: None
   size: 2562
   timestamp: 1578324546067
-- name: _openmp_mutex
+- platform: linux-64
+  name: _openmp_mutex
   version: '4.5'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgomp: '>=7.5.0'
-    _libgcc_mutex: ==0.1 conda_forge
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
     md5: 73aaf86a425cc6e73fcf236a5a46396d
     sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  optional: false
-  category: main
   build: 2_gnu
   arch: x86_64
   subdir: linux-64
@@ -59,18 +58,17 @@ package:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- name: blinker
-  version: 1.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2fb79ec81bad9492b6d59a06b3b647a4
-    sha256: b6f32491536823e47cf6eb4717dd341385600a2b901235028dedc629a77aeb82
-  optional: false
+- platform: linux-64
+  name: blinker
+  version: 1.7.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 550da20b2c2e38be9cc44bb819fda5d5
+    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -78,20 +76,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18215
-  timestamp: 1681349906223
-- name: blinker
-  version: 1.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2fb79ec81bad9492b6d59a06b3b647a4
-    sha256: b6f32491536823e47cf6eb4717dd341385600a2b901235028dedc629a77aeb82
-  optional: false
+  size: 17886
+  timestamp: 1698890303249
+- platform: osx-64
+  name: blinker
+  version: 1.7.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 550da20b2c2e38be9cc44bb819fda5d5
+    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -99,20 +96,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18215
-  timestamp: 1681349906223
-- name: blinker
-  version: 1.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2fb79ec81bad9492b6d59a06b3b647a4
-    sha256: b6f32491536823e47cf6eb4717dd341385600a2b901235028dedc629a77aeb82
-  optional: false
+  size: 17886
+  timestamp: 1698890303249
+- platform: osx-arm64
+  name: blinker
+  version: 1.7.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 550da20b2c2e38be9cc44bb819fda5d5
+    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -120,20 +116,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18215
-  timestamp: 1681349906223
-- name: blinker
-  version: 1.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2fb79ec81bad9492b6d59a06b3b647a4
-    sha256: b6f32491536823e47cf6eb4717dd341385600a2b901235028dedc629a77aeb82
-  optional: false
+  size: 17886
+  timestamp: 1698890303249
+- platform: win-64
+  name: blinker
+  version: 1.7.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 550da20b2c2e38be9cc44bb819fda5d5
+    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -141,172 +136,164 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 18215
-  timestamp: 1681349906223
-- name: bzip2
+  size: 17886
+  timestamp: 1698890303249
+- platform: linux-64
+  name: bzip2
   version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
-  hash:
-    md5: a1fd65c7ccbf10880423d82bca54eb54
-    sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
-  optional: false
   category: main
-  build: h7f98852_4
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  hash:
+    md5: 69b8b6202a07720f448be700e300ccf4
+    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+  build: hd590300_5
   arch: x86_64
   subdir: linux-64
-  build_number: 4
+  build_number: 5
   license: bzip2-1.0.6
   license_family: BSD
-  size: 495686
-  timestamp: 1606604745109
-- name: bzip2
+  size: 254228
+  timestamp: 1699279927352
+- platform: osx-64
+  name: bzip2
   version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
-  hash:
-    md5: 37edc4e6304ca87316e160f5ca0bd1b5
-    sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
-  optional: false
   category: main
-  build: h0d85af4_4
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+  hash:
+    md5: 6097a6ca9ada32699b5fc4312dd6ef18
+    sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
+  build: h10d778d_5
   arch: x86_64
   subdir: osx-64
-  build_number: 4
+  build_number: 5
   license: bzip2-1.0.6
   license_family: BSD
-  size: 158829
-  timestamp: 1618862580095
-- name: bzip2
+  size: 127885
+  timestamp: 1699280178474
+- platform: osx-arm64
+  name: bzip2
   version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
-  hash:
-    md5: fc76ace7b94fb1f694988ab1b14dd248
-    sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
-  optional: false
   category: main
-  build: h3422bc3_4
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+  hash:
+    md5: 1bbc659ca658bfd49a481b5ef7a0f40f
+    sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+  build: h93a5062_5
   arch: aarch64
   subdir: osx-arm64
-  build_number: 4
+  build_number: 5
   license: bzip2-1.0.6
   license_family: BSD
-  size: 151850
-  timestamp: 1618862645215
-- name: bzip2
+  size: 122325
+  timestamp: 1699280294368
+- platform: win-64
+  name: bzip2
   version: 1.0.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
-  hash:
-    md5: 7c03c66026944073040cb19a4f3ec3c9
-    sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
-  optional: false
   category: main
-  build: h8ffe710_4
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+  hash:
+    md5: 26eb8ca6ea332b675e11704cce84a3be
+    sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
+  build: hcfcfb64_5
   arch: x86_64
   subdir: win-64
-  build_number: 4
+  build_number: 5
   license: bzip2-1.0.6
   license_family: BSD
-  size: 152247
-  timestamp: 1606605223049
-- name: ca-certificates
-  version: 2023.5.7
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.5.7-hbcca054_0.conda
-  hash:
-    md5: f5c65075fc34438d5b456c7f3f5ab695
-    sha256: 0cf1bb3d0bfc5519b60af2c360fa4888fb838e1476b1e0f65b9dbc48b45c7345
-  optional: false
+  size: 124580
+  timestamp: 1699280668742
+- platform: linux-64
+  name: ca-certificates
+  version: 2023.11.17
   category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
+  hash:
+    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
+    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
   build: hbcca054_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: ISC
-  size: 148360
-  timestamp: 1683451720318
-- name: ca-certificates
-  version: 2023.5.7
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.5.7-h8857fd0_0.conda
-  hash:
-    md5: b704e4b79ba0d887c4870b7b09d6a4df
-    sha256: a06c9c788de81da3a3868ac56781680cc1fc50a0b5a545d4453818975c141b2c
-  optional: false
+  size: 154117
+  timestamp: 1700280881924
+- platform: osx-64
+  name: ca-certificates
+  version: 2023.11.17
   category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.11.17-h8857fd0_0.conda
+  hash:
+    md5: c687e9d14c49e3d3946d50a413cdbf16
+    sha256: 7e05d80a97beb7cb7492fae38584a68d51f338a5eddf73a14b5bd266597db90e
   build: h8857fd0_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: ISC
-  size: 148522
-  timestamp: 1683451939937
-- name: ca-certificates
-  version: 2023.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.5.7-hf0a4a13_0.conda
-  hash:
-    md5: a8387be82224743cf849fb907790b91a
-    sha256: 27214b54d1cb9a92455689e20d0007a0ff9ace99b853867d53a05a04c24bdae5
-  optional: false
+  size: 154404
+  timestamp: 1700280995538
+- platform: osx-arm64
+  name: ca-certificates
+  version: 2023.11.17
   category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.11.17-hf0a4a13_0.conda
+  hash:
+    md5: c01da7c77cfcba2107174e25c1d47384
+    sha256: 75f4762a55f7e9453a603c967d549bfa0a7a9669d502d103cb6fbf8c86d993c6
   build: hf0a4a13_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: ISC
-  size: 148524
-  timestamp: 1683451885269
-- name: ca-certificates
-  version: 2023.5.7
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.5.7-h56e8100_0.conda
-  hash:
-    md5: 604212634bd8c4d6f20d44b946e8eedb
-    sha256: d0488a3e7a86cc11f8c847a7c12a5f1fb8567f05646faae78944807862f9d167
-  optional: false
+  size: 154444
+  timestamp: 1700280972188
+- platform: win-64
+  name: ca-certificates
+  version: 2023.11.17
   category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.11.17-h56e8100_0.conda
+  hash:
+    md5: 1163114b483f26761f993c709e65271f
+    sha256: c6177e2a4967db7a4e929c6ecd2fafde36e489dbeda23ceda640f4915cb0e877
   build: h56e8100_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: ISC
-  size: 148581
-  timestamp: 1683451822049
-- name: click
-  version: 8.1.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: '*'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.4-unix_pyh707e725_0.conda
-  hash:
-    md5: fcae73fbdce7981fd500c626bb1ba6ab
-    sha256: 63f2b103488ba80b274f25bade66394fdd02344024fce45ab44e45861931c61d
-  optional: false
+  size: 154700
+  timestamp: 1700281021312
+- platform: linux-64
+  name: click
+  version: 8.1.7
   category: main
+  manager: conda
+  dependencies:
+  - __unix
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  hash:
+    md5: f3ad426304898027fc619827ff428eca
+    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
   build: unix_pyh707e725_0
   arch: x86_64
   subdir: linux-64
@@ -314,21 +301,20 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 84812
-  timestamp: 1688733100100
-- name: click
-  version: 8.1.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: '*'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.4-unix_pyh707e725_0.conda
-  hash:
-    md5: fcae73fbdce7981fd500c626bb1ba6ab
-    sha256: 63f2b103488ba80b274f25bade66394fdd02344024fce45ab44e45861931c61d
-  optional: false
+  size: 84437
+  timestamp: 1692311973840
+- platform: osx-64
+  name: click
+  version: 8.1.7
   category: main
+  manager: conda
+  dependencies:
+  - __unix
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  hash:
+    md5: f3ad426304898027fc619827ff428eca
+    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
   build: unix_pyh707e725_0
   arch: x86_64
   subdir: osx-64
@@ -336,21 +322,20 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 84812
-  timestamp: 1688733100100
-- name: click
-  version: 8.1.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: '*'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.4-unix_pyh707e725_0.conda
-  hash:
-    md5: fcae73fbdce7981fd500c626bb1ba6ab
-    sha256: 63f2b103488ba80b274f25bade66394fdd02344024fce45ab44e45861931c61d
-  optional: false
+  size: 84437
+  timestamp: 1692311973840
+- platform: osx-arm64
+  name: click
+  version: 8.1.7
   category: main
+  manager: conda
+  dependencies:
+  - __unix
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  hash:
+    md5: f3ad426304898027fc619827ff428eca
+    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
   build: unix_pyh707e725_0
   arch: aarch64
   subdir: osx-arm64
@@ -358,22 +343,21 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 84812
-  timestamp: 1688733100100
-- name: click
-  version: 8.1.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    __win: '*'
-    colorama: '*'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.4-win_pyh7428d3b_0.conda
-  hash:
-    md5: efa9a4c3abc022b74ea3485d830432c9
-    sha256: 1e7fe89aa3f18f501a672f229e19ddbbd560e5df29fe93b8f5a93ac76c50e8e7
-  optional: false
+  size: 84437
+  timestamp: 1692311973840
+- platform: win-64
+  name: click
+  version: 8.1.7
   category: main
+  manager: conda
+  dependencies:
+  - __win
+  - colorama
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
+  hash:
+    md5: 3549ecbceb6cd77b91a105511b7d0786
+    sha256: 90236b113b9a20041736e80b80ee965167f9aac0468315c55e2bad902d673fb0
   build: win_pyh7428d3b_0
   arch: x86_64
   subdir: win-64
@@ -381,20 +365,19 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 85043
-  timestamp: 1688733349522
-- name: colorama
+  size: 85051
+  timestamp: 1692312207348
+- platform: win-64
+  name: colorama
   version: 0.4.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3faab06a954c2a04039983f2c4a50d99
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -404,24 +387,23 @@ package:
   noarch: python
   size: 25170
   timestamp: 1666700778190
-- name: flask
-  version: 2.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    blinker: '>=1.6.2'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    python: '>=3.8'
-    click: '>=8.1.3'
-    werkzeug: '>=2.3.3'
-    jinja2: '>=3.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 816d75d4c0f2e41b5765d17498c57a2e
-    sha256: f93246be286f2d0f93e85c4f08f9ce48f3eed875a79225e2ea119e70c0237421
-  optional: false
+- platform: linux-64
+  name: flask
+  version: 2.3.3
   category: main
+  manager: conda
+  dependencies:
+  - blinker >=1.6.2
+  - click >=8.1.3
+  - importlib-metadata >=3.6.0
+  - itsdangerous >=2.1.2
+  - jinja2 >=3.1.2
+  - python >=3.8
+  - werkzeug >=2.3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b0d29067484a8dfacfae85b8fba81bc
+    sha256: 4f84ffdc5471236e8225db86c7508426b46aa2c3802d58ca40b3c3e174533b39
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -429,26 +411,25 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 79865
-  timestamp: 1682966703279
-- name: flask
-  version: 2.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    blinker: '>=1.6.2'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    python: '>=3.8'
-    click: '>=8.1.3'
-    werkzeug: '>=2.3.3'
-    jinja2: '>=3.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 816d75d4c0f2e41b5765d17498c57a2e
-    sha256: f93246be286f2d0f93e85c4f08f9ce48f3eed875a79225e2ea119e70c0237421
-  optional: false
+  size: 79782
+  timestamp: 1692686247131
+- platform: osx-64
+  name: flask
+  version: 2.3.3
   category: main
+  manager: conda
+  dependencies:
+  - blinker >=1.6.2
+  - click >=8.1.3
+  - importlib-metadata >=3.6.0
+  - itsdangerous >=2.1.2
+  - jinja2 >=3.1.2
+  - python >=3.8
+  - werkzeug >=2.3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b0d29067484a8dfacfae85b8fba81bc
+    sha256: 4f84ffdc5471236e8225db86c7508426b46aa2c3802d58ca40b3c3e174533b39
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -456,26 +437,25 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 79865
-  timestamp: 1682966703279
-- name: flask
-  version: 2.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    blinker: '>=1.6.2'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    python: '>=3.8'
-    click: '>=8.1.3'
-    werkzeug: '>=2.3.3'
-    jinja2: '>=3.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 816d75d4c0f2e41b5765d17498c57a2e
-    sha256: f93246be286f2d0f93e85c4f08f9ce48f3eed875a79225e2ea119e70c0237421
-  optional: false
+  size: 79782
+  timestamp: 1692686247131
+- platform: osx-arm64
+  name: flask
+  version: 2.3.3
   category: main
+  manager: conda
+  dependencies:
+  - blinker >=1.6.2
+  - click >=8.1.3
+  - importlib-metadata >=3.6.0
+  - itsdangerous >=2.1.2
+  - jinja2 >=3.1.2
+  - python >=3.8
+  - werkzeug >=2.3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b0d29067484a8dfacfae85b8fba81bc
+    sha256: 4f84ffdc5471236e8225db86c7508426b46aa2c3802d58ca40b3c3e174533b39
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -483,26 +463,25 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 79865
-  timestamp: 1682966703279
-- name: flask
-  version: 2.3.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    blinker: '>=1.6.2'
-    importlib-metadata: '>=3.6.0'
-    itsdangerous: '>=2.1.2'
-    python: '>=3.8'
-    click: '>=8.1.3'
-    werkzeug: '>=2.3.3'
-    jinja2: '>=3.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 816d75d4c0f2e41b5765d17498c57a2e
-    sha256: f93246be286f2d0f93e85c4f08f9ce48f3eed875a79225e2ea119e70c0237421
-  optional: false
+  size: 79782
+  timestamp: 1692686247131
+- platform: win-64
+  name: flask
+  version: 2.3.3
   category: main
+  manager: conda
+  dependencies:
+  - blinker >=1.6.2
+  - click >=8.1.3
+  - importlib-metadata >=3.6.0
+  - itsdangerous >=2.1.2
+  - jinja2 >=3.1.2
+  - python >=3.8
+  - werkzeug >=2.3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+  hash:
+    md5: 9b0d29067484a8dfacfae85b8fba81bc
+    sha256: 4f84ffdc5471236e8225db86c7508426b46aa2c3802d58ca40b3c3e174533b39
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -510,21 +489,20 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 79865
-  timestamp: 1682966703279
-- name: importlib-metadata
+  size: 79782
+  timestamp: 1692686247131
+- platform: linux-64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
@@ -534,19 +512,18 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: importlib-metadata
+- platform: osx-64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
@@ -556,19 +533,18 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: importlib-metadata
+- platform: osx-arm64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
@@ -578,19 +554,18 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: importlib-metadata
+- platform: win-64
+  name: importlib-metadata
   version: 6.8.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
+  - python >=3.8
+  - zipp >=0.5
   url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
   hash:
     md5: 4e9f59a060c3be52bc4ddc46ee9b6946
     sha256: 2797ed927d65324309b6c630190d917b9f2111e0c217b721f80429aeb57f9fcf
-  optional: false
-  category: main
   build: pyha770c72_0
   arch: x86_64
   subdir: win-64
@@ -600,18 +575,17 @@ package:
   noarch: python
   size: 25910
   timestamp: 1688754651944
-- name: itsdangerous
+- platform: linux-64
+  name: itsdangerous
   version: 2.1.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3c3de74912f11d2b590184f03c7cd09b
     sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -621,18 +595,17 @@ package:
   noarch: python
   size: 16377
   timestamp: 1648147263536
-- name: itsdangerous
+- platform: osx-64
+  name: itsdangerous
   version: 2.1.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3c3de74912f11d2b590184f03c7cd09b
     sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -642,18 +615,17 @@ package:
   noarch: python
   size: 16377
   timestamp: 1648147263536
-- name: itsdangerous
+- platform: osx-arm64
+  name: itsdangerous
   version: 2.1.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3c3de74912f11d2b590184f03c7cd09b
     sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -663,18 +635,17 @@ package:
   noarch: python
   size: 16377
   timestamp: 1648147263536
-- name: itsdangerous
+- platform: win-64
+  name: itsdangerous
   version: 2.1.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.1.2-pyhd8ed1ab_0.tar.bz2
   hash:
     md5: 3c3de74912f11d2b590184f03c7cd09b
     sha256: 31e3492686b4e92b53db9b48bc0eb03873b1caaf28629fee7d2d47627a2c56d3
-  optional: false
-  category: main
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -684,19 +655,18 @@ package:
   noarch: python
   size: 16377
   timestamp: 1648147263536
-- name: jinja2
+- platform: linux-64
+  name: jinja2
   version: 3.1.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.7'
-    markupsafe: '>=2.0'
+  - markupsafe >=2.0
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
     sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_1
   arch: x86_64
   subdir: linux-64
@@ -706,19 +676,18 @@ package:
   noarch: python
   size: 101443
   timestamp: 1654302514195
-- name: jinja2
+- platform: osx-64
+  name: jinja2
   version: 3.1.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    python: '>=3.7'
-    markupsafe: '>=2.0'
+  - markupsafe >=2.0
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
     sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_1
   arch: x86_64
   subdir: osx-64
@@ -728,19 +697,18 @@ package:
   noarch: python
   size: 101443
   timestamp: 1654302514195
-- name: jinja2
+- platform: osx-arm64
+  name: jinja2
   version: 3.1.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-    markupsafe: '>=2.0'
+  - markupsafe >=2.0
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
     sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_1
   arch: aarch64
   subdir: osx-arm64
@@ -750,19 +718,18 @@ package:
   noarch: python
   size: 101443
   timestamp: 1654302514195
-- name: jinja2
+- platform: win-64
+  name: jinja2
   version: 3.1.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    python: '>=3.7'
-    markupsafe: '>=2.0'
+  - markupsafe >=2.0
+  - python >=3.7
   url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
   hash:
     md5: c8490ed5c70966d232fdd389d0dbed37
     sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-  optional: false
-  category: main
   build: pyhd8ed1ab_1
   arch: x86_64
   subdir: win-64
@@ -772,17 +739,16 @@ package:
   noarch: python
   size: 101443
   timestamp: 1654302514195
-- name: ld_impl_linux-64
+- platform: linux-64
+  name: ld_impl_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
   hash:
     md5: 7aca3059a1729aa76c597603f10b0dd3
     sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  optional: false
-  category: main
   build: h41732ed_0
   arch: x86_64
   subdir: linux-64
@@ -793,18 +759,17 @@ package:
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- name: libexpat
+- platform: linux-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
   hash:
     md5: 6305a3dd2752c76335295da4e581f2fd
     sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  optional: false
-  category: main
   build: hcb278e6_1
   arch: x86_64
   subdir: linux-64
@@ -815,17 +780,16 @@ package:
   license_family: MIT
   size: 77980
   timestamp: 1680190528313
-- name: libexpat
+- platform: osx-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
   hash:
     md5: 6c81cb022780ee33435cca0127dd43c9
     sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
-  optional: false
-  category: main
   build: hf0c8a7f_1
   arch: x86_64
   subdir: osx-64
@@ -836,17 +800,16 @@ package:
   license_family: MIT
   size: 69602
   timestamp: 1680191040160
-- name: libexpat
+- platform: osx-arm64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
   hash:
     md5: 5a097ad3d17e42c148c9566280481317
     sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  optional: false
-  category: main
   build: hb7217d7_1
   arch: aarch64
   subdir: osx-arm64
@@ -857,17 +820,16 @@ package:
   license_family: MIT
   size: 63442
   timestamp: 1680190916539
-- name: libexpat
+- platform: win-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
   hash:
     md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
     sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
@@ -878,18 +840,17 @@ package:
   license_family: MIT
   size: 138689
   timestamp: 1680190844101
-- name: libffi
+- platform: linux-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
+  - libgcc-ng >=9.4.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   hash:
     md5: d645c6d2ac96843a2bfaccd2d62b3ac3
     sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  optional: false
-  category: main
   build: h7f98852_5
   arch: x86_64
   subdir: linux-64
@@ -898,17 +859,16 @@ package:
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- name: libffi
+- platform: osx-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
   hash:
     md5: ccb34fb14960ad8b125962d3d79b31a9
     sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-  optional: false
-  category: main
   build: h0d85af4_5
   arch: x86_64
   subdir: osx-64
@@ -917,17 +877,16 @@ package:
   license_family: MIT
   size: 51348
   timestamp: 1636488394370
-- name: libffi
+- platform: osx-arm64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
   hash:
     md5: 086914b672be056eb70fd4285b6783b6
     sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  optional: false
-  category: main
   build: h3422bc3_5
   arch: aarch64
   subdir: osx-arm64
@@ -936,19 +895,18 @@ package:
   license_family: MIT
   size: 39020
   timestamp: 1636488587153
-- name: libffi
+- platform: win-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
   hash:
     md5: 2c96d1b6915b408893f9472569dee135
     sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-  optional: false
-  category: main
   build: h8ffe710_5
   arch: x86_64
   subdir: win-64
@@ -957,160 +915,152 @@ package:
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- name: libgcc-ng
-  version: 13.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
-  hash:
-    md5: cd93f779ff018dd85c7544c015c9db3c
-    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
-  optional: false
+- platform: linux-64
+  name: libgcc-ng
+  version: 13.2.0
   category: main
-  build: he5830b7_0
+  manager: conda
+  dependencies:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+  hash:
+    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
+    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
+  build: h807b86a_3
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 3
   constrains:
-  - libgomp 13.1.0 he5830b7_0
+  - libgomp 13.2.0 h807b86a_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 776294
-  timestamp: 1685816209343
-- name: libgomp
-  version: 13.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
-  hash:
-    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
-    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
-  optional: false
+  size: 773629
+  timestamp: 1699753612541
+- platform: linux-64
+  name: libgomp
+  version: 13.2.0
   category: main
-  build: he5830b7_0
+  manager: conda
+  dependencies:
+  - _libgcc_mutex 0.1 conda_forge
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda
+  hash:
+    md5: 7124cbb46b13d395bdde68f2d215c989
+    sha256: 6ebedee39b6bbbc969715d0d7fa4b381cce67e1139862604ffa393f821c08e81
+  build: h807b86a_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 421834
+  timestamp: 1699753531479
+- platform: linux-64
+  name: libnsl
+  version: 2.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  hash:
+    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  build: hd590300_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
-  license: GPL-3.0-only WITH GCC-exception-3.1
+  license: LGPL-2.1-only
   license_family: GPL
-  size: 419184
-  timestamp: 1685816132543
-- name: libnsl
-  version: 2.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.0-h7f98852_0.tar.bz2
-  hash:
-    md5: 39b1328babf85c7c3a61636d9cd50206
-    sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
-  optional: false
+  size: 33408
+  timestamp: 1697359010159
+- platform: linux-64
+  name: libsqlite
+  version: 3.44.0
   category: main
-  build: h7f98852_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: GPL-2.0-only
-  license_family: GPL
-  size: 31236
-  timestamp: 1633040059627
-- name: libsqlite
-  version: 3.42.0
   manager: conda
-  platform: linux-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.42.0-h2797004_0.conda
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
   hash:
-    md5: fdaae20a1cf7cd62130a0973190a31b7
-    sha256: 72e958870f49174ebc0ddcd4129e9a9f48de815f20aa3b553f136b514f29bb3a
-  optional: false
-  category: main
+    md5: b58e6816d137f3aabf77d341dd5d732b
+    sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
   build: h2797004_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Unlicense
-  size: 828910
-  timestamp: 1684264791037
-- name: libsqlite
-  version: 3.42.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.42.0-h58db7d2_0.conda
-  hash:
-    md5: a7d3b44b7b0c9901ac7813b7a0462893
-    sha256: 182689f4b1a5ed638cd615c7774e1a9974842bc127c59173f1d25e31a8795eef
-  optional: false
+  size: 845977
+  timestamp: 1698854720770
+- platform: osx-64
+  name: libsqlite
+  version: 3.44.0
   category: main
-  build: h58db7d2_0
+  manager: conda
+  dependencies:
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+  hash:
+    md5: 5dd5e957ebfee02720c30e0e2d127bbe
+    sha256: 0832dc9cf18e811d2b41f8f4951d5ab608678e3459b1a4f36347097d8a9abf68
+  build: h92b6c6a_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Unlicense
-  size: 878744
-  timestamp: 1684265213849
-- name: libsqlite
-  version: 3.42.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.42.0-hb31c410_0.conda
-  hash:
-    md5: 6ae1bbf3ae393a45a75685072fffbe8d
-    sha256: 120913cf0fb694546fbaf95dff211ac5c1e3e91bc69c73350891a05dc106355f
-  optional: false
+  size: 891073
+  timestamp: 1698854990507
+- platform: osx-arm64
+  name: libsqlite
+  version: 3.44.0
   category: main
-  build: hb31c410_0
+  manager: conda
+  dependencies:
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.0-h091b4b1_0.conda
+  hash:
+    md5: 28eb31a5b4e704353ed575758e2fcf1d
+    sha256: 38e98953b572e2871f2b318fa7fe8d9997b0927970916c2d09402273b60ff832
+  build: h091b4b1_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Unlicense
-  size: 822883
-  timestamp: 1684265273102
-- name: libsqlite
-  version: 3.42.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.42.0-hcfcfb64_0.conda
-  hash:
-    md5: 9a71d93deb99cc09d8939d5235b5909a
-    sha256: 70bc1fdb72de847807355c13144666d4f151894f9b141ee559f5d243bdf577e2
-  optional: false
+  size: 815079
+  timestamp: 1698855024189
+- platform: win-64
+  name: libsqlite
+  version: 3.44.0
   category: main
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+  hash:
+    md5: 446fb1973cfeb8b32de4add3c9ac1057
+    sha256: b2be4125343d89765269b537e90ea5ab7f219e7398e7ad610ddcdcf31e7b9e65
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Unlicense
-  size: 839797
-  timestamp: 1684265312954
-- name: libuuid
+  size: 852871
+  timestamp: 1698855272921
+- platform: linux-64
+  name: libuuid
   version: 2.38.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   hash:
     md5: 40b61aab5c7ba9ff276c41cfffe6b80b
     sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  optional: false
-  category: main
   build: h0b41bf4_0
   arch: x86_64
   subdir: linux-64
@@ -1119,18 +1069,17 @@ package:
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- name: libzlib
+- platform: linux-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
   hash:
     md5: f36c115f1ee199da648e0597ec2047ad
     sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  optional: false
-  category: main
   build: hd590300_5
   arch: x86_64
   subdir: linux-64
@@ -1141,17 +1090,16 @@ package:
   license_family: Other
   size: 61588
   timestamp: 1686575217516
-- name: libzlib
+- platform: osx-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
   hash:
     md5: 4a3ad23f6e16f99c04e166767193d700
     sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
-  optional: false
-  category: main
   build: h8a1eda9_5
   arch: x86_64
   subdir: osx-64
@@ -1162,17 +1110,16 @@ package:
   license_family: Other
   size: 59404
   timestamp: 1686575566695
-- name: libzlib
+- platform: osx-arm64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
   hash:
     md5: 1a47f5236db2e06a320ffa0392f81bd8
     sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
-  optional: false
-  category: main
   build: h53f4e23_5
   arch: aarch64
   subdir: osx-arm64
@@ -1183,20 +1130,19 @@ package:
   license_family: Other
   size: 48102
   timestamp: 1686575426584
-- name: libzlib
+- platform: win-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
   hash:
     md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
     sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  optional: false
-  category: main
   build: hcfcfb64_5
   arch: x86_64
   subdir: win-64
@@ -1207,275 +1153,266 @@ package:
   license_family: Other
   size: 55800
   timestamp: 1686575452215
-- name: markupsafe
+- platform: linux-64
+  name: markupsafe
   version: 2.1.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    python: '>=3.11,<3.12.0a0'
-    libgcc-ng: '>=12'
-    python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_0.conda
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
   hash:
-    md5: 9904dc4adb5d547cb21e136f98cb24b0
-    sha256: 747b00706156b61d48565710f38cdb382e22f7db03e5b429532a2d5d5917c313
-  optional: false
-  category: main
-  build: py311h459d7ec_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26975
-  timestamp: 1685769213443
-- name: markupsafe
-  version: 2.1.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_0.conda
-  hash:
-    md5: 65b70928fcc2a81891ad1a8a6a7b085a
-    sha256: 93dbcca2a1a1c0ee1dbd60b578a66b650da2b166845ccf9ec54eed948ae42e47
-  optional: false
-  category: main
-  build: py311h2725bcf_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 25795
-  timestamp: 1685769434455
-- name: markupsafe
-  version: 2.1.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.11,<3.12.0a0 *_cpython'
-    python_abi: 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_0.conda
-  hash:
-    md5: 64767fbeb9e55231662b75405f9e01e4
-    sha256: 3d8fc172185c479b9df33259300bd204e40f13d958c030249cd35952709d61bf
-  optional: false
-  category: main
-  build: py311heffc1b2_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 26729
-  timestamp: 1685769407109
-- name: markupsafe
-  version: 2.1.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    python: '>=3.11,<3.12.0a0'
-    python_abi: 3.11.* *_cp311
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_0.conda
-  hash:
-    md5: db2c2f72a83bdc5b70947964e1ddc8bb
-    sha256: 53093042d6223531559fab2096eed85abee39d9386df9d7d42f9398e40017f04
-  optional: false
-  category: main
-  build: py311ha68e1ae_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 29453
-  timestamp: 1685769449108
-- name: ncurses
-  version: '6.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
-  hash:
-    md5: 681105bccc2a3f7f1a837d47d39c9179
-    sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
-  optional: false
-  category: main
-  build: hcb278e6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: X11 AND BSD-3-Clause
-  size: 880967
-  timestamp: 1686076725450
-- name: ncurses
-  version: '6.4'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
-  hash:
-    md5: c3dbae2411164d9b02c69090a9a91857
-    sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
-  optional: false
-  category: main
-  build: hf0c8a7f_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: X11 AND BSD-3-Clause
-  size: 828118
-  timestamp: 1686077056765
-- name: ncurses
-  version: '6.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
-  hash:
-    md5: 318337fb9d0c53ba635efb7888242373
-    sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
-  optional: false
-  category: main
-  build: h7ea286d_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: X11 AND BSD-3-Clause
-  size: 799196
-  timestamp: 1686077139703
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ca-certificates: '*'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.1-hd590300_1.conda
-  hash:
-    md5: 2e1d7b458ac8f1e3ca4e18b77add6277
-    sha256: 407d655643389bdb49266842a816815c981ae98f3513a6a2059b908b3abb380a
-  optional: false
-  category: main
-  build: hd590300_1
+    md5: 71120b5155a0c500826cf81536721a15
+    sha256: e1a9930f35e39bf65bc293e24160b83ebf9f800f02749f65358e1c04882ee6b0
+  build: py311h459d7ec_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2642411
-  timestamp: 1685517327134
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    ca-certificates: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.1-h8a1eda9_1.conda
-  hash:
-    md5: c7822d6ee74e34af1fd74365cfd18983
-    sha256: 67855f92bf50f24cbbc44879864d7a040b1f351e95b599cfcf4cc49b2cc3fd08
-  optional: false
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27174
+  timestamp: 1695367575909
+- platform: osx-64
+  name: markupsafe
+  version: 2.1.3
   category: main
-  build: h8a1eda9_1
+  manager: conda
+  dependencies:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_1.conda
+  hash:
+    md5: 52ee86f482b552e547e2b1d6c01adf55
+    sha256: 5a8f8caa89eeba6ea6e9e96d3e7c109b675bc3c6ed4b109b8931757da2411d48
+  build: py311h2725bcf_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2326872
-  timestamp: 1685518213128
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    ca-certificates: '*'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.1-h53f4e23_1.conda
-  hash:
-    md5: 7451b96ed28b5fd02f0df32689327755
-    sha256: 898aac8f8753385e9cd378d539364647d1deb9396032b7c1fd8f0f08107e020b
-  optional: false
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25917
+  timestamp: 1695367980802
+- platform: osx-arm64
+  name: markupsafe
+  version: 2.1.3
   category: main
-  build: h53f4e23_1
+  manager: conda
+  dependencies:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_1.conda
+  hash:
+    md5: 5a7b68cb9eea46bea31aaf2d11d0dd2f
+    sha256: 307c1e3b2e4a2a992a6c94975910adff88cc523e2c9a41e81b2d506d8c9e7359
+  build: py311heffc1b2_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   constrains:
-  - pyopenssl >=22.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 2223980
-  timestamp: 1685517736396
-- name: openssl
-  version: 3.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    ca-certificates: '*'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.1-hcfcfb64_1.conda
-  hash:
-    md5: 1d913a5de46c6b2f7e4cfbd26b106b8b
-    sha256: 4424486fb9a2aeaba912a8dd8a5b5cdb6fcd65d7708fd854e3ea27449bb352a3
-  optional: false
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26764
+  timestamp: 1695368008221
+- platform: win-64
+  name: markupsafe
+  version: 2.1.3
   category: main
-  build: hcfcfb64_1
+  manager: conda
+  dependencies:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_1.conda
+  hash:
+    md5: bc93b9d445824cfce3933b5dcc1087b4
+    sha256: 435c4c2df8d98cd49d8332d22b6f4847fc4b594500f0cdf0f9437274c668642b
+  build: py311ha68e1ae_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29466
+  timestamp: 1695367841578
+- platform: linux-64
+  name: ncurses
+  version: '6.4'
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  hash:
+    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  build: h59595ed_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: X11 AND BSD-3-Clause
+  size: 884434
+  timestamp: 1698751260967
+- platform: osx-64
+  name: ncurses
+  version: '6.4'
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+  hash:
+    md5: e58f366bd4d767e9ab97ab8b272e7670
+    sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
+  build: h93d8f39_2
+  arch: x86_64
+  subdir: osx-64
+  build_number: 2
+  license: X11 AND BSD-3-Clause
+  size: 822031
+  timestamp: 1698751567986
+- platform: osx-arm64
+  name: ncurses
+  version: '6.4'
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+  hash:
+    md5: 52b6f254a7b9663e854f44b6570ed982
+    sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+  build: h463b476_2
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 2
+  license: X11 AND BSD-3-Clause
+  size: 794741
+  timestamp: 1698751574074
+- platform: linux-64
+  name: openssl
+  version: 3.1.4
+  category: main
+  manager: conda
+  dependencies:
+  - ca-certificates
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+  hash:
+    md5: 412ba6938c3e2abaca8b1129ea82e238
+    sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
+  build: hd590300_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 7415451
-  timestamp: 1685519134254
-- name: python
-  version: 3.11.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    openssl: '>=3.1.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libgcc-ng: '>=12'
-    libnsl: '>=2.0.0,<2.1.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libuuid: '>=2.38.1,<3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    tzdata: '*'
-    libffi: '>=3.4,<4.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.4-hab00c5b_0_cpython.conda
-  hash:
-    md5: 1c628861a2a126b9fc9363ca1b7d014e
-    sha256: 04422f10d5bcb251fd254d6a9b0659dcde55e900d48cca159cb1fef637b0050c
-  optional: false
+  size: 2648006
+  timestamp: 1698164814626
+- platform: osx-64
+  name: openssl
+  version: 3.1.4
   category: main
+  manager: conda
+  dependencies:
+  - ca-certificates
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.4-hd75f5a5_0.conda
+  hash:
+    md5: bc9201da6eb1e0df4107901df5371347
+    sha256: 1c436103a8de0dc82c9c56974badaa1b8b8f8cd9f37c2766bd50cd9899720f6b
+  build: hd75f5a5_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2320542
+  timestamp: 1698165459976
+- platform: osx-arm64
+  name: openssl
+  version: 3.1.4
+  category: main
+  manager: conda
+  dependencies:
+  - ca-certificates
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.4-h0d3ecfb_0.conda
+  hash:
+    md5: 5a89552fececf4cd99628318ccbb67a3
+    sha256: 3c715b1d4940c7ad6065935db18924b85a54048dde066f963cfc250340639457
+  build: h0d3ecfb_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2147225
+  timestamp: 1698164947105
+- platform: win-64
+  name: openssl
+  version: 3.1.4
+  category: main
+  manager: conda
+  dependencies:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
+  hash:
+    md5: 2eebbc64373a1c6db62ad23304e9678e
+    sha256: e30b7f55c27d06e3322876c9433a3522e751d06a40b3bb6c4f8b4bcd781a3794
+  build: hcfcfb64_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 7427765
+  timestamp: 1698166937344
+- platform: linux-64
+  name: python
+  version: 3.11.6
+  category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
+  hash:
+    md5: b0dfbe2fcbfdb097d321bfd50ecddab1
+    sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
   build: hab00c5b_0_cpython
   arch: x86_64
   subdir: linux-64
@@ -1483,30 +1420,29 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 30679695
-  timestamp: 1686421868353
-- name: python
-  version: 3.11.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    tzdata: '*'
-    openssl: '>=3.1.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    ncurses: '>=6.4,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.4-h30d4d87_0_cpython.conda
-  hash:
-    md5: e40b3075f85db0184d5f61d17c580ef7
-    sha256: d2c00c7b1a616ad309afd864db6a7be33935710a68a7572509526495346655dc
-  optional: false
+  size: 30720625
+  timestamp: 1696331287478
+- platform: osx-64
+  name: python
+  version: 3.11.6
   category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
+  hash:
+    md5: 4d66c5fc01e9be526afe5d828d4de24d
+    sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
   build: h30d4d87_0_cpython
   arch: x86_64
   subdir: osx-64
@@ -1514,30 +1450,29 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 15324849
-  timestamp: 1686421760912
-- name: python
-  version: 3.11.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    tzdata: '*'
-    openssl: '>=3.1.1,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    ncurses: '>=6.4,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.4-h47c9636_0_cpython.conda
-  hash:
-    md5: b790b3cac8db7bdf2aaced9460bdbce4
-    sha256: 7865a28f7ec5c453cd8d3e7f539e02028ba5aa2aa33ccaa9915ba2654ae03ab2
-  optional: false
+  size: 15393521
+  timestamp: 1696330855485
+- platform: osx-arm64
+  name: python
+  version: 3.11.6
   category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
+  hash:
+    md5: 2271df1db9534f5cac7c2d0820c3359d
+    sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
   build: h47c9636_0_cpython
   arch: aarch64
   subdir: osx-arm64
@@ -1545,31 +1480,30 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 14666250
-  timestamp: 1686420844311
-- name: python
-  version: 3.11.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    tzdata: '*'
-    openssl: '>=3.1.1,<4.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.42.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    tk: '>=8.6.12,<8.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.4-h2628c8c_0_cpython.conda
-  hash:
-    md5: 3187a32fba79e835f099ecea054026f4
-    sha256: d43fa70a3549fea27d3993f79ba2584ec6d6fe2aaf6e5890847f974e89a744e0
-  optional: false
+  size: 14626958
+  timestamp: 1696329727433
+- platform: win-64
+  name: python
+  version: 3.11.6
   category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
+  hash:
+    md5: 80b761856b20383615a3fe8b1b13eef8
+    sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
   build: h2628c8c_0_cpython
   arch: x86_64
   subdir: win-64
@@ -1577,105 +1511,100 @@ package:
   constrains:
   - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 18116100
-  timestamp: 1686420267149
-- name: python_abi
+  size: 18121128
+  timestamp: 1696329396864
+- platform: linux-64
+  name: python_abi
   version: '3.11'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-3_cp311.conda
-  hash:
-    md5: c2e2630ddb68cf52eec74dc7dfab20b5
-    sha256: 2966a87dcb0b11fad28f9fe8216bfa4071115776b47ffc7547492fed176e1a1f
-  optional: false
   category: main
-  build: 3_cp311
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: d786502c97404c94d7d58d258a445a65
+    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+  build: 4_cp311
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 5682
-  timestamp: 1669071702664
-- name: python_abi
+  size: 6385
+  timestamp: 1695147338551
+- platform: osx-64
+  name: python_abi
   version: '3.11'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-3_cp311.conda
-  hash:
-    md5: 5e0a069a585445333868d2c6651c3b3f
-    sha256: 145edb385d464227aca8ce963b9e22f5f36cacac9085eb38f574961ebc69684e
-  optional: false
   category: main
-  build: 3_cp311
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: fef7a52f0eca6bae9e8e2e255bc86394
+    sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
+  build: 4_cp311
   arch: x86_64
   subdir: osx-64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 5766
-  timestamp: 1669071853731
-- name: python_abi
+  size: 6478
+  timestamp: 1695147518012
+- platform: osx-arm64
+  name: python_abi
   version: '3.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-3_cp311.conda
-  hash:
-    md5: e1586496f8acd1c9293019ab14dbde9d
-    sha256: cd2bad56c398e77b7f559314c29dd54e9eeb842896ff1de5078ed3192e5e14a6
-  optional: false
   category: main
-  build: 3_cp311
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: 8d3751bc73d3bbb66f216fa2331d5649
+    sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
+  build: 4_cp311
   arch: aarch64
   subdir: osx-arm64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 5768
-  timestamp: 1669071844807
-- name: python_abi
+  size: 6492
+  timestamp: 1695147509940
+- platform: win-64
+  name: python_abi
   version: '3.11'
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-3_cp311.conda
-  hash:
-    md5: fd1634ba85cfea9376e1fc02d6f592e9
-    sha256: e042841d13274354d651a69a4f2589e9b46fd23b416368c9821bf3c6676f19d7
-  optional: false
   category: main
-  build: 3_cp311
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: 70513332c71b56eace4ee6441e66c012
+    sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+  build: 4_cp311
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 4
   constrains:
   - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6124
-  timestamp: 1669071848353
-- name: readline
+  size: 6755
+  timestamp: 1695147711935
+- platform: linux-64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   hash:
     md5: 47d31b792659ce70f470b5c82fdfb7a4
     sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  optional: false
-  category: main
   build: h8228510_1
   arch: x86_64
   subdir: linux-64
@@ -1684,18 +1613,17 @@ package:
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- name: readline
+- platform: osx-64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
   hash:
     md5: f17f77f2acf4d344734bda76829ce14e
     sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
-  optional: false
-  category: main
   build: h9e318b2_1
   arch: x86_64
   subdir: osx-64
@@ -1704,18 +1632,17 @@ package:
   license_family: GPL
   size: 255870
   timestamp: 1679532707590
-- name: readline
+- platform: osx-arm64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
   hash:
     md5: 8cbb776a2f641b943d413b3e19df71f4
     sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
-  optional: false
-  category: main
   build: h92ec313_1
   arch: aarch64
   subdir: osx-arm64
@@ -1724,99 +1651,95 @@ package:
   license_family: GPL
   size: 250351
   timestamp: 1679532511311
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libzlib: '>=1.2.11,<1.3.0a0'
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2
-  hash:
-    md5: 5b8c42eb62e9fc961af70bdd6a26e168
-    sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
-  optional: false
+- platform: linux-64
+  name: tk
+  version: 8.6.13
   category: main
-  build: h27826a3_0
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  hash:
+    md5: d453b98d9c83e71da0741bb0ff4d76bc
+    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  build: noxft_h4845f30_101
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 101
   license: TCL
   license_family: BSD
-  size: 3456292
-  timestamp: 1645033615058
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libzlib: '>=1.2.11,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2
-  hash:
-    md5: 8e9480d9c47061db2ed1b4ecce519a7f
-    sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
-  optional: false
+  size: 3318875
+  timestamp: 1699202167581
+- platform: osx-64
+  name: tk
+  version: 8.6.13
   category: main
-  build: h5dbffcc_0
+  manager: conda
+  dependencies:
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+  hash:
+    md5: bf830ba5afc507c6232d4ef0fb1a882d
+    sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+  build: h1abcd95_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: TCL
   license_family: BSD
-  size: 3531016
-  timestamp: 1645032719565
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libzlib: '>=1.2.11,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2
-  hash:
-    md5: 2cb3d18eac154109107f093860bd545f
-    sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
-  optional: false
+  size: 3270220
+  timestamp: 1699202389792
+- platform: osx-arm64
+  name: tk
+  version: 8.6.13
   category: main
-  build: he1e0b03_0
+  manager: conda
+  dependencies:
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  hash:
+    md5: b50a57ba89c32b62428b71a875291c9b
+    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  build: h5083fa2_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: TCL
   license_family: BSD
-  size: 3382710
-  timestamp: 1645032642101
-- name: tk
-  version: 8.6.12
-  manager: conda
-  platform: win-64
-  dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
-  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.12-h8ffe710_0.tar.bz2
-  hash:
-    md5: c69a5047cc9291ae40afd4a1ad6f0c0f
-    sha256: 087795090a99a1d397ef1ed80b4a01fabfb0122efb141562c168e3c0a76edba6
-  optional: false
+  size: 3145523
+  timestamp: 1699202432999
+- platform: win-64
+  name: tk
+  version: 8.6.13
   category: main
-  build: h8ffe710_0
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+  hash:
+    md5: fc048363eb8f03cd1737600a5d08aafe
+    sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+  build: h5226925_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: TCL
   license_family: BSD
-  size: 3681762
-  timestamp: 1645033031535
-- name: tzdata
+  size: 3503410
+  timestamp: 1699202577803
+- platform: linux-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: linux-64
@@ -1825,17 +1748,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: osx-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: osx-64
@@ -1844,17 +1766,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: osx-arm64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: aarch64
   subdir: osx-arm64
@@ -1863,17 +1784,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: win-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: win-64
@@ -1882,17 +1802,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: ucrt
+- platform: win-64
+  name: ucrt
   version: 10.0.22621.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
   hash:
     md5: 72608f6cd3e5898229c3ea16deb1ac43
     sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
-  optional: false
-  category: main
   build: h57928b3_0
   arch: x86_64
   subdir: win-64
@@ -1903,41 +1822,38 @@ package:
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- name: vc
+- platform: win-64
+  name: vc
   version: '14.3'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc14_runtime: '>=14.36.32532'
+  - vc14_runtime >=14.36.32532
   url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
   hash:
     md5: 67ff6791f235bb606659bf2a5c169191
     sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
-  optional: false
-  category: main
   build: h64f974e_17
   arch: x86_64
   subdir: win-64
   build_number: 17
-  track_features:
-  - vc14
+  track_features: vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 17176
   timestamp: 1688020629925
-- name: vc14_runtime
+- platform: win-64
+  name: vc14_runtime
   version: 14.36.32532
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hfdfe4a8_17.conda
-  hash:
-    md5: 91c1ecaf3996889532fc0456178b1058
-    sha256: e76986c555647347a0185e646ef65625dabed60da255f6b30367df8bd6dc6cd8
-  optional: false
   category: main
-  build: hfdfe4a8_17
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
+  hash:
+    md5: d0de20f2f3fc806a81b44fcdd941aaf7
+    sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
+  build: hdcecf7f_17
   arch: x86_64
   subdir: win-64
   build_number: 17
@@ -1945,20 +1861,19 @@ package:
   - vs2015_runtime 14.36.32532.* *_17
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
-  size: 740599
-  timestamp: 1688020615962
-- name: vs2015_runtime
+  size: 739437
+  timestamp: 1694292382336
+- platform: win-64
+  name: vs2015_runtime
   version: 14.36.32532
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc14_runtime: '>=14.36.32532'
+  - vc14_runtime >=14.36.32532
   url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
   hash:
     md5: 4618046c39f7c81861e53ded842e738a
     sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
-  optional: false
-  category: main
   build: h05e6639_17
   arch: x86_64
   subdir: win-64
@@ -1967,19 +1882,18 @@ package:
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
-- name: werkzeug
-  version: 2.3.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    markupsafe: '>=2.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 55fbbb3e67185820ee2007395bfe0073
-    sha256: 28515f7ddb8a20f1436b9ac3a6ba2aa9be337995e4ee63c72d0f5d0efd6a2062
-  optional: false
+- platform: linux-64
+  name: werkzeug
+  version: 3.0.1
   category: main
+  manager: conda
+  dependencies:
+  - markupsafe >=2.1.1
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: af8d825d93dbe6331ee6d61c69869ca0
+    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -1987,21 +1901,20 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 254000
-  timestamp: 1686273829710
-- name: werkzeug
-  version: 2.3.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    markupsafe: '>=2.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 55fbbb3e67185820ee2007395bfe0073
-    sha256: 28515f7ddb8a20f1436b9ac3a6ba2aa9be337995e4ee63c72d0f5d0efd6a2062
-  optional: false
+  size: 241704
+  timestamp: 1698235401441
+- platform: osx-64
+  name: werkzeug
+  version: 3.0.1
   category: main
+  manager: conda
+  dependencies:
+  - markupsafe >=2.1.1
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: af8d825d93dbe6331ee6d61c69869ca0
+    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -2009,21 +1922,20 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 254000
-  timestamp: 1686273829710
-- name: werkzeug
-  version: 2.3.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    markupsafe: '>=2.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 55fbbb3e67185820ee2007395bfe0073
-    sha256: 28515f7ddb8a20f1436b9ac3a6ba2aa9be337995e4ee63c72d0f5d0efd6a2062
-  optional: false
+  size: 241704
+  timestamp: 1698235401441
+- platform: osx-arm64
+  name: werkzeug
+  version: 3.0.1
   category: main
+  manager: conda
+  dependencies:
+  - markupsafe >=2.1.1
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: af8d825d93dbe6331ee6d61c69869ca0
+    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -2031,21 +1943,20 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 254000
-  timestamp: 1686273829710
-- name: werkzeug
-  version: 2.3.6
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    markupsafe: '>=2.1.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-2.3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 55fbbb3e67185820ee2007395bfe0073
-    sha256: 28515f7ddb8a20f1436b9ac3a6ba2aa9be337995e4ee63c72d0f5d0efd6a2062
-  optional: false
+  size: 241704
+  timestamp: 1698235401441
+- platform: win-64
+  name: werkzeug
+  version: 3.0.1
   category: main
+  manager: conda
+  dependencies:
+  - markupsafe >=2.1.1
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: af8d825d93dbe6331ee6d61c69869ca0
+    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -2053,20 +1964,19 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 254000
-  timestamp: 1686273829710
-- name: xz
+  size: 241704
+  timestamp: 1698235401441
+- platform: linux-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   hash:
     md5: 2161070d867d1b1204ea749c8eec4ef0
     sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -2074,17 +1984,16 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- name: xz
+- platform: osx-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
   hash:
     md5: a72f9d4ea13d55d745ff1ed594747f10
     sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-  optional: false
-  category: main
   build: h775f41a_0
   arch: x86_64
   subdir: osx-64
@@ -2092,17 +2001,16 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 238119
   timestamp: 1660346964847
-- name: xz
+- platform: osx-arm64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
   hash:
     md5: 39c6b54e94014701dd157f4f576ed211
     sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-  optional: false
-  category: main
   build: h57fd34a_0
   arch: aarch64
   subdir: osx-arm64
@@ -2110,19 +2018,18 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
-- name: xz
+- platform: win-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
   hash:
     md5: 515d77642eaa3639413c6b1bc3f94219
     sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  optional: false
-  category: main
   build: h8d14728_0
   arch: x86_64
   subdir: win-64
@@ -2130,18 +2037,17 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- name: zipp
-  version: 3.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8be65b18d05ecd2801964e69c42f4fca
-    sha256: de563512a84818e5b367414e68985196dfb40964c12147fc731a6645f2e029e5
-  optional: false
+- platform: linux-64
+  name: zipp
+  version: 3.17.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -2149,20 +2055,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 17482
-  timestamp: 1688903060076
-- name: zipp
-  version: 3.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8be65b18d05ecd2801964e69c42f4fca
-    sha256: de563512a84818e5b367414e68985196dfb40964c12147fc731a6645f2e029e5
-  optional: false
+  size: 18954
+  timestamp: 1695255262261
+- platform: osx-64
+  name: zipp
+  version: 3.17.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -2170,20 +2075,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 17482
-  timestamp: 1688903060076
-- name: zipp
-  version: 3.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8be65b18d05ecd2801964e69c42f4fca
-    sha256: de563512a84818e5b367414e68985196dfb40964c12147fc731a6645f2e029e5
-  optional: false
+  size: 18954
+  timestamp: 1695255262261
+- platform: osx-arm64
+  name: zipp
+  version: 3.17.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -2191,20 +2095,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 17482
-  timestamp: 1688903060076
-- name: zipp
-  version: 3.16.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8be65b18d05ecd2801964e69c42f4fca
-    sha256: de563512a84818e5b367414e68985196dfb40964c12147fc731a6645f2e029e5
-  optional: false
+  size: 18954
+  timestamp: 1695255262261
+- platform: win-64
+  name: zipp
+  version: 3.17.0
   category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -2212,6 +2115,5 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 17482
-  timestamp: 1688903060076
-version: 1
+  size: 18954
+  timestamp: 1695255262261

--- a/examples/pypi/pixi.lock
+++ b/examples/pypi/pixi.lock
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 metadata:
   content_hash:
     linux-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
@@ -62,10 +62,8 @@ package:
   name: absl-py
   version: 2.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/01/e4/dc0a1dcc4e74e08d7abedab278c795eef54a224363bb18f5692f416d834f/absl_py-2.0.0-py3-none-any.whl#sha256=9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3
   hash:
     md5: null
@@ -74,10 +72,8 @@ package:
   name: absl-py
   version: 2.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/01/e4/dc0a1dcc4e74e08d7abedab278c795eef54a224363bb18f5692f416d834f/absl_py-2.0.0-py3-none-any.whl#sha256=9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3
   hash:
     md5: null
@@ -86,10 +82,8 @@ package:
   name: absl-py
   version: 2.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/01/e4/dc0a1dcc4e74e08d7abedab278c795eef54a224363bb18f5692f416d834f/absl_py-2.0.0-py3-none-any.whl#sha256=9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3
   hash:
     md5: null
@@ -98,10 +92,8 @@ package:
   name: absl-py
   version: 2.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/01/e4/dc0a1dcc4e74e08d7abedab278c795eef54a224363bb18f5692f416d834f/absl_py-2.0.0-py3-none-any.whl#sha256=9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3
   hash:
     md5: null
@@ -110,11 +102,10 @@ package:
   name: astunparse
   version: 1.6.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - wheel <1.0, >=0.23.0
   - six <2.0, >=1.6.1
-  extras: []
   url: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl#sha256=c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
   hash:
     md5: null
@@ -123,11 +114,10 @@ package:
   name: astunparse
   version: 1.6.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - wheel <1.0, >=0.23.0
   - six <2.0, >=1.6.1
-  extras: []
   url: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl#sha256=c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
   hash:
     md5: null
@@ -136,11 +126,10 @@ package:
   name: astunparse
   version: 1.6.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - wheel <1.0, >=0.23.0
   - six <2.0, >=1.6.1
-  extras: []
   url: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl#sha256=c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
   hash:
     md5: null
@@ -149,119 +138,112 @@ package:
   name: astunparse
   version: 1.6.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - wheel <1.0, >=0.23.0
   - six <2.0, >=1.6.1
-  extras: []
   url: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl#sha256=c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
   hash:
     md5: null
     sha256: c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
 - platform: linux-64
   name: black
-  version: 23.11.0
+  version: 22.12.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
-  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
+  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
+  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
+  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/46/0a/964b242c01b8dbadec60afd2f1d3e08ad574315d34a33a692e96f121a32b/black-23.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221
+  requires_python: '>=3.7'
+  url: https://files.pythonhosted.org/packages/e9/e0/6aa02d14785c4039b38bfed6f9ee28a952b2d101c64fc97b15811fa8bd04/black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f
   hash:
     md5: null
-    sha256: 760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221
+    sha256: d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f
 - platform: osx-64
   name: black
-  version: 23.11.0
+  version: 22.12.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
-  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
+  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
+  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
+  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/3b/d8/ea841502c79d85675e56c40d77de59aae44e311f17b463815d6a9659608c/black-23.11.0-cp311-cp311-macosx_10_9_x86_64.whl#sha256=cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479
+  requires_python: '>=3.7'
+  url: https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl#sha256=436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
   hash:
     md5: null
-    sha256: cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479
+    sha256: 436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
 - platform: osx-arm64
   name: black
-  version: 23.11.0
+  version: 22.12.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
-  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
+  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
+  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
+  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/4e/09/75c374a20c458230ed8288d1e68ba38ecf508e948b8bf8980e8b0fd4c3b1/black-23.11.0-cp311-cp311-macosx_11_0_arm64.whl#sha256=698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244
+  requires_python: '>=3.7'
+  url: https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl#sha256=436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
   hash:
     md5: null
-    sha256: 698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244
+    sha256: 436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
 - platform: win-64
   name: black
-  version: 23.11.0
+  version: 22.12.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
-  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
+  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
+  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
+  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/37/0b/2cf6d012a3cdb3f76d5c4e0c311b39f311a265d7dda315800ae34fb639c6/black-23.11.0-cp311-cp311-win_amd64.whl#sha256=58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5
+  requires_python: '>=3.7'
+  url: https://files.pythonhosted.org/packages/4c/49/420dcfccba3215dc4e5790fa47572ef14129df1c5e95dd87b5ad30211b01/black-22.12.0-cp311-cp311-win_amd64.whl#sha256=7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4
   hash:
     md5: null
-    sha256: 58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5
+    sha256: 7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4
 - platform: linux-64
   name: blinker
   version: 1.7.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl#sha256=c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9
   hash:
     md5: null
@@ -270,10 +252,8 @@ package:
   name: blinker
   version: 1.7.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl#sha256=c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9
   hash:
     md5: null
@@ -282,10 +262,8 @@ package:
   name: blinker
   version: 1.7.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl#sha256=c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9
   hash:
     md5: null
@@ -294,10 +272,8 @@ package:
   name: blinker
   version: 1.7.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl#sha256=c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9
   hash:
     md5: null
@@ -380,21 +356,21 @@ package:
   timestamp: 1699280668742
 - platform: linux-64
   name: ca-certificates
-  version: 2023.7.22
+  version: 2023.11.17
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
   hash:
-    md5: a73ecd2988327ad4c8f2c331482917f2
-    sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
+    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
+    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
   build: hbcca054_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: ISC
-  size: 149515
-  timestamp: 1690026108541
+  size: 154117
+  timestamp: 1700280881924
 - platform: osx-64
   name: ca-certificates
   version: 2023.11.17
@@ -431,29 +407,27 @@ package:
   timestamp: 1700280972188
 - platform: win-64
   name: ca-certificates
-  version: 2023.7.22
+  version: 2023.11.17
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.11.17-h56e8100_0.conda
   hash:
-    md5: b1c2327b36f1a25d96f2039b0d3e3739
-    sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
+    md5: 1163114b483f26761f993c709e65271f
+    sha256: c6177e2a4967db7a4e929c6ecd2fafde36e489dbeda23ceda640f4915cb0e877
   build: h56e8100_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: ISC
-  size: 150013
-  timestamp: 1690026269050
+  size: 154700
+  timestamp: 1700281021312
 - platform: linux-64
   name: cachetools
   version: 5.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/a2/91/2d843adb9fbd911e0da45fbf6f18ca89d07a087c3daa23e955584f90ebf4/cachetools-5.3.2-py3-none-any.whl#sha256=861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1
   hash:
     md5: null
@@ -462,10 +436,8 @@ package:
   name: cachetools
   version: 5.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/a2/91/2d843adb9fbd911e0da45fbf6f18ca89d07a087c3daa23e955584f90ebf4/cachetools-5.3.2-py3-none-any.whl#sha256=861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1
   hash:
     md5: null
@@ -474,10 +446,8 @@ package:
   name: cachetools
   version: 5.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/a2/91/2d843adb9fbd911e0da45fbf6f18ca89d07a087c3daa23e955584f90ebf4/cachetools-5.3.2-py3-none-any.whl#sha256=861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1
   hash:
     md5: null
@@ -486,10 +456,8 @@ package:
   name: cachetools
   version: 5.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/a2/91/2d843adb9fbd911e0da45fbf6f18ca89d07a087c3daa23e955584f90ebf4/cachetools-5.3.2-py3-none-any.whl#sha256=861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1
   hash:
     md5: null
@@ -498,10 +466,8 @@ package:
   name: certifi
   version: 2023.11.17
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl#sha256=e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
   hash:
     md5: null
@@ -510,10 +476,8 @@ package:
   name: certifi
   version: 2023.11.17
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl#sha256=e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
   hash:
     md5: null
@@ -522,10 +486,8 @@ package:
   name: certifi
   version: 2023.11.17
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl#sha256=e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
   hash:
     md5: null
@@ -534,10 +496,8 @@ package:
   name: certifi
   version: 2023.11.17
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl#sha256=e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
   hash:
     md5: null
@@ -546,10 +506,8 @@ package:
   name: charset-normalizer
   version: 3.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7.0'
-  extras: []
   url: https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8
   hash:
     md5: null
@@ -558,10 +516,8 @@ package:
   name: charset-normalizer
   version: 3.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7.0'
-  extras: []
   url: https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl#sha256=573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96
   hash:
     md5: null
@@ -570,10 +526,8 @@ package:
   name: charset-normalizer
   version: 3.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7.0'
-  extras: []
   url: https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl#sha256=549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e
   hash:
     md5: null
@@ -582,10 +536,8 @@ package:
   name: charset-normalizer
   version: 3.3.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7.0'
-  extras: []
   url: https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl#sha256=663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77
   hash:
     md5: null
@@ -594,12 +546,11 @@ package:
   name: click
   version: 8.1.7
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - colorama ; platform_system == 'Windows'
   - importlib-metadata ; python_version < '3.8'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl#sha256=ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   hash:
     md5: null
@@ -608,12 +559,11 @@ package:
   name: click
   version: 8.1.7
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - colorama ; platform_system == 'Windows'
   - importlib-metadata ; python_version < '3.8'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl#sha256=ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   hash:
     md5: null
@@ -622,12 +572,11 @@ package:
   name: click
   version: 8.1.7
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - colorama ; platform_system == 'Windows'
   - importlib-metadata ; python_version < '3.8'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl#sha256=ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   hash:
     md5: null
@@ -636,12 +585,11 @@ package:
   name: click
   version: 8.1.7
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - colorama ; platform_system == 'Windows'
   - importlib-metadata ; python_version < '3.8'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl#sha256=ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
   hash:
     md5: null
@@ -650,10 +598,8 @@ package:
   name: colorama
   version: 0.4.6
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl#sha256=4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
   hash:
     md5: null
@@ -662,7 +608,7 @@ package:
   name: flask
   version: 3.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - Werkzeug >=3.0.0
   - Jinja2 >=3.1.2
@@ -673,7 +619,6 @@ package:
   - asgiref >=3.2 ; extra == 'async'
   - python-dotenv ; extra == 'dotenv'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl#sha256=21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638
   hash:
     md5: null
@@ -682,7 +627,7 @@ package:
   name: flask
   version: 3.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - Werkzeug >=3.0.0
   - Jinja2 >=3.1.2
@@ -693,7 +638,6 @@ package:
   - asgiref >=3.2 ; extra == 'async'
   - python-dotenv ; extra == 'dotenv'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl#sha256=21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638
   hash:
     md5: null
@@ -702,7 +646,7 @@ package:
   name: flask
   version: 3.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - Werkzeug >=3.0.0
   - Jinja2 >=3.1.2
@@ -713,7 +657,6 @@ package:
   - asgiref >=3.2 ; extra == 'async'
   - python-dotenv ; extra == 'dotenv'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl#sha256=21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638
   hash:
     md5: null
@@ -722,7 +665,7 @@ package:
   name: flask
   version: 3.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - Werkzeug >=3.0.0
   - Jinja2 >=3.1.2
@@ -733,7 +676,6 @@ package:
   - asgiref >=3.2 ; extra == 'async'
   - python-dotenv ; extra == 'dotenv'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl#sha256=21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638
   hash:
     md5: null
@@ -742,9 +684,7 @@ package:
   name: flatbuffers
   version: 23.5.26
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/6f/12/d5c79ee252793ffe845d58a913197bfa02ae9a0b5c9bc3dc4b58d477b9e7/flatbuffers-23.5.26-py2.py3-none-any.whl#sha256=c0ff356da363087b915fde4b8b45bdda73432fc17cddb3c8157472eab1422ad1
   hash:
     md5: null
@@ -753,9 +693,7 @@ package:
   name: flatbuffers
   version: 23.5.26
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/6f/12/d5c79ee252793ffe845d58a913197bfa02ae9a0b5c9bc3dc4b58d477b9e7/flatbuffers-23.5.26-py2.py3-none-any.whl#sha256=c0ff356da363087b915fde4b8b45bdda73432fc17cddb3c8157472eab1422ad1
   hash:
     md5: null
@@ -764,9 +702,7 @@ package:
   name: flatbuffers
   version: 23.5.26
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/6f/12/d5c79ee252793ffe845d58a913197bfa02ae9a0b5c9bc3dc4b58d477b9e7/flatbuffers-23.5.26-py2.py3-none-any.whl#sha256=c0ff356da363087b915fde4b8b45bdda73432fc17cddb3c8157472eab1422ad1
   hash:
     md5: null
@@ -775,9 +711,7 @@ package:
   name: flatbuffers
   version: 23.5.26
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/6f/12/d5c79ee252793ffe845d58a913197bfa02ae9a0b5c9bc3dc4b58d477b9e7/flatbuffers-23.5.26-py2.py3-none-any.whl#sha256=c0ff356da363087b915fde4b8b45bdda73432fc17cddb3c8157472eab1422ad1
   hash:
     md5: null
@@ -786,10 +720,8 @@ package:
   name: gast
   version: 0.5.4
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/39/5aae571e5a5f4de9c3445dae08a530498e5c53b0e74410eeeb0991c79047/gast-0.5.4-py3-none-any.whl#sha256=6fc4fa5fa10b72fb8aab4ae58bcb023058386e67b6fa2e3e34cec5c769360316
   hash:
     md5: null
@@ -798,10 +730,8 @@ package:
   name: gast
   version: 0.5.4
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/39/5aae571e5a5f4de9c3445dae08a530498e5c53b0e74410eeeb0991c79047/gast-0.5.4-py3-none-any.whl#sha256=6fc4fa5fa10b72fb8aab4ae58bcb023058386e67b6fa2e3e34cec5c769360316
   hash:
     md5: null
@@ -810,10 +740,8 @@ package:
   name: gast
   version: 0.5.4
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/39/5aae571e5a5f4de9c3445dae08a530498e5c53b0e74410eeeb0991c79047/gast-0.5.4-py3-none-any.whl#sha256=6fc4fa5fa10b72fb8aab4ae58bcb023058386e67b6fa2e3e34cec5c769360316
   hash:
     md5: null
@@ -822,10 +750,8 @@ package:
   name: gast
   version: 0.5.4
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/39/5aae571e5a5f4de9c3445dae08a530498e5c53b0e74410eeeb0991c79047/gast-0.5.4-py3-none-any.whl#sha256=6fc4fa5fa10b72fb8aab4ae58bcb023058386e67b6fa2e3e34cec5c769360316
   hash:
     md5: null
@@ -834,7 +760,7 @@ package:
   name: google-auth
   version: 2.23.4
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cachetools <6.0, >=2.0.0
   - pyasn1-modules >=0.2.1
@@ -848,7 +774,6 @@ package:
   - pyu2f >=0.1.5 ; extra == 'reauth'
   - requests <3.0.0.dev0, >=2.20.0 ; extra == 'requests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/86/a7/75911c13a242735d5aeaca6a272da380335ff4ba5f26d6b2ae20ff682d13/google_auth-2.23.4-py2.py3-none-any.whl#sha256=d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2
   hash:
     md5: null
@@ -857,7 +782,7 @@ package:
   name: google-auth
   version: 2.23.4
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cachetools <6.0, >=2.0.0
   - pyasn1-modules >=0.2.1
@@ -871,7 +796,6 @@ package:
   - pyu2f >=0.1.5 ; extra == 'reauth'
   - requests <3.0.0.dev0, >=2.20.0 ; extra == 'requests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/86/a7/75911c13a242735d5aeaca6a272da380335ff4ba5f26d6b2ae20ff682d13/google_auth-2.23.4-py2.py3-none-any.whl#sha256=d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2
   hash:
     md5: null
@@ -880,7 +804,7 @@ package:
   name: google-auth
   version: 2.23.4
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cachetools <6.0, >=2.0.0
   - pyasn1-modules >=0.2.1
@@ -894,7 +818,6 @@ package:
   - pyu2f >=0.1.5 ; extra == 'reauth'
   - requests <3.0.0.dev0, >=2.20.0 ; extra == 'requests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/86/a7/75911c13a242735d5aeaca6a272da380335ff4ba5f26d6b2ae20ff682d13/google_auth-2.23.4-py2.py3-none-any.whl#sha256=d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2
   hash:
     md5: null
@@ -903,7 +826,7 @@ package:
   name: google-auth
   version: 2.23.4
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cachetools <6.0, >=2.0.0
   - pyasn1-modules >=0.2.1
@@ -917,7 +840,6 @@ package:
   - pyu2f >=0.1.5 ; extra == 'reauth'
   - requests <3.0.0.dev0, >=2.20.0 ; extra == 'requests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/86/a7/75911c13a242735d5aeaca6a272da380335ff4ba5f26d6b2ae20ff682d13/google_auth-2.23.4-py2.py3-none-any.whl#sha256=d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2
   hash:
     md5: null
@@ -926,13 +848,12 @@ package:
   name: google-auth-oauthlib
   version: 1.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - google-auth >=2.15.0
   - requests-oauthlib >=0.7.0
   - click >=6.0.0 ; extra == 'tool'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/4a/07/8d9a8186e6768b55dfffeb57c719bc03770cf8a970a074616ae6f9e26a57/google_auth_oauthlib-1.0.0-py2.py3-none-any.whl#sha256=95880ca704928c300f48194d1770cf5b1462835b6e49db61445a520f793fd5fb
   hash:
     md5: null
@@ -941,13 +862,12 @@ package:
   name: google-auth-oauthlib
   version: 1.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - google-auth >=2.15.0
   - requests-oauthlib >=0.7.0
   - click >=6.0.0 ; extra == 'tool'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/4a/07/8d9a8186e6768b55dfffeb57c719bc03770cf8a970a074616ae6f9e26a57/google_auth_oauthlib-1.0.0-py2.py3-none-any.whl#sha256=95880ca704928c300f48194d1770cf5b1462835b6e49db61445a520f793fd5fb
   hash:
     md5: null
@@ -956,13 +876,12 @@ package:
   name: google-auth-oauthlib
   version: 1.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - google-auth >=2.15.0
   - requests-oauthlib >=0.7.0
   - click >=6.0.0 ; extra == 'tool'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/4a/07/8d9a8186e6768b55dfffeb57c719bc03770cf8a970a074616ae6f9e26a57/google_auth_oauthlib-1.0.0-py2.py3-none-any.whl#sha256=95880ca704928c300f48194d1770cf5b1462835b6e49db61445a520f793fd5fb
   hash:
     md5: null
@@ -971,13 +890,12 @@ package:
   name: google-auth-oauthlib
   version: 1.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - google-auth >=2.15.0
   - requests-oauthlib >=0.7.0
   - click >=6.0.0 ; extra == 'tool'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/4a/07/8d9a8186e6768b55dfffeb57c719bc03770cf8a970a074616ae6f9e26a57/google_auth_oauthlib-1.0.0-py2.py3-none-any.whl#sha256=95880ca704928c300f48194d1770cf5b1462835b6e49db61445a520f793fd5fb
   hash:
     md5: null
@@ -986,10 +904,9 @@ package:
   name: google-pasta
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - six
-  extras: []
   url: https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl#sha256=b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed
   hash:
     md5: null
@@ -998,10 +915,9 @@ package:
   name: google-pasta
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - six
-  extras: []
   url: https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl#sha256=b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed
   hash:
     md5: null
@@ -1010,10 +926,9 @@ package:
   name: google-pasta
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - six
-  extras: []
   url: https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl#sha256=b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed
   hash:
     md5: null
@@ -1022,10 +937,9 @@ package:
   name: google-pasta
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - six
-  extras: []
   url: https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl#sha256=b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed
   hash:
     md5: null
@@ -1034,11 +948,10 @@ package:
   name: grpcio
   version: 1.59.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - grpcio-tools >=1.59.3 ; extra == 'protobuf'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/bb/7e/0eb6cdadb2df7190a6854f03caaec9b43b4c7a22753f212858c5f52450ca/grpcio-1.59.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=8239b853226e4824e769517e1b5232e7c4dda3815b200534500338960fcc6118
   hash:
     md5: null
@@ -1047,11 +960,10 @@ package:
   name: grpcio
   version: 1.59.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - grpcio-tools >=1.59.3 ; extra == 'protobuf'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/92/93/3cbc00a269b46277ff26355074a8315eeb4c87240c27d6f7efeabe818fd9/grpcio-1.59.3-cp311-cp311-macosx_10_10_universal2.whl#sha256=cb4e9cbd9b7388fcb06412da9f188c7803742d06d6f626304eb838d1707ec7e3
   hash:
     md5: null
@@ -1060,11 +972,10 @@ package:
   name: grpcio
   version: 1.59.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - grpcio-tools >=1.59.3 ; extra == 'protobuf'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/92/93/3cbc00a269b46277ff26355074a8315eeb4c87240c27d6f7efeabe818fd9/grpcio-1.59.3-cp311-cp311-macosx_10_10_universal2.whl#sha256=cb4e9cbd9b7388fcb06412da9f188c7803742d06d6f626304eb838d1707ec7e3
   hash:
     md5: null
@@ -1073,11 +984,10 @@ package:
   name: grpcio
   version: 1.59.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - grpcio-tools >=1.59.3 ; extra == 'protobuf'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/e5/f656b17fe1ccda1e2a4fe20298b8bcf7c804561c90ee763e39efc1c3772f/grpcio-1.59.3-cp311-cp311-win_amd64.whl#sha256=ed26826ee423b11477297b187371cdf4fa1eca874eb1156422ef3c9a60590dd9
   hash:
     md5: null
@@ -1086,11 +996,10 @@ package:
   name: h5py
   version: 3.10.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.17.3
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/1e/e9/61d7338e503d63d2ce733373fa86256614f579b173cf3d0571d4f46cb561/h5py-3.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=6c013d2e79c00f28ffd0cc24e68665ea03ae9069e167087b2adb5727d2736a52
   hash:
     md5: null
@@ -1099,11 +1008,10 @@ package:
   name: h5py
   version: 3.10.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.17.3
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/c3/99/570fedd40048daeb04d4738ed4f1d0e77259fb631387f7f188aac3d85c31/h5py-3.10.0-cp311-cp311-macosx_10_9_x86_64.whl#sha256=2381e98af081b6df7f6db300cd88f88e740649d77736e4b53db522d8874bf2dc
   hash:
     md5: null
@@ -1112,11 +1020,10 @@ package:
   name: h5py
   version: 3.10.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.17.3
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/8d/70/2b0b99507287f66e71a6b2e66c5ad2ec2461ef2c534668eef96c3b48eb6d/h5py-3.10.0-cp311-cp311-macosx_11_0_arm64.whl#sha256=667fe23ab33d5a8a6b77970b229e14ae3bb84e4ea3382cc08567a02e1499eedd
   hash:
     md5: null
@@ -1125,11 +1032,10 @@ package:
   name: h5py
   version: 3.10.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.17.3
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/b6/35/ed21094eb4d8acf31ccc7666a4d8701c1ce38f8d1fa3c7036f24416f6337/h5py-3.10.0-cp311-cp311-win_amd64.whl#sha256=92273ce69ae4983dadb898fd4d3bea5eb90820df953b401282ee69ad648df684
   hash:
     md5: null
@@ -1194,10 +1100,8 @@ package:
   name: idna
   version: '3.4'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl#sha256=90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   hash:
     md5: null
@@ -1206,10 +1110,8 @@ package:
   name: idna
   version: '3.4'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl#sha256=90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   hash:
     md5: null
@@ -1218,10 +1120,8 @@ package:
   name: idna
   version: '3.4'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl#sha256=90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   hash:
     md5: null
@@ -1230,10 +1130,8 @@ package:
   name: idna
   version: '3.4'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl#sha256=90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   hash:
     md5: null
@@ -1260,10 +1158,8 @@ package:
   name: itsdangerous
   version: 2.1.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl#sha256=2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44
   hash:
     md5: null
@@ -1272,10 +1168,8 @@ package:
   name: itsdangerous
   version: 2.1.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl#sha256=2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44
   hash:
     md5: null
@@ -1284,10 +1178,8 @@ package:
   name: itsdangerous
   version: 2.1.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl#sha256=2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44
   hash:
     md5: null
@@ -1296,10 +1188,8 @@ package:
   name: itsdangerous
   version: 2.1.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl#sha256=2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44
   hash:
     md5: null
@@ -1308,12 +1198,11 @@ package:
   name: jinja2
   version: 3.1.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.0
   - Babel >=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
   hash:
     md5: null
@@ -1322,12 +1211,11 @@ package:
   name: jinja2
   version: 3.1.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.0
   - Babel >=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
   hash:
     md5: null
@@ -1336,12 +1224,11 @@ package:
   name: jinja2
   version: 3.1.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.0
   - Babel >=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
   hash:
     md5: null
@@ -1350,12 +1237,11 @@ package:
   name: jinja2
   version: 3.1.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.0
   - Babel >=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/c3/f068337a370801f372f2f8f6bad74a5c140f6fda3d9de154052708dd3c65/Jinja2-3.1.2-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
   hash:
     md5: null
@@ -1364,10 +1250,8 @@ package:
   name: keras
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/58/34d4d8f1aa11120c2d36d7ad27d0526164b1a8ae45990a2fede31d0e59bf/keras-2.14.0-py3-none-any.whl#sha256=d7429d1d2131cc7eb1f2ea2ec330227c7d9d38dab3dfdf2e78defee4ecc43fcd
   hash:
     md5: null
@@ -1376,10 +1260,8 @@ package:
   name: keras
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/58/34d4d8f1aa11120c2d36d7ad27d0526164b1a8ae45990a2fede31d0e59bf/keras-2.14.0-py3-none-any.whl#sha256=d7429d1d2131cc7eb1f2ea2ec330227c7d9d38dab3dfdf2e78defee4ecc43fcd
   hash:
     md5: null
@@ -1388,10 +1270,8 @@ package:
   name: keras
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/58/34d4d8f1aa11120c2d36d7ad27d0526164b1a8ae45990a2fede31d0e59bf/keras-2.14.0-py3-none-any.whl#sha256=d7429d1d2131cc7eb1f2ea2ec330227c7d9d38dab3dfdf2e78defee4ecc43fcd
   hash:
     md5: null
@@ -1400,10 +1280,8 @@ package:
   name: keras
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/58/34d4d8f1aa11120c2d36d7ad27d0526164b1a8ae45990a2fede31d0e59bf/keras-2.14.0-py3-none-any.whl#sha256=d7429d1d2131cc7eb1f2ea2ec330227c7d9d38dab3dfdf2e78defee4ecc43fcd
   hash:
     md5: null
@@ -1434,191 +1312,191 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libopenblas >=0.3.24,<0.3.25.0a0
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+  - libopenblas >=0.3.25,<0.3.26.0a0
+  - libopenblas >=0.3.25,<1.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: 420f4e9be59d0dc9133a0f43f7bab3f3
-    sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
-  build: 19_linux64_openblas
+    md5: 2b7bb4f7562c8cf334fc2e20c2d28abc
+    sha256: 8a0ee1de693a9b3da4a11b95ec81b40dd434bd01fa1f5f38f8268cd2146bf8f0
+  build: 20_linux64_openblas
   arch: x86_64
   subdir: linux-64
-  build_number: 19
+  build_number: 20
   constrains:
+  - liblapacke 3.9.0 20_linux64_openblas
+  - libcblas 3.9.0 20_linux64_openblas
   - blas * openblas
-  - libcblas 3.9.0 19_linux64_openblas
-  - liblapack 3.9.0 19_linux64_openblas
-  - liblapacke 3.9.0 19_linux64_openblas
+  - liblapack 3.9.0 20_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14566
-  timestamp: 1697484219912
+  size: 14433
+  timestamp: 1700568383457
 - platform: osx-64
   name: libblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libopenblas >=0.3.24,<0.3.25.0a0
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+  - libopenblas >=0.3.25,<0.3.26.0a0
+  - libopenblas >=0.3.25,<1.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-20_osx64_openblas.conda
   hash:
-    md5: e932b99c38915fa2ee252cdff6ea1f01
-    sha256: c2c96103aa23a65f45b76716df49940cb0722258d3e0416f8fa06ade02464b23
-  build: 19_osx64_openblas
+    md5: 1673476d205d14a9042172be795f63cb
+    sha256: 89cac4653b52817d44802d96c13e5f194320e2e4ea805596641d0f3e22e32525
+  build: 20_osx64_openblas
   arch: x86_64
   subdir: osx-64
-  build_number: 19
+  build_number: 20
   constrains:
-  - liblapacke 3.9.0 19_osx64_openblas
-  - libcblas 3.9.0 19_osx64_openblas
-  - liblapack 3.9.0 19_osx64_openblas
   - blas * openblas
+  - liblapack 3.9.0 20_osx64_openblas
+  - liblapacke 3.9.0 20_osx64_openblas
+  - libcblas 3.9.0 20_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14812
-  timestamp: 1697484725085
+  size: 14739
+  timestamp: 1700568675962
 - platform: osx-arm64
   name: libblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libopenblas >=0.3.24,<0.3.25.0a0
-  - libopenblas >=0.3.24,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+  - libopenblas >=0.3.25,<0.3.26.0a0
+  - libopenblas >=0.3.25,<1.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-20_osxarm64_openblas.conda
   hash:
-    md5: f50b1fd98593278e18319653cff9c475
-    sha256: 51e78e3c9fa57f3fec12936b760928715ba0ab5253d02815202f9ec4c2c9255d
-  build: 19_osxarm64_openblas
+    md5: 49bc8dec26663241ee064b2d7116ec2d
+    sha256: 5b5b8394352c8ca06b15dcc9319d0af3e9f1dc03fc0a6f6deef05d664d6b763a
+  build: 20_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
-  build_number: 19
+  build_number: 20
   constrains:
-  - libcblas 3.9.0 19_osxarm64_openblas
-  - liblapack 3.9.0 19_osxarm64_openblas
+  - liblapack 3.9.0 20_osxarm64_openblas
+  - liblapacke 3.9.0 20_osxarm64_openblas
+  - libcblas 3.9.0 20_osxarm64_openblas
   - blas * openblas
-  - liblapacke 3.9.0 19_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14817
-  timestamp: 1697484577887
+  size: 14722
+  timestamp: 1700568881837
 - platform: win-64
   name: libblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - mkl 2023.2.0 h6a75c08_50496
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+  - mkl 2023.2.0 h6a75c08_50497
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-20_win64_mkl.conda
   hash:
-    md5: 4f8a1a63cfbf74bc7b2813d9c6c205be
-    sha256: 915eae5e0dedbf87733a0b8c6f410678c77111a3fb26ca0a272e11ff979e7ef2
-  build: 19_win64_mkl
+    md5: 6cad6cd2fbdeef4d651b8f752a4da960
+    sha256: 34becfe991510be7b9ee05b4ae466c5a26a72af275c3071c1ca7e2308d3f7e64
+  build: 20_win64_mkl
   arch: x86_64
   subdir: win-64
-  build_number: 19
+  build_number: 20
   constrains:
-  - liblapack 3.9.0 19_win64_mkl
-  - libcblas 3.9.0 19_win64_mkl
-  - liblapacke 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 20_win64_mkl
   - blas * mkl
+  - liblapack 3.9.0 20_win64_mkl
+  - libcblas 3.9.0 20_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 4984180
-  timestamp: 1697485304263
+  size: 4981090
+  timestamp: 1700569135332
 - platform: linux-64
   name: libcblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+  - libblas 3.9.0 20_linux64_openblas
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: d12374af44575413fbbd4a217d46ea33
-    sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
-  build: 19_linux64_openblas
+    md5: 36d486d72ab64ffea932329a1d3729a3
+    sha256: 0e34fb0f82262f02fcb279ab4a1db8d50875dc98e3019452f8f387e6bf3c0247
+  build: 20_linux64_openblas
   arch: x86_64
   subdir: linux-64
-  build_number: 19
+  build_number: 20
   constrains:
+  - liblapacke 3.9.0 20_linux64_openblas
   - blas * openblas
-  - liblapack 3.9.0 19_linux64_openblas
-  - liblapacke 3.9.0 19_linux64_openblas
+  - liblapack 3.9.0 20_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14458
-  timestamp: 1697484230827
+  size: 14383
+  timestamp: 1700568410580
 - platform: osx-64
   name: libcblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_osx64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+  - libblas 3.9.0 20_osx64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-20_osx64_openblas.conda
   hash:
-    md5: 40e412c219ad8cf87ba664466071bcf6
-    sha256: 70afde49736007bbb804d126a3983ba1fa04383006aae416a2971d538e274427
-  build: 19_osx64_openblas
+    md5: b324ad206d39ce529fb9073f9d062062
+    sha256: b0a4eab6d22b865d9b0e39f358f17438602621709db66b8da159197bedd2c5eb
+  build: 20_osx64_openblas
   arch: x86_64
   subdir: osx-64
-  build_number: 19
+  build_number: 20
   constrains:
-  - liblapack 3.9.0 19_osx64_openblas
-  - liblapacke 3.9.0 19_osx64_openblas
+  - liblapack 3.9.0 20_osx64_openblas
+  - liblapacke 3.9.0 20_osx64_openblas
   - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14717
-  timestamp: 1697484740520
+  size: 14648
+  timestamp: 1700568722960
 - platform: osx-arm64
   name: libcblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+  - libblas 3.9.0 20_osxarm64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-20_osxarm64_openblas.conda
   hash:
-    md5: 5460a8d1beffd7f63994d891e6a20da4
-    sha256: 19b1c5e3ddd383ec14540336f4704938218d3c1db4707ae10d5357afb22cccc1
-  build: 19_osxarm64_openblas
+    md5: 89f4718753c08afe8cda4dd5791ba94c
+    sha256: d3a74638f60e034202e373cf2950c69a8d831190d497881d13cbf789434d2489
+  build: 20_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
-  build_number: 19
+  build_number: 20
   constrains:
-  - liblapack 3.9.0 19_osxarm64_openblas
+  - liblapack 3.9.0 20_osxarm64_openblas
+  - liblapacke 3.9.0 20_osxarm64_openblas
   - blas * openblas
-  - liblapacke 3.9.0 19_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14738
-  timestamp: 1697484590682
+  size: 14642
+  timestamp: 1700568912840
 - platform: win-64
   name: libcblas
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+  - libblas 3.9.0 20_win64_mkl
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-20_win64_mkl.conda
   hash:
-    md5: 1b9ede5cff953aa1a5f4d9f8ec644972
-    sha256: 66c8934bf8ead1e3ab3653155697a7d70878e96115742b681aac16d9bd25dd3d
-  build: 19_win64_mkl
+    md5: e6d36cfcb2f2dff0f659d2aa0813eb2d
+    sha256: e526023ed8e7f6fde43698cd326dd16c8448f29414bab8a9594b33deb57a5347
+  build: 20_win64_mkl
   arch: x86_64
   subdir: win-64
-  build_number: 19
+  build_number: 20
   constrains:
-  - liblapack 3.9.0 19_win64_mkl
-  - liblapacke 3.9.0 19_win64_mkl
   - blas * mkl
+  - liblapack 3.9.0 20_win64_mkl
+  - liblapacke 3.9.0 20_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 4984046
-  timestamp: 1697485351545
+  size: 4980937
+  timestamp: 1700569208640
 - platform: linux-64
   name: libclang
   version: 16.0.6
@@ -2245,92 +2123,92 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_linux64_openblas
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+  - libblas 3.9.0 20_linux64_openblas
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_openblas.conda
   hash:
-    md5: 9f100edf65436e3eabc2a51fc00b2c37
-    sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
-  build: 19_linux64_openblas
+    md5: 6fabc51f5e647d09cc010c40061557e0
+    sha256: ad7745b8d0f2ccb9c3ba7aaa7167d62fc9f02e45eb67172ae5f0dfb5a3b1a2cc
+  build: 20_linux64_openblas
   arch: x86_64
   subdir: linux-64
-  build_number: 19
+  build_number: 20
   constrains:
+  - liblapacke 3.9.0 20_linux64_openblas
+  - libcblas 3.9.0 20_linux64_openblas
   - blas * openblas
-  - libcblas 3.9.0 19_linux64_openblas
-  - liblapacke 3.9.0 19_linux64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14487
-  timestamp: 1697484241613
+  size: 14350
+  timestamp: 1700568424034
 - platform: osx-64
   name: liblapack
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_osx64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+  - libblas 3.9.0 20_osx64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-20_osx64_openblas.conda
   hash:
-    md5: 2e714df18db99ee6d7b4ac728f53ca62
-    sha256: 6a1704c43a03195fecbbb226be5c257b2e37621e793967c3f31c8521f19e18df
-  build: 19_osx64_openblas
+    md5: 704bfc2af1288ea973b6755281e6ad32
+    sha256: d64e11b93dada339cd0dcc057b3f3f6a5114b8c9bdf90cf6c04cbfa75fb02104
+  build: 20_osx64_openblas
   arch: x86_64
   subdir: osx-64
-  build_number: 19
+  build_number: 20
   constrains:
-  - libcblas 3.9.0 19_osx64_openblas
-  - liblapacke 3.9.0 19_osx64_openblas
   - blas * openblas
+  - liblapacke 3.9.0 20_osx64_openblas
+  - libcblas 3.9.0 20_osx64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14724
-  timestamp: 1697484756327
+  size: 14658
+  timestamp: 1700568740660
 - platform: osx-arm64
   name: liblapack
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+  - libblas 3.9.0 20_osxarm64_openblas
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-20_osxarm64_openblas.conda
   hash:
-    md5: 3638eacb084c374f41f9efa40d20a47b
-    sha256: f19cff537403c9feed98c7e18259022102b087f2b72a757e8a417476b9cf30c1
-  build: 19_osxarm64_openblas
+    md5: 1fefac78f2315455ce2d7f34782eac0a
+    sha256: e13f79828a7752f6e0a74cbe62df80c551285f6c37de86bc3bd9987c97faca57
+  build: 20_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
-  build_number: 19
+  build_number: 20
   constrains:
-  - libcblas 3.9.0 19_osxarm64_openblas
+  - liblapacke 3.9.0 20_osxarm64_openblas
+  - libcblas 3.9.0 20_osxarm64_openblas
   - blas * openblas
-  - liblapacke 3.9.0 19_osxarm64_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 14721
-  timestamp: 1697484603691
+  size: 14648
+  timestamp: 1700568930669
 - platform: win-64
   name: liblapack
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 19_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+  - libblas 3.9.0 20_win64_mkl
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-20_win64_mkl.conda
   hash:
-    md5: 574e6e8bcc85df2885eb2a87d31ae005
-    sha256: e53093eab7674528e9eafbd5efa28f3170ec1388b8df6c9b8343760696f47907
-  build: 19_win64_mkl
+    md5: 9510d07424d70fcac553d86b3e4a7c14
+    sha256: 7627ef580c26e48c3496b5885fd32be4e4db49fa1077eb21235dc638489565f6
+  build: 20_win64_mkl
   arch: x86_64
   subdir: win-64
-  build_number: 19
+  build_number: 20
   constrains:
-  - libcblas 3.9.0 19_win64_mkl
-  - liblapacke 3.9.0 19_win64_mkl
+  - liblapacke 3.9.0 20_win64_mkl
   - blas * mkl
+  - libcblas 3.9.0 20_win64_mkl
   license: BSD-3-Clause
   license_family: BSD
-  size: 4984073
-  timestamp: 1697485397401
+  size: 4980967
+  timestamp: 1700569262298
 - platform: linux-64
   name: libllvm16
   version: 16.0.6
@@ -2419,148 +2297,148 @@ package:
   timestamp: 1697359010159
 - platform: linux-64
   name: libopenblas
-  version: 0.3.24
+  version: 0.3.25
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
   - libgfortran-ng
   - libgfortran5 >=12.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.25-pthreads_h413a1c8_0.conda
   hash:
-    md5: 6e4ef6ca28655124dcde9bd500e44c32
-    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
+    md5: d172b34a443b95f86089e8229ddc9a17
+    sha256: 628564517895ee1b09cf72c817548bd80ef1acce6a8214a8520d9f7b44c4cfaf
   build: pthreads_h413a1c8_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
+  - openblas >=0.3.25,<0.3.26.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5492091
-  timestamp: 1693785223074
+  size: 5545169
+  timestamp: 1700536004164
 - platform: osx-64
   name: libopenblas
-  version: 0.3.24
+  version: 0.3.25
   category: main
   manager: conda
   dependencies:
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
-  - llvm-openmp >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+  - llvm-openmp >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.25-openmp_hfef2a42_0.conda
   hash:
-    md5: 077718837dd06cf0c3089070108869f6
-    sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
-  build: openmp_h48a4ad5_0
+    md5: a01b96f00c3155c830d98a518c7dcbfb
+    sha256: 9895bccdbaa34958ab7dd1f29de66d1dfb94c551c7bb5a663666a500c67ee93c
+  build: openmp_hfef2a42_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
+  - openblas >=0.3.25,<0.3.26.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6157393
-  timestamp: 1693785988209
+  size: 6019426
+  timestamp: 1700537709900
 - platform: osx-arm64
   name: libopenblas
-  version: 0.3.24
+  version: 0.3.25
   category: main
   manager: conda
   dependencies:
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
-  - llvm-openmp >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+  - llvm-openmp >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.25-openmp_h6c19121_0.conda
   hash:
-    md5: aacb05989f358affe1bafd4ea7294db4
-    sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
-  build: openmp_hd76b1f2_0
+    md5: a1843550403212b9dedeeb31466ade03
+    sha256: b112e0d500bc0314ea8d393efac3ab8c67857e5a2b345348c98e703ee92723e5
+  build: openmp_h6c19121_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
+  - openblas >=0.3.25,<0.3.26.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2849225
-  timestamp: 1693784744674
+  size: 2896390
+  timestamp: 1700535987588
 - platform: linux-64
   name: libsqlite
-  version: 3.44.0
+  version: 3.44.1
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.1-h2797004_0.conda
   hash:
-    md5: b58e6816d137f3aabf77d341dd5d732b
-    sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+    md5: b4ad86d2527b890e43ff2efc68b239f4
+    sha256: c37bb6ec8b09f690d84e8f14fabb75e00c221d11a256137d5b206e26f37e9483
   build: h2797004_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Unlicense
-  size: 845977
-  timestamp: 1698854720770
+  size: 846227
+  timestamp: 1700684372427
 - platform: osx-64
   name: libsqlite
-  version: 3.44.0
+  version: 3.44.1
   category: main
   manager: conda
   dependencies:
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.1-h92b6c6a_0.conda
   hash:
-    md5: 5dd5e957ebfee02720c30e0e2d127bbe
-    sha256: 0832dc9cf18e811d2b41f8f4951d5ab608678e3459b1a4f36347097d8a9abf68
+    md5: 7cf15accdee2a4a1cf267a78c4b76c3d
+    sha256: e51e3e3e84df3cee02434283c8c83ed604fa50cea945a3b14904a59fac5537a5
   build: h92b6c6a_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Unlicense
-  size: 891073
-  timestamp: 1698854990507
+  size: 890892
+  timestamp: 1700684863628
 - platform: osx-arm64
   name: libsqlite
-  version: 3.44.0
+  version: 3.44.1
   category: main
   manager: conda
   dependencies:
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.0-h091b4b1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.1-h091b4b1_0.conda
   hash:
-    md5: 28eb31a5b4e704353ed575758e2fcf1d
-    sha256: 38e98953b572e2871f2b318fa7fe8d9997b0927970916c2d09402273b60ff832
+    md5: 1750563ea42661aa9e83f1077e58b75a
+    sha256: 03da3a7c97a9f24371ccb4d187454bac5db7463bd5a38c22fc5d91ee8b436515
   build: h091b4b1_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Unlicense
-  size: 815079
-  timestamp: 1698855024189
+  size: 815120
+  timestamp: 1700684967912
 - platform: win-64
   name: libsqlite
-  version: 3.44.0
+  version: 3.44.1
   category: main
   manager: conda
   dependencies:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.1-hcfcfb64_0.conda
   hash:
-    md5: 446fb1973cfeb8b32de4add3c9ac1057
-    sha256: b2be4125343d89765269b537e90ea5ab7f219e7398e7ad610ddcdcf31e7b9e65
+    md5: cb795bb06d345285ce8b9a4b0553574f
+    sha256: cdcc7e14f0b12e521c2a7255a04a8c259b06a2c8394f7e571412c0e07ec514f5
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Unlicense
-  size: 852871
-  timestamp: 1698855272921
+  size: 853647
+  timestamp: 1700684837686
 - platform: linux-64
   name: libstdcxx-ng
   version: 13.2.0
@@ -2667,7 +2545,7 @@ package:
   timestamp: 1700245318212
 - platform: win-64
   name: libxml2
-  version: 2.11.5
+  version: 2.11.6
   category: main
   manager: conda
   dependencies:
@@ -2676,18 +2554,18 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.6-hc3477c8_0.conda
   hash:
-    md5: 27974f880a010b1441093d9f737a949f
-    sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
-  build: hc3477c8_1
+    md5: 08ffbb4c22dd3622e122058368f8b708
+    sha256: 6ed853ef69bf43998eacc6fd022d7ac170d9e2d3d273b0be0dc3da593fb0fc90
+  build: hc3477c8_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 1600640
-  timestamp: 1692960798126
+  size: 1627582
+  timestamp: 1700245325646
 - platform: linux-64
   name: libzlib
   version: 1.2.13
@@ -2816,7 +2694,7 @@ package:
   name: markdown
   version: 3.5.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - importlib-metadata >=4.4 ; python_version < '3.10'
   - mkdocs >=1.5 ; extra == 'docs'
@@ -2829,7 +2707,6 @@ package:
   - coverage ; extra == 'testing'
   - pyyaml ; extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/58/2c5a654173937d9f540a4971c569b44dcd55e5424a484d954cdaeebcf79c/Markdown-3.5.1-py3-none-any.whl#sha256=5874b47d4ee3f0b14d764324d2c94c03ea66bee56f2d929da9f2508d65e722dc
   hash:
     md5: null
@@ -2838,7 +2715,7 @@ package:
   name: markdown
   version: 3.5.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - importlib-metadata >=4.4 ; python_version < '3.10'
   - mkdocs >=1.5 ; extra == 'docs'
@@ -2851,7 +2728,6 @@ package:
   - coverage ; extra == 'testing'
   - pyyaml ; extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/58/2c5a654173937d9f540a4971c569b44dcd55e5424a484d954cdaeebcf79c/Markdown-3.5.1-py3-none-any.whl#sha256=5874b47d4ee3f0b14d764324d2c94c03ea66bee56f2d929da9f2508d65e722dc
   hash:
     md5: null
@@ -2860,7 +2736,7 @@ package:
   name: markdown
   version: 3.5.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - importlib-metadata >=4.4 ; python_version < '3.10'
   - mkdocs >=1.5 ; extra == 'docs'
@@ -2873,7 +2749,6 @@ package:
   - coverage ; extra == 'testing'
   - pyyaml ; extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/58/2c5a654173937d9f540a4971c569b44dcd55e5424a484d954cdaeebcf79c/Markdown-3.5.1-py3-none-any.whl#sha256=5874b47d4ee3f0b14d764324d2c94c03ea66bee56f2d929da9f2508d65e722dc
   hash:
     md5: null
@@ -2882,7 +2757,7 @@ package:
   name: markdown
   version: 3.5.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - importlib-metadata >=4.4 ; python_version < '3.10'
   - mkdocs >=1.5 ; extra == 'docs'
@@ -2895,7 +2770,6 @@ package:
   - coverage ; extra == 'testing'
   - pyyaml ; extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/58/2c5a654173937d9f540a4971c569b44dcd55e5424a484d954cdaeebcf79c/Markdown-3.5.1-py3-none-any.whl#sha256=5874b47d4ee3f0b14d764324d2c94c03ea66bee56f2d929da9f2508d65e722dc
   hash:
     md5: null
@@ -2904,10 +2778,8 @@ package:
   name: markupsafe
   version: 2.1.3
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/21/2eff1de472ca6c99ec3993eab11308787b9879af9ca8bbceb4868cf4f2ca/MarkupSafe-2.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=bfce63a9e7834b12b87c64d6b155fdd9b3b96191b6bd334bf37db7ff1fe457f2
   hash:
     md5: null
@@ -2916,22 +2788,18 @@ package:
   name: markupsafe
   version: 2.1.3
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
-  url: https://files.pythonhosted.org/packages/c0/c7/171f5ac6b065e1425e8fabf4a4dfbeca76fd8070072c6a41bd5c07d90d8b/MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_x86_64.whl#sha256=3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575
+  url: https://files.pythonhosted.org/packages/fe/09/c31503cb8150cf688c1534a7135cc39bb9092f8e0e6369ec73494d16ee0e/MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl#sha256=ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c
   hash:
     md5: null
-    sha256: 3c0fae6c3be832a0a0473ac912810b2877c8cb9d76ca48de1ed31e1c68386575
+    sha256: ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c
 - platform: osx-arm64
   name: markupsafe
   version: 2.1.3
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/09/c31503cb8150cf688c1534a7135cc39bb9092f8e0e6369ec73494d16ee0e/MarkupSafe-2.1.3-cp311-cp311-macosx_10_9_universal2.whl#sha256=ad9e82fb8f09ade1c3e1b996a6337afac2b8b9e365f926f5a61aacc71adc5b3c
   hash:
     md5: null
@@ -2940,10 +2808,8 @@ package:
   name: markupsafe
   version: 2.1.3
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/be/bb/08b85bc194034efbf572e70c3951549c8eca0ada25363afc154386b5390a/MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl#sha256=134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686
   hash:
     md5: null
@@ -2956,23 +2822,23 @@ package:
   dependencies:
   - intel-openmp 2023.*
   - tbb 2021.*
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50497.conda
   hash:
-    md5: 03da367d935ecf4d3e4005cf705d0e21
-    sha256: 40dc6ac2aa071ca248223de7cdbdfdb216bc8632a17104b1507bcbf9276265d4
-  build: h6a75c08_50496
+    md5: 064cea9f45531e7b53584acf4bd8b044
+    sha256: 46ec9e767279da219398b6e79c8fa95822b2ed3c8e02ab604615b7d1213a5d5a
+  build: h6a75c08_50497
   arch: x86_64
   subdir: win-64
-  build_number: 50496
+  build_number: 50497
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
-  size: 144749783
-  timestamp: 1695995252418
+  size: 144666110
+  timestamp: 1698352013664
 - platform: linux-64
   name: ml-dtypes
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >1.20
   - numpy >=1.23.3 ; python_version > '3.10'
@@ -2983,7 +2849,6 @@ package:
   - pylint >=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/87/91/d57c2d22e4801edeb7f3e7939214c0ea8a28c6e16f85208c2df2145e0213/ml_dtypes-0.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=e85ba8e24cf48d456e564688e981cf379d4c8e644db0a2f719b78de281bac2ca
   hash:
     md5: null
@@ -2992,7 +2857,7 @@ package:
   name: ml-dtypes
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >1.20
   - numpy >=1.23.3 ; python_version > '3.10'
@@ -3003,7 +2868,6 @@ package:
   - pylint >=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/15/da/43bee505963da0c730ee50e951c604bfdb90d4cccc9c0044c946b10e68a7/ml_dtypes-0.2.0-cp311-cp311-macosx_10_9_universal2.whl#sha256=e70047ec2c83eaee01afdfdabee2c5b0c133804d90d0f7db4dd903360fcc537c
   hash:
     md5: null
@@ -3012,7 +2876,7 @@ package:
   name: ml-dtypes
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >1.20
   - numpy >=1.23.3 ; python_version > '3.10'
@@ -3023,7 +2887,6 @@ package:
   - pylint >=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/15/da/43bee505963da0c730ee50e951c604bfdb90d4cccc9c0044c946b10e68a7/ml_dtypes-0.2.0-cp311-cp311-macosx_10_9_universal2.whl#sha256=e70047ec2c83eaee01afdfdabee2c5b0c133804d90d0f7db4dd903360fcc537c
   hash:
     md5: null
@@ -3032,7 +2895,7 @@ package:
   name: ml-dtypes
   version: 0.2.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >1.20
   - numpy >=1.23.3 ; python_version > '3.10'
@@ -3043,7 +2906,6 @@ package:
   - pylint >=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/08/89/c727fde1a3d12586e0b8c01abf53754707d76beaa9987640e70807d4545f/ml_dtypes-0.2.0-cp311-cp311-win_amd64.whl#sha256=832a019a1b6db5c4422032ca9940a990fa104eee420f643713241b3a518977fa
   hash:
     md5: null
@@ -3052,10 +2914,8 @@ package:
   name: mypy-extensions
   version: 1.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl#sha256=4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
   hash:
     md5: null
@@ -3064,10 +2924,8 @@ package:
   name: mypy-extensions
   version: 1.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl#sha256=4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
   hash:
     md5: null
@@ -3076,10 +2934,8 @@ package:
   name: mypy-extensions
   version: 1.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl#sha256=4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
   hash:
     md5: null
@@ -3088,10 +2944,8 @@ package:
   name: mypy-extensions
   version: 1.0.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl#sha256=4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d
   hash:
     md5: null
@@ -3177,6 +3031,8 @@ package:
   license_family: BSD
   size: 8039946
   timestamp: 1694920380273
+  purls:
+  - pkg:pypi/numpy
 - platform: osx-64
   name: numpy
   version: 1.26.0
@@ -3203,6 +3059,8 @@ package:
   license_family: BSD
   size: 7616817
   timestamp: 1694920728660
+  purls:
+  - pkg:pypi/numpy
 - platform: osx-arm64
   name: numpy
   version: 1.26.0
@@ -3230,6 +3088,8 @@ package:
   license_family: BSD
   size: 6780798
   timestamp: 1694920700859
+  purls:
+  - pkg:pypi/numpy
 - platform: win-64
   name: numpy
   version: 1.26.0
@@ -3258,18 +3118,19 @@ package:
   license_family: BSD
   size: 7085715
   timestamp: 1694920741486
+  purls:
+  - pkg:pypi/numpy
 - platform: linux-64
   name: oauthlib
   version: 3.2.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cryptography >=3.0.0 ; extra == 'rsa'
   - blinker >=1.4.0 ; extra == 'signals'
   - cryptography >=3.0.0 ; extra == 'signedtoken'
   - pyjwt <3, >=2.0.0 ; extra == 'signedtoken'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl#sha256=8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca
   hash:
     md5: null
@@ -3278,14 +3139,13 @@ package:
   name: oauthlib
   version: 3.2.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cryptography >=3.0.0 ; extra == 'rsa'
   - blinker >=1.4.0 ; extra == 'signals'
   - cryptography >=3.0.0 ; extra == 'signedtoken'
   - pyjwt <3, >=2.0.0 ; extra == 'signedtoken'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl#sha256=8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca
   hash:
     md5: null
@@ -3294,14 +3154,13 @@ package:
   name: oauthlib
   version: 3.2.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cryptography >=3.0.0 ; extra == 'rsa'
   - blinker >=1.4.0 ; extra == 'signals'
   - cryptography >=3.0.0 ; extra == 'signedtoken'
   - pyjwt <3, >=2.0.0 ; extra == 'signedtoken'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl#sha256=8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca
   hash:
     md5: null
@@ -3310,14 +3169,13 @@ package:
   name: oauthlib
   version: 3.2.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - cryptography >=3.0.0 ; extra == 'rsa'
   - blinker >=1.4.0 ; extra == 'signals'
   - cryptography >=3.0.0 ; extra == 'signedtoken'
   - pyjwt <3, >=2.0.0 ; extra == 'signedtoken'
   requires_python: '>=3.6'
-  extras: []
   url: https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl#sha256=8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca
   hash:
     md5: null
@@ -3414,7 +3272,7 @@ package:
   name: opt-einsum
   version: 3.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.7
   - sphinx ==1.2.3 ; extra == 'docs'
@@ -3425,7 +3283,6 @@ package:
   - pytest-cov ; extra == 'tests'
   - pytest-pep8 ; extra == 'tests'
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/19/404708a7e54ad2798907210462fd950c3442ea51acc8790f3da48d2bee8b/opt_einsum-3.3.0-py3-none-any.whl#sha256=2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147
   hash:
     md5: null
@@ -3434,7 +3291,7 @@ package:
   name: opt-einsum
   version: 3.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.7
   - sphinx ==1.2.3 ; extra == 'docs'
@@ -3445,7 +3302,6 @@ package:
   - pytest-cov ; extra == 'tests'
   - pytest-pep8 ; extra == 'tests'
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/19/404708a7e54ad2798907210462fd950c3442ea51acc8790f3da48d2bee8b/opt_einsum-3.3.0-py3-none-any.whl#sha256=2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147
   hash:
     md5: null
@@ -3454,7 +3310,7 @@ package:
   name: opt-einsum
   version: 3.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.7
   - sphinx ==1.2.3 ; extra == 'docs'
@@ -3465,7 +3321,6 @@ package:
   - pytest-cov ; extra == 'tests'
   - pytest-pep8 ; extra == 'tests'
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/19/404708a7e54ad2798907210462fd950c3442ea51acc8790f3da48d2bee8b/opt_einsum-3.3.0-py3-none-any.whl#sha256=2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147
   hash:
     md5: null
@@ -3474,7 +3329,7 @@ package:
   name: opt-einsum
   version: 3.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy >=1.7
   - sphinx ==1.2.3 ; extra == 'docs'
@@ -3485,7 +3340,6 @@ package:
   - pytest-cov ; extra == 'tests'
   - pytest-pep8 ; extra == 'tests'
   requires_python: '>=3.5'
-  extras: []
   url: https://files.pythonhosted.org/packages/bc/19/404708a7e54ad2798907210462fd950c3442ea51acc8790f3da48d2bee8b/opt_einsum-3.3.0-py3-none-any.whl#sha256=2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147
   hash:
     md5: null
@@ -3494,10 +3348,8 @@ package:
   name: packaging
   version: '23.2'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl#sha256=8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
   hash:
     md5: null
@@ -3506,10 +3358,8 @@ package:
   name: packaging
   version: '23.2'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl#sha256=8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
   hash:
     md5: null
@@ -3518,10 +3368,8 @@ package:
   name: packaging
   version: '23.2'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl#sha256=8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
   hash:
     md5: null
@@ -3530,10 +3378,8 @@ package:
   name: packaging
   version: '23.2'
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl#sha256=8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
   hash:
     md5: null
@@ -3542,10 +3388,8 @@ package:
   name: pathspec
   version: 0.11.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl#sha256=1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20
   hash:
     md5: null
@@ -3554,10 +3398,8 @@ package:
   name: pathspec
   version: 0.11.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl#sha256=1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20
   hash:
     md5: null
@@ -3566,10 +3408,8 @@ package:
   name: pathspec
   version: 0.11.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl#sha256=1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20
   hash:
     md5: null
@@ -3578,10 +3418,8 @@ package:
   name: pathspec
   version: 0.11.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl#sha256=1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20
   hash:
     md5: null
@@ -3590,7 +3428,7 @@ package:
   name: platformdirs
   version: 4.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - typing-extensions >=4.7.1 ; python_version < '3.8'
   - furo >=2023.7.26 ; extra == 'docs'
@@ -3603,7 +3441,6 @@ package:
   - pytest-mock >=3.11.1 ; extra == 'test'
   - pytest >=7.4 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/31/16/70be3b725073035aa5fc3229321d06e22e73e3e09f6af78dcfdf16c7636c/platformdirs-4.0.0-py3-none-any.whl#sha256=118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b
   hash:
     md5: null
@@ -3612,7 +3449,7 @@ package:
   name: platformdirs
   version: 4.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - typing-extensions >=4.7.1 ; python_version < '3.8'
   - furo >=2023.7.26 ; extra == 'docs'
@@ -3625,7 +3462,6 @@ package:
   - pytest-mock >=3.11.1 ; extra == 'test'
   - pytest >=7.4 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/31/16/70be3b725073035aa5fc3229321d06e22e73e3e09f6af78dcfdf16c7636c/platformdirs-4.0.0-py3-none-any.whl#sha256=118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b
   hash:
     md5: null
@@ -3634,7 +3470,7 @@ package:
   name: platformdirs
   version: 4.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - typing-extensions >=4.7.1 ; python_version < '3.8'
   - furo >=2023.7.26 ; extra == 'docs'
@@ -3647,7 +3483,6 @@ package:
   - pytest-mock >=3.11.1 ; extra == 'test'
   - pytest >=7.4 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/31/16/70be3b725073035aa5fc3229321d06e22e73e3e09f6af78dcfdf16c7636c/platformdirs-4.0.0-py3-none-any.whl#sha256=118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b
   hash:
     md5: null
@@ -3656,7 +3491,7 @@ package:
   name: platformdirs
   version: 4.0.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - typing-extensions >=4.7.1 ; python_version < '3.8'
   - furo >=2023.7.26 ; extra == 'docs'
@@ -3669,7 +3504,6 @@ package:
   - pytest-mock >=3.11.1 ; extra == 'test'
   - pytest >=7.4 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/31/16/70be3b725073035aa5fc3229321d06e22e73e3e09f6af78dcfdf16c7636c/platformdirs-4.0.0-py3-none-any.whl#sha256=118c954d7e949b35437270383a3f2531e99dd93cf7ce4dc8340d3356d30f173b
   hash:
     md5: null
@@ -3678,10 +3512,8 @@ package:
   name: protobuf
   version: 4.25.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/ae/5b/7ed02a9b8e752c8f7bca8661779c0275b9e3e6a903a3045e6da51f796dda/protobuf-4.25.1-cp37-abi3-manylinux2014_x86_64.whl#sha256=ca37bf6a6d0046272c152eea90d2e4ef34593aaa32e8873fc14c16440f22d4b7
   hash:
     md5: null
@@ -3690,10 +3522,8 @@ package:
   name: protobuf
   version: 4.25.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/e6/db/7b2edc72807d45d72f9db42f3eb86ddaf37f9e55d923159b1dbfc9d835bc/protobuf-4.25.1-cp37-abi3-macosx_10_9_universal2.whl#sha256=0bf384e75b92c42830c0a679b0cd4d6e2b36ae0cf3dbb1e1dfdda48a244f4bcd
   hash:
     md5: null
@@ -3702,10 +3532,8 @@ package:
   name: protobuf
   version: 4.25.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/e6/db/7b2edc72807d45d72f9db42f3eb86ddaf37f9e55d923159b1dbfc9d835bc/protobuf-4.25.1-cp37-abi3-macosx_10_9_universal2.whl#sha256=0bf384e75b92c42830c0a679b0cd4d6e2b36ae0cf3dbb1e1dfdda48a244f4bcd
   hash:
     md5: null
@@ -3714,10 +3542,8 @@ package:
   name: protobuf
   version: 4.25.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/fe/6b/7f177e8d6fe4caa14f4065433af9f879d4fab84f0d17dcba7b407f6bd808/protobuf-4.25.1-cp310-abi3-win_amd64.whl#sha256=3497c1af9f2526962f09329fd61a36566305e6c72da2590ae0d7d1322818843b
   hash:
     md5: null
@@ -3742,61 +3568,52 @@ package:
   timestamp: 1537755684331
 - platform: linux-64
   name: pyasn1
-  version: 0.5.0
+  version: 0.5.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
-  url: https://files.pythonhosted.org/packages/14/e5/b56a725cbde139aa960c26a1a3ca4d4af437282e20b5314ee6a3501e7dfc/pyasn1-0.5.0-py2.py3-none-any.whl#sha256=87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+  url: https://files.pythonhosted.org/packages/d1/75/4686d2872bf2fc0b37917cbc8bbf0dd3a5cdb0990799be1b9cbf1e1eb733/pyasn1-0.5.1-py2.py3-none-any.whl#sha256=4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
   hash:
     md5: null
-    sha256: 87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+    sha256: 4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
 - platform: osx-64
   name: pyasn1
-  version: 0.5.0
+  version: 0.5.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
-  url: https://files.pythonhosted.org/packages/14/e5/b56a725cbde139aa960c26a1a3ca4d4af437282e20b5314ee6a3501e7dfc/pyasn1-0.5.0-py2.py3-none-any.whl#sha256=87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+  url: https://files.pythonhosted.org/packages/d1/75/4686d2872bf2fc0b37917cbc8bbf0dd3a5cdb0990799be1b9cbf1e1eb733/pyasn1-0.5.1-py2.py3-none-any.whl#sha256=4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
   hash:
     md5: null
-    sha256: 87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+    sha256: 4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
 - platform: osx-arm64
   name: pyasn1
-  version: 0.5.0
+  version: 0.5.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
-  url: https://files.pythonhosted.org/packages/14/e5/b56a725cbde139aa960c26a1a3ca4d4af437282e20b5314ee6a3501e7dfc/pyasn1-0.5.0-py2.py3-none-any.whl#sha256=87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+  url: https://files.pythonhosted.org/packages/d1/75/4686d2872bf2fc0b37917cbc8bbf0dd3a5cdb0990799be1b9cbf1e1eb733/pyasn1-0.5.1-py2.py3-none-any.whl#sha256=4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
   hash:
     md5: null
-    sha256: 87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+    sha256: 4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
 - platform: win-64
   name: pyasn1
-  version: 0.5.0
+  version: 0.5.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
-  url: https://files.pythonhosted.org/packages/14/e5/b56a725cbde139aa960c26a1a3ca4d4af437282e20b5314ee6a3501e7dfc/pyasn1-0.5.0-py2.py3-none-any.whl#sha256=87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+  url: https://files.pythonhosted.org/packages/d1/75/4686d2872bf2fc0b37917cbc8bbf0dd3a5cdb0990799be1b9cbf1e1eb733/pyasn1-0.5.1-py2.py3-none-any.whl#sha256=4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
   hash:
     md5: null
-    sha256: 87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57
+    sha256: 4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58
 - platform: linux-64
   name: pyasn1-modules
   version: 0.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 <0.6.0, >=0.4.6
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/cd/8e/bea464350e1b8c6ed0da3a312659cb648804a08af6cacc6435867f74f8bd/pyasn1_modules-0.3.0-py2.py3-none-any.whl#sha256=d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d
   hash:
     md5: null
@@ -3805,11 +3622,10 @@ package:
   name: pyasn1-modules
   version: 0.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 <0.6.0, >=0.4.6
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/cd/8e/bea464350e1b8c6ed0da3a312659cb648804a08af6cacc6435867f74f8bd/pyasn1_modules-0.3.0-py2.py3-none-any.whl#sha256=d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d
   hash:
     md5: null
@@ -3818,11 +3634,10 @@ package:
   name: pyasn1-modules
   version: 0.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 <0.6.0, >=0.4.6
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/cd/8e/bea464350e1b8c6ed0da3a312659cb648804a08af6cacc6435867f74f8bd/pyasn1_modules-0.3.0-py2.py3-none-any.whl#sha256=d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d
   hash:
     md5: null
@@ -3831,11 +3646,10 @@ package:
   name: pyasn1-modules
   version: 0.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 <0.6.0, >=0.4.6
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/cd/8e/bea464350e1b8c6ed0da3a312659cb648804a08af6cacc6435867f74f8bd/pyasn1_modules-0.3.0-py2.py3-none-any.whl#sha256=d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d
   hash:
     md5: null
@@ -3844,7 +3658,7 @@ package:
   name: pyboy
   version: 1.6.6
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy
   - pysdl2
@@ -3854,7 +3668,6 @@ package:
   - pdoc3 ; extra == 'all'
   - gym ; extra == 'all'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/b8/50/7425532d3e3ea4107a095617c16484b88f507fd77f172ce90bab366d32c6/pyboy-1.6.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl#sha256=4e60e8faf92836c91123529dcbb1daf5d686d16d8bc23009d4d69db722bdeae6
   hash:
     md5: null
@@ -3863,7 +3676,7 @@ package:
   name: pyboy
   version: 1.6.6
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy
   - pysdl2
@@ -3873,7 +3686,6 @@ package:
   - pdoc3 ; extra == 'all'
   - gym ; extra == 'all'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/57/0f/85fbc988095c614ebec2ea471dac5fc777bd9083e235cbcc45cea4275c06/pyboy-1.6.6-cp311-cp311-macosx_10_9_universal2.whl#sha256=14c56a005c8272b4e9e956ab6e6f3c8855a2fab5732d2367dd84c08460367c2c
   hash:
     md5: null
@@ -3882,7 +3694,7 @@ package:
   name: pyboy
   version: 1.6.6
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy
   - pysdl2
@@ -3892,7 +3704,6 @@ package:
   - pdoc3 ; extra == 'all'
   - gym ; extra == 'all'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/57/0f/85fbc988095c614ebec2ea471dac5fc777bd9083e235cbcc45cea4275c06/pyboy-1.6.6-cp311-cp311-macosx_10_9_universal2.whl#sha256=14c56a005c8272b4e9e956ab6e6f3c8855a2fab5732d2367dd84c08460367c2c
   hash:
     md5: null
@@ -3901,7 +3712,7 @@ package:
   name: pyboy
   version: 1.6.6
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - numpy
   - pysdl2
@@ -3911,7 +3722,6 @@ package:
   - pdoc3 ; extra == 'all'
   - gym ; extra == 'all'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/66/e7/1c223e5e749fe568a0c8e24def8e0004da1fbc48e3f4cabb449ee655deaa/pyboy-1.6.6-cp311-cp311-win_amd64.whl#sha256=bc10363e3b83330c1bb19fc9a16590a6308f94f37df12b0db93ff1c164c1a43c
   hash:
     md5: null
@@ -3920,9 +3730,7 @@ package:
   name: pysdl2
   version: 0.9.12
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/93/01/e5ea0002b3b9bd366efd76b2baf941d6afda736ef6841f41656c21d0a8f9/PySDL2-0.9.12-py3-none-any.whl#sha256=e5e766e3551eae82ba8a406a34e78a512eadd427524b2110b26809e0cb6aab85
   hash:
     md5: null
@@ -3931,9 +3739,7 @@ package:
   name: pysdl2
   version: 0.9.12
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/93/01/e5ea0002b3b9bd366efd76b2baf941d6afda736ef6841f41656c21d0a8f9/PySDL2-0.9.12-py3-none-any.whl#sha256=e5e766e3551eae82ba8a406a34e78a512eadd427524b2110b26809e0cb6aab85
   hash:
     md5: null
@@ -3942,9 +3748,7 @@ package:
   name: pysdl2
   version: 0.9.12
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/93/01/e5ea0002b3b9bd366efd76b2baf941d6afda736ef6841f41656c21d0a8f9/PySDL2-0.9.12-py3-none-any.whl#sha256=e5e766e3551eae82ba8a406a34e78a512eadd427524b2110b26809e0cb6aab85
   hash:
     md5: null
@@ -3953,9 +3757,7 @@ package:
   name: pysdl2
   version: 0.9.12
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/93/01/e5ea0002b3b9bd366efd76b2baf941d6afda736ef6841f41656c21d0a8f9/PySDL2-0.9.12-py3-none-any.whl#sha256=e5e766e3551eae82ba8a406a34e78a512eadd427524b2110b26809e0cb6aab85
   hash:
     md5: null
@@ -3964,9 +3766,7 @@ package:
   name: pysdl2-dll
   version: 2.28.4
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/8e/19/c7bd736204ed2b08f0e3fc993d1d83d84a77bf69c740314498cf9a03e700/pysdl2_dll-2.28.4-py2.py3-none-manylinux2014_x86_64.whl#sha256=d77f13a0f411abb3abd6d49f8b41c1373f72b86b1973236023dc37d563c2d0db
   hash:
     md5: null
@@ -3975,20 +3775,16 @@ package:
   name: pysdl2-dll
   version: 2.28.4
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
-  url: https://files.pythonhosted.org/packages/d5/5f/f81e86c7ab456b2621b84a1c9d8dcc9e8c2655aa6a29db9b6c58d04f198d/pysdl2_dll-2.28.4-py2.py3-none-macosx_10_11_x86_64.whl#sha256=a35ab0f06b9e42ba12575b6960ad7ea013fc0f49e6935b4b53d66a0a06668eae
+  manager: pypi
+  url: https://files.pythonhosted.org/packages/c4/6d/d126e2f31422a8fecdcd72f1d4a2ef744744cabeefddb9fa7fdfbe904597/pysdl2_dll-2.28.4-py2.py3-none-macosx_10_11_universal2.whl#sha256=1acff652e62f906109a6ca4874ff1e210eebb4989df651955c48add43f89c077
   hash:
     md5: null
-    sha256: a35ab0f06b9e42ba12575b6960ad7ea013fc0f49e6935b4b53d66a0a06668eae
+    sha256: 1acff652e62f906109a6ca4874ff1e210eebb4989df651955c48add43f89c077
 - platform: osx-arm64
   name: pysdl2-dll
   version: 2.28.4
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/c4/6d/d126e2f31422a8fecdcd72f1d4a2ef744744cabeefddb9fa7fdfbe904597/pysdl2_dll-2.28.4-py2.py3-none-macosx_10_11_universal2.whl#sha256=1acff652e62f906109a6ca4874ff1e210eebb4989df651955c48add43f89c077
   hash:
     md5: null
@@ -3997,9 +3793,7 @@ package:
   name: pysdl2-dll
   version: 2.28.4
   category: main
-  manager: pip
-  requires_dist: []
-  extras: []
+  manager: pypi
   url: https://files.pythonhosted.org/packages/51/05/8ed2f36afe7deebb019d23c6ea4925d3db880beb2bedc2b590cc7c8ed203/pysdl2_dll-2.28.4-py2.py3-none-win_amd64.whl#sha256=667628a119e00f45aed279e480516ccc484c2f9a5d03c901dd1996c3af4c5840
   hash:
     md5: null
@@ -4271,7 +4065,7 @@ package:
   name: requests
   version: 2.31.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - charset-normalizer <4, >=2
   - idna <4, >=2.5
@@ -4280,7 +4074,6 @@ package:
   - PySocks !=1.5.7, >=1.5.6 ; extra == 'socks'
   - chardet <6, >=3.0.2 ; extra == 'use_chardet_on_py3'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl#sha256=58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
   hash:
     md5: null
@@ -4289,7 +4082,7 @@ package:
   name: requests
   version: 2.31.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - charset-normalizer <4, >=2
   - idna <4, >=2.5
@@ -4298,7 +4091,6 @@ package:
   - PySocks !=1.5.7, >=1.5.6 ; extra == 'socks'
   - chardet <6, >=3.0.2 ; extra == 'use_chardet_on_py3'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl#sha256=58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
   hash:
     md5: null
@@ -4307,7 +4099,7 @@ package:
   name: requests
   version: 2.31.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - charset-normalizer <4, >=2
   - idna <4, >=2.5
@@ -4316,7 +4108,6 @@ package:
   - PySocks !=1.5.7, >=1.5.6 ; extra == 'socks'
   - chardet <6, >=3.0.2 ; extra == 'use_chardet_on_py3'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl#sha256=58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
   hash:
     md5: null
@@ -4325,7 +4116,7 @@ package:
   name: requests
   version: 2.31.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - charset-normalizer <4, >=2
   - idna <4, >=2.5
@@ -4334,7 +4125,6 @@ package:
   - PySocks !=1.5.7, >=1.5.6 ; extra == 'socks'
   - chardet <6, >=3.0.2 ; extra == 'use_chardet_on_py3'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl#sha256=58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
   hash:
     md5: null
@@ -4343,13 +4133,12 @@ package:
   name: requests-oauthlib
   version: 1.3.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - oauthlib >=3.0.0
   - requests >=2.0.0
   - oauthlib[signedtoken] >=3.0.0 ; extra == 'rsa'
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/6f/bb/5deac77a9af870143c684ab46a7934038a53eb4aa975bc0687ed6ca2c610/requests_oauthlib-1.3.1-py2.py3-none-any.whl#sha256=2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5
   hash:
     md5: null
@@ -4358,13 +4147,12 @@ package:
   name: requests-oauthlib
   version: 1.3.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - oauthlib >=3.0.0
   - requests >=2.0.0
   - oauthlib[signedtoken] >=3.0.0 ; extra == 'rsa'
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/6f/bb/5deac77a9af870143c684ab46a7934038a53eb4aa975bc0687ed6ca2c610/requests_oauthlib-1.3.1-py2.py3-none-any.whl#sha256=2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5
   hash:
     md5: null
@@ -4373,13 +4161,12 @@ package:
   name: requests-oauthlib
   version: 1.3.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - oauthlib >=3.0.0
   - requests >=2.0.0
   - oauthlib[signedtoken] >=3.0.0 ; extra == 'rsa'
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/6f/bb/5deac77a9af870143c684ab46a7934038a53eb4aa975bc0687ed6ca2c610/requests_oauthlib-1.3.1-py2.py3-none-any.whl#sha256=2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5
   hash:
     md5: null
@@ -4388,13 +4175,12 @@ package:
   name: requests-oauthlib
   version: 1.3.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - oauthlib >=3.0.0
   - requests >=2.0.0
   - oauthlib[signedtoken] >=3.0.0 ; extra == 'rsa'
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/6f/bb/5deac77a9af870143c684ab46a7934038a53eb4aa975bc0687ed6ca2c610/requests_oauthlib-1.3.1-py2.py3-none-any.whl#sha256=2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5
   hash:
     md5: null
@@ -4403,11 +4189,10 @@ package:
   name: rsa
   version: '4.9'
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 >=0.1.3
   requires_python: '>=3.6, <4'
-  extras: []
   url: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl#sha256=90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
   hash:
     md5: null
@@ -4416,11 +4201,10 @@ package:
   name: rsa
   version: '4.9'
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 >=0.1.3
   requires_python: '>=3.6, <4'
-  extras: []
   url: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl#sha256=90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
   hash:
     md5: null
@@ -4429,11 +4213,10 @@ package:
   name: rsa
   version: '4.9'
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 >=0.1.3
   requires_python: '>=3.6, <4'
-  extras: []
   url: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl#sha256=90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
   hash:
     md5: null
@@ -4442,22 +4225,22 @@ package:
   name: rsa
   version: '4.9'
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pyasn1 >=0.1.3
   requires_python: '>=3.6, <4'
-  extras: []
   url: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl#sha256=90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
   hash:
     md5: null
     sha256: 90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
 - platform: linux-64
   name: setuptools
-  version: 68.2.2
+  version: 69.0.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - sphinx >=3.5 ; extra == 'docs'
+  - sphinx <7.2.5 ; extra == 'docs'
   - jaraco.packaging >=9.3 ; extra == 'docs'
   - rst.linker >=1.9 ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -4469,7 +4252,6 @@ package:
   - sphinx-reredirects ; extra == 'docs'
   - sphinxcontrib-towncrier ; extra == 'docs'
   - sphinx-notfound-page <2, >=1 ; extra == 'docs'
-  - sphinx-hoverxref <2 ; extra == 'docs'
   - pytest >=6 ; extra == 'testing'
   - pytest-checkdocs >=2.4 ; extra == 'testing'
   - pytest-enabler >=2.2 ; extra == 'testing'
@@ -4503,18 +4285,18 @@ package:
   - pytest-ruff ; sys_platform != 'cygwin' and extra == 'testing'
   - pytest-perf ; sys_platform != 'cygwin' and extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl#sha256=b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+  url: https://files.pythonhosted.org/packages/bb/e1/ed2dd0850446b8697ad28d118df885ad04140c64ace06c4bd559f7c8a94f/setuptools-69.0.2-py3-none-any.whl#sha256=1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
   hash:
     md5: null
-    sha256: b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+    sha256: 1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
 - platform: osx-64
   name: setuptools
-  version: 68.2.2
+  version: 69.0.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - sphinx >=3.5 ; extra == 'docs'
+  - sphinx <7.2.5 ; extra == 'docs'
   - jaraco.packaging >=9.3 ; extra == 'docs'
   - rst.linker >=1.9 ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -4526,7 +4308,6 @@ package:
   - sphinx-reredirects ; extra == 'docs'
   - sphinxcontrib-towncrier ; extra == 'docs'
   - sphinx-notfound-page <2, >=1 ; extra == 'docs'
-  - sphinx-hoverxref <2 ; extra == 'docs'
   - pytest >=6 ; extra == 'testing'
   - pytest-checkdocs >=2.4 ; extra == 'testing'
   - pytest-enabler >=2.2 ; extra == 'testing'
@@ -4560,18 +4341,18 @@ package:
   - pytest-ruff ; sys_platform != 'cygwin' and extra == 'testing'
   - pytest-perf ; sys_platform != 'cygwin' and extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl#sha256=b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+  url: https://files.pythonhosted.org/packages/bb/e1/ed2dd0850446b8697ad28d118df885ad04140c64ace06c4bd559f7c8a94f/setuptools-69.0.2-py3-none-any.whl#sha256=1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
   hash:
     md5: null
-    sha256: b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+    sha256: 1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
 - platform: osx-arm64
   name: setuptools
-  version: 68.2.2
+  version: 69.0.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - sphinx >=3.5 ; extra == 'docs'
+  - sphinx <7.2.5 ; extra == 'docs'
   - jaraco.packaging >=9.3 ; extra == 'docs'
   - rst.linker >=1.9 ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -4583,7 +4364,6 @@ package:
   - sphinx-reredirects ; extra == 'docs'
   - sphinxcontrib-towncrier ; extra == 'docs'
   - sphinx-notfound-page <2, >=1 ; extra == 'docs'
-  - sphinx-hoverxref <2 ; extra == 'docs'
   - pytest >=6 ; extra == 'testing'
   - pytest-checkdocs >=2.4 ; extra == 'testing'
   - pytest-enabler >=2.2 ; extra == 'testing'
@@ -4617,18 +4397,18 @@ package:
   - pytest-ruff ; sys_platform != 'cygwin' and extra == 'testing'
   - pytest-perf ; sys_platform != 'cygwin' and extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl#sha256=b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+  url: https://files.pythonhosted.org/packages/bb/e1/ed2dd0850446b8697ad28d118df885ad04140c64ace06c4bd559f7c8a94f/setuptools-69.0.2-py3-none-any.whl#sha256=1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
   hash:
     md5: null
-    sha256: b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+    sha256: 1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
 - platform: win-64
   name: setuptools
-  version: 68.2.2
+  version: 69.0.2
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - sphinx >=3.5 ; extra == 'docs'
+  - sphinx <7.2.5 ; extra == 'docs'
   - jaraco.packaging >=9.3 ; extra == 'docs'
   - rst.linker >=1.9 ; extra == 'docs'
   - furo ; extra == 'docs'
@@ -4640,7 +4420,6 @@ package:
   - sphinx-reredirects ; extra == 'docs'
   - sphinxcontrib-towncrier ; extra == 'docs'
   - sphinx-notfound-page <2, >=1 ; extra == 'docs'
-  - sphinx-hoverxref <2 ; extra == 'docs'
   - pytest >=6 ; extra == 'testing'
   - pytest-checkdocs >=2.4 ; extra == 'testing'
   - pytest-enabler >=2.2 ; extra == 'testing'
@@ -4674,19 +4453,16 @@ package:
   - pytest-ruff ; sys_platform != 'cygwin' and extra == 'testing'
   - pytest-perf ; sys_platform != 'cygwin' and extra == 'testing'
   requires_python: '>=3.8'
-  extras: []
-  url: https://files.pythonhosted.org/packages/bb/26/7945080113158354380a12ce26873dd6c1ebd88d47f5bc24e2c5bb38c16a/setuptools-68.2.2-py3-none-any.whl#sha256=b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+  url: https://files.pythonhosted.org/packages/bb/e1/ed2dd0850446b8697ad28d118df885ad04140c64ace06c4bd559f7c8a94f/setuptools-69.0.2-py3-none-any.whl#sha256=1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
   hash:
     md5: null
-    sha256: b454a35605876da60632df1a60f736524eb73cc47bbc9f3f1ef1b644de74fd2a
+    sha256: 1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2
 - platform: linux-64
   name: six
   version: 1.16.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl#sha256=8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   hash:
     md5: null
@@ -4695,10 +4471,8 @@ package:
   name: six
   version: 1.16.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl#sha256=8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   hash:
     md5: null
@@ -4707,10 +4481,8 @@ package:
   name: six
   version: 1.16.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl#sha256=8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   hash:
     md5: null
@@ -4719,10 +4491,8 @@ package:
   name: six
   version: 1.16.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*'
-  extras: []
   url: https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl#sha256=8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   hash:
     md5: null
@@ -4753,7 +4523,7 @@ package:
   name: tensorboard
   version: 2.14.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=0.4
   - grpcio >=1.48.2
@@ -4768,7 +4538,6 @@ package:
   - tensorboard-data-server <0.8.0, >=0.7.0
   - werkzeug >=1.0.1
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/73/a2/66ed644f6ed1562e0285fcd959af17670ea313c8f331c46f79ee77187eb9/tensorboard-2.14.1-py3-none-any.whl#sha256=3db108fb58f023b6439880e177743c5f1e703e9eeb5fb7d597871f949f85fd58
   hash:
     md5: null
@@ -4777,7 +4546,7 @@ package:
   name: tensorboard
   version: 2.14.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=0.4
   - grpcio >=1.48.2
@@ -4792,7 +4561,6 @@ package:
   - tensorboard-data-server <0.8.0, >=0.7.0
   - werkzeug >=1.0.1
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/73/a2/66ed644f6ed1562e0285fcd959af17670ea313c8f331c46f79ee77187eb9/tensorboard-2.14.1-py3-none-any.whl#sha256=3db108fb58f023b6439880e177743c5f1e703e9eeb5fb7d597871f949f85fd58
   hash:
     md5: null
@@ -4801,7 +4569,7 @@ package:
   name: tensorboard
   version: 2.14.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=0.4
   - grpcio >=1.48.2
@@ -4816,7 +4584,6 @@ package:
   - tensorboard-data-server <0.8.0, >=0.7.0
   - werkzeug >=1.0.1
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/73/a2/66ed644f6ed1562e0285fcd959af17670ea313c8f331c46f79ee77187eb9/tensorboard-2.14.1-py3-none-any.whl#sha256=3db108fb58f023b6439880e177743c5f1e703e9eeb5fb7d597871f949f85fd58
   hash:
     md5: null
@@ -4825,7 +4592,7 @@ package:
   name: tensorboard
   version: 2.14.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=0.4
   - grpcio >=1.48.2
@@ -4840,7 +4607,6 @@ package:
   - tensorboard-data-server <0.8.0, >=0.7.0
   - werkzeug >=1.0.1
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/73/a2/66ed644f6ed1562e0285fcd959af17670ea313c8f331c46f79ee77187eb9/tensorboard-2.14.1-py3-none-any.whl#sha256=3db108fb58f023b6439880e177743c5f1e703e9eeb5fb7d597871f949f85fd58
   hash:
     md5: null
@@ -4849,10 +4615,8 @@ package:
   name: tensorboard-data-server
   version: 0.7.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl#sha256=7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
   hash:
     md5: null
@@ -4861,10 +4625,8 @@ package:
   name: tensorboard-data-server
   version: 0.7.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl#sha256=7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
   hash:
     md5: null
@@ -4873,10 +4635,8 @@ package:
   name: tensorboard-data-server
   version: 0.7.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl#sha256=7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
   hash:
     md5: null
@@ -4885,10 +4645,8 @@ package:
   name: tensorboard-data-server
   version: 0.7.2
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl#sha256=7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb
   hash:
     md5: null
@@ -4897,7 +4655,7 @@ package:
   name: tensorflow
   version: 2.14.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=1.0.0
   - astunparse >=1.6.0
@@ -4935,7 +4693,6 @@ package:
   - nvidia-cuda-nvcc-cu11 ==11.8.89 ; extra == 'and-cuda'
   - tensorrt ==8.5.3.1 ; extra == 'and-cuda'
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/09/63/25e76075081ea98ec48f23929cefee58be0b42212e38074a9ec5c19e838c/tensorflow-2.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=a80cabe6ab5f44280c05533e5b4a08e5b128f0d68d112564cffa3b96638e28aa
   hash:
     md5: null
@@ -4944,7 +4701,7 @@ package:
   name: tensorflow
   version: 2.14.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=1.0.0
   - astunparse >=1.6.0
@@ -4980,7 +4737,6 @@ package:
   - nvidia-cuda-nvcc-cu11 ==11.8.89 ; extra == 'and-cuda'
   - tensorrt ==8.5.3.1 ; extra == 'and-cuda'
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/22/50/1e211cbb5e1f52e55eeae1605789c9d24403962d37581cf0deb3e6b33377/tensorflow-2.14.0-cp311-cp311-macosx_10_15_x86_64.whl#sha256=00c42e7d8280c660b10cf5d0b3164fdc5e38fd0bf16b3f9963b7cd0e546346d8
   hash:
     md5: null
@@ -4989,7 +4745,7 @@ package:
   name: tensorflow
   version: 2.14.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - tensorflow-macos ==2.14.0 ; platform_system == 'Darwin' and platform_machine == 'arm64'
   - tensorflow-cpu-aws ==2.14.0 ; platform_system == 'Linux' and (platform_machine == 'arm64' or platform_machine == 'aarch64')
@@ -5006,7 +4762,6 @@ package:
   - nvidia-nccl-cu11 ==2.16.5 ; extra == 'and-cuda'
   - tensorrt ==8.5.3.1 ; extra == 'and-cuda'
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/de/ea/90267db2c02fb61f4d03b9645c7446d3cbca6d5c08522e889535c88edfcd/tensorflow-2.14.0-cp311-cp311-macosx_12_0_arm64.whl#sha256=c92f5526c2029d31a036be06eb229c71f1c1821472876d34d0184d19908e318c
   hash:
     md5: null
@@ -5015,7 +4770,7 @@ package:
   name: tensorflow
   version: 2.14.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - tensorflow-macos ==2.14.0 ; platform_system == 'Darwin' and platform_machine == 'arm64'
   - tensorflow-cpu-aws ==2.14.0 ; platform_system == 'Linux' and (platform_machine == 'arm64' or platform_machine == 'aarch64')
@@ -5032,7 +4787,6 @@ package:
   - nvidia-nccl-cu11 ==2.16.5 ; extra == 'and-cuda'
   - tensorrt ==8.5.3.1 ; extra == 'and-cuda'
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/80/6f/57d36f6507e432d7fc1956b2e9e8530c5c2d2bfcd8821bcbfae271cd6688/tensorflow-2.14.0-cp311-cp311-win_amd64.whl#sha256=0587ece626c4f7c4fcb2132525ea6c77ad2f2f5659a9b0f4451b1000be1b5e16
   hash:
     md5: null
@@ -5041,10 +4795,8 @@ package:
   name: tensorflow-estimator
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/d1/da/4f264c196325bb6e37a6285caec5b12a03def489b57cc1fdac02bb6272cd/tensorflow_estimator-2.14.0-py2.py3-none-any.whl#sha256=820bf57c24aa631abb1bbe4371739ed77edb11361d61381fd8e790115ac0fd57
   hash:
     md5: null
@@ -5053,10 +4805,8 @@ package:
   name: tensorflow-estimator
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/d1/da/4f264c196325bb6e37a6285caec5b12a03def489b57cc1fdac02bb6272cd/tensorflow_estimator-2.14.0-py2.py3-none-any.whl#sha256=820bf57c24aa631abb1bbe4371739ed77edb11361d61381fd8e790115ac0fd57
   hash:
     md5: null
@@ -5065,10 +4815,8 @@ package:
   name: tensorflow-estimator
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/d1/da/4f264c196325bb6e37a6285caec5b12a03def489b57cc1fdac02bb6272cd/tensorflow_estimator-2.14.0-py2.py3-none-any.whl#sha256=820bf57c24aa631abb1bbe4371739ed77edb11361d61381fd8e790115ac0fd57
   hash:
     md5: null
@@ -5077,10 +4825,8 @@ package:
   name: tensorflow-estimator
   version: 2.14.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/d1/da/4f264c196325bb6e37a6285caec5b12a03def489b57cc1fdac02bb6272cd/tensorflow_estimator-2.14.0-py2.py3-none-any.whl#sha256=820bf57c24aa631abb1bbe4371739ed77edb11361d61381fd8e790115ac0fd57
   hash:
     md5: null
@@ -5089,7 +4835,7 @@ package:
   name: tensorflow-intel
   version: 2.14.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=1.0.0
   - astunparse >=1.6.0
@@ -5125,7 +4871,6 @@ package:
   - nvidia-cuda-nvcc-cu11 ==11.8.89 ; extra == 'and-cuda'
   - tensorrt ==8.5.3.1 ; extra == 'and-cuda'
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/ad/6e/1bfe367855dd87467564f7bf9fa14f3b17889988e79598bc37bf18f5ffb6/tensorflow_intel-2.14.0-cp311-cp311-win_amd64.whl#sha256=51f96c729d61ff8e2e340df5b3b4db81a938258f1c9282ab09277896d0c408ae
   hash:
     md5: null
@@ -5134,7 +4879,7 @@ package:
   name: tensorflow-io-gcs-filesystem
   version: 0.34.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - tensorflow <2.14.0, >=2.13.0 ; extra == 'tensorflow'
   - tensorflow-aarch64 <2.14.0, >=2.13.0 ; extra == 'tensorflow-aarch64'
@@ -5142,7 +4887,6 @@ package:
   - tensorflow-gpu <2.14.0, >=2.13.0 ; extra == 'tensorflow-gpu'
   - tensorflow-rocm <2.14.0, >=2.13.0 ; extra == 'tensorflow-rocm'
   requires_python: '>=3.7, <3.12'
-  extras: []
   url: https://files.pythonhosted.org/packages/4c/64/245746084cdd5fafa680a6e7effeecf87abeeac2796decfa835a99b397c7/tensorflow_io_gcs_filesystem-0.34.0-cp311-cp311-manylinux_2_12_x86_64.manylinux2010_x86_64.whl#sha256=cbe26c4a3332589c7b724f147df453b5c226993aa8d346a15536358d77b364c4
   hash:
     md5: null
@@ -5151,7 +4895,7 @@ package:
   name: tensorflow-io-gcs-filesystem
   version: 0.34.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - tensorflow <2.14.0, >=2.13.0 ; extra == 'tensorflow'
   - tensorflow-aarch64 <2.14.0, >=2.13.0 ; extra == 'tensorflow-aarch64'
@@ -5159,7 +4903,6 @@ package:
   - tensorflow-gpu <2.14.0, >=2.13.0 ; extra == 'tensorflow-gpu'
   - tensorflow-rocm <2.14.0, >=2.13.0 ; extra == 'tensorflow-rocm'
   requires_python: '>=3.7, <3.12'
-  extras: []
   url: https://files.pythonhosted.org/packages/3d/34/252794e3f737594f8ac4ac9f2ee9ba7b806b6825832af3ff9b2fd893ce8f/tensorflow_io_gcs_filesystem-0.34.0-cp311-cp311-macosx_10_14_x86_64.whl#sha256=a17a616d2c7fae83de4424404815843507d40d4eb0d507c636a5493a20c3d958
   hash:
     md5: null
@@ -5168,7 +4911,7 @@ package:
   name: tensorflow-io-gcs-filesystem
   version: 0.34.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - tensorflow <2.14.0, >=2.13.0 ; extra == 'tensorflow'
   - tensorflow-aarch64 <2.14.0, >=2.13.0 ; extra == 'tensorflow-aarch64'
@@ -5176,7 +4919,6 @@ package:
   - tensorflow-gpu <2.14.0, >=2.13.0 ; extra == 'tensorflow-gpu'
   - tensorflow-rocm <2.14.0, >=2.13.0 ; extra == 'tensorflow-rocm'
   requires_python: '>=3.7, <3.12'
-  extras: []
   url: https://files.pythonhosted.org/packages/5b/e9/1444afc87596a90066704cc46ed661a4e7b348eec03a3fc2ca10ab917254/tensorflow_io_gcs_filesystem-0.34.0-cp311-cp311-macosx_12_0_arm64.whl#sha256=ec4604c99cbb5b708f4516dee27aa655abae222b876c98b740f4c2f89dd5c001
   hash:
     md5: null
@@ -5185,7 +4927,7 @@ package:
   name: tensorflow-io-gcs-filesystem
   version: 0.31.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - tensorflow <2.12.0, >=2.11.0 ; extra == 'tensorflow'
   - tensorflow-aarch64 <2.12.0, >=2.11.0 ; extra == 'tensorflow-aarch64'
@@ -5193,7 +4935,6 @@ package:
   - tensorflow-gpu <2.12.0, >=2.11.0 ; extra == 'tensorflow-gpu'
   - tensorflow-rocm <2.12.0, >=2.11.0 ; extra == 'tensorflow-rocm'
   requires_python: '>=3.7, <3.12'
-  extras: []
   url: https://files.pythonhosted.org/packages/ac/4e/9566a313927be582ca99455a9523a097c7888fc819695bdc08415432b202/tensorflow_io_gcs_filesystem-0.31.0-cp311-cp311-win_amd64.whl#sha256=4bb37d23f21c434687b11059cb7ffd094d52a7813368915ba1b7057e3c16e414
   hash:
     md5: null
@@ -5202,7 +4943,7 @@ package:
   name: tensorflow-macos
   version: 2.14.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - absl-py >=1.0.0
   - astunparse >=1.6.0
@@ -5238,7 +4979,6 @@ package:
   - nvidia-cuda-nvcc-cu11 ==11.8.89 ; extra == 'and-cuda'
   - tensorrt ==8.5.3.1 ; extra == 'and-cuda'
   requires_python: '>=3.9'
-  extras: []
   url: https://files.pythonhosted.org/packages/d3/4b/ae9037ea22ba94eb2cf267e991384c3444f3e6142fa49923352b4ab73e14/tensorflow_macos-2.14.0-cp311-cp311-macosx_12_0_arm64.whl#sha256=064e98b67d7a89e72c37c90254c0a322a0b8d0ce9b68f23286816210e3ef6685
   hash:
     md5: null
@@ -5247,12 +4987,11 @@ package:
   name: termcolor
   version: 2.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/67/e1/434566ffce04448192369c1a282931cf4ae593e91907558eaecd2e9f2801/termcolor-2.3.0-py3-none-any.whl#sha256=3afb05607b89aed0ffe25202399ee0867ad4d3cb4180d98aaf8eefa6a5f7d475
   hash:
     md5: null
@@ -5261,12 +5000,11 @@ package:
   name: termcolor
   version: 2.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/67/e1/434566ffce04448192369c1a282931cf4ae593e91907558eaecd2e9f2801/termcolor-2.3.0-py3-none-any.whl#sha256=3afb05607b89aed0ffe25202399ee0867ad4d3cb4180d98aaf8eefa6a5f7d475
   hash:
     md5: null
@@ -5275,12 +5013,11 @@ package:
   name: termcolor
   version: 2.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/67/e1/434566ffce04448192369c1a282931cf4ae593e91907558eaecd2e9f2801/termcolor-2.3.0-py3-none-any.whl#sha256=3afb05607b89aed0ffe25202399ee0867ad4d3cb4180d98aaf8eefa6a5f7d475
   hash:
     md5: null
@@ -5289,12 +5026,11 @@ package:
   name: termcolor
   version: 2.3.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/67/e1/434566ffce04448192369c1a282931cf4ae593e91907558eaecd2e9f2801/termcolor-2.3.0-py3-none-any.whl#sha256=3afb05607b89aed0ffe25202399ee0867ad4d3cb4180d98aaf8eefa6a5f7d475
   hash:
     md5: null
@@ -5382,10 +5118,8 @@ package:
   name: typing-extensions
   version: 4.8.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/24/21/7d397a4b7934ff4028987914ac1044d3b7d52712f30e2ac7a2ae5bc86dd0/typing_extensions-4.8.0-py3-none-any.whl#sha256=8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0
   hash:
     md5: null
@@ -5394,10 +5128,8 @@ package:
   name: typing-extensions
   version: 4.8.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/24/21/7d397a4b7934ff4028987914ac1044d3b7d52712f30e2ac7a2ae5bc86dd0/typing_extensions-4.8.0-py3-none-any.whl#sha256=8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0
   hash:
     md5: null
@@ -5406,10 +5138,8 @@ package:
   name: typing-extensions
   version: 4.8.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/24/21/7d397a4b7934ff4028987914ac1044d3b7d52712f30e2ac7a2ae5bc86dd0/typing_extensions-4.8.0-py3-none-any.whl#sha256=8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0
   hash:
     md5: null
@@ -5418,10 +5148,8 @@ package:
   name: typing-extensions
   version: 4.8.0
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/24/21/7d397a4b7934ff4028987914ac1044d3b7d52712f30e2ac7a2ae5bc86dd0/typing_extensions-4.8.0-py3-none-any.whl#sha256=8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0
   hash:
     md5: null
@@ -5522,14 +5250,13 @@ package:
   name: urllib3
   version: 2.1.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - brotli >=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
   - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
   - pysocks !=1.5.7, <2.0, >=1.5.6 ; extra == 'socks'
   - zstandard >=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl#sha256=55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
   hash:
     md5: null
@@ -5538,14 +5265,13 @@ package:
   name: urllib3
   version: 2.1.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - brotli >=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
   - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
   - pysocks !=1.5.7, <2.0, >=1.5.6 ; extra == 'socks'
   - zstandard >=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl#sha256=55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
   hash:
     md5: null
@@ -5554,14 +5280,13 @@ package:
   name: urllib3
   version: 2.1.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - brotli >=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
   - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
   - pysocks !=1.5.7, <2.0, >=1.5.6 ; extra == 'socks'
   - zstandard >=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl#sha256=55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
   hash:
     md5: null
@@ -5570,14 +5295,13 @@ package:
   name: urllib3
   version: 2.1.0
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - brotli >=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
   - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
   - pysocks !=1.5.7, <2.0, >=1.5.6 ; extra == 'socks'
   - zstandard >=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl#sha256=55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
   hash:
     md5: null
@@ -5646,12 +5370,11 @@ package:
   name: werkzeug
   version: 3.0.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.1.1
   - watchdog >=2.3 ; extra == 'watchdog'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl#sha256=90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10
   hash:
     md5: null
@@ -5660,12 +5383,11 @@ package:
   name: werkzeug
   version: 3.0.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.1.1
   - watchdog >=2.3 ; extra == 'watchdog'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl#sha256=90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10
   hash:
     md5: null
@@ -5674,12 +5396,11 @@ package:
   name: werkzeug
   version: 3.0.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.1.1
   - watchdog >=2.3 ; extra == 'watchdog'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl#sha256=90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10
   hash:
     md5: null
@@ -5688,12 +5409,11 @@ package:
   name: werkzeug
   version: 3.0.1
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - MarkupSafe >=2.1.1
   - watchdog >=2.3 ; extra == 'watchdog'
   requires_python: '>=3.8'
-  extras: []
   url: https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl#sha256=90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10
   hash:
     md5: null
@@ -5702,12 +5422,11 @@ package:
   name: wheel
   version: 0.41.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest >=6.0.0 ; extra == 'test'
   - setuptools >=65 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/7f/4c07234086edbce4a0a446209dc0cb08a19bb206a3ea53b2f56a403f983b/wheel-0.41.3-py3-none-any.whl#sha256=488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942
   hash:
     md5: null
@@ -5716,12 +5435,11 @@ package:
   name: wheel
   version: 0.41.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest >=6.0.0 ; extra == 'test'
   - setuptools >=65 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/7f/4c07234086edbce4a0a446209dc0cb08a19bb206a3ea53b2f56a403f983b/wheel-0.41.3-py3-none-any.whl#sha256=488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942
   hash:
     md5: null
@@ -5730,12 +5448,11 @@ package:
   name: wheel
   version: 0.41.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest >=6.0.0 ; extra == 'test'
   - setuptools >=65 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/7f/4c07234086edbce4a0a446209dc0cb08a19bb206a3ea53b2f56a403f983b/wheel-0.41.3-py3-none-any.whl#sha256=488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942
   hash:
     md5: null
@@ -5744,12 +5461,11 @@ package:
   name: wheel
   version: 0.41.3
   category: main
-  manager: pip
+  manager: pypi
   requires_dist:
   - pytest >=6.0.0 ; extra == 'test'
   - setuptools >=65 ; extra == 'test'
   requires_python: '>=3.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/fa/7f/4c07234086edbce4a0a446209dc0cb08a19bb206a3ea53b2f56a403f983b/wheel-0.41.3-py3-none-any.whl#sha256=488609bc63a29322326e05560731bf7bfea8e48ad646e1f5e40d366607de0942
   hash:
     md5: null
@@ -5758,10 +5474,8 @@ package:
   name: wrapt
   version: 1.14.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/7f/1b/e0439eec0db6520968c751bc7e12480bb80bb8d939190e0e55ed762f3c7a/wrapt-1.14.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=a9008dad07d71f68487c91e96579c8567c98ca4c3881b9b113bc7b33e9fd78b8
   hash:
     md5: null
@@ -5770,10 +5484,8 @@ package:
   name: wrapt
   version: 1.14.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/e7/f9/8c078b4973604cd968b23eb3dff52028b5c48f2a02c4f1f975f4d5e344d1/wrapt-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl#sha256=ecee4132c6cd2ce5308e21672015ddfed1ff975ad0ac8d27168ea82e71413f55
   hash:
     md5: null
@@ -5782,10 +5494,8 @@ package:
   name: wrapt
   version: 1.14.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/6e/79/aec8185eefe20e8f49e5adeb0c2e20e016d5916d10872c17705ddac41be2/wrapt-1.14.1-cp311-cp311-macosx_11_0_arm64.whl#sha256=2020f391008ef874c6d9e208b24f28e31bcb85ccff4f335f15a3251d222b92d9
   hash:
     md5: null
@@ -5794,10 +5504,8 @@ package:
   name: wrapt
   version: 1.14.1
   category: main
-  manager: pip
-  requires_dist: []
+  manager: pypi
   requires_python: '!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, >=2.7'
-  extras: []
   url: https://files.pythonhosted.org/packages/ba/7e/14113996bc6ee68eb987773b4139c87afd3ceff60e27e37648aa5eb2798a/wrapt-1.14.1-cp311-cp311-win_amd64.whl#sha256=26046cd03936ae745a502abf44dac702a5e6880b2b01c29aea8ddf3353b68224
   hash:
     md5: null

--- a/examples/pypi/pixi.lock
+++ b/examples/pypi/pixi.lock
@@ -148,96 +148,96 @@ package:
     sha256: c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
 - platform: linux-64
   name: black
-  version: 22.12.0
+  version: 23.11.0
   category: main
   manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
+  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
-  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
-  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
+  - tomli >=1.1.0 ; python_version < '3.11'
+  - typing-extensions >=4.0.1 ; python_version < '3.11'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.7'
-  url: https://files.pythonhosted.org/packages/e9/e0/6aa02d14785c4039b38bfed6f9ee28a952b2d101c64fc97b15811fa8bd04/black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f
+  requires_python: '>=3.8'
+  url: https://files.pythonhosted.org/packages/46/0a/964b242c01b8dbadec60afd2f1d3e08ad574315d34a33a692e96f121a32b/black-23.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221
   hash:
     md5: null
-    sha256: d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f
+    sha256: 760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221
 - platform: osx-64
   name: black
-  version: 22.12.0
+  version: 23.11.0
   category: main
   manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
+  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
-  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
-  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
+  - tomli >=1.1.0 ; python_version < '3.11'
+  - typing-extensions >=4.0.1 ; python_version < '3.11'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.7'
-  url: https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl#sha256=436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
+  requires_python: '>=3.8'
+  url: https://files.pythonhosted.org/packages/3b/d8/ea841502c79d85675e56c40d77de59aae44e311f17b463815d6a9659608c/black-23.11.0-cp311-cp311-macosx_10_9_x86_64.whl#sha256=cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479
   hash:
     md5: null
-    sha256: 436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
+    sha256: cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479
 - platform: osx-arm64
   name: black
-  version: 22.12.0
+  version: 23.11.0
   category: main
   manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
+  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
-  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
-  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
+  - tomli >=1.1.0 ; python_version < '3.11'
+  - typing-extensions >=4.0.1 ; python_version < '3.11'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.7'
-  url: https://files.pythonhosted.org/packages/0c/51/1f7f93c0555eaf4cbb628e26ba026e3256174a45bd9397ff1ea7cf96bad5/black-22.12.0-py3-none-any.whl#sha256=436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
+  requires_python: '>=3.8'
+  url: https://files.pythonhosted.org/packages/4e/09/75c374a20c458230ed8288d1e68ba38ecf508e948b8bf8980e8b0fd4c3b1/black-23.11.0-cp311-cp311-macosx_11_0_arm64.whl#sha256=698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244
   hash:
     md5: null
-    sha256: 436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf
+    sha256: 698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244
 - platform: win-64
   name: black
-  version: 22.12.0
+  version: 23.11.0
   category: main
   manager: pypi
   requires_dist:
   - click >=8.0.0
   - mypy-extensions >=0.4.3
+  - packaging >=22.0
   - pathspec >=0.9.0
   - platformdirs >=2
-  - tomli >=1.1.0 ; python_full_version < '3.11.0a7'
-  - typed-ast >=1.4.2 ; python_version < '3.8' and implementation_name == 'cpython'
-  - typing-extensions >=3.10.0.0 ; python_version < '3.10'
+  - tomli >=1.1.0 ; python_version < '3.11'
+  - typing-extensions >=4.0.1 ; python_version < '3.11'
   - colorama >=0.4.3 ; extra == 'colorama'
   - aiohttp >=3.7.4 ; extra == 'd'
   - ipython >=7.8.0 ; extra == 'jupyter'
   - tokenize-rt >=3.2.0 ; extra == 'jupyter'
   - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.7'
-  url: https://files.pythonhosted.org/packages/4c/49/420dcfccba3215dc4e5790fa47572ef14129df1c5e95dd87b5ad30211b01/black-22.12.0-cp311-cp311-win_amd64.whl#sha256=7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4
+  requires_python: '>=3.8'
+  url: https://files.pythonhosted.org/packages/37/0b/2cf6d012a3cdb3f76d5c4e0c311b39f311a265d7dda315800ae34fb639c6/black-23.11.0-cp311-cp311-win_amd64.whl#sha256=58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5
   hash:
     md5: null
-    sha256: 7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4
+    sha256: 58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5
 - platform: linux-64
   name: blinker
   version: 1.7.0

--- a/examples/pypi/pixi.toml
+++ b/examples/pypi/pixi.toml
@@ -17,7 +17,7 @@ libclang = "~=16.0.6"
 pyboy = "==1.6.6"
 tensorflow = "==2.14.0"
 flask = "*"
-black = "~=23.10"
+black = "~=22.10"
 
 [system-requirements]
 # Tensorflow on macOS arm64 requires macOS 12.0 or higher

--- a/examples/pypi/pixi.toml
+++ b/examples/pypi/pixi.toml
@@ -17,7 +17,7 @@ libclang = "~=16.0.6"
 pyboy = "==1.6.6"
 tensorflow = "==2.14.0"
 flask = "*"
-black = "~=22.10"
+black = "~=23.10"
 
 [system-requirements]
 # Tensorflow on macOS arm64 requires macOS 12.0 or higher

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -253,6 +253,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             _ = ctrl_c => { unreachable!("Ctrl+C should not be triggered") }
         };
         if status_code == 127 {
+            // TODO: fix this issue
+            if project
+                .manifest
+                .pypi_dependencies
+                .as_ref()
+                .map_or(false, |deps| !deps.is_empty())
+            {
+                tracing::warn!("ALPHA feature enabled: pixi doesn't support entrypoints from PyPI packages yet!");
+            }
+
             let formatted: String = project
                 .tasks(Some(Platform::current()))
                 .into_keys()
@@ -260,7 +270,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 .map(|name| format!("\t{}\n", console::style(name).bold()))
                 .collect();
 
-            eprintln!("\nAvailable tasks:\n{}", formatted);
+            if !formatted.is_empty() {
+                eprintln!("\nAvailable tasks:\n{}", formatted);
+            }
         }
         if status_code != 0 {
             std::process::exit(status_code);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -256,6 +256,15 @@ async fn update_python_distributions(
             rip::uninstall::uninstall_distribution(&prefix.root().join(site_package_path), relative_dist_info)
                 .into_diagnostic()
                 .with_context(|| format!("could not uninstall python package {}-{}. Manually remove the `.pixi/env` folder and try again.", &python_distribution.name, &python_distribution.version))?;
+
+            // HACK: Also remove the HASH file that pixi writes. Ignore the error if its there. We
+            // should probably actually add this file to the RECORD.
+            let _ = std::fs::remove_file(
+                prefix
+                    .root()
+                    .join(&python_distribution.dist_info)
+                    .join("HASH"),
+            );
         }
     }
 
@@ -507,6 +516,10 @@ fn remove_old_python_distributions(
         rip::uninstall::uninstall_distribution(&prefix.root().join(site_package_path), relative_dist_info)
             .into_diagnostic()
             .with_context(|| format!("could not uninstall python package {}-{}. Manually remove the `.pixi/env` folder and try again.", &python_package.name, &python_package.version))?;
+
+        // HACK: Also remove the HASH file that pixi writes. Ignore the error if its there. We
+        // should probably actually add this file to the RECORD.
+        let _ = std::fs::remove_file(prefix.root().join(&python_package.dist_info).join("HASH"));
 
         pb.inc(1);
     }

--- a/src/lock_file/package_identifier.rs
+++ b/src/lock_file/package_identifier.rs
@@ -1,0 +1,249 @@
+use super::python_name_mapping;
+use pep508_rs::{Requirement, VersionOrUrl};
+use rattler_conda_types::{PackageUrl, RepoDataRecord};
+use rattler_lock::{LockedDependency, LockedDependencyKind};
+use rip::PinnedPackage;
+use std::{collections::HashSet, str::FromStr};
+use thiserror::Error;
+
+/// Defines information about a Pypi package extracted from either a python package or from a
+/// conda package.
+#[derive(Debug)]
+pub struct PypiPackageIdentifier {
+    pub name: rip::NormalizedPackageName,
+    pub version: rip::Version,
+    pub extras: HashSet<rip::Extra>,
+}
+
+impl PypiPackageIdentifier {
+    /// Extracts the python packages that will be installed when the specified conda package is
+    /// installed.
+    pub fn from_record(record: &RepoDataRecord) -> Result<Vec<Self>, ConversionError> {
+        let mut result = Vec::new();
+        Self::from_record_into(record, &mut result)?;
+        Ok(result)
+    }
+
+    /// Constructs a new instance from a [`LockedDependency`].
+    pub fn from_locked_dependency(
+        locked_dependency: &LockedDependency,
+    ) -> Result<Vec<Self>, ConversionError> {
+        match &locked_dependency.kind {
+            LockedDependencyKind::Conda(_) => Self::from_locked_conda_dependency(locked_dependency),
+            LockedDependencyKind::Pypi(_) => {
+                Ok(vec![Self::from_locked_pypi_dependency(locked_dependency)?])
+            }
+        }
+    }
+
+    /// Constructs a new instance from a locked Pypi dependency. This function assumes that the
+    /// locked dependency is a Pypi dependency.
+    fn from_locked_pypi_dependency(
+        locked_dependency: &LockedDependency,
+    ) -> Result<Self, ConversionError> {
+        let Some(pypi) = locked_dependency.as_pypi() else {
+            panic!("expected conda dependency");
+        };
+
+        let name = rip::NormalizedPackageName::from_str(&locked_dependency.name)
+            .map_err(|e| ConversionError::PackageName(locked_dependency.name.clone(), e))?;
+        let version = rip::Version::from_str(&locked_dependency.version)
+            .map_err(|_| ConversionError::Version(locked_dependency.version.clone()))?;
+        let extras = pypi
+            .extras
+            .iter()
+            .map(|e| rip::Extra::from_str(e).map_err(|_| ConversionError::Extra(e.clone())))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            name,
+            version,
+            extras,
+        })
+    }
+
+    /// Determine the python packages that will be installed when the specified locked dependency is
+    /// installed.
+    fn from_locked_conda_dependency(
+        locked_dependency: &LockedDependency,
+    ) -> Result<Vec<Self>, ConversionError> {
+        let Some(conda) = locked_dependency.as_conda() else {
+            panic!("expected conda dependency");
+        };
+
+        let mut result = Vec::new();
+
+        // Get the PyPI urls from the package
+        let mut has_pypi_purl = false;
+        for purl in conda.purls.iter() {
+            if let Some(entry) = Self::try_from_purl(purl, &locked_dependency.version)? {
+                result.push(entry);
+                has_pypi_purl = true;
+            }
+        }
+
+        // If there is no pypi purl, but the package is a conda-forge package, we just assume that
+        // the name of the package is equivalent to the name of the python package.
+        if !has_pypi_purl && python_name_mapping::is_conda_forge_url(&conda.url) {
+            // Convert the conda package names to pypi package names. If the conversion fails we
+            // just assume that its not a valid python package.
+            let name = rip::NormalizedPackageName::from_str(&locked_dependency.name).ok();
+            let version = rip::Version::from_str(&locked_dependency.version).ok();
+            if let (Some(name), Some(version)) = (name, version) {
+                result.push(PypiPackageIdentifier {
+                    name,
+                    version,
+                    // TODO: We can't really tell which python extras are enabled in a conda package.
+                    extras: Default::default(),
+                });
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Helper function to write the result of extract the python packages that will be installed
+    /// into a pre-allocated vector.
+    fn from_record_into(
+        record: &RepoDataRecord,
+        result: &mut Vec<Self>,
+    ) -> Result<(), ConversionError> {
+        // Check the PURLs for a python package.
+        let mut has_pypi_purl = false;
+        for purl in record.package_record.purls.iter() {
+            if let Some(entry) = Self::try_from_purl(purl, &record.package_record.version.as_str())?
+            {
+                result.push(entry);
+                has_pypi_purl = true;
+            }
+        }
+
+        // If there is no pypi purl, but the package is a conda-forge package, we just assume that
+        // the name of the package is equivalent to the name of the python package.
+        if !has_pypi_purl && python_name_mapping::is_conda_forge_record(record) {
+            // Convert the conda package names to pypi package names. If the conversion fails we
+            // just assume that its not a valid python package.
+            let name =
+                rip::NormalizedPackageName::from_str(record.package_record.name.as_source()).ok();
+            let version = rip::Version::from_str(&record.package_record.version.as_str()).ok();
+            if let (Some(name), Some(version)) = (name, version) {
+                result.push(PypiPackageIdentifier {
+                    name,
+                    version,
+                    // TODO: We can't really tell which python extras are enabled in a conda package.
+                    extras: Default::default(),
+                })
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Given a list of conda package records, extract the python packages that will be installed
+    /// when these conda packages are installed.
+    pub fn from_records(records: &[RepoDataRecord]) -> Result<Vec<Self>, ConversionError> {
+        let mut result = Vec::new();
+        for record in records {
+            Self::from_record_into(record, &mut result)?;
+        }
+        Ok(result)
+    }
+
+    /// Tries to construct an instance from a generic PURL.
+    ///
+    /// The `fallback_version` is used if the PURL does not contain a version.
+    pub fn try_from_purl(
+        package_url: &PackageUrl,
+        fallback_version: &str,
+    ) -> Result<Option<Self>, ConversionError> {
+        if package_url.package_type() == "pypi" {
+            Self::from_pypi_purl(package_url, fallback_version).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Constructs a new instance from a PyPI package URL.
+    ///
+    /// The `fallback_version` is used if the PURL does not contain a version.
+    pub fn from_pypi_purl(
+        package_url: &PackageUrl,
+        fallback_version: &str,
+    ) -> Result<Self, ConversionError> {
+        assert_eq!(package_url.package_type(), "pypi");
+        let name = package_url.name();
+        let name = rip::NormalizedPackageName::from_str(name)
+            .map_err(|e| ConversionError::PackageName(name.to_string(), e))?;
+        let version_str = package_url.version().unwrap_or(fallback_version);
+        let version = rip::Version::from_str(version_str)
+            .map_err(|_| ConversionError::Version(version_str.to_string()))?;
+
+        // TODO: We can't really tell which python extras are enabled from a PURL.
+        let extras = HashSet::new();
+
+        Ok(Self {
+            name,
+            version,
+            extras,
+        })
+    }
+
+    pub fn satisfies(&self, requirement: &Requirement) -> bool {
+        // Parse the name of the requirement. If the name cannot be parsed to a normalized package
+        // the names will also not match.
+        let Ok(req_name) = rip::NormalizedPackageName::from_str(&requirement.name) else {
+            return false;
+        };
+
+        // Verify the name of the package
+        if self.name != req_name {
+            return false;
+        }
+
+        // Check the version of the requirement
+        match &requirement.version_or_url {
+            None => {}
+            Some(VersionOrUrl::Url(_)) => {
+                unimplemented!("urls are not yet supported in the lockfile")
+            }
+            Some(VersionOrUrl::VersionSpecifier(spec)) => {
+                if !spec.contains(&self.version) {
+                    return false;
+                }
+            }
+        }
+
+        // Check if the required extras exist
+        for extra in requirement.extras.iter().flat_map(|e| e.iter()) {
+            if !self.extras.contains(extra.as_str()) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ConversionError {
+    #[error("'{0}' is not a valid python package name")]
+    PackageName(String, #[source] rip::ParsePackageNameError),
+
+    #[error("'{0}' is not a valid python version")]
+    Version(String),
+
+    #[error("'{0}' is not a valid python extra")]
+    Extra(String),
+}
+
+impl<'a> From<PypiPackageIdentifier> for PinnedPackage<'a> {
+    fn from(value: PypiPackageIdentifier) -> Self {
+        PinnedPackage {
+            name: value.name,
+            version: value.version,
+            extras: value.extras,
+            // We are not aware of artifacts for conda python packages.
+            artifacts: vec![],
+        }
+    }
+}

--- a/src/lock_file/python_name_mapping.rs
+++ b/src/lock_file/python_name_mapping.rs
@@ -1,11 +1,9 @@
-use itertools::Itertools;
+use async_once_cell::OnceCell;
 use miette::{IntoDiagnostic, WrapErr};
-use rattler_conda_types::RepoDataRecord;
-use reqwest::Response;
-use rip::PinnedPackage;
+use rattler_conda_types::{PackageUrl, RepoDataRecord};
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
+use url::Url;
 
 #[derive(Deserialize)]
 struct CondaPyPiNameMapping {
@@ -13,66 +11,65 @@ struct CondaPyPiNameMapping {
     pypi_name: String,
 }
 
-/// Determine the python packages that are installed as part of the conda packages.
-/// TODO: Add some form of HTTP caching mechanisms here.
-pub async fn find_conda_python_packages<'p>(
-    records: &[RepoDataRecord],
-) -> miette::Result<Vec<PinnedPackage<'p>>> {
-    // Get all the records from conda-forge
-    let conda_forge_records = records
-        .iter()
-        .filter(|r| is_conda_forge_package(r))
-        .collect_vec();
+/// Downloads and caches the conda-forge conda-to-pypi name mapping.
+pub async fn conda_pypi_name_mapping() -> miette::Result<&'static HashMap<String, String>> {
+    static MAPPING: OnceCell<HashMap<String, String>> = OnceCell::new();
+    MAPPING.get_or_try_init((|| async {
+        let response = reqwest::get("https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/name_mapping.json").await
+            .into_diagnostic()
+            .context("failed to download pypi name mapping")?;
+        let mapping: Vec<CondaPyPiNameMapping> = response
+            .json()
+            .await
+            .into_diagnostic()
+            .context("failed to parse pypi name mapping")?;
+        let mapping_by_name: HashMap<_, _> = mapping
+            .into_iter()
+            .map(|m| (m.conda_name, m.pypi_name))
+            .collect();
+        Ok(mapping_by_name)
+    })()).await
+}
 
-    // If there are none we can stop here
-    if conda_forge_records.is_empty() {
-        return Ok(Vec::new());
+/// Updates the specified repodata record to include an optional PyPI package name if it is missing.
+///
+/// This function guesses the PyPI package name from the conda package name if the record refers to
+/// a conda-forge package.
+pub fn amend_pypi_purls(
+    record: &mut RepoDataRecord,
+    conda_forge_mapping: &'static HashMap<String, String>,
+) -> miette::Result<()> {
+    // If the package already has a pypi name we can stop here.
+    if record
+        .package_record
+        .purls
+        .iter()
+        .any(|p| p.package_type() == "pypi")
+    {
+        return Ok(());
     }
 
-    // Download the conda-forge pypi name mapping
-    let response = reqwest::get("https://raw.githubusercontent.com/regro/cf-graph-countyfair/master/mappings/pypi/name_mapping.json")
-        .await
-        .and_then(Response::error_for_status)
-        .into_diagnostic()
-        .context("failed to download pypi name mapping")?;
-    let mapping: Vec<CondaPyPiNameMapping> = response
-        .json()
-        .await
-        .into_diagnostic()
-        .context("failed to parse pypi name mapping")?;
-    let mapping_by_name: HashMap<_, _> = mapping
-        .into_iter()
-        .map(|m| (m.conda_name, m.pypi_name))
-        .collect();
+    // If this package is a conda-forge package we can try to guess the pypi name from the conda
+    // name.
+    if is_conda_forge_record(record) {
+        if let Some(mapped_name) =
+            conda_forge_mapping.get(record.package_record.name.as_normalized())
+        {
+            record.package_record.purls.push(
+                PackageUrl::new(String::from("pypi"), mapped_name).expect("valid pypi package url"),
+            );
+        }
+    }
 
-    // Find python package names from the conda-forge package names
-    let packages = conda_forge_records
-        .iter()
-        .filter_map(|r| {
-            // Lookup the pypi name for the conda package. If the mapping is not found simply use
-            // the conda name.
-            let conda_name = r.package_record.name.as_normalized();
-            let pypi_name = mapping_by_name
-                .get(conda_name)
-                .map(String::as_str)
-                .unwrap_or(conda_name);
-            let pypi_name = rip::NormalizedPackageName::from_str(pypi_name).ok()?;
-            let version = rip::Version::from_str(&r.package_record.version.as_str()).ok()?;
-            Some(PinnedPackage {
-                name: pypi_name,
-                version,
-                extras: Default::default(),
-                artifacts: vec![],
-            })
-        })
-        .collect();
-
-    Ok(packages)
+    Ok(())
 }
 
 /// Returns `true` if the specified record refers to a conda-forge package.
-fn is_conda_forge_package(record: &RepoDataRecord) -> bool {
-    let channel = record.channel.as_str();
-    channel.starts_with("https://conda.anaconda.org/conda-forge")
-        || channel.starts_with("https://repo.prefix.dev/conda-forge")
+pub fn is_conda_forge_record(record: &RepoDataRecord) -> bool {
+    Url::from_str(&record.channel).map_or(false, |u| is_conda_forge_url(&u))
+}
+
+/// Returns `true` if the specified url refers to a conda-forge channel.
+pub fn is_conda_forge_url(url: &Url) -> bool {
+    url.path().starts_with("/conda-forge")
 }

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -1,0 +1,334 @@
+use super::package_identifier;
+use crate::lock_file::python::{determine_marker_environment, is_python};
+use crate::Project;
+use itertools::Itertools;
+use miette::IntoDiagnostic;
+use pep508_rs::Requirement;
+use rattler_conda_types::{MatchSpec, PackageName, Platform, Version};
+use rattler_lock::{CondaLock, LockedDependency, LockedDependencyKind};
+use rip::NormalizedPackageName;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+#[derive(Clone)]
+enum DependencyKind {
+    Conda(MatchSpec),
+    PyPi(pep508_rs::Requirement),
+}
+
+impl Display for DependencyKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DependencyKind::Conda(spec) => write!(f, "{}", spec),
+            DependencyKind::PyPi(req) => write!(f, "{}", req),
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Hash)]
+enum DependencyName {
+    Conda(PackageName),
+    PyPi(rip::NormalizedPackageName),
+}
+
+/// Returns true if the locked packages match the dependencies in the project.
+pub fn lock_file_satisfies_project(
+    project: &Project,
+    lock_file: &CondaLock,
+) -> miette::Result<bool> {
+    let platforms = project.platforms();
+
+    // If a platform is missing from the lock file the lock file is completely out-of-date.
+    if HashSet::<Platform>::from_iter(lock_file.metadata.platforms.iter().copied())
+        != HashSet::from_iter(platforms.iter().copied())
+    {
+        return Ok(false);
+    }
+
+    // Check if the channels in the lock file match our current configuration. Note that the order
+    // matters here. If channels are added in a different order, the solver might return a different
+    // result.
+    let channels = project
+        .channels()
+        .iter()
+        .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()))
+        .collect_vec();
+    if lock_file.metadata.channels.iter().ne(channels.iter()) {
+        return Ok(false);
+    }
+
+    // For each platform,
+    for platform in platforms.iter().cloned() {
+        // Check if all dependencies exist in the lock-file.
+        let conda_dependencies = project
+            .all_dependencies(platform)?
+            .into_iter()
+            .map(|(name, spec)| DependencyKind::Conda(MatchSpec::from_nameless(spec, Some(name))))
+            .collect::<Vec<_>>();
+
+        let mut pypi_dependencies = project
+            .pypi_dependencies()
+            .into_iter()
+            .flat_map(|deps| deps.into_iter().map(|(name, req)| req.as_pep508(name)))
+            .map(DependencyKind::PyPi)
+            .peekable();
+
+        // Determine the python marker environment from the lock-file.
+        let python_maker_env = if pypi_dependencies.peek().is_some() {
+            // Determine the python executable
+            let Ok(conda_packages) = lock_file
+                .get_conda_packages_by_platform(platform) else {
+                    tracing::info!("failed to convert conda package to RepoDataRecord, assuming the lockfile is corrupt.");
+                    return Ok(false);
+                };
+
+            // Find the python package
+            let Some(python_record) = conda_packages.into_iter().find(is_python) else {
+                tracing::info!("there are pypi-dependencies but there is no python version in the lock-file");
+                return Ok(false);
+            };
+
+            // Construct the marker environment
+            let marker_environment =
+                match determine_marker_environment(platform, &python_record.package_record) {
+                    Ok(marker_environment) => marker_environment,
+                    Err(e) => {
+                        tracing::info!(
+                            "failed to determine marker environment from the lock-file: {e}"
+                        );
+                        return Ok(false);
+                    }
+                };
+
+            Some(marker_environment)
+        } else {
+            None
+        };
+
+        let dependencies = conda_dependencies
+            .into_iter()
+            .chain(pypi_dependencies)
+            .collect::<VecDeque<_>>();
+
+        // Construct a queue of dependencies that we wanna find in the lock file
+        let mut queue = dependencies.clone();
+
+        // Get the virtual packages for the system
+        let virtual_packages = project
+            .virtual_packages(platform)?
+            .into_iter()
+            .map(|vpkg| (vpkg.name.clone(), vpkg))
+            .collect::<HashMap<_, _>>();
+
+        // Keep track of which dependencies we already found. Since there can always only be one
+        // version per named package we can just keep track of the package names.
+        let mut seen = dependencies
+            .iter()
+            .filter_map(|req| match req {
+                DependencyKind::Conda(spec) => spec.name.clone().map(DependencyName::Conda),
+                DependencyKind::PyPi(req) => Some(DependencyName::PyPi(
+                    NormalizedPackageName::from(rip::PackageName::from_str(&req.name).ok()?),
+                )),
+            })
+            .collect::<HashSet<_>>();
+
+        while let Some(dependency) = queue.pop_back() {
+            let locked_package = match &dependency {
+                DependencyKind::Conda(match_spec) => {
+                    // Is this a virtual package? And does it match?
+                    if let Some(vpkg) = match_spec
+                        .name
+                        .as_ref()
+                        .and_then(|name| virtual_packages.get(name))
+                    {
+                        if let Some(version_spec) = &match_spec.version {
+                            if !version_spec.matches(&vpkg.version) {
+                                tracing::info!("found a dependency on virtual package '{}' but the version spec '{}' does not match the expected version of the virtual package '{}'.", vpkg.name.as_source(), &version_spec, &vpkg.version);
+                                return Ok(false);
+                            }
+                        }
+                        if let Some(build_spec) = &match_spec.build {
+                            if !build_spec.matches(&vpkg.build_string) {
+                                tracing::info!("found a dependency on virtual package '{}' but the build spec '{}' does not match the expected build of the virtual package '{}'.", vpkg.name.as_source(), &build_spec, &vpkg.build_string);
+                                return Ok(false);
+                            }
+                        }
+
+                        // Virtual package matches
+                        continue;
+                    }
+
+                    // Find the package in the lock-file that matches our dependency.
+                    lock_file
+                        .get_packages_by_platform(platform)
+                        .find(|locked_package| {
+                            locked_dependency_satisfies_match_spec(locked_package, match_spec)
+                        })
+                }
+                DependencyKind::PyPi(requirement) => {
+                    // Find the package in the lock-file that matches our requirement.
+                    lock_file
+                        .get_packages_by_platform(platform)
+                        .find_map(|locked_package| {
+                            match locked_dependency_satisfies_requirement(locked_package, requirement) {
+                                Ok(true) => Some(Ok(locked_package)),
+                                Ok(false) => None,
+                                Err(e) => {
+                                    tracing::info!("failed to check if locked package '{}' satisfies requirement '{}': {e}", locked_package.name, requirement);
+                                    Some(Err(e))
+                                }
+                            }
+                        }).transpose()?
+                }
+            };
+
+            match locked_package {
+                None => {
+                    // No package found that matches the dependency, the lock file is not in a
+                    // consistent state.
+                    tracing::info!("failed to find a locked package for '{}', assuming the lock file is out of date.", &dependency);
+                    return Ok(false);
+                }
+                Some(package) => match &package.kind {
+                    LockedDependencyKind::Conda(conda_package) => {
+                        for spec in conda_package.dependencies.iter() {
+                            let Ok(spec) = MatchSpec::from_str(spec) else {
+                                    tracing::warn!(
+                                    "failed to parse spec '{}', assuming the lock file is corrupt.",
+                                    spec
+                                );
+                                    return Ok(false);
+                                };
+
+                            if let Some(name) = spec.name.clone() {
+                                let dependency_name = DependencyName::Conda(name);
+                                if !seen.contains(&dependency_name) {
+                                    queue.push_back(DependencyKind::Conda(spec));
+                                    seen.insert(dependency_name);
+                                }
+                            }
+                        }
+                    }
+                    LockedDependencyKind::Pypi(pypi_package) => {
+                        // TODO: We have to verify that the python version is compatible
+
+                        for req in pypi_package.requires_dist.iter() {
+                            let Ok(req) = pep508_rs::Requirement::from_str(req) else {
+                                tracing::warn!(
+                                    "failed to parse requirement '{}', assuming the lock file is corrupt.",
+                                    req
+                                );
+                                return Ok(false);
+                            };
+                            // Filter the requirement based on the environment markers
+                            if !python_maker_env
+                                .as_ref()
+                                .map(|env| {
+                                    req.evaluate_markers(
+                                        env,
+                                        pypi_package.extras.iter().cloned().collect_vec(),
+                                    )
+                                })
+                                .unwrap_or(true)
+                            {
+                                continue;
+                            }
+                            let Ok(name) =
+                                rip::PackageName::from_str(&req.name).map(NormalizedPackageName::from) else {
+                                tracing::warn!(
+                                    "failed to parse package name '{}', assuming the lock file is corrupt.",
+                                    req.name
+                                );
+                                return Ok(false);
+                            };
+                            let dependency_name = DependencyName::PyPi(name);
+                            if !seen.contains(&dependency_name) {
+                                queue.push_back(DependencyKind::PyPi(req));
+                                seen.insert(dependency_name);
+                            }
+                        }
+                    }
+                },
+            }
+        }
+
+        // If the number of "seen" dependencies is less than the number of packages for this
+        // platform in the first place, there are more packages in the lock file than are used. This
+        // means the lock file is also out of date.
+        if seen.len() < lock_file.packages_for_platform(platform).count() {
+            tracing::info!("there are more packages in the lock-file than required to fulfill all dependency requirements. Assuming the lock file is out of date.");
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+/// Check whether the specified requirement is satisfied by the given locked package.
+fn locked_dependency_satisfies_requirement(
+    locked_package: &LockedDependency,
+    requirement: &Requirement,
+) -> miette::Result<bool> {
+    let pypi_packages =
+        package_identifier::PypiPackageIdentifier::from_locked_dependency(locked_package)
+            .into_diagnostic()?;
+    Ok(pypi_packages
+        .into_iter()
+        .any(|pypi_package| pypi_package.satisfies(requirement)))
+}
+
+/// Returns true if the specified [`conda_lock::LockedDependency`] satisfies the given MatchSpec.
+/// TODO: Move this back to rattler.
+/// TODO: Make this more elaborate to include all properties of MatchSpec
+fn locked_dependency_satisfies_match_spec(
+    locked_package: &LockedDependency,
+    match_spec: &MatchSpec,
+) -> bool {
+    // Only conda packages can match matchspecs.
+    let Some(conda) = locked_package.as_conda() else {
+        return false;
+    };
+
+    // Check if the name of the package matches
+    if match_spec
+        .name
+        .as_ref()
+        .map(|name| locked_package.name != name.as_normalized())
+        .unwrap_or(false)
+    {
+        return false;
+    }
+
+    // Check if the version matches
+    if let Some(version_spec) = &match_spec.version {
+        let v = match Version::from_str(&locked_package.version) {
+            Err(_) => return false,
+            Ok(v) => v,
+        };
+
+        if !version_spec.matches(&v) {
+            return false;
+        }
+    }
+
+    // Check if the build string matches
+    match (match_spec.build.as_ref(), &conda.build) {
+        (Some(build_spec), Some(build)) => {
+            if !build_spec.matches(build) {
+                return false;
+            }
+        }
+        (Some(_), None) => return false,
+        _ => {}
+    }
+
+    // If there is a channel specified, check if the channel matches
+    if let Some(channel) = &match_spec.channel {
+        if !conda.url.as_str().starts_with(channel.base_url.as_str()) {
+            return false;
+        }
+    }
+
+    true
+}

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -75,7 +75,7 @@ pub fn lock_file_satisfies_project(
             .peekable();
 
         // Determine the python marker environment from the lock-file.
-        let python_maker_env = if pypi_dependencies.peek().is_some() {
+        let python_marker_env = if pypi_dependencies.peek().is_some() {
             // Determine the python executable
             let Ok(conda_packages) = lock_file
                 .get_conda_packages_by_platform(platform) else {
@@ -222,7 +222,7 @@ pub fn lock_file_satisfies_project(
                                 return Ok(false);
                             };
                             // Filter the requirement based on the environment markers
-                            if !python_maker_env
+                            if !python_marker_env
                                 .as_ref()
                                 .map(|env| {
                                     req.evaluate_markers(

--- a/tests/common/package_database.rs
+++ b/tests/common/package_database.rs
@@ -217,6 +217,7 @@ impl PackageBuilder {
                 timestamp: None,
                 track_features: vec![],
                 version: self.version,
+                purls: vec![],
             },
             subdir,
             archive_type: self.archive_type,


### PR DESCRIPTION
This PR adds support for checking the satisfiability of the lock-file which includes pypi-dependencies.

Purls have been added to the lock-file (https://github.com/mamba-org/rattler/pull/414) (See also: https://github.com/conda-incubator/ceps/pull/63). This enables checking which conda packages will install which pypi packages without needing to check the internet. This ensures we can still check if a lock-file is up to date quickly.

I did not profile this code but I think there are a lot of places we can improve the performance. Thats for a later PR.

I also didn't add tests. I think we should but we can also do that in another PR.

Closes #467 