### PR TITLE
fix: update to the latest rattler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,8 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.21.0"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c954c00bfef8915def6b043db4d61d4d61a4436c89382915839c4360424a02e"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3447,8 +3448,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.20.5"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4109edd67464a8f43c3a68b031df0f92c8efe89b3d1cf09fdc407cd90abae"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3474,8 +3476,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "0.19.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7143db952a9256f187ec5f69d6289c87d51b73e591cb21c653034b06fb0de7"
 dependencies = [
  "blake2",
  "digest",
@@ -3489,8 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.1"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6c653f0af03d910a09e8c2d2938da6462c1218518760d3c88eddb776221d57"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3511,8 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "0.19.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cef20e8356ea6840294e5754c6a8663b0eb1b97f29d517642f0f99215a2483"
 dependencies = [
  "quote",
  "syn 2.0.60",
@@ -3520,8 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.20.1"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4586c089e479cfb541d81db67cd8b43e0036507ffbf536e1d393e8147aa685c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,8 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.20.3"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4761292a1fb0346ad20a76c81da1261454bf87a4993935506b220429d8e2b63c"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3571,8 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.19.6"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f450d02a301c9da95b6f48d8fe29a921af036bb43553eee0b58b390dba70219"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3609,8 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.19.6"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3d2cc94dc0b26d871688be08bc72d8d24a69cafdf408adf7a1c4dab9dc32e4"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
@@ -3626,8 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.20.5"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ecc29d71862c0b9307a18c8dc8dcddb6042715f26d44085f950426e8b2ef65b"
 dependencies = [
  "chrono",
  "futures",
@@ -3643,8 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.19.6"
-source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0ce73b5939df90e9f968d3d3751e97314bc030bc35ee084e6e292a1e27690a"
 dependencies = [
  "archspec",
  "libloading",
@@ -3985,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3997,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
 dependencies = [
  "cfg-if",
  "glob",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -818,7 +818,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -981,7 +981,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -992,7 +992,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1202,7 +1202,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1235,7 +1235,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1515,7 +1515,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2180,7 +2180,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2423,7 +2423,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2434,7 +2434,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2729,7 +2729,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2808,7 +2808,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2982,7 +2982,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "unicase",
 ]
 
@@ -3013,7 +3013,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3114,7 +3114,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.11",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3261,7 +3261,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "version_check",
  "yansi",
 ]
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.21.0"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3448,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.20.5"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "0.19.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "blake2",
  "digest",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.22.1"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "chrono",
  "fxhash",
@@ -3512,16 +3512,16 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "0.19.2"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "rattler_networking"
 version = "0.20.1"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.20.3"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "bzip2",
  "chrono",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.19.6"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.19.6"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
@@ -3627,7 +3627,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "0.20.5"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "chrono",
  "futures",
@@ -3644,7 +3644,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "0.19.6"
-source = "git+https://github.com/mamba-org/rattler?branch=main#e47528f4ca6eea1885ba7632e3ec976dbb0d056e"
+source = "git+https://github.com/mamba-org/rattler?branch=main#b9ddf52b7697c6b1532527e3bb6bf86b3826a95b"
 dependencies = [
  "archspec",
  "libloading",
@@ -3963,9 +3963,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddb316f4b9cae1a3e89c02f1926d557d1142d0d2e684b038c11c1b77705229a"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -4008,7 +4008,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.59",
+ "syn 2.0.60",
  "unicode-ident",
 ]
 
@@ -4251,7 +4251,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4274,7 +4274,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4325,7 +4325,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4363,7 +4363,7 @@ checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4593,7 +4593,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4642,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4683,9 +4683,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.10"
+version = "0.30.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d7c217777061d5a2d652aea771fb9ba98b6dade657204b08c4b9604d11555b"
+checksum = "87341a165d73787554941cd5ef55ad728011566fe714e987d1b976c15dbc3a83"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -4772,7 +4772,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4863,7 +4863,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4938,7 +4938,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.9",
+ "toml_edit 0.22.11",
 ]
 
 [[package]]
@@ -4963,9 +4963,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "fb686a972ccef8537b39eead3968b0e8616cb5040dbb9bba93007c8e07c9215f"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -5022,7 +5022,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5732,7 +5732,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -5766,7 +5766,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5916,7 +5916,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5927,7 +5927,7 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branc
 # rattler = { path = "../rattler/crates/rattler" }
 
 # Change these lines if you want a patched version of uv
-[patch.'https://github.com/astral-sh/uv']
+# [patch.'https://github.com/astral-sh/uv']
 # pep440_rs = { git = "https://github.com/wolfv/uv", branch = "expose-yanks" }
 # pep508_rs = { git = "https://github.com/wolfv/uv", branch = "expose-yanks" }
 # uv-build = { git = "https://github.com/wolfv/uv", tag = "expose-yanks" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ slow_integration_tests = []
 assert_matches = "1.5.0"
 async-once-cell = "0.5.3"
 cfg-if = "1.0"
-chrono = "0.4.37"
+chrono = "0.4.38"
 clap = { version = "4.5.4", default-features = false, features = [
     "derive",
     "usage",
@@ -39,7 +39,7 @@ clap = { version = "4.5.4", default-features = false, features = [
     "env",
 ] }
 clap-verbosity-flag = "2.2.0"
-clap_complete = "4.5.1"
+clap_complete = "4.5.2"
 console = { version = "0.15.8", features = ["windows-console-colors"] }
 crossbeam-channel = "0.5.12"
 deno_task_shell = "0.16.0"
@@ -69,44 +69,44 @@ miette = { version = "7.2.0", features = [
     "terminal_size",
     "textwrap",
 ] }
-minijinja = { version = "1.0.16", features = ["builtins"] }
+minijinja = { version = "1.0.20", features = ["builtins"] }
 once_cell = "1.19.0"
 pep440_rs = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 pep508_rs = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 pyproject-toml = "0.10.0"
-rattler = { version = "0.21.0", default-features = false, features = [
+rattler = { version = "0.22.0", default-features = false, features = [
     "cli-tools",
 ] }
-rattler_conda_types = { version = "0.20.4", default-features = false }
-rattler_digest = { version = "0.19.2", default-features = false }
-rattler_lock = { version = "0.22.0", default-features = false }
-rattler_networking = { version = "0.20.0", default-features = false }
-rattler_repodata_gateway = { version = "0.19.5", default-features = false, features = [
+rattler_conda_types = { version = "0.21.0", default-features = false }
+rattler_digest = { version = "0.19.3", default-features = false }
+rattler_lock = { version = "0.22.2", default-features = false }
+rattler_networking = { version = "0.20.2", default-features = false }
+rattler_repodata_gateway = { version = "0.19.7", default-features = false, features = [
     "sparse",
 ] }
-rattler_shell = { version = "0.19.5", default-features = false, features = [
+rattler_shell = { version = "0.20.0", default-features = false, features = [
     "sysinfo",
 ] }
-rattler_solve = { version = "0.20.4", default-features = false, features = [
+rattler_solve = { version = "0.20.6", default-features = false, features = [
     "resolvo",
 ] }
-rattler_virtual_packages = { version = "0.19.5", default-features = false }
+rattler_virtual_packages = { version = "0.19.7", default-features = false }
 regex = "1.10.4"
 requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 reqwest = { version = "0.12.3", default-features = false }
 reqwest-middleware = "0.3.0"
 reqwest-retry = "0.5.0"
 self-replace = "1.3.7"
-serde = "1.0.197"
+serde = "1.0.198"
 serde-untagged = "0.1.5"
-serde_json = "1.0.115"
+serde_json = "1.0.116"
 serde_with = { version = "3.7.0", features = ["indexmap"] }
 serde_yaml = "0.9.34"
 shlex = "1.3.0"
 spdx = "0.10.4"
-strsim = "0.11.0"
+strsim = "0.11.1"
 tabwriter = { version = "1.4.0", features = ["ansi_formatting"] }
 tar = "0.4.40"
 tempfile = "3.10.1"
@@ -117,7 +117,7 @@ tokio = { version = "1.37.0", features = [
     "signal",
 ] }
 tokio-util = "0.7.10"
-toml_edit = { version = "0.22.9", features = ["serde"] }
+toml_edit = { version = "0.22.11", features = ["serde"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.0"
@@ -151,9 +151,9 @@ signal-hook = "0.3.17"
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["yaml", "glob"] }
-rattler_digest = "0.19.2"
-rstest = "0.18.2"
-serde_json = "1.0.115"
+rattler_digest = "0.19.3"
+rstest = "0.19.0"
+serde_json = "1.0.116"
 serial_test = "3.0.0"
 tokio = { version = "1.37.0", features = ["rt"] }
 toml = "0.8.12"
@@ -164,15 +164,15 @@ toml = "0.8.12"
 pep440_rs = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 pep508_rs = { git = "https://github.com/astral-sh/uv", tag = "0.1.32" }
 # deno_task_shell = { path = "../deno_task_shell" }
-rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_lock = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
-rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_conda_types = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_digest = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_lock = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_networking = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_repodata_gateway = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_shell = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_solve = { git = "https://github.com/mamba-org/rattler", branch = "main" }
+# rattler_virtual_packages = { git = "https://github.com/mamba-org/rattler", branch = "main" }
 # rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }
 # rattler_digest = { path = "../rattler/crates/rattler_digest" }
 # rattler_networking = { path = "../rattler/crates/rattler_networking" }

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -62,18 +62,9 @@ fn create_activation_script(prefix: &Prefix, shell: ShellEnum) -> miette::Result
 
     // Add a shebang on unix based platforms
     let script = if cfg!(unix) {
-        format!(
-            "#!/bin/sh\n{}",
-            result
-                .script
-                .contents()
-                .expect("Could not format the script")
-        )
+        format!("#!/bin/sh\n{}", result.script.contents().into_diagnostic()?)
     } else {
-        result
-            .script
-            .contents()
-            .expect("Could not format the script")
+        result.script.contents().into_diagnostic()?
     };
 
     Ok(script)

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -62,9 +62,18 @@ fn create_activation_script(prefix: &Prefix, shell: ShellEnum) -> miette::Result
 
     // Add a shebang on unix based platforms
     let script = if cfg!(unix) {
-        format!("#!/bin/sh\n{}", result.script)
+        format!(
+            "#!/bin/sh\n{}",
+            result
+                .script
+                .contents()
+                .expect("Could not format the script")
+        )
     } else {
-        result.script
+        result
+            .script
+            .contents()
+            .expect("Could not format the script")
     };
 
     Ok(script)

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
-use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform, RepoDataRecord};
+use rattler_conda_types::{Channel, PackageName, Platform, RepoDataRecord};
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use regex::Regex;
 
@@ -14,6 +14,7 @@ use strsim::jaro;
 use tokio::task::spawn_blocking;
 
 use crate::config::Config;
+use crate::util::default_channel_config;
 use crate::utils::reqwest::build_reqwest_clients;
 use crate::{progress::await_in_progress, repodata::fetch_sparse_repodata, Project};
 
@@ -402,7 +403,7 @@ fn print_matching_packages<W: Write>(
         (packages, &[][..])
     };
 
-    let channel_config = ChannelConfig::default();
+    let channel_config = default_channel_config();
     for package in packages {
         // TODO: change channel fetch logic to be more robust
         // currently it relies on channel field being a url with trailing slash

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -61,10 +61,7 @@ async fn generate_activation_script(
         })
         .into_diagnostic()?;
 
-    Ok(result
-        .script
-        .contents()
-        .expect("Could not format the script"))
+    Ok(result.script.contents().into_diagnostic()?)
 }
 
 /// Prints the activation script to the stdout.

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -61,7 +61,10 @@ async fn generate_activation_script(
         })
         .into_diagnostic()?;
 
-    Ok(result.script)
+    Ok(result
+        .script
+        .contents()
+        .expect("Could not format the script"))
 }
 
 /// Prints the activation script to the stdout.

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -61,7 +61,7 @@ async fn generate_activation_script(
         })
         .into_diagnostic()?;
 
-    Ok(result.script.contents().into_diagnostic()?)
+    result.script.contents().into_diagnostic()
 }
 
 /// Prints the activation script to the stdout.

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use std::process::{Command, Stdio};
 use url::Url;
 
 use crate::consts;
+use crate::util::default_channel_config;
 
 /// Determines the default author based on the default git author. Both the name and the email
 /// address of the author are returned.
@@ -112,7 +113,7 @@ pub struct RepodataConfig {
     pub disable_zstd: Option<bool>,
 }
 
-#[derive(Clone, Default, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub default_channels: Vec<String>,
@@ -135,11 +136,26 @@ pub struct Config {
     #[serde(skip)]
     pub loaded_from: Vec<PathBuf>,
 
-    #[serde(skip)]
+    #[serde(skip, default = "default_channel_config")]
     pub channel_config: ChannelConfig,
 
     /// Configuration for repodata fetching.
     pub repodata_config: Option<RepodataConfig>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            default_channels: Vec::new(),
+            change_ps1: None,
+            authentication_override_file: None,
+            tls_no_verify: None,
+            mirrors: HashMap::new(),
+            loaded_from: Vec::new(),
+            channel_config: default_channel_config(),
+            repodata_config: None,
+        }
+    }
 }
 
 impl From<ConfigCli> for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,8 +269,8 @@ impl Config {
                 .or(self.authentication_override_file),
             mirrors: self.mirrors,
             loaded_from: self.loaded_from,
-            // currently this is always the default so just use the current value
-            channel_config: self.channel_config,
+            // currently this is always the default so just use the other value
+            channel_config: other.channel_config,
             repodata_config: other.repodata_config.or(self.repodata_config),
         }
     }
@@ -369,6 +369,7 @@ mod tests {
         let mut config = Config::default();
         let other = Config {
             default_channels: vec!["conda-forge".to_string()],
+            channel_config: ChannelConfig::default_with_root_dir(PathBuf::from("/root/dir")),
             tls_no_verify: Some(true),
             ..Default::default()
         };
@@ -382,6 +383,10 @@ mod tests {
 
         let config_1 = Config::from_path(&d.join("config_1.toml")).unwrap();
         let config_2 = Config::from_path(&d.join("config_2.toml")).unwrap();
+        let config_2 = Config {
+            channel_config: ChannelConfig::default_with_root_dir(PathBuf::from("/root/dir")),
+            ..config_2
+        };
 
         let mut merged = config_1.clone();
         merged = merged.merge_config(config_2);

--- a/src/install.rs
+++ b/src/install.rs
@@ -12,6 +12,7 @@ use rattler::install::{
     link_package, unlink_package, InstallDriver, InstallOptions, Transaction, TransactionOperation,
 };
 use rattler::package_cache::PackageCache;
+use rattler_conda_types::prefix_record::{Link, LinkType};
 use rattler_conda_types::{PrefixRecord, RepoDataRecord};
 use reqwest_middleware::ClientWithMiddleware;
 use std::cmp::Ordering;
@@ -285,7 +286,7 @@ async fn install_package_to_environment(
     let prefix_record = PrefixRecord {
         repodata_record,
         package_tarball_full_path: None,
-        extracted_package_dir: Some(package_dir),
+        extracted_package_dir: Some(package_dir.clone()),
         files: paths
             .iter()
             .map(|entry| entry.relative_path.clone())
@@ -293,8 +294,10 @@ async fn install_package_to_environment(
         paths_data: paths.into(),
         // TODO: Retrieve the requested spec for this package from the request
         requested_spec: None,
-        // TODO: What to do with this?
-        link: None,
+        link: Some(Link {
+            source: package_dir,
+            link_type: Some(LinkType::HardLink),
+        }),
     };
 
     // Create the conda-meta directory if it doesn't exist yet.

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -1,9 +1,9 @@
 use miette::{miette, Report};
-use rattler_conda_types::{ChannelConfig, NamelessMatchSpec, PackageName, Platform};
+use rattler_conda_types::{NamelessMatchSpec, PackageName, Platform};
 use std::{fmt, path::Path};
 use toml_edit::{value, Array, InlineTable, Item, Table, Value};
 
-use crate::{consts, FeatureName, SpecType, Task};
+use crate::{consts, util::default_channel_config, FeatureName, SpecType, Task};
 
 use super::{python::PyPiPackageName, PyPiRequirement};
 
@@ -380,7 +380,7 @@ fn nameless_match_spec_to_toml(spec: &NamelessMatchSpec) -> Value {
             if let Some(channel) = channel {
                 table.insert(
                     "channel",
-                    ChannelConfig::default()
+                    default_channel_config()
                         .canonical_name(channel.base_url())
                         .as_str()
                         .into(),

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -17,6 +17,7 @@ use crate::project::manifest::environment::TomlEnvironmentMapOrSeq;
 use crate::project::manifest::python::PyPiPackageName;
 use crate::pypi_mapping::{ChannelName, MappingLocation, MappingSource};
 use crate::task::TaskName;
+use crate::util::default_channel_config;
 use crate::{consts, project::SpecType, task::Task, utils::spanned::PixiSpanned};
 pub use activation::Activation;
 use document::ManifestSource;
@@ -32,7 +33,7 @@ use pyproject::PyProjectManifest;
 pub use python::PyPiRequirement;
 use rattler_conda_types::Channel;
 use rattler_conda_types::{
-    ChannelConfig, MatchSpec, NamelessMatchSpec, PackageName,
+    MatchSpec, NamelessMatchSpec, PackageName,
     ParseStrictness::{Lenient, Strict},
     Platform, Version,
 };
@@ -567,7 +568,7 @@ impl Manifest {
                         .channel
                         .base_url
                         .as_str()
-                        .contains(ChannelConfig::default().channel_alias.as_str())
+                        .contains(default_channel_config().channel_alias.as_str())
                     {
                         stored_channels.insert(channel.channel.name().to_string());
                     } else {
@@ -1173,6 +1174,10 @@ mod tests {
         channels = []
         platforms = ["linux-64", "win-64", "osx-64"]
         "#;
+
+    fn channel_config() -> ChannelConfig {
+        ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+    }
 
     #[test]
     fn test_from_path() {
@@ -1941,7 +1946,7 @@ platforms = ["linux-64", "win-64"]
         assert_eq!(manifest.parsed.project.channels, vec![]);
 
         let conda_forge = PrioritizedChannel::from_channel(
-            Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+            Channel::from_str("conda-forge", &channel_config()).unwrap(),
         );
         manifest
             .add_channels([conda_forge.clone()], &FeatureName::Default)
@@ -1949,7 +1954,7 @@ platforms = ["linux-64", "win-64"]
 
         let cuda_feature = FeatureName::Named("cuda".to_string());
         let nvidia = PrioritizedChannel::from_channel(
-            Channel::from_str("nvidia", &ChannelConfig::default()).unwrap(),
+            Channel::from_str("nvidia", &channel_config()).unwrap(),
         );
         manifest
             .add_channels([nvidia.clone()], &cuda_feature)
@@ -1960,10 +1965,10 @@ platforms = ["linux-64", "win-64"]
             .add_channels(
                 [
                     PrioritizedChannel::from_channel(
-                        Channel::from_str("test", &ChannelConfig::default()).unwrap(),
+                        Channel::from_str("test", &channel_config()).unwrap(),
                     ),
                     PrioritizedChannel::from_channel(
-                        Channel::from_str("test2", &ChannelConfig::default()).unwrap(),
+                        Channel::from_str("test2", &channel_config()).unwrap(),
                     ),
                 ],
                 &test_feature,
@@ -1973,7 +1978,7 @@ platforms = ["linux-64", "win-64"]
         assert_eq!(
             manifest.parsed.project.channels,
             vec![PrioritizedChannel {
-                channel: Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+                channel: Channel::from_str("conda-forge", &channel_config()).unwrap(),
                 priority: None
             }]
         );
@@ -1986,7 +1991,7 @@ platforms = ["linux-64", "win-64"]
         assert_eq!(
             manifest.parsed.project.channels,
             vec![PrioritizedChannel {
-                channel: Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+                channel: Channel::from_str("conda-forge", &channel_config()).unwrap(),
                 priority: None
             }]
         );
@@ -2001,7 +2006,7 @@ platforms = ["linux-64", "win-64"]
                 .clone()
                 .unwrap(),
             vec![PrioritizedChannel {
-                channel: Channel::from_str("nvidia", &ChannelConfig::default()).unwrap(),
+                channel: Channel::from_str("nvidia", &channel_config()).unwrap(),
                 priority: None
             }]
         );
@@ -2019,7 +2024,7 @@ platforms = ["linux-64", "win-64"]
                 .clone()
                 .unwrap(),
             vec![PrioritizedChannel {
-                channel: Channel::from_str("nvidia", &ChannelConfig::default()).unwrap(),
+                channel: Channel::from_str("nvidia", &channel_config()).unwrap(),
                 priority: None
             }]
         );
@@ -2035,11 +2040,11 @@ platforms = ["linux-64", "win-64"]
                 .unwrap(),
             vec![
                 PrioritizedChannel {
-                    channel: Channel::from_str("test", &ChannelConfig::default()).unwrap(),
+                    channel: Channel::from_str("test", &channel_config()).unwrap(),
                     priority: None
                 },
                 PrioritizedChannel {
-                    channel: Channel::from_str("test2", &ChannelConfig::default()).unwrap(),
+                    channel: Channel::from_str("test2", &channel_config()).unwrap(),
                     priority: None
                 }
             ]
@@ -2047,8 +2052,7 @@ platforms = ["linux-64", "win-64"]
 
         // Test custom channel urls
         let custom_channel = PrioritizedChannel {
-            channel: Channel::from_str("https://custom.com/channel", &ChannelConfig::default())
-                .unwrap(),
+            channel: Channel::from_str("https://custom.com/channel", &channel_config()).unwrap(),
             priority: None,
         };
         manifest
@@ -2084,14 +2088,14 @@ platforms = ["linux-64", "win-64"]
         assert_eq!(
             manifest.parsed.project.channels,
             vec![PrioritizedChannel::from_channel(
-                Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap()
+                Channel::from_str("conda-forge", &channel_config()).unwrap()
             )]
         );
 
         manifest
             .remove_channels(
                 [PrioritizedChannel {
-                    channel: Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+                    channel: Channel::from_str("conda-forge", &channel_config()).unwrap(),
                     priority: None,
                 }],
                 &FeatureName::Default,
@@ -2103,7 +2107,7 @@ platforms = ["linux-64", "win-64"]
         manifest
             .remove_channels(
                 [PrioritizedChannel {
-                    channel: Channel::from_str("test_channel", &ChannelConfig::default()).unwrap(),
+                    channel: Channel::from_str("test_channel", &channel_config()).unwrap(),
                     priority: None,
                 }],
                 &FeatureName::Named("test".to_string()),
@@ -2293,11 +2297,11 @@ platforms = ["linux-64", "win-64"]
                 .collect::<Vec<_>>(),
             vec![
                 &PrioritizedChannel {
-                    channel: Channel::from_str("pytorch", &ChannelConfig::default()).unwrap(),
+                    channel: Channel::from_str("pytorch", &channel_config()).unwrap(),
                     priority: None
                 },
                 &PrioritizedChannel {
-                    channel: Channel::from_str("nvidia", &ChannelConfig::default()).unwrap(),
+                    channel: Channel::from_str("nvidia", &channel_config()).unwrap(),
                     priority: Some(-1)
                 }
             ]

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -1176,7 +1176,7 @@ mod tests {
         "#;
 
     fn channel_config() -> ChannelConfig {
-        ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+        default_channel_config()
     }
 
     #[test]

--- a/src/snapshots/pixi__config__tests__config_merge.snap
+++ b/src/snapshots/pixi__config__tests__config_merge.snap
@@ -36,6 +36,7 @@ Config {
             query: None,
             fragment: None,
         },
+        root_dir: "/root/dir",
     },
     repodata_config: Some(
         RepodataConfig {

--- a/src/util.rs
+++ b/src/util.rs
@@ -33,7 +33,7 @@ impl<'a> MakeWriter<'a> for IndicatifWriter {
 }
 
 pub fn default_channel_config() -> ChannelConfig {
-    return ChannelConfig::default_with_root_dir(
+    ChannelConfig::default_with_root_dir(
         std::env::current_dir().expect("Could not retrieve the current directory"),
-    );
+    )
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use indicatif::MultiProgress;
+use rattler_conda_types::ChannelConfig;
 use std::io;
 use tracing_subscriber::fmt::MakeWriter;
 
@@ -29,4 +30,10 @@ impl<'a> MakeWriter<'a> for IndicatifWriter {
     fn make_writer(&'a self) -> Self::Writer {
         self.clone()
     }
+}
+
+pub fn default_channel_config() -> ChannelConfig {
+    return ChannelConfig::default_with_root_dir(
+        std::env::current_dir().expect("Could not retrieve the current directory"),
+    );
 }

--- a/tests/init_tests.rs
+++ b/tests/init_tests.rs
@@ -1,7 +1,8 @@
 mod common;
 
 use crate::common::PixiControl;
-use rattler_conda_types::{Channel, ChannelConfig, Version};
+use pixi::util::default_channel_config;
+use rattler_conda_types::{Channel, Version};
 use std::str::FromStr;
 
 #[tokio::test]
@@ -50,8 +51,8 @@ async fn specific_channel() {
     assert_eq!(
         channels,
         [
-            &Channel::from_str("random", &ChannelConfig::default()).unwrap(),
-            &Channel::from_str("foobar", &ChannelConfig::default()).unwrap()
+            &Channel::from_str("random", &default_channel_config()).unwrap(),
+            &Channel::from_str("foobar", &default_channel_config()).unwrap()
         ]
     )
 }
@@ -71,6 +72,6 @@ async fn default_channel() {
     let channels = Vec::from_iter(project.channels());
     assert_eq!(
         channels,
-        [&Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap()]
+        [&Channel::from_str("conda-forge", &default_channel_config()).unwrap()]
     )
 }

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use crate::{common::package_database::PackageDatabase, common::PixiControl};
 use insta::assert_debug_snapshot;
-use pixi::Project;
-use rattler_conda_types::{Channel, ChannelConfig, Platform};
+use pixi::{util::default_channel_config, Project};
+use rattler_conda_types::{Channel, Platform};
 use tempfile::TempDir;
 use url::Url;
 
@@ -44,7 +44,7 @@ async fn add_channel() {
     // Our channel should be in the list of channels
     let local_channel = Channel::from_str(
         Url::from_directory_path(additional_channel_dir.path()).unwrap(),
-        &ChannelConfig::default(),
+        &default_channel_config(),
     )
     .unwrap();
     assert!(project.channels().contains(&local_channel));


### PR DESCRIPTION
This fixes a few issues:

- #1189 
- Entrypoints for prefix with a space in the path should work better on Windows (e.g. when installing noarch python packages such as flask, it wasn't working before). For example if you create a pixi env in `C:\path\to\spacey project\`, then `pixi run flask` should work without issues now
- #1229 
- I tried to fix #1159 but haven't wired it up yet (basically the previous behavior is still there). I need to take another look at how we deserialize the channels, because we cannot inject any configuration into the deserializer (at least not without going through some global static variables). 