### PR TITLE
fix: pixi list shows path and editable

### DIFF
--- a/examples/pypi-source-deps/pixi.toml
+++ b/examples/pypi-source-deps/pixi.toml
@@ -30,4 +30,4 @@ minimal-project = { path = "./minimal-project", editable = true}
 click = { url = "https://github.com/pallets/click/releases/download/8.1.7/click-8.1.7-py3-none-any.whl" }
 
 # You can also just the default git repo, it will checkout the default branch
-pytest = { git = "https://github.com/pytest-dev/pytest.git"}
+pytest = { git = "https://github.com/pytest-dev/pytest.git" }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -65,7 +65,7 @@ pub struct Args {
 }
 
 fn serde_skip_is_editable(editable: &bool) -> bool {
-    *editable == false
+    !(*editable)
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Fixes #1085 

![image](https://github.com/prefix-dev/pixi/assets/4995967/24b8e556-804f-4f35-8874-98cfcd12c247)