### PR TITLE
feat: Allow user to set the cache directory

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -1,7 +1,7 @@
 use crate::install::execute_transaction;
 use crate::repodata::friendly_channel_name;
 use crate::{
-    default_authenticated_client, prefix::Prefix, progress::await_in_progress,
+    config, default_authenticated_client, prefix::Prefix, progress::await_in_progress,
     repodata::fetch_sparse_repodata,
 };
 use clap::Parser;
@@ -447,8 +447,7 @@ pub(super) async fn globally_install_package(
             execute_transaction(
                 &transaction,
                 prefix.root().to_path_buf(),
-                rattler::default_cache_dir()
-                    .map_err(|_| miette::miette!("could not determine default cache directory"))?,
+                config::get_cache_dir()?,
                 default_authenticated_client(),
             ),
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 /// Determines the default author based on the default git author. Both the name and the email
@@ -27,4 +28,18 @@ pub fn get_default_author() -> Option<(String, String)> {
     }
 
     Some((name?, email.unwrap_or_else(|| "".into())))
+}
+
+/// Returns the default cache directory.
+/// Most important is the `PIXI_CACHE_DIR` environment variable.
+/// If that is not set, the `RATTLER_CACHE_DIR` environment variable is used.
+/// If that is not set, the default cache directory of [`rattler::default_cache_dir`] is used.
+pub fn get_cache_dir() -> miette::Result<PathBuf> {
+    std::env::var("PIXI_CACHE_DIR")
+        .map(PathBuf::from)
+        .or_else(|_| std::env::var("RATTLER_CACHE_DIR").map(PathBuf::from))
+        .or_else(|_| {
+            rattler::default_cache_dir()
+                .map_err(|_| miette::miette!("could not determine default cache directory"))
+        })
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,5 +1,5 @@
 use crate::{
-    consts, default_authenticated_client, install, install_pypi, lock_file, prefix::Prefix,
+    config, consts, default_authenticated_client, install, install_pypi, lock_file, prefix::Prefix,
     progress, Project,
 };
 use miette::IntoDiagnostic;
@@ -285,8 +285,7 @@ pub async fn update_prefix_conda(
             install::execute_transaction(
                 &transaction,
                 prefix.root().to_path_buf(),
-                rattler::default_cache_dir()
-                    .map_err(|_| miette::miette!("could not determine default cache directory"))?,
+                config::get_cache_dir()?,
                 default_authenticated_client(),
             ),
         )

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -24,6 +24,7 @@ use std::{
 };
 
 use crate::{
+    config,
     consts::{self, PROJECT_MANIFEST},
     default_client,
     task::Task,
@@ -326,11 +327,7 @@ impl Project {
                 PackageDb::new(
                     default_client(),
                     &self.pypi_index_urls(),
-                    &rattler::default_cache_dir()
-                        .map_err(|_| {
-                            miette::miette!("could not determine default cache directory")
-                        })?
-                        .join("pypi/"),
+                    &config::get_cache_dir()?.join("pypi/"),
                 )
                 .into_diagnostic()
                 .map(Arc::new)

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -1,4 +1,4 @@
-use crate::{default_authenticated_client, progress, project::Project};
+use crate::{config, default_authenticated_client, progress, project::Project};
 use futures::{stream, StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -50,9 +50,7 @@ pub async fn fetch_sparse_repodata(
     top_level_progress.set_message("fetching latest repodata");
     top_level_progress.enable_steady_tick(Duration::from_millis(50));
 
-    let repodata_cache_path = rattler::default_cache_dir()
-        .map_err(|_| miette::miette!("could not determine default cache directory"))?
-        .join("repodata");
+    let repodata_cache_path = config::get_cache_dir()?.join("repodata");
     let repodata_download_client = default_authenticated_client();
     let multi_progress = progress::global_multi_progress();
     let mut progress_bars = Vec::new();


### PR DESCRIPTION
Closes #681 

This adds the ability to set the cache dir using an environment variable:

```
export PIXI_CACHE_DIR=/path/to/cache
# OR 
export RATTLER_CACHE_DIR=/path/to/cache
```
I added the `RATTLER_CACHE_DIR` so that we could use that in all our libraries so that it gets shared (like it does before this change)
I added the `PIXI_CACHE_DIR` to not confuse users that don't have any knowledge that rattler is our backend.