### PR TITLE
Fix running a deno task: Quote part of the command that have brackets [ or ]

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -228,7 +228,7 @@ pub fn quote(in_str: &str) -> Cow<str> {
         "\"\"".into()
     } else if in_str
         .bytes()
-        .any(|c| matches!(c as char, '\t' | '\r' | '\n' | ' '))
+        .any(|c| matches!(c as char, '\t' | '\r' | '\n' | ' ' | '[' | ']'))
     {
         let mut out: Vec<u8> = Vec::new();
         out.push(b'"');
@@ -267,5 +267,6 @@ mod test {
             quote("PATH=\"$PATH;build/Debug\""),
             "PATH=\"$PATH;build/Debug\""
         );
+        assert_eq!(quote("name=[64,64]"), "\"name=[64,64]\"");
     }
 }


### PR DESCRIPTION
Running a task that have [ or ] as part of command gives an error about `glob: no matches found '....'` 

To reproduce run `pixi run python test.py arg=[12,12]` which gives `glob: no matches found '/home/juruc/workspaces/pixi_ws/pixi/arg=[12,12]'`

This PR quote the part of the command that have [ or ]