### PR TITLE
fix: use project root directory instead of task.working_directory for base dir when hashing

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -150,7 +150,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         {
             CanSkip::No(cache) => cache,
             CanSkip::Yes => {
-                eprintln!("Task can be skipped (cache hit) 🚀");
+                eprintln!("Task \"{}\" can be skipped (cache hit) 🚀", executable_task.name().unwrap_or(""));
                 task_idx += 1;
                 continue;
             }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -150,7 +150,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         {
             CanSkip::No(cache) => cache,
             CanSkip::Yes => {
-                eprintln!("Task \"{}\" can be skipped (cache hit) 🚀", executable_task.name().unwrap_or(""));
+                eprintln!(
+                    "Task \"{}\" can be skipped (cache hit) 🚀",
+                    executable_task.name().unwrap_or("")
+                );
                 task_idx += 1;
                 continue;
             }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -129,9 +129,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 eprintln!();
             }
             eprintln!(
-                "{}{}{}{}{}",
+                "{}{}{} in {}{}{}",
                 console::Emoji("✨ ", ""),
                 console::style("Pixi task (").bold(),
+                console::style(executable_task.name().unwrap_or("unnamed"))
+                    .green()
+                    .bold(),
                 executable_task
                     .run_environment
                     .name()

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -151,8 +151,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             CanSkip::No(cache) => cache,
             CanSkip::Yes => {
                 eprintln!(
-                    "Task \"{}\" can be skipped (cache hit) 🚀",
-                    executable_task.name().unwrap_or("")
+                    "Task '{}' can be skipped (cache hit) 🚀",
+                    console::style(executable_task.name().unwrap_or("")).bold()
                 );
                 task_idx += 1;
                 continue;

--- a/src/task/task_hash.rs
+++ b/src/task/task_hash.rs
@@ -132,7 +132,7 @@ impl InputHashes {
             return Ok(None);
         };
 
-        let files = FileHashes::from_files(&task.working_directory()?, inputs.iter()).await?;
+        let files = FileHashes::from_files(&task.project().root(), inputs.iter()).await?;
         Ok(Some(Self { files }))
     }
 }
@@ -150,7 +150,7 @@ impl OutputHashes {
             return Ok(None);
         };
 
-        let files = FileHashes::from_files(&task.working_directory()?, outputs.iter()).await?;
+        let files = FileHashes::from_files(&task.project().root(), outputs.iter()).await?;
         Ok(Some(Self { files }))
     }
 }

--- a/src/task/task_hash.rs
+++ b/src/task/task_hash.rs
@@ -86,7 +86,7 @@ impl TaskHash {
         lock_file: &LockFile,
     ) -> Result<Option<Self>, InputHashesError> {
         let input_hashes = InputHashes::from_task(task).await?;
-        let output_hashes = OutputHashes::from_task(task).await?;
+        let output_hashes = OutputHashes::from_task(task, false).await?;
 
         if input_hashes.is_none() && output_hashes.is_none() {
             return Ok(None);
@@ -104,7 +104,7 @@ impl TaskHash {
         &mut self,
         task: &ExecutableTask<'_>,
     ) -> Result<(), InputHashesError> {
-        self.outputs = OutputHashes::from_task(task).await?;
+        self.outputs = OutputHashes::from_task(task, true).await?;
         Ok(())
     }
 
@@ -132,7 +132,20 @@ impl InputHashes {
             return Ok(None);
         };
 
-        let files = FileHashes::from_files(&task.project().root(), inputs.iter()).await?;
+        let files = FileHashes::from_files(task.project().root(), inputs.iter()).await?;
+
+        // check if any files were matched
+        if files.files.is_empty() {
+            tracing::warn!(
+                "No files matched the input globs for task '{}'",
+                task.name().unwrap_or_default()
+            );
+            tracing::warn!(
+                "Input globs: {:?}",
+                inputs.iter().map(|g| g.as_str()).collect::<Vec<_>>()
+            );
+        }
+
         Ok(Some(Self { files }))
     }
 }
@@ -144,13 +157,30 @@ pub struct OutputHashes {
 }
 
 impl OutputHashes {
-    /// Compute the input hashes from a task.
-    pub async fn from_task(task: &ExecutableTask<'_>) -> Result<Option<Self>, InputHashesError> {
+    /// Compute the output hashes from a task.
+    pub async fn from_task(
+        task: &ExecutableTask<'_>,
+        warn: bool,
+    ) -> Result<Option<Self>, InputHashesError> {
         let Some(ref outputs) = task.task().as_execute().and_then(|e| e.outputs.clone()) else {
             return Ok(None);
         };
 
-        let files = FileHashes::from_files(&task.project().root(), outputs.iter()).await?;
+        let files = FileHashes::from_files(task.project().root(), outputs.iter()).await?;
+
+        // check if any files were matched
+        if warn && files.files.is_empty() {
+            tracing::warn!(
+                "No files matched the output globs for task` '{}'",
+                task.name().unwrap_or_default()
+            );
+            tracing::warn!(
+                "Output globs: {:?}",
+                outputs.iter().map(|g| g.as_str()).collect::<Vec<_>>()
+            );
+            return Ok(None);
+        }
+
         Ok(Some(Self { files }))
     }
 }


### PR DESCRIPTION
Should improve https://github.com/prefix-dev/pixi/issues/1139

I still want to implement a warning when glob does not match anything at all.