### PR TITLE
fix: extend path comparison in lockfile satisfiablity

### DIFF
--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -316,7 +316,28 @@ pub fn pypi_satifisfies_requirement(locked_data: &PypiPackageData, spec: &Requir
                     ),
                     UrlOrPath::Path(path) => UrlOrPath::Path(path),
                 };
-                spec_path_or_url == locked_path_or_url
+                match spec_path_or_url {
+                    UrlOrPath::Url(spec_url) => match locked_path_or_url {
+                        UrlOrPath::Url(locked_url) => spec_url == locked_url,
+                        UrlOrPath::Path(path) => {
+                            if spec_url.scheme() == "file" {
+                                PathBuf::from(spec_url.path()) == path
+                            } else {
+                                false
+                            }
+                        }
+                    },
+                    UrlOrPath::Path(spec_path) => match locked_path_or_url {
+                        UrlOrPath::Url(url) => {
+                            if url.scheme() == "file" {
+                                PathBuf::from(url.path()) == spec_path
+                            } else {
+                                false
+                            }
+                        }
+                        UrlOrPath::Path(locked_path) => spec_path == locked_path,
+                    },
+                }
             }
         }
     }

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -827,12 +827,27 @@ mod tests {
     }
 
     #[test]
-    pub fn test_absolute_file_path() {
-        let file_path = if cfg!(windows) {
-            "C:/path/to/my_pkg"
-        } else {
-            "/path/to/my_pkg"
+    pub fn test_absolute_file_path_win() {
+        let file_path = "C:\\path\\to\\my_pkg";
+
+        // Mock locked data with path
+        let locked_data = PypiPackageData {
+            name: "mypkg".parse().unwrap(),
+            version: Version::from_str("0.1.0").unwrap(),
+            url_or_path: UrlOrPath::Path(PathBuf::from(file_path)),
+            hash: None,
+            requires_dist: vec![],
+            requires_python: None,
+            editable: false,
         };
+
+        let spec = Requirement::from_str(&format!("mypkg @ file://{}", file_path)).unwrap();
+        // This should satisfy:
+        assert!(pypi_satifisfies_requirement(&locked_data, &spec));
+    }
+    #[test]
+    pub fn test_absolute_file_path_unix() {
+        let file_path = "/tmp/bla/my_pkg";
 
         // Mock locked data with path
         let locked_data = PypiPackageData {


### PR DESCRIPTION
This was an issue when using path dependencies in pyproject.toml 