### PR TITLE
chore: small code fixes for pyproject code

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -243,7 +243,7 @@ mod tests {
         [environments]
         test = ["test"]
         "#;
-        let project = Project::from_str(Path::new(""), multi_env_project).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), multi_env_project).unwrap();
 
         let default_env = project.default_environment();
         let env = default_env.get_metadata_env();
@@ -270,7 +270,7 @@ mod tests {
         channels = ["conda-forge"]
         platforms = ["linux-64", "osx-64", "win-64"]
         "#;
-        let project = Project::from_str(Path::new(""), project).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
         let env = project.get_metadata_env();
 
         assert_eq!(env.get("PIXI_PROJECT_NAME").unwrap(), project.name());

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -114,7 +114,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         //  - Implement it for `[crate::project::manifest::ProjectManifest]` to do this for other filetypes, e.g. (pyproject.toml, requirements.txt)
         let (conda_deps, pypi_deps, channels) = conda_env_to_manifest(conda_env_file, &config)?;
         let rv = render_project(&env, name, version, &author, channels, &platforms);
-        let mut project = Project::from_str(&dir, &rv)?;
+        let mut project = Project::from_str(&dir.join("pixi.toml"), &rv)?;
         for spec in conda_deps {
             for platform in platforms.iter() {
                 // TODO: fix serialization of channels in rattler_conda_types::MatchSpec

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -363,7 +363,7 @@ mod tests {
     #[test]
     fn test_default_channels() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"
@@ -393,7 +393,7 @@ mod tests {
     #[test]
     fn test_default_platforms() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"
@@ -413,7 +413,7 @@ mod tests {
     #[test]
     fn test_default_tasks() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"
@@ -463,7 +463,7 @@ mod tests {
     #[test]
     fn test_dependencies() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"
@@ -502,7 +502,7 @@ mod tests {
     #[test]
     fn test_activation() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"
@@ -538,7 +538,7 @@ mod tests {
     #[test]
     fn test_channel_priorities() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -1,7 +1,7 @@
 use miette::{miette, Report};
 use rattler_conda_types::{NamelessMatchSpec, PackageName, Platform};
 use std::{fmt, path::Path};
-use toml_edit::{Array, Item, Table, Value};
+use toml_edit::{value, Array, Item, Table, Value};
 
 use crate::{consts, FeatureName, SpecType, Task};
 
@@ -315,12 +315,22 @@ impl ManifestSource {
 
         Ok(())
     }
+
+    /// Sets the description of the project
+    pub fn set_description(&mut self, description: &str) {
+        self.as_table_mut()["project"]["description"] = value(description);
+    }
+
+    /// Sets the version of the project
+    pub fn set_version(&mut self, version: &str) {
+        self.as_table_mut()["project"]["version"] = value(version);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::project::manifest::{Manifest, ManifestKind};
+    use crate::project::manifest::Manifest;
     use insta::assert_snapshot;
     use std::path::Path;
 
@@ -334,8 +344,7 @@ mod tests {
 
     #[test]
     fn test_get_or_insert_toml_table() {
-        let mut manifest =
-            Manifest::from_str(Path::new(""), PROJECT_BOILERPLATE, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), PROJECT_BOILERPLATE).unwrap();
         let _ = manifest
             .document
             .get_or_insert_toml_table(None, &FeatureName::Default, "tasks");
@@ -369,8 +378,7 @@ platforms = ["linux-64", "win-64"]
 
         "#;
 
-        let manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
         // Test all different options for the feature name and platform
         assert_eq!(
             "dependencies".to_string(),

--- a/src/project/manifest/feature.rs
+++ b/src/project/manifest/feature.rs
@@ -290,14 +290,14 @@ impl<'de> Deserialize<'de> for Feature {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::project::manifest::{Manifest, ManifestKind};
+    use crate::project::manifest::Manifest;
     use assert_matches::assert_matches;
     use std::path::Path;
 
     #[test]
     fn test_dependencies_borrowed() {
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foo"
@@ -316,7 +316,6 @@ mod tests {
         [feature.bla.host-dependencies]
         # empty on purpose
         "#,
-            ManifestKind::Pixi,
         )
         .unwrap();
 
@@ -365,7 +364,7 @@ mod tests {
     #[test]
     fn test_activation() {
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foo"
@@ -378,7 +377,6 @@ mod tests {
         [target.linux-64.activation]
         scripts = ["linux-64.bat"]
         "#,
-            ManifestKind::Pixi,
         )
         .unwrap();
 

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -24,7 +24,7 @@ use indexmap::map::Entry;
 use indexmap::{Equivalent, IndexMap, IndexSet};
 use itertools::Itertools;
 pub use metadata::ProjectMetadata;
-use miette::{miette, Diagnostic, IntoDiagnostic, LabeledSpan, NamedSource};
+use miette::{miette, Diagnostic, IntoDiagnostic, LabeledSpan, NamedSource, WrapErr};
 use pyproject::PyProjectManifest;
 pub use python::PyPiRequirement;
 use rattler_conda_types::{
@@ -47,7 +47,7 @@ use std::{
 pub use system_requirements::{LibCSystemRequirement, SystemRequirements};
 pub use target::{Target, TargetSelector, Targets};
 use thiserror::Error;
-use toml_edit::{value, DocumentMut, TomlError};
+use toml_edit::{DocumentMut, TomlError};
 
 /// Errors that can occur when getting a feature.
 #[derive(Debug, Clone, Error, Diagnostic)]
@@ -60,6 +60,17 @@ pub enum GetFeatureError {
 pub enum ManifestKind {
     Pixi,
     Pyproject,
+}
+
+impl ManifestKind {
+    /// Try to determine the type of manifest from a path
+    pub fn try_from_path(path: &Path) -> Option<Self> {
+        match path.file_name().and_then(OsStr::to_str)? {
+            consts::PROJECT_MANIFEST => Some(Self::Pixi),
+            consts::PYPROJECT_MANIFEST => Some(Self::Pyproject),
+            _ => None,
+        }
+    }
 }
 
 /// Handles the project's manifest file.
@@ -86,31 +97,21 @@ pub struct Manifest {
 impl Manifest {
     /// Create a new manifest from a path
     pub fn from_path(path: impl AsRef<Path>) -> miette::Result<Self> {
-        let kind = match path.as_ref().file_name().and_then(OsStr::to_str) {
-            Some(consts::PROJECT_MANIFEST) => ManifestKind::Pixi,
-            Some(consts::PYPROJECT_MANIFEST) => ManifestKind::Pyproject,
-            _ => miette::bail!(
-                "the manifest-path must point to a {} or {} file",
-                consts::PROJECT_MANIFEST,
-                consts::PYPROJECT_MANIFEST,
-            ),
-        };
         let contents = std::fs::read_to_string(path.as_ref()).into_diagnostic()?;
-        let parent = path
-            .as_ref()
-            .parent()
-            .expect("Path should always have a parent");
-        Self::from_str(parent, contents, kind)
+        Self::from_str(path.as_ref(), contents)
     }
 
     /// Create a new manifest from a string
-    pub fn from_str(
-        root: &Path,
-        contents: impl Into<String>,
-        kind: ManifestKind,
-    ) -> miette::Result<Self> {
+    pub fn from_str(manifest_path: &Path, contents: impl Into<String>) -> miette::Result<Self> {
+        let manifest_kind = ManifestKind::try_from_path(manifest_path).ok_or_else(|| {
+            miette::miette!("unrecognized manifest file: {}", manifest_path.display())
+        })?;
+        let root = manifest_path
+            .parent()
+            .expect("manifest_path should always have a parent");
+
         let contents = contents.into();
-        let parsed = match kind {
+        let parsed = match manifest_kind {
             ManifestKind::Pixi => ProjectManifest::from_toml_str(&contents),
             ManifestKind::Pyproject => {
                 PyProjectManifest::from_toml_str(&contents).map(|x| x.into())
@@ -155,19 +156,13 @@ impl Manifest {
             }
         }
 
-        let (source, path) = match kind {
-            ManifestKind::Pixi => (
-                ManifestSource::PixiToml(document),
-                root.join(consts::PROJECT_MANIFEST),
-            ),
-            ManifestKind::Pyproject => (
-                ManifestSource::PyProjectToml(document),
-                root.join(consts::PYPROJECT_MANIFEST),
-            ),
+        let source = match manifest_kind {
+            ManifestKind::Pixi => ManifestSource::PixiToml(document),
+            ManifestKind::Pyproject => ManifestSource::PyProjectToml(document),
         };
 
         Ok(Self {
-            path,
+            path: manifest_path.to_path_buf(),
             contents,
             document: source,
             parsed: manifest,
@@ -613,28 +608,23 @@ impl Manifest {
     }
 
     /// Set the project description
-    pub fn set_description(&mut self, description: &String) -> miette::Result<()> {
+    pub fn set_description(&mut self, description: &str) -> miette::Result<()> {
         // Update in both the manifest and the toml
         self.parsed.project.description = Some(description.to_string());
-        let document = match &mut self.document {
-            ManifestSource::PyProjectToml(document) => document,
-            ManifestSource::PixiToml(document) => document,
-        };
-        document["project"]["description"] = value(description);
+        self.document.set_description(description);
 
         Ok(())
     }
 
     /// Set the project version
-    pub fn set_version(&mut self, version: &String) -> miette::Result<()> {
+    pub fn set_version(&mut self, version: &str) -> miette::Result<()> {
         // Update in both the manifest and the toml
-        self.parsed.project.version = Some(Version::from_str(version).unwrap());
-        let document = match &mut self.document {
-            ManifestSource::PyProjectToml(document) => document,
-            ManifestSource::PixiToml(document) => document,
-        };
-        document["project"]["version"] = value(version);
-
+        self.parsed.project.version = Some(
+            Version::from_str(version)
+                .into_diagnostic()
+                .context("could not convert version to a valid project version")?,
+        );
+        self.document.set_version(version);
         Ok(())
     }
 
@@ -1317,7 +1307,7 @@ mod tests {
             scripts = [".pixi/install/setup.sh", "test"]
             "#;
 
-        let manifest = Manifest::from_str(Path::new(""), contents, ManifestKind::Pixi).unwrap();
+        let manifest = Manifest::from_str(Path::new("pixi.toml"), contents).unwrap();
         let default_activation_scripts = manifest
             .default_feature()
             .targets
@@ -1427,8 +1417,7 @@ mod tests {
         platform: Option<Platform>,
         feature_name: &FeatureName,
     ) {
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         // Initially the dependency should exist
         assert!(manifest
@@ -1479,8 +1468,7 @@ mod tests {
         platform: Option<Platform>,
         feature_name: &FeatureName,
     ) {
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         let package_name = PyPiPackageName::from_str(name).unwrap();
 
@@ -1625,8 +1613,7 @@ feature_target_dep = "*"
             fooz = "*"
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         manifest
             .remove_dependency(
@@ -1675,8 +1662,7 @@ feature_target_dep = "*"
             platforms = ["linux-64", "win-64"]
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         assert_eq!(
             manifest.parsed.project.version.as_ref().unwrap().clone(),
@@ -1703,8 +1689,7 @@ feature_target_dep = "*"
             platforms = ["linux-64", "win-64"]
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         assert_eq!(
             manifest
@@ -1745,8 +1730,7 @@ feature_target_dep = "*"
             platforms = ["linux-64", "win-64"]
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         assert_eq!(
             manifest.parsed.project.platforms.value,
@@ -1817,8 +1801,7 @@ feature_target_dep = "*"
             test = ["test"]
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         assert_eq!(
             manifest.parsed.project.platforms.value,
@@ -1878,8 +1861,7 @@ platforms = ["linux-64", "win-64"]
 [feature.test.dependencies]
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         assert_eq!(manifest.parsed.project.channels, vec![]);
 
@@ -2022,8 +2004,7 @@ platforms = ["linux-64", "win-64"]
             channels = ["test_channel"]
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         assert_eq!(
             manifest.parsed.project.channels,
@@ -2091,8 +2072,7 @@ platforms = ["linux-64", "win-64"]
             test1 = {features = ["test", "py310"], solve-group = "test"}
             test2 = {features = ["py39"], solve-group = "test"}
         "#;
-        let manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
         let default_env = manifest.default_environment();
         assert_eq!(default_env.name, EnvironmentName::Default);
         assert_eq!(default_env.features, vec!["py39"]);
@@ -2151,8 +2131,7 @@ platforms = ["linux-64", "win-64"]
             target.osx-arm64 = {dependencies = {mlx = "x.y.z"}}
 
         "#;
-        let manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         let cuda_feature = manifest
             .parsed
@@ -2285,9 +2264,8 @@ platforms = ["linux-64", "win-64"]
         #[case] should_have_pypi_dependencies: bool,
     ) {
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-            ManifestKind::Pixi,
         )
         .unwrap();
         assert_eq!(
@@ -2311,8 +2289,7 @@ test = "test initial"
 
         "#;
 
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         manifest
             .add_task(
@@ -2363,8 +2340,7 @@ foo = "*"
 [feature.test.dependencies]
 bar = "*"
             "#;
-        let mut manifest =
-            Manifest::from_str(Path::new(""), file_contents, ManifestKind::Pixi).unwrap();
+        let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
         manifest
             .add_dependency(
                 &MatchSpec::from_str(" baz >=1.2.3", Strict).unwrap(),

--- a/src/project/manifest/pyproject.rs
+++ b/src/project/manifest/pyproject.rs
@@ -110,7 +110,7 @@ mod tests {
     use insta::assert_snapshot;
 
     use crate::{
-        project::manifest::{python::PyPiPackageName, Manifest, ManifestKind, PyPiRequirement},
+        project::manifest::{python::PyPiPackageName, Manifest, PyPiRequirement},
         FeatureName,
     };
 
@@ -274,18 +274,13 @@ mod tests {
 
     #[test]
     fn test_build_manifest() {
-        let _manifest =
-            Manifest::from_str(Path::new(""), PYPROJECT_FULL, ManifestKind::Pyproject).unwrap();
+        let _manifest = Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_FULL).unwrap();
     }
 
     #[test]
     fn test_add_pypi_dependency() {
-        let mut manifest = Manifest::from_str(
-            Path::new(""),
-            PYPROJECT_BOILERPLATE,
-            ManifestKind::Pyproject,
-        )
-        .unwrap();
+        let mut manifest =
+            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_BOILERPLATE).unwrap();
 
         // Add numpy to pyproject
         let name = PyPiPackageName::from_str("numpy").unwrap();
@@ -310,12 +305,8 @@ mod tests {
 
     #[test]
     fn test_remove_pypi_dependency() {
-        let mut manifest = Manifest::from_str(
-            Path::new(""),
-            PYPROJECT_BOILERPLATE,
-            ManifestKind::Pyproject,
-        )
-        .unwrap();
+        let mut manifest =
+            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_BOILERPLATE).unwrap();
 
         // Remove flask from pyproject
         let name = PyPiPackageName::from_str("flask").unwrap();

--- a/src/project/manifest/target.rs
+++ b/src/project/manifest/target.rs
@@ -457,7 +457,7 @@ mod tests {
     #[test]
     fn test_targets_overwrite_order() {
         let manifest = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "test"

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -40,7 +40,7 @@ pub use dependencies::Dependencies;
 pub use environment::Environment;
 pub use solve_group::SolveGroup;
 
-use self::manifest::{Environments, ManifestKind};
+use self::manifest::Environments;
 
 /// The dependency types we support
 #[derive(Debug, Copy, Clone)]
@@ -147,8 +147,8 @@ impl Project {
 
     /// Constructs a project from a manifest.
     /// Assumes the manifest is a Pixi manifest
-    pub fn from_str(root: &Path, content: &str) -> miette::Result<Self> {
-        let manifest = Manifest::from_str(root, content, ManifestKind::Pixi)?;
+    pub fn from_str(manifest_path: &Path, content: &str) -> miette::Result<Self> {
+        let manifest = Manifest::from_str(manifest_path, content)?;
         Ok(Self::from_manifest(manifest))
     }
 
@@ -471,19 +471,26 @@ pub fn find_project_manifest() -> Option<PathBuf> {
             .find_map(|manifest| {
                 let path = dir.join(manifest);
                 if path.is_file() {
-                    // Only match pyproject.toml files that contain "[tool.pixi.project]"
-                    if *manifest == PYPROJECT_MANIFEST {
-                        let contents = fs::read_to_string(&path).ok()?;
-                        if !contents.contains("[tool.pixi.project]") {
-                            return None;
+                    match *manifest {
+                        PROJECT_MANIFEST => Some(path.to_path_buf()),
+                        PYPROJECT_MANIFEST if is_valid_pixi_pyproject_toml(&path) => {
+                            Some(path.to_path_buf())
                         }
+                        _ => None,
                     }
-                    Some(path.to_path_buf())
                 } else {
                     None
                 }
             })
     })
+}
+
+/// Checks whether a path is a valid `pyproject.toml` for use with pixi file by checking if it
+/// contains the `[tool.pixi.project]` section.
+fn is_valid_pixi_pyproject_toml(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .map(|content| content.contains("[tool.pixi.project]"))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -528,8 +535,7 @@ mod tests {
         for file_content in file_contents {
             let file_content = format!("{PROJECT_BOILERPLATE}\n{file_content}");
 
-            let manifest =
-                Manifest::from_str(Path::new(""), &file_content, ManifestKind::Pixi).unwrap();
+            let manifest = Manifest::from_str(Path::new("pixi.toml"), &file_content).unwrap();
             let project = Project::from_manifest(manifest);
             let expected_result = vec![VirtualPackage::LibC(LibC {
                 family: "glibc".to_string(),
@@ -562,9 +568,8 @@ mod tests {
         "#;
 
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-            ManifestKind::Pixi,
         )
         .unwrap();
         let project = Project::from_manifest(manifest);
@@ -596,9 +601,8 @@ mod tests {
         wolflib = "1.0"
         "#;
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-            ManifestKind::Pixi,
         )
         .unwrap();
         let project = Project::from_manifest(manifest);
@@ -626,9 +630,8 @@ mod tests {
             scripts = ["pixi.toml", "pixi.lock"]
             "#;
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-            ManifestKind::Pixi,
         )
         .unwrap();
         let project = Project::from_manifest(manifest);
@@ -655,9 +658,8 @@ mod tests {
             test = "test linux"
             "#;
         let manifest = Manifest::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-            ManifestKind::Pixi,
         )
         .unwrap();
 

--- a/src/project/solve_group.rs
+++ b/src/project/solve_group.rs
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn test_solve_group() {
         let project = Project::from_str(
-            Path::new(""),
+            Path::new("pixi.toml"),
             r#"
         [project]
         name = "foobar"

--- a/src/task/task_environment.rs
+++ b/src/task/task_environment.rs
@@ -216,7 +216,7 @@ mod tests {
             [environments]
             test = ["test"]
         "#;
-        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(result.is_ok());
@@ -240,7 +240,7 @@ mod tests {
             [environments]
             test = ["test"]
         "#;
-        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(matches!(result, Err(FindTaskError::AmbiguousTask(_))));
@@ -266,7 +266,7 @@ mod tests {
             test = ["test"]
             prod = ["prod"]
         "#;
-        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(matches!(result, Err(FindTaskError::AmbiguousTask(_))));
@@ -298,7 +298,7 @@ mod tests {
             test = ["test"]
             prod = ["prod"]
         "#;
-        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(result.unwrap().0.name().is_default());
@@ -330,7 +330,7 @@ mod tests {
             [environments]
             other = ["other"]
         "#;
-        let project = Project::from_str(Path::new(""), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("bla".into(), FindTaskSource::CmdArgs);
         // Ambiguous task because it is the same name and code but it is defined in different environments

--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -309,7 +309,7 @@ mod test {
         platform: Option<Platform>,
         environment_name: Option<EnvironmentName>,
     ) -> Vec<String> {
-        let project = Project::from_str(Path::new(""), project_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), project_str).unwrap();
 
         let environment = environment_name.map(|name| project.environment(&name).unwrap());
         let search_envs = SearchEnvironments::from_opt_env(&project, environment, platform);

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -61,7 +61,7 @@ async fn parse_project() {
     }
 
     let pixi_toml = include_str!("./pixi_tomls/many_targets.toml");
-    let project = Project::from_str(&PathBuf::from("./many"), pixi_toml).unwrap();
+    let project = Project::from_str(&PathBuf::from("./many/pixi.toml"), pixi_toml).unwrap();
     assert_debug_snapshot!(dependency_names(&project, Platform::Linux64));
     assert_debug_snapshot!(dependency_names(&project, Platform::OsxArm64));
     assert_debug_snapshot!(dependency_names(&project, Platform::Win64));
@@ -76,7 +76,7 @@ async fn parse_valid_schema_projects() {
         let path = entry.path();
         if path.extension().map(|ext| ext == "toml").unwrap_or(false) {
             let pixi_toml = std::fs::read_to_string(&path).unwrap();
-            let _project = Project::from_str(&PathBuf::from(""), &pixi_toml).unwrap();
+            let _project = Project::from_str(&PathBuf::from("pixi.toml"), &pixi_toml).unwrap();
         }
     }
 }


### PR DESCRIPTION
Some small minor code changes to the pyproject implementation:

* Move some setters to the `ManifestSource` enum.
* `Manifest::from_str` determine the type of manifest from the path argument instead of taking an additional argument.
* Move detection of valid pyproject file in project/mod.rs into a function.