### PR TITLE
feat: add new commands for `pixi project {version|channel|platform|description}`

### DIFF
--- a/src/cli/project/channel/list.rs
+++ b/src/cli/project/channel/list.rs
@@ -1,0 +1,28 @@
+use crate::Project;
+use clap::Parser;
+
+/// List the channels in the project file.
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+    /// Whether to display the channel's names or urls
+    #[clap(long)]
+    pub urls: bool,
+}
+
+pub async fn execute(project: Project, args: Args) -> miette::Result<()> {
+    project.channels().iter().for_each(|channel| {
+        if args.urls {
+            // Print the channel's url
+            eprintln!("{}", channel.base_url());
+        } else {
+            // Print the channel's name and fallback to the url if it doesn't have one
+            let name = channel
+                .name
+                .as_deref()
+                .unwrap_or(channel.base_url().as_str());
+            eprintln!("{}", name);
+        }
+    });
+
+    Ok(())
+}

--- a/src/cli/project/channel/mod.rs
+++ b/src/cli/project/channel/mod.rs
@@ -1,4 +1,6 @@
 pub mod add;
+pub mod list;
+pub mod remove;
 
 use crate::Project;
 use clap::Parser;
@@ -19,6 +21,8 @@ pub struct Args {
 #[derive(Parser, Debug)]
 pub enum Command {
     Add(add::Args),
+    List(list::Args),
+    Remove(remove::Args),
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
@@ -26,5 +30,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     match args.command {
         Command::Add(args) => add::execute(project, args).await,
+        Command::List(args) => list::execute(project, args).await,
+        Command::Remove(args) => remove::execute(project, args).await,
     }
 }

--- a/src/cli/project/channel/remove.rs
+++ b/src/cli/project/channel/remove.rs
@@ -1,0 +1,87 @@
+use crate::environment::update_prefix;
+use crate::lock_file::{load_lock_file, update_lock_file};
+use crate::prefix::Prefix;
+use crate::Project;
+use clap::Parser;
+use itertools::Itertools;
+use miette::IntoDiagnostic;
+use rattler_conda_types::{Channel, ChannelConfig, Platform};
+
+/// Remove a channel(s) to the project file and updates the lockfile.
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+    /// The channel name(s) or URL
+    #[clap(required = true, num_args=1..)]
+    pub channel: Vec<String>,
+
+    /// Don't update the environment, only remove the channel(s) to the lock-file.
+    #[clap(long)]
+    pub no_install: bool,
+}
+
+pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
+    // Determine which channels are missing
+    let channel_config = ChannelConfig::default();
+    let channels = args
+        .channel
+        .into_iter()
+        .map(|channel_str| {
+            Channel::from_str(&channel_str, &channel_config).map(|channel| (channel_str, channel))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .into_diagnostic()?;
+
+    let channels_to_remove = channels
+        .into_iter()
+        .filter(|(_name, channel)| project.channels().contains(channel))
+        .collect_vec();
+
+    if channels_to_remove.is_empty() {
+        eprintln!(
+            "{}The channel(s) are not present.",
+            console::style(console::Emoji("✔ ", "")).green(),
+        );
+        return Ok(());
+    }
+
+    // Load the existing lock-file
+    let lock_file = load_lock_file(&project).await?;
+
+    // Add the channels to the lock-file
+    project
+        .manifest
+        .remove_channels(channels_to_remove.iter().map(|(name, _channel)| name))?;
+
+    // Try to update the lock-file with the new channels
+    let lock_file = update_lock_file(&project, lock_file, None).await?;
+    project.save()?;
+
+    // Update the installation if needed
+    if !args.no_install {
+        // Get the currently installed packages
+        let prefix = Prefix::new(project.root().join(".pixi/env"))?;
+        let installed_packages = prefix.find_installed_packages(None).await?;
+
+        // Update the prefix
+        update_prefix(
+            project.pypi_package_db()?,
+            &prefix,
+            installed_packages,
+            &lock_file,
+            Platform::current(),
+        )
+        .await?;
+    }
+
+    // Report back to the user
+    for (name, channel) in channels_to_remove {
+        eprintln!(
+            "{}Removed {} ({})",
+            console::style(console::Emoji("✔ ", "")).green(),
+            name,
+            channel.base_url()
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/project/description/get.rs
+++ b/src/cli/project/description/get.rs
@@ -1,0 +1,14 @@
+use crate::Project;
+use clap::Parser;
+
+/// Get the project description.
+#[derive(Parser, Debug, Default)]
+pub struct Args {}
+
+pub async fn execute(project: Project, _args: Args) -> miette::Result<()> {
+    // Print the description if it exists
+    if let Some(description) = project.manifest.parsed.project.description {
+        eprintln!("{}", description);
+    }
+    Ok(())
+}

--- a/src/cli/project/description/mod.rs
+++ b/src/cli/project/description/mod.rs
@@ -1,0 +1,35 @@
+pub mod get;
+pub mod set;
+
+use crate::Project;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Commands to manage project description.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The path to 'pixi.toml'
+    #[clap(long, global = true)]
+    pub manifest_path: Option<PathBuf>,
+
+    /// The subcommand to execute
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Parser, Debug)]
+pub enum Command {
+    Get(get::Args),
+    Set(set::Args),
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+
+    match args.command {
+        Command::Get(args) => get::execute(project, args).await?,
+        Command::Set(args) => set::execute(project, args).await?,
+    }
+
+    Ok(())
+}

--- a/src/cli/project/description/set.rs
+++ b/src/cli/project/description/set.rs
@@ -1,0 +1,33 @@
+use crate::Project;
+use clap::Parser;
+
+/// Set the project description.
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+    /// The project description
+    #[clap(required = true, num_args = 1)]
+    pub description: String,
+}
+
+pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
+    // Set the description
+    project.manifest.set_description(args.description)?;
+
+    // Save the manifest on disk
+    project.save()?;
+
+    // Report back to the user
+    eprintln!(
+        "{}Updated project description to '{}'.",
+        console::style(console::Emoji("✔ ", "")).green(),
+        project
+            .manifest
+            .parsed
+            .project
+            .description
+            .as_ref()
+            .unwrap()
+    );
+
+    Ok(())
+}

