### PR TITLE
feat: add upgrade command to pixi

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -328,7 +328,7 @@ Globally installed binary packages:
 
 ### `global upgrade`
 
-This command upgrades a globally installed package to the latest version. 
+This command upgrades a globally installed package to the latest version.
 
 ##### Options
 
@@ -350,7 +350,7 @@ This command upgrades all globally installed packages to their latest version.
 - `--channel (-c)`: specify a channel that the project uses. Defaults to `conda-forge`. (Allowed to be used more than once)
 
 ```shell
-pixi global upgrade-all 
+pixi global upgrade-all
 pixi global upgrade-all --channel conda-forge --channel bioconda
 # Or in a more concise form
 pixi global upgrade-all -c conda-forge -c bioconda trackplot

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -326,6 +326,36 @@ Globally installed binary packages:
      -  [bin] zsh-5
 ```
 
+### `global upgrade`
+
+This command upgrades a globally installed package to the latest version. 
+
+##### Options
+
+- `--channel (-c)`: specify a channel that the project uses. Defaults to `conda-forge`. (Allowed to be used more than once)
+
+```shell
+pixi global upgrade ruff
+pixi global upgrade --channel conda-forge --channel bioconda trackplot
+# Or in a more concise form
+pixi global upgrade -c conda-forge -c bioconda trackplot
+```
+
+### `global upgrade-all`
+
+This command upgrades all globally installed packages to their latest version.
+
+##### Options
+
+- `--channel (-c)`: specify a channel that the project uses. Defaults to `conda-forge`. (Allowed to be used more than once)
+
+```shell
+pixi global upgrade-all 
+pixi global upgrade-all --channel conda-forge --channel bioconda
+# Or in a more concise form
+pixi global upgrade-all -c conda-forge -c bioconda trackplot
+```
+
 ### `global remove`
 
 Removes a package previously installed into a globally accessible location via

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -46,19 +46,7 @@ fn print_no_packages_found_message() {
 }
 
 pub async fn execute(_args: Args) -> miette::Result<()> {
-    let mut packages = vec![];
-    let mut dir_contents = tokio::fs::read_dir(bin_env_dir()?)
-        .await
-        .into_diagnostic()?;
-    while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
-        if entry.file_type().await.into_diagnostic()?.is_dir() {
-            let Ok(name) = PackageName::from_str(entry.file_name().to_string_lossy().as_ref())
-            else {
-                continue;
-            };
-            packages.push(name);
-        }
-    }
+    let packages = list_global_packages().await?;
 
     let mut package_info = vec![];
 
@@ -117,4 +105,23 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
+    let mut packages = vec![];
+    let mut dir_contents = tokio::fs::read_dir(bin_env_dir()?)
+        .await
+        .into_diagnostic()?;
+
+    while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
+        if entry.file_type().await.into_diagnostic()?.is_dir() {
+            let Ok(name) = PackageName::from_str(entry.file_name().to_string_lossy().as_ref())
+            else {
+                continue;
+            };
+            packages.push(name);
+        }
+    }
+
+    Ok(packages)
 }

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -3,6 +3,7 @@ mod install;
 mod list;
 mod remove;
 mod upgrade;
