### PR TITLE
fix: unsolvable when moving dependency from conda to pypi

### DIFF
--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -17,9 +17,7 @@ pub use outdated::OutdatedEnvironments;
 pub use package_identifier::PypiPackageIdentifier;
 pub use records_by_name::{PypiRecordsByName, RepoDataRecordsByName};
 pub use resolve::{resolve_conda, resolve_pypi, UvResolutionContext};
-pub use satisfiability::{
-    verify_environment_satisfiability, verify_platform_satisfiability, PlatformUnsat,
-};
+pub use satisfiability::{verify_environment_satisfiability, verify_platform_satisfiability};
 pub use update::{LockFileDerivedData, UpdateLockFileOptions};
 
 /// A list of conda packages that are locked for a specific platform.

--- a/src/lock_file/outdated.rs
+++ b/src/lock_file/outdated.rs
@@ -1,4 +1,4 @@
-use super::{verify_environment_satisfiability, verify_platform_satisfiability, PlatformUnsat};
+use super::{verify_environment_satisfiability, verify_platform_satisfiability};
 use crate::lock_file::satisfiability::EnvironmentUnsat;
 use crate::{consts, project::Environment, project::SolveGroup, Project};
 use itertools::Itertools;
@@ -152,7 +152,7 @@ fn find_unsatisfiable_targets<'p>(
                 project.root(),
             ) {
                 Ok(_) => {}
-                Err(unsat @ PlatformUnsat::UnsatisfiableRequirement(_, _)) => {
+                Err(unsat) if unsat.is_pypi_only() => {
                     tracing::info!(
                         "the pypi dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
                         environment.name().fancy_display()


### PR DESCRIPTION
Fixes #1098 

When a package was moved from conda dependencies to pypi dependencies and the version is changed  the satisfiability reported that a requirement was satisfiable. However, if a pep508 requirement isn't satisfiable, only the pypi packages are updated, but in this case the conda packages should also be updated.

To fix this I added a separate error for a requirement mismatch on a conda package. This will trigger updating the conda packages as well.