### PR TITLE
misc: use default env if task available in it.

### DIFF
--- a/src/project/manifest/environment.rs
+++ b/src/project/manifest/environment.rs
@@ -32,6 +32,11 @@ impl EnvironmentName {
             EnvironmentName::Named(name) => name.as_str(),
         }
     }
+
+    /// Returns true if the environment is the default environment.
+    pub fn is_default(&self) -> bool {
+        matches!(self, EnvironmentName::Default)
+    }
 }
 
 impl Borrow<str> for EnvironmentName {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -21,7 +21,7 @@ pub use task_environment::{
 pub use task_graph::{TaskGraph, TaskGraphError, TaskId, TaskNode};
 
 /// Represents different types of scripts
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum Task {
     Plain(String),
@@ -113,7 +113,7 @@ impl Task {
 
 /// A command script executes a single command from the environment
 #[serde_as]
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Execute {
     /// A list of arguments, the first argument denotes the command to run. When deserializing both
@@ -136,7 +136,7 @@ impl From<Execute> for Task {
 }
 
 /// A custom command script executes a single command in the environment
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct Custom {
     /// A list of arguments, the first argument denotes the command to run. When deserializing both
     /// an array of strings and a single string are supported.
@@ -151,7 +151,7 @@ impl From<Custom> for Task {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum CmdArgs {
     Single(String),
@@ -188,7 +188,7 @@ impl CmdArgs {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde_as]
 pub struct Alias {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -21,7 +21,7 @@ pub use task_environment::{
 pub use task_graph::{TaskGraph, TaskGraphError, TaskId, TaskNode};
 
 /// Represents different types of scripts
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum Task {
     Plain(String),
@@ -113,7 +113,7 @@ impl Task {
 
 /// A command script executes a single command from the environment
 #[serde_as]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct Execute {
     /// A list of arguments, the first argument denotes the command to run. When deserializing both
@@ -136,7 +136,7 @@ impl From<Execute> for Task {
 }
 
 /// A custom command script executes a single command in the environment
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Custom {
     /// A list of arguments, the first argument denotes the command to run. When deserializing both
     /// an array of strings and a single string are supported.
@@ -151,7 +151,7 @@ impl From<Custom> for Task {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum CmdArgs {
     Single(String),
@@ -188,7 +188,7 @@ impl CmdArgs {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 #[serde_as]
 pub struct Alias {

--- a/src/task/task_environment.rs
+++ b/src/task/task_environment.rs
@@ -116,10 +116,33 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
         source: FindTaskSource<'p>,
     ) -> Result<TaskAndEnvironment<'p>, FindTaskError> {
         // If the task was specified on the command line and there is no explicit environment and
-        // the task is the default environment, use the default environment.
+        // the task is defined only in the default feature, use the default environment.
         if matches!(source, FindTaskSource::CmdArgs) && self.explicit_environment.is_none() {
-            if let Ok(task) = self.project.default_environment().task(name, self.platform) {
-                return Ok((self.project.default_environment(), task));
+            if let Some(task) = self
+                .project
+                .manifest
+                .default_feature()
+                .targets
+                .resolve(self.platform)
+                .find_map(|target| target.tasks.get(name))
+            {
+                // No other feature then default has the task defined.
+                if !self
+                    .project
+                    .manifest
+                    .parsed
+                    .features
+                    .iter()
+                    .filter(|(name, _feature)| name.as_str() != "default")
+                    .any(|(_, feature)| {
+                        feature
+                            .targets
+                            .resolve(self.platform)
+                            .any(|target| target.tasks.contains_key(name))
+                    })
+                {
+                    return Ok((self.project.default_environment(), task));
+                }
             }
         }
 
@@ -168,5 +191,56 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_find_task_default_defined() {
+        let manifest_str = r#"
+            [project]
+            name = "foo"
+            channels = ["foo"]
+            platforms = ["linux-64"]
+
+            [tasks]
+            test = "cargo test"
+            [feature.test.dependencies]
+            pytest = "*"
+            [environments]
+            test = ["test"]
+        "#;
+        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let search = SearchEnvironments::from_opt_env(&project, None, None);
+        let result = search.find_task("test", FindTaskSource::CmdArgs);
+        assert!(result.is_ok());
+        assert!(result.unwrap().0.name().is_default());
+    }
+
+    #[test]
+    fn test_find_task_dual_defined() {
+        let manifest_str = r#"
+            [project]
+            name = "foo"
+            channels = ["foo"]
+            platforms = ["linux-64"]
+
+            [tasks]
+            test = "cargo test"
+
+            [feature.test.tasks]
+            test = "cargo test --all-features"
+
+            [environments]
+            test = ["test"]
+        "#;
+        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let search = SearchEnvironments::from_opt_env(&project, None, None);
+        let result = search.find_task("test", FindTaskSource::CmdArgs);
+        assert!(matches!(result, Err(FindTaskError::AmbiguousTask(_))));
     }
 }


### PR DESCRIPTION
This addresses @pavelzw issue in #767 

Which means that if a task is in the default environment we always automatically run it from that environment.