### PR TITLE
fix: environment and feature names in pixi info --json

### DIFF
--- a/src/project/manifest/environment.rs
+++ b/src/project/manifest/environment.rs
@@ -3,7 +3,8 @@ use crate::utils::spanned::PixiSpanned;
 use lazy_static::lazy_static;
 use miette::Diagnostic;
 use regex::Regex;
-use serde::{self, Deserialize, Deserializer, Serialize};
+use serde::{self, Deserialize, Deserializer};
+use serde_with::SerializeDisplay;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -11,7 +12,7 @@ use std::str::FromStr;
 use thiserror::Error;
 
 /// The name of an environment. This is either a string or default for the default environment.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, SerializeDisplay)]
 pub enum EnvironmentName {
     Default,
     Named(String),

--- a/src/project/manifest/feature.rs
+++ b/src/project/manifest/feature.rs
@@ -10,14 +10,14 @@ use indexmap::IndexMap;
 use itertools::Either;
 use rattler_conda_types::{NamelessMatchSpec, PackageName, Platform};
 use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize};
-use serde_with::serde_as;
+use serde::{Deserialize, Deserializer};
+use serde_with::{serde_as, SerializeDisplay};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
 use std::fmt;
 
 /// The name of a feature. This is either a string or default for the default feature.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, SerializeDisplay, Default)]
 pub enum FeatureName {
     #[default]
     Default,


### PR DESCRIPTION
Changes the output of `project info --json` to output proper environment names:

before: 

```json
{
      "name": {
        "Named": "pl017"
      },
      "features": [
        {
          "Named": "pl017"
        },
        {
          "Named": "py310"
        },
        {
          "Named": "test"
        },
        "Default"
      ],
```

after:

```json
{
      "name": "pl017",
      "features": [
        "pl017",
        "py310",
        "test",
        "default"
      ],
```

Im also wondering if the `"default"` feature should be include in the above list ..