### PR TITLE
feat(cli): refined global upgrade commands

### DIFF
--- a/src/cli/global/common.rs
+++ b/src/cli/global/common.rs
@@ -1,0 +1,230 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use miette::IntoDiagnostic;
+use rattler_conda_types::{
+    Channel, ChannelConfig, MatchSpec, PackageName, Platform, PrefixRecord, RepoDataRecord,
+};
+use rattler_networking::AuthenticationMiddleware;
+use rattler_repodata_gateway::sparse::SparseRepoData;
+use rattler_solve::{resolvo, SolverImpl, SolverTask};
+use reqwest_middleware::ClientWithMiddleware;
+
+use crate::{prefix::Prefix, repodata};
+
+/// Global binaries directory, default to `$HOME/.pixi/bin`
+pub struct BinDir(pub PathBuf);
+
+impl BinDir {
+    /// Create the Binary Executable directory
+    pub async fn create() -> miette::Result<Self> {
+        let bin_dir = bin_dir()?;
+        tokio::fs::create_dir_all(&bin_dir)
+            .await
+            .into_diagnostic()?;
+        Ok(Self(bin_dir))
+    }
+
+    /// Get the Binary Executable directory, erroring if it doesn't already exist.
+    pub async fn from_existing() -> miette::Result<Self> {
+        let bin_dir = bin_dir()?;
+        if tokio::fs::try_exists(&bin_dir).await.into_diagnostic()? {
+            Ok(Self(bin_dir))
+        } else {
+            Err(miette::miette!(
+                "binary executable directory does not exist"
+            ))
+        }
+    }
+}
+
+/// Get pixi home directory, default to `$HOME/.pixi`
+///
+/// It may be overridden by the `PIXI_HOME` environment variable.
+///
+/// # Returns
+///
+/// The pixi home directory
+pub fn home_path() -> miette::Result<PathBuf> {
+    if let Some(path) = std::env::var_os("PIXI_HOME") {
+        Ok(PathBuf::from(path))
+    } else {
+        dirs::home_dir()
+            .map(|path| path.join(".pixi"))
+            .ok_or_else(|| miette::miette!("could not find home directory"))
+    }
+}
+
+/// Global binaries directory, default to `$HOME/.pixi/bin`
+///
+/// # Returns
+///
+/// The global binaries directory
+pub fn bin_dir() -> miette::Result<PathBuf> {
+    home_path().map(|path| path.join("bin"))
+}
+
+/// Global binary environments directory, default to `$HOME/.pixi/envs`
+pub struct BinEnvDir(pub PathBuf);
+
+impl BinEnvDir {
+    /// Construct the path to the env directory for the binary package `package_name`.
+    fn package_bin_env_dir(package_name: &PackageName) -> miette::Result<PathBuf> {
+        Ok(bin_env_dir()?.join(package_name.as_normalized()))
+    }
+
+    /// Get the Binary Environment directory, erroring if it doesn't already exist.
+    pub async fn from_existing(package_name: &PackageName) -> miette::Result<Self> {
+        let bin_env_dir = Self::package_bin_env_dir(package_name)?;
+        if tokio::fs::try_exists(&bin_env_dir)
+            .await
+            .into_diagnostic()?
+        {
+            Ok(Self(bin_env_dir))
+        } else {
+            Err(miette::miette!(
+                "could not find environment for package {}",
+                package_name.as_source()
+            ))
+        }
+    }
+
+    /// Create the Binary Environment directory
+    pub async fn create(package_name: &PackageName) -> miette::Result<Self> {
+        let bin_env_dir = Self::package_bin_env_dir(package_name)?;
+        tokio::fs::create_dir_all(&bin_env_dir)
+            .await
+            .into_diagnostic()?;
+        Ok(Self(bin_env_dir))
+    }
+}
+
+/// Global binary environments directory, default to `$HOME/.pixi/envs`
+///
+/// # Returns
+///
+/// The global binary environments directory
+pub fn bin_env_dir() -> miette::Result<PathBuf> {
+    home_path().map(|path| path.join("envs"))
+}
+
+/// Returns the package name from a MatchSpec
+///
+/// # Returns
+///
+/// The package name from the given MatchSpec
+pub(super) fn package_name(package_matchspec: &MatchSpec) -> miette::Result<PackageName> {
+    package_matchspec.name.clone().ok_or_else(|| {
+        miette::miette!(
+            "could not find package name in MatchSpec {}",
+            package_matchspec
+        )
+    })
+}
+
+/// Get the friendly channel name of a [`PrefixRecord`]
+///
+/// # Returns
+///
+/// The friendly channel name of the given prefix record
+pub(super) fn channel_name_from_prefix(
+    prefix_package: &PrefixRecord,
+    channel_config: &ChannelConfig,
+) -> String {
+    Channel::from_str(&prefix_package.repodata_record.channel, channel_config)
+        .map(|ch| repodata::friendly_channel_name(&ch))
+        .unwrap_or_else(|_| prefix_package.repodata_record.channel.clone())
+}
+
+/// Load package records from [`SparseRepoData`] for the given package MatchSpec
+///
+/// # Returns
+///
+/// The package records (with dependencies records) for the given package MatchSpec
+pub fn load_package_records(
+    package_matchspec: MatchSpec,
+    sparse_repodata: &IndexMap<(Channel, Platform), SparseRepoData>,
+) -> miette::Result<Vec<RepoDataRecord>> {
+    let package_name = package_name(&package_matchspec)?;
+    let available_packages =
+        SparseRepoData::load_records_recursive(sparse_repodata.values(), vec![package_name], None)
+            .into_diagnostic()?;
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::current()
+        .into_diagnostic()?
+        .iter()
+        .cloned()
+        .map(Into::into)
+        .collect();
+
+    // Solve for environment
+    // Construct a solver task that we can start solving.
+    let task = SolverTask {
+        specs: vec![package_matchspec],
+        available_packages: &available_packages,
+        virtual_packages,
+        locked_packages: vec![],
+        pinned_packages: vec![],
+        timeout: None,
+    };
+
+    // Solve it
+    let records = resolvo::Solver.solve(task).into_diagnostic()?;
+
+    Ok(records)
+}
+
+/// Get networking Client and fetch [`SparseRepoData`] for the given channels and
+/// current platform using the client
+///
+/// # Returns
+///
+/// The network client and the fetched sparse repodata
+pub(super) async fn get_client_and_sparse_repodata(
+    channels: impl IntoIterator<Item = &'_ Channel>,
+) -> miette::Result<(
+    ClientWithMiddleware,
+    IndexMap<(Channel, Platform), SparseRepoData>,
+)> {
+    let authenticated_client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+        .with_arc(Arc::new(AuthenticationMiddleware::default()))
+        .build();
+    let platform_sparse_repodata =
+        repodata::fetch_sparse_repodata(channels, [Platform::current()], &authenticated_client)
+            .await?;
+    Ok((authenticated_client, platform_sparse_repodata))
+}
+
+/// Find the globally installed package with the given [`PackageName`]
+///
+/// # Returns
+///
+/// The PrefixRecord of the installed package
+pub(super) async fn find_installed_package(
+    package_name: &PackageName,
+) -> miette::Result<PrefixRecord> {
+    let BinEnvDir(bin_prefix) = BinEnvDir::from_existing(package_name).await.or_else(|_| {
+        miette::bail!(
+            "Package {} is not globally installed",
+            package_name.as_source()
+        )
+    })?;
+    let prefix = Prefix::new(bin_prefix);
+    find_designated_package(&prefix, package_name).await
+}
+
+/// Find the designated package in the given [`Prefix`]
+///
+/// # Returns
+///
+/// The PrefixRecord of the designated package
+pub async fn find_designated_package(
+    prefix: &Prefix,
+    package_name: &PackageName,
+) -> miette::Result<PrefixRecord> {
+    let prefix_records = prefix.find_installed_packages(None).await?;
+    prefix_records
+        .into_iter()
+        .find(|r| r.repodata_record.package_record.name == *package_name)
+        .ok_or_else(|| miette::miette!("could not find {} in prefix", package_name.as_source()))
+}

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -6,11 +6,10 @@ use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler_conda_types::PackageName;
 
