### PR TITLE
refactor: extract dependencies to `Environment`

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -329,7 +329,7 @@ pub fn determine_best_version(
     // Build the combined set of specs while updating the dependencies with the new specs.
     let dependencies = SpecType::all()
         .map(|spec_type| {
-            let mut deps = project.dependencies(spec_type, Some(platform));
+            let mut deps = project.dependencies(Some(spec_type), Some(platform));
             if spec_type == new_specs_type {
                 for (new_name, new_spec) in new_specs.iter() {
                     deps.remove(new_name); // Remove any existing specs

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -161,7 +161,7 @@ fn last_updated(path: impl Into<PathBuf>) -> miette::Result<String> {
 /// Returns number of dependencies on current platform
 fn dependency_count(project: &Project) -> u64 {
     project
-        .all_dependencies(Some(Platform::current()))
+        .dependencies(None, Some(Platform::current()))
         .names()
         .count() as _
 }

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -33,7 +33,7 @@ pub struct Args {
 pub struct ProjectInfo {
     tasks: Vec<String>,
     manifest_path: PathBuf,
-    package_count: Option<u64>,
+    package_count: u64,
     environment_size: Option<String>,
     last_updated: Option<String>,
     platforms: Vec<Platform>,
@@ -93,9 +93,7 @@ impl Display for Info {
                 pi.manifest_path.to_string_lossy()
             )?;
 
-            if let Some(count) = pi.package_count {
-                writeln!(f, "{:20}: {}", "Dependency count", count)?;
-            }
+            writeln!(f, "{:20}: {}", "Dependency count", pi.package_count)?;
 
             if let Some(size) = &pi.environment_size {
                 writeln!(f, "{:20}: {}", "Environment size", size)?;
@@ -161,14 +159,11 @@ fn last_updated(path: impl Into<PathBuf>) -> miette::Result<String> {
 }
 
 /// Returns number of dependencies on current platform
-fn dependency_count(project: &Project) -> miette::Result<u64> {
-    let dep_count = project
-        .all_dependencies(Platform::current())
-        .keys()
-        .cloned()
-        .fold(0, |acc, _| acc + 1);
-
-    Ok(dep_count)
+fn dependency_count(project: &Project) -> u64 {
+    project
+        .all_dependencies(Some(Platform::current()))
+        .names()
+        .count() as _
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
@@ -201,7 +196,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             .into_keys()
             .map(|k| k.to_string())
             .collect(),
-        package_count: dependency_count(&p).ok(),
+        package_count: dependency_count(&p),
         environment_size,
         last_updated: last_updated(p.lock_file_path()).ok(),
         platforms: p.platforms().into_iter().collect(),

--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -305,14 +305,14 @@ async fn resolve_platform(
     platform: Platform,
     pb: ProgressBar,
 ) -> miette::Result<LockedPackagesBuilder> {
-    let dependencies = project.all_dependencies(platform);
+    let dependencies = project.all_dependencies(Some(platform));
     let match_specs = dependencies
-        .iter()
+        .iter_specs()
         .map(|(name, constraint)| MatchSpec::from_nameless(constraint.clone(), Some(name.clone())))
         .collect_vec();
 
     // Extract the package names from the dependencies
-    let package_names = dependencies.keys().cloned().collect_vec();
+    let package_names = dependencies.names().cloned().collect_vec();
 
     // Get the virtual packages for this platform
     let virtual_packages = project.virtual_packages(platform);

--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -305,7 +305,7 @@ async fn resolve_platform(
     platform: Platform,
     pb: ProgressBar,
 ) -> miette::Result<LockedPackagesBuilder> {
-    let dependencies = project.all_dependencies(Some(platform));
+    let dependencies = project.dependencies(None, Some(platform));
     let match_specs = dependencies
         .iter_specs()
         .map(|(name, constraint)| MatchSpec::from_nameless(constraint.clone(), Some(name.clone())))

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -45,7 +45,7 @@ pub fn lock_file_satisfies_project(
     for platform in platforms.iter().cloned() {
         // Check if all dependencies exist in the lock-file.
         let conda_dependencies = project
-            .all_dependencies(Some(platform))
+            .dependencies(None, Some(platform))
             .iter_specs()
             .map(|(name, spec)| {
                 DependencyKind::Conda(MatchSpec::from_nameless(spec.clone(), Some(name.clone())))

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -45,9 +45,11 @@ pub fn lock_file_satisfies_project(
     for platform in platforms.iter().cloned() {
         // Check if all dependencies exist in the lock-file.
         let conda_dependencies = project
-            .all_dependencies(platform)
-            .into_iter()
-            .map(|(name, spec)| DependencyKind::Conda(MatchSpec::from_nameless(spec, Some(name))))
+            .all_dependencies(Some(platform))
+            .iter_specs()
+            .map(|(name, spec)| {
+                DependencyKind::Conda(MatchSpec::from_nameless(spec.clone(), Some(name.clone())))
+            })
             .collect::<Vec<_>>();
 
         let mut pypi_dependencies = project

--- a/src/project/dependencies.rs
+++ b/src/project/dependencies.rs
@@ -1,0 +1,122 @@
+use indexmap::{Equivalent, IndexMap};
+use rattler_conda_types::{NamelessMatchSpec, PackageName};
+use std::hash::Hash;
+
+/// Holds a list of dependencies where for each package name there can be multiple requirements.
+///
+/// This is used when combining the dependencies of multiple features. Although each target can only
+/// have one requirement for a given package, when combining the dependencies of multiple features
+/// there can be multiple requirements for a given package.
+#[derive(Default, Debug, Clone)]
+pub struct Dependencies {
+    map: IndexMap<PackageName, Vec<NamelessMatchSpec>>,
+}
+
+impl From<IndexMap<PackageName, Vec<NamelessMatchSpec>>> for Dependencies {
+    fn from(map: IndexMap<PackageName, Vec<NamelessMatchSpec>>) -> Self {
+        Self { map }
+    }
+}
+
+impl From<IndexMap<PackageName, NamelessMatchSpec>> for Dependencies {
+    fn from(map: IndexMap<PackageName, NamelessMatchSpec>) -> Self {
+        Self {
+            map: map.into_iter().map(|(k, v)| (k, vec![v])).collect(),
+        }
+    }
+}
+
+impl Dependencies {
+    /// Adds the given spec to the list of dependencies.
+    pub fn insert(&mut self, name: PackageName, spec: NamelessMatchSpec) {
+        self.map.entry(name).or_default().push(spec);
+    }
+
+    /// Adds a list of specs to the list of dependencies.
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = (PackageName, NamelessMatchSpec)>) {
+        for (name, spec) in iter {
+            self.insert(name, spec);
+        }
+    }
+
+    /// Adds a list of specs to the list of dependencies overwriting any existing requirements for
+    /// packages that already exist in the list of dependencies.
+    pub fn extend_overwrite(
+        &mut self,
+        iter: impl IntoIterator<Item = (PackageName, NamelessMatchSpec)>,
+    ) {
+        for (name, spec) in iter {
+            *self.map.entry(name).or_default() = vec![spec];
+        }
+    }
+
+    /// Removes all requirements for the given package and returns them.
+    pub fn remove<Q: ?Sized>(&mut self, name: &Q) -> Option<(PackageName, Vec<NamelessMatchSpec>)>
+    where
+        Q: Hash + Equivalent<PackageName>,
+    {
+        self.map.shift_remove_entry(name)
+    }
+
+    /// Combine two sets of dependencies together where the requirements of `self` are extended if
+    /// the same package is also defined in `other`.
+    pub fn union(&self, other: &Self) -> Self {
+        let mut map = self.map.clone();
+        for (name, specs) in other.map.iter() {
+            map.entry(name.clone()).or_default().extend(specs.clone());
+        }
+        Self { map }
+    }
+
+    /// Combines two sets of dependencies where the requirements of `self` are overwritten if the
+    /// same package is also defined in `other`.
+    pub fn overwrite(&self, other: &Self) -> Self {
+        let mut map = self.map.clone();
+        for (name, specs) in other.map.iter() {
+            map.insert(name.clone(), specs.clone());
+        }
+        Self { map }
+    }
+
+    /// Returns an iterator over the package names and their corresponding requirements.
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&PackageName, &Vec<NamelessMatchSpec>)> + DoubleEndedIterator + '_
+    {
+        self.map.iter()
+    }
+
+    /// Returns an iterator over all the requirements.
+    pub fn iter_specs(
+        &self,
+    ) -> impl Iterator<Item = (&PackageName, &NamelessMatchSpec)> + DoubleEndedIterator + '_ {
+        self.map
+            .iter()
+            .flat_map(|(name, specs)| specs.iter().map(move |spec| (name, spec)))
+    }
+
+    /// Returns the names of all the packages that have requirements.
+    pub fn names(
+        &self,
+    ) -> impl Iterator<Item = &PackageName> + DoubleEndedIterator + ExactSizeIterator + '_ {
+        self.map.keys()
+    }
+
+    /// Convert this instance into an iterator over the package names and their corresponding
+    pub fn into_specs(
+        self,
+    ) -> impl Iterator<Item = (PackageName, NamelessMatchSpec)> + DoubleEndedIterator {
+        self.map
+            .into_iter()
+            .flat_map(|(name, specs)| specs.into_iter().map(move |spec| (name.clone(), spec)))
+    }
+}
+
+impl IntoIterator for Dependencies {
+    type Item = (PackageName, Vec<NamelessMatchSpec>);
+    type IntoIter = indexmap::map::IntoIter<PackageName, Vec<NamelessMatchSpec>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}

--- a/src/project/manifest/environment.rs
+++ b/src/project/manifest/environment.rs
@@ -1,12 +1,20 @@
 use crate::consts;
 use crate::utils::spanned::PixiSpanned;
 use serde::{self, Deserialize, Deserializer};
+use std::borrow::Borrow;
+use std::hash::{Hash, Hasher};
 
 /// The name of an environment. This is either a string or default for the default environment.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EnvironmentName {
     Default,
     Named(String),
+}
+
+impl Hash for EnvironmentName {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
+    }
 }
 
 impl EnvironmentName {
@@ -17,6 +25,12 @@ impl EnvironmentName {
             EnvironmentName::Default => consts::DEFAULT_ENVIRONMENT_NAME,
             EnvironmentName::Named(name) => name.as_str(),
         }
+    }
+}
+
+impl Borrow<str> for EnvironmentName {
+    fn borrow(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -15,7 +15,7 @@ use ::serde::{Deserialize, Deserializer};
 pub use activation::Activation;
 pub use environment::{Environment, EnvironmentName};
 pub use feature::{Feature, FeatureName};
-use indexmap::IndexMap;
+use indexmap::{Equivalent, IndexMap};
 use itertools::Itertools;
 pub use metadata::ProjectMetadata;
 use miette::{IntoDiagnostic, LabeledSpan, NamedSource};
@@ -24,6 +24,7 @@ use rattler_conda_types::{
     Channel, ChannelConfig, MatchSpec, NamelessMatchSpec, PackageName, Platform, Version,
 };
 use serde_with::{serde_as, DisplayFromStr, Map, PickFirst};
+use std::hash::Hash;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -488,7 +489,10 @@ impl Manifest {
     }
 
     /// Returns the environment with the given name or `None` if it does not exist.
-    pub fn environment(&self, name: &EnvironmentName) -> Option<&Environment> {
+    pub fn environment<Q: ?Sized>(&self, name: &Q) -> Option<&Environment>
+    where
+        Q: Hash + Equivalent<EnvironmentName>,
+    {
         self.parsed.environments.get(name)
     }
 }

--- a/src/project/manifest/snapshots/pixi__project__manifest__target__tests__targets.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__target__tests__targets.snap
@@ -1,0 +1,7 @@
+---
+source: src/project/manifest/target.rs
+expression: "manifest.manifest.default_feature().targets.default().combined_dependencies().iter().map(|(name,\n                spec)| format!(\"{} = {}\", name.as_source(), spec)).join(\"\\n\")"
+---
+run = ==1.0
+host = ==1.0
+build = ==1.0

--- a/src/project/manifest/target.rs
+++ b/src/project/manifest/target.rs
@@ -10,6 +10,7 @@ use itertools::Either;
 use rattler_conda_types::{NamelessMatchSpec, PackageName, Platform};
 use serde::{Deserialize, Deserializer};
 use serde_with::{serde_as, DisplayFromStr, PickFirst};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -44,6 +45,44 @@ impl Target {
     /// Returns the build dependencies of the target
     pub fn build_dependencies(&self) -> Option<&IndexMap<PackageName, NamelessMatchSpec>> {
         self.dependencies.get(&SpecType::Build)
+    }
+
+    /// Returns the dependencies to use for the given `spec_type`. If `None` is specified, the
+    /// combined dependencies are returned.
+    ///
+    /// The `build` dependencies overwrite the `host` dependencies which overwrite the `run`
+    /// dependencies.
+    pub fn dependencies(
+        &self,
+        spec_type: Option<SpecType>,
+    ) -> Cow<'_, IndexMap<PackageName, NamelessMatchSpec>> {
+        if let Some(spec_type) = spec_type {
+            self.dependencies
+                .get(&spec_type)
+                .map(Cow::Borrowed)
+                .unwrap_or(Cow::Owned(IndexMap::new()))
+        } else {
+            Cow::Owned(self.combined_dependencies())
+        }
+    }
+
+    /// Determines the combined set of dependencies.
+    ///
+    /// The `build` dependencies overwrite the `host` dependencies which overwrite the `run`
+    /// dependencies.
+    fn combined_dependencies(&self) -> IndexMap<PackageName, NamelessMatchSpec> {
+        let mut all_deps = IndexMap::new();
+        for spec_type in [SpecType::Run, SpecType::Host, SpecType::Build] {
+            for (name, spec) in self.dependencies.get(&spec_type).into_iter().flatten() {
+                match all_deps.get_mut(name) {
+                    Some(existing_spec) => *existing_spec = spec.clone(),
+                    None => {
+                        all_deps.insert(name.clone(), spec.clone());
+                    }
+                }
+            }
+        }
+        all_deps
     }
 
     /// Removes a dependency from this target.
@@ -324,5 +363,53 @@ impl Targets {
     /// Returns the source location of the target selector in the manifest.
     pub fn source_loc(&self, selector: &TargetSelector) -> Option<std::ops::Range<usize>> {
         self.source_locs.get(selector).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Project;
+    use insta::assert_snapshot;
+    use itertools::Itertools;
+    use std::path::Path;
+
+    #[test]
+    fn test_targets_overwrite_order() {
+        let manifest = Project::from_str(
+            Path::new(""),
+            r#"
+        [project]
+        name = "test"
+        channels = []
+        platforms = []
+
+        [dependencies]
+        run = "1.0"
+
+        [build-dependencies]
+        run = "2.0"
+        host = "2.0"
+        build = "1.0"
+
+        [host-dependencies]
+        run = "3.0"
+        host = "1.0"
+        "#,
+        )
+        .unwrap();
+
+        assert_snapshot!(manifest
+            .manifest
+            .default_feature()
+            .targets
+            .default()
+            .dependencies(None)
+            .iter()
+            .map(|(name, spec)| format!("{} = {}", name.as_source(), spec))
+            .join("\n"), @r###"
+        run = ==2.0
+        host = ==2.0
+        build = ==1.0
+        "###);
     }
 }

--- a/src/project/manifest/target.rs
+++ b/src/project/manifest/target.rs
@@ -213,7 +213,10 @@ impl Targets {
     /// order, with the most specific selector first and the default target last.
     ///
     /// This also always includes the default target.
-    pub fn resolve(&self, platform: Option<Platform>) -> impl Iterator<Item = &'_ Target> + '_ {
+    pub fn resolve(
+        &self,
+        platform: Option<Platform>,
+    ) -> impl Iterator<Item = &'_ Target> + DoubleEndedIterator + '_ {
         if let Some(platform) = platform {
             Either::Left(self.resolve_for_platform(platform))
         } else {
@@ -229,7 +232,10 @@ impl Targets {
     /// This also always includes the default target.
     ///
     /// You should use the [`Self::resolve`] function.
-    fn resolve_for_platform(&self, platform: Platform) -> impl Iterator<Item = &'_ Target> + '_ {
+    fn resolve_for_platform(
+        &self,
+        platform: Platform,
+    ) -> impl Iterator<Item = &'_ Target> + DoubleEndedIterator + '_ {
         std::iter::once(&self.default_target)
             .chain(self.targets.iter().filter_map(move |(selector, target)| {
                 if selector.matches(platform) {

--- a/src/project/snapshots/pixi__project__environment__test__dependencies.snap
+++ b/src/project/snapshots/pixi__project__environment__test__dependencies.snap
@@ -1,0 +1,8 @@
+---
+source: src/project/environment.rs
+expression: format_dependencies(deps)
+---
+foo = >=1.0
+foo = <2.0
+foo = <4.0
+bar = >=1.0

--- a/src/project/snapshots/pixi__project__tests__dependency_target_sets.snap
+++ b/src/project/snapshots/pixi__project__tests__dependency_target_sets.snap
@@ -1,10 +1,10 @@
 ---
 source: src/project/mod.rs
-expression: "format_dependencies(project.all_dependencies(Platform::Linux64))"
+expression: "format_dependencies(project.dependencies(None, Some(Platform::Linux64)))"
 ---
 foo = "==1.0"
-wolflib = "==1.0"
 libc = "==2.12"
-banksy = "==1.0"
 bar = "==1.0"
+wolflib = "==1.0"
+banksy = "==1.0"
 baz = "==1.0"

--- a/tests/add_tests.rs
+++ b/tests/add_tests.rs
@@ -93,15 +93,15 @@ async fn add_functionality_union() {
     let project = pixi.project().unwrap();
 
     // Should contain all added dependencies
-    let dependencies = project.dependencies(Platform::current(), SpecType::Run);
-    let (name, _) = dependencies.first().unwrap();
-    assert_eq!(name, &PackageName::try_from("rattler").unwrap());
-    let host_deps = project.dependencies(Platform::current(), SpecType::Host);
-    let (name, _) = host_deps.first().unwrap();
-    assert_eq!(name, &PackageName::try_from("libcomputer").unwrap());
-    let build_deps = project.dependencies(Platform::current(), SpecType::Build);
-    let (name, _) = build_deps.first().unwrap();
-    assert_eq!(name, &PackageName::try_from("libidk").unwrap());
+    let dependencies = project.dependencies(SpecType::Run, Some(Platform::current()));
+    let (name, _) = dependencies.into_specs().next().unwrap();
+    assert_eq!(name, PackageName::try_from("rattler").unwrap());
+    let host_deps = project.dependencies(SpecType::Host, Some(Platform::current()));
+    let (name, _) = host_deps.into_specs().next().unwrap();
+    assert_eq!(name, PackageName::try_from("libcomputer").unwrap());
+    let build_deps = project.dependencies(SpecType::Build, Some(Platform::current()));
+    let (name, _) = build_deps.into_specs().next().unwrap();
+    assert_eq!(name, PackageName::try_from("libidk").unwrap());
 
     // Lock file should contain all packages as well
     let lock = pixi.lock_file().await.unwrap();

--- a/tests/add_tests.rs
+++ b/tests/add_tests.rs
@@ -93,13 +93,13 @@ async fn add_functionality_union() {
     let project = pixi.project().unwrap();
 
     // Should contain all added dependencies
-    let dependencies = project.dependencies(SpecType::Run, Some(Platform::current()));
+    let dependencies = project.dependencies(Some(SpecType::Run), Some(Platform::current()));
     let (name, _) = dependencies.into_specs().next().unwrap();
     assert_eq!(name, PackageName::try_from("rattler").unwrap());
-    let host_deps = project.dependencies(SpecType::Host, Some(Platform::current()));
+    let host_deps = project.dependencies(Some(SpecType::Host), Some(Platform::current()));
     let (name, _) = host_deps.into_specs().next().unwrap();
     assert_eq!(name, PackageName::try_from("libcomputer").unwrap());
-    let build_deps = project.dependencies(SpecType::Build, Some(Platform::current()));
+    let build_deps = project.dependencies(Some(SpecType::Build), Some(Platform::current()));
     let (name, _) = build_deps.into_specs().next().unwrap();
     assert_eq!(name, PackageName::try_from("libidk").unwrap());
 


### PR DESCRIPTION
This PR extracts the dependencies code to `Environment`. This is a little bit more involved than previous PRs because there can be multiple features that define requirements on the same package. Instead of overwriting each other we take into account all requirements of the different features.