### PR TITLE
feat: Enable to force PIXI_ARCH for installation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ To install `pixi` you can run the following command in your terminal:
 
     On Apple Silicon, you can force the installation of the x86 version:
     ```shell
-    export PIXI_ARCH=x86_64 && curl -fsSL https://pixi.sh/install.sh | bash
+    PIXI_ARCH=x86_64 curl -fsSL https://pixi.sh/install.sh | bash
     ```
 
 === "Windows"

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,11 @@ To install `pixi` you can run the following command in your terminal:
 
     The script will also update your `~/.bash_profile` to include `~/.pixi/bin` in your PATH, allowing you to invoke the `pixi` command from anywhere.
 
+    On Apple Silicon, you can force the installation of the x86 version:
+    ```shell
+    export PIXI_ARCH=x86_64 && curl -fsSL https://pixi.sh/install.sh | bash
+    ```
+
 === "Windows"
     `PowerShell`:
     ```powershell

--- a/install/install.sh
+++ b/install/install.sh
@@ -9,7 +9,7 @@ BIN_DIR="$PIXI_HOME/bin"
 
 REPO=prefix-dev/pixi
 PLATFORM=$(uname -s)
-ARCH=$(uname -m)
+ARCH=${PIXI_ARCH:-$(uname -m)}
 
 if [[ $PLATFORM == "Darwin" ]]; then
   PLATFORM="apple-darwin"


### PR DESCRIPTION
On Apple Silicon, one might want to force installing the x86_64 version of pixi. Using the `PIXI_ARCH` variable, this can now be done using:

```
export PIXI_ARCH=x86_64 && curl -fsSL https://pixi.sh/install.sh | bash
```

My use case is to run pixi on GitLab CI saas-macos-medium-m1 runners.
This would make it easier to install pixi for aarch64 or x86_64.