### PR TITLE
feat: move uv options into context

### DIFF
--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -33,7 +33,7 @@ use uv_installer::{Downloader, SitePackages};
 use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_normalize::PackageName;
 
-use uv_traits::{ConfigSettings, NoBinary, NoBuild, SetupPyStrategy};
+use uv_traits::{ConfigSettings, SetupPyStrategy};
 
 type CombinedPypiPackageData = (PypiPackageData, PypiPackageEnvironmentData);
 
@@ -351,10 +351,6 @@ pub async fn update_python_distributions(
         FlatIndex::from_entries(entries, &tags)
     };
 
-    // Track in-flight downloads, builds, etc., across resolutions.
-    let no_build = NoBuild::None;
-    let no_binary = NoBinary::None;
-
     let in_memory_index = InMemoryIndex::default();
     let config_settings = ConfigSettings::default();
 
@@ -376,8 +372,8 @@ pub async fn update_python_distributions(
         &uv_context.in_flight,
         SetupPyStrategy::default(),
         &config_settings,
-        &no_build,
-        &no_binary,
+        &uv_context.no_build,
+        &uv_context.no_binary,
     )
     .with_build_extra_env_vars(environment_variables.iter());
 

--- a/src/lock_file/resolve.rs
+++ b/src/lock_file/resolve.rs
@@ -59,6 +59,8 @@ pub struct UvResolutionContext {
     pub registry_client: Arc<RegistryClient>,
     pub in_flight: Arc<InFlight>,
     pub index_locations: Arc<IndexLocations>,
+    pub no_build: NoBuild,
+    pub no_binary: NoBinary,
 }
 
 impl UvResolutionContext {
@@ -83,6 +85,8 @@ impl UvResolutionContext {
             registry_client,
             in_flight,
             index_locations,
+            no_build: NoBuild::None,
+            no_binary: NoBinary::None,
         })
     }
 }
@@ -304,8 +308,8 @@ pub async fn resolve_pypi(
         &context.in_flight,
         SetupPyStrategy::default(),
         &config_settings,
-        &NoBuild::None,
-        &NoBinary::None,
+        &context.no_build,
+        &context.no_binary,
     )
     .with_options(options)
     .with_build_extra_env_vars(env_variables.iter());


### PR DESCRIPTION
Move the uv no-binary and no-build options into the shared context. So that they are the same across resolve and install.