### PR TITLE
feat: add tcsh install support

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -31,7 +31,7 @@ else
   DOWNLOAD_URL=https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}.tar.gz
 fi
 
-printf "This script will automatically download and install Pixi (${VERSION}) for you.\nGetting it from this url: $DOWNLOAD_URL\nThe binary will be installed into '$BIN_DIR'\n"
+printf "This script will automatically download and install Pixi (${VERSION}) for you.\nGetting it from this url: $DOWNLOAD_URL\n"
 
 if ! hash curl 2> /dev/null && ! hash wget 2> /dev/null; then
   echo "error: you need either 'curl' or 'wget' installed for this script."
@@ -74,6 +74,8 @@ fi
 # Extract pixi from the downloaded tar file
 mkdir -p "$BIN_DIR"
 tar -xzf "$TEMP_FILE" -C "$BIN_DIR"
+chmod +x "$BIN_DIR/pixi"
+echo "The 'pixi' binary is installed into '${BIN_DIR}'"
 
 update_shell() {
     FILE=$1
@@ -92,8 +94,10 @@ update_shell() {
     then
         echo "Updating '${FILE}'"
         echo "$LINE" >> "$FILE"
+        echo "Please restart or source your shell."
     fi
 }
+
 case "$(basename "$SHELL")" in
     bash)
         if [ -f ~/.bash_profile ]; then
@@ -122,12 +126,9 @@ case "$(basename "$SHELL")" in
         ;;
 
     *)
-        echo "Unsupported shell: $(basename "$0")"
+        echo "Could not update shell: $(basename "$SHELL")"
+        echo "Please permanently add '${BIN_DIR}' to your \$PATH to enable the 'pixi' command."
         ;;
 esac
-
-chmod +x "$BIN_DIR/pixi"
-
-echo "Please restart or source your shell."
 
 }; __wrap__

--- a/install/install.sh
+++ b/install/install.sh
@@ -116,6 +116,11 @@ case "$(basename "$SHELL")" in
         update_shell ~/.zshrc "$LINE"
         ;;
 
+    tcsh)
+        LINE="set path = ( \$path ${BIN_DIR} )"
+        update_shell ~/.tcshrc "$LINE"
+        ;;
+
     *)
         echo "Unsupported shell: $(basename "$0")"
         ;;


### PR DESCRIPTION
This addresses https://github.com/prefix-dev/pixi/issues/897

# Before

##  case supported shell: bash

```
$ echo $SHELL
/bin/bash

$ bash ./install/install.sh
This script will automatically download and install Pixi (latest) for you.
Getting it from this url: https://github.com/prefix-dev/pixi/releases/latest/download/pixi-aarch64-apple-darwin.tar.gz
The binary will be installed into '/Users/romain/.pixi/bin'
######################################################################## 100.0%
Updating '/Users/romain/.bash_profile'
Please restart or source your shell.
```

##  case unsupported shell: tcsh

```
$ echo $SHELL
/bin/tcsh

$ bash ./install/install.sh
This script will automatically download and install Pixi (latest) for you.
Getting it from this url: https://github.com/prefix-dev/pixi/releases/latest/download/pixi-aarch64-apple-darwin.tar.gz
The binary will be installed into '/Users/romain/.pixi/bin'
######################################################################## 100.0%
Unsupported shell: bash
Please restart or source your shell.
```

# Now

##  case supported shell: tcsh

```
$ echo $SHELL
/bin/tcsh

$ bash ./install/install.sh
This script will automatically download and install Pixi (latest) for you.
Getting it from this url: https://github.com/prefix-dev/pixi/releases/latest/download/pixi-aarch64-apple-darwin.tar.gz
######################################################################### 100.0%
The 'pixi' binary is installed into '/Users/romain/.pixi/bin'
Updating '/Users/romain/.tcshrc'
Please restart or source your shell.
```

See references:
- append `path` in `.tcshrc`: https://www.peachpit.com/articles/article.aspx?p=31442&seqNum=4

## case unsupported shell: ksh

```
$ echo $SHELL
/bin/ksh

$ bash ./install/install.sh
This script will automatically download and install Pixi (latest) for you.
Getting it from this url: https://github.com/prefix-dev/pixi/releases/latest/download/pixi-aarch64-apple-darwin.tar.gz
######################################################################### 100.0%
The 'pixi' binary is installed into '/Users/romain/.pixi/bin'
Could not update shell: ksh
Please permanently add '/Users/romain/.pixi/bin' to your $PATH to enable the 'pixi' command.
```
I believe the error message is clearer and the user can proceed on their own to enable `pixi`. See issue https://github.com/prefix-dev/pixi/issues/897 for more explanations own why I find the previous error confusing/misguiding.