### PR TITLE
feat: Auto-run `postinstall` task on `pixi install` if provided

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -23,7 +23,8 @@ pub struct Args {
 pub async fn execute(args: Args) -> miette::Result<()> {
     let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
     let environment_name = args
-        .environment.clone()
+        .environment
+        .clone()
         .map_or_else(|| EnvironmentName::Default, EnvironmentName::Named);
     let environment = project
         .environment(&environment_name)
@@ -37,7 +38,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     )
     .await?;
 
-    if environment.task(&TaskName::from("postinstall"), None).is_ok() {
+    if environment
+        .task(&TaskName::from("postinstall"), None)
+        .is_ok()
+    {
         tracing::info!("`postintall` task detected in current environment");
 
         // Construct arguments to call postinstall task

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -205,7 +205,7 @@ async fn postinstall() {
     pixi.init().await.unwrap();
     // Add and update lockfile with this version of python
     pixi.add("python==3.9.1").await.unwrap();
-    
+
     // Add a simple postinstall task
     pixi.tasks()
         .add("postinstall".into(), None, FeatureName::Default)


### PR DESCRIPTION
Automatically run the `postinstall` task if defined on `pixi install`. Implements one of potential lifecycle scripts as discussed in #524.