### PR TITLE
docs: Fix authentication path

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -66,4 +66,4 @@ On Linux, one can use `GNOME Keyring` (or just Keyring) to access credentials th
 ## Fallback storage
 
 If you run on a server with none of the aforementioned keychains available, then pixi falls back to store the credentials in an _insecure_ JSON file.
-This JSON file is located at `~/.rattler/rattler_auth_store.json` and contains the credentials.
+This JSON file is located at `~/.rattler/credentials.json` and contains the credentials.


### PR DESCRIPTION
https://github.com/mamba-org/rattler/blob/main/crates/rattler_networking/src/authentication_storage/backends/file.rs?rgh-link-date=2024-02-09T12%3A34%3A06Z#L119