### PR TITLE
Fix linux installer

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -80,7 +80,7 @@ update_shell() {
     LINE=$2
 
     # shell update can be suppressed by `PIXI_NO_PATH_UPDATE` env var
-    [[ ! -z "$PIXI_NO_PATH_UPDATE" ]] && return
+    [[ -z "${PIXI_NO_PATH_UPDATE-}" ]] && return
 
     # Create the file if it doesn't exist
     if [ -f "$FILE" ]; then


### PR DESCRIPTION
The linux installer was broken by #692 and fails currently with 

```
bash: line 83: PIXI_NO_PATH_UPDATE: unbound variable
```

This changes this to use a default value and checks if the string is empty instead