### PR TITLE
fix: Avoid duplicate pip dependency while importing environment.yaml

### DIFF
--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -135,9 +135,8 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
 
 pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
     let mut packages = vec![];
-    let mut dir_contents = tokio::fs::read_dir(bin_env_dir()?)
-        .await
-        .into_diagnostic()?;
+    let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?)
+        .await else {return Ok(packages)};
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -135,8 +135,9 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
 
 pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
     let mut packages = vec![];
-    let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?)
-        .await else { return Ok(vec![]) };
+    let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?).await else {
+        return Ok(vec![]);
+    };
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -136,7 +136,7 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
 pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
     let mut packages = vec![];
     let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?)
-        .await else {return Ok(packages)};
+        .await else { return Ok(vec![]) };
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -580,7 +580,7 @@ mod tests {
         file.write_all(example_conda_env_file.as_bytes()).unwrap();
 
         let conda_env_file_data = CondaEnvFile::from_path(path).unwrap();
-        let (conda_deps, pip_deps, mut channels) =
+        let (conda_deps, pip_deps, _) =
             parse_dependencies(conda_env_file_data.dependencies().clone()).unwrap();
 
         assert_eq!(conda_deps, vec![MatchSpec::from_str("pip==24.0").unwrap(),]);

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -589,7 +589,7 @@ mod tests {
         assert_eq!(
             pip_deps,
             vec![(
-                PackageName::from_str("requests").unwrap(),
+                PyPiPackageName::from_str("requests").unwrap(),
                 PyPiRequirement {
                     version: None,
                     extras: None,

--- a/src/cli/snapshots/pixi__cli__init__tests__test_import_from_env_yaml.cockpit.yml.snap
+++ b/src/cli/snapshots/pixi__cli__init__tests__test_import_from_env_yaml.cockpit.yml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/cli/init.rs
-expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_channels(env_info.channels), env_info.name)"
+expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (
     (
@@ -825,23 +825,6 @@ expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_cha
                 namespace: Some(
                     "",
                 ),
-                md5: None,
-                sha256: None,
-            },
-            MatchSpec {
-                name: Some(
-                    PackageName {
-                        normalized: None,
-                        source: "pip",
-                    },
-                ),
-                version: None,
-                build: None,
-                build_number: None,
-                file_name: None,
-                channel: None,
-                subdir: None,
-                namespace: None,
                 md5: None,
                 sha256: None,
             },

--- a/src/cli/snapshots/pixi__cli__init__tests__test_import_from_env_yaml.crnnft.yml.snap
+++ b/src/cli/snapshots/pixi__cli__init__tests__test_import_from_env_yaml.crnnft.yml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/cli/init.rs
-expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_channels(env_info.channels), env_info.name)"
+expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (
     (
@@ -104,23 +104,6 @@ expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_cha
                         ),
                     ),
                 ),
-                build: None,
-                build_number: None,
-                file_name: None,
-                channel: None,
-                subdir: None,
-                namespace: None,
-                md5: None,
-                sha256: None,
-            },
-            MatchSpec {
-                name: Some(
-                    PackageName {
-                        normalized: None,
-                        source: "pip",
-                    },
-                ),
-                version: None,
                 build: None,
                 build_number: None,
                 file_name: None,

--- a/src/cli/snapshots/pixi__cli__init__tests__test_import_from_env_yaml.let-plot.yml.snap
+++ b/src/cli/snapshots/pixi__cli__init__tests__test_import_from_env_yaml.let-plot.yml.snap
@@ -1,6 +1,6 @@
 ---
 source: src/cli/init.rs
-expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_channels(env_info.channels), env_info.name)"
+expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (
     (
@@ -175,23 +175,6 @@ expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_cha
                         },
                     ),
                 ),
-                build: None,
-                build_number: None,
-                file_name: None,
-                channel: None,
-                subdir: None,
-                namespace: None,
-                md5: None,
-                sha256: None,
-            },
-            MatchSpec {
-                name: Some(
-                    PackageName {
-                        normalized: None,
-                        source: "pip",
-                    },
-                ),
-                version: None,
                 build: None,
                 build_number: None,
                 file_name: None,


### PR DESCRIPTION
closes https://github.com/prefix-dev/pixi/issues/877

Please let me know if I can make this more idiomatic.