### PR TITLE
fix: start pwsh interactive instead of no-exit

### DIFF
--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -61,7 +61,7 @@ fn start_powershell(
 
     let mut command = std::process::Command::new(pwsh.executable());
     command.arg("-NoLogo");
-    command.arg("-NoExit");
+    command.arg("-Interactive");
     command.arg("-File");
     command.arg(&temp_path);
 

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -62,6 +62,7 @@ fn start_powershell(
     let mut command = std::process::Command::new(pwsh.executable());
     command.arg("-NoLogo");
     command.arg("-Interactive");
+    command.arg("-NoExit");
     command.arg("-File");
     command.arg(&temp_path);
 


### PR DESCRIPTION
Closes #514 