### PR TITLE
fix: avoid pypi deadlock

### DIFF
--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -322,7 +322,8 @@ fn stream_python_artifacts<'a>(
                 ))
             }
         })
-        .buffer_unordered(20)
+        // TODO: put this back on 20 when there is not deadlock anymore.
+        .buffer_unordered(1)
         .right_stream();
 
     (download_stream, Some(pb))


### PR DESCRIPTION
This is a temp fix for the pypi wheel building deadlock that occurred. Solving that is ongoing but this is a workaround for now. 