### PR TITLE
fix: replace `_` with `-` when creating environments from features

### DIFF
--- a/src/project/manifest/pyproject.rs
+++ b/src/project/manifest/pyproject.rs
@@ -204,7 +204,8 @@ impl PyProjectToml {
                         }
                     }
                 }
-                environments.insert(extra.clone(), features);
+                // Environments can only contain number, strings and dashes
+                environments.insert(extra.replace('_', "-").clone(), features);
             }
         }
         environments


### PR DESCRIPTION
I had a `pyproject.toml` that was using optional deps like:

```toml
[project.optional-dependencies]
test = ["pytest"]
conda_build = ["bla"]
```

Upon conversion, pixi complained because 

```
  × failed to parse project manifest
    ╭─[pyproject.toml:26:1]
 25 │ default = { solve-group = "default" }
 26 │ conda_build = { features = ["conda_build"], solve-group = "default" }
    · ─────┬─────
    ·      ╰── Failed to parse environment name 'conda_build', please use only lowercase letters, numbers and dashes
 27 │ test = { features = ["test"], solve-group = "default" }
    ╰────
```

This fixes that issue.