### PR TITLE
Remove custom dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - dependencies
     commit-message:
       prefix: bump
     ignore:
@@ -18,8 +16,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
-      - dependencies
     commit-message:
       prefix: chore(ci)
     groups:


### PR DESCRIPTION
https://github.com/prefix-dev/pixi/pull/611#issuecomment-1875564017

dependabot should automatically add its own labels anyway, see https://github.com/prefix-dev/setup-pixi/pull/62 and https://github.com/prefix-dev/setup-pixi/pull/30