### PR TITLE
fix: add user agent to pixi http client

### DIFF
--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -220,15 +220,15 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     #[cfg(target_family = "windows")]
     let res = match interactive_shell {
         ShellEnum::NuShell(nushell) => {
-            start_nu_shell(nushell, &env, prompt::get_nu_prompt(prompt_name.as_str())).await
+            start_nu_shell(nushell, env, prompt::get_nu_prompt(prompt_name.as_str())).await
         }
         ShellEnum::PowerShell(pwsh) => start_powershell(
             pwsh,
-            &env,
+            env,
             prompt::get_powershell_prompt(prompt_name.as_str()),
         ),
         ShellEnum::CmdExe(cmdexe) => {
-            start_cmdexe(cmdexe, &env, prompt::get_cmd_prompt(prompt_name.as_str()))
+            start_cmdexe(cmdexe, env, prompt::get_cmd_prompt(prompt_name.as_str()))
         }
         _ => {
             miette::bail!("Unsupported shell: {:?}", interactive_shell);

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -116,10 +116,7 @@ impl Debug for Project {
 impl Project {
     /// Constructs a new instance from an internal manifest representation
     pub fn from_manifest(manifest: Manifest) -> Self {
-        let client = reqwest::Client::new();
-        let authenticated_client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(AuthenticationMiddleware::default()))
-            .build();
+        let (client, authenticated_client) = build_reqwest_clients();
 
         let env_vars = Project::init_env_vars(&manifest.parsed.environments);
 
@@ -191,20 +188,7 @@ impl Project {
 
         let env_vars = Project::init_env_vars(&manifest.parsed.environments);
 
-        static APP_USER_AGENT: &str =
-            concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
-
-        let timeout = 5 * 60;
-        let client = Client::builder()
-            .pool_max_idle_per_host(20)
-            .user_agent(APP_USER_AGENT)
-            .timeout(std::time::Duration::from_secs(timeout))
-            .build()
-            .expect("failed to create reqwest Client");
-
-        let authenticated_client = reqwest_middleware::ClientBuilder::new(client.clone())
-            .with_arc(Arc::new(AuthenticationMiddleware::default()))
-            .build();
+        let (client, authenticated_client) = build_reqwest_clients();
 
         Ok(Self {
             root: root.to_owned(),
@@ -212,7 +196,6 @@ impl Project {
             authenticated_client,
             manifest,
             env_vars,
-            manifest,
         })
     }
 
@@ -474,6 +457,24 @@ impl Project {
         })
         .await
     }
+}
+
+fn build_reqwest_clients() -> (Client, ClientWithMiddleware) {
+    static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
+    let timeout = 5 * 60;
+    let client = Client::builder()
+        .pool_max_idle_per_host(20)
+        .user_agent(APP_USER_AGENT)
+        .timeout(std::time::Duration::from_secs(timeout))
+        .build()
+        .expect("failed to create reqwest Client");
+
+    let authenticated_client = reqwest_middleware::ClientBuilder::new(client.clone())
+        .with_arc(Arc::new(AuthenticationMiddleware::default()))
+        .build();
+
+    (client, authenticated_client)
 }
 
 /// Iterates over the current directory and all its parent directories and returns the first


### PR DESCRIPTION
This PR adds a user agent to the http Client. Apparently this is needed for some mirrors. 

Fixes #753