### PR TITLE
fix: dont allow extra keys in pypi requirements

### DIFF
--- a/src/project/manifest/python.rs
+++ b/src/project/manifest/python.rs
@@ -116,7 +116,7 @@ impl<'de> Deserialize<'de> for VersionOrStar {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case", deny_unknown_fields)]
 pub enum PyPiRequirement {
     Git {
         git: Url,


### PR DESCRIPTION
Fixes #1065 

Rejects unknown keys in Pypi requirements. The error message is still quite terrible but at least you get an error.