### PR TITLE
docs: add instructions for installing on Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ You can install `pixi` from the [extra repository](https://archlinux.org/package
 pacman -S pixi
 ```
 
+#### Alpine Linux
+
+`pixi` is available for [Alpine Edge](https://pkgs.alpinelinux.org/packages?name=pixi&branch=edge). It can be installed via [apk](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) after enabling the [testing repository](https://wiki.alpinelinux.org/wiki/Repositories).
+
+```shell
+apk add pixi
+```
+
 ## Windows
 To install Pixi on Windows, open a PowerShell terminal (you may need to run it as an administrator) and run the following command:
 

--- a/README.md
+++ b/README.md
@@ -77,26 +77,6 @@ brew install pixi
 The script will also update your ~/.bash_profile to include ~/.pixi/bin in your PATH, allowing you to invoke the pixi command from anywhere.
 You might need to restart your terminal or source your shell for the changes to take effect.
 
-### Distro Packages
-
-[![Packaging status](https://repology.org/badge/vertical-allrepos/pixi.svg)](https://repology.org/project/pixi/versions)
-
-#### Arch Linux
-
-You can install `pixi` from the [extra repository](https://archlinux.org/packages/extra/x86_64/pixi/) using [pacman](https://wiki.archlinux.org/title/Pacman):
-
-```shell
-pacman -S pixi
-```
-
-#### Alpine Linux
-
-`pixi` is available for [Alpine Edge](https://pkgs.alpinelinux.org/packages?name=pixi&branch=edge). It can be installed via [apk](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) after enabling the [testing repository](https://wiki.alpinelinux.org/wiki/Repositories).
-
-```shell
-apk add pixi
-```
-
 ### Windows
 
 To install Pixi on Windows, open a PowerShell terminal (you may need to run it as an administrator) and run the following command:
@@ -131,6 +111,26 @@ Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-
 ```
 
 And then restart the shell or source the shell config file.
+
+### Distro Packages
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pixi.svg)](https://repology.org/project/pixi/versions)
+
+#### Arch Linux
+
+You can install `pixi` from the [extra repository](https://archlinux.org/packages/extra/x86_64/pixi/) using [pacman](https://wiki.archlinux.org/title/Pacman):
+
+```shell
+pacman -S pixi
+```
+
+#### Alpine Linux
+
+`pixi` is available for [Alpine Edge](https://pkgs.alpinelinux.org/packages?name=pixi&branch=edge). It can be installed via [apk](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) after enabling the [testing repository](https://wiki.alpinelinux.org/wiki/Repositories).
+
+```shell
+apk add pixi
+```
 
 ## Build/install from source
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ brew install pixi
 The script will also update your ~/.bash_profile to include ~/.pixi/bin in your PATH, allowing you to invoke the pixi command from anywhere.
 You might need to restart your terminal or source your shell for the changes to take effect.
 
+### Distro Packages
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/pixi.svg)](https://repology.org/project/pixi/versions)
+
 #### Arch Linux
 
 You can install `pixi` from the [extra repository](https://archlinux.org/packages/extra/x86_64/pixi/) using [pacman](https://wiki.archlinux.org/title/Pacman):

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ curl -fsSL https://pixi.sh/install.sh | bash
 # or with brew
 brew install pixi
 ```
+
 The script will also update your ~/.bash_profile to include ~/.pixi/bin in your PATH, allowing you to invoke the pixi command from anywhere.
 You might need to restart your terminal or source your shell for the changes to take effect.
 
@@ -84,7 +85,7 @@ You might need to restart your terminal or source your shell for the changes to 
 
 You can install `pixi` from the [extra repository](https://archlinux.org/packages/extra/x86_64/pixi/) using [pacman](https://wiki.archlinux.org/title/Pacman):
 
-```sh
+```shell
 pacman -S pixi
 ```
 
@@ -96,18 +97,20 @@ pacman -S pixi
 apk add pixi
 ```
 
-## Windows
+### Windows
+
 To install Pixi on Windows, open a PowerShell terminal (you may need to run it as an administrator) and run the following command:
 
 ```powershell
 iwr -useb https://pixi.sh/install.ps1 | iex
 ```
+
 The script will inform you once the installation is successful and add the ~/.pixi/bin directory to your PATH, which will allow you to run the pixi command from any location.
 Or with `winget`
-```
+
+```shell
 winget install prefix-dev.pixi
 ```
-
 
 ### Autocompletion
 
@@ -129,7 +132,7 @@ Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-
 
 And then restart the shell or source the shell config file.
 
-## Install from source
+## Build/install from source
 
 `pixi` is 100% written in Rust and therefore it can be installed, built and tested with cargo.
 To start using `pixi` from a source build run:
@@ -151,17 +154,22 @@ If you have any issues building because of the dependency on `rattler` checkout
 it's [compile steps](https://github.com/mamba-org/rattler/tree/main#give-it-a-try)
 
 ## Uninstall
+
 To uninstall the pixi binary should be removed.
 Delete `pixi` from the `$PIXI_DIR` which is default to `~/.pixi/bin/pixi`
 
 So on Linux its:
+
 ```shell
 rm ~/.pixi/bin/pixi
 ```
+
 and on Windows:
+
 ```shell
 $PIXI_BIN = "$Env:LocalAppData\pixi\bin\pixi"; Remove-Item -Path $PIXI_BIN
 ```
+
 After this command you can still use the tools you installed with `pixi`.
 To remove these as well just remove the whole `~/.pixi` directory and remove the directory from your path.
 
@@ -222,6 +230,7 @@ pixi run cowpy "Thanks for using pixi"
 ```
 
 Activate a shell in the environment
+
 ```shell
 pixi shell
 cowpy "Thanks for using pixi"
@@ -269,6 +278,7 @@ We're very active and would be happy to welcome you to our
 community. [Join our discord server today!][chat-url]
 
 <a name="pixibuilt"></a>
+
 ## Built using pixi
 
 To see what's being built with `pixi` check out the [Community](/docs/Community.md) page.


### PR DESCRIPTION
I created the Alpine package for `pixi`: <https://pkgs.alpinelinux.org/packages?name=pixi>

This PR aims to add the instructions for installing `pixi` on Alpine.

Also, I made some formatting changes and added repology badge.
