### PR TITLE
docs: Add more documentation on `environments`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -356,7 +356,7 @@ To exit the pixi shell, simply run `exit`.
 - `--manifest-path <MANIFEST_PATH>`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
 - `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
-- `--environment <ENVIRONMENT> (-e)`: The environment to activate the shell in, if non provided the default environment will be used or a selector will be given to select the right environment.
+- `--environment <ENVIRONMENT> (-e)`: The environment to activate the shell in, if none are provided the default environment will be used or a selector will be given to select the right environment.
 
 ```shell
 pixi shell

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,6 +106,7 @@ You cannot run `pixi run source setup.bash` as `source` is not available in the 
 - `--manifest-path <MANIFEST_PATH>`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
 - `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
+- `--environment <ENVIRONMENT> (-e)`: The environment to run the task in, if non provided the default environment will be used or a selector will be given to select the right environment.
 
 ```shell
 pixi run python
@@ -117,6 +118,9 @@ pixi run --locked python
 pixi run build
 # Extra arguments will be passed to the tasks command.
 pixi run task argument1 argument2
+
+# If you have multiple environments you can select the right one with the --environment flag.
+pixi run --environment cuda python
 ```
 
 !!! info
@@ -352,6 +356,7 @@ To exit the pixi shell, simply run `exit`.
 - `--manifest-path <MANIFEST_PATH>`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
 - `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
+- `--environment <ENVIRONMENT> (-e)`: The environment to activate the shell in, if non provided the default environment will be used or a selector will be given to select the right environment.
 
 ```shell
 pixi shell
@@ -361,6 +366,8 @@ exit
 pixi shell --frozen
 exit
 pixi shell --locked
+exit
+pixi shell --environment cuda
 exit
 ```
 
@@ -374,6 +381,7 @@ This command prints the activation script of an environment.
 - `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
 - `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
+- `--environment <ENVIRONMENT> (-e)`: The environment to activate, if non provided the default environment will be used or a selector will be given to select the right environment.
 
 ```shell
 pixi shell-hook
@@ -382,6 +390,7 @@ pixi shell-hook --shell zsh
 pixi shell-hook --manifest-path ~/myproject/pixi.toml
 pixi shell-hook --frozen
 pixi shell-hook --locked
+pixi shell-hook --environment cuda
 ```
 Example use-case, when you want to get rid of the `pixi` executable in a Docker container.
 ```shell

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,7 +106,7 @@ You cannot run `pixi run source setup.bash` as `source` is not available in the 
 - `--manifest-path <MANIFEST_PATH>`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
 - `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
-- `--environment <ENVIRONMENT> (-e)`: The environment to run the task in, if non provided the default environment will be used or a selector will be given to select the right environment.
+- `--environment <ENVIRONMENT> (-e)`: The environment to run the task in, if none are provided the default environment will be used or a selector will be given to select the right environment.
 
 ```shell
 pixi run python

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -381,7 +381,7 @@ This command prints the activation script of an environment.
 - `--manifest-path`: the path to `pixi.toml`, by default it searches for one in the parent directories.
 - `--frozen`: install the environment as defined in the lockfile. Without checking the status of the lockfile. It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
 - `--locked`: only install if the `pixi.lock` is up-to-date with the `pixi.toml`[^1]. It can also be controlled by the `PIXI_LOCKED` environment variable (example: `PIXI_LOCKED=true`). Conflicts with `--frozen`.
-- `--environment <ENVIRONMENT> (-e)`: The environment to activate, if non provided the default environment will be used or a selector will be given to select the right environment.
+- `--environment <ENVIRONMENT> (-e)`: The environment to activate, if none are provided the default environment will be used or a selector will be given to select the right environment.
 
 ```shell
 pixi shell-hook

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -455,7 +455,8 @@ The environments table is defined using the following fields:
 - `solve-group: String`: The solve group is used to group environments together at the solve stage.
   This is useful for environments that need to have the same dependencies but might extend them with additional dependencies.
   For instance when testing a production environment with additional test dependencies.
