### PR TITLE
fix: support adding dependencies for project's unsupported platforms

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -113,7 +113,7 @@ pub async fn get_up_to_date_prefix(
     if !no_install {
         let current_platform = Platform::current();
         if !project.platforms().contains(&current_platform) {
-            tracing::warn!("Not installing dependency on current platform: ({current_platform}) as it is not part of the supported platforms.");
+            tracing::warn!("Not installing dependency on current platform: ({current_platform}) as it is not part of this project's supported platforms.");
             no_install = true;
         }
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -110,10 +110,12 @@ pub async fn get_up_to_date_prefix(
     sparse_repo_data: Option<Vec<SparseRepoData>>,
 ) -> miette::Result<Prefix> {
     // Do not install if the platform is not supported
-    let current_platform = Platform::current();
-    if !project.platforms().contains(&current_platform) {
-        tracing::warn!("Not installing dependency on current platform: ({current_platform}) as it is not part of the supported platforms.");
-        no_install = true;
+    if !no_install {
+        let current_platform = Platform::current();
+        if !project.platforms().contains(&current_platform) {
+            tracing::warn!("Not installing dependency on current platform: ({current_platform}) as it is not part of the supported platforms.");
+            no_install = true;
+        }
     }
 
     // Make sure the project is in a sane state


### PR DESCRIPTION
fixes #650

reproducible case (on Linux):

```yaml
channels = ["conda-forge"]
platforms = [
  # "linux-64",
  "osx-arm64",
]
name = "bug"

[dependencies]
python = "=3.11.*"
```

Run:

```
$ pixi add --no-install ruff

 WARN pixi::environment: Adding dependency for unsupported platform (linux-64).
✔ Added ruff
```

`ruff = ">=0.1.13,<0.2"` added to `pixi.toml` 🎉
