### PR TITLE
fix: Don't allow the use of reflinks

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -35,6 +35,7 @@ pub async fn execute_transaction(
     let install_options = InstallOptions {
         python_info: transaction.python_info.clone(),
         platform: Some(transaction.platform),
+        allow_ref_links: Some(false),
         ..Default::default()
     };
 


### PR DESCRIPTION
If you are using `pixi` `v0.11.1` you got a feature activated called `reflinking`. This however doesn't work correctly yet.

The issue you might get is:
```
Permission denied (os error 13)
```
This (as far as we know) only happens on `btrfs`  filesystems, like my Fedora setup. 

You can check if your on `btrfs` using the following command:
```
> lsblk -f
...
nvme0n1                                                                                            
├─nvme0n1p1 vfat   FAT32                       4C  581,4M     3% /boot/efi
├─nvme0n1p2 ext4   1.0                         3a  611,7M    30% /boot
└─nvme0n1p3 btrfs        fedora_localhost-live 87   69,6G    91% /home
```