### PR TITLE
fix: more proper scanning of the conda-meta folder for `json` entries

### DIFF
--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -39,7 +39,7 @@ impl Prefix {
         {
             let entry = entry.into_diagnostic()?;
             let path = entry.path();
-            if path.ends_with(".json") {
+            if !path.is_file() || path.extension() != Some("json".as_ref()) {
                 continue;
             }
 


### PR DESCRIPTION
The `path::ends_with` function only compares full segments. We need to compare the extension if we want to filter only `JSON` files. 

The condition was anyways wrong (we would have skipped over files that end with json but those are the ones we are interested in).

cc @ruben-arts I believe this would fix the issue with putting the `prefix` file into the `conda-meta` folder.

cc @baszalmstra 