### PR TITLE
refactor: task run code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ name = "pixi"
 version = "0.9.1"
 dependencies = [
  "async-once-cell",
+ "async-recursion",
  "chrono",
  "clap",
  "clap-verbosity-flag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ slow_integration_tests = []
 
 [dependencies]
 async-once-cell = "0.5.3"
+async-recursion = "1.0.5"
 chrono = "0.4.31"
 clap = { version = "4.4.10", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context"] }
 clap-verbosity-flag = "2.1.0"

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::string::String;
@@ -7,7 +8,7 @@ use clap::Parser;
 use deno_task_shell::parser::SequentialList;
 use deno_task_shell::{execute_with_pipes, pipe, ShellPipeWriter, ShellState};
 use itertools::Itertools;
-use miette::{miette, Context, IntoDiagnostic};
+use miette::{miette, Context, Diagnostic, IntoDiagnostic};
 use rattler_conda_types::Platform;
 
 use crate::prefix::Prefix;
@@ -19,6 +20,7 @@ use rattler_shell::{
     activation::{ActivationVariables, Activator, PathModificationBehavior},
     shell::ShellEnum,
 };
+use thiserror::Error;
 use tokio::task::JoinHandle;
 use tracing::Level;
 
@@ -50,129 +52,162 @@ pub struct Args {
     pub frozen: bool,
 }
 
-pub fn order_tasks(
-    tasks: Vec<String>,
-    project: &Project,
-) -> miette::Result<VecDeque<(Task, Vec<String>)>> {
-    let tasks: Vec<_> = tasks.iter().map(|c| c.to_string()).collect();
+#[derive(Debug, Error, Diagnostic)]
+#[error("could not find the task '{task_name}'")]
+pub struct MissingTaskError {
+    task_name: String,
+}
 
-    // Find the command in the tasks.
-    let (task_name, task, additional_args) = tasks
-        .first()
-        // First search in the target specific tasks
-        .and_then(|cmd_name| {
-            project
-                .target_specific_tasks(Platform::current())
-                .get(cmd_name.as_str())
-                .map(|&cmd| {
-                    (
-                        Some(cmd_name.clone()),
-                        cmd.clone(),
-                        tasks[1..].iter().cloned().collect_vec(),
-                    )
-                })
-        })
-        // If it isn't found in the target specific tasks try to find it in the default tasks.
-        .or_else(|| {
-            tasks.first().and_then(|cmd_name| {
-                project.task_opt(cmd_name).map(|cmd| {
-                    (
-                        Some(cmd_name.clone()),
-                        cmd.clone(),
-                        tasks[1..].iter().cloned().collect_vec(),
-                    )
-                })
-            })
-        })
-        // When no task is found, just execute the command.
-        .unwrap_or_else(|| {
-            (
-                None,
+#[derive(Debug, Error, Diagnostic)]
+#[error("deno task shell failed to parse '{script}': {error}")]
+pub struct FailedToParseShellScript {
+    script: String,
+    error: String,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("invalid working directory '{path}'")]
+pub struct InvalidWorkingDirectory {
+    path: String,
+}
+
+/// A task that contains enough information to be able to execute it. The lifetime [`'p`] refers to
+/// the lifetime of the project that contains the tasks.
+#[derive(Debug, Clone)]
+pub struct ExecutableTask<'p> {
+    name: Option<String>,
+    task: Cow<'p, Task>,
+    additional_args: Vec<String>,
+}
+
+impl<'p> ExecutableTask<'p> {
+    /// Parses command line arguments into an [`ExecutableTask`].
+    pub fn from_cmd_args(
+        project: &'p Project,
+        args: Vec<String>,
+        platform: Option<Platform>,
+    ) -> Self {
+        let mut args = args;
+
+        if let Some(name) = args.first() {
+            // Find the task in the project. First searches for platform specific tasks and falls
+            // back to looking for the task in the default tasks.
+            if let Some(task) = project.task_opt(name, platform) {
+                return Self {
+                    name: Some(args.remove(0)),
+                    task: Cow::Borrowed(task),
+                    additional_args: args,
+                };
+            }
+        }
+
+        // When no task is found, just execute the command verbatim.
+        Self {
+            name: None,
+            task: Cow::Owned(
                 Custom {
-                    cmd: CmdArgs::from(tasks),
-                    cwd: Some(env::current_dir().unwrap_or(project.root().to_path_buf())),
+                    cmd: CmdArgs::from(args),
+                    cwd: env::current_dir().ok(),
                 }
                 .into(),
-                Vec::new(),
-            )
-        });
-
-    // Perform post order traversal of the tasks and their `depends_on` to make sure they are
-    // executed in the right order.
-    let mut s1 = VecDeque::new();
-    let mut s2 = VecDeque::new();
-    let mut added = HashSet::new();
-
-    // Add the command specified on the command line first
-    s1.push_back((task, additional_args));
-    if let Some(task_name) = task_name {
-        added.insert(task_name);
-    }
-
-    while let Some((task, additional_args)) = s1.pop_back() {
-        // Get the dependencies of the command
-        let depends_on = task.depends_on();
-
-        // Locate the dependencies in the project and add them to the stack
-        for dependency in depends_on.iter() {
-            if !added.contains(dependency) {
-                let cmd = project
-                    .target_specific_tasks(Platform::current())
-                    .get(dependency.as_str())
-                    .copied()
-                    // If there is no target specific task try to find it in the default tasks.
-                    .or_else(|| project.task_opt(dependency))
-                    .ok_or_else(|| miette::miette!("failed to find dependency {}", dependency))?;
-
-                s1.push_back((cmd.clone(), Vec::new()));
-                added.insert(dependency.clone());
-            }
-        }
-
-        if task.is_executable() {
-            s2.push_back((task, additional_args))
+            ),
+            additional_args: vec![],
         }
     }
 
-    Ok(s2)
-}
+    /// Returns a list of [`ExecutableTask`]s that includes this task and its dependencies in the
+    /// order they should be executed (topologically sorted).
+    pub fn get_ordered_dependencies(
+        self,
+        project: &'p Project,
+        platform: Option<Platform>,
+    ) -> Result<Vec<Self>, MissingTaskError> {
+        let mut sorted = Vec::new();
+        visit(self, project, platform, &mut sorted, &mut HashSet::new())?;
+        return Ok(sorted);
 
-pub async fn create_script(task: &Task, args: &[String]) -> miette::Result<SequentialList> {
-    // Construct the script from the task
-    let task = task
-        .as_single_command()
-        .ok_or_else(|| miette::miette!("the task does not provide a runnable command"))?;
-
-    // Append the command line arguments
-    let cli_args = quote_arguments(args.iter().map(|arg| arg.as_str()));
-    let full_script = format!("{task} {cli_args}");
-
-    // Parse the shell command
-    deno_task_shell::parser::parse(full_script.trim()).map_err(|e| miette!("{e}"))
-}
-
-/// Select a working directory based on a given path or the project.
-pub fn select_cwd(path: Option<&Path>, project: &Project) -> miette::Result<PathBuf> {
-    Ok(match path {
-        Some(cwd) if cwd.is_absolute() => cwd.to_path_buf(),
-        Some(cwd) => {
-            let abs_path = project.root().join(cwd);
-            if !abs_path.exists() {
-                miette::bail!("Can't find the 'cwd': '{}'", abs_path.display());
+        fn visit<'p>(
+            task: ExecutableTask<'p>,
+            project: &'p Project,
+            platform: Option<Platform>,
+            sorted: &mut Vec<ExecutableTask<'p>>,
+            visited: &mut HashSet<String>,
+        ) -> Result<(), MissingTaskError> {
+            // If the task has a name that we already visited we can immediately return.
+            if let Some(name) = task.name.as_deref() {
+                if visited.contains(name) {
+                    return Ok(());
+                }
+                visited.insert(name.to_string());
             }
-            abs_path
+
+            // Locate the dependencies in the project and add them to the stack
+            for dependency in task.task.depends_on() {
+                let dependency =
+                    project
+                        .task_opt(dependency, platform)
+                        .ok_or_else(|| MissingTaskError {
+                            task_name: dependency.clone(),
+                        })?;
+
+                visit(
+                    ExecutableTask {
+                        name: Some(dependency.to_string()),
+                        task: Cow::Borrowed(dependency),
+                        additional_args: Vec::new(),
+                    },
+                    project,
+                    platform,
+                    sorted,
+                    visited,
+                )?;
+            }
+
+            sorted.push(task);
+            Ok(())
         }
-        None => project.root().to_path_buf(),
-    })
-}
-/// Executes the given command within the specified project and with the given environment.
-pub async fn execute_script(
-    script: SequentialList,
-    command_env: &HashMap<String, String>,
-    cwd: &Path,
-) -> miette::Result<i32> {
-    // Execute the shell command
-    Ok(deno_task_shell::execute(script, command_env.clone(), cwd, Default::default()).await)
+    }
+
+    /// Returns a [`SequentialList`] which can be executed by deno task shell. Returns `None` if the
+    /// command is not executable like in the case of an alias.
+    pub fn as_deno_script(&self) -> Result<Option<SequentialList>, FailedToParseShellScript> {
+        // Convert the task into an executable string
+        let Some(task) = self.task.as_single_command() else {
+            return Ok(None);
+        };
+
+        // Append the command line arguments
+        let cli_args = quote_arguments(self.additional_args.iter().map(|arg| arg.as_str()));
+        let full_script = format!("{task} {cli_args}");
+
+        // Parse the shell command
+        deno_task_shell::parser::parse(full_script.trim())
+            .map_err(|e| FailedToParseShellScript {
+                script: full_script,
+                error: e.to_string(),
+            })
+            .map(Some)
+    }
+
+    /// Returns the working directory for this task.
+    pub fn working_directory(
+        &self,
+        project: &'p Project,
+    ) -> Result<PathBuf, InvalidWorkingDirectory> {
+        Ok(match self.task.working_directory() {
+            Some(cwd) if cwd.is_absolute() => cwd.to_path_buf(),
+            Some(cwd) => {
+                let abs_path = project.root().join(cwd);
+                if !abs_path.exists() {
+                    return Err(InvalidWorkingDirectory {
+                        path: cwd.to_string_lossy().to_string(),
+                    });
+                }
+                abs_path
+            }
+            None => project.root().to_path_buf(),
+        })
+    }
 }
 
 pub async fn execute_script_with_output(
@@ -206,49 +241,57 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // `"test 1 == 0 || echo failed"` or `"echo foo && echo bar"` or `"echo 'Hello World'"`
     // This prevents shell interpretation of pixi run inputs.
     // Use as-is if 'task' already contains multiple elements.
-    let task = if args.task.len() == 1 {
+    let task_args = if args.task.len() == 1 {
         shlex::split(args.task[0].as_str())
             .ok_or(miette!("Could not split task, assuming non valid task"))?
     } else {
         args.task
     };
-    tracing::debug!("Task parsed from run command: {:?}", task);
+    tracing::debug!("Task parsed from run command: {:?}", task_args);
 
     // Get the correctly ordered commands
-    let mut ordered_commands = order_tasks(task, &project)?;
+    let executable_tasks =
+        ExecutableTask::from_cmd_args(&project, task_args, Some(Platform::current()))
+            .get_ordered_dependencies(&project, Some(Platform::current()))?;
 
     // Get the environment to run the commands in.
     let command_env = get_task_env(&project, args.locked, args.frozen).await?;
 
     // Execute the commands in the correct order
-    while let Some((command, arguments)) = ordered_commands.pop_back() {
-        let cwd = select_cwd(command.working_directory(), &project)?;
+    for task in executable_tasks {
+        let Some(script) = task.as_deno_script()? else {
+            continue;
+        };
+        let cwd = task.working_directory(&project)?;
+
         // Ignore CTRL+C
         // Specifically so that the child is responsible for its own signal handling
         // NOTE: one CTRL+C is registered it will always stay registered for the rest of the runtime of the program
         // which is fine when using run in isolation, however if we start to use run in conjunction with
         // some other command we might want to revaluate this.
         let ctrl_c = tokio::spawn(async { while tokio::signal::ctrl_c().await.is_ok() {} });
-        let script = create_script(&command, &arguments).await?;
 
         // Showing which command is being run if the level and type allows it.
-        if tracing::enabled!(Level::WARN) && !matches!(command, Task::Custom(_)) {
+        if tracing::enabled!(Level::WARN) && !matches!(task.task.as_ref(), Task::Custom(_)) {
             eprintln!(
                 "{}{} {}",
                 console::style("✨ Pixi task: ").bold(),
                 console::style(
-                    &command
+                    &task
+                        .task
                         .as_single_command()
                         .expect("The command should already be parsed")
                 )
                 .blue()
                 .bold(),
-                console::style(arguments.join(" ")).blue(),
+                console::style(task.additional_args.join(" ")).blue(),
             );
         }
 
+        let execute_future =
+            deno_task_shell::execute(script, command_env.clone(), &cwd, Default::default());
         let status_code = tokio::select! {
-            code = execute_script(script, &command_env, &cwd) => code?,
+            code = execute_future => code,
             // This should never exit
             _ = ctrl_c => { unreachable!("Ctrl+C should not be triggered") }
         };
@@ -354,4 +397,145 @@ fn get_output_writer_and_handle() -> (ShellPipeWriter, JoinHandle<String>) {
     let (reader, writer) = pipe();
     let handle = reader.pipe_to_string_handle();
     (writer, handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ordered_commands() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+        [tasks]
+        root = "echo root"
+        task1 = {cmd="echo task1", depends_on=["root"]}
+        task2 = {cmd="echo task2", depends_on=["root"]}
+        top = {cmd="echo top", depends_on=["task1","task2"]}
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["top".to_string(), "--test".to_string()],
+            Some(Platform::current()),
+        )
+        .get_ordered_dependencies(&project, Some(Platform::current()))
+        .unwrap();
+
+        let ordered_task_names: Vec<_> = executable_tasks
+            .iter()
+            .map(|task| task.task.as_single_command().unwrap())
+            .collect();
+
+        assert_eq!(
+            ordered_task_names,
+            vec!["echo root", "echo task1", "echo task2", "echo top"]
+        );
+
+        // Also check if the arguments are passed correctly
+        assert_eq!(
+            executable_tasks.last().unwrap().additional_args,
+            vec!["--test".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_cycle_ordered_commands() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+        [tasks]
+        root = {cmd="echo root", depends_on=["task1"]}
+        task1 = {cmd="echo task1", depends_on=["root"]}
+        task2 = {cmd="echo task2", depends_on=["root"]}
+        top = {cmd="echo top", depends_on=["task1","task2"]}
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["top".to_string()],
+            Some(Platform::current()),
+        )
+        .get_ordered_dependencies(&project, Some(Platform::current()))
+        .unwrap();
+
+        let ordered_task_names: Vec<_> = executable_tasks
+            .iter()
+            .map(|task| task.task.as_single_command().unwrap())
+            .collect();
+
+        assert_eq!(
+            ordered_task_names,
+            vec!["echo root", "echo task1", "echo task2", "echo top"]
+        );
+    }
+
+    #[test]
+    fn test_platform_ordered_commands() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+        [tasks]
+        root = "echo root"
+        task1 = {cmd="echo task1", depends_on=["root"]}
+        task2 = {cmd="echo task2", depends_on=["root"]}
+        top = {cmd="echo top", depends_on=["task1","task2"]}
+        [target.linux-64.tasks]
+        root = {cmd="echo linux", depends_on=["task1"]}
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["top".to_string()],
+            Some(Platform::Linux64),
+        )
+        .get_ordered_dependencies(&project, Some(Platform::Linux64))
+        .unwrap();
+
+        let ordered_task_names: Vec<_> = executable_tasks
+            .iter()
+            .map(|task| task.task.as_single_command().unwrap())
+            .collect();
+
+        assert_eq!(
+            ordered_task_names,
+            vec!["echo linux", "echo task1", "echo task2", "echo top",]
+        );
+    }
+
+    #[test]
+    fn test_custom_command() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["echo bla".to_string()],
+            Some(Platform::Linux64),
+        )
+        .get_ordered_dependencies(&project, Some(Platform::Linux64))
+        .unwrap();
+
+        assert_eq!(executable_tasks.len(), 1);
+
+        let task = executable_tasks.get(0).unwrap();
+        assert!(matches!(task.task.as_ref(), &Task::Custom(_)));
+
+        assert_eq!(task.task.as_single_command().unwrap(), r###""echo bla""###);
+    }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -56,7 +56,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
     tracing::debug!("Task parsed from run command: {:?}", task_args);
 
-    // Get the correctly ordered commands
+    // Get the task to execute
     let executable_task =
         ExecutableTask::from_cmd_args(&project, task_args, Some(Platform::current()));
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -198,7 +198,7 @@ impl<'p> ExecutableTask<'p> {
             Some(cwd) if cwd.is_absolute() => cwd.to_path_buf(),
             Some(cwd) => {
                 let abs_path = project.root().join(cwd);
-                if !abs_path.exists() {
+                if !abs_path.is_dir() {
                     return Err(InvalidWorkingDirectory {
                         path: cwd.to_string_lossy().to_string(),
                     });

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -96,9 +96,11 @@ impl From<AddArgs> for Task {
                 .join(" ")
         };
 
-        // Depending on whether the task should have depends_on or not we create a Plain or complex
-        // command.
-        if depends_on.is_empty() && value.cwd.is_none() {
+        // Depending on whether the task has a command, and depends_on or not we create a plain or
+        // complex, or alias command.
+        if cmd_args.trim().is_empty() && !depends_on.is_empty() {
+            Self::Alias(Alias { depends_on })
+        } else if depends_on.is_empty() && value.cwd.is_none() {
             Self::Plain(cmd_args)
         } else {
             Self::Execute(Execute {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -896,8 +896,16 @@ impl Project {
         Ok(full_paths)
     }
 
-    /// Get the default task with the specified name or `None` if no such task exists.
-    pub fn task_opt(&self, name: &str) -> Option<&Task> {
+    /// Get the task with the specified `name` or `None` if no such task exists. If `platform` is
+    /// specified then the task will first be looked up in the target specific tasks for the given
+    /// platform.
+    pub fn task_opt(&self, name: &str, platform: Option<Platform>) -> Option<&Task> {
+        if let Some(platform) = platform {
+            if let Some(task) = self.target_specific_tasks(platform).get(name) {
+                return Some(*task);
+            }
+        }
+
         self.manifest.tasks.get(name)
     }
 

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -1,0 +1,379 @@
+use crate::{
+    task::{quote_arguments, CmdArgs, Custom, Task},
+    Project,
+};
+use deno_task_shell::{
+    execute_with_pipes, parser::SequentialList, pipe, ShellPipeWriter, ShellState,
+};
+use miette::Diagnostic;
+use rattler_conda_types::Platform;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    env,
+    fmt::{Display, Formatter},
+    path::PathBuf,
+};
+use thiserror::Error;
+use tokio::task::JoinHandle;
+
+/// Runs task in project.
+#[derive(Default, Debug)]
+pub struct RunOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("could not find the task '{task_name}'")]
+pub struct MissingTaskError {
+    pub task_name: String,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("deno task shell failed to parse '{script}': {error}")]
+pub struct FailedToParseShellScript {
+    pub script: String,
+    pub error: String,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("invalid working directory '{path}'")]
+pub struct InvalidWorkingDirectory {
+    pub path: String,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum TaskExecutionError {
+    #[error(transparent)]
+    InvalidWorkingDirectory(#[from] InvalidWorkingDirectory),
+    #[error(transparent)]
+    FailedToParseShellScript(#[from] FailedToParseShellScript),
+}
+
+/// A task that contains enough information to be able to execute it. The lifetime [`'p`] refers to
+/// the lifetime of the project that contains the tasks.
+#[derive(Clone)]
+pub struct ExecutableTask<'p> {
+    pub(super) project: &'p Project,
+    pub(super) name: Option<String>,
+    pub(super) task: Cow<'p, Task>,
+    pub(super) additional_args: Vec<String>,
+    pub(super) platform: Option<Platform>,
+}
+
+impl<'p> ExecutableTask<'p> {
+    /// Returns the name of the task or `None` if this is an anonymous task.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Returns the task description from the project.
+    pub fn task(&self) -> &Task {
+        self.task.as_ref()
+    }
+
+    /// Returns any additional args to pass to the execution of the task.
+    pub fn additional_args(&self) -> &[String] {
+        &self.additional_args
+    }
+
+    /// Returns the project in which this task is defined.
+    pub fn project(&self) -> &'p Project {
+        self.project
+    }
+
+    /// Parses command line arguments into an [`ExecutableTask`].
+    pub fn from_cmd_args(
+        project: &'p Project,
+        args: Vec<String>,
+        platform: Option<Platform>,
+    ) -> Self {
+        let mut args = args;
+
+        if let Some(name) = args.first() {
+            // Find the task in the project. First searches for platform specific tasks and falls
+            // back to looking for the task in the default tasks.
+            if let Some(task) = project.task_opt(name, platform) {
+                return Self {
+                    project,
+                    name: Some(args.remove(0)),
+                    task: Cow::Borrowed(task),
+                    additional_args: args,
+                    platform,
+                };
+            }
+        }
+
+        // When no task is found, just execute the command verbatim.
+        Self {
+            project,
+            name: None,
+            task: Cow::Owned(
+                Custom {
+                    cmd: CmdArgs::from(args),
+                    cwd: env::current_dir().ok(),
+                }
+                .into(),
+            ),
+            additional_args: vec![],
+            platform,
+        }
+    }
+
+    /// Returns a [`SequentialList`] which can be executed by deno task shell. Returns `None` if the
+    /// command is not executable like in the case of an alias.
+    pub fn as_deno_script(&self) -> Result<Option<SequentialList>, FailedToParseShellScript> {
+        // Convert the task into an executable string
+        let Some(task) = self.task.as_single_command() else {
+            return Ok(None);
+        };
+
+        // Append the command line arguments
+        let cli_args = quote_arguments(self.additional_args.iter().map(|arg| arg.as_str()));
+        let full_script = format!("{task} {cli_args}");
+
+        // Parse the shell command
+        deno_task_shell::parser::parse(full_script.trim())
+            .map_err(|e| FailedToParseShellScript {
+                script: full_script,
+                error: e.to_string(),
+            })
+            .map(Some)
+    }
+
+    /// Returns the working directory for this task.
+    pub fn working_directory(&self) -> Result<PathBuf, InvalidWorkingDirectory> {
+        Ok(match self.task.working_directory() {
+            Some(cwd) if cwd.is_absolute() => cwd.to_path_buf(),
+            Some(cwd) => {
+                let abs_path = self.project.root().join(cwd);
+                if !abs_path.is_dir() {
+                    return Err(InvalidWorkingDirectory {
+                        path: cwd.to_string_lossy().to_string(),
+                    });
+                }
+                abs_path
+            }
+            None => self.project.root().to_path_buf(),
+        })
+    }
+
+    /// Returns an object that implements [`Display`] which outputs the command of the wrapped task.
+    pub fn display_command(&self) -> impl Display + '_ {
+        ExecutableTaskConsoleDisplay { task: self }
+    }
+
+    /// Executes the task and capture its output.
+    pub async fn execute_with_pipes(
+        &self,
+        command_env: &HashMap<String, String>,
+        input: Option<&[u8]>,
+    ) -> Result<RunOutput, TaskExecutionError> {
+        let Some(script) = self.as_deno_script()? else {
+            return Ok(RunOutput {
+                exit_code: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            });
+        };
+        let cwd = self.working_directory()?;
+        let (stdin, mut stdin_writer) = pipe();
+        if let Some(stdin) = input {
+            stdin_writer.write_all(stdin).unwrap();
+        }
+        drop(stdin_writer); // prevent a deadlock by dropping the writer
+        let (stdout, stdout_handle) = get_output_writer_and_handle();
+        let (stderr, stderr_handle) = get_output_writer_and_handle();
+        let state = ShellState::new(command_env.clone(), &cwd, Default::default());
+        let code = execute_with_pipes(script, state, stdin, stdout, stderr).await;
+        Ok(RunOutput {
+            exit_code: code,
+            stdout: stdout_handle.await.unwrap(),
+            stderr: stderr_handle.await.unwrap(),
+        })
+    }
+}
+
+/// A helper object that implements [`Display`] to display (with ascii color) the command of the
+/// task.
+struct ExecutableTaskConsoleDisplay<'p, 't> {
+    task: &'t ExecutableTask<'p>,
+}
+
+impl<'p, 't> Display for ExecutableTaskConsoleDisplay<'p, 't> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let command = self.task.task.as_single_command();
+        write!(
+            f,
+            "{}",
+            console::style(command.as_deref().unwrap_or("<alias>"))
+                .blue()
+                .bold()
+        )?;
+        if !self.task.additional_args.is_empty() {
+            write!(
+                f,
+                " {}",
+                console::style(self.task.additional_args.join(" ")).blue()
+            )?;
+        }
+        Ok(())
+    }
+}
+/// Helper function to create a pipe that we can get the output from.
+fn get_output_writer_and_handle() -> (ShellPipeWriter, JoinHandle<String>) {
+    let (reader, writer) = pipe();
+    let handle = reader.pipe_to_string_handle();
+    (writer, handle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[tokio::test]
+    async fn test_ordered_commands() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+        [tasks]
+        root = "echo root"
+        task1 = {cmd="echo task1", depends_on=["root"]}
+        task2 = {cmd="echo task2", depends_on=["root"]}
+        top = {cmd="echo top", depends_on=["task1","task2"]}
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["top".to_string(), "--test".to_string()],
+            Some(Platform::current()),
+        )
+        .get_ordered_dependencies()
+        .await
+        .unwrap();
+
+        let ordered_task_names: Vec<_> = executable_tasks
+            .iter()
+            .map(|task| task.task().as_single_command().unwrap())
+            .collect();
+
+        assert_eq!(
+            ordered_task_names,
+            vec!["echo root", "echo task1", "echo task2", "echo top"]
+        );
+
+        // Also check if the arguments are passed correctly
+        assert_eq!(
+            executable_tasks.last().unwrap().additional_args(),
+            vec!["--test".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cycle_ordered_commands() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+        [tasks]
+        root = {cmd="echo root", depends_on=["task1"]}
+        task1 = {cmd="echo task1", depends_on=["root"]}
+        task2 = {cmd="echo task2", depends_on=["root"]}
+        top = {cmd="echo top", depends_on=["task1","task2"]}
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["top".to_string()],
+            Some(Platform::current()),
+        )
+        .get_ordered_dependencies()
+        .await
+        .unwrap();
+
+        let ordered_task_names: Vec<_> = executable_tasks
+            .iter()
+            .map(|task| task.task().as_single_command().unwrap())
+            .collect();
+
+        assert_eq!(
+            ordered_task_names,
+            vec!["echo root", "echo task1", "echo task2", "echo top"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_platform_ordered_commands() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+        [tasks]
+        root = "echo root"
+        task1 = {cmd="echo task1", depends_on=["root"]}
+        task2 = {cmd="echo task2", depends_on=["root"]}
+        top = {cmd="echo top", depends_on=["task1","task2"]}
+        [target.linux-64.tasks]
+        root = {cmd="echo linux", depends_on=["task1"]}
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["top".to_string()],
+            Some(Platform::Linux64),
+        )
+        .get_ordered_dependencies()
+        .await
+        .unwrap();
+
+        let ordered_task_names: Vec<_> = executable_tasks
+            .iter()
+            .map(|task| task.task().as_single_command().unwrap())
+            .collect();
+
+        assert_eq!(
+            ordered_task_names,
+            vec!["echo linux", "echo task1", "echo task2", "echo top",]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_custom_command() {
+        let file_content = r#"
+        [project]
+        name = "pixi"
+        channels = ["conda-forge"]
+        platforms = ["linux-64"]
+    "#;
+        let project = Project::from_manifest_str(Path::new(""), file_content.to_string()).unwrap();
+
+        let executable_tasks = ExecutableTask::from_cmd_args(
+            &project,
+            vec!["echo bla".to_string()],
+            Some(Platform::Linux64),
+        )
+        .get_ordered_dependencies()
+        .await
+        .unwrap();
+
+        assert_eq!(executable_tasks.len(), 1);
+
+        let task = executable_tasks.get(0).unwrap();
+        assert!(task.task().is_custom());
+
+        assert_eq!(
+            task.task().as_single_command().unwrap(),
+            r###""echo bla""###
+        );
+    }
+}

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -5,6 +5,15 @@ use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 
+mod executable_task;
+mod traverse;
+
+pub use executable_task::{
+    ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory, RunOutput,
+    TaskExecutionError,
+};
+pub use traverse::TraversalError;
+
 /// Represents different types of scripts
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -88,6 +88,11 @@ impl Task {
             Task::Alias(_) => None,
         }
     }
+
+    /// True if this task is a custom task instead of something defined in a project.
+    pub fn is_custom(&self) -> bool {
+        matches!(self, Task::Custom(_))
+    }
 }
 
 /// A command script executes a single command from the environment

--- a/src/task/traverse.rs
+++ b/src/task/traverse.rs
@@ -1,0 +1,125 @@
+use crate::task::executable_task::MissingTaskError;
+use crate::task::ExecutableTask;
+use miette::Diagnostic;
+use std::borrow::Cow;
+use std::collections::HashSet;
+use std::future::Future;
+use thiserror::Error;
+
+/// An error that might occur when traversing a task (see [`ExecutableTask::traverse`]).
+#[derive(Debug, Error, Diagnostic)]
+pub enum TraversalError {
+    #[error(transparent)]
+    MissingTask(MissingTaskError),
+}
+
+impl<'p> ExecutableTask<'p> {
+    /// Returns a list of [`ExecutableTask`]s that includes this task and its dependencies in the
+    /// order they should be executed (topologically sorted).
+    ///
+    /// Internally this function uses the [`ExecutableTask::traverse`] function to collect the
+    /// tasks in the order they are traversed.
+    pub async fn get_ordered_dependencies(self) -> Result<Vec<ExecutableTask<'p>>, TraversalError> {
+        self.traverse(
+            Vec::new(),
+            |mut tasks, task| async move {
+                tasks.push(task);
+                Ok(tasks)
+            },
+            |_, _| async { true },
+        )
+        .await
+    }
+
+    /// Traverses the task and its dependencies in topological order.
+    ///
+    /// The `visit` function is called for each task. If the `visit` function returns an error, the
+    /// traversal is stopped and the error is returned.
+    ///
+    /// The `should_visit` function is called for each task. If the `should_visit` function returns
+    /// `false`, the task and its dependencies are skipped.
+    pub async fn traverse<State, R, RFut, F, FFut, Err>(
+        self,
+        initial_state: State,
+        mut visit: R,
+        mut should_visit: F,
+    ) -> Result<State, Err>
+    where
+        RFut: Future<Output = Result<State, Err>>,
+        R: FnMut(State, ExecutableTask<'p>) -> RFut,
+        FFut: Future<Output = bool>,
+        F: FnMut(&State, &ExecutableTask<'p>) -> FFut,
+        Err: From<TraversalError>,
+    {
+        return inner(
+            initial_state,
+            self,
+            &mut HashSet::new(),
+            &mut visit,
+            &mut should_visit,
+        )
+        .await;
+
+        #[async_recursion::async_recursion(?Send)]
+        async fn inner<'p, State, R, RFut, F, FFut, Err>(
+            state: State,
+            task: ExecutableTask<'p>,
+            visited: &mut HashSet<String>,
+            visit: &mut R,
+            should_visit: &mut F,
+        ) -> Result<State, Err>
+        where
+            RFut: Future<Output = Result<State, Err>>,
+            R: FnMut(State, ExecutableTask<'p>) -> RFut,
+            FFut: Future<Output = bool>,
+            F: FnMut(&State, &ExecutableTask<'p>) -> FFut,
+            Err: From<TraversalError>,
+            'p: 'async_recursion,
+        {
+            // If the task has a name that we already visited we can immediately return.
+            if let Some(name) = task.name() {
+                if visited.contains(name) {
+                    return Ok(state);
+                }
+                visited.insert(name.to_string());
+            }
+
+            // Determine if we should even visit this task (and its dependencies in the first place).
+            if !should_visit(&state, &task).await {
+                return Ok(state);
+            }
+
+            // Locate the dependencies in the project and add them to the stack
+            let mut state = state;
+            for dependency in task.task().depends_on() {
+                let dependency = task
+                    .project()
+                    .task_opt(dependency, task.platform)
+                    .ok_or_else(|| MissingTaskError {
+                        task_name: dependency.clone(),
+                    })
+                    .map_err(TraversalError::MissingTask)?;
+
+                state = inner(
+                    state,
+                    ExecutableTask {
+                        project: task.project,
+                        name: Some(dependency.to_string()),
+                        task: Cow::Borrowed(dependency),
+                        additional_args: Vec::new(),
+                        platform: task.platform,
+                    },
+                    visited,
+                    visit,
+                    should_visit,
+                )
+                .await?;
+            }
+
+            match visit(state, task).await {
+                Ok(state) => Ok(state),
+                Err(err) => Err(err),
+            }
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -228,18 +228,15 @@ impl PixiControl {
         args.manifest_path = args.manifest_path.or_else(|| Some(self.manifest_path()));
         let project = self.project()?;
         let tasks = ExecutableTask::from_cmd_args(&project, args.task, Some(Platform::current()))
-            .get_ordered_dependencies(&project, Some(Platform::current()))
-            .unwrap();
+            .get_ordered_dependencies(&project, Some(Platform::current()))?;
 
         let project = self.project().unwrap();
-        let task_env = get_task_env(&project, args.frozen, args.locked)
-            .await
-            .unwrap();
+        let task_env = get_task_env(&project, args.frozen, args.locked).await?;
 
         let mut result = RunOutput::default();
         for task in tasks {
-            let cwd = task.working_directory(&project).unwrap();
-            let Some(script) = task.as_deno_script().unwrap() else {
+            let cwd = task.working_directory(&project)?;
+            let Some(script) = task.as_deno_script()? else {
                 continue;
             };
             let output = execute_script_with_output(script, cwd.as_path(), &task_env, None).await;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -245,7 +245,7 @@ impl PixiControl {
         #[derive(Error, Debug, Diagnostic)]
         enum RunError {
             #[error(transparent)]
-            TravereError(#[from] TraversalError),
+            TraverseError(#[from] TraversalError),
             #[error(transparent)]
             ExecutionError(#[from] TaskExecutionError),
             #[error("the task executed with a non-zero exit code {0}")]


### PR DESCRIPTION
Refactor run code a bit. Includes changes of #550.

I also refactored the traversal code to use a single `traverse` method that is reused all over the place. This includes a `should_visit` function that we can later use to skip executing certain tasks if certain conditions hold. 