### PR TITLE
fix: limit the number of concurrent solves

### DIFF
--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -87,6 +87,16 @@ pub async fn update_lock_file(
         .collect_vec();
 
     // Solve each platform concurrently
+    let num_concurrent = if project.has_pypi_dependencies() {
+        // HACK: There is a bug in rip that causes a dead-lock when solving multiple environments
+        // at the same time. So if there are pypi dependencies we limit the number of concurrent
+        // solves to 1.
+        1
+    } else {
+        // By default we solve 2 platforms concurrently. Could probably do more but solving takes
+        // a significant amount of memory.
+        2
+    };
     let result: miette::Result<Vec<_>> =
         stream::iter(platforms.iter().zip(solve_bars.iter().cloned()))
             .map(|(platform, pb)| {
@@ -124,7 +134,7 @@ pub async fn update_lock_file(
                     Ok(result)
                 }
             })
-            .buffer_unordered(2)
+            .buffer_unordered(num_concurrent)
             .try_collect()
             .await;
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -489,6 +489,34 @@ impl Project {
             .collect::<IndexMap<_, _>>()
     }
 
+    /// Returns true if the project contains any pypi dependencies
+    pub fn has_pypi_dependencies(&self) -> bool {
+        // Do we have base pypi dependencies?
+        if !self
+            .manifest
+            .pypi_dependencies
+            .as_ref()
+            .map(IndexMap::is_empty)
+            .unwrap_or(true)
+        {
+            return true;
+        }
+
+        // Do we have target specific pypi dependencies?
+        for (_, target) in self.manifest.target.iter() {
+            if !target
+                .pypi_dependencies
+                .as_ref()
+                .map(IndexMap::is_empty)
+                .unwrap_or(true)
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Returns the Python index URLs to use for this project.
     pub fn pypi_index_urls(&self) -> Vec<Url> {
         let index_url = normalize_index_url(Url::parse("https://pypi.org/simple/").unwrap());


### PR DESCRIPTION
This PR works around the file locking deadlock issue that we encountered by limiting the number of concurrent solves when also solving pypi dependencies.