### PR TITLE
fix: test failure on riscv64

### DIFF
--- a/src/task/task_environment.rs
+++ b/src/task/task_environment.rs
@@ -229,7 +229,7 @@ mod tests {
             [project]
             name = "foo"
             channels = ["foo"]
-            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64"]
+            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64", "linux-riscv64"]
 
             [tasks]
             test = "cargo test"
@@ -252,7 +252,7 @@ mod tests {
             [project]
             name = "foo"
             channels = ["foo"]
-            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64"]
+            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64", "linux-riscv64"]
 
             [tasks]
             test = "pytest"
@@ -319,7 +319,7 @@ mod tests {
             [project]
             name = "foo"
             channels = ["foo"]
-            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64"]
+            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64", "linux-riscv64"]
 
             [tasks]
             bla = "echo foo"

--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -408,7 +408,7 @@ mod test {
         [project]
         name = "pixi"
         channels = ["conda-forge"]
-        platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+        platforms = ["linux-64", "osx-64", "win-64", "osx-arm64", "linux-riscv64"]
     "#,
                 &["echo bla"],
                 None,
@@ -538,7 +538,7 @@ mod test {
         [project]
         name = "pixi"
         channels = ["conda-forge"]
-        platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
+        platforms = ["linux-64", "osx-64", "win-64", "osx-arm64", "linux-riscv64"]
 
         [tasks]
         foo = "echo foo"


### PR DESCRIPTION
Those tests' results are affected by unsupported platform error. Adding riscv64 to platforms fixes the issue on it.

Error log:

```
failures:

---- task::task_graph::test::test_multi_env_defaults_ambigu stdout ----
note: test did not panic as expected
---- task::task_environment::tests::test_find_task_explicit_defined stdout ----
thread 'task::task_environment::tests::test_find_task_explicit_defined' panicked at src/task/task_environment.rs:272:9:
assertion failed: matches!(result, Err(FindTaskError::AmbiguousTask(_)))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- task::task_environment::tests::test_find_task_dual_defined stdout ----
thread 'task::task_environment::tests::test_find_task_dual_defined' panicked at src/task/task_environment.rs:246:9:
assertion failed: matches!(result, Err(FindTaskError::AmbiguousTask(_)))

---- task::task_environment::tests::test_find_ambiguous_task stdout ----
thread 'task::task_environment::tests::test_find_ambiguous_task' panicked at src/task/task_environment.rs:337:9:
assertion failed: matches!(result, Err(FindTaskError::AmbiguousTask(_)))

---- task::task_graph::test::test_custom_command stdout ----
thread 'task::task_graph::test::test_custom_command' panicked at src/task/task_graph.rs:322:10:
called `Result::unwrap()` on an `Err` value: UnsupportedPlatform(UnsupportedPlatform(UnsupportedPlatformError { environments_platforms: [Linux64, Win64, Osx64, OsxArm64], environment: Default, platform: LinuxRiscv64 }))


failures:
    task::task_environment::tests::test_find_ambiguous_task
    task::task_environment::tests::test_find_task_dual_defined
    task::task_environment::tests::test_find_task_explicit_defined
    task::task_graph::test::test_custom_command
    task::task_graph::test::test_multi_env_defaults_ambigu

test result: FAILED. 125 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 24.84s
```