### PR TITLE
feat: use named environments (only "default" for now)

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -105,7 +105,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let spec_platforms = &args.platform;
 
     // Sanity check of prefix location
-    verify_prefix_location_unchanged(project.pixi_dir().join(consts::PREFIX_FILE_NAME).as_path())?;
+    verify_prefix_location_unchanged(
+        project
+            .default_environment()
+            .dir()
+            .join(consts::PREFIX_FILE_NAME)
+            .as_path(),
+    )?;
 
     // Add the platform if it is not already present
     let platforms_to_add = spec_platforms

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -2,7 +2,7 @@ pub const PROJECT_MANIFEST: &str = "pixi.toml";
 pub const PROJECT_LOCK_FILE: &str = "pixi.lock";
 pub const PIXI_DIR: &str = ".pixi";
 pub const PREFIX_FILE_NAME: &str = "prefix";
-pub const ENVIRONMENT_DIR: &str = "env";
+pub const ENVIRONMENTS_DIR: &str = "envs";
 pub const PYPI_DEPENDENCIES: &str = "pypi-dependencies";
 
 pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -69,6 +69,17 @@ pub fn sanity_check_project(project: &Project) -> miette::Result<()> {
     // Make sure the system requirements are met
     verify_current_platform_has_required_virtual_packages(&project.default_environment())?;
 
+    // TODO: remove on a 1.0 release
+    // Check for old `env` folder as we moved to `envs` in 0.13.0
+    let old_pixi_env_dir = project.pixi_dir().join("env");
+    if old_pixi_env_dir.exists() {
+        tracing::warn!(
+            "The `{}` folder is deprecated, please remove it as we now use the `{}` folder",
+            old_pixi_env_dir.display(),
+            consts::ENVIRONMENTS_DIR
+        );
+    }
+
     Ok(())
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -2,7 +2,7 @@ use crate::{
     consts, default_authenticated_client, install, install_pypi, lock_file, prefix::Prefix,
     progress, Project,
 };
-use miette::{Context, IntoDiagnostic};
+use miette::IntoDiagnostic;
 
 use crate::lock_file::lock_file_satisfies_project;
 use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
@@ -58,7 +58,13 @@ fn create_prefix_location_file(prefix_file: &Path) -> miette::Result<()> {
 ///     2. It verifies that the system requirements are met.
 pub fn sanity_check_project(project: &Project) -> miette::Result<()> {
     // Sanity check of prefix location
-    verify_prefix_location_unchanged(project.pixi_dir().join(consts::PREFIX_FILE_NAME).as_path())?;
+    verify_prefix_location_unchanged(
+        project
+            .default_environment()
+            .dir()
+            .join(consts::PREFIX_FILE_NAME)
+            .as_path(),
+    )?;
 
     // Make sure the system requirements are met
     verify_current_platform_has_required_virtual_packages(&project.default_environment())?;
@@ -122,7 +128,7 @@ pub async fn get_up_to_date_prefix(
     sanity_check_project(project)?;
 
     // Start loading the installed packages in the background
-    let prefix = Prefix::new(project.environment_dir())?;
+    let prefix = Prefix::new(project.default_environment().dir())?;
     let installed_packages_future = {
         let prefix = prefix.clone();
         tokio::spawn(async move { prefix.find_installed_packages(None).await })
@@ -277,14 +283,7 @@ pub async fn update_prefix_conda(
     }
 
     // Mark the location of the prefix
-    create_prefix_location_file(
-        &prefix
-            .root()
-            .parent()
-            .map(|p| p.join(consts::PREFIX_FILE_NAME))
-            .ok_or_else(|| miette::miette!("we should be able to create a prefix file name."))?,
-    )
-    .with_context(|| "failed to create prefix location file.".to_string())?;
+    create_prefix_location_file(&prefix.root().join(consts::PREFIX_FILE_NAME))?;
 
     // Determine if the python version changed.
     Ok(PythonStatus::from_transaction(&transaction))

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -57,6 +57,13 @@ impl<'p> Environment<'p> {
         self.environment
     }
 
+    /// Returns the directory where this environment is stored.
+    pub fn dir(&self) -> std::path::PathBuf {
+        self.project
+            .environments_dir()
+            .join(self.environment.name.as_str())
+    }
+
     /// Returns references to the features that make up this environment. The default feature is
     /// always added at the end.
     pub fn features(&self) -> impl Iterator<Item = &'p Feature> + DoubleEndedIterator + '_ {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -198,8 +198,8 @@ impl Project {
     }
 
     /// Returns the environment directory
-    pub fn environment_dir(&self) -> PathBuf {
-        self.pixi_dir().join(consts::ENVIRONMENT_DIR)
+    pub fn environments_dir(&self) -> PathBuf {
+        self.pixi_dir().join(consts::ENVIRONMENTS_DIR)
     }
 
     /// Returns the path to the manifest file.


### PR DESCRIPTION
Now the environments would be put in:

```
pixi/.pixi
└── envs
    └── default
        ├── bin
        ├── ...
        └── prefix  <--- prefix file
```