-
+  These dependencies will then be the same version in all environments that have the same solve group.
+  But the different environments contain different subsets of the solve-groups dependencies set.
 
 ```toml title="Simplest example"
 [environments]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -452,7 +452,7 @@ The `environments` table allows you to define environments that are created usin
 The environments table is defined using the following fields:
 
 - `features: Vec<Feature>`: The features that are included in the environment set, which is also the default field in the environments.
-- `solve-group: String`: **[NOT IMPLEMENTED YET, ONLY DESERIALIZABLE]** The solve group is used to group environments together at the solve stage.
+- `solve-group: String`: The solve group is used to group environments together at the solve stage.
   This is useful for environments that need to have the same dependencies but might extend them with additional dependencies.
   For instance when testing a production environment with additional test dependencies.
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -49,7 +49,7 @@ rm -rf .pixi/envs/default
 rm -rf .pixi/envs/cuda
 
 ## Activation
-As an environment is nothing more than a set of file correctly located in a directory.
+An environment is nothing more than a set of files that are installed into a certain location, that somewhat mimics a global system install.
 You need to activate the environment to use it.
 In them most simple sense that mean adding the `bin` directory of the environment to the `PATH` variable.
 But there is more to it in a conda environment, as it also sets some environment variables.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -121,4 +121,4 @@ So if you have multiple projects that use the same packages, pixi will only down
 The cache is located in the `~/.cache/rattler/cache` directory by default.
 This location is configurable by setting the `PIXI_CACHE_DIR` or `RATTLER_CACHE_DIR` environment variable.
 
-When you want to clean the cache, you can simply delete the cache directory, and pixi will recreate the cache when needed.
+When you want to clean the cache, you can simply delete the cache directory, and pixi will re-create the cache when needed.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -41,11 +41,12 @@ If this is not the case then all the commands that use the environment will auto
 ### Cleaning up
 If you want to clean up the environments, you can simply delete the `.pixi/envs` directory, and pixi will recreate the environments when needed.
 ```shell
+# either:
 rm -rf .pixi/envs
-# or per environment
+
+# or per environment:
 rm -rf .pixi/envs/default
 rm -rf .pixi/envs/cuda
