### PR TITLE
docs: add tip to help users when no PROFILE file exists

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,11 +57,16 @@ To get autocompletion run:
     echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
     ```
 === "Windows"
+
     PowerShell:
     ```powershell
     Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
     ```
-
+    !!! tip "Failure because no profile file exists"
+        Make sure your profile file exists, otherwise create it with:
+        ```PowerShell
+        New-Item -Path $PROFILE -ItemType File -Force
+        ```
 
 And then restart the shell or source the shell config file.
 


### PR DESCRIPTION
fixes: #917 

There isn't a lot we can do to keep this script a readable one liner so I added a tip so the users will be helped if they have an error. 