### PR TITLE
feat: add error for unsupported pypi dependencies

### DIFF
--- a/src/lock_file/outdated.rs
+++ b/src/lock_file/outdated.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 ///
 /// Use the [`OutdatedEnvironments::from_project_and_lock_file`] to create an instance of this
 /// struct by examining the project and lock-file and finding any mismatches.
+#[derive(Debug)]
 pub struct OutdatedEnvironments<'p> {
     /// The conda environments that are considered out of date with the lock-file.
     pub conda: HashMap<Environment<'p>, HashSet<Platform>>,


### PR DESCRIPTION
Fixes #1036

With the following pixi toml:

```toml
[project]
name = "project"
channels = ["conda-forge"]
platforms = ["linux-64", "osx-arm64"]

[dependencies]
python = "3.11.8"

[pypi-dependencies]
timeago = "==1.0.16"

[feature.test]
platforms = ["linux-64"]

[environments]
test = ["test"]
```

The environment `test` is only solvable for `linux-64`. However, when trying to solve this lock-file on another platform no python interpreter can be installed for the environment because the environment does not support it.

This PR shows a problem that we should fix, see #1051 for that tracking issue.