-```
 
 ## Activation
 As an environment is nothing more than a set of file correctly located in a directory.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -36,7 +36,7 @@ If you look at the `.pixi/envs` directory, you will see a directory for each env
 
 These directories are conda environments, and you can use them as such, but you cannot manually edit them, this should always go through the `pixi.toml`.
 Pixi will always make sure the environment is in sync with the `pixi.lock` file.
-If this is not the case all the commands that use the environment will automatically update the environment, e.g. `pixi run`, `pixi shell`.
+If this is not the case then all the commands that use the environment will automatically update the environment, e.g. `pixi run`, `pixi shell`.
 
 ### Cleaning up
 If you want to clean up the environments, you can simply delete the `.pixi/envs` directory, and pixi will recreate the environments when needed.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -99,7 +99,7 @@ The following environment variables are set by pixi, when using the `pixi run`, 
 - `PATH`: We prepend the `bin` directory of the environment to the `PATH` variable, so you can use the tools installed in the environment directly.
 
 !!! note
-    The variables are set by pixi but can not be overwritten, so you can not change the root of the project by setting `PIXI_PROJECT_ROOT` in the environment.
+    Even though the variables are environment variables these cannot be overridden. E.g. you can not change the root of the project by setting `PIXI_PROJECT_ROOT` in the environment.
 
 ## Solving environments
 When you run a command that uses the environment, pixi will check if the environment is in sync with the `pixi.lock` file.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -4,7 +4,86 @@ title: Environment
 description: The resulting environment of a pixi installation.
 ---
 
-# Environment variables
+# Environments
+Pixi is a tool to manage virtual environments.
+This document explains what an environment looks like and how to use it.
+
+## Structure
+A pixi environment is located in the `.pixi/envs` directory of the project.
+This location is **not** configurable as it is a specific design decision to keep the environments in the project directory.
+This keeps your machine and your project clean and isolated from each other, and makes it easy to clean up after a project is done.
+
+If you look at the `.pixi/envs` directory, you will see a directory for each environment, the `default` being the one that is used if you only have one environment.
+
+```shell
+.pixi
+└── envs
+    ├── cuda
+    │   ├── bin
+    │   ├── conda-meta
+    │   ├── etc
+    │   ├── include
+    │   ├── lib
+    │   ...
+    └── default
+        ├── bin
+        ├── conda-meta
+        ├── etc
+        ├── include
+        ├── lib
+        ...
+```
+
+These directories are conda environments, and you can use them as such, but you cannot manually edit them, this should always go through the `pixi.toml`.
+Pixi will always make sure the environment is in sync with the `pixi.lock` file.
+If this is not the case all the commands that use the environment will automatically update the environment, e.g. `pixi run`, `pixi shell`.
+
+### Cleaning up
+If you want to clean up the environments, you can simply delete the `.pixi/envs` directory, and pixi will recreate the environments when needed.
+```shell
+rm -rf .pixi/envs
+# or per environment
+rm -rf .pixi/envs/default
+rm -rf .pixi/envs/cuda
+```
+
+## Activation
+As an environment is nothing more than a set of file correctly located in a directory.
+You need to activate the environment to use it.
+In them most simple sense that mean adding the `bin` directory of the environment to the `PATH` variable.
+But there is more to it in a conda environment, as it also sets some environment variables.
+
+To do the activation we have multiple options:
+- Use the `pixi shell` command to open a shell with the environment activated.
+- Use the `pixi shell-hook` command to print the command to activate the environment in your current shell.
+- Use the `pixi run` command to run a command in the environment.
+
+Where the `run` command is special as it runs its own cross-platform shell and has the ability to run tasks.
+More information about tasks can be found in the [tasks documentation](advanced/advanced_tasks.md).
+
+Using the `pixi shell-hook` in pixi you would get the following output:
+```shell
+export PATH="/home/user/development/pixi/.pixi/envs/default/bin:/home/user/.local/bin:/home/user/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/home/user/.pixi/bin"
+export CONDA_PREFIX="/home/user/development/pixi/.pixi/envs/default"
+export PIXI_PROJECT_NAME="pixi"
+export PIXI_PROJECT_ROOT="/home/user/development/pixi"
+export PIXI_PROJECT_VERSION="0.12.0"
+export PIXI_PROJECT_MANIFEST="/home/user/development/pixi/pixi.toml"
+export CONDA_DEFAULT_ENV="pixi"
+export PIXI_ENVIRONMENT_PLATFORMS="osx-64,linux-64,win-64,osx-arm64"
+export PIXI_ENVIRONMENT_NAME="default"
+export PIXI_PROMPT="(pixi) "
+. "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/activate-binutils_linux-64.sh"
+. "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/activate-gcc_linux-64.sh"
+. "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/activate-gfortran_linux-64.sh"
+. "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/activate-gxx_linux-64.sh"
+. "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/libglib_activate.sh"
+. "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/rust.sh"
+```
+It sets the `PATH` and some more environment variables. But more importantly it also runs activation scripts that are presented by the installed packages.
+Thus, just adding the `bin` directory to the `PATH` is not enough.
+
+## Environment variables
 The following environment variables are set by pixi, when using the `pixi run`, `pixi shell`, or `pixi shell-hook` command:
 
 - `PIXI_PROJECT_ROOT`: The root directory of the project.
@@ -17,3 +96,28 @@ The following environment variables are set by pixi, when using the `pixi run`, 
 - `CONDA_PREFIX`: The path to the environment. (Used by multiple tools that already understand conda environments)
 - `CONDA_DEFAULT_ENV`: The name of the environment. (Used by multiple tools that already understand conda environments)
 - `PATH`: We prepend the `bin` directory of the environment to the `PATH` variable, so you can use the tools installed in the environment directly.
+
+!!! note
+    The variables are set by pixi but can not be overwritten, so you can not change the root of the project by setting `PIXI_PROJECT_ROOT` in the environment.
+
+## Solving environments
+When you run a command that uses the environment, pixi will check if the environment is in sync with the `pixi.lock` file.
+If it is not, pixi will solve the environment and update it.
+This means that pixi will retrieve the best set of packages for the dependency requirements that you specified in the `pixi.toml` and will put the output of the solve step into the `pixi.lock` file.
+Solving is a mathematical problem and can take some time, but we take pride in the way we solve environments, and we are confident that we can solve your environment in a reasonable time.
+If you want to learn more about the solving process, you can read these:
+
+- [Rattler(conda) resolver blog](https://prefix.dev/blog/the_new_rattler_resolver)
+- [Rip(PyPI) resolver blog](https://prefix.dev/blog/introducing_rip)
+
+Pixi solves both the `conda` and `PyPI` dependencies, where the `PyPI` dependencies use the conda packages as a base, so you can be sure that the packages are compatible with each other.
+These solvers are split between the `rattler` and `rip` library, these do the heavy lifting of the solving process.
+
+## Caching
+Pixi caches the packages used in the environment.
+So if you have multiple projects that use the same packages, pixi will only download the packages once.
+
+The cache is located in the `~/.cache/rattler/cache` directory by default.
+This location is configurable by setting the `PIXI_CACHE_DIR` or `RATTLER_CACHE_DIR` environment variable.
+
+When you want to clean the cache, you can simply delete the cache directory, and pixi will recreate the cache when needed.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -51,7 +51,7 @@ rm -rf .pixi/envs/cuda
 ## Activation
 An environment is nothing more than a set of files that are installed into a certain location, that somewhat mimics a global system install.
 You need to activate the environment to use it.
-In them most simple sense that mean adding the `bin` directory of the environment to the `PATH` variable.
+In the most simple sense that mean adding the `bin` directory of the environment to the `PATH` variable.
 But there is more to it in a conda environment, as it also sets some environment variables.
 
 To do the activation we have multiple options:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -13,7 +13,7 @@ A pixi environment is located in the `.pixi/envs` directory of the project.
 This location is **not** configurable as it is a specific design decision to keep the environments in the project directory.
 This keeps your machine and your project clean and isolated from each other, and makes it easy to clean up after a project is done.
 
-If you look at the `.pixi/envs` directory, you will see a directory for each environment, the `default` being the one that is used if you only have one environment.
+If you look at the `.pixi/envs` directory, you will see a directory for each environment, the `default` being the one that is normally used, if you specify a custom environment the name you specified will be used.
 
 ```shell
 .pixi
