### PR TITLE
fix(cli): make `pixi search` result correct

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -64,9 +64,10 @@ where
         let mut records = Vec::new();
 
         for repo in repo_data {
-            records.extend(repo
-                .load_records(&PackageName::new_unchecked(*package))
-                .into_diagnostic()?);
+            records.extend(
+                repo.load_records(&PackageName::new_unchecked(*package))
+                    .into_diagnostic()?,
+            );
         }
 
         // sort records by version, get the latest one

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -53,30 +53,29 @@ where
             repo.package_names()
                 .filter(|&name| filter_func(name, package))
         })
+        .unique()
         .collect::<Vec<&str>>();
 
     let mut latest_packages = Vec::new();
 
     // search for `similar_packages` in all platform's repodata
     // add the latest version of the fetched package to latest_packages vector
-    for repo in repo_data {
-        for package in &similar_packages {
-            let mut records = repo
+    for package in &similar_packages {
+        let mut records = Vec::new();
+
+        for repo in repo_data {
+            records.extend(repo
                 .load_records(&PackageName::new_unchecked(*package))
-                .into_diagnostic()?;
-            // sort records by version, get the latest one
-            records.sort_by(|a, b| a.package_record.version.cmp(&b.package_record.version));
-            let latest_package = records.last().cloned();
-            if let Some(latest_package) = latest_package {
-                latest_packages.push(latest_package);
-            }
+                .into_diagnostic()?);
+        }
+
+        // sort records by version, get the latest one
+        records.sort_by(|a, b| a.package_record.version.cmp(&b.package_record.version));
+        let latest_package = records.last().cloned();
+        if let Some(latest_package) = latest_package {
+            latest_packages.push(latest_package);
         }
     }
-
-    latest_packages = latest_packages
-        .into_iter()
-        .unique_by(|record| record.package_record.name.clone())
-        .collect::<Vec<_>>();
 
     Ok(latest_packages)
 }


### PR DESCRIPTION
Close #712 

*before*
```
❯ pixi search jupyterlab

jupyterlab py37_0
-----------------

Name                jupyterlab
Version             1.0.10
Build               py37_0
Size                13936631
License             BSD-3-Clause
Subdir              win-64
File Name           jupyterlab-1.0.10-py37_0.tar.bz2
URL                 https://conda.anaconda.org/conda-forge/win-64/jupyterlab-1.0.10-py37_0.tar.bz2
MD5                 bd9a55e6d10092c8230fdcc00efdaceb
SHA256              f674dd303a889e7adeabdb609bde2801f8078020513438c585a941f7a7efe75f

Dependencies:
 - jinja2 >=2.10
 - jupyterlab_server >=1.0.0,<2.0.0
 - notebook >=4.3.1
 - python >=3.7,<3.8.0a0
 - tornado !=6.0.0,!=6.0.1,!=6.0.2

❯ pixi search jupyterlab*
Package                                  Version             Channel
jupyterlab                               1.0.10              conda-forge
jupyterlab-sos                           0.9.0               conda-forge
jupyterlab-day                           0.1.0               conda-forge
jupyterlab-git                           0.50.0              conda-forge
jupyterlab-lsp                           5.0.2               conda-forge
jupyterlab_sos                           0.9.0               conda-forge
jupyterlab_vim                           4.1.0               conda-forge
jupyterlab-daw                           0.2.1               conda-forge
jupyterlab-dash                          0.1.0a3             conda-forge
jupyterlab-deck                          0.2.0               conda-forge
jupyterlab-myst                          2.1.0               conda-forge
jupyterlab-tour                          4.0.0               conda-forge
jupyterlab-urdf                          0.3.2               conda-forge
jupyterlab-wipp                          1.2.0               conda-forge
jupyterlab_genv                          0.3.0               conda-forge
```

*after*
```
❯ .\target\release\pixi.exe search jupyterlab

jupyterlab pyhd8ed1ab_0
-----------------------

Name                jupyterlab
Version             4.0.11
Build               pyhd8ed1ab_0
Size                5861540
License             BSD-3-Clause
Subdir              noarch
File Name           jupyterlab-4.0.11-pyhd8ed1ab_0.conda
URL                 https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.11-pyhd8ed1ab_0.conda
MD5                 42370604825af7396ef4317b67b22e2c
SHA256              a6193a5160b9d3760a6b898858c69e9cfafddb126db45782429fc6b898011eee

Dependencies:
 - async-lru >=1.0.0
 - importlib_metadata >=4.8.3
 - importlib_resources >=1.4
 - ipykernel
 - jinja2 >=3.0.3
 - jupyter-lsp >=2.0.0
 - jupyter_core
 - jupyter_server >=2.4.0,<3
 - jupyterlab_server >=2.19.0,<3
 - notebook-shim >=0.2
 - packaging
 - python >=3.8
 - tomli
 - tornado >=6.2.0
 - traitlets

❯ .\target\release\pixi.exe search jupyterlab*
Package                                  Version             Channel
jupyterlab                               4.0.11              conda-forge
jupyterlab-sos                           0.9.0               conda-forge
jupyterlab-day                           0.1.0               conda-forge
jupyterlab-git                           0.50.0              conda-forge
jupyterlab-lsp                           5.0.2               conda-forge
jupyterlab_sos                           0.9.0               conda-forge
jupyterlab_vim                           4.1.0               conda-forge
jupyterlab-daw                           0.2.1               conda-forge
jupyterlab-dash                          0.1.0a3             conda-forge
jupyterlab-deck                          0.2.0               conda-forge
jupyterlab-myst                          2.1.0               conda-forge
jupyterlab-tour                          4.0.0               conda-forge
jupyterlab-urdf                          0.3.2               conda-forge
jupyterlab-wipp                          1.2.0               conda-forge
jupyterlab_genv                          0.3.0               conda-forge
```
