### PR TITLE
docs: `zsh` may be used for installation on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ brew install pixi
 The script will also update your ~/.bash_profile to include ~/.pixi/bin in your PATH, allowing you to invoke the pixi command from anywhere.
 You might need to restart your terminal or source your shell for the changes to take effect.
 
+Starting with macOS Catalina [zsh is the default login shell and interactive shell](https://support.apple.com/en-us/102360). Therefore, you might want to use `zsh` instead of `bash` in the install command:
+
+```zsh
+curl -fsSL https://pixi.sh/install.sh | zsh
+```
+
+The script will also update your ~/.zshrc to include ~/.pixi/bin in your PATH, allowing you to invoke the pixi command from anywhere.
+
 ### Windows
 
 To install Pixi on Windows, open a PowerShell terminal (you may need to run it as an administrator) and run the following command:


### PR DESCRIPTION
The installation modified my ` ~/.zshrc` and added the path to `pixi`, i.e. `export PATH=$PATH:~/.pixi/bin`.

Rational: I had problems with the default installation script because my bash was broken. It installed a osx-64 instead of osx-arm64 executable on my M1 MacBook. Going with default shell seems to be sensible. 