### PR TITLE
fix: Avoid creating Empty TOML tables

### DIFF
--- a/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_bar.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_bar.snap
@@ -2,7 +2,6 @@
 source: src/project/manifest/mod.rs
 expression: manifest.document.to_string()
 ---
-
             [project]
             name = "foo"
             version = "0.1.0"
@@ -12,8 +11,5 @@ expression: manifest.document.to_string()
             [dependencies]
             fooz = "*"
 
-            [target.win-64.dependencies]
-
             [target.linux-64.build-dependencies]
             baz = "*"
-        

--- a/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_baz.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_baz.snap
@@ -2,7 +2,6 @@
 source: src/project/manifest/mod.rs
 expression: manifest.document.to_string()
 ---
-
             [project]
             name = "foo"
             version = "0.1.0"
@@ -14,6 +13,3 @@ expression: manifest.document.to_string()
 
             [target.win-64.dependencies]
             bar = "*"
-
-            [target.linux-64.build-dependencies]
-        

--- a/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_fooz.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_fooz.snap
@@ -2,18 +2,14 @@
 source: src/project/manifest/mod.rs
 expression: manifest.document.to_string()
 ---
-
             [project]
             name = "foo"
             version = "0.1.0"
             channels = []
             platforms = ["linux-64", "win-64"]
 
-            [dependencies]
-
             [target.win-64.dependencies]
             bar = "*"
 
             [target.linux-64.build-dependencies]
             baz = "*"
-        

--- a/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_pypi_feature_dep.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_pypi_feature_dep.snap
@@ -22,8 +22,5 @@ requests = "*"
 xpackage = "==1.2.3"
 ypackage = {version = ">=1.2.3"}
 
-[feature.test.pypi-dependencies]
-
 [feature.test.target.linux-64.pypi-dependencies]
 feature_target_dep = "*"
-

--- a/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_pypi_feature_target_dep.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_pypi_feature_target_dep.snap
@@ -24,6 +24,3 @@ ypackage = {version = ">=1.2.3"}
 
 [feature.test.pypi-dependencies]
 feature_dep = "*"
-
-[feature.test.target.linux-64.pypi-dependencies]
-

--- a/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_pypi_requests.snap
+++ b/src/project/manifest/snapshots/pixi__project__manifest__tests__test_remove_pypi_requests.snap
@@ -11,8 +11,6 @@ platforms = ["linux-64", "win-64"]
 [dependencies]
 python = ">=3.12.1,<3.13"
 
-[pypi-dependencies]
-
 [target.win-64.pypi-dependencies]
 jax = { version = "*", extras = ["cpu"] }
 requests = "*"
@@ -26,4 +24,3 @@ feature_dep = "*"
 
 [feature.test.target.linux-64.pypi-dependencies]
 feature_target_dep = "*"
-


### PR DESCRIPTION
Currently, pixi can create, or leave behind, empty tables in the TOML manifest.

This PR avoids that