### PR TITLE
Feat: non-global reqwest client

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -15,7 +15,6 @@ use rattler_shell::{
     shell::ShellEnum,
 };
 use rattler_solve::{resolvo, SolverImpl};
-use reqwest::Client;
 use std::ffi::OsStr;
 use std::{
     path::{Path, PathBuf},
@@ -329,7 +328,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .map(|c| Channel::from_str(c, &channel_config))
         .collect::<Result<Vec<Channel>, _>>()
         .into_diagnostic()?;
-    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
+    let authenticated_client = AuthenticatedClient::default();
 
     // Find the MatchSpec we want to install
     let package_matchspec = MatchSpec::from_str(&args.package).into_diagnostic()?;

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -1,15 +1,13 @@
 use crate::install::execute_transaction;
 use crate::repodata::friendly_channel_name;
-use crate::{
-    config, default_authenticated_client, prefix::Prefix, progress::await_in_progress,
-    repodata::fetch_sparse_repodata,
-};
+use crate::{config, prefix::Prefix, progress::await_in_progress, repodata::fetch_sparse_repodata};
 use clap::Parser;
 use dirs::home_dir;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler::install::Transaction;
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, PackageName, Platform, PrefixRecord};
+use rattler_networking::AuthenticatedClient;
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_shell::{
     activation::{ActivationVariables, Activator, PathModificationBehavior},
@@ -17,6 +15,7 @@ use rattler_shell::{
     shell::ShellEnum,
 };
 use rattler_solve::{resolvo, SolverImpl};
+use reqwest::Client;
 use std::ffi::OsStr;
 use std::{
     path::{Path, PathBuf},
@@ -330,18 +329,21 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .map(|c| Channel::from_str(c, &channel_config))
         .collect::<Result<Vec<Channel>, _>>()
         .into_diagnostic()?;
+    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
 
     // Find the MatchSpec we want to install
     let package_matchspec = MatchSpec::from_str(&args.package).into_diagnostic()?;
 
     // Fetch sparse repodata
-    let platform_sparse_repodata = fetch_sparse_repodata(&channels, [Platform::current()]).await?;
+    let platform_sparse_repodata =
+        fetch_sparse_repodata(&channels, [Platform::current()], &authenticated_client).await?;
 
     // Install the package
     let (prefix_package, scripts, _) = globally_install_package(
         package_matchspec,
         &platform_sparse_repodata,
         &channel_config,
+        authenticated_client,
     )
     .await?;
 
@@ -394,6 +396,7 @@ pub(super) async fn globally_install_package(
     package_matchspec: MatchSpec,
     platform_sparse_repodata: &[SparseRepoData],
     channel_config: &ChannelConfig,
+    authenticated_client: AuthenticatedClient,
 ) -> miette::Result<(PrefixRecord, Vec<PathBuf>, bool)> {
     let package_name = package_name(&package_matchspec)?;
 
@@ -449,7 +452,7 @@ pub(super) async fn globally_install_package(
                 &prefix_records,
                 prefix.root().to_path_buf(),
                 config::get_cache_dir()?,
-                default_authenticated_client(),
+                authenticated_client,
             ),
         )
         .await?;

--- a/src/cli/global/upgrade.rs
+++ b/src/cli/global/upgrade.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 use clap::Parser;
 use miette::IntoDiagnostic;
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, Platform};
+use rattler_networking::AuthenticatedClient;
+use reqwest::Client;
 
 use crate::repodata::fetch_sparse_repodata;
 
@@ -53,14 +55,17 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     }
 
+    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
     // Fetch sparse repodata
-    let platform_sparse_repodata = fetch_sparse_repodata(&channels, [Platform::current()]).await?;
+    let platform_sparse_repodata =
+        fetch_sparse_repodata(&channels, [Platform::current()], &authenticated_client).await?;
 
     // Install the package
     let (package_record, _, upgraded) = globally_install_package(
         package_matchspec,
         &platform_sparse_repodata,
         &channel_config,
+        authenticated_client,
     )
     .await?;
 

