### PR TITLE
refactor: Use generics over PyPiDependencies and CondaDependencies

### DIFF
--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -365,8 +365,7 @@ pub fn verify_package_platform_satisfiability(
     // Determine the dependencies requested by the environment
     let conda_specs = environment
         .dependencies(None, Some(platform))
-        .into_specs()
-        .map(move |(name, spec)| MatchSpec::from_nameless(spec, Some(name.clone())))
+        .into_match_specs()
         .map(|spec| Dependency::Conda(spec, "<environment>".into()))
         .collect_vec();
 

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -365,7 +365,8 @@ pub fn verify_package_platform_satisfiability(
     // Determine the dependencies requested by the environment
     let conda_specs = environment
         .dependencies(None, Some(platform))
-        .into_match_specs()
+        .into_specs()
+        .map(move |(name, spec)| MatchSpec::from_nameless(spec, Some(name.clone())))
         .map(|spec| Dependency::Conda(spec, "<environment>".into()))
         .collect_vec();
 

--- a/src/project/dependencies.rs
+++ b/src/project/dependencies.rs
@@ -1,6 +1,6 @@
 use indexmap::{Equivalent, IndexMap, IndexSet};
 use itertools::Either;
-use rattler_conda_types::{NamelessMatchSpec, PackageName};
+use rattler_conda_types::{MatchSpec, NamelessMatchSpec, PackageName};
 use std::{borrow::Cow, hash::Hash};
 
 use super::manifest::{python::PyPiPackageName, PyPiRequirement};
@@ -117,5 +117,16 @@ impl<N: Hash + Eq + Clone, D: Hash + Eq + Clone> Dependencies<N, D> {
         self.map
             .into_iter()
             .flat_map(|(name, specs)| specs.into_iter().map(move |spec| (name.clone(), spec)))
+    }
+}
+
+impl Dependencies<PackageName, NamelessMatchSpec> {
+    /// Converts this instance into an iterator of [`MatchSpec`]s.
+    pub fn into_match_specs(self) -> impl DoubleEndedIterator<Item = MatchSpec> {
+        self.map.into_iter().flat_map(|(name, specs)| {
+            specs
+                .into_iter()
+                .map(move |spec| MatchSpec::from_nameless(spec, Some(name.clone())))
+        })
     }
 }

--- a/src/project/dependencies.rs
+++ b/src/project/dependencies.rs
@@ -1,77 +1,88 @@
 use indexmap::{Equivalent, IndexMap, IndexSet};
-use rattler_conda_types::{MatchSpec, NamelessMatchSpec, PackageName};
-use std::{hash::Hash, iter::once};
+use itertools::Either;
+use rattler_conda_types::{NamelessMatchSpec, PackageName};
+use std::{borrow::Cow, hash::Hash};
+
+use super::manifest::{python::PyPiPackageName, PyPiRequirement};
+
+pub type PyPiDependencies = Dependencies<PyPiPackageName, PyPiRequirement>;
+pub type CondaDependencies = Dependencies<PackageName, NamelessMatchSpec>;
 
 /// Holds a list of dependencies where for each package name there can be multiple requirements.
 ///
 /// This is used when combining the dependencies of multiple features. Although each target can only
 /// have one requirement for a given package, when combining the dependencies of multiple features
 /// there can be multiple requirements for a given package.
-#[derive(Default, Debug, Clone)]
-pub struct Dependencies {
-    map: IndexMap<PackageName, IndexSet<NamelessMatchSpec>>,
+///
+/// The generic 'Dependencies' struct is aliased as specific PyPiDependencies and CondaDependencies struct to represent
+/// Pypi and Conda dependencies respectively.
+
+#[derive(Debug, Clone)]
+pub struct Dependencies<N: Hash + Eq + Clone, D: Hash + Eq + Clone> {
+    map: IndexMap<N, IndexSet<D>>,
 }
 
-impl From<IndexMap<PackageName, IndexSet<NamelessMatchSpec>>> for Dependencies {
-    fn from(map: IndexMap<PackageName, IndexSet<NamelessMatchSpec>>) -> Self {
-        Self { map }
-    }
-}
-
-impl From<IndexMap<PackageName, NamelessMatchSpec>> for Dependencies {
-    fn from(map: IndexMap<PackageName, NamelessMatchSpec>) -> Self {
-        Self {
-            map: map
-                .into_iter()
-                .map(|(k, v)| (k, once(v).collect()))
-                .collect(),
+impl<N: Hash + Eq + Clone, D: Hash + Eq + Clone> Default for Dependencies<N, D> {
+    fn default() -> Self {
+        Dependencies {
+            map: IndexMap::new(),
         }
     }
 }
 
-impl Dependencies {
-    /// Adds the given spec to the list of dependencies.
-    pub fn insert(&mut self, name: PackageName, spec: NamelessMatchSpec) {
+impl<N: Hash + Eq + Clone, D: Hash + Eq + Clone> IntoIterator for Dependencies<N, D> {
+    type Item = (N, IndexSet<D>);
+    type IntoIter = indexmap::map::IntoIter<N, IndexSet<D>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a, M, N: Hash + Eq + Clone + 'a, D: Hash + Eq + Clone + 'a> From<M> for Dependencies<N, D>
+where
+    M: IntoIterator<Item = Cow<'a, IndexMap<N, D>>>,
+{
+    /// Create Dependencies<N, D> from an iterator over items of type Cow<'a, IndexMap<N, D>
+    fn from(m: M) -> Self {
+        m.into_iter().fold(Self::default(), |mut acc: Self, deps| {
+            // Either clone the values from the Cow or move the values from the owned map.
+            let deps_iter = match deps {
+                Cow::Borrowed(borrowed) => Either::Left(
+                    borrowed
+                        .into_iter()
+                        .map(|(name, spec)| (name.clone(), spec.clone())),
+                ),
+                Cow::Owned(owned) => Either::Right(owned.into_iter()),
+            };
+
+            // Add the requirements to the accumulator.
+            for (name, spec) in deps_iter {
+                acc.insert(name, spec);
+            }
+
+            acc
+        })
+    }
+}
+
+impl<N: Hash + Eq + Clone, D: Hash + Eq + Clone> Dependencies<N, D> {
+    /// Adds a requirement to the list of dependencies.
+    pub fn insert(&mut self, name: N, spec: D) {
         self.map.entry(name).or_default().insert(spec);
     }
 
-    /// Adds a list of specs to the list of dependencies.
-    pub fn extend(&mut self, iter: impl IntoIterator<Item = (PackageName, NamelessMatchSpec)>) {
-        for (name, spec) in iter {
-            self.insert(name, spec);
-        }
+    /// Check if there is any dependency
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
     }
 
-    /// Adds a list of specs to the list of dependencies overwriting any existing requirements for
-    /// packages that already exist in the list of dependencies.
-    pub fn extend_overwrite(
-        &mut self,
-        iter: impl IntoIterator<Item = (PackageName, NamelessMatchSpec)>,
-    ) {
-        for (name, spec) in iter {
-            *self.map.entry(name).or_default() = once(spec).collect();
-        }
-    }
-
-    /// Removes all requirements for the given package and returns them.
-    pub fn remove<Q: ?Sized>(
-        &mut self,
-        name: &Q,
-    ) -> Option<(PackageName, IndexSet<NamelessMatchSpec>)>
+    /// Removes a specific dependency
+    pub fn remove<Q: ?Sized>(&mut self, name: &Q) -> Option<(N, IndexSet<D>)>
     where
-        Q: Hash + Equivalent<PackageName>,
+        Q: Hash + Equivalent<N>,
     {
         self.map.shift_remove_entry(name)
-    }
-
-    /// Combine two sets of dependencies together where the requirements of `self` are extended if
-    /// the same package is also defined in `other`.
-    pub fn union(&self, other: &Self) -> Self {
-        let mut map = self.map.clone();
-        for (name, specs) in &other.map {
-            map.entry(name.clone()).or_default().extend(specs.clone())
-        }
-        Self { map }
     }
 
     /// Combines two sets of dependencies where the requirements of `self` are overwritten if the
@@ -84,49 +95,27 @@ impl Dependencies {
         Self { map }
     }
 
-    /// Returns an iterator over the package names and their corresponding requirements.
-    pub fn iter(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (&PackageName, &IndexSet<NamelessMatchSpec>)> + '_ {
+    /// Returns an iterator over tuples of dependency names and their combined requirements.
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&N, &IndexSet<D>)> + '_ {
         self.map.iter()
     }
 
-    /// Returns an iterator over all the requirements.
-    pub fn iter_specs(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = (&PackageName, &NamelessMatchSpec)> + '_ {
+    /// Returns an iterator over tuples of dependency names and individual requirements.
+    pub fn iter_specs(&self) -> impl DoubleEndedIterator<Item = (&N, &D)> + '_ {
         self.map
             .iter()
             .flat_map(|(name, specs)| specs.iter().map(move |spec| (name, spec)))
     }
 
-    /// Returns the names of all the packages that have requirements.
-    pub fn names(&self) -> impl DoubleEndedIterator<Item = &PackageName> + ExactSizeIterator + '_ {
+    /// Return an iterator over the dependency names.
+    pub fn names(&self) -> impl DoubleEndedIterator<Item = &N> + ExactSizeIterator + '_ {
         self.map.keys()
     }
 
-    /// Convert this instance into an iterator over the package names and their corresponding
-    pub fn into_specs(self) -> impl DoubleEndedIterator<Item = (PackageName, NamelessMatchSpec)> {
+    /// Converts this instance into an iterator over tuples of dependency names and individual requirements.
+    pub fn into_specs(self) -> impl DoubleEndedIterator<Item = (N, D)> {
         self.map
             .into_iter()
             .flat_map(|(name, specs)| specs.into_iter().map(move |spec| (name.clone(), spec)))
-    }
-
-    /// Converts this instance into an iterator of [`MatchSpec`]s.
-    pub fn into_match_specs(self) -> impl DoubleEndedIterator<Item = MatchSpec> {
-        self.map.into_iter().flat_map(|(name, specs)| {
-            specs
-                .into_iter()
-                .map(move |spec| MatchSpec::from_nameless(spec, Some(name.clone())))
-        })
-    }
-}
-
-impl IntoIterator for Dependencies {
-    type Item = (PackageName, IndexSet<NamelessMatchSpec>);
-    type IntoIter = indexmap::map::IntoIter<PackageName, IndexSet<NamelessMatchSpec>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map.into_iter()
     }
 }

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -221,7 +221,7 @@ impl<'p> Hash for Environment<'p> {
 
 #[cfg(test)]
 mod tests {
-    use crate::project::Dependencies;
+    use crate::project::CondaDependencies;
 
     use super::*;
     use insta::assert_snapshot;
@@ -322,7 +322,7 @@ mod tests {
             .is_err())
     }
 
-    fn format_dependencies(dependencies: Dependencies) -> String {
+    fn format_dependencies(dependencies: CondaDependencies) -> String {
         dependencies
             .into_specs()
             .map(|(name, spec)| format!("{} = {}", name.as_source(), spec))

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -8,8 +8,7 @@ mod solve_group;
 pub mod virtual_packages;
 
 use async_once_cell::OnceCell as AsyncCell;
-
-use indexmap::{Equivalent, IndexMap, IndexSet};
+use indexmap::{Equivalent, IndexSet};
 use miette::{IntoDiagnostic, NamedSource};
 
 use rattler_conda_types::{Channel, Platform, Version};
@@ -35,17 +34,15 @@ use crate::{
     consts::{self, PROJECT_MANIFEST, PYPROJECT_MANIFEST},
     task::Task,
 };
-use manifest::{EnvironmentName, Manifest, PyPiRequirement, SystemRequirements};
-
-use crate::project::manifest::python::PyPiPackageName;
-pub use dependencies::Dependencies;
-pub use environment::Environment;
-pub use solve_group::SolveGroup;
+use manifest::{EnvironmentName, Manifest, SystemRequirements};
 
 use self::{
     has_features::HasFeatures,
     manifest::{pyproject::PyProjectToml, Environments},
 };
+pub use dependencies::{CondaDependencies, PyPiDependencies};
+pub use environment::Environment;
+pub use solve_group::SolveGroup;
 
 /// The dependency types we support
 #[derive(Debug, Copy, Clone)]
@@ -437,17 +434,18 @@ impl Project {
     /// Returns the dependencies of the project.
     ///
     /// TODO: Remove this function and use the `dependencies` function from the default environment instead.
-    pub fn dependencies(&self, kind: Option<SpecType>, platform: Option<Platform>) -> Dependencies {
+    pub fn dependencies(
+        &self,
+        kind: Option<SpecType>,
+        platform: Option<Platform>,
+    ) -> CondaDependencies {
         self.default_environment().dependencies(kind, platform)
     }
 
     /// Returns the PyPi dependencies of the project
     ///
     /// TODO: Remove this function and use the `dependencies` function from the default environment instead.
-    pub fn pypi_dependencies(
-        &self,
-        platform: Option<Platform>,
-    ) -> IndexMap<PyPiPackageName, IndexSet<PyPiRequirement>> {
+    pub fn pypi_dependencies(&self, platform: Option<Platform>) -> PyPiDependencies {
         self.default_environment().pypi_dependencies(platform)
     }
 
@@ -597,7 +595,7 @@ mod tests {
         }
     }
 
-    fn format_dependencies(deps: Dependencies) -> String {
+    fn format_dependencies(deps: CondaDependencies) -> String {
         deps.iter_specs()
             .map(|(name, spec)| format!("{} = \"{}\"", name.as_source(), spec))
             .join("\n")


### PR DESCRIPTION
@tdejager , this aligns the way Pypi and Conda dependencies are being merged in the `HasFeatures` trait