### PR TITLE
fix: save file after lockfile is correctly updated

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -219,9 +219,10 @@ pub async fn add_pypi_specs_to_project(
             }
         }
     }
-    project.save()?;
 
     update_lockfile(project, None, no_install, no_update_lockfile).await?;
+
+    project.save()?;
 
     Ok(())
 }


### PR DESCRIPTION
`pixi add --pypi bla`  would save `bla = "*"` to file but we obviously don't want to add failing dependencies.