### PR TITLE
fix: switching channels

### DIFF
--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -546,6 +546,14 @@ pub async fn ensure_up_to_date_lock_file(
     let locked_grouped_repodata_records = all_grouped_environments
         .iter()
         .filter_map(|group| {
+            // If any content of the environments in the group are outdated we need to disregard the locked content.
+            if group
+                .environments()
+                .any(|e| outdated.disregard_locked_content.contains(&e))
+            {
+                return None;
+            }
+
             let records = match group {
                 GroupedEnvironment::Environment(env) => locked_repodata_records.get(env)?.clone(),
                 GroupedEnvironment::Group(group) => {

--- a/src/project/grouped_environment.rs
+++ b/src/project/grouped_environment.rs
@@ -53,6 +53,14 @@ impl<'p> From<Environment<'p>> for GroupedEnvironment<'p> {
 }
 
 impl<'p> GroupedEnvironment<'p> {
+    /// Returns an iterator over all the environments in the group.
+    pub fn environments(&self) -> impl Iterator<Item = Environment<'p>> {
+        match self {
+            GroupedEnvironment::Group(group) => Either::Left(group.environments()),
+            GroupedEnvironment::Environment(env) => Either::Right(std::iter::once(env.clone())),
+        }
+    }
+
     /// Constructs a `GroupedEnvironment` from a `GroupedEnvironmentName`.
     pub fn from_name(project: &'p Project, name: &GroupedEnvironmentName) -> Option<Self> {
         match name {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -163,6 +163,14 @@ impl PixiControl {
         Ok(pixi)
     }
 
+    /// Updates the complete manifest
+    pub fn update_manifest(&self, manifest: &str) -> miette::Result<()> {
+        std::fs::write(&self.manifest_path(), manifest)
+            .into_diagnostic()
+            .context("failed to write pixi.toml")?;
+        Ok(())
+    }
+
     /// Loads the project manifest and returns it.
     pub fn project(&self) -> miette::Result<Project> {
         Project::load_or_else_discover(Some(&self.manifest_path()))


### PR DESCRIPTION
When switching channels we should disregard all locked conda packages.

Fixes #922 