### PR TITLE
docs: fix order of --no-deps when pip installing in editable mode

### DIFF
--- a/docs/advanced/github_actions.md
+++ b/docs/advanced/github_actions.md
@@ -202,7 +202,7 @@ This can be useful if you want to run commands inside of the pixi environment, b
 ```yaml
 - run: | # (1)!
     python --version
-    pip install -e --no-deps .
+    pip install --no-deps -e .
   shell: pixi run bash -e {0}
 ```
 


### PR DESCRIPTION
The current documentation will trigger the following error:

```shell
ERROR: --no-deps is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).
```

In editable mode, `--no-deps` is just required to be before the `-e`.