### PR TITLE
feat: add to pypi in feature

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -176,6 +176,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
             add_pypi_specs_to_project(
                 &mut project,
+                &feature_name,
                 specs,
                 spec_platforms,
                 args.no_lockfile_update,
@@ -218,6 +219,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
 pub async fn add_pypi_specs_to_project(
     project: &mut Project,
+    feature_name: &FeatureName,
     specs: Vec<(PyPiPackageName, PyPiRequirement)>,
     specs_platforms: &[Platform],
     no_update_lockfile: bool,
@@ -227,12 +229,14 @@ pub async fn add_pypi_specs_to_project(
         // TODO: Get best version
         // Add the dependency to the project
         if specs_platforms.is_empty() {
-            project.manifest.add_pypi_dependency(name, spec, None)?;
+            project
+                .manifest
+                .add_pypi_dependency(name, spec, None, feature_name)?;
         } else {
             for platform in specs_platforms.iter() {
                 project
                     .manifest
-                    .add_pypi_dependency(name, spec, Some(*platform))?;
+                    .add_pypi_dependency(name, spec, Some(*platform), feature_name)?;
             }
         }
     }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -136,6 +136,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     &spec.0,
                     &spec.1,
                     Some(platform.parse().into_diagnostic()?),
+                    &FeatureName::default(),
                 )?;
             }
         }

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -226,14 +226,7 @@ impl ManifestSource {
         feature_name: &FeatureName,
     ) -> Result<(), Report> {
         match self {
-            ManifestSource::PixiToml(_) => self.add_dependency_helper(
-                name.as_source(),
-                (*requirement).clone().into(),
-                consts::PYPI_DEPENDENCIES,
-                platform,
-                feature_name,
-            ),
-            ManifestSource::PyProjectToml(_) => {
+            ManifestSource::PyProjectToml(_) if feature_name.is_default() => {
                 let dep = requirement
                     .as_pep508(name.as_normalized(), project_root)
                     .map_err(|_| {
@@ -260,6 +253,13 @@ impl ManifestSource {
                 }
                 Ok(())
             }
+            _ => self.add_dependency_helper(
+                name.as_source(),
+                (*requirement).clone().into(),
+                consts::PYPI_DEPENDENCIES,
+                platform,
+                feature_name,
+            ),
         }
     }
 

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -255,7 +255,7 @@ impl ManifestSource {
             }
             _ => self.add_dependency_helper(
                 name.as_source(),
-                (*requirement).clone().into(),
+                requirement.clone().into(),
                 consts::PYPI_DEPENDENCIES,
                 platform,
                 feature_name,

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -223,6 +223,7 @@ impl ManifestSource {
         requirement: &PyPiRequirement,
         platform: Option<Platform>,
         project_root: &Path,
+        feature_name: &FeatureName,
     ) -> Result<(), Report> {
         match self {
             ManifestSource::PixiToml(_) => self.add_dependency_helper(
@@ -230,7 +231,7 @@ impl ManifestSource {
                 (*requirement).clone().into(),
                 consts::PYPI_DEPENDENCIES,
                 platform,
-                &FeatureName::Default,
+                feature_name,
             ),
             ManifestSource::PyProjectToml(_) => {
                 let dep = requirement

--- a/src/project/manifest/feature.rs
+++ b/src/project/manifest/feature.rs
@@ -60,6 +60,11 @@ impl FeatureName {
         self.name().unwrap_or(consts::DEFAULT_FEATURE_NAME)
     }
 
+    /// Returns true if the feature is the default feature.
+    pub fn is_default(&self) -> bool {
+        matches!(self, FeatureName::Default)
+    }
+
     /// Returns a styled version of the feature name for display in the console.
     pub fn fancy_display(&self) -> console::StyledObject<&str> {
         console::style(self.as_str()).cyan()

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -391,17 +391,23 @@ impl Manifest {
         name: &PyPiPackageName,
         requirement: &PyPiRequirement,
         platform: Option<Platform>,
+        feature_name: &FeatureName,
     ) -> miette::Result<()> {
         // Add the pypi dependency to the TOML document
         let project_root = self
             .path
             .parent()
             .expect("Path should always have a parent");
-        self.document
-            .add_pypi_dependency(name, requirement, platform, project_root)?;
+        self.document.add_pypi_dependency(
+            name,
+            requirement,
+            platform,
+            project_root,
+            feature_name,
+        )?;
 
         // Add the dependency to the manifest as well
-        self.target_mut(platform, None)
+        self.target_mut(platform, Some(feature_name))
             .add_pypi_dependency(name.clone(), requirement.clone());
 
         Ok(())

--- a/src/project/manifest/pyproject.rs
+++ b/src/project/manifest/pyproject.rs
@@ -376,11 +376,34 @@ mod tests {
         let name = PyPiPackageName::from_str("numpy").unwrap();
         let requirement = PyPiRequirement::RawVersion(">=3.12".parse().unwrap());
         manifest
-            .add_pypi_dependency(&name, &requirement, None)
+            .add_pypi_dependency(&name, &requirement, None, &FeatureName::Default)
             .unwrap();
 
         assert!(manifest
             .default_feature_mut()
+            .targets
+            .for_opt_target(None)
+            .unwrap()
+            .pypi_dependencies
+            .as_ref()
+            .unwrap()
+            .get(&name)
+            .is_some());
+
+        // Add numpy to feature in pyproject
+        let name = PyPiPackageName::from_str("pytest").unwrap();
+        let requirement = PyPiRequirement::RawVersion(">=3.12".parse().unwrap());
+        manifest
+            .add_pypi_dependency(
+                &name,
+                &requirement,
+                None,
+                &FeatureName::Named("test".to_string()),
+            )
+            .unwrap();
+        assert!(manifest
+            .feature(&FeatureName::Named("test".to_string()))
+            .unwrap()
             .targets
             .for_opt_target(None)
             .unwrap()

--- a/src/project/manifest/snapshots/pixi__project__manifest__pyproject__tests__add_pypi_dependency.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__pyproject__tests__add_pypi_dependency.snap
@@ -19,3 +19,6 @@ expression: manifest.document.to_string()
 
         [tool.pixi.tasks]
         start = "python -m flask run --port=5050"
+
+[tool.pixi.feature.test.pypi-dependencies]
+pytest = ">=3.12"


### PR DESCRIPTION
fixes #1133 

Now you can also run:
```shell
pixi add --feature test --pypi elsie
```
This results in a `pixi.toml`  to:
```toml
[feature.test.pypi-dependencies]
elsie = "*"
```

and in a `pyproject.toml` to:
```toml
[tool.pixi.feature.test.pypi-dependencies]
elsie = "*"
```

Note, it doesn't add it to the `optional dependencies` not sure if we should do that. @olivier-lacroix what do you think?