### PR TITLE
fix: remove using source name

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -24,9 +24,6 @@ rust = "~=1.73.0"
 openssl = "3.*"
 pkg-config = "0.29.*"
 git = "2.42.0.*"
-
-# Documentation building
-mkdocs = "1.5.3.*"
 mkdocs-material = "9.4.4.*"
 pillow = ">=9.4.0.*"
 cairosvg = "2.7.1.*"

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -339,7 +339,7 @@ impl Manifest {
         feature_name: &FeatureName,
     ) -> miette::Result<(PackageName, NamelessMatchSpec)> {
         get_or_insert_toml_table(&mut self.document, platform, feature_name, spec_type.name())?
-            .remove(dep.as_normalized())
+            .remove(dep.as_source())
             .ok_or_else(|| {
                 let table_name =
                     get_nested_toml_table_name(feature_name, platform, spec_type.name());


### PR DESCRIPTION
This allows the user to call `pixi rm MatPlotLib` if they have that in the pixi.toml. 
closes #761 