@@ -47,6 +47,7 @@ rm -rf .pixi/envs
 # or per environment:
 rm -rf .pixi/envs/default
 rm -rf .pixi/envs/cuda
+```
 
 ## Activation
 An environment is nothing more than a set of files that are installed into a certain location, that somewhat mimics a global system install.
@@ -82,6 +83,7 @@ export PIXI_PROMPT="(pixi) "
 . "/home/user/development/pixi/.pixi/envs/default/etc/conda/activate.d/rust.sh"
 ```
 It sets the `PATH` and some more environment variables. But more importantly it also runs activation scripts that are presented by the installed packages.
+An example of this would be the [`libglib_activate.sh`](https://github.com/conda-forge/glib-feedstock/blob/52ba1944dffdb2d882d824d6548325155b58819b/recipe/scripts/activate.sh) script.
 Thus, just adding the `bin` directory to the `PATH` is not enough.
 
 ## Environment variables
@@ -112,7 +114,13 @@ If you want to learn more about the solving process, you can read these:
 - [Rip(PyPI) resolver blog](https://prefix.dev/blog/introducing_rip)
 
 Pixi solves both the `conda` and `PyPI` dependencies, where the `PyPI` dependencies use the conda packages as a base, so you can be sure that the packages are compatible with each other.
-These solvers are split between the `rattler` and `rip` library, these do the heavy lifting of the solving process.
+These solvers are split between the [`rattler`](https://github.com/mamba-org/rattler) and [`rip`](https://github.com/prefix-dev/rip) library, these control the heavy lifting of the solving process, which is executed by our custom SAT solver: [`resolvo`](https://github.com/mamba-org/resolvo).
+`resolve` is able to solve multiple ecosystem like `conda` and `PyPI`. It implements the lazy solving process for `PyPI` packages, which means that it only downloads the metadata of the packages that are needed to solve the environment.
+It also supports the `conda` way of solving, which means that it downloads the metadata of all the packages at once and then solves in one go.
+
+For the `[pypi-dependencies]`, `rip` implements `sdist` building to retrieve the metadata of the packages, and `wheel` building to install the packages.
+For this building step, `pixi` requires to first install `python` in the (conda)`[dependencies]` section of the `pixi.toml` file.
+This will always be slower than the pure conda solves. So for the best pixi experience you should stay within the `[dependencies]` section of the `pixi.toml` file.
 
 ## Caching
 Pixi caches the packages used in the environment.


### PR DESCRIPTION
Fixup missing CLI options and did a pass on explaining a pixi environment and how to use it. 