### PR TITLE
feat: build pixi for windows arm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,7 +104,7 @@ jobs:
         include:
           - { name: "Linux",       target: x86_64-unknown-linux-musl,  os: ubuntu-20.04 }
           - { name: "macOS",       target: x86_64-apple-darwin,        os: macOS-latest }
-          - { name: "macOS-arm",      target: aarch64-apple-darwin,       os: macOS-14 }
+          - { name: "macOS-arm",   target: aarch64-apple-darwin,       os: macOS-14 }
           - { name: "Windows",     target: x86_64-pc-windows-msvc,     os: windows-latest }
     steps:
       - uses: actions/checkout@v4
@@ -152,6 +152,7 @@ jobs:
           - { name: "macOS-arm",      target: aarch64-apple-darwin,       os: macOS-14 }  # macOS-14 is the ARM chipset
 
           - { name: "Windows",        target: x86_64-pc-windows-msvc,     os: windows-latest }
+          - { name: "Windows-arm",    target: aarch64-pc-windows-msvc,    os: windows-latest }
     env:
       #
       # These are some environment variables that configure the build so that the binary size is reduced.


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi/issues/1008

Adds a windows arm build to CI . This PR does not test the generated binary.