### PR TITLE
fix: Amend syntax in `conda-meta/history` to prevent `conda.history.History.parse()` error

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -137,7 +137,7 @@ fn create_history_file(environment_dir: &Path) -> miette::Result<()> {
         tracing::info!("Creating history file: {}", history_file.display());
         std::fs::write(
             history_file,
-            "# not relevant for pixi but for `conda run -p`",
+            "// not relevant for pixi but for `conda run -p`",
         )
         .into_diagnostic()?;
     }


### PR DESCRIPTION
https://github.com/prefix-dev/pixi/pull/995 introduced a Pixi-generated `conda-meta/history`. Sadly, `#` is a special character in the `history` file, which ends up breaking the `conda.history.History.parse()` function:

```
$ python -c "from conda.history import History as H; print(H('.pixi/envs/default').parse())"                  
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jrodriguez/devel/conda-pip/.pixi/envs/default/lib/python3.10/site-packages/conda/history.py", line 138, in parse
    res[-1][2].append(line)
IndexError: list index out of range
```

`//` does work without issues. 