### PR TITLE
refactor: update to rattler lock v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "anyhow",
  "async-compression 0.4.6",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "blake2",
  "digest",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3157,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "anyhow",
  "async-compression 0.4.6",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.1.0",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#7115a87787d3c734c76063852330d2a318b039fc"
 dependencies = [
  "cfg-if",
  "libloading",
@@ -3875,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "anyhow",
  "async-compression 0.4.6",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "blake2",
  "digest",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3157,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "anyhow",
  "async-compression 0.4.6",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.1.0",
@@ -3237,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "0.16.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#a8e022d031da57933b22ae3a7e0a0c7f50548d6a"
+source = "git+https://github.com/mamba-org/rattler?branch=main#0e036039e204c743f69b4f608c569e5f6ee55895"
 dependencies = [
  "cfg-if",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "anyhow",
  "async-compression 0.4.6",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3028,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "blake2",
  "digest",
@@ -3101,13 +3101,15 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "chrono",
  "fxhash",
  "indexmap 2.1.0",
+ "itertools 0.12.0",
  "pep440_rs",
  "pep508_rs",
+ "purl",
  "rattler_conda_types",
  "rattler_digest 0.16.2",
  "serde",
@@ -3122,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -3131,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3155,7 +3157,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3180,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "anyhow",
  "async-compression 0.4.6",
@@ -3218,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.1.0",
@@ -3235,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3254,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "0.16.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#d1fec29e06e5f6ae7e36e06e510f7f7c43250ef3"
+source = "git+https://github.com/baszalmstra/rattler?branch=refactor/rattler_lock_v4#c8878ccb7f2d37cf4d4622d1ddc27ae596e2663c"
 dependencies = [
  "cfg-if",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,15 +88,15 @@ tokio = { version = "1.35.1", features = ["rt"] }
 toml = "0.8.8"
 
 [patch.crates-io]
-rattler = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
-rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_lock = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
 #rip = { package = "rattler_installs_packages", git = "https://github.com/prefix-dev/rattler_installs_packages", branch = "main" }
 #deno_task_shell = { path = "../deno_task_shell" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,15 +88,15 @@ tokio = { version = "1.35.1", features = ["rt"] }
 toml = "0.8.8"
 
 [patch.crates-io]
-rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_lock = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+rattler = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
+rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "refactor/rattler_lock_v4" }
 #rip = { package = "rattler_installs_packages", git = "https://github.com/prefix-dev/rattler_installs_packages", branch = "main" }
 #deno_task_shell = { path = "../deno_task_shell" }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -119,13 +119,25 @@ pub async fn execute() -> miette::Result<()> {
     console::set_colors_enabled(use_colors);
     console::set_colors_enabled_stderr(use_colors);
 
-    let (level_filter, pixi_level) = match args.verbose.log_level_filter() {
-        clap_verbosity_flag::LevelFilter::Off => (LevelFilter::OFF, LevelFilter::OFF),
-        clap_verbosity_flag::LevelFilter::Error => (LevelFilter::ERROR, LevelFilter::WARN),
-        clap_verbosity_flag::LevelFilter::Warn => (LevelFilter::WARN, LevelFilter::INFO),
-        clap_verbosity_flag::LevelFilter::Info => (LevelFilter::INFO, LevelFilter::INFO),
-        clap_verbosity_flag::LevelFilter::Debug => (LevelFilter::DEBUG, LevelFilter::DEBUG),
-        clap_verbosity_flag::LevelFilter::Trace => (LevelFilter::TRACE, LevelFilter::TRACE),
+    let (low_level_filter, level_filter, pixi_level) = match args.verbose.log_level_filter() {
+        clap_verbosity_flag::LevelFilter::Off => {
+            (LevelFilter::OFF, LevelFilter::OFF, LevelFilter::OFF)
+        }
+        clap_verbosity_flag::LevelFilter::Error => {
+            (LevelFilter::ERROR, LevelFilter::ERROR, LevelFilter::WARN)
+        }
+        clap_verbosity_flag::LevelFilter::Warn => {
+            (LevelFilter::WARN, LevelFilter::WARN, LevelFilter::INFO)
+        }
+        clap_verbosity_flag::LevelFilter::Info => {
+            (LevelFilter::WARN, LevelFilter::INFO, LevelFilter::INFO)
+        }
+        clap_verbosity_flag::LevelFilter::Debug => {
+            (LevelFilter::INFO, LevelFilter::DEBUG, LevelFilter::DEBUG)
+        }
+        clap_verbosity_flag::LevelFilter::Trace => {
+            (LevelFilter::TRACE, LevelFilter::TRACE, LevelFilter::TRACE)
+        }
     };
 
     let env_filter = EnvFilter::builder()
@@ -135,6 +147,11 @@ pub async fn execute() -> miette::Result<()> {
         // filter logs from apple codesign because they are very noisy
         .add_directive("apple_codesign=off".parse().into_diagnostic()?)
         .add_directive(format!("pixi={}", pixi_level).parse().into_diagnostic()?)
+        .add_directive(
+            format!("resolvo={}", low_level_filter)
+                .parse()
+                .into_diagnostic()?,
+        )
         .add_directive(
             format!("rattler_installs_packages={}", pixi_level)
                 .parse()

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -162,7 +162,7 @@ pub async fn get_up_to_date_prefix(
     let update_lock_file = if usage.should_check_if_out_of_date() {
         match lock_file_satisfies_project(project, &lock_file) {
             Err(err) => {
-                tracing::debug!(
+                tracing::info!(
                     "the lock-file is not up to date with the project.\n{:?}",
                     err
                 );
@@ -243,12 +243,13 @@ pub async fn get_up_to_date_prefix(
     // to the `locked_pypi_records` or to the `updated_pypi_records`.
     let mut updated_pypi_records = None;
     let pypi_records: &_ = if project.has_pypi_dependencies() && update_lock_file {
+        let python_path = python_status.location().map(|p| prefix.root().join(p));
         updated_pypi_records.insert(
             lock_file::update_lock_file_for_pypi(
                 &environment,
                 repodata_records,
                 &locked_pypi_records,
-                python_status.location(),
+                python_path.as_deref(),
                 sdist_resolution,
             )
             .await?,

--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -13,32 +13,50 @@ use rattler_conda_types::{
     GenericVirtualPackage, MatchSpec, PackageName, Platform, RepoDataRecord,
 };
 use rattler_lock::{
-    builder::{
-        CondaLockedDependencyBuilder, LockFileBuilder, LockedPackagesBuilder,
-        PypiLockedDependencyBuilder,
-    },
-    CondaLock, LockedDependencyKind, PackageHashes,
+    LockFile, PackageHashes, PypiPackageData, PypiPackageDataRef, PypiPackageEnvironmentData,
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{resolvo, SolverImpl};
 use rip::resolve::SDistResolution;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::Path;
 use std::{sync::Arc, time::Duration};
 
+use crate::project::Environment;
 pub use satisfiability::lock_file_satisfies_project;
 
+/// A list of conda packages that are locked for a specific platform.
+pub type LockedCondaPackages = Vec<RepoDataRecord>;
+
+/// A list of Pypi packages that are locked for a specific platform.
+pub type LockedPypiPackages = Vec<(PypiPackageData, PypiPackageEnvironmentData)>;
+
+/// A list of references to conda packages that are locked for a specific platform.
+pub type LockedCondaPackagesRef<'p> = &'p LockedCondaPackages;
+
+/// A list of references to pypi packages that are locked for a specific platform.
+pub type LockedPypiPackagesRef<'p> = Vec<PypiPackageDataRef<'p>>;
+
+/// A list of conda packages that are locked for all supported platforms.
+pub type LockedCondaEnvironment = HashMap<Platform, LockedCondaPackages>;
+
+/// A list of Pypi packages that are locked for all supported platforms.
+pub type LockedPypiEnvironment = HashMap<Platform, LockedPypiPackages>;
+
+/// A list of Pypi packages that are locked for all supported platforms.
+pub type LockedPypiEnvironmentRef<'p> = HashMap<Platform, LockedPypiPackagesRef<'p>>;
+
 /// Loads the lockfile for the specified project or returns a dummy one if none could be found.
-pub async fn load_lock_file(project: &Project) -> miette::Result<CondaLock> {
+pub async fn load_lock_file(project: &Project) -> miette::Result<LockFile> {
     let lock_file_path = project.lock_file_path();
-    tokio::task::spawn_blocking(move || {
-        if lock_file_path.is_file() {
-            CondaLock::from_path(&lock_file_path).into_diagnostic()
-        } else {
-            LockFileBuilder::default().build().into_diagnostic()
-        }
-    })
-    .await
-    .unwrap_or_else(|e| Err(e).into_diagnostic())
+    if lock_file_path.is_file() {
+        // Spawn a background task because loading the file might be IO bound.
+        tokio::task::spawn_blocking(move || LockFile::from_path(&lock_file_path).into_diagnostic())
+            .await
+            .unwrap_or_else(|e| Err(e).into_diagnostic())
+    } else {
+        Ok(LockFile::default())
+    }
 }
 
 fn main_progress_bar(num_bars: u64, message: &'static str) -> ProgressBar {
@@ -70,204 +88,171 @@ fn platform_solve_bars(platforms: impl IntoIterator<Item = Platform>) -> Vec<Pro
 
 /// Updates the lock file for conda dependencies for the specified project.
 pub async fn update_lock_file_conda(
-    project: &Project,
-    existing_lock_file: CondaLock,
+    environment: &Environment<'_>,
+    existing_lock_file: LockedCondaEnvironment,
     repodata: Option<Vec<SparseRepoData>>,
-) -> miette::Result<CondaLock> {
-    let platforms = project.platforms();
+) -> miette::Result<LockedCondaEnvironment> {
+    let platforms = environment.platforms();
 
     // Get the repodata for the project
     let sparse_repo_data: Arc<[_]> = if let Some(sparse_repo_data) = repodata {
         sparse_repo_data
     } else {
-        project.fetch_sparse_repodata().await?
+        environment.fetch_sparse_repodata().await?
     }
     .into();
 
-    // Construct a progress bar
+    // Construct a progress bar, a main one and one for each platform.
     let _top_level_progress =
         main_progress_bar(platforms.len() as u64, "resolving conda dependencies");
-    // Create progress bars for each platform
     let solve_bars = platform_solve_bars(platforms.iter().copied());
 
-    // Construct a conda lock file
-    let channels = project
-        .channels()
-        .into_iter()
-        .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()));
+    let result = stream::iter(platforms.iter().zip(solve_bars.iter().cloned()))
+        .map(|(platform, pb)| {
+            pb.reset_elapsed();
+            pb.set_style(
+                indicatif::ProgressStyle::with_template(&format!(
+                    "  {{spinner:.dim}} {:<9} [{{elapsed_precise}}] {{msg:.dim}}",
+                    platform.to_string(),
+                ))
+                .unwrap(),
+            );
 
-    let result: miette::Result<Vec<_>> =
-        stream::iter(platforms.iter().zip(solve_bars.iter().cloned()))
-            .map(|(platform, pb)| {
-                pb.reset_elapsed();
+            let existing_lock_file = &existing_lock_file;
+            let sparse_repo_data = sparse_repo_data.clone();
+            async move {
+                let empty_vec = vec![];
+                let result = resolve_platform(
+                    environment,
+                    existing_lock_file.get(platform).unwrap_or(&empty_vec),
+                    sparse_repo_data.clone(),
+                    *platform,
+                    pb.clone(),
+                )
+                .await?;
+
                 pb.set_style(
                     indicatif::ProgressStyle::with_template(&format!(
-                        "  {{spinner:.dim}} {:<9} [{{elapsed_precise}}] {{msg:.dim}}",
+                        "  {} {:<9} [{{elapsed_precise}}]",
+                        console::style(console::Emoji("✔", "↳")).green(),
                         platform.to_string(),
                     ))
                     .unwrap(),
                 );
+                pb.finish();
 
-                let existing_lock_file = &existing_lock_file;
-                let sparse_repo_data = sparse_repo_data.clone();
-                async move {
-                    let result = resolve_platform(
-                        project,
-                        existing_lock_file,
-                        sparse_repo_data.clone(),
-                        *platform,
-                        pb.clone(),
-                    )
-                    .await?;
-
-                    pb.set_style(
-                        indicatif::ProgressStyle::with_template(&format!(
-                            "  {} {:<9} [{{elapsed_precise}}]",
-                            console::style(console::Emoji("✔", "↳")).green(),
-                            platform.to_string(),
-                        ))
-                        .unwrap(),
-                    );
-                    pb.finish();
-
-                    Ok(result)
-                }
-            })
-            .buffer_unordered(2)
-            .try_collect()
-            .await;
-
-    for bar in solve_bars {
-        bar.finish_and_clear();
-    }
-
-    // Collect the result of each individual solve
-    let mut builder = LockFileBuilder::new(channels, platforms.iter().cloned(), vec![]);
-    for locked_packages in result? {
-        builder = builder.add_locked_packages(locked_packages);
-    }
-    let conda_lock = builder.build().into_diagnostic()?;
-
-    // Write the conda lock to disk
-    conda_lock
-        .to_path(&project.lock_file_path())
-        .into_diagnostic()?;
-
-    Ok(conda_lock)
-}
-
-pub async fn update_lock_file_for_pypi(
-    project: &Project,
-    lock_for_conda: CondaLock,
-    python_location: &Option<PathBuf>,
-    sdist_resolution: SDistResolution,
-) -> miette::Result<CondaLock> {
-    let platforms = project.platforms();
-    let _top_level_progress =
-        main_progress_bar(platforms.len() as u64, "resolving pypi dependencies");
-    let solve_bars = platform_solve_bars(platforms.iter().copied());
-
-    let records = platforms
-        .iter()
-        .map(|plat| lock_for_conda.get_conda_packages_by_platform(*plat));
-
-    let result: miette::Result<Vec<_>> =
-        stream::iter(izip!(platforms.iter(), solve_bars.iter().cloned(), records))
-            .map(|(platform, pb, records)| {
-                pb.reset_elapsed();
-                pb.set_style(
-                    indicatif::ProgressStyle::with_template(&format!(
-                        "  {{spinner:.dim}} {:<9} [{{elapsed_precise}}] {{msg:.dim}}",
-                        platform.to_string(),
-                    ))
-                    .unwrap(),
-                );
-
-                async move {
-                    let locked_packages = LockedPackagesBuilder::new(*platform);
-                    let result = resolve_pypi(
-                        project,
-                        &records.into_diagnostic()?,
-                        locked_packages,
-                        *platform,
-                        &pb,
-                        python_location,
-                        sdist_resolution,
-                    )
-                    .await?;
-
-                    pb.set_style(
-                        indicatif::ProgressStyle::with_template(&format!(
-                            "  {} {:<9} [{{elapsed_precise}}]",
-                            console::style(console::Emoji("✔", "↳")).green(),
-                            platform.to_string(),
-                        ))
-                        .unwrap(),
-                    );
-                    pb.finish();
-
-                    Ok(result)
-                }
-            })
-            // TODO: Hack to ensure we do not encounter file-locking issues in windows, should look at a better solution
-            .buffer_unordered(1)
-            .try_collect()
-            .await;
+                Ok((*platform, result))
+            }
+        })
+        .buffer_unordered(2)
+        .try_collect()
+        .await;
 
     // Clear all progress bars
     for bar in solve_bars {
         bar.finish_and_clear();
     }
 
-    let channels = project
-        .channels()
-        .into_iter()
-        .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()));
-    let mut builder = LockFileBuilder::new(channels, platforms.iter().cloned(), vec![]);
-    for locked_packages in result? {
-        builder = builder.add_locked_packages(locked_packages);
+    result
+}
+
+pub async fn update_lock_file_for_pypi(
+    environment: &Environment<'_>,
+    locked_conda_packages: &LockedCondaEnvironment,
+    locked_pypi_packages: LockedPypiEnvironment,
+    python_location: Option<&Path>,
+    sdist_resolution: SDistResolution,
+) -> miette::Result<LockedPypiEnvironment> {
+    let platforms = environment.platforms().into_iter().collect_vec();
+
+    // Construct the progress bars
+    let _top_level_progress =
+        main_progress_bar(platforms.len() as u64, "resolving pypi dependencies");
+    let solve_bars = platform_solve_bars(platforms.iter().copied());
+
+    // Extract conda packages per platform.
+    let empty_vec = vec![];
+    let lock_conda_packages_per_platform = platforms
+        .iter()
+        .map(|platform| locked_conda_packages.get(platform).unwrap_or(&empty_vec));
+
+    // Extract previous locked pypi packages per platform
+    let empty_vec = vec![];
+    let locked_pypi_packages_per_platform = platforms
+        .iter()
+        .map(|platform| locked_pypi_packages.get(platform).unwrap_or(&empty_vec));
+
+    let result = stream::iter(izip!(
+        platforms.iter(),
+        lock_conda_packages_per_platform,
+        locked_pypi_packages_per_platform,
+        solve_bars.iter().cloned(),
+    ))
+    .map(
+        |(platform, locked_conda_packages, locked_pypi_packages, pb)| {
+            pb.reset_elapsed();
+            pb.set_style(
+                indicatif::ProgressStyle::with_template(&format!(
+                    "  {{spinner:.dim}} {:<9} [{{elapsed_precise}}] {{msg:.dim}}",
+                    platform.to_string(),
+                ))
+                .unwrap(),
+            );
+
+            async move {
+                let result = resolve_pypi(
+                    environment,
+                    locked_conda_packages,
+                    locked_pypi_packages,
+                    *platform,
+                    &pb,
+                    python_location,
+                    sdist_resolution,
+                )
+                .await?;
+
+                pb.set_style(
+                    indicatif::ProgressStyle::with_template(&format!(
+                        "  {} {:<9} [{{elapsed_precise}}]",
+                        console::style(console::Emoji("✔", "↳")).green(),
+                        platform.to_string(),
+                    ))
+                    .unwrap(),
+                );
+                pb.finish();
+
+                Ok((*platform, result))
+            }
+        },
+    )
+    // TODO: Hack to ensure we do not encounter file-locking issues in windows, should look at a better solution
+    .buffer_unordered(1)
+    .try_collect()
+    .await;
+
+    // Clear all progress bars
+    for bar in solve_bars {
+        bar.finish_and_clear();
     }
-    let conda_lock_pypi_only = builder.build().into_diagnostic()?;
 
-    // TODO: think of a better way to do this
-    // Seeing as we are not using the content-hash anyways this seems to be fine
-    let latest_lock = CondaLock {
-        metadata: lock_for_conda.metadata,
-        package: conda_lock_pypi_only
-            .package
-            .into_iter()
-            .chain(
-                lock_for_conda
-                    .package
-                    .into_iter()
-                    .filter(|p| matches!(p.kind, LockedDependencyKind::Conda(_))),
-            )
-            .collect(),
-    };
-
-    // Write the conda lock to disk
-    latest_lock
-        .to_path(&project.lock_file_path())
-        .into_diagnostic()?;
-
-    Ok(latest_lock)
+    result
 }
 
 async fn resolve_pypi(
-    project: &Project,
-    records: &[RepoDataRecord],
-    mut locked_packages: LockedPackagesBuilder,
+    environment: &Environment<'_>,
+    locked_conda_records: &[RepoDataRecord],
+    _locked_pypi_records: &[(PypiPackageData, PypiPackageEnvironmentData)],
     platform: Platform,
     pb: &ProgressBar,
-    python_location: &Option<PathBuf>,
+    python_location: Option<&Path>,
     sdist_resolution: SDistResolution,
-) -> miette::Result<LockedPackagesBuilder> {
+) -> miette::Result<LockedPypiPackages> {
     // Solve python packages
     pb.set_message("resolving pypi dependencies");
     let python_artifacts = pypi::resolve_dependencies(
-        project,
+        environment,
         platform,
-        records,
+        locked_conda_records,
         python_location,
         sdist_resolution,
     )
@@ -277,8 +262,9 @@ async fn resolve_pypi(
     pb.set_message("");
 
     // Add pip packages
+    let mut locked_packages = LockedPypiPackages::with_capacity(python_artifacts.len());
     for python_artifact in python_artifacts {
-        let (artifact, metadata) = project
+        let (artifact, metadata) = environment.project()
             .pypi_package_db()?
             // No need for a WheelBuilder here since any builds should have been done during the
             // [`python::resolve_dependencies`] call.
@@ -287,42 +273,40 @@ async fn resolve_pypi(
             .expect("failed to get metadata for a package for which we have already fetched metadata during solving.")
             .expect("no metadata for a package for which we have already fetched metadata during solving.");
 
-        let locked_package = PypiLockedDependencyBuilder {
+        let pkg_data = PypiPackageData {
             name: python_artifact.name.to_string(),
-            version: python_artifact.version.to_string(),
-            requires_dist: metadata
-                .requires_dist
-                .into_iter()
-                .map(|r| r.to_string())
-                .collect(),
-            requires_python: metadata.requires_python.map(|r| r.to_string()),
-            extras: python_artifact
-                .extras
-                .into_iter()
-                .map(|e| e.as_str().to_string())
-                .collect(),
+            version: python_artifact.version,
+            requires_dist: metadata.requires_dist,
+            requires_python: metadata.requires_python,
             url: artifact.url.clone(),
             hash: artifact
                 .hashes
                 .as_ref()
                 .and_then(|hash| PackageHashes::from_hashes(None, hash.sha256)),
-            source: None,
-            build: None,
         };
 
-        locked_packages.add_locked_package(locked_package)
+        let pkg_env = PypiPackageEnvironmentData {
+            extras: python_artifact
+                .extras
+                .into_iter()
+                .map(|e| e.as_str().to_string())
+                .collect(),
+        };
+
+        locked_packages.push((pkg_data, pkg_env));
     }
+
     Ok(locked_packages)
 }
 
 async fn resolve_platform(
-    project: &Project,
-    existing_lock_file: &CondaLock,
+    environment: &Environment<'_>,
+    existing_lock_file: &LockedCondaPackages,
     sparse_repo_data: Arc<[SparseRepoData]>,
     platform: Platform,
     pb: ProgressBar,
-) -> miette::Result<LockedPackagesBuilder> {
-    let dependencies = project.dependencies(None, Some(platform));
+) -> miette::Result<LockedCondaPackages> {
+    let dependencies = environment.dependencies(None, Some(platform));
     let match_specs = dependencies
         .iter_specs()
         .map(|(name, constraint)| MatchSpec::from_nameless(constraint.clone(), Some(name.clone())))
@@ -332,14 +316,7 @@ async fn resolve_platform(
     let package_names = dependencies.names().cloned().collect_vec();
 
     // Get the virtual packages for this platform
-    let virtual_packages = project.virtual_packages(platform);
-
-    // Get the packages that were contained in the last lock-file. We use these as favored packages
-    // for the solver (which is called `locked` for rattler_solve).
-    let locked_packages = existing_lock_file
-        .get_conda_packages_by_platform(platform)
-        .into_diagnostic()
-        .context("failed to retrieve the conda packages from the previous lock-file")?;
+    let virtual_packages = environment.virtual_packages(platform);
 
     // Get the repodata for the current platform and for NoArch
     pb.set_message("loading repodata");
@@ -351,26 +328,18 @@ async fn resolve_platform(
     let mut records = resolve_conda_dependencies(
         match_specs,
         virtual_packages,
-        locked_packages,
+        // TODO(baszalmstra): We should not need to clone here. We should be able to pass a reference to the data instead.
+        existing_lock_file.clone(),
         available_packages,
     )
     .await?;
 
     // Add purl's for the conda packages that are also available as pypi packages if we need them.
-    if project.manifest.has_pypi_dependencies() {
+    if environment.has_pypi_dependencies() {
         pypi::amend_pypi_purls(&mut records).await?;
     }
 
-    // Update lock file
-    let mut locked_packages = LockedPackagesBuilder::new(platform);
-
-    // Add conda packages
-    for record in records.iter() {
-        let locked_package = CondaLockedDependencyBuilder::try_from(record).into_diagnostic()?;
-        locked_packages.add_locked_package(locked_package);
-    }
-
-    Ok(locked_packages)
+    Ok(records)
 }
 
 /// Solves the conda package environment for the given input. This function is async because it
@@ -381,7 +350,7 @@ async fn resolve_conda_dependencies(
     virtual_packages: Vec<GenericVirtualPackage>,
     locked_packages: Vec<RepoDataRecord>,
     available_packages: Vec<Vec<RepoDataRecord>>,
-) -> miette::Result<Vec<RepoDataRecord>> {
+) -> miette::Result<LockedCondaPackages> {
     // Construct a solver task that we can start solving.
     let task = rattler_solve::SolverTask {
         specs,

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -9,6 +9,7 @@ use pep440_rs::VersionSpecifiers;
 use pep508_rs::Requirement;
 use rattler_conda_types::{MatchSpec, ParseMatchSpecError, Platform};
 use rattler_lock::{CondaPackage, LockFile, Package, PypiPackage};
+use rip::types::NormalizedPackageName;
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -94,7 +95,7 @@ pub fn verify_environment_satisfiability(
         .into_iter()
         .map(|channel| rattler_lock::Channel::from(channel.base_url().to_string()))
         .collect_vec();
-    if locked_environment.channels().eq(&channels) {
+    if !locked_environment.channels().eq(&channels) {
         return Err(EnvironmentUnsat::ChannelsMismatch);
     }
 
@@ -319,9 +320,18 @@ pub fn verify_pypi_platform_satisfiability(
 
     // Iterate over all the requirements and find a packages that match the requirements.
     while let Some((requirement, source)) = requirements.pop() {
+        // Convert the name to a normalized string. If the name is not valid, we also won't be able
+        // to satisfy the requirement.
+        let Ok(name) = NormalizedPackageName::from_str(requirement.name.as_str()) else {
+            return Err(PlatformUnsat::UnsatisfiableRequirement(
+                requirement,
+                source.to_string(),
+            ));
+        };
+
         // Look-up the identifier that matches the requirement
         let matched_package = name_to_package_identifiers
-            .get(requirement.name.as_str())
+            .get(&name)
             .into_iter()
             .flat_map(|idxs| idxs.iter().map(|idx| &package_identifiers[*idx]))
             .find(|(identifier, _pypi_package_idx)| identifier.satisfies(&requirement));

--- a/src/project/dependencies.rs
+++ b/src/project/dependencies.rs
@@ -1,5 +1,5 @@
 use indexmap::{Equivalent, IndexMap};
-use rattler_conda_types::{NamelessMatchSpec, PackageName};
+use rattler_conda_types::{MatchSpec, NamelessMatchSpec, PackageName};
 use std::hash::Hash;
 
 /// Holds a list of dependencies where for each package name there can be multiple requirements.
@@ -109,6 +109,15 @@ impl Dependencies {
         self.map
             .into_iter()
             .flat_map(|(name, specs)| specs.into_iter().map(move |spec| (name.clone(), spec)))
+    }
+
+    /// Converts this instance into an iterator of [`MatchSpec`]s.
+    pub fn into_match_specs(self) -> impl Iterator<Item = MatchSpec> + DoubleEndedIterator {
+        self.map.into_iter().flat_map(|(name, specs)| {
+            specs
+                .into_iter()
+                .map(move |spec| MatchSpec::from_nameless(spec, Some(name.clone())))
+        })
     }
 }
 

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -45,6 +45,11 @@ impl Debug for Environment<'_> {
 }
 
 impl<'p> Environment<'p> {
+    /// Returns the project this environment belongs to.
+    pub fn project(&self) -> &'p Project {
+        self.project
+    }
+
     /// Returns the name of this environment.
     pub fn name(&self) -> &EnvironmentName {
         &self.environment.name
@@ -261,6 +266,11 @@ impl<'p> Environment<'p> {
         }
 
         Ok(())
+    }
+
+    /// Returns true if the environments contains any reference to a pypi dependency.
+    pub fn has_pypi_dependencies(&self) -> bool {
+        self.features().any(|f| f.has_pypi_dependencies())
     }
 }
 

--- a/src/project/manifest/feature.rs
+++ b/src/project/manifest/feature.rs
@@ -195,6 +195,13 @@ impl Feature {
             .filter_map(|a| a.scripts.as_ref())
             .next()
     }
+
+    /// Returns true if the feature contains any reference to a pypi dependencies.
+    pub fn has_pypi_dependencies(&self) -> bool {
+        self.targets
+            .targets()
+            .any(|t| t.pypi_dependencies.iter().flatten().next().is_some())
+    }
 }
 
 impl<'de> Deserialize<'de> for Feature {

--- a/src/pypi_tags.rs
+++ b/src/pypi_tags.rs
@@ -1,13 +1,13 @@
 use crate::project::manifest::{LibCSystemRequirement, SystemRequirements};
 use crate::project::virtual_packages::{default_glibc_version, default_mac_os_version};
 use itertools::Itertools;
-use rattler_conda_types::{PackageRecord, Platform, RepoDataRecord, Version};
+use rattler_conda_types::{PackageRecord, Platform, Version};
 use rip::python_env::{WheelTag, WheelTags};
 use std::str::FromStr;
 
 /// Returns true if the specified record refers to a version/variant of python.
-pub fn is_python_record(record: &RepoDataRecord) -> bool {
-    package_name_is_python(&record.package_record.name)
+pub fn is_python_record(record: impl AsRef<PackageRecord>) -> bool {
+    package_name_is_python(&record.as_ref().name)
 }
 
 /// Returns true if the specified name refers to a version/variant of python.

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -1,3 +1,4 @@
+use crate::project::Environment;
 use crate::{config, default_authenticated_client, progress, project::Project};
 use futures::{stream, StreamExt, TryStreamExt};
 use indicatif::ProgressBar;
@@ -9,6 +10,13 @@ use rattler_repodata_gateway::{fetch, sparse::SparseRepoData};
 use std::{path::Path, time::Duration};
 
 impl Project {
+    // TODO: Remove this function once everything is migrated to the new environment system.
+    pub async fn fetch_sparse_repodata(&self) -> miette::Result<Vec<SparseRepoData>> {
+        self.default_environment().fetch_sparse_repodata().await
+    }
+}
+
+impl Environment<'_> {
     pub async fn fetch_sparse_repodata(&self) -> miette::Result<Vec<SparseRepoData>> {
         let channels = self.channels();
         let platforms = self.platforms();

--- a/tests/add_tests.rs
+++ b/tests/add_tests.rs
@@ -3,6 +3,7 @@ mod common;
 use crate::common::package_database::{Package, PackageDatabase};
 use crate::common::LockFileExt;
 use crate::common::PixiControl;
+use pixi::consts::DEFAULT_ENVIRONMENT_NAME;
 use pixi::project::{DependencyType, SpecType};
 use rattler_conda_types::{PackageName, Platform};
 use rip::resolve::SDistResolution;
@@ -46,9 +47,9 @@ async fn add_functionality() {
         .unwrap();
 
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("rattler==3"));
-    assert!(!lock.contains_matchspec("rattler==2"));
-    assert!(!lock.contains_matchspec("rattler==1"));
+    assert!(lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "rattler==3"));
+    assert!(!lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "rattler==2"));
+    assert!(!lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "rattler==1"));
 }
 
 /// Test that we get the union of all packages in the lockfile for the run, build and host
@@ -106,9 +107,13 @@ async fn add_functionality_union() {
 
     // Lock file should contain all packages as well
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("rattler==1"));
-    assert!(lock.contains_matchspec("libcomputer==1.2"));
-    assert!(lock.contains_matchspec("libidk==3.1"));
+    assert!(lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "rattler==1"));
+    assert!(lock.contains_match_spec(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::current(),
+        "libcomputer==1.2"
+    ));
+    assert!(lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "libidk==3.1"));
 }
 
 /// Test adding a package for a specific OS
@@ -145,7 +150,7 @@ async fn add_functionality_os() {
         .unwrap();
 
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec_for_platform("rattler==1", Platform::LinuxS390X));
+    assert!(lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::LinuxS390X, "rattler==1"));
 }
 
 /// Test the `pixi add --pypi` functionality
@@ -208,18 +213,21 @@ async fn add_pypi_functionality() {
         .unwrap();
 
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_package(&PackageName::from_str("pipx").unwrap()));
-    assert!(lock.contains_pep508_requirement_for_platform(
-        pep508_rs::Requirement::from_str("boto3>=1.33").unwrap(),
-        Platform::Osx64
+    assert!(lock.contains_pypi_package(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "pipx"));
+    assert!(lock.contains_pep508_requirement(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::Osx64,
+        pep508_rs::Requirement::from_str("boto3>=1.33").unwrap()
     ));
-    assert!(lock.contains_pep508_requirement_for_platform(
+    assert!(lock.contains_pep508_requirement(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::Linux64,
         pep508_rs::Requirement::from_str("pytest[all]").unwrap(),
-        Platform::Linux64
     ));
-    assert!(lock.contains_pep508_requirement_for_platform(
+    assert!(lock.contains_pep508_requirement(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::Linux64,
         pep508_rs::Requirement::from_str("requests [security,tests] >= 2.8.1, == 2.8.*").unwrap(),
-        Platform::Linux64
     ));
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,16 +19,14 @@ use pixi::{
     task::{ExecutableTask, RunOutput, TraversalError},
     Project,
 };
-use rattler_conda_types::{MatchSpec, PackageName, Platform, Version};
-use rattler_lock::{CondaLock, LockedDependencyKind};
+use rattler_conda_types::{MatchSpec, Platform};
 
 use miette::{Diagnostic, IntoDiagnostic};
-use pep508_rs::VersionOrUrl;
 use pixi::cli::LockFileUsageArgs;
 use pixi::project::manifest::FeatureName;
 use pixi::task::TaskExecutionError;
+use rattler_lock::{LockFile, Package};
 use std::{
-    collections::HashSet,
     path::{Path, PathBuf},
     process::Output,
     str::FromStr,
@@ -65,101 +63,86 @@ pub fn string_from_iter(iter: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<
 
 pub trait LockFileExt {
     /// Check if this package is contained in the lockfile
-    fn contains_package(&self, name: &PackageName) -> bool;
+    fn contains_conda_package(&self, environment: &str, platform: Platform, name: &str) -> bool;
+    fn contains_pypi_package(&self, environment: &str, platform: Platform, name: &str) -> bool;
     /// Check if this matchspec is contained in the lockfile
-    fn contains_matchspec(&self, matchspec: impl IntoMatchSpec) -> bool;
-    /// Check if this matchspec is contained in the lockfile for this platform
-    fn contains_matchspec_for_platform(
+    fn contains_match_spec(
         &self,
-        matchspec: impl IntoMatchSpec,
-        platform: impl Into<Platform>,
+        environment: &str,
+        platform: Platform,
+        match_spec: impl IntoMatchSpec,
     ) -> bool;
+
     /// Check if the pep508 requirement is contained in the lockfile for this platform
-    fn contains_pep508_requirement_for_platform(
+    fn contains_pep508_requirement(
         &self,
+        environment: &str,
+        platform: Platform,
         requirement: pep508_rs::Requirement,
-        platform: impl Into<Platform>,
     ) -> bool;
 }
 
-impl LockFileExt for CondaLock {
-    fn contains_package(&self, name: &PackageName) -> bool {
-        self.package
-            .iter()
-            .any(|locked_dep| locked_dep.name == *name.as_normalized())
+impl LockFileExt for LockFile {
+    fn contains_conda_package(&self, environment: &str, platform: Platform, name: &str) -> bool {
+        let Some(env) = self.environment(environment) else {
+            return false;
+        };
+        let package_found = env
+            .packages(platform)
+            .into_iter()
+            .flatten()
+            .filter_map(Package::into_conda)
+            .any(|package| package.package_record().name.as_normalized() == name);
+        package_found
+    }
+    fn contains_pypi_package(&self, environment: &str, platform: Platform, name: &str) -> bool {
+        let Some(env) = self.environment(environment) else {
+            return false;
+        };
+        let package_found = env
+            .packages(platform)
+            .into_iter()
+            .flatten()
+            .filter_map(Package::into_pypi)
+            .any(|pkg| pkg.data().package.name == name);
+        package_found
     }
 
-    fn contains_matchspec(&self, matchspec: impl IntoMatchSpec) -> bool {
-        let matchspec = matchspec.into();
-        let name = matchspec.name.expect("expected matchspec to have a name");
-        let version = matchspec
-            .version
-            .expect("expected versionspec to have a name");
-        self.package.iter().any(|locked_dep| {
-            let package_version =
-                Version::from_str(&locked_dep.version).expect("could not parse version");
-            locked_dep.name == name.as_normalized() && version.matches(&package_version)
-        })
-    }
-
-    fn contains_matchspec_for_platform(
+    fn contains_match_spec(
         &self,
-        matchspec: impl IntoMatchSpec,
-        platform: impl Into<Platform>,
+        environment: &str,
+        platform: Platform,
+        match_spec: impl IntoMatchSpec,
     ) -> bool {
-        let matchspec = matchspec.into();
-        let name = matchspec.name.expect("expected matchspec to have a name");
-        let version = matchspec
-            .version
-            .expect("expected versionspec to have a name");
-        let platform = platform.into();
-        self.package.iter().any(|locked_dep| {
-            let package_version =
-                Version::from_str(&locked_dep.version).expect("could not parse version");
-            locked_dep.name == name.as_normalized()
-                && version.matches(&package_version)
-                && locked_dep.platform == platform
-        })
+        let match_spec = match_spec.into();
+        let Some(env) = self.environment(environment) else {
+            return false;
+        };
+        let package_found = env
+            .packages(platform)
+            .into_iter()
+            .flatten()
+            .filter_map(Package::into_conda)
+            .any(move |p| p.satisfies(&match_spec));
+        package_found
     }
 
-    fn contains_pep508_requirement_for_platform(
+    fn contains_pep508_requirement(
         &self,
+        environment: &str,
+        platform: Platform,
         requirement: pep508_rs::Requirement,
-        platform: impl Into<Platform>,
     ) -> bool {
-        let name = requirement.name;
-        let version: Option<pep440_rs::VersionSpecifiers> =
-            requirement
-                .version_or_url
-                .and_then(|version_or_url| match version_or_url {
-                    VersionOrUrl::VersionSpecifier(version) => Some(version),
-                    VersionOrUrl::Url(_) => unimplemented!(),
-                });
-
-        let platform = platform.into();
-        self.package.iter().any(|locked_dep| {
-            let package_version =
-                pep440_rs::Version::from_str(&locked_dep.version).expect("could not parse version");
-
-            let req_extras = requirement
-                .extras
-                .as_ref()
-                .map(|extras| extras.iter().cloned().collect::<HashSet<_>>())
-                .unwrap_or_default();
-
-            locked_dep.name == *name
-                && version
-                    .as_ref()
-                    .map_or(true, |v| v.contains(&package_version))
-                && locked_dep.platform == platform
-                // Check if the extras are the same.
-                && match &locked_dep.kind {
-                    LockedDependencyKind::Conda(_) => false,
-                    LockedDependencyKind::Pypi(locked) => {
-                        req_extras == locked.extras.iter().cloned().collect()
-                    }
-                }
-        })
+        let Some(env) = self.environment(environment) else {
+            return false;
+        };
+        let package_found = env
+            .packages(platform)
+            .into_iter()
+            .flatten()
+            .filter_map(Package::into_pypi)
+            .any(move |p| p.satisfies(&requirement));
+        package_found
     }
 }
 
@@ -290,7 +273,7 @@ impl PixiControl {
     }
 
     /// Get the associated lock file
-    pub async fn lock_file(&self) -> miette::Result<CondaLock> {
+    pub async fn lock_file(&self) -> miette::Result<LockFile> {
         let project = Project::load_or_else_discover(Some(&self.manifest_path()))?;
         pixi::lock_file::load_lock_file(&project).await
     }

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -4,6 +4,8 @@ use crate::common::builders::string_from_iter;
 use crate::common::package_database::{Package, PackageDatabase};
 use common::{LockFileExt, PixiControl};
 use pixi::cli::{run, LockFileUsageArgs};
+use pixi::consts::DEFAULT_ENVIRONMENT_NAME;
+use rattler_conda_types::Platform;
 use serial_test::serial;
 use tempfile::TempDir;
 
@@ -19,7 +21,11 @@ async fn install_run_python() {
 
     // Check if lock has python version
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("python==3.11.0"));
+    assert!(lock.contains_match_spec(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::current(),
+        "python==3.11.0"
+    ));
 
     // Check if python is installed and can be run
     let result = pixi
@@ -77,8 +83,8 @@ async fn test_incremental_lock_file() {
 
     // Get the created lock-file
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("foo ==1"));
-    assert!(lock.contains_matchspec("bar ==1"));
+    assert!(lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "foo ==1"));
+    assert!(lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "bar ==1"));
 
     // Add version 2 of both `foo` and `bar`.
     package_database.add_package(Package::build("bar", "2").finish());
@@ -98,11 +104,11 @@ async fn test_incremental_lock_file() {
 
     let lock = pixi.lock_file().await.unwrap();
     assert!(
-        lock.contains_matchspec("foo ==2"),
+        lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "foo ==2"),
         "expected `foo` to be on version 2 because we changed the requirement"
     );
     assert!(
-        lock.contains_matchspec("bar ==1"),
+        lock.contains_match_spec(DEFAULT_ENVIRONMENT_NAME, Platform::current(), "bar ==1"),
         "expected `bar` to remain locked to version 1."
     );
 }
@@ -127,7 +133,11 @@ async fn install_locked() {
 
     // Check if it didn't accidentally update the lockfile
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("python==3.8.0"));
+    assert!(lock.contains_match_spec(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::current(),
+        "python==3.8.0"
+    ));
 
     // After an install with lockfile update the locked install should succeed.
     pixi.install().await.unwrap();
@@ -135,7 +145,11 @@ async fn install_locked() {
 
     // Check if lock has python version updated
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("python==3.9.0"));
+    assert!(lock.contains_match_spec(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::current(),
+        "python==3.9.0"
+    ));
 }
 
 /// Test `pixi install/run --frozen` functionality
@@ -158,7 +172,11 @@ async fn install_frozen() {
 
     // Check if it didn't accidentally update the lockfile
     let lock = pixi.lock_file().await.unwrap();
-    assert!(lock.contains_matchspec("python==3.9.1"));
+    assert!(lock.contains_match_spec(
+        DEFAULT_ENVIRONMENT_NAME,
+        Platform::current(),
+        "python==3.9.1"
+    ));
 
     // Check if running with frozen doesn't suddenly install the latest update.
     let result = pixi


### PR DESCRIPTION
Refactors pixi to make use of the changes made in https://github.com/mamba-org/rattler/pull/484 .

This completely refactors how lock-files are checked and how they are rebuilt. 

@ruben-arts Please carefully test that lock-files are still properly verified and updated.

Note that this does **not** add multi-env support yet. This work is just done to integrate with multi-env capable lock-files.