### PR TITLE
Working towards `self-update`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,6 +2651,7 @@ dependencies = [
  "rattler_virtual_packages",
  "regex",
  "reqwest",
+ "self-replace",
  "serde",
  "serde_json",
  "serde_spanned",
@@ -3556,6 +3557,17 @@ checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "self-replace"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525db198616b2bcd0f245daf7bfd8130222f7ee6af9ff9984c19a61bf1160c55"
+dependencies = [
+ "fastrand 1.9.0",
+ "tempfile",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ rattler_virtual_packages = { version = "0.14.0", default-features = false }
 regex = "1.10.2"
 reqwest = { version = "0.11.22", default-features = false }
 rip = { package = "rattler_installs_packages", version = "0.1.0", default-features = false }
+self-replace = "1.3.7"
 serde = "1.0.193"
 serde_json = "1.0.108"
 serde_spanned = "0.6.4"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub mod project;
 pub mod remove;
 pub mod run;
 pub mod search;
+pub mod self_update;
 pub mod shell;
 pub mod task;
 pub mod upload;
@@ -69,6 +70,7 @@ pub enum Command {
     Project(project::Args),
     #[clap(alias = "rm")]
     Remove(remove::Args),
+    SelfUpdate(self_update::Args),
 }
 
 #[derive(Parser, Debug, Default)]
@@ -165,6 +167,7 @@ pub async fn execute_command(command: Command) -> miette::Result<()> {
         Command::Search(cmd) => search::execute(cmd).await,
         Command::Project(cmd) => project::execute(cmd).await,
         Command::Remove(cmd) => remove::execute(cmd).await,
+        Command::SelfUpdate(cmd) => self_update::execute(cmd).await,
     }
 }
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1,0 +1,117 @@
+use std::io::Write;
+
+use miette::IntoDiagnostic;
+use reqwest::Client;
+use serde::Deserialize;
+
+/// Update pixi to the latest version
+#[derive(Debug, clap::Parser)]
+pub struct Args {
+    /// The desired version (to downgrade or upgrade to)
+    #[clap(long)]
+    version: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    name: String,
+    body: String,
+    html_url: String,
+    assets: Vec<GithubReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+fn user_agent() -> String {
+    format!("pixi {}", env!("CARGO_PKG_VERSION"))
+}
+
+fn default_name() -> Option<String> {
+    if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "x86_64") {
+            Some("pixi-x86_64-apple-darwin".to_string())
+        } else {
+            Some("pixi-aarch64-apple-darwin".to_string())
+        }
+    } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        Some("pixi-x86_64-pc-windows-msvc.exe".to_string())
+    } else if cfg!(target_os = "linux") {
+        if cfg!(target_arch = "x86_64") {
+            Some("pixi-x86_64-unknown-linux-musl".to_string())
+        } else if cfg!(target_arch = "aarch64") {
+            Some("pixi-aarch64-unknown-linux-musl".to_string())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    // fetch latest version from github
+    let url = if let Some(version) = args.version {
+        format!(
+            "https://api.github.com/repos/prefix-dev/pixi/releases/tags/v{}",
+            version
+        )
+    } else {
+        "https://api.github.com/repos/prefix-dev/pixi/releases/latest".to_string()
+    };
+
+    let client = Client::new();
+
+    let res = client
+        .get(url)
+        .header("User-Agent", user_agent())
+        .send()
+        .await
+        .unwrap();
+    let body = res.text().await.unwrap();
+
+    // compare latest version with current version
+    let json = serde_json::from_str::<GithubRelease>(&body).unwrap();
+
+    let version = json.tag_name.trim_start_matches('v');
+
+    // if latest version is newer, download and replace binary
+    if version != env!("CARGO_PKG_VERSION") {
+        println!("A newer version is available: {}", version);
+    } else {
+        println!("You are already using the latest version: {}", version);
+    }
+
+    let name = default_name().unwrap();
+
+    let url = json
+        .assets
+        .iter()
+        .find(|asset| asset.name == name)
+        .unwrap()
+        .browser_download_url
+        .clone();
+
+    // if latest version is newer, download and replace binary (using self_replace)
+    let tempfile = tempfile::NamedTempFile::new().into_diagnostic()?;
+
+    let mut res = client
+        .get(&url)
+        .header("User-Agent", user_agent())
+        .send()
+        .await
+        .unwrap();
+
+    while let Some(chunk) = res.chunk().await.into_diagnostic()? {
+        tempfile.as_file().write_all(&chunk).into_diagnostic()?;
+    }
+
+    self_replace::self_replace(&tempfile).into_diagnostic()?;
+
+    Ok(())
+}


### PR DESCRIPTION
- [ ] this uses the uncompressed release from Github. We could use the compressed one.
- [ ] It updates unconditionally. We should check wether pixi is in the "default" location (~/.pixi/bin/pixi) and if not, probably not touch it (externally managed by homebrew or conda etc.). Maybe add a `--force` option to allow overwriting in other locations.
- [ ] The version comparison code is a bit brittle right now but should probably work fine.
