### PR TITLE
fix: issue 507

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -20,6 +20,9 @@ use rip::{
 use std::{io::ErrorKind, path::Path, str::FromStr, time::Duration};
 use tokio::task::JoinError;
 
+/// The installer name for pypi packages installed by pixi.
+const PIXI_PYPI_INSTALLER: &str = env!("CARGO_PKG_NAME");
+
 /// Verify the location of the prefix folder is not changed so the applied prefix path is still valid.
 /// Errors when there is a file system error or the path does not align with the defined prefix.
 /// Returns false when the file is not present.
@@ -323,7 +326,7 @@ async fn install_python_distributions(
                             &root,
                             &install_paths,
                             &UnpackWheelOptions {
-                                installer: Some(env!("CARGO_PKG_NAME").into()),
+                                installer: Some(PIXI_PYPI_INSTALLER.into()),
                             },
                         )
                         .into_diagnostic()
@@ -562,8 +565,8 @@ fn determine_python_distributions_to_remove_and_install<'p>(
             desired_python_packages.remove(found_desired_packages_idx);
             false
         } else {
-            // If this package was installed as a conda package we should not remove it.
-            current_python_packages.installer.as_deref() != Some("conda")
+            // Only if this package was previously installed by us do we remove it.
+            current_python_packages.installer.as_deref() == Some(PIXI_PYPI_INSTALLER)
         }
     });
 


### PR DESCRIPTION
Fix #507 

Pixi simply removed all redundant python packages. Only packages without an INSTALLER where left alone. I changed this behavior to only remove python packages installed by pixi itself.