### PR TITLE
fix: Improve global list UX when there is no global env dir created

### DIFF
--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -135,9 +135,8 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
 
 pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
     let mut packages = vec![];
-    let mut dir_contents = tokio::fs::read_dir(bin_env_dir()?)
-        .await
-        .into_diagnostic()?;
+    let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?)
+        .await else {return Ok(packages)};
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -135,8 +135,9 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
 
 pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
     let mut packages = vec![];
-    let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?)
-        .await else { return Ok(vec![]) };
+    let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?).await else {
+        return Ok(vec![]);
+    };
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -136,7 +136,7 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
 pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
     let mut packages = vec![];
     let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?)
-        .await else {return Ok(packages)};
+        .await else { return Ok(vec![]) };
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {


### PR DESCRIPTION
Before
<img width="747" alt="image" src="https://github.com/prefix-dev/pixi/assets/33193748/aa541e0b-c8af-47a7-a828-1e414510545c">

After
<img width="728" alt="image" src="https://github.com/prefix-dev/pixi/assets/33193748/b62fc4a3-2371-4a75-80e7-318695751ebb">

I have handled the read_dir as catch all under assumption that most error would be related to dirs doesn't exist