--- a/src/cli/project/mod.rs
+++ b/src/cli/project/mod.rs
@@ -3,11 +3,13 @@ use std::path::PathBuf;
 
 pub mod channel;
 pub mod description;
+pub mod platform;
 
 #[derive(Debug, Parser)]
 pub enum Command {
     Channel(channel::Args),
     Description(description::Args),
+    Platform(platform::Args),
 }
 
 /// Modify the project configuration file through the command line.
@@ -24,6 +26,7 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
     match cmd.command {
         Command::Channel(args) => channel::execute(args).await?,
         Command::Description(args) => description::execute(args).await?,
+        Command::Platform(args) => platform::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/project/mod.rs
+++ b/src/cli/project/mod.rs
@@ -2,10 +2,12 @@ use clap::Parser;
 use std::path::PathBuf;
 
 pub mod channel;
+pub mod description;
 
 #[derive(Debug, Parser)]
 pub enum Command {
     Channel(channel::Args),
+    Description(description::Args),
 }
 
 /// Modify the project configuration file through the command line.
@@ -21,6 +23,7 @@ pub struct Args {
 pub async fn execute(cmd: Args) -> miette::Result<()> {
     match cmd.command {
         Command::Channel(args) => channel::execute(args).await?,
+        Command::Description(args) => description::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/project/mod.rs
+++ b/src/cli/project/mod.rs
@@ -4,12 +4,14 @@ use std::path::PathBuf;
 pub mod channel;
 pub mod description;
 pub mod platform;
+pub mod version;
 
 #[derive(Debug, Parser)]
 pub enum Command {
     Channel(channel::Args),
     Description(description::Args),
     Platform(platform::Args),
+    Version(version::Args),
 }
 
 /// Modify the project configuration file through the command line.
@@ -27,6 +29,7 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
         Command::Channel(args) => channel::execute(args).await?,
         Command::Description(args) => description::execute(args).await?,
         Command::Platform(args) => platform::execute(args).await?,
+        Command::Version(args) => version::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/project/platform/add.rs
+++ b/src/cli/project/platform/add.rs
@@ -1,0 +1,83 @@
+use std::str::FromStr;
+
+use crate::environment::update_prefix;
+use crate::lock_file::{load_lock_file, update_lock_file};
+use crate::prefix::Prefix;
+use crate::Project;
+use clap::Parser;
+use itertools::Itertools;
+use miette::IntoDiagnostic;
+use rattler_conda_types::Platform;
+
+/// Adds a platform(s) to the project file and updates the lockfile.
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+    /// The platform name(s) to add.
+    #[clap(required = true, num_args=1..)]
+    pub platform: Vec<String>,
+
+    /// Don't update the environment, only add changed packages to the lock-file.
+    #[clap(long)]
+    pub no_install: bool,
+}
+
+pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
+    // Determine which platforms are missing
+    let platforms = args
+        .platform
+        .into_iter()
+        .map(|platform_str| Platform::from_str(&platform_str))
+        .collect::<Result<Vec<_>, _>>()
+        .into_diagnostic()?;
+
+    let missing_platforms = platforms
+        .into_iter()
+        .filter(|x| !project.platforms().contains(x))
+        .collect_vec();
+
+    if missing_platforms.is_empty() {
+        eprintln!(
+            "{}All platform(s) have already been added.",
+            console::style(console::Emoji("✔ ", "")).green(),
+        );
+        return Ok(());
+    }
+
+    // Load the existing lock-file
+    let lock_file = load_lock_file(&project).await?;
+
+    // Add the platforms to the lock-file
+    project.manifest.add_platforms(missing_platforms.iter())?;
+
+    // Try to update the lock-file with the new channels
+    let lock_file = update_lock_file(&project, lock_file, None).await?;
+    project.save()?;
+
+    // Update the installation if needed
+    if !args.no_install {
+        // Get the currently installed packages
+        let prefix = Prefix::new(project.root().join(".pixi/env"))?;
+        let installed_packages = prefix.find_installed_packages(None).await?;
+
+        // Update the prefix
+        update_prefix(
+            project.pypi_package_db()?,
+            &prefix,
+            installed_packages,
+            &lock_file,
+            Platform::current(),
+        )
+        .await?;
+    }
+
+    // Report back to the user
+    for platform in missing_platforms {
+        eprintln!(
+            "{}Added {}",
+            console::style(console::Emoji("✔ ", "")).green(),
+            platform
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/project/platform/list.rs
+++ b/src/cli/project/platform/list.rs
@@ -1,0 +1,14 @@
+use crate::Project;
+use clap::Parser;
+
+/// List the platforms in the project file.
+#[derive(Parser, Debug, Default)]
+pub struct Args {}
+
+pub async fn execute(project: Project, _args: Args) -> miette::Result<()> {
+    project.platforms().iter().for_each(|platform| {
+        eprintln!("{}", platform.as_str());
+    });
+
+    Ok(())
+}

--- a/src/cli/project/platform/mod.rs
+++ b/src/cli/project/platform/mod.rs
@@ -1,0 +1,36 @@
+pub mod add;
+pub mod list;
+pub mod remove;
+
+use crate::Project;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Commands to manage project channels.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The path to 'pixi.toml'
+    #[clap(long, global = true)]
+    pub manifest_path: Option<PathBuf>,
+
+    /// The subcommand to execute
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Parser, Debug)]
+pub enum Command {
+    Add(add::Args),
+    List(list::Args),
+    Remove(remove::Args),
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+
+    match args.command {
+        Command::Add(args) => add::execute(project, args).await,
+        Command::List(args) => list::execute(project, args).await,
+        Command::Remove(args) => remove::execute(project, args).await,
+    }
+}

--- a/src/cli/project/platform/remove.rs
+++ b/src/cli/project/platform/remove.rs
@@ -1,0 +1,87 @@
+use crate::environment::update_prefix;
+use crate::lock_file::{load_lock_file, update_lock_file};
+use crate::prefix::Prefix;
+use crate::Project;
+use clap::Parser;
+use itertools::Itertools;
+use miette::IntoDiagnostic;
+use rattler_conda_types::{Channel, ChannelConfig, Platform};
+
+/// Remove a channel(s) to the project file and updates the lockfile.
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+    /// The channel name(s) or URL
+    #[clap(required = true, num_args=1..)]
+    pub channel: Vec<String>,
+
+    /// Don't update the environment, only remove the channel(s) to the lock-file.
+    #[clap(long)]
+    pub no_install: bool,
+}
+
+pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
+    // Determine which channels are missing
+    let channel_config = ChannelConfig::default();
+    let channels = args
+        .channel
+        .into_iter()
+        .map(|channel_str| {
+            Channel::from_str(&channel_str, &channel_config).map(|channel| (channel_str, channel))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .into_diagnostic()?;
+
+    let channels_to_remove = channels
+        .into_iter()
+        .filter(|(_name, channel)| project.channels().contains(channel))
+        .collect_vec();
+
+    if channels_to_remove.is_empty() {
+        eprintln!(
+            "{}The channel(s) are not present.",
+            console::style(console::Emoji("✔ ", "")).green(),
+        );
+        return Ok(());
+    }
+
+    // Load the existing lock-file
+    let lock_file = load_lock_file(&project).await?;
+
+    // Add the channels to the lock-file
+    project
+        .manifest
+        .remove_channels(channels_to_remove.iter().map(|(name, _channel)| name))?;
+
+    // Try to update the lock-file with the new channels
+    let lock_file = update_lock_file(&project, lock_file, None).await?;
+    project.save()?;
+
+    // Update the installation if needed
+    if !args.no_install {
+        // Get the currently installed packages
+        let prefix = Prefix::new(project.root().join(".pixi/env"))?;
+        let installed_packages = prefix.find_installed_packages(None).await?;
+
+        // Update the prefix
+        update_prefix(
+            project.pypi_package_db()?,
+            &prefix,
+            installed_packages,
+            &lock_file,
+            Platform::current(),
+        )
+        .await?;
+    }
+
+    // Report back to the user
+    for (name, channel) in channels_to_remove {
+        eprintln!(
+            "{}Removed {} ({})",
+            console::style(console::Emoji("✔ ", "")).green(),
+            name,
+            channel.base_url()
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/project/platform/remove.rs
+++ b/src/cli/project/platform/remove.rs
@@ -5,14 +5,15 @@ use crate::Project;
 use clap::Parser;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
-use rattler_conda_types::{Channel, ChannelConfig, Platform};
+use rattler_conda_types::Platform;
+use std::str::FromStr;
 
-/// Remove a channel(s) to the project file and updates the lockfile.
+/// Remove a platform(s) to the project file and updates the lockfile.
 #[derive(Parser, Debug, Default)]
 pub struct Args {
-    /// The channel name(s) or URL
+    /// The platform name(s) to add.
     #[clap(required = true, num_args=1..)]
-    pub channel: Vec<String>,
+    pub platform: Vec<String>,
 
     /// Don't update the environment, only remove the channel(s) to the lock-file.
     #[clap(long)]
@@ -20,25 +21,22 @@ pub struct Args {
 }
 
 pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
-    // Determine which channels are missing
-    let channel_config = ChannelConfig::default();
-    let channels = args
-        .channel
+    // Determine which platforms are missing
+    let platforms = args
+        .platform
         .into_iter()
-        .map(|channel_str| {
-            Channel::from_str(&channel_str, &channel_config).map(|channel| (channel_str, channel))
-        })
+        .map(|platform_str| Platform::from_str(&platform_str))
         .collect::<Result<Vec<_>, _>>()
         .into_diagnostic()?;
 
-    let channels_to_remove = channels
+    let platforms_to_remove = platforms
         .into_iter()
-        .filter(|(_name, channel)| project.channels().contains(channel))
+        .filter(|x| project.platforms().contains(x))
         .collect_vec();
 
-    if channels_to_remove.is_empty() {
+    if platforms_to_remove.is_empty() {
         eprintln!(
-            "{}The channel(s) are not present.",
+            "{}The platforms(s) are not present.",
             console::style(console::Emoji("✔ ", "")).green(),
         );
         return Ok(());
@@ -50,7 +48,7 @@ pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
     // Add the channels to the lock-file
     project
         .manifest
-        .remove_channels(channels_to_remove.iter().map(|(name, _channel)| name))?;
+        .remove_platforms(platforms_to_remove.iter().map(|p| p.to_string()))?;
 
     // Try to update the lock-file with the new channels
     let lock_file = update_lock_file(&project, lock_file, None).await?;
@@ -74,12 +72,11 @@ pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
     }
 
     // Report back to the user
-    for (name, channel) in channels_to_remove {
+    for platform in platforms_to_remove {
         eprintln!(
-            "{}Removed {} ({})",
+            "{}Removed {}",
             console::style(console::Emoji("✔ ", "")).green(),
-            name,
-            channel.base_url()
+            platform,
         );
     }
 

--- a/src/cli/project/version/bump.rs
+++ b/src/cli/project/version/bump.rs
@@ -1,0 +1,40 @@
+use crate::Project;
+use clap::Parser;
+
+pub enum BumpType {
+    Major,
+    Minor,
+    Patch,
+}
+
+/// Bump the project version.
+#[derive(Parser, Debug, Default)]
+pub struct Args {}
+
+pub async fn execute(bump_type: BumpType, mut project: Project, _args: Args) -> miette::Result<()> {
+    let current_version = project.version().as_ref().unwrap().clone();
+
+    // NOTE(hadim): logic is the same everywhere (bump last component)
+    // The correct logic should be added on rattler probably.
+    let new_version = match bump_type {
+        BumpType::Major => current_version.bump(),
+        BumpType::Minor => current_version.bump(),
+        BumpType::Patch => current_version.bump(),
+    };
+
+    // Set the version
+    project.manifest.set_version(new_version.to_string())?;
+
+    // Save the manifest on disk
+    project.save()?;
+
+    // Report back to the user
+    eprintln!(
+        "{}Bump project version from '{}' to '{}'.",
+        console::style(console::Emoji("✔ ", "")).green(),
+        current_version,
+        new_version
+    );
+
+    Ok(())
+}

--- a/src/cli/project/version/get.rs
+++ b/src/cli/project/version/get.rs
@@ -1,0 +1,11 @@
+use crate::Project;
+use clap::Parser;
+
+/// Get the project version.
+#[derive(Parser, Debug, Default)]
+pub struct Args {}
+
+pub async fn execute(project: Project, _args: Args) -> miette::Result<()> {
+    eprintln!("{}", project.version().as_ref().unwrap());
+    Ok(())
+}

--- a/src/cli/project/version/mod.rs
+++ b/src/cli/project/version/mod.rs
@@ -1,0 +1,35 @@
+pub mod get;
+pub mod set;
+
+use crate::Project;
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Commands to manage project description.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The path to 'pixi.toml'
+    #[clap(long, global = true)]
+    pub manifest_path: Option<PathBuf>,
+
+    /// The subcommand to execute
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Parser, Debug)]
+pub enum Command {
+    Get(get::Args),
+    Set(set::Args),
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+
+    match args.command {
+        Command::Get(args) => get::execute(project, args).await?,
+        Command::Set(args) => set::execute(project, args).await?,
+    }
+
+    Ok(())
+}

--- a/src/cli/project/version/mod.rs
+++ b/src/cli/project/version/mod.rs
@@ -1,3 +1,4 @@
+pub mod bump;
 pub mod get;
 pub mod set;
 
@@ -21,6 +22,9 @@ pub struct Args {
 pub enum Command {
     Get(get::Args),
     Set(set::Args),
+    Major(bump::Args),
+    Minor(bump::Args),
+    Patch(bump::Args),
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
@@ -29,6 +33,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     match args.command {
         Command::Get(args) => get::execute(project, args).await?,
         Command::Set(args) => set::execute(project, args).await?,
+        Command::Major(args) => bump::execute(bump::BumpType::Major, project, args).await?,
+        Command::Minor(args) => bump::execute(bump::BumpType::Minor, project, args).await?,
+        Command::Patch(args) => bump::execute(bump::BumpType::Patch, project, args).await?,
     }
 
     Ok(())

--- a/src/cli/project/version/set.rs
+++ b/src/cli/project/version/set.rs
@@ -1,0 +1,27 @@
+use crate::Project;
+use clap::Parser;
+
+/// Set the project version.
+#[derive(Parser, Debug, Default)]
+pub struct Args {
+    /// The new project version
+    #[clap(required = true, num_args = 1)]
+    pub version: String,
+}
+
+pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
+    // Set the version
+    project.manifest.set_version(args.version)?;
+
+    // Save the manifest on disk
+    project.save()?;
+
+    // Report back to the user
+    eprintln!(
+        "{}Updated project version to '{}'.",
+        console::style(console::Emoji("✔ ", "")).green(),
+        project.version().as_ref().unwrap()
+    );
+
+    Ok(())
+}

--- a/src/project/manifest.rs
+++ b/src/project/manifest.rs
@@ -17,7 +17,7 @@ use serde_with::{serde_as, DeserializeAs, DisplayFromStr, PickFirst};
 use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use toml_edit::{Array, Document, Item, Table, TomlError, Value};
+use toml_edit::{value, Array, Document, Item, Table, TomlError, Value};
 use url::Url;
 
 /// Handles the project's manifest file.
@@ -493,6 +493,16 @@ impl Manifest {
         for channel in stored_channels {
             channels_array.push(channel);
         }
+
+        Ok(())
+    }
+
+    /// Set the project description
+    pub fn set_description(&mut self, description: String) -> miette::Result<()> {
+        // NOTE(hadim): It feels strange to set description on both `parsed` and `document`.
+        // But I am not sure what approach is preferred here.
+        self.parsed.project.description = Some(description.clone());
+        self.document["project"]["description"] = value(description);
 
         Ok(())
     }

--- a/src/project/manifest.rs
+++ b/src/project/manifest.rs
@@ -586,10 +586,18 @@ impl Manifest {
 
     /// Set the project description
     pub fn set_description(&mut self, description: String) -> miette::Result<()> {
-        // NOTE(hadim): It feels strange to set description on both `parsed` and `document`.
-        // But I am not sure what approach is preferred here.
+        // Update in both the manifest and the toml
         self.parsed.project.description = Some(description.clone());
         self.document["project"]["description"] = value(description);
+
+        Ok(())
+    }
+
+    /// Set the project version
+    pub fn set_version(&mut self, version: String) -> miette::Result<()> {
+        // Update in both the manifest and the toml
+        self.parsed.project.version = Some(Version::from_str(&version).unwrap());
+        self.document["project"]["version"] = value(version);
 
         Ok(())
     }

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use crate::{common::package_database::PackageDatabase, common::PixiControl};
+use pixi::cli::run;
 use rattler_conda_types::{Channel, ChannelConfig};
 use tempfile::TempDir;
 use url::Url;
@@ -46,4 +47,30 @@ async fn add_channel() {
     )
     .unwrap();
     assert!(project.channels().contains(&local_channel));
+}
+
+#[tokio::test]
+async fn description() {
+    // Get a pixi instance
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+
+    let _command = "project description set \"Hello world\"";
+
+    // // Set the description
+    // let result = pixi
+    //     .run(run::Args {
+    //         task: command.split(" ").map(|s| s.to_string()).collect(),
+    //         ..Default::default()
+    //     })
+    //     .await
+    //     .unwrap();
+
+    // println!("{:?}", result);
+
+    // assert_eq!(result.exit_code, 0);
+    // assert_eq!(result.stdout.trim(), "Python 3.11.0");
+    // assert!(result.stderr.is_empty());
+
+    // let project = pixi.project().unwrap();
 }

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use crate::{common::package_database::PackageDatabase, common::PixiControl};
-use pixi::cli::run;
 use rattler_conda_types::{Channel, ChannelConfig};
 use tempfile::TempDir;
 use url::Url;


### PR DESCRIPTION
A first proposal for https://github.com/prefix-dev/pixi/issues/575

The idea is to add a few new `pixi project` commands:

- [x] `pixi project description set`
- [x] `pixi project description get`
- [x] `pixi project channel list`
- [x] `pixi project channel remove`
- [x] `pixi project platform list`
- [x] `pixi project platform remove`
- [x] `pixi project platform add`
- [x] `pixi project version get`
- [x] `pixi project version set`
- [x] `pixi project version {major,minor,patch}`: I did a first pass, but I feel the logic should live on rattler, no?

Tests are missing.

See also a few comments/questions below.