### PR TITLE
refactor: use tabwriter instead of comfy_table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,18 +725,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "comfy-table"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
-dependencies = [
- "crossterm",
- "strum",
- "strum_macros",
- "unicode-width",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,28 +816,6 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.4.2",
- "crossterm_winapi",
- "libc",
- "parking_lot",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "crunchy"
@@ -2692,7 +2658,6 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
- "comfy-table",
  "console",
  "deno_task_shell",
  "dirs",
@@ -2738,6 +2703,7 @@ dependencies = [
  "signal-hook",
  "spdx",
  "strsim",
+ "tabwriter",
  "tar",
  "tempfile",
  "thiserror",
@@ -4161,6 +4127,15 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a327282c4f64f6dc37e3bba4c2b6842cc3a992f204fa58d917696a89f691e5f6"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ chrono = "0.4.32"
 clap = { version = "4.4.18", default-features = false, features = ["derive", "usage", "wrap_help", "std", "color", "error-context", "env"] }
 clap-verbosity-flag = "2.1.2"
 clap_complete = "4.4.9"
-comfy-table = "7.1.0"
 console = { version = "0.15.8", features = ["windows-console-colors"] }
 deno_task_shell = "0.14.3"
 dirs = "5.0.1"
@@ -65,6 +64,7 @@ serde_with = { version = "3.5.0", features = ["indexmap"] }
 shlex = "1.3.0"
 spdx = "0.10.3"
 strsim = "0.10.0"
+tabwriter = { version = "1.4.0", features = ["ansi_formatting"] }
 tar = "0.4.40"
 tempfile = "3.9.0"
 thiserror = "1.0.56"

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -139,7 +139,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         json_packages(&packages_to_output, args.json_pretty);
     } else {
         // print packages as table
-        print_packages_as_table(&packages_to_output).expect("an io error occured");
+        print_packages_as_table(&packages_to_output).expect("an io error occurred");
     }
 
     Ok(())


### PR DESCRIPTION
Fix #741 

Replaces `comfy_table` with the much simpler `tabwriter`. This allows us to simply use `console` for all styling which should then follow the rules around `--color`.