### PR TITLE
fix: use `home_path()` in self-update location check

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -10,6 +10,8 @@ use miette::{Context, IntoDiagnostic};
 use reqwest::Client;
 use serde::Deserialize;
 
+use crate::config::home_path;
+
 /// Update pixi to the latest version or a specific version. If the pixi binary is not found in the default location
 /// (e.g. `~/.pixi/bin/pixi`), pixi won't updated to prevent breaking the current installation (Homebrew, etc).
 /// The behaviour can be overridden with the `--force` flag.
@@ -240,9 +242,8 @@ fn pixi_binary_name() -> String {
 }
 
 fn default_pixi_binary_path() -> std::path::PathBuf {
-    dirs::home_dir()
+    home_path()
         .expect("Could not find the home directory")
-        .join(".pixi")
         .join("bin")
         .join(pixi_binary_name())
 }


### PR DESCRIPTION
Since `install.sh` installs to `$PIXI_HOME/bin/pixi`, I think it's reasonable for `pixi self-update` to match the installer's logic for determining the "default pixi binary path".