### PR TITLE
fix: make requires-python take precedence, improve version conversion

### DIFF
--- a/src/project/manifest/error.rs
+++ b/src/project/manifest/error.rs
@@ -68,8 +68,6 @@ pub enum RequirementConversionError {
     InvalidPackageNameError(#[from] InvalidPackageNameError),
     #[error("Failed to parse specification")]
     ParseError(#[from] ParseMatchSpecError),
-    #[error("Error converting requirement from pypi to conda")]
-    Unimplemented,
 }
 
 #[derive(Error, Debug, Clone)]


### PR DESCRIPTION
This improves the logic a little bit.

Python versions like `==3.11.*` now get parsed to `3.11.*` which works better for conda requirements.

We warn the user if there is both a `requires-python` and a `python` dependency in the `tool.pixi.dependencies` section.

We prefer the `requires-python` over a value in the pixi deps.

cc @olivier-lacroix 

fixes #1193 