+mod upgrade_all;
 
 #[derive(Debug, Parser)]
 pub enum Command {
@@ -14,6 +15,8 @@ pub enum Command {
     List(list::Args),
     #[clap(alias = "u")]
     Upgrade(upgrade::Args),
+    #[clap(alias = "ua")]
+    UpgradeAll(upgrade_all::Args),
 }
 
 /// Global is the main entry point for the part of pixi that executes on the global(system) level.
@@ -31,6 +34,7 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
         Command::Remove(args) => remove::execute(args).await?,
         Command::List(args) => list::execute(args).await?,
         Command::Upgrade(args) => upgrade::execute(args).await?,
+        Command::UpgradeAll(args) => upgrade_all::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 mod install;
 mod list;
 mod remove;
+mod upgrade;
 
 #[derive(Debug, Parser)]
 pub enum Command {
@@ -11,6 +12,8 @@ pub enum Command {
     Remove(remove::Args),
     #[clap(alias = "ls")]
     List(list::Args),
+    #[clap(alias = "u")]
+    Upgrade(upgrade::Args),
 }
 
 /// Global is the main entry point for the part of pixi that executes on the global(system) level.
@@ -27,6 +30,7 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
         Command::Install(args) => install::execute(args).await?,
         Command::Remove(args) => remove::execute(args).await?,
         Command::List(args) => list::execute(args).await?,
+        Command::Upgrade(args) => upgrade::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/global/upgrade.rs
+++ b/src/cli/global/upgrade.rs
@@ -1,0 +1,90 @@
+use std::str::FromStr;
+
+use clap::Parser;
+use miette::IntoDiagnostic;
+use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, Platform};
+use rattler_repodata_gateway::sparse::SparseRepoData;
+
+use crate::repodata::fetch_sparse_repodata;
+
+use super::{
+    install::{install_package, package_name},
+    list::list_global_packages,
+};
+
+/// Upgrade specific package which is installed globally.
+#[derive(Parser, Debug)]
+#[clap(arg_required_else_help = true)]
+pub struct Args {
+    /// Specifies the package that is to be upgraded.
+    package: String,
+
+    /// Represents the channels from which to upgrade specified package.
+    /// Multiple channels can be specified by using this field multiple times.
+    ///
+    /// When specifying a channel, it is common that the selected channel also
+    /// depends on the `conda-forge` channel.
+    /// For example: `pixi global upgrade --channel conda-forge --channel bioconda`.
+    ///
+    /// By default, if no channel is provided, `conda-forge` is used.
+    #[clap(short, long, default_values = ["conda-forge"])]
+    channel: Vec<String>,
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    let package = args.package;
+    // Figure out what channels we are using
+    let channel_config = ChannelConfig::default();
+    let channels = args
+        .channel
+        .iter()
+        .map(|c| Channel::from_str(c, &channel_config))
+        .collect::<Result<Vec<Channel>, _>>()
+        .into_diagnostic()?;
+
+    // Find the MatchSpec we want to install
+    let package_matchspec = MatchSpec::from_str(&package).into_diagnostic()?;
+    let package_name = package_name(&package_matchspec)?;
+
+    // Return with error if this package is not globally installed.
+    if !list_global_packages()
+        .await?
+        .iter()
+        .any(|global_package| global_package.as_source() == package)
+    {
+        // TODO: Maybe this can be an error
+        miette::bail!(
+            "{} Package is not globally installed",
+            console::style("!").yellow().bold()
+        );
+    }
+
+    let platform = Platform::current();
+
+    // Fetch sparse repodata
+    let platform_sparse_repodata = fetch_sparse_repodata(&channels, &[platform]).await?;
+
+    let available_packages = SparseRepoData::load_records_recursive(
+        platform_sparse_repodata.iter(),
+        vec![package_name.clone()],
+        None,
+    )
+    .into_diagnostic()?;
+
+    // Install the package
+    let (package_record, _, _) = install_package(
+        package_matchspec,
+        available_packages,
+        &channel_config,
+        platform,
+    )
+    .await?;
+
+    eprintln!(
+        "Updated package {} to version {}",
+        package_name.as_source(),
+        package_record.repodata_record.package_record.version
+    );
+
+    Ok(())
+}

--- a/src/cli/global/upgrade.rs
+++ b/src/cli/global/upgrade.rs
@@ -54,7 +54,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     // Fetch sparse repodata
-    let platform_sparse_repodata = fetch_sparse_repodata(&channels, &[Platform::current()]).await?;
+    let platform_sparse_repodata = fetch_sparse_repodata(&channels, [Platform::current()]).await?;
 
     // Install the package
     let (package_record, _, upgraded) = globally_install_package(

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -1,0 +1,75 @@
+use clap::Parser;
+use futures::{stream, StreamExt, TryStreamExt};
+use miette::IntoDiagnostic;
+use rattler_conda_types::{Channel, ChannelConfig, Platform};
+
+use crate::repodata::fetch_sparse_repodata;
+
+use super::{install::globally_install_package, list::list_global_packages};
+
+const UPGRADE_ALL_CONCURRENCY: usize = 5;
+
+/// Upgrade all globally installed packages
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Represents the channels from which to upgrade packages.
+    /// Multiple channels can be specified by using this field multiple times.
+    ///
+    /// When specifying a channel, it is common that the selected channel also
+    /// depends on the `conda-forge` channel.
+    /// For example: `pixi global upgrade --channel conda-forge --channel bioconda`.
+    ///
+    /// By default, if no channel is provided, `conda-forge` is used.
+    #[clap(short, long, default_values = ["conda-forge"])]
+    channel: Vec<String>,
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    // Figure out what channels we are using
+    let channel_config = ChannelConfig::default();
+    let platform = Platform::current();
+    let channels = args
+        .channel
+        .iter()
+        .map(|c| Channel::from_str(c, &channel_config))
+        .collect::<Result<Vec<Channel>, _>>()
+        .into_diagnostic()?;
+
+    let packages = list_global_packages().await?;
+
+    // Fetch sparse repodata
+    let platform_sparse_repodata = fetch_sparse_repodata(&channels, &[platform]).await?;
+
+    let tasks = packages
+        .iter()
+        .map(|package| package.as_source().parse())
+        .collect::<Result<Vec<_>, _>>()
+        .into_diagnostic()?;
+
+    let task_stream = stream::iter(tasks)
+        .map(|matchspec| {
+            globally_install_package(matchspec, &platform_sparse_repodata, &channel_config)
+        })
+        .buffered(UPGRADE_ALL_CONCURRENCY);
+
+    let res: Vec<_> = task_stream.try_collect().await?;
+
+    let mut packages_upgraded = 0;
+    for (prefix_record, _, upgraded) in res {
+        if upgraded {
+            packages_upgraded += 1;
+            let record = prefix_record.repodata_record.package_record;
+            eprintln!(
+                "Upgraded {} {}",
+                console::style(record.name.as_normalized()).bold(),
+                console::style(record.version).bold(),
+            );
+        }
+    }
+
+    if packages_upgraded == 0 {
+        eprintln!("Nothing to upgrade");
+    }
+
+    Ok(())
+}

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -17,7 +17,7 @@ pub struct Args {
     ///
     /// When specifying a channel, it is common that the selected channel also
     /// depends on the `conda-forge` channel.
-    /// For example: `pixi global upgrade --channel conda-forge --channel bioconda`.
+    /// For example: `pixi global upgrade-all --channel conda-forge --channel bioconda`.
     ///
     /// By default, if no channel is provided, `conda-forge` is used.
     #[clap(short, long, default_values = ["conda-forge"])]

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -27,7 +27,6 @@ pub struct Args {
 pub async fn execute(args: Args) -> miette::Result<()> {
     // Figure out what channels we are using
     let channel_config = ChannelConfig::default();
-    let platform = Platform::current();
     let channels = args
         .channel
         .iter()
@@ -38,7 +37,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let packages = list_global_packages().await?;
 
     // Fetch sparse repodata
-    let platform_sparse_repodata = fetch_sparse_repodata(&channels, &[platform]).await?;
+    let platform_sparse_repodata = fetch_sparse_repodata(&channels, [Platform::current()]).await?;
 
     let tasks = packages
         .iter()


### PR DESCRIPTION
Fixes: #613 

### Description
Introduce a new 'upgrade' and `upgrade-all` subcommand to 'pixi'.

Users can specify the target package with the 'package' option and choose upgrade channels using the 'channel' option.

### Example
```sh
pixi global upgrade <package> --channel <channel>
```
```sh
pixi global upgrade-all  --channel <channel>
```

