### PR TITLE
fix: parse lockfile matchspecs lenient

### DIFF
--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -7,8 +7,7 @@ use itertools::Itertools;
 use miette::Diagnostic;
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::Requirement;
-use rattler_conda_types::ParseStrictness::Strict;
-use rattler_conda_types::{MatchSpec, ParseMatchSpecError, Platform};
+use rattler_conda_types::{MatchSpec, ParseMatchSpecError, ParseStrictness, Platform};
 use rattler_lock::{CondaPackage, Package, PypiPackage};
 use std::collections::{HashMap, HashSet};
 use thiserror::Error;
@@ -221,7 +220,7 @@ pub fn verify_conda_platform_satisfiability(
             .file_name()
             .unwrap_or_else(|| record.package_record().name.as_normalized());
         for depends in &record.package_record().depends {
-            let spec = MatchSpec::from_str(depends.as_str(), Strict)
+            let spec = MatchSpec::from_str(depends.as_str(), ParseStrictness::Lenient)
                 .map_err(|e| PlatformUnsat::FailedToParseMatchSpec(depends.clone(), e))?;
             specs.push((spec, source))
         }


### PR DESCRIPTION
Fixes the issue of `lock-file not up-to-date with the project` when a lockfile contains dependencies that contain matchspecs that can't be parsed using the strict version parsing.  (e.g. `!=1.2.*`, `>=1.2.*`)