### PR TITLE
feature: allow specifying the environment in shell-hook

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,7 +228,7 @@ moo = { depends_on = ["cow"] }
 This command starts a new shell in the project's environment.
 To exit the pixi shell, simply run `exit`.
 
-#####Options
+##### Options
 
 - `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile.
@@ -243,6 +243,31 @@ pixi shell --frozen
 exit
 pixi shell --locked
 exit
+```
+
+## `shell-hook`
+
+This command prints the activation script of an environment.
+
+##### Options
+- `--shell`: The shell for which the activation script should be printed. Defaults to the current shell.
+    Currently supported variants: [`Bash`,  `Zsh`,  `Xonsh`,  `CmdExe`,  `PowerShell`,  `Fish`,  `NuShell`]
+- `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
+- `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile.
+- `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. Conflicts with `--frozen`.
+
+```shell
+pixi shell-hook
+pixi shell-hook --shell bash
+pixi shell-hook --shell zsh
+pixi shell-hook --manifest-path ~/myproject/pixi.toml
+pixi shell-hook --frozen
+pixi shell-hook --locked
+```
+Example use-case, when you want to get rid of the `pixi` executable in a Docker container.
+```shell
+pixi shell-hook --shell bash > /etc/profile.d/pixi.sh
+rm ~/.pixi/bin/pixi # Now the environment will be activated without the need for the pixi executable.
 ```
 
 ## `search`

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -60,7 +60,6 @@ pub enum Command {
     Run(run::Args),
     #[clap(alias = "s")]
     Shell(shell::Args),
-    #[clap(hide = true)]
     ShellHook(shell_hook::Args),
     #[clap(alias = "g")]
     Global(global::Args),

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -4,37 +4,39 @@ use rattler_shell::{
     activation::{ActivationVariables, PathModificationBehavior},
     shell::ShellEnum,
 };
+use std::path::PathBuf;
 
-use crate::{
-    activation::get_activator,
-    environment::{get_up_to_date_prefix, LockFileUsage},
-    Project,
-};
+use crate::cli::LockFileUsageArgs;
+use crate::project::manifest::EnvironmentName;
+use crate::project::Environment;
+use crate::{activation::get_activator, environment::get_up_to_date_prefix, Project};
 
-/// Print the activation script
+/// Print the activation script so users can source it in their shell, without needing the pixi executable.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Sets the shell
     #[arg(short, long)]
     shell: Option<ShellEnum>,
+
+    /// The path to 'pixi.toml'
+    #[arg(long)]
+    manifest_path: Option<PathBuf>,
+
+    #[clap(flatten)]
+    lock_file_usage: LockFileUsageArgs,
+
+    /// The environment to activate in the script
+    #[arg(long, short)]
+    environment: Option<String>,
 }
 
 /// Generates the activation script.
-async fn generate_activation_script(shell: Option<ShellEnum>) -> miette::Result<String> {
-    let project = Project::discover()?;
-    let environment = project.default_environment();
-
-    get_up_to_date_prefix(
-        &environment,
-        LockFileUsage::Frozen,
-        false,
-        None,
-        Default::default(),
-    )
-    .await?;
-
+async fn generate_activation_script(
+    shell: Option<ShellEnum>,
+    environment: &Environment<'_>,
+) -> miette::Result<String> {
     let shell = shell.unwrap_or_default();
-    let activator = get_activator(&environment, shell).into_diagnostic()?;
+    let activator = get_activator(environment, shell).into_diagnostic()?;
 
     let path = std::env::var("PATH")
         .ok()
@@ -50,13 +52,33 @@ async fn generate_activation_script(shell: Option<ShellEnum>) -> miette::Result<
         })
         .into_diagnostic()?;
 
-    Ok(result.script.clone())
+    Ok(result.script)
 }
 
 /// Prints the activation script to the stdout.
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let script = generate_activation_script(args.shell).await?;
-    println!("{script}");
+    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let environment_name = args
+        .environment
+        .map_or_else(|| EnvironmentName::Default, EnvironmentName::Named);
+    let environment = project
+        .environment(&environment_name)
+        .ok_or_else(|| miette::miette!("unknown environment '{environment_name}'"))?;
+
+    get_up_to_date_prefix(
+        &environment,
+        args.lock_file_usage.into(),
+        false,
+        None,
+        Default::default(),
+    )
+    .await?;
+
+    let script = generate_activation_script(args.shell, &environment).await?;
+
+    // Print the script
+    println!("{}", script);
+
     Ok(())
 }
 
@@ -66,7 +88,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_shell_hook() {
-        let script = generate_activation_script(None).await.unwrap();
+        let project = Project::discover().unwrap();
+        let environment = project.default_environment();
+        let script = generate_activation_script(None, &environment)
+            .await
+            .unwrap();
         if cfg!(unix) {
             assert!(script.contains("export PATH="));
             assert!(script.contains("export CONDA_PREFIX="));


### PR DESCRIPTION
Now you can do:
```
pixi shell-hook -e prod
pixi shell-hook --manifest-path ~/project/pixi.toml
pixi shell-hook --locked
pixi shell-hook --frozen
```

closes #719 