-use crate::cli::global::install::{
-    bin_env_dir, find_and_map_executable_scripts, find_designated_package, home_path, BinDir,
-    BinEnvDir, BinScriptMapping,
-};
 use crate::prefix::Prefix;
+
+use super::common::{bin_env_dir, find_designated_package, home_path, BinDir, BinEnvDir};
+use super::install::{find_and_map_executable_scripts, BinScriptMapping};
 
 /// Lists all packages previously installed into a globally accessible location via `pixi global install`.
 #[derive(Parser, Debug)]
@@ -133,7 +132,12 @@ pub async fn execute(_args: Args) -> miette::Result<()> {
     Ok(())
 }
 
-pub(super) async fn list_global_packages() -> Result<Vec<PackageName>, miette::ErrReport> {
+/// List all globally installed packages
+///
+/// # Returns
+///
+/// A list of all globally installed packages represented as [`PackageName`]s
+pub(super) async fn list_global_packages() -> miette::Result<Vec<PackageName>> {
     let mut packages = vec![];
     let Ok(mut dir_contents) = tokio::fs::read_dir(bin_env_dir()?).await else {
         return Ok(vec![]);

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -1,4 +1,6 @@
 use clap::Parser;
+
+mod common;
 mod install;
 mod list;
 mod remove;

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -7,10 +7,10 @@ use miette::IntoDiagnostic;
 use rattler_conda_types::ParseStrictness::Strict;
 use rattler_conda_types::{MatchSpec, PackageName};
 
-use crate::cli::global::install::{
-    find_and_map_executable_scripts, find_designated_package, BinDir, BinEnvDir, BinScriptMapping,
-};
 use crate::prefix::Prefix;
+
+use super::common::{find_designated_package, BinDir, BinEnvDir};
+use super::install::{find_and_map_executable_scripts, BinScriptMapping};
 
 /// Removes a package previously installed into a globally accessible location via `pixi global install`.
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Closes #914 , closes #943

## What changes

1. Globalcli module codebase refactor, reusable definitions/functions are decoupled and moved to `common.rs`, doc comments are added for these definitions/functions.
1. Address #914, refined `pixi global upgrade/upgrade-all` ergonomic output
    ![pixi-global-refined](https://github.com/prefix-dev/pixi/assets/5764917/a186a91b-b733-48a7-96b6-2bb052a85fd9)
1. Address #943, `pixi global upgrade/upgrade-all` now prevents package downgrade (by comparing versions before committing transaction) and will by default use the channel the package was installed from.  
    ![pixi-global-refined-upgrade](https://github.com/prefix-dev/pixi/assets/5764917/01702992-92f2-4868-ad93-2340eab0e91e)
1. Globally installing package with no executables now prints a warning instead of throws out a miette error.
    before:
    ![pixi-global-refined-install-before](https://github.com/prefix-dev/pixi/assets/5764917/e1b9ea55-4a11-4d40-adde-31a8ec75e0af)
    after:
    ![pixi-global-refined-install-after](https://github.com/prefix-dev/pixi/assets/5764917/ce525896-9862-4467-ab22-5ee8b261dd92)

