### PR TITLE
feat: add winget releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Package.Identifier
+          installers-regex: '\.msi' # Only .msi files
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ To install Pixi on Windows, open a PowerShell terminal (you may need to run it a
 iwr -useb https://pixi.sh/install.ps1 | iex
 ```
 The script will inform you once the installation is successful and add the ~/.pixi/bin directory to your PATH, which will allow you to run the pixi command from any location.
+Or with `winget`
+```
+winget install prefix-dev.pixi
+```
+
 
 ### Autocompletion
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,11 +23,14 @@ To install `pixi` you can run the following command in your terminal:
     The script will also update your `~/.bash_profile` to include `~/.pixi/bin` in your PATH, allowing you to invoke the `pixi` command from anywhere.
 
 === "Windows"
-    PowerShell:
+    `PowerShell`:
     ```powershell
     iwr -useb https://pixi.sh/install.ps1 | iex
     ```
-
+    `winget`:
+    ```
+    winget install prefix-dev.pixi
+    ```
     The above invocation will automatically download the latest version of `pixi`, extract it, and move the `pixi` binary to `LocalAppData/pixi/bin`.
     If this directory does not already exist, the script will create it.
 


### PR DESCRIPTION
This should start automatically making prs on the winget-pkg repo when we make a new release. 

Added the WINGET_TOKEN to pixi using the `public-repo` access from my personal account:
![image](https://github.com/prefix-dev/pixi/assets/12893423/5672d535-28b7-4e71-8fda-032a2f0e562b)

Closes #323 as we then have automated the release. 