### PR TITLE
feat: add windows, macos, linux and unix to targets

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,19 +342,25 @@ The target table is currently implemented for the following sub-tables:
 
 The target table is defined using `[target.PLATFORM.SUB-TABLE]`.
 E.g `[target.linux-64.dependencies]`
-The platform can be any of the target [platforms](#platforms) but must also be defined there.
+
+The platform can be any of:
+
+- `win`, `osx`, `linux` or `unix` (`unix` matches `linux` and `osx`)
+- or any of the (more) specific [target platforms](#platforms), e.g. `linux-64`, `osx-arm64`
+
 The sub-table can be any of the specified above.
 
 To make it a bit more clear, let's look at an example below.
 Currently, pixi combines the top level tables like `dependencies` with the target-specific ones into a single set.
 Which, in the case of dependencies, can both add or overwrite dependencies.
-In the example below, we have `cmake` being used for all targets but on `osx-64` a different version of python will be selected.
+In the example below, we have `cmake` being used for all targets but on `osx-64` or `osx-arm64` a different version of python will be selected.
+
 ```toml
 [dependencies]
 cmake = "3.26.4"
 python = "3.10"
 
-[target.osx-64.dependencies]
+[target.osx.dependencies]
 python = "3.11"
 ```
 

--- a/src/project/manifest/target.rs
+++ b/src/project/manifest/target.rs
@@ -130,6 +130,10 @@ impl Target {
 pub enum TargetSelector {
     // Platform specific configuration
     Platform(Platform),
+    Unix,
+    Linux,
+    Win,
+    MacOs,
     // TODO: Add minijinja coolness here.
 }
 
@@ -138,6 +142,10 @@ impl TargetSelector {
     pub fn matches(&self, platform: Platform) -> bool {
         match self {
             TargetSelector::Platform(p) => p == &platform,
+            TargetSelector::Linux => platform.is_linux(),
+            TargetSelector::Unix => platform.is_unix(),
+            TargetSelector::Win => platform.is_windows(),
+            TargetSelector::MacOs => platform.is_osx(),
         }
     }
 }
@@ -146,6 +154,10 @@ impl ToString for TargetSelector {
     fn to_string(&self) -> String {
         match self {
             TargetSelector::Platform(p) => p.to_string(),
+            TargetSelector::Linux => "linux".to_string(),
+            TargetSelector::Unix => "unix".to_string(),
+            TargetSelector::Win => "windows".to_string(),
+            TargetSelector::MacOs => "macos".to_string(),
         }
     }
 }
@@ -161,9 +173,16 @@ impl<'de> Deserialize<'de> for TargetSelector {
     where
         D: Deserializer<'de>,
     {
-        Ok(TargetSelector::Platform(Platform::deserialize(
-            deserializer,
-        )?))
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "linux" => Ok(TargetSelector::Linux),
+            "unix" => Ok(TargetSelector::Unix),
+            "windows" => Ok(TargetSelector::Win),
+            "macos" => Ok(TargetSelector::MacOs),
+            _ => Platform::from_str(&s)
+                .map(TargetSelector::Platform)
+                .map_err(serde::de::Error::custom),
+        }
     }
 }
 

--- a/src/project/manifest/target.rs
+++ b/src/project/manifest/target.rs
@@ -156,8 +156,8 @@ impl ToString for TargetSelector {
             TargetSelector::Platform(p) => p.to_string(),
             TargetSelector::Linux => "linux".to_string(),
             TargetSelector::Unix => "unix".to_string(),
-            TargetSelector::Win => "windows".to_string(),
-            TargetSelector::MacOs => "macos".to_string(),
+            TargetSelector::Win => "win".to_string(),
+            TargetSelector::MacOs => "osx".to_string(),
         }
     }
 }
@@ -177,8 +177,8 @@ impl<'de> Deserialize<'de> for TargetSelector {
         match s.as_str() {
             "linux" => Ok(TargetSelector::Linux),
             "unix" => Ok(TargetSelector::Unix),
-            "windows" => Ok(TargetSelector::Win),
-            "macos" => Ok(TargetSelector::MacOs),
+            "win" => Ok(TargetSelector::Win),
+            "osx" => Ok(TargetSelector::MacOs),
             _ => Platform::from_str(&s)
                 .map(TargetSelector::Platform)
                 .map_err(serde::de::Error::custom),

--- a/tests/pixi_tomls/many_targets.toml
+++ b/tests/pixi_tomls/many_targets.toml
@@ -1,0 +1,34 @@
+[project]
+name = "pixi"
+version = "0.14.0"
+description = "Package management made easy!"
+authors = ["Wolf Vollprecht <wolf@prefix.dev>", "Bas Zalmstra <bas@prefix.dev>", "Tim de Jager <tim@prefix.dev>", "Ruben Arts <ruben@prefix.dev>"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+[dependencies]
+all = "*"
+
+[target.linux-64.dependencies]
+linux = "*"
+
+[target.win-64.dependencies]
+win = "*"
+
+[target.osx-64.dependencies]
+osx_64 = "*"
+
+[target.osx-arm64.dependencies]
+osx_arm64 = "*"
+
+[target.linux.dependencies]
+all_linux = "*"
+
+[target.windows.dependencies]
+all_win = "*"
+
+[target.macos.dependencies]
+all_macos = "*"
+
+[target.unix.dependencies]
+all_unix = "*"

--- a/tests/pixi_tomls/many_targets.toml
+++ b/tests/pixi_tomls/many_targets.toml
@@ -24,10 +24,10 @@ osx_arm64 = "*"
 [target.linux.dependencies]
 all_linux = "*"
 
-[target.windows.dependencies]
+[target.win.dependencies]
 all_win = "*"
 
-[target.macos.dependencies]
+[target.osx.dependencies]
 all_macos = "*"
 
 [target.unix.dependencies]

--- a/tests/snapshots/project_tests__parse_project-2.snap
+++ b/tests/snapshots/project_tests__parse_project-2.snap
@@ -1,0 +1,10 @@
+---
+source: tests/project_tests.rs
+expression: "dependency_names(&project, Platform::OsxArm64)"
+---
+[
+    "all",
+    "osx_arm64",
+    "all_macos",
+    "all_unix",
+]

--- a/tests/snapshots/project_tests__parse_project-3.snap
+++ b/tests/snapshots/project_tests__parse_project-3.snap
@@ -1,0 +1,9 @@
+---
+source: tests/project_tests.rs
+expression: "dependency_names(&project, Platform::Win64)"
+---
+[
+    "all",
+    "win",
+    "all_win",
+]

--- a/tests/snapshots/project_tests__parse_project.snap
+++ b/tests/snapshots/project_tests__parse_project.snap
@@ -1,0 +1,10 @@
+---
+source: tests/project_tests.rs
+expression: "dependency_names(&project, Platform::Linux64)"
+---
+[
+    "all",
+    "linux",
+    "all_linux",
+    "all_unix",
+]


### PR DESCRIPTION
I added a few more targets that should make it easier to select packages for some sets of platforms.

You can now do:

```toml
[target.unix.dependencies]
special-unix-pkg = "*"

[target.windows.dependencies]
pywin32 = "3.12"

# ... linux and macos are also available.
```

We could consider to overload `osx`, too. The correct name for osx is macOS though, since a while. Unfortunately that is not reflected in the "subdir" name.