### PR TITLE
Add env variable to configure locked, frozen and color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ assert_matches = "1.5.0"
 async-once-cell = "0.5.3"
 async-recursion = "1.0.5"
 chrono = "0.4.32"
-clap = { version = "4.4.18", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context"] }
+clap = { version = "4.4.18", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context", "env"] }
 clap-verbosity-flag = "2.1.2"
 clap_complete = "4.4.9"
 comfy-table = "7.1.0"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -38,7 +38,7 @@ struct Args {
     verbose: Verbosity,
 
     /// Whether the log needs to be colored.
-    #[clap(long, default_value = "auto", global = true)]
+    #[clap(long, default_value = "auto", global = true, env = "PIXI_COLOR")]
     color: ColorOutput,
 }
 
@@ -83,10 +83,10 @@ pub enum Command {
 /// Lock file usage from the CLI
 pub struct LockFileUsageArgs {
     /// Don't check or update the lockfile, continue with previously installed environment.
-    #[clap(long, conflicts_with = "locked")]
+    #[clap(long, conflicts_with = "locked", env = "PIXI_FROZEN")]
     pub frozen: bool,
     /// Check if lockfile is up to date, aborts when lockfile isn't up to date with the manifest file.
-    #[clap(long, conflicts_with = "frozen")]
+    #[clap(long, conflicts_with = "frozen", env = "PIXI_LOCKED")]
     pub locked: bool,
 }
 


### PR DESCRIPTION
See https://github.com/prefix-dev/pixi/issues/714 for context.

In short, it adds:

- `PIXI_COLOR` to configure `--color`
- `PIXI_LOCKED` to configure `--locked`
- `PIXI_FROZEN` to configure `--frozen`

I could not find a way to configure `--quiet` and `--verbose` since the `Verbosity` struct belongs to `clap_verbosity_flag`.

I went the easy way for the name of the env variables, but please let me know if you prefer something else.