### PR TITLE
chore: Some cleanups

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -61,7 +61,7 @@ pub struct Args {
     #[arg(required = true)]
     pub specs: Vec<String>,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -29,7 +29,7 @@ pub struct Args {
     #[arg(long)]
     json: bool,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 }
@@ -293,7 +293,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     let project_info = project.clone().map(|p| ProjectInfo {
-        manifest_path: p.root().to_path_buf().join("pixi.toml"),
+        manifest_path: p.manifest_path(),
         last_updated: last_updated(p.lock_file_path()).ok(),
         pixi_folder_size,
         configuration: p.config().loaded_from.clone(),

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,22 +1,15 @@
 use crate::config::Config;
 use crate::environment::{get_up_to_date_prefix, LockFileUsage};
-use crate::project::manifest::python::PyPiPackageName;
-use crate::project::manifest::PyPiRequirement;
-use crate::utils::conda_environment_file::{CondaEnvDep, CondaEnvFile};
+use crate::utils::conda_environment_file::CondaEnvFile;
 use crate::{config::get_default_author, consts};
 use crate::{FeatureName, Project};
 use clap::Parser;
 use indexmap::IndexMap;
-use itertools::Itertools;
 use miette::IntoDiagnostic;
 use minijinja::{context, Environment};
-use rattler_conda_types::ParseStrictness::{Lenient, Strict};
-use rattler_conda_types::{Channel, MatchSpec, Platform};
-use regex::Regex;
+use rattler_conda_types::Platform;
 use std::io::{Error, ErrorKind, Write};
 use std::path::Path;
-use std::str::FromStr;
-use std::sync::Arc;
 use std::{fs, path::PathBuf};
 
 /// Creates a new project
@@ -78,19 +71,16 @@ pixi.lock linguist-language=YAML
 pub async fn execute(args: Args) -> miette::Result<()> {
     let env = Environment::new();
     let dir = get_dir(args.path).into_diagnostic()?;
-    let manifest_path = dir.join(consts::PROJECT_MANIFEST);
+    let pixi_manifest_path = dir.join(consts::PROJECT_MANIFEST);
+    let pyproject_manifest_path = dir.join(consts::PYPROJECT_MANIFEST);
     let gitignore_path = dir.join(".gitignore");
     let gitattributes_path = dir.join(".gitattributes");
     let config = Config::load_global();
 
-    // Check if the project file doesn't already exist. We don't want to overwrite it.
-    if fs::metadata(&manifest_path).map_or(false, |x| x.is_file()) {
-        miette::bail!("{} already exists", consts::PROJECT_MANIFEST);
-    }
-
-    // Fail silently if it already exists or cannot be created.
+    // Fail silently if the directory already exists or cannot be created.
     fs::create_dir_all(&dir).ok();
 
+    let default_name = get_name_from_dir(&dir).unwrap_or_else(|_| String::from("new_project"));
     let version = "0.1.0";
     let author = get_default_author();
     let platforms = if args.platforms.is_empty() {
@@ -99,22 +89,22 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         args.platforms.clone()
     };
 
-    // If env file load that else use default template only
-    if let Some(env_file) = args.env_file {
-        let conda_env_file = CondaEnvFile::from_path(&env_file)?;
+    // Create a 'pixi.toml' manifest and populate it by importing a conda environment file
+    if let Some(env_file_path) = args.env_file {
+        // Check if the 'pixi.toml' project file doesn't already exist. We don't want to overwrite it.
+        if pixi_manifest_path.is_file() {
+            miette::bail!("{} already exists", consts::PROJECT_MANIFEST);
+        }
 
-        let name = match conda_env_file.name() {
-            // Default to something to avoid errors
-            None => get_name_from_dir(&dir).unwrap_or_else(|_| String::from("new_project")),
-            Some(name) => name.to_string(),
-        };
+        let env_file = CondaEnvFile::from_path(&env_file_path)?;
+        let name = env_file.name().unwrap_or(default_name.as_str()).to_string();
 
         // TODO: Improve this:
         //  - Use .condarc as channel config
         //  - Implement it for `[crate::project::manifest::ProjectManifest]` to do this for other filetypes, e.g. (pyproject.toml, requirements.txt)
-        let (conda_deps, pypi_deps, channels) = conda_env_to_manifest(conda_env_file, &config)?;
+        let (conda_deps, pypi_deps, channels) = env_file.to_manifest(&config)?;
         let rv = render_project(&env, name, version, &author, channels, &platforms);
-        let mut project = Project::from_str(&dir.join("pixi.toml"), &rv)?;
+        let mut project = Project::from_str(&pixi_manifest_path, &rv)?;
         for spec in conda_deps {
             for platform in platforms.iter() {
                 // TODO: fix serialization of channels in rattler_conda_types::MatchSpec
@@ -145,26 +135,22 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         )
         .await?;
     } else {
-        // Default to something to avoid errors
-        let name = get_name_from_dir(&dir).unwrap_or_else(|_| String::from("new_project"));
-
         let channels = if let Some(channels) = args.channels {
             channels
         } else {
             config.default_channels().to_vec()
         };
 
-        // Inject a tool.pixi.project section into an existing pyproject.toml file if there is one without
-        if dir.join(consts::PYPROJECT_MANIFEST).is_file() {
-            let path = dir.join(consts::PYPROJECT_MANIFEST);
-            let file = fs::read_to_string(path.clone()).unwrap();
+        // Inject a tool.pixi.project section into an existing pyproject.toml file if there is one without '[tool.pixi.project]'
+        if pyproject_manifest_path.is_file() {
+            let file = fs::read_to_string(pyproject_manifest_path.clone()).unwrap();
             if !file.contains("[tool.pixi.project]") {
                 let rv = env
                     .render_named_str(
                         consts::PYPROJECT_MANIFEST,
                         PYROJECT_TEMPLATE,
                         context! {
-                            name,
+                            default_name,
                             channels,
                             platforms
                         },
@@ -173,12 +159,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 if let Err(e) = {
                     fs::OpenOptions::new()
                         .append(true)
-                        .open(path.clone())
+                        .open(pyproject_manifest_path.clone())
                         .and_then(|mut p| p.write_all(rv.as_bytes()))
                 } {
                     tracing::warn!(
                         "Warning, couldn't update '{}' because of: {}",
-                        path.to_string_lossy(),
+                        pyproject_manifest_path.to_string_lossy(),
                         e
                     );
                 }
@@ -186,8 +172,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // Create a pixi.toml
         } else {
-            let rv = render_project(&env, name, version, &author, channels, &platforms);
-            fs::write(&manifest_path, rv).into_diagnostic()?;
+            // Check if the 'pixi.toml' project file doesn't already exist. We don't want to overwrite it.
+            if pixi_manifest_path.is_file() {
+                miette::bail!("{} already exists", consts::PROJECT_MANIFEST);
+            }
+            let rv = render_project(&env, default_name, version, &author, channels, &platforms);
+            fs::write(&pixi_manifest_path, rv).into_diagnostic()?;
         };
     }
 
@@ -287,107 +277,6 @@ fn get_dir(path: PathBuf) -> Result<PathBuf, Error> {
     }
 }
 
-type PipReq = (PyPiPackageName, PyPiRequirement);
-type ParsedDependencies = (Vec<MatchSpec>, Vec<PipReq>, Vec<Arc<Channel>>);
-
-fn conda_env_to_manifest(
-    env_info: CondaEnvFile,
-    config: &Config,
-) -> miette::Result<(Vec<MatchSpec>, Vec<PipReq>, Vec<String>)> {
-    let channels = parse_channels(env_info.channels().clone());
-    let (conda_deps, pip_deps, mut extra_channels) =
-        parse_dependencies(env_info.dependencies().clone())?;
-
-    extra_channels.extend(
-        channels
-            .into_iter()
-            .map(|c| Arc::new(Channel::from_str(c, config.channel_config()).unwrap())),
-    );
-    let mut channels: Vec<_> = extra_channels
-        .into_iter()
-        .unique()
-        .map(|c| {
-            if c.base_url()
-                .as_str()
-                .starts_with(config.channel_config().channel_alias.as_str())
-            {
-                c.name().to_string()
-            } else {
-                c.base_url().to_string()
-            }
-        })
-        .collect();
-    if channels.is_empty() {
-        channels = config.default_channels();
-    }
-
-    Ok((conda_deps, pip_deps, channels))
-}
-
-fn parse_dependencies(deps: Vec<CondaEnvDep>) -> miette::Result<ParsedDependencies> {
-    let mut conda_deps = vec![];
-    let mut pip_deps = vec![];
-    let mut picked_up_channels = vec![];
-    for dep in deps {
-        match dep {
-            CondaEnvDep::Conda(d) => {
-                let match_spec = MatchSpec::from_str(&d, Lenient).into_diagnostic()?;
-                if let Some(channel) = match_spec.clone().channel {
-                    picked_up_channels.push(channel);
-                }
-                conda_deps.push(match_spec);
-            }
-            CondaEnvDep::Pip { pip } => pip_deps.extend(
-                pip.into_iter()
-                    .map(|mut dep| {
-                        let re = Regex::new(r"/([^/]+)\.git").unwrap();
-                        if let Some(caps) = re.captures(dep.as_str()) {
-                            let name= caps.get(1).unwrap().as_str().to_string();
-                            tracing::warn!("The dependency '{}' is a git repository, as that is not available in pixi we'll try to install it as a package with the name: {}", dep, name);
-                            dep = name;
-                        }
-                        let req = pep508_rs::Requirement::from_str(&dep).into_diagnostic()?;
-                        let name = PyPiPackageName::from_normalized(req.name.clone());
-                        let requirement = PyPiRequirement::from(req);
-                        Ok((name, requirement))
-                    })
-                    .collect::<miette::Result<Vec<_>>>()?,
-            ),
-        }
-    }
-
-    if !pip_deps.is_empty()
-        && !conda_deps.iter().any(|spec| {
-            spec.name
-                .as_ref()
-                .filter(|name| name.as_normalized() == "pip")
-                .is_some()
-        })
-    {
-        conda_deps.push(MatchSpec::from_str("pip", Strict).into_diagnostic()?);
-    }
-
-    Ok((conda_deps, pip_deps, picked_up_channels))
-}
-
-fn parse_channels(channels: Vec<String>) -> Vec<String> {
-    let mut new_channels = vec![];
-    for channel in channels {
-        if channel == "defaults" {
-            // https://docs.anaconda.com/free/working-with-conda/reference/default-repositories/#active-default-channels
-            new_channels.push("main".to_string());
-            new_channels.push("r".to_string());
-            new_channels.push("msys2".to_string());
-        } else {
-            let channel = channel.trim();
-            if !channel.is_empty() {
-                new_channels.push(channel.to_string());
-            }
-        }
-    }
-    new_channels
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -395,90 +284,6 @@ mod tests {
     use std::io::Read;
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
-
-    #[test]
-    fn test_parse_conda_env_file() {
-        let example_conda_env_file = r#"
-        name: pixi_example_project
-        channels:
-          - conda-forge
-          - https://custom-server.com/channel
-        dependencies:
-          - python
-          - pytorch::torchvision
-          - conda-forge::pytest
-          - wheel=0.31.1
-          - sel(linux): blabla
-          - foo >=1.2.3.*  # only valid when parsing in lenient mode
-          - pip:
-            - requests
-            - git+https://git@github.com/fsschneider/DeepOBS.git@develop#egg=deepobs
-            - torch==1.8.1
-        "#;
-
-        let mut f = tempfile::NamedTempFile::new().unwrap();
-        f.write_all(example_conda_env_file.as_bytes()).unwrap();
-        let (_file, path) = f.into_parts();
-
-        let conda_env_file_data = CondaEnvFile::from_path(&path).unwrap();
-
-        assert_eq!(conda_env_file_data.name(), Some("pixi_example_project"));
-        assert_eq!(
-            conda_env_file_data.channels(),
-            &vec![
-                "conda-forge".to_string(),
-                "https://custom-server.com/channel".to_string()
-            ]
-        );
-
-        let config = Config::default();
-        let (conda_deps, pip_deps, channels) =
-            conda_env_to_manifest(conda_env_file_data, &config).unwrap();
-
-        assert_eq!(
-            channels,
-            vec![
-                "pytorch".to_string(),
-                "conda-forge".to_string(),
-                "https://custom-server.com/channel/".to_string()
-            ]
-        );
-
-        println!("{conda_deps:?}");
-        assert_eq!(
-            conda_deps,
-            vec![
-                MatchSpec::from_str("python", Strict).unwrap(),
-                MatchSpec::from_str("pytorch::torchvision", Strict).unwrap(),
-                MatchSpec::from_str("conda-forge::pytest", Strict).unwrap(),
-                MatchSpec::from_str("wheel=0.31.1", Strict).unwrap(),
-                MatchSpec::from_str("foo >=1.2.3", Strict).unwrap(),
-                MatchSpec::from_str("pip", Strict).unwrap(),
-            ]
-        );
-
-        assert_eq!(
-            pip_deps,
-            vec![
-                (
-                    PyPiPackageName::from_str("requests").unwrap(),
-                    PyPiRequirement::default()
-                ),
-                (
-                    PyPiPackageName::from_str("deepobs").unwrap(),
-                    PyPiRequirement::default()
-                ),
-                (
-                    PyPiPackageName::from_str("torch").unwrap(),
-                    PyPiRequirement::Version {
-                        version: "==1.8.1".parse().unwrap(),
-                        index: None,
-                        extras: vec![],
-                    }
-                ),
-            ]
-        );
-    }
 
     #[test]
     fn test_get_name() {
@@ -535,77 +340,5 @@ mod tests {
         assert!(create_or_append_file(dir.path(), template).is_err());
 
         dir.close().unwrap();
-    }
-
-    #[test]
-    fn test_import_from_env_yamls() {
-        let test_files_path = Path::new(&env!("CARGO_MANIFEST_DIR"))
-            .join("tests")
-            .join("environment_yamls");
-
-        let entries = match fs::read_dir(test_files_path) {
-            Ok(entries) => entries,
-            Err(e) => panic!("Failed to read directory: {}", e),
-        };
-
-        let mut paths = Vec::new();
-        for entry in entries {
-            let entry = entry.expect("Failed to read directory entry");
-            if entry.path().is_file() {
-                paths.push(entry.path());
-            }
-        }
-
-        for path in paths {
-            let env_info = CondaEnvFile::from_path(&path).unwrap();
-            // Try `cargo insta test` to run all at once
-            let snapshot_name = format!(
-                "test_import_from_env_yaml.{}",
-                path.file_name().unwrap().to_string_lossy()
-            );
-
-            insta::assert_debug_snapshot!(
-                snapshot_name,
-                (
-                    parse_dependencies(env_info.dependencies().clone()).unwrap(),
-                    parse_channels(env_info.channels().clone()),
-                    env_info.name()
-                )
-            );
-        }
-    }
-    #[test]
-    fn test_parse_conda_env_file_with_explicit_pip_dep() {
-        let example_conda_env_file = r#"
-        name: pixi_example_project
-        channels:
-          - conda-forge
-        dependencies:
-          - pip==24.0
-          - pip:
-            - requests
-        "#;
-
-        let f = tempfile::NamedTempFile::new().unwrap();
-        let path = f.path();
-        let mut file = std::fs::File::create(path).unwrap();
-        file.write_all(example_conda_env_file.as_bytes()).unwrap();
-
-        let conda_env_file_data = CondaEnvFile::from_path(path).unwrap();
-        let (conda_deps, pip_deps, _) =
-            parse_dependencies(conda_env_file_data.dependencies().clone()).unwrap();
-
-        assert_eq!(
-            conda_deps,
-            vec![MatchSpec::from_str("pip==24.0", Strict).unwrap(),]
-        );
-
-        assert_eq!(
-            pip_deps,
-            vec![(
-                PyPiPackageName::from_str("requests").unwrap(),
-                PyPiRequirement::default()
-            ),]
-        );
     }
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -50,6 +50,8 @@ platforms = ["{{ platforms|join("\", \"") }}"]
 [dependencies]
 
 "#;
+
+/// The pyproject.toml template
 const PYROJECT_TEMPLATE: &str = r#"
 [tool.pixi.project]
 name = "{{ name }}"
@@ -91,7 +93,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Create a 'pixi.toml' manifest and populate it by importing a conda environment file
     if let Some(env_file_path) = args.env_file {
-        // Check if the 'pixi.toml' project file doesn't already exist. We don't want to overwrite it.
+        // Check if the 'pixi.toml' file doesn't already exist. We don't want to overwrite it.
         if pixi_manifest_path.is_file() {
             miette::bail!("{} already exists", consts::PROJECT_MANIFEST);
         }
@@ -170,9 +172,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 }
             }
 
-        // Create a pixi.toml
+        // Create a 'pixi.toml' manifest
         } else {
-            // Check if the 'pixi.toml' project file doesn't already exist. We don't want to overwrite it.
+            // Check if the 'pixi.toml' file doesn't already exist. We don't want to overwrite it.
             if pixi_manifest_path.is_file() {
                 miette::bail!("{} already exists", consts::PROJECT_MANIFEST);
             }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 /// Install all dependencies
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -48,7 +48,7 @@ pub struct Args {
     #[arg(long, default_value = "name", value_enum)]
     pub sort_by: SortBy,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/project/channel/mod.rs
+++ b/src/cli/project/channel/mod.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 /// Commands to manage project channels.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[clap(long, global = true)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/project/description/mod.rs
+++ b/src/cli/project/description/mod.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 /// Commands to manage project description.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[clap(long, global = true)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/project/mod.rs
+++ b/src/cli/project/mod.rs
@@ -19,7 +19,7 @@ pub enum Command {
 pub struct Args {
     #[command(subcommand)]
     command: Command,
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 }

--- a/src/cli/project/platform/mod.rs
+++ b/src/cli/project/platform/mod.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 /// Commands to manage project channels.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[clap(long, global = true)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/project/version/mod.rs
+++ b/src/cli/project/version/mod.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 /// Commands to manage project description.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[clap(long, global = true)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -19,7 +19,7 @@ pub struct Args {
     #[arg(required = true)]
     pub deps: Vec<String>,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -36,7 +36,7 @@ pub struct Args {
     /// The task you want to run in the projects environment.
     pub task: Vec<String>,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -30,7 +30,7 @@ pub struct Args {
     #[clap(short, long)]
     channel: Option<Vec<String>>,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -21,7 +21,7 @@ use rattler_shell::shell::CmdExe;
 /// Start a shell in the pixi environment of the project
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -22,7 +22,7 @@ pub struct Args {
     #[arg(short, long)]
     shell: Option<ShellEnum>,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     manifest_path: Option<PathBuf>,
 

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -147,7 +147,7 @@ pub struct Args {
     #[clap(subcommand)]
     pub operation: Operation,
 
-    /// The path to 'pixi.toml'
+    /// The path to 'pixi.toml' or 'pyproject.toml'
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 }

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -9,7 +9,7 @@ use super::{python::PyPiPackageName, PyPiRequirement};
 
 const PYPROJECT_PIXI_PREFIX: &str = "tool.pixi";
 
-/// Discriminates between a pixi.toml and a pyproject.toml manifest
+/// Discriminates between a 'pixi.toml' and a 'pyproject.toml' manifest
 #[derive(Debug, Clone)]
 pub enum ManifestSource {
     PyProjectToml(toml_edit::DocumentMut),

--- a/src/project/manifest/validation.rs
+++ b/src/project/manifest/validation.rs
@@ -1,8 +1,5 @@
 use crate::project::manifest::{Environment, FeatureName, SystemRequirements};
-use crate::{
-    consts,
-    project::manifest::{Feature, ProjectManifest, TargetSelector},
-};
+use crate::project::manifest::{Feature, ProjectManifest, TargetSelector};
 use itertools::Itertools;
 use miette::{IntoDiagnostic, LabeledSpan, NamedSource, Report, WrapErr};
 use rattler_conda_types::Platform;
@@ -206,8 +203,7 @@ fn create_unsupported_platform_report(
             format!("'{}' is not a supported platform", platform)
         )],
         help = format!(
-            "Add any of '{platform}' to the `{}` array of the {} manifest.",
-            consts::PROJECT_MANIFEST,
+            "Add any of '{platform}' to the `{}` array of the TOML manifest.",
             if feature.platforms.is_some() {
                 format!(
                     "feature.{}.platforms",

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -170,7 +170,7 @@ impl Project {
     /// Returns the source code of the project as [`NamedSource`].
     /// Used in error reporting.
     pub fn manifest_named_source(&self) -> NamedSource<String> {
-        NamedSource::new(PROJECT_MANIFEST, self.manifest.contents.clone())
+        NamedSource::new(self.manifest.file_name(), self.manifest.contents.clone())
     }
 
     /// Loads a project from manifest file.

--- a/src/utils/conda_environment_file.rs
+++ b/src/utils/conda_environment_file.rs
@@ -253,7 +253,6 @@ mod tests {
                     PyPiPackageName::from_str("torch").unwrap(),
                     PyPiRequirement::Version {
                         version: "==1.8.1".parse().unwrap(),
-                        index: None,
                         extras: vec![],
                     }
                 ),
@@ -298,6 +297,7 @@ mod tests {
             );
         }
     }
+
     #[test]
     fn test_parse_conda_env_file_with_explicit_pip_dep() {
         let example_conda_env_file = r#"

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.cockpit.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.cockpit.yml.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/init.rs
+source: src/utils/conda_environment_file.rs
 expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.conda.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.conda.yml.snap
@@ -1,6 +1,6 @@
 ---
-source: src/cli/init.rs
-expression: "(parse_dependencies(env_info.dependencies).unwrap(),\n    parse_channels(env_info.channels), env_info.name)"
+source: src/utils/conda_environment_file.rs
+expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (
     (

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.crnnft.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.crnnft.yml.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/init.rs
+source: src/utils/conda_environment_file.rs
 expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.crnnft.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.crnnft.yml.snap
@@ -133,7 +133,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.let-plot.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.let-plot.yml.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/init.rs
+source: src/utils/conda_environment_file.rs
 expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.test_env.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.test_env.yml.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/init.rs
+source: src/utils/conda_environment_file.rs
 expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n    parse_channels(env_info.channels().clone()), env_info.name())"
 ---
 (

--- a/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.test_env.yml.snap
+++ b/src/utils/snapshots/pixi__utils__conda_environment_file__tests__test_import_from_env_yaml.test_env.yml.snap
@@ -119,7 +119,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -141,7 +140,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -163,7 +161,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -185,7 +182,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -207,7 +203,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -229,7 +224,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -251,7 +245,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -273,7 +266,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [],
                 },
             ),
@@ -297,7 +289,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                 },
                 Version {
                     version: Star,
-                    index: None,
                     extras: [
                         ExtraName(
                             "extra",
@@ -314,7 +305,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                 },
                 Version {
                     version: Star,
-                    index: None,
                     extras: [
                         ExtraName(
                             "extra1",
@@ -343,7 +333,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [
                         ExtraName(
                             "extra1",
@@ -372,7 +361,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [
                         ExtraName(
                             "extra1",
@@ -401,7 +389,6 @@ expression: "(parse_dependencies(env_info.dependencies().clone()).unwrap(),\n   
                             ],
                         ),
                     ),
-                    index: None,
                     extras: [
                         ExtraName(
                             "extra1",


### PR DESCRIPTION
For "separation of concerns" reasons, I moved all conda environment import related code to a single file (the existing one in utils). The logic is untouched; I just turned the function `conda_env_to_manifest` into a the method `to_manifest`, which felt more idiomatic. 

I also removed bits and pieces related to `PyPiRequirement::Version` index field, which was unused.

Finally, I altered code in places to account for having now two possible names for the manifest file (pixi.toml an pyproject.toml). The only remaining place referring to pixi.toml is in [PixiControl](https://github.com/olivier-lacroix/pixi/blob/faf98db1e47232bcb4617551961428571c0cd2f8/tests/common/mod.rs#L186). Does this have any impact?