--- a/src/cli/global/upgrade.rs
+++ b/src/cli/global/upgrade.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 use miette::IntoDiagnostic;
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, Platform};
 use rattler_networking::AuthenticatedClient;
-use reqwest::Client;
 
 use crate::repodata::fetch_sparse_repodata;
 
@@ -55,7 +54,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     }
 
-    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
+    let authenticated_client = AuthenticatedClient::default();
     // Fetch sparse repodata
     let platform_sparse_repodata =
         fetch_sparse_repodata(&channels, [Platform::current()], &authenticated_client).await?;

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -3,7 +3,6 @@ use futures::{stream, StreamExt, TryStreamExt};
 use miette::IntoDiagnostic;
 use rattler_conda_types::{Channel, ChannelConfig, Platform};
 use rattler_networking::AuthenticatedClient;
-use reqwest::Client;
 
 use crate::repodata::fetch_sparse_repodata;
 
@@ -38,7 +37,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let packages = list_global_packages().await?;
 
-    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
+    let authenticated_client = AuthenticatedClient::default();
     // Fetch sparse repodata
     let platform_sparse_repodata =
         fetch_sparse_repodata(&channels, [Platform::current()], &authenticated_client).await?;

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use futures::{stream, StreamExt, TryStreamExt};
 use miette::IntoDiagnostic;
 use rattler_conda_types::{Channel, ChannelConfig, Platform};
+use rattler_networking::AuthenticatedClient;
+use reqwest::Client;
 
 use crate::repodata::fetch_sparse_repodata;
 
@@ -36,8 +38,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let packages = list_global_packages().await?;
 
+    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
     // Fetch sparse repodata
-    let platform_sparse_repodata = fetch_sparse_repodata(&channels, [Platform::current()]).await?;
+    let platform_sparse_repodata =
+        fetch_sparse_repodata(&channels, [Platform::current()], &authenticated_client).await?;
 
     let tasks = packages
         .iter()
@@ -47,7 +51,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let task_stream = stream::iter(tasks)
         .map(|matchspec| {
-            globally_install_package(matchspec, &platform_sparse_repodata, &channel_config)
+            globally_install_package(
+                matchspec,
+                &platform_sparse_repodata,
+                &channel_config,
+                authenticated_client.clone(),
+            )
         })
         .buffered(UPGRADE_ALL_CONCURRENCY);
 

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -5,8 +5,10 @@ use clap::Parser;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform, RepoDataRecord};
+use rattler_networking::AuthenticatedClient;
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use regex::Regex;
+use reqwest::Client;
 use strsim::jaro;
 use tokio::task::spawn_blocking;
 
@@ -99,8 +101,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     let package_name_filter = args.package;
-    let repo_data =
-        fetch_sparse_repodata(channels.iter().map(AsRef::as_ref), [Platform::current()]).await?;
+    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
+    let repo_data = fetch_sparse_repodata(
+        channels.iter().map(AsRef::as_ref),
+        [Platform::current()],
+        &authenticated_client,
+    )
+    .await?;
 
     // When package name filter contains * (wildcard), it will search and display a list of packages matching this filter
     if package_name_filter.contains('*') {

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -8,7 +8,7 @@ use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform, RepoDat
 use rattler_networking::AuthenticatedClient;
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use regex::Regex;
-use reqwest::Client;
+
 use strsim::jaro;
 use tokio::task::spawn_blocking;
 
@@ -101,7 +101,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     let package_name_filter = args.package;
-    let authenticated_client = AuthenticatedClient::from_client(Client::new(), Default::default());
+    let authenticated_client = AuthenticatedClient::default();
     let repo_data = fetch_sparse_repodata(
         channels.iter().map(AsRef::as_ref),
         [Platform::current()],

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -6,10 +6,12 @@ use indicatif::HumanBytes;
 use miette::IntoDiagnostic;
 
 use rattler_digest::{compute_file_digest, Sha256};
+use rattler_networking::AuthenticatedClient;
+use reqwest::Client;
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 
-use crate::{default_authenticated_client, progress};
+use crate::progress;
 
 /// Upload a package to a prefix.dev channel
 #[derive(Parser, Debug)]
@@ -39,7 +41,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         HumanBytes(filesize)
     );
 
-    let client = default_authenticated_client();
+    let client = AuthenticatedClient::from_client(Client::new(), Default::default());
 
     let sha256sum = format!(
         "{:x}",

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -7,7 +7,7 @@ use miette::IntoDiagnostic;
 
 use rattler_digest::{compute_file_digest, Sha256};
 use rattler_networking::AuthenticatedClient;
-use reqwest::Client;
+
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 
@@ -41,7 +41,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         HumanBytes(filesize)
     );
 
-    let client = AuthenticatedClient::from_client(Client::new(), Default::default());
+    let client = AuthenticatedClient::default();
 
     let sha256sum = format!(
         "{:x}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,16 +27,3 @@ use rattler_networking::retry_policies::ExponentialBackoff;
 pub fn default_retry_policy() -> ExponentialBackoff {
     ExponentialBackoff::builder().build_with_max_retries(3)
 }
-
-// Returns the default client to use for networking.
-// pub fn default_client() -> Client {
-//     static CLIENT: Lazy<Client> = Lazy::new(Default::default);
-//     CLIENT.clone()
-// }
-
-// Returns the default authenticated client to use for rattler authenticated networking.
-// pub fn default_authenticated_client() -> AuthenticatedClient {
-//     static CLIENT: Lazy<AuthenticatedClient> =
-//         Lazy::new(|| AuthenticatedClient::from_client(default_client(), Default::default()));
-//     CLIENT.clone()
-// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,8 @@ pub mod utils;
 mod pypi_marker_env;
 mod pypi_tags;
 
-use once_cell::sync::Lazy;
 pub use project::Project;
 use rattler_networking::retry_policies::ExponentialBackoff;
-use rattler_networking::AuthenticatedClient;
-use reqwest::Client;
 
 /// The default retry policy employed by pixi.
 /// TODO: At some point we might want to make this configurable.
@@ -31,15 +28,15 @@ pub fn default_retry_policy() -> ExponentialBackoff {
     ExponentialBackoff::builder().build_with_max_retries(3)
 }
 
-/// Returns the default client to use for networking.
-pub fn default_client() -> Client {
-    static CLIENT: Lazy<Client> = Lazy::new(Default::default);
-    CLIENT.clone()
-}
+// Returns the default client to use for networking.
+// pub fn default_client() -> Client {
+//     static CLIENT: Lazy<Client> = Lazy::new(Default::default);
+//     CLIENT.clone()
+// }
 
-/// Returns the default authenticated client to use for rattler authenticated networking.
-pub fn default_authenticated_client() -> AuthenticatedClient {
-    static CLIENT: Lazy<AuthenticatedClient> =
-        Lazy::new(|| AuthenticatedClient::from_client(default_client(), Default::default()));
-    CLIENT.clone()
-}
+// Returns the default authenticated client to use for rattler authenticated networking.
+// pub fn default_authenticated_client() -> AuthenticatedClient {
+//     static CLIENT: Lazy<AuthenticatedClient> =
+//         Lazy::new(|| AuthenticatedClient::from_client(default_client(), Default::default()));
+//     CLIENT.clone()
+// }

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -1084,11 +1084,7 @@ mod tests {
             .clone()
             .into_iter()
             .flat_map(|d| d.into_iter())
-            .map(|(name, spec)| format!(
-                "{} = {}",
-                name.as_source_str(),
-                Item::from(spec).to_string()
-            ))
+            .map(|(name, spec)| format!("{} = {}", name.as_source_str(), Item::from(spec)))
             .join("\n"));
     }
 
@@ -1104,10 +1100,7 @@ mod tests {
         // Initially the dependency should exist
         assert!(manifest
             .feature_mut(feature_name)
-            .expect(&*format!(
-                "feature `{}` should exist",
-                feature_name.as_str()
-            ))
+            .expect(&format!("feature `{}` should exist", feature_name.as_str()))
             .targets
             .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
             .unwrap()
@@ -1130,10 +1123,7 @@ mod tests {
         // The dependency should no longer exist
         assert!(manifest
             .feature_mut(feature_name)
-            .expect(&*format!(
-                "feature `{}` should exist",
-                feature_name.as_str()
-            ))
+            .expect(&format!("feature `{}` should exist", feature_name.as_str()))
             .targets
             .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
             .unwrap()
@@ -1163,10 +1153,7 @@ mod tests {
         // Initially the dependency should exist
         assert!(manifest
             .feature_mut(feature_name)
-            .expect(&*format!(
-                "feature `{}` should exist",
-                feature_name.as_str()
-            ))
+            .expect(&format!("feature `{}` should exist", feature_name.as_str()))
             .targets
             .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
             .unwrap()
@@ -1184,10 +1171,7 @@ mod tests {
         // The dependency should no longer exist
         assert!(manifest
             .feature_mut(feature_name)
-            .expect(&*format!(
-                "feature `{}` should exist",
-                feature_name.as_str()
-            ))
+            .expect(&format!("feature `{}` should exist", feature_name.as_str()))
             .targets
             .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
             .unwrap()

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -1,4 +1,4 @@
-use crate::{config, default_authenticated_client, progress, project::Project};
+use crate::{config, progress, project::Project};
 use futures::{stream, StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -12,13 +12,14 @@ impl Project {
     pub async fn fetch_sparse_repodata(&self) -> miette::Result<Vec<SparseRepoData>> {
         let channels = self.channels();
         let platforms = self.platforms();
-        fetch_sparse_repodata(channels, platforms).await
+        fetch_sparse_repodata(channels, platforms, self.authenticated_client()).await
     }
 }
 
 pub async fn fetch_sparse_repodata(
     channels: impl IntoIterator<Item = &'_ Channel>,
     target_platforms: impl IntoIterator<Item = Platform>,
+    authenticated_client: &AuthenticatedClient,
 ) -> miette::Result<Vec<SparseRepoData>> {
     let channels = channels.into_iter();
     let target_platforms = target_platforms.into_iter().collect_vec();
@@ -51,7 +52,6 @@ pub async fn fetch_sparse_repodata(
     top_level_progress.enable_steady_tick(Duration::from_millis(50));
 
     let repodata_cache_path = config::get_cache_dir()?.join("repodata");
-    let repodata_download_client = default_authenticated_client();
     let multi_progress = progress::global_multi_progress();
     let mut progress_bars = Vec::new();
 
@@ -68,7 +68,7 @@ pub async fn fetch_sparse_repodata(
 
             // Spawn a future that downloads the repodata in the background
             let repodata_cache = repodata_cache_path.clone();
-            let download_client = repodata_download_client.clone();
+            let download_client = authenticated_client.clone();
             let top_level_progress = top_level_progress.clone();
 
             async move {

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -115,7 +115,7 @@ async fn install_locked() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
     // Add and update lockfile with this version of python
-    pixi.add("python==3.8.0").await.unwrap();
+    pixi.add("python==3.10.0").await.unwrap();
 
     // Add new version of python only to the manifest
     pixi.add("python==3.9.0")
@@ -127,7 +127,7 @@ async fn install_locked() {
 
     // Check if it didn't accidentally update the lockfile
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("python==3.8.0"));
+    assert!(lock.contains_matchspec("python==3.10.0"));
 
     // After an install with lockfile update the locked install should succeed.
     pixi.install().await.unwrap();


### PR DESCRIPTION
Because `Client` and `AuthenticatedClient` were re-used in the binary, when using a different runtime these were also shared. Because multiple tests have different runtimes, we ran into this issue:

https://users.rust-lang.org/t/runtime-dropped-the-dispatch-task/91915

This should hopefully fix this.