### PR TITLE
feat: make environment name parsing strict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "insta",
  "is_executable",
  "itertools 0.12.0",
+ "lazy_static",
  "libc",
  "miette",
  "minijinja",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ indicatif = "0.17.7"
 insta = { version = "1.34.0", features = ["yaml"] }
 is_executable = "1.0.1"
 itertools = "0.12.0"
+lazy_static = "1.4.0"
 miette = { version = "5.10.0", features = ["fancy", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
 minijinja = { version = "1.0.11", features = ["builtins"] }
 once_cell = "1.19.0"

--- a/src/project/manifest/environment.rs
+++ b/src/project/manifest/environment.rs
@@ -1,5 +1,6 @@
 use crate::consts;
 use crate::utils::spanned::PixiSpanned;
+use lazy_static::lazy_static;
 use miette::Diagnostic;
 use regex::Regex;
 use serde::{self, Deserialize, Deserializer};
@@ -47,8 +48,11 @@ pub struct ParseEnvironmentNameError {
 impl FromStr for EnvironmentName {
     type Err = ParseEnvironmentNameError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(r"^[a-z0-9-]+$").unwrap(); // Compile the regex
-        if !re.is_match(s) {
+        lazy_static! {
+            static ref REGEX: Regex = Regex::new(r"^[a-z0-9-]+$").expect("Regex should be able to compile"); // Compile the regex
+        }
+
+        if !REGEX.is_match(s) {
             // Return an error if the string does not match the regex
             return Err(ParseEnvironmentNameError {
                 attempted_parse: s.to_string(),


### PR DESCRIPTION
Added the `from_str` in preperation for the CLI and now it is really strict with some good error msgs.