### PR TITLE
fix: pypi dependencies not being removed

### DIFF
--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -50,6 +50,7 @@ fn elapsed(duration: Duration) -> String {
 }
 
 /// Derived from uv [`uv_installer::Plan`]
+#[derive(Debug)]
 struct PixiInstallPlan {
     /// The distributions that are not already installed in the current environment, but are
     /// available in the local cache.

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -107,35 +107,33 @@ impl<'p> LockFileDerivedData<'p> {
             .unwrap_or_default();
         let pypi_records = self.pypi_records(environment, platform).unwrap_or_default();
 
-        if environment.has_pypi_dependencies() {
-            let uv_context = match &self.uv_context {
-                None => {
-                    let context = UvResolutionContext::from_project(self.project)?;
-                    self.uv_context = Some(context.clone());
-                    context
-                }
-                Some(context) => context.clone(),
-            };
+        let uv_context = match &self.uv_context {
+            None => {
+                let context = UvResolutionContext::from_project(self.project)?;
+                self.uv_context = Some(context.clone());
+                context
+            }
+            Some(context) => context.clone(),
+        };
 
-            let env_variables = environment.project().get_env_variables(environment).await?;
-            // Update the prefix with Pypi records
-            environment::update_prefix_pypi(
-                environment.name(),
-                &prefix,
-                platform,
-                &repodata_records,
-                &pypi_records,
-                &python_status,
-                &environment.system_requirements(),
-                uv_context,
-                env_variables,
-            )
-            .await?;
+        let env_variables = environment.project().get_env_variables(environment).await?;
+        // Update the prefix with Pypi records
+        environment::update_prefix_pypi(
+            environment.name(),
+            &prefix,
+            platform,
+            &repodata_records,
+            &pypi_records,
+            &python_status,
+            &environment.system_requirements(),
+            uv_context,
+            env_variables,
+        )
+        .await?;
 
-            // Store that we updated the environment, so we won't have to do it again.
-            self.updated_pypi_prefixes
-                .insert(environment.clone(), prefix.clone());
-        }
+        // Store that we updated the environment, so we won't have to do it again.
+        self.updated_pypi_prefixes
+            .insert(environment.clone(), prefix.clone());
 
         Ok(prefix)
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -11,7 +11,7 @@ use pixi::{
     cli::{
         add, init,
         install::Args,
-        project, run,
+        project, remove, run,
         task::{self, AddArgs, AliasArgs},
     },
     consts, EnvironmentName, ExecutableTask, Project, RunOutput, SearchEnvironments, TaskGraph,
@@ -34,6 +34,8 @@ use std::{
 };
 use tempfile::TempDir;
 use thiserror::Error;
+
+use self::builders::RemoveBuilder;
 
 /// To control the pixi process
 pub struct PixiControl {
@@ -224,6 +226,21 @@ impl PixiControl {
                 no_lockfile_update: false,
                 platform: Default::default(),
                 pypi: false,
+                feature: None,
+            },
+        }
+    }
+
+    /// Remove dependencies from the project. Returns a [`RemoveBuilder`].
+    pub fn remove(&self, spec: &str) -> RemoveBuilder {
+        RemoveBuilder {
+            args: remove::Args {
+                deps: vec![spec.to_string()],
+                manifest_path: Some(self.manifest_path()),
+                host: false,
+                build: false,
+                pypi: false,
+                platform: Default::default(),
                 feature: None,
             },
         }

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -250,6 +250,41 @@ async fn pypi_reinstall_python() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+// Check if we add and remove a pypi package that the site-packages is cleared
+async fn pypi_add_remove() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+    // Add and update lockfile with this version of python
+    pixi.add("python==3.11").with_install(true).await.unwrap();
+
+    // Add flask from pypi
+    pixi.add("flask")
+        .with_install(true)
+        .set_type(pixi::DependencyType::PypiDependency)
+        .await
+        .unwrap();
+
+    let prefix = pixi.project().unwrap().root().join(".pixi/envs/default");
+
+    let cache = uv_cache::Cache::temp().unwrap();
+
+    // Check if site-packages has entries
+    let env = create_uv_environment(&prefix, &cache);
+    let installed_311 = uv_installer::SitePackages::from_executable(&env).unwrap();
+    assert!(installed_311.iter().count() > 0);
+
+    pixi.remove("flask")
+        .set_type(pixi::DependencyType::PypiDependency)
+        .await
+        .unwrap();
+
+    let installed_311 = uv_installer::SitePackages::from_executable(&env).unwrap();
+    assert!(installed_311.iter().count() == 0);
+}
+
 #[tokio::test]
 async fn test_channels_changed() {
     // Write a channel with a package `bar` with only one version


### PR DESCRIPTION
This fixes the situation where pypi dependencies were not removed from the prefix, while they were removed in the toml. 

The problem was that if you have a single pypi dependency and removed this, the project would say it does not have pypi dependencies and the updating of the pypi prefix was never done. 

This bug was introduced by me in #863, I think it would be nice to skip this code in the right situation, but seeing as this is a pretty big bug. I think its prudent to use this PR for now.
But hey 🤷‍♂️ , at least we have an add/remove tested now, and the test cli has expanded a bit.

@ruben-arts I've noticed there is also not a test for the conda situation here, maybe we should add it as well.