### PR TITLE
fix: use project virtual packages in add command

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,7 +6,6 @@ use crate::{
     lock_file::{load_lock_file, update_lock_file},
     project::python::PyPiRequirement,
     project::Project,
-    virtual_packages::get_minimal_virtual_packages,
 };
 use clap::Parser;
 use indexmap::IndexMap;
@@ -271,6 +270,7 @@ pub async fn add_conda_specs_to_project(
 
         // Solve the environment with the new specs added
         let solved_versions = match determine_best_version(
+            project,
             &new_specs,
             &current_specs,
             &sparse_repo_data,
@@ -373,6 +373,7 @@ async fn update_environment(
 }
 /// Given several specs determines the highest installable version for them.
 pub fn determine_best_version(
+    project: &Project,
     new_specs: &HashMap<PackageName, NamelessMatchSpec>,
     current_specs: &IndexMap<PackageName, NamelessMatchSpec>,
     sparse_repo_data: &[SparseRepoData],
@@ -409,10 +410,7 @@ pub fn determine_best_version(
 
         available_packages: &available_packages,
 
-        virtual_packages: get_minimal_virtual_packages(platform)
-            .into_iter()
-            .map(Into::into)
-            .collect(),
+        virtual_packages: project.virtual_packages(platform)?,
 
         // TODO: Add the information from the current lock file here.
         locked_packages: vec![],


### PR DESCRIPTION
Previously, the `add` command was using the default set of virtual packages from [get_minimal_virtual_packages](https://github.com/prefix-dev/pixi/blob/5a16570ae4af85b4de5b5fb858050e4c1e59b132/src/virtual_packages.rs#L28C8-L28C36) for solving, rather than using the actual virtual packages for the current project; see #607 for more detail.

(Hopefully this will resolve the `__cuda` issue in #607, though I haven't yet tested that on my target machine.)