### PR TITLE
fix: turn back on jlap for faster repodata fetching

### DIFF
--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -141,7 +141,6 @@ async fn fetch_repo_data_records_with_progress(
         client,
         repodata_cache.to_path_buf(),
         FetchRepoDataOptions {
-            jlap_enabled: false,
             ..FetchRepoDataOptions::default()
         },
         Some(Box::new(move |fetch::DownloadProgress { total, bytes }| {


### PR DESCRIPTION
Decided to turn back on jlap to improve speed of updating cache for slow internet situations. There are plans to improve the Jlap implementation overall soon.