### PR TITLE
feat: remove empty folders on python uninstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 [[package]]
 name = "rattler_installs_packages"
 version = "0.1.0"
-source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#2ee92fdabfd2c73d52b5d6702b39268b48897a41"
+source = "git+https://github.com/prefix-dev/rattler_installs_packages?branch=main#94d965f055cb23dc82a821c53a3338d4dcc74bd7"
 dependencies = [
  "async-once-cell",
  "async-trait",

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -257,9 +257,6 @@ async fn update_python_distributions(
                 .dist_info
                 .strip_prefix(site_package_path)
                 .expect("the dist-info path must be a sub-path of the site-packages path");
-            rip::uninstall::uninstall_distribution(&prefix.root().join(site_package_path), relative_dist_info)
-                .into_diagnostic()
-                .with_context(|| format!("could not uninstall python package {}-{}. Manually remove the `.pixi/env` folder and try again.", &python_distribution.name, &python_distribution.version))?;
 
             // HACK: Also remove the HASH file that pixi writes. Ignore the error if its there. We
             // should probably actually add this file to the RECORD.
@@ -269,6 +266,10 @@ async fn update_python_distributions(
                     .join(&python_distribution.dist_info)
                     .join("HASH"),
             );
+
+            rip::uninstall::uninstall_distribution(&prefix.root().join(site_package_path), relative_dist_info)
+                .into_diagnostic()
+                .with_context(|| format!("could not uninstall python package {}-{}. Manually remove the `.pixi/env` folder and try again.", &python_distribution.name, &python_distribution.version))?;
         }
     }
 
@@ -534,13 +535,14 @@ fn remove_old_python_distributions(
             .dist_info
             .strip_prefix(site_package_path)
             .expect("the dist-info path must be a sub-path of the site-packages path");
-        rip::uninstall::uninstall_distribution(&prefix.root().join(site_package_path), relative_dist_info)
-            .into_diagnostic()
-            .with_context(|| format!("could not uninstall python package {}-{}. Manually remove the `.pixi/env` folder and try again.", &python_package.name, &python_package.version))?;
 
         // HACK: Also remove the HASH file that pixi writes. Ignore the error if its there. We
         // should probably actually add this file to the RECORD.
         let _ = std::fs::remove_file(prefix.root().join(&python_package.dist_info).join("HASH"));
+
+        rip::uninstall::uninstall_distribution(&prefix.root().join(site_package_path), relative_dist_info)
+            .into_diagnostic()
+            .with_context(|| format!("could not uninstall python package {}-{}. Manually remove the `.pixi/env` folder and try again.", &python_package.name, &python_package.version))?;
 
         pb.inc(1);
     }


### PR DESCRIPTION
Remove empty folders when uninstalling a pypi dependency.