### PR TITLE
refactor: move code from `Project` to `Environment`

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use clap::Parser;
 use indexmap::IndexMap;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 
 use miette::{IntoDiagnostic, WrapErr};
 use rattler_conda_types::{
@@ -255,11 +255,11 @@ pub async fn add_conda_specs_to_project(
     let mut package_versions = HashMap::<PackageName, HashSet<Version>>::new();
 
     let platforms = if specs_platforms.is_empty() {
-        project.platforms()
+        Either::Left(project.platforms().into_iter())
     } else {
-        specs_platforms
-    }
-    .to_vec();
+        Either::Right(specs_platforms.iter().copied())
+    };
+
     for platform in platforms {
         // TODO: `build` and `host` has to be separated when we have separated environments for them.
         //       While we combine them on install we should also do that on getting the best version.

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -338,7 +338,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let platform = Platform::current();
 
     // Fetch sparse repodata
-    let platform_sparse_repodata = fetch_sparse_repodata(&channels, &[platform]).await?;
+    let platform_sparse_repodata = fetch_sparse_repodata(&channels, [platform]).await?;
 
     let available_packages = SparseRepoData::load_records_recursive(
         platform_sparse_repodata.iter(),

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -204,7 +204,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         package_count: dependency_count(&p).ok(),
         environment_size,
         last_updated: last_updated(p.lock_file_path()).ok(),
-        platforms: p.platforms().to_vec(),
+        platforms: p.platforms().into_iter().collect(),
     });
 
     let virtual_packages = VirtualPackage::current()

--- a/src/cli/project/channel/list.rs
+++ b/src/cli/project/channel/list.rs
@@ -9,7 +9,7 @@ pub struct Args {
 }
 
 pub async fn execute(project: Project, args: Args) -> miette::Result<()> {
-    project.channels().iter().for_each(|channel| {
+    project.channels().into_iter().for_each(|channel| {
         if args.urls {
             // Print the channel's url
             println!("{}", channel.base_url());

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -178,19 +178,22 @@ pub fn execute(args: Args) -> miette::Result<()> {
                 }
 
                 // Check if task has dependencies
-                let depends_on = project.task_names_depending_on(name);
-                if !depends_on.is_empty() && !args.names.contains(name) {
-                    eprintln!(
-                        "{}: {}",
-                        console::style("Warning, the following task/s depend on this task")
-                            .yellow(),
-                        console::style(depends_on.iter().to_owned().join(", ")).bold()
-                    );
-                    eprintln!(
-                        "{}",
-                        console::style("Be sure to modify these after the removal\n").yellow()
-                    );
-                }
+                // TODO: Make this properly work by inspecting which actual tasks depend on the task
+                //  we just removed taking into account environments and features.
+                // let depends_on = project.task_names_depending_on(name);
+                // if !depends_on.is_empty() && !args.names.contains(name) {
+                //     eprintln!(
+                //         "{}: {}",
+                //         console::style("Warning, the following task/s depend on this task")
+                //             .yellow(),
+                //         console::style(depends_on.iter().to_owned().join(", ")).bold()
+                //     );
+                //     eprintln!(
+                //         "{}",
+                //         console::style("Be sure to modify these after the removal\n").yellow()
+                //     );
+                // }
+
                 // Safe to remove
                 to_remove.push((name, args.platform));
             }
@@ -220,7 +223,10 @@ pub fn execute(args: Args) -> miette::Result<()> {
             );
         }
         Operation::List(args) => {
-            let tasks = project.task_names(Some(Platform::current()));
+            let tasks = project
+                .tasks(Some(Platform::current()))
+                .into_keys()
+                .collect_vec();
             if tasks.is_empty() {
                 eprintln!("No tasks found",);
             } else {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,3 +4,5 @@ pub const PIXI_DIR: &str = ".pixi";
 pub const PREFIX_FILE_NAME: &str = "prefix";
 pub const ENVIRONMENT_DIR: &str = "env";
 pub const PYPI_DEPENDENCIES: &str = "pypi-dependencies";
+
+pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";

--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -48,12 +48,11 @@ fn main_progress_bar(num_bars: u64, message: &'static str) -> ProgressBar {
     top_level_progress
 }
 
-fn platform_solve_bars(platforms: &[Platform]) -> Vec<ProgressBar> {
+fn platform_solve_bars(platforms: impl IntoIterator<Item = Platform>) -> Vec<ProgressBar> {
     platforms
-        .iter()
+        .into_iter()
         .map(|platform| {
-            let pb =
-                progress::global_multi_progress().add(ProgressBar::new(platforms.len() as u64));
+            let pb = progress::global_multi_progress().add(ProgressBar::new(0));
             pb.set_style(
                 indicatif::ProgressStyle::with_template(&format!(
                     "    {:<9} ..",
@@ -87,12 +86,12 @@ pub async fn update_lock_file_conda(
     let _top_level_progress =
         main_progress_bar(platforms.len() as u64, "resolving conda dependencies");
     // Create progress bars for each platform
-    let solve_bars = platform_solve_bars(platforms);
+    let solve_bars = platform_solve_bars(platforms.iter().copied());
 
     // Construct a conda lock file
     let channels = project
         .channels()
-        .iter()
+        .into_iter()
         .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()));
 
     let result: miette::Result<Vec<_>> =
@@ -162,7 +161,7 @@ pub async fn update_lock_file_for_pypi(
     let platforms = project.platforms();
     let _top_level_progress =
         main_progress_bar(platforms.len() as u64, "resolving pypi dependencies");
-    let solve_bars = platform_solve_bars(platforms);
+    let solve_bars = platform_solve_bars(platforms.iter().copied());
 
     let records = platforms
         .iter()
@@ -216,7 +215,7 @@ pub async fn update_lock_file_for_pypi(
 
     let channels = project
         .channels()
-        .iter()
+        .into_iter()
         .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()));
     let mut builder = LockFileBuilder::new(channels, platforms.iter().cloned(), vec![]);
     for locked_packages in result? {

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -34,7 +34,7 @@ pub fn lock_file_satisfies_project(
     // result.
     let channels = project
         .channels()
-        .iter()
+        .into_iter()
         .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()))
         .collect_vec();
     if lock_file.metadata.channels.iter().ne(channels.iter()) {

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -64,7 +64,7 @@ impl<'p> Environment<'p> {
                     .parsed
                     .features
                     .get(&FeatureName::Named(feature_name.clone()))
-                    .expect("fea")
+                    .expect("feature usage should have been validated upfront")
             })
             .chain([self.project.manifest.default_feature()])
     }
@@ -114,7 +114,9 @@ impl<'p> Environment<'p> {
                 .copied()
                 .collect::<HashSet<_>>()
             })
-            .reduce(|value, feat| value.intersection(&feat).copied().collect())
+            .reduce(|accumulated_platforms, feat| {
+                accumulated_platforms.intersection(&feat).copied().collect()
+            })
             .unwrap_or_default()
     }
 

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -1,0 +1,163 @@
+use crate::project::manifest;
+use crate::project::manifest::{EnvironmentName, Feature, FeatureName};
+use crate::Project;
+use indexmap::IndexSet;
+use rattler_conda_types::{Channel, Platform};
+use std::collections::HashSet;
+
+/// Describes a single environment from a project manifest. This is used to describe environments
+/// that can be installed and activated.
+///
+/// This struct is a higher level representation of a [`manifest::Environment`]. The
+/// `manifest::Environment` describes the data stored in the manifest file, while this struct
+/// provides methods to easily interact with an environment without having to deal with the
+/// structure of the project model.
+///
+/// This type does not provide manipulation methods. To modify the data model you should directly
+/// interact with the manifest instead.
+///
+/// The lifetime `'p` refers to the lifetime of the project that this environment belongs to.
+pub struct Environment<'p> {
+    /// The project this environment belongs to.
+    pub(super) project: &'p Project,
+
+    /// The environment that this environment is based on.
+    pub(super) environment: &'p manifest::Environment,
+}
+
+impl<'p> Environment<'p> {
+    /// Returns the name of this environment.
+    pub fn name(&self) -> &EnvironmentName {
+        &self.environment.name
+    }
+
+    /// Returns the manifest definition of this environment. See the documentation of
+    /// [`Environment`] for an overview of the difference between [`manifest::Environment`] and
+    /// [`Environment`].
+    pub fn manifest(&self) -> &'p manifest::Environment {
+        self.environment
+    }
+
+    /// Returns references to the features that make up this environment. The default feature is
+    /// always added at the end.
+    pub fn features(&self) -> impl Iterator<Item = &'p Feature> + '_ {
+        self.environment
+            .features
+            .iter()
+            .map(|feature_name| {
+                self.project
+                    .manifest
+                    .parsed
+                    .features
+                    .get(&FeatureName::Named(feature_name.clone()))
+                    .expect("fea")
+            })
+            .chain([self.project.manifest.default_feature()])
+    }
+
+    /// Returns the channels associated with this environment.
+    ///
+    /// Users can specify custom channels on a per feature basis. This method collects and
+    /// deduplicates all the channels from all the features in the order they are defined in the
+    /// manifest.
+    ///
+    /// If a feature does not specify any channel the default channels from the project metadata are
+    /// used instead. However, these are not considered during deduplication. This means the default
+    /// channels are always added to the end of the list.
+    pub fn channels(&self) -> IndexSet<&'p Channel> {
+        self.features()
+            .filter_map(|feature| match feature.name {
+                // Use the user-specified channels of each feature if the feature defines them. Only
+                // for the default feature do we use the default channels from the project metadata
+                // if the feature itself does not specify any channels. This guarantees that the
+                // channels from the default feature are always added to the end of the list.
+                FeatureName::Named(_) => feature.channels.as_deref(),
+                FeatureName::Default => feature
+                    .channels
+                    .as_deref()
+                    .or(Some(&self.project.manifest.parsed.project.channels)),
+            })
+            .flatten()
+            .collect()
+    }
+
+    /// Returns the platforms that this environment is compatible with.
+    ///
+    /// Which platforms an environment support depends on which platforms the selected features of
+    /// the environment supports. The platforms that are supported by the environment is the
+    /// intersection of the platforms supported by its features.
+    ///
+    /// Features can specify which platforms they support through the `platforms` key. If a feature
+    /// does not specify any platforms the features defined by the project are used.
+    pub fn platforms(&self) -> HashSet<Platform> {
+        self.features()
+            .map(|feature| {
+                match &feature.platforms {
+                    Some(platforms) => &platforms.value,
+                    None => &self.project.manifest.parsed.project.platforms.value,
+                }
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>()
+            })
+            .reduce(|value, feat| value.intersection(&feat).copied().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use itertools::Itertools;
+    use std::path::Path;
+
+    #[test]
+    fn test_default_channels() {
+        let manifest = Project::from_str(
+            Path::new(""),
+            r#"
+        [project]
+        name = "foobar"
+        channels = ["foo", "bar"]
+        platforms = []
+        "#,
+        )
+        .unwrap();
+
+        let channels = manifest
+            .default_environment()
+            .channels()
+            .into_iter()
+            .map(Channel::canonical_name)
+            .collect_vec();
+        assert_eq!(
+            channels,
+            vec![
+                "https://conda.anaconda.org/foo/",
+                "https://conda.anaconda.org/bar/"
+            ]
+        );
+    }
+
+    // TODO: Add a test to verify that feature specific channels work as expected.
+
+    #[test]
+    fn test_default_platforms() {
+        let manifest = Project::from_str(
+            Path::new(""),
+            r#"
+        [project]
+        name = "foobar"
+        channels = []
+        platforms = ["linux-64", "osx-64"]
+        "#,
+        )
+        .unwrap();
+
+        let channels = manifest.default_environment().platforms();
+        assert_eq!(
+            channels,
+            HashSet::from_iter([Platform::Linux64, Platform::Osx64,])
+        );
+    }
+}

--- a/src/project/errors.rs
+++ b/src/project/errors.rs
@@ -1,0 +1,78 @@
+use crate::project::manifest::EnvironmentName;
+use crate::Project;
+use itertools::Itertools;
+use miette::{Diagnostic, LabeledSpan};
+use rattler_conda_types::Platform;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use thiserror::Error;
+
+/// An error that occurs when data is requested for a platform that is not supported.
+/// TODO: Make this error better by also explaining to the user why a certain platform was not
+///  supported and with suggestions as how to fix it.
+#[derive(Debug, Clone)]
+pub struct UnsupportedPlatformError<'p> {
+    /// The project that the platform is not supported for.
+    pub project: &'p Project,
+
+    /// The environment that the platform is not supported for.
+    pub environment: EnvironmentName,
+
+    /// The platform that was requested
+    pub platform: Platform,
+}
+
+impl<'p> Error for UnsupportedPlatformError<'p> {}
+
+impl<'p> Display for UnsupportedPlatformError<'p> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.environment {
+            EnvironmentName::Default => {
+                write!(f, "the project does not support '{}'", self.platform)
+            }
+            EnvironmentName::Named(name) => write!(
+                f,
+                "the environment '{}' does not support '{}'",
+                name, self.platform
+            ),
+        }
+    }
+}
+
+impl<'p> Diagnostic for UnsupportedPlatformError<'p> {
+    fn code(&self) -> Option<Box<dyn Display + '_>> {
+        Some(Box::new("unsupported-platform".to_string()))
+    }
+
+    fn help(&self) -> Option<Box<dyn Display + '_>> {
+        let env = self.project.environment(&self.environment)?;
+        Some(Box::new(format!(
+            "supported platforms are {}",
+            env.platforms().into_iter().format(", ")
+        )))
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        None
+    }
+}
+
+/// An error that occurs when a task is requested which could not be found.
+/// TODO: Make this error better.
+///     - Include names that might have been meant instead
+///     - If the tasks is only available for a certain platform, explain that.
+#[derive(Debug, Clone, Diagnostic, Error)]
+#[error("the task '{task_name}' could not be found")]
+pub struct UnknownTask<'p> {
+    /// The project that the platform is not supported for.
+    pub project: &'p Project,
+
+    /// The environment that the platform is not supported for.
+    pub environment: EnvironmentName,
+
+    /// The platform that was requested (if any)
+    pub platform: Option<Platform>,
+
+    /// The name of the task
+    pub task_name: String,
+}

--- a/src/project/manifest/environment.rs
+++ b/src/project/manifest/environment.rs
@@ -1,4 +1,4 @@
-use crate::utils::spanned::PixiSpanned;
+use crate::consts;
 
 /// The name of an environment. This is either a string or default for the default environment.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
@@ -8,11 +8,12 @@ pub enum EnvironmentName {
 }
 
 impl EnvironmentName {
-    /// Returns the name of the environment or `None` if this is the default environment.
-    pub fn name(&self) -> Option<&str> {
+    /// Returns the name of the environment. This is either the name of the environment or the name
+    /// of the default environment.
+    pub fn as_str(&self) -> &str {
         match self {
-            EnvironmentName::Default => None,
-            EnvironmentName::Named(name) => Some(name),
+            EnvironmentName::Default => consts::DEFAULT_ENVIRONMENT_NAME,
+            EnvironmentName::Named(name) => name.as_str(),
         }
     }
 }
@@ -30,7 +31,10 @@ pub struct Environment {
     ///
     /// Note that the default feature is always added to the set of features that make up the
     /// environment.
-    pub features: PixiSpanned<Vec<String>>,
+    pub features: Vec<String>,
+
+    /// The optional location of where the features are defined in the manifest toml.
+    pub features_source_loc: Option<std::ops::Range<usize>>,
 
     /// An optional solver-group. Multiple environments can share the same solve-group. All the
     /// dependencies of the environment that share the same solve-group will be solved together.

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -485,6 +485,11 @@ impl Manifest {
     pub fn default_environment(&self) -> &Environment {
         self.parsed.default_environment()
     }
+
+    /// Returns the environment with the given name or `None` if it does not exist.
+    pub fn environment(&self, name: &EnvironmentName) -> Option<&Environment> {
+        self.parsed.environments.get(name)
+    }
 }
 
 /// Ensures that the specified TOML target table exists within a given document,

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -7,13 +7,9 @@ mod python;
 mod serde;
 mod system_requirements;
 mod target;
+mod validation;
 
-use crate::{
-    consts,
-    project::{manifest::target::Targets, SpecType},
-    task::Task,
-    utils::spanned::PixiSpanned,
-};
+use crate::{consts, project::SpecType, task::Task, utils::spanned::PixiSpanned};
 use ::serde::{Deserialize, Deserializer};
 pub use activation::Activation;
 pub use environment::{Environment, EnvironmentName};
@@ -21,7 +17,7 @@ pub use feature::{Feature, FeatureName};
 use indexmap::IndexMap;
 use itertools::Itertools;
 pub use metadata::ProjectMetadata;
-use miette::{Context, IntoDiagnostic, LabeledSpan, NamedSource, Report};
+use miette::{IntoDiagnostic, LabeledSpan, NamedSource};
 pub use python::PyPiRequirement;
 use rattler_conda_types::{
     Channel, ChannelConfig, MatchSpec, NamelessMatchSpec, PackageName, Platform, Version,
@@ -29,12 +25,11 @@ use rattler_conda_types::{
 use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use std::{
     collections::HashMap,
-    ops::Range,
     path::{Path, PathBuf},
     str::FromStr,
 };
 pub use system_requirements::{LibCFamilyAndVersion, LibCSystemRequirement, SystemRequirements};
-pub use target::{Target, TargetSelector};
+pub use target::{Target, TargetSelector, Targets};
 use toml_edit::{value, Array, Document, Item, Table, TomlError, Value};
 
 /// Handles the project's manifest file.
@@ -613,9 +608,11 @@ impl ProjectManifest {
     /// feature. The default environment can be overwritten by a environment named `default`.
     pub fn default_environment(&self) -> &Environment {
         let envs = &self.environments;
-        envs.get(&EnvironmentName::Named(String::from("default")))
-            .or_else(|| envs.get(&EnvironmentName::Default))
-            .expect("default environment should always exist")
+        envs.get(&EnvironmentName::Named(String::from(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+        )))
+        .or_else(|| envs.get(&EnvironmentName::Default))
+        .expect("default environment should always exist")
     }
 }
 
@@ -701,7 +698,8 @@ impl<'de> Deserialize<'de> for ProjectManifest {
         // Construct a default environment
         let default_environment = Environment {
             name: EnvironmentName::Default,
-            features: Vec::new().into(),
+            features: Vec::new(),
+            features_source_loc: None,
             solve_group: None,
         };
 
@@ -711,95 +709,6 @@ impl<'de> Deserialize<'de> for ProjectManifest {
             environments: IndexMap::from_iter([(EnvironmentName::Default, default_environment)]),
         })
     }
-}
-
-impl ProjectManifest {
-    /// Validate the
-    pub fn validate(&self, source: NamedSource, root_folder: &Path) -> miette::Result<()> {
-        // Check if the targets are defined for existing platforms
-        for feature in self.features.values() {
-            let platforms = feature
-                .platforms
-                .as_ref()
-                .unwrap_or(&self.project.platforms);
-            for target_sel in feature.targets.user_defined_selectors() {
-                match target_sel {
-                    TargetSelector::Platform(p) => {
-                        if !platforms.as_ref().contains(p) {
-                            return Err(create_unsupported_platform_report(
-                                source,
-                                feature.targets.source_loc(target_sel).unwrap_or_default(),
-                                p,
-                                feature,
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-
-        // parse the SPDX license expression to make sure that it is a valid expression.
-        if let Some(spdx_expr) = &self.project.license {
-            spdx::Expression::parse(spdx_expr)
-                .into_diagnostic()
-                .with_context(|| {
-                    format!(
-                        "failed to parse the SPDX license expression '{}'",
-                        spdx_expr
-                    )
-                })?;
-        }
-
-        let check_file_existence = |x: &Option<PathBuf>| {
-            if let Some(path) = x {
-                let full_path = root_folder.join(path);
-                if !full_path.exists() {
-                    return Err(miette::miette!(
-                        "the file '{}' does not exist",
-                        full_path.display()
-                    ));
-                }
-            }
-            Ok(())
-        };
-
-        check_file_existence(&self.project.license_file)?;
-        check_file_existence(&self.project.readme)?;
-
-        Ok(())
-    }
-}
-
-// Create an error report for using a platform that is not supported by the project.
-fn create_unsupported_platform_report(
-    source: NamedSource,
-    span: Range<usize>,
-    platform: &Platform,
-    feature: &Feature,
-) -> Report {
-    miette::miette!(
-        labels = vec![LabeledSpan::at(
-            span,
-            format!("'{}' is not a supported platform", platform)
-        )],
-        help = format!(
-            "Add '{platform}' to the `{}` array of the {} manifest.",
-            consts::PROJECT_MANIFEST,
-            if feature.platforms.is_some() {
-                format!(
-                    "feature.{}.platforms",
-                    feature
-                        .name
-                        .name()
-                        .expect("default feature never defines custom platforms")
-                )
-            } else {
-                String::from("project.platforms")
-            }
-        ),
-        "targeting a platform that this project does not support"
-    )
-    .with_source_code(source)
 }
 
 #[cfg(test)]

--- a/src/project/manifest/target.rs
+++ b/src/project/manifest/target.rs
@@ -162,7 +162,7 @@ impl<'de> Deserialize<'de> for Target {
 }
 
 /// A collect of targets including a default target.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Targets {
     default_target: Target,
 

--- a/src/project/manifest/validation.rs
+++ b/src/project/manifest/validation.rs
@@ -1,0 +1,148 @@
+use crate::project::manifest::{Environment, FeatureName};
+use crate::{
+    consts,
+    project::manifest::{Feature, ProjectManifest, TargetSelector},
+};
+use miette::{IntoDiagnostic, LabeledSpan, NamedSource, Report, WrapErr};
+use rattler_conda_types::Platform;
+use std::collections::HashSet;
+use std::{
+    ops::Range,
+    path::{Path, PathBuf},
+};
+
+impl ProjectManifest {
+    /// Validate the project manifest.
+    pub fn validate(&self, source: NamedSource, root_folder: &Path) -> miette::Result<()> {
+        // Check if the targets are defined for existing platforms
+        for feature in self.features.values() {
+            let platforms = feature
+                .platforms
+                .as_ref()
+                .unwrap_or(&self.project.platforms);
+            for target_sel in feature.targets.user_defined_selectors() {
+                match target_sel {
+                    TargetSelector::Platform(p) => {
+                        if !platforms.as_ref().contains(p) {
+                            return Err(create_unsupported_platform_report(
+                                source,
+                                feature.targets.source_loc(target_sel).unwrap_or_default(),
+                                p,
+                                feature,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        // parse the SPDX license expression to make sure that it is a valid expression.
+        if let Some(spdx_expr) = &self.project.license {
+            spdx::Expression::parse(spdx_expr)
+                .into_diagnostic()
+                .with_context(|| {
+                    format!(
+                        "failed to parse the SPDX license expression '{}'",
+                        spdx_expr
+                    )
+                })?;
+        }
+
+        let check_file_existence = |x: &Option<PathBuf>| {
+            if let Some(path) = x {
+                let full_path = root_folder.join(path);
+                if !full_path.exists() {
+                    return Err(miette::miette!(
+                        "the file '{}' does not exist",
+                        full_path.display()
+                    ));
+                }
+            }
+            Ok(())
+        };
+
+        check_file_existence(&self.project.license_file)?;
+        check_file_existence(&self.project.readme)?;
+
+        // Validate the environments defined in the project
+        for (_name, env) in self.environments.iter() {
+            if let Err(report) = self.validate_environment(env) {
+                return Err(report.with_source_code(source));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validates that the given environment is valid.
+    fn validate_environment(&self, env: &Environment) -> Result<(), Report> {
+        let mut features_seen = HashSet::new();
+
+        for feature in env.features.iter() {
+            // Make sure that the environment does not have any duplicate features.
+            if !features_seen.insert(feature) {
+                return Err(miette::miette!(
+                    labels = vec![LabeledSpan::at(
+                        env.features_source_loc.clone().unwrap_or_default(),
+                        format!("the feature '{}' was defined more than once.", feature)
+                    )],
+                    help =
+                        "since the order of the features matters a duplicate feature is ambiguous",
+                    "the feature '{}' is defined multiple times in the environment '{}'",
+                    feature,
+                    env.name.as_str()
+                ));
+            }
+
+            // Make sure that every feature actually exists.
+            if !self
+                .features
+                .contains_key(&FeatureName::Named(feature.clone()))
+            {
+                return Err(miette::miette!(
+                    labels = vec![LabeledSpan::at(
+                        env.features_source_loc.clone().unwrap_or_default(),
+                        format!("unknown feature '{}'", feature)
+                    )],
+                    help = "add the feature to the project manifest",
+                    "the feature '{}' is not defined in the project manifest",
+                    feature
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Create an error report for using a platform that is not supported by the project.
+fn create_unsupported_platform_report(
+    source: NamedSource,
+    span: Range<usize>,
+    platform: &Platform,
+    feature: &Feature,
+) -> Report {
+    miette::miette!(
+        labels = vec![LabeledSpan::at(
+            span,
+            format!("'{}' is not a supported platform", platform)
+        )],
+        help = format!(
+            "Add '{platform}' to the `{}` array of the {} manifest.",
+            consts::PROJECT_MANIFEST,
+            if feature.platforms.is_some() {
+                format!(
+                    "feature.{}.platforms",
+                    feature
+                        .name
+                        .name()
+                        .expect("default feature never defines custom platforms")
+                )
+            } else {
+                String::from("project.platforms")
+            }
+        ),
+        "targeting a platform that this project does not support"
+    )
+    .with_source_code(source)
+}

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,14 +1,15 @@
+mod environment;
 pub mod manifest;
 pub mod metadata;
 
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use miette::{IntoDiagnostic, NamedSource, WrapErr};
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{Channel, MatchSpec, NamelessMatchSpec, PackageName, Platform, Version};
 use rattler_virtual_packages::VirtualPackage;
 use rip::{index::PackageDb, normalize_index_url};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::{
     env,
     ffi::OsStr,
@@ -23,6 +24,7 @@ use crate::{
     task::Task,
     virtual_packages::non_relevant_virtual_packages_for_platform,
 };
+use environment::Environment;
 use manifest::{Manifest, PyPiRequirement, SystemRequirements};
 use rip::types::NormalizedPackageName;
 use std::fmt::{Display, Formatter};
@@ -86,6 +88,12 @@ impl Project {
             package_db: Default::default(),
             manifest,
         }
+    }
+
+    /// Constructs a project from a manifest.
+    pub fn from_str(root: &Path, content: &str) -> miette::Result<Self> {
+        let manifest = Manifest::from_str(root, content)?;
+        Ok(Self::from_manifest(manifest))
     }
 
     /// Discovers the project manifest file in the current directory or any of the parent
@@ -190,14 +198,26 @@ impl Project {
         self.manifest.save()
     }
 
-    /// Returns the channels used by this project
-    pub fn channels(&self) -> &[Channel] {
-        &self.manifest.parsed.project.channels
+    /// Returns the default environment of the project.
+    pub fn default_environment(&self) -> Environment<'_> {
+        Environment {
+            project: self,
+            environment: self.manifest.default_environment(),
+        }
+    }
+
+    /// Returns the channels used by this project.
+    ///
+    /// TODO: Remove this function and use the channels from the default environment instead.
+    pub fn channels(&self) -> IndexSet<&Channel> {
+        self.default_environment().channels()
     }
 
     /// Returns the platforms this project targets
-    pub fn platforms(&self) -> &[Platform] {
-        self.manifest.parsed.project.platforms.as_ref().as_slice()
+    ///
+    /// TODO: Remove this function and use the channels from the default environment instead.
+    pub fn platforms(&self) -> HashSet<Platform> {
+        self.default_environment().platforms()
     }
 
     /// Get the tasks of this project

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -1,6 +1,7 @@
 use crate::{default_authenticated_client, progress, project::Project};
 use futures::{stream, StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
+use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::{Channel, Platform};
 use rattler_networking::AuthenticatedClient;
@@ -16,18 +17,17 @@ impl Project {
 }
 
 pub async fn fetch_sparse_repodata(
-    channels: &[Channel],
-    target_platforms: &[Platform],
+    channels: impl IntoIterator<Item = &'_ Channel>,
+    target_platforms: impl IntoIterator<Item = Platform>,
 ) -> miette::Result<Vec<SparseRepoData>> {
-    if channels.is_empty() {
-        return Ok(vec![]);
-    }
+    let channels = channels.into_iter();
+    let target_platforms = target_platforms.into_iter().collect_vec();
 
     // Determine all the repodata that requires fetching.
-    let mut fetch_targets = Vec::with_capacity(channels.len() * target_platforms.len());
+    let mut fetch_targets = Vec::with_capacity(channels.size_hint().0 * target_platforms.len());
     for channel in channels {
         // Determine the platforms to use for this channel.
-        let platforms = channel.platforms.as_deref().unwrap_or(target_platforms);
+        let platforms = channel.platforms.as_deref().unwrap_or(&target_platforms);
         for platform in platforms {
             fetch_targets.push((channel.clone(), *platform));
         }
@@ -37,6 +37,10 @@ pub async fn fetch_sparse_repodata(
         if noarch_missing {
             fetch_targets.push((channel.clone(), Platform::NoArch));
         }
+    }
+
+    if fetch_targets.is_empty() {
+        return Ok(vec![]);
     }
 
     // Construct a top-level progress bar

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -254,7 +254,7 @@ mod tests {
         let executable_tasks = ExecutableTask::from_cmd_args(
             &project,
             vec!["top".to_string(), "--test".to_string()],
-            Some(Platform::current()),
+            None,
         )
         .get_ordered_dependencies()
         .await
@@ -293,14 +293,11 @@ mod tests {
         let manifest = Manifest::from_str(Path::new(""), file_content.to_string()).unwrap();
         let project = Project::from_manifest(manifest);
 
-        let executable_tasks = ExecutableTask::from_cmd_args(
-            &project,
-            vec!["top".to_string()],
-            Some(Platform::current()),
-        )
-        .get_ordered_dependencies()
-        .await
-        .unwrap();
+        let executable_tasks =
+            ExecutableTask::from_cmd_args(&project, vec!["top".to_string()], None)
+                .get_ordered_dependencies()
+                .await
+                .unwrap();
 
         let ordered_task_names: Vec<_> = executable_tasks
             .iter()

--- a/tests/init_tests.rs
+++ b/tests/init_tests.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use crate::common::PixiControl;
+use itertools::Itertools;
 use rattler_conda_types::{Channel, ChannelConfig, Version};
 use std::str::FromStr;
 
@@ -46,12 +47,12 @@ async fn specific_channel() {
     let project = pixi.project().unwrap();
 
     // The only channel should be the "random" channel
-    let channels = project.channels();
+    let channels = Vec::from_iter(project.channels());
     assert_eq!(
         channels,
-        &[
-            Channel::from_str("random", &ChannelConfig::default()).unwrap(),
-            Channel::from_str("foobar", &ChannelConfig::default()).unwrap()
+        [
+            &Channel::from_str("random", &ChannelConfig::default()).unwrap(),
+            &Channel::from_str("foobar", &ChannelConfig::default()).unwrap()
         ]
     )
 }
@@ -68,9 +69,9 @@ async fn default_channel() {
     let project = pixi.project().unwrap();
 
     // The only channel should be the "conda-forge" channel
-    let channels = project.channels();
+    let channels = Vec::from_iter(project.channels());
     assert_eq!(
         channels,
-        &[Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap()]
+        [&Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap()]
     )
 }

--- a/tests/init_tests.rs
+++ b/tests/init_tests.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use crate::common::PixiControl;
-use itertools::Itertools;
 use rattler_conda_types::{Channel, ChannelConfig, Version};
 use std::str::FromStr;
 


### PR DESCRIPTION
This PR refactors the code to extract project information from `Environment`s instead of directly from the project. 

This initial PR tries to retain the same surface level API as before where the accessors on the `Project` struct remains intact. 

A next PR will remove this functions and force users to go through `Environment`s instead of `Project`.

This PR currently refactos the `platforms`, `channels` and `tasks` functions. I will create a follow-up PRs to also refactor the `system-requirements`, `activation` and `dependency` functions.