### PR TITLE
feat: check if pypi package is conda package

### DIFF
--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -173,11 +173,13 @@ async fn test_compressed_mapping_catch_missing_package() {
             .await
             .unwrap();
     let compressed_mapping = HashMap::from([("foo-bar-car".to_owned(), "my-test-name".to_owned())]);
+    let not_pypi_name_mapping = Vec::from(["pandoc".to_owned()]);
 
     pypi_mapping::prefix_pypi_name_mapping::amend_pypi_purls_for_record(
         &mut repo_data_record,
         &conda_mapping,
         &compressed_mapping,
+        &not_pypi_name_mapping,
     )
     .unwrap();
 


### PR DESCRIPTION
High overview logic:

**from parselmouth side:**

* collect all conda packages from` conda-forge/subdir/repodata.json`
* collect all missing packages where ( [1] hash of package is missing in our extensive mapping or [2] pypi_normalized_names of that package in mapping is None )
* request pypi by package name from list of missing packages
* if package name is present and it's not it compressed mapping version,  we save it in `non_pypi_names.json` list - this means that conda package is non the same as pypi even if names are the same. Some older conda-packages can't be parsed with get_artifact_info, so their hash is missing but name is present in compressed mapping.
* if package name is missing from pypi we add it to `non_existing_pypi_packages.json` list - this means that for conda-package the python package is get directly from source so there are no pypi package for it. This should be addressed in future to deal with the fact that other pypi package can be published by this name even if it's different.

**from pixi side:**
* during the amendment step if conda name is not present in compressed or extensive mapping we check if it's name is in `non_pypi_names.json` map. If yes, this means that the conda package is not pypi one - ( pandoc issue ).
We write the purl for it with the type purl:/non-pypi that will tell us later that the package is **not** coming from pypi artifactory so we should install also the pypi one. 
Downside for this is that we **possible** break the contract of purl spec:
`A purl is a URL string used to identify and locate a software package in a mostly universal and uniform way across programing languages, package managers, packaging conventions, tools, APIs and databases.` because we can't locate it by purl.

* if the name is also missed from `non-conda` map we rollback to our old logic that assume that they are the same




