### PR TITLE
fix: issue 1082

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -235,6 +235,9 @@ pub async fn get_task_env<'p>(
     lock_file_derived_data: &mut LockFileDerivedData<'p>,
     environment: &Environment<'p>,
 ) -> miette::Result<HashMap<String, String>> {
+    // Make sure the system requirements are met
+    verify_current_platform_has_required_virtual_packages(environment).into_diagnostic()?;
+
     // Ensure there is a valid prefix
     lock_file_derived_data.prefix(environment).await?;
 

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -15,6 +15,7 @@ use crate::unix::PtySession;
 
 use crate::cli::LockFileUsageArgs;
 use crate::project::manifest::EnvironmentName;
+use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
 #[cfg(target_family = "windows")]
 use rattler_shell::shell::CmdExe;
 
@@ -207,6 +208,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let environment = project
         .environment(&environment_name)
         .ok_or_else(|| miette::miette!("unknown environment '{environment_name}'"))?;
+
+    verify_current_platform_has_required_virtual_packages(&environment).into_diagnostic()?;
 
     let prompt_name = match environment_name {
         EnvironmentName::Default => project.name().to_string(),

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -8,7 +8,6 @@ use crate::{
     project::{
         grouped_environment::GroupedEnvironment,
         manifest::{EnvironmentName, SystemRequirements},
-        virtual_packages::verify_current_platform_has_required_virtual_packages,
         Environment,
     },
     Project,
@@ -116,10 +115,6 @@ fn create_history_file(environment_dir: &Path) -> miette::Result<()> {
 pub fn sanity_check_project(project: &Project) -> miette::Result<()> {
     // Sanity check of prefix location
     verify_prefix_location_unchanged(project.default_environment().dir().as_path())?;
-
-    // Make sure the system requirements are met
-    verify_current_platform_has_required_virtual_packages(&project.default_environment())
-        .into_diagnostic()?;
 
     // TODO: remove on a 1.0 release
     // Check for old `env` folder as we moved to `envs` in 0.13.0


### PR DESCRIPTION
Fixes #1082

Checking if the current machine meets the project requirements is only really required when using `run` or `shell`. This PR moves the logic to check if the system meets the minimum system requirements to those specific CLI commands. This allows you to create lock-files for other platforms than your own. (as long as you dont have pypi dependencies)