### PR TITLE
feat: update lock on `pixi list`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -298,6 +298,11 @@ List project's packages. Highlighted packages are explicit dependencies.
 - `--sort-by <SORT_BY>`: Sorting strategy [default: name] [possible values: size, name, type]
 - `--manifest-path <MANIFEST_PATH>`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--environment`(`-e`): the environment's packages to list, if non is provided the default environment's packages will be listed.
+- `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
+- `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
+- `--no-install`: do not update the environment, only add changed packages to the lock-file. (Implied by `--frozen` and `--locked`)
+
+```shell
 
 ```shell
 pixi list
@@ -305,6 +310,9 @@ pixi list --json-pretty
 pixi list --sort-by size
 pixi list --platform win-64
 pixi list --environment cuda
+pixi list --frozen
+pixi list --locked
+pixi list --no-install
 ```
 Output will look like this, where `python` will be green as it is the package that was explicitly added to the `pixi.toml`:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -296,11 +296,11 @@ List project's packages. Highlighted packages are explicit dependencies.
 - `--json`: Whether to output in json format.
 - `--json-pretty`: Whether to output in pretty json format
 - `--sort-by <SORT_BY>`: Sorting strategy [default: name] [possible values: size, name, type]
-- `--manifest-path <MANIFEST_PATH>`: the path to `pixi.toml`, by default it searches for one in the parent directories.
-- `--environment`(`-e`): the environment's packages to list, if non is provided the default environment's packages will be listed.
-- `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
-- `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
-- `--no-install`: do not update the environment, only add changed packages to the lock-file. (Implied by `--frozen` and `--locked`)
+- `--manifest-path <MANIFEST_PATH>`: The path to `pixi.toml`, by default it searches for one in the parent directories.
+- `--environment`(`-e`): The environment's packages to list, if non is provided the default environment's packages will be listed.
+- `--frozen`: Install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
+- `--locked`: Only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
+- `--no-install`: Don't install the environment for pypi solving, only update the lock-file if it can solve without installing. (Implied by `--frozen` and `--locked`)
 
 ```shell
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -2,9 +2,11 @@ use std::io;
 use std::io::{stdout, Write};
 use std::path::PathBuf;
 
+use crate::environment::get_up_to_date_prefix;
 use clap::Parser;
 use console::Color;
 use human_bytes::human_bytes;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use rattler_conda_types::Platform;
 use rattler_lock::Package;
@@ -53,6 +55,13 @@ pub struct Args {
     /// The environment to list packages for. Defaults to the default environment.
     #[arg(short, long)]
     pub environment: Option<String>,
+
+    #[clap(flatten)]
+    pub lock_file_usage: super::LockFileUsageArgs,
+
+    /// Don't install the environment, only update the lock-file.
+    #[arg(long)]
+    pub no_install: bool,
 }
 
 #[derive(Serialize)]
@@ -74,6 +83,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let environment = project
         .environment(&environment_name)
         .ok_or_else(|| miette::miette!("unknown environment '{environment_name}'"))?;
+
+    get_up_to_date_prefix(
+        &environment,
+        args.lock_file_usage.into(),
+        args.no_install,
+        IndexMap::default(),
+    )
+    .await?;
 
     // Load the platform
     let platform = args.platform.unwrap_or_else(Platform::current);


### PR DESCRIPTION
This avoid list output which is not uptodate with the pixi.toml

closes #774 