### PR TITLE
fix: improve parse deno error and make task a required field in the cli

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -34,6 +34,7 @@ use tracing::Level;
 #[clap(trailing_var_arg = true, arg_required_else_help = true)]
 pub struct Args {
     /// The task you want to run in the projects environment.
+    #[arg(required = true)]
     pub task: Vec<String>,
 
     /// The path to 'pixi.toml' or 'pyproject.toml'

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -32,7 +32,7 @@ pub struct RunOutput {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("deno task shell failed to parse '{script}': {error}")]
+#[error("The task failed to parse. task: '{script}' error: '{error}'")]
 pub struct FailedToParseShellScript {
     pub script: String,
     pub error: String,
@@ -139,7 +139,13 @@ impl<'p> ExecutableTask<'p> {
 
         // Append the command line arguments
         let cli_args = quote_arguments(self.additional_args.iter().map(|arg| arg.as_str()));
-        let full_script = format!("{export}\n{task} {cli_args}");
+
+        // Skip the export if it's empty, to avoid newlines
+        let full_script = if export.is_empty() {
+            format!("{task} {cli_args}")
+        } else {
+            format!("{export}\n{task} {cli_args}")
+        };
 
         // Parse the shell command
         deno_task_shell::parser::parse(full_script.trim())


### PR DESCRIPTION
Fixes #1256 

Note this does error now on `pixi run -e docs` as we had a requirement to set any option but we meant to say that you need to set a task. This is in theory breaking but it was wrong in my opinion.