### PR TITLE
fix: add `tool` to strict json schema

### DIFF
--- a/schema/examples/valid/full.toml
+++ b/schema/examples/valid/full.toml
@@ -138,3 +138,15 @@ mlx = "x.y.z"
 [feature.cuda2]
 channels = ["nvidia"]
 platforms = ["linux-64", "osx-arm64"]
+
+
+[tool.poetry]
+test = "bla"
+test1 = ["bla", "bli"]
+test2= { version = "~=1.1", channel = "test" }
+
+[tool.poetry.dependencies]
+test = "bla"
+
+[tool.ruff]
+config = "ruff.yaml"

--- a/schema/model.py
+++ b/schema/model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import (
     AnyHttpUrl,
@@ -278,6 +278,9 @@ class BaseManifest(StrictBaseModel):
         None,
         description="The targets of the project",
         examples=[{"linux": {"dependencies": {"python": "3.8"}}}],
+    )
+    tool: Any = Field(
+        None, description="A third-party tool configuration, ignored by pixi"
     )
 
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1174,6 +1174,11 @@
         }
       ],
       "title": "Target"
+    },
+    "tool": {
+      "default": null,
+      "description": "A third-party tool configuration, ignored by pixi",
+      "title": "Tool"
     }
   },
   "required": [


### PR DESCRIPTION
Add `tool` to the schema so it will be accepted by the parser.

(Thanks for the ping @pavelzw)