### PR TITLE
feat: skip micromamba style selector lines and warn about them

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -375,13 +375,19 @@ mod tests {
           - pytorch::torchvision
           - conda-forge::pytest
           - wheel=0.31.1
+          - sel(linux): blabla
           - pip:
             - requests
             - git+https://git@github.com/fsschneider/DeepOBS.git@develop#egg=deepobs
             - torch==1.8.1
         "#;
-        let conda_env_file_data: CondaEnvFile =
-            serde_yaml::from_str(example_conda_env_file).unwrap();
+
+        let f = tempfile::NamedTempFile::new().unwrap();
+        let path = f.path();
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(example_conda_env_file.as_bytes()).unwrap();
+
+        let conda_env_file_data = CondaEnvFile::from_path(path).unwrap();
 
         assert_eq!(conda_env_file_data.name(), Some("pixi_example_project"));
         assert_eq!(


### PR DESCRIPTION
When importing an environment.yml file we skip the micromamba selector lines. They are very seldomly used and so this is not going to affect many users. 
We are still importing everything that is trivial to import.