### PR TITLE
chore: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,7 +1640,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1853,7 +1853,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.4"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1985,9 +1985,9 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "insta"
-version = "1.35.1"
+version = "1.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2"
+checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
 dependencies = [
  "console",
  "lazy_static",
@@ -2466,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -2939,7 +2939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -3054,7 +3054,7 @@ dependencies = [
  "http-cache-reqwest",
  "human_bytes",
  "humantime",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "indicatif",
  "insta",
  "install-wheel-rs",
@@ -3176,7 +3176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
  "base64 0.21.7",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "line-wrap",
  "quick-xml",
  "serde",
@@ -3298,7 +3298,7 @@ name = "pubgrub"
 version = "0.2.1"
 source = "git+https://github.com/zanieb/pubgrub?rev=aab132a3d4d444dd8dd41d8c4e605abd69dacfe1#aab132a3d4d444dd8dd41d8c4e605abd69dacfe1"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "log",
  "priority-queue",
  "rustc-hash",
@@ -3345,7 +3345,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b80f889b6d413c3f8963a2c7db03f95dd6e1d85e1074137cb2013ea2faa8898"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "pep440_rs",
  "pep508_rs",
  "serde",
@@ -3428,7 +3428,7 @@ dependencies = [
  "futures",
  "fxhash",
  "hex",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "itertools",
  "memchr",
  "memmap2 0.9.4",
@@ -3466,7 +3466,7 @@ dependencies = [
  "fxhash",
  "glob",
  "hex",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "itertools",
  "lazy-regex",
  "nom",
@@ -3508,7 +3508,7 @@ source = "git+https://github.com/mamba-org/rattler?rev=7e0a130f0603fc2ff204649df
 dependencies = [
  "chrono",
  "fxhash",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "itertools",
  "pep440_rs",
  "pep508_rs",
@@ -3632,7 +3632,7 @@ version = "0.19.0"
 source = "git+https://github.com/mamba-org/rattler?rev=7e0a130f0603fc2ff204649df9adba78422de2c8#7e0a130f0603fc2ff204649df9adba78422de2c8"
 dependencies = [
  "enum_dispatch",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "itertools",
  "rattler_conda_types",
  "serde_json",
@@ -4309,7 +4309,7 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -4357,7 +4357,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4383,7 +4383,7 @@ version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -5016,7 +5016,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -5027,7 +5027,7 @@ version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5557,7 +5557,7 @@ dependencies = [
  "either",
  "fs-err",
  "futures",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "install-wheel-rs",
  "itertools",
  "once-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,9 @@ futures = "0.3.30"
 http-cache-reqwest = "0.13.0"
 human_bytes = "0.4.3"
 humantime = "2.1.0"
-indexmap = { version = "2.2.4", features = ["serde"] }
+indexmap = { version = "2.2.5", features = ["serde"] }
 indicatif = "0.17.8"
-insta = { version = "1.35.1", features = ["yaml"] }
+insta = { version = "1.36.1", features = ["yaml"] }
 
 install-wheel-rs = { git = "https://github.com/astral-sh/uv", rev = "9a99aa777618c55d21a9376699a2aeb646501bd6" }
 is_executable = "1.0.1"


### PR DESCRIPTION
fixes: https://github.com/prefix-dev/pixi/security/dependabot/8