### PR TITLE
feat: Directly download executable instead of archive

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -23,18 +23,17 @@ if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
   ARCH="aarch64"
 fi
 
-
-
 BINARY="pixi-${ARCH}-${PLATFORM}"
-EXTENSION="tar.gz"
+SUFFIX=""
 if [[ $(uname -o) == "Msys" ]]; then
-  EXTENSION="zip"
+  SUFFIX=".exe"
 fi
+TARGET_FILE="${BIN_DIR}/${BINARY}${SUFFIX}"
 
 if [[ $VERSION == "latest" ]]; then
-  DOWNLOAD_URL=https://github.com/${REPO}/releases/latest/download/${BINARY}.${EXTENSION}
+  DOWNLOAD_URL=https://github.com/${REPO}/releases/latest/download/${BINARY}${SUFFIX}
 else
-  DOWNLOAD_URL=https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}.${EXTENSION}
+  DOWNLOAD_URL=https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}${SUFFIX}
 fi
 
 printf "This script will automatically download and install Pixi (${VERSION}) for you.\nGetting it from this url: $DOWNLOAD_URL\n"
@@ -44,46 +43,23 @@ if ! hash curl 2> /dev/null && ! hash wget 2> /dev/null; then
   exit 1
 fi
 
-if ! hash tar 2> /dev/null; then
-  echo "error: you do not have 'tar' installed which is required for this script."
-  exit 1
-fi
-
-TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/.pixi_install.XXXXXXXX")
-
-cleanup() {
-  rm -f "$TEMP_FILE"
-}
-
-trap cleanup EXIT
+mkdir -p "$BIN_DIR"
 
 if hash curl 2> /dev/null; then
-  HTTP_CODE=$(curl -SL --progress-bar "$DOWNLOAD_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
+  HTTP_CODE=$(curl -SL --progress-bar "$DOWNLOAD_URL" --output "$TARGET_FILE" --write-out "%{http_code}")
   if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]]; then
     echo "error: '${DOWNLOAD_URL}' is not available"
     exit 1
   fi
 elif hash wget 2> /dev/null; then
-  if ! wget -q --show-progress --output-document="$TEMP_FILE" "$DOWNLOAD_URL"; then
+  if ! wget -q --show-progress --output-document="$TARGET_FILE" "$DOWNLOAD_URL"; then
     echo "error: '${DOWNLOAD_URL}' is not available"
     exit 1
   fi
 fi
 
-# Check that file was correctly created (https://github.com/prefix-dev/pixi/issues/446)
-if [[ ! -s $TEMP_FILE ]]; then
-  echo "error: temporary file ${TEMP_FILE} not correctly created."
-  echo "       As a workaround, you can try set TMPDIR env variable to directory with write permissions."
-  exit 1
-fi
-
-# Extract pixi from the downloaded file
-mkdir -p "$BIN_DIR"
-if [[ $(uname -o) == "Msys" ]]; then
-  unzip "$TEMP_FILE" -d "$BIN_DIR"
-else
-  tar -xzf "$TEMP_FILE" -C "$BIN_DIR"
-  chmod +x "$BIN_DIR/pixi"
+if [[ $(uname -o) != "Msys" ]]; then
+  chmod +x "$TARGET_FILE"
 fi
 
 echo "The 'pixi' binary is installed into '${BIN_DIR}'"


### PR DESCRIPTION
Is there a reason why the archive was downloaded instead of the executable? Seems a bit easier this way and doesn't require a `tar` installation or `mktemp` to function properly...

(not tested yet)

We could probably do the same for `install.ps1` but I haven't written much powershell in my life 😅 