### PR TITLE
fix: test with the correct version

### DIFF
--- a/examples/pypi-source-deps/test/test_imports.py
+++ b/examples/pypi-source-deps/test/test_imports.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version
 
 def test_flask():
-    assert version("flask") == "3.0.2"
+    assert version("flask") == "3.1.0.dev0"
 
 def test_rich():
     assert version("rich").split(".")[0] == "13"


### PR DESCRIPTION
Seems like the lock-file was regenerated for the `pypi-source-deps` example, but was never really updated :)

