### PR TITLE
feat: Add /etc/pixi/config.toml to global configuration search paths

### DIFF
--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -4,16 +4,17 @@ Pixi supports some global configuration options, as well as project-scoped
 configuration (that does not belong into the project file). The configuration is
 loaded in the following order:
 
-1. XDG compliant configuration folder (`$XDG_CONFIG_HOME/pixi/config.toml` or
+1. System configuration folder (`/etc/pixi/config.toml` or `C:\ProgramData\pixi\config.toml`)
+2. XDG compliant configuration folder (`$XDG_CONFIG_HOME/pixi/config.toml` or
    `$HOME/.config/pixi/config.toml`)
-2. Global configuration folder, depending on the OS:
+3. Global configuration folder, depending on the OS:
    - Linux: `$HOME/.config/pixi/config.toml`
    - macOS: `$HOME/Library/Application Support/pixi/config.toml`
    - Windows: `%APPDATA%\pixi\config.toml`
-3. Global .pixi folder: `~/.pixi/config.toml` (or `$PIXI_HOME/config.toml` if
+4. Global .pixi folder: `~/.pixi/config.toml` (or `$PIXI_HOME/config.toml` if
    the `PIXI_HOME` environment variable is set)
-4. Project-local .pixi folder: `$PIXI_PROJECT/.pixi/config.toml`
-5. Command line arguments (`--tls-no-verify`, `--change-ps1=false` etc.)
+5. Project-local .pixi folder: `$PIXI_PROJECT/.pixi/config.toml`
+6. Command line arguments (`--tls-no-verify`, `--change-ps1=false` etc.)
 
 !!! note
     To find the locations where `pixi` looks for configuration files, run

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,12 +190,18 @@ impl Config {
 
     /// Load the global config file from the home directory (~/.pixi/config.toml)
     pub fn load_global() -> Config {
+        #[cfg(target_os = "windows")]
+        let base_path = PathBuf::from("C:\\ProgramData");
+        #[cfg(not(target_os = "windows"))]
+        let base_path = PathBuf::from("/etc");
+
         let xdg_config_home = std::env::var_os("XDG_CONFIG_HOME").map_or_else(
             || dirs::home_dir().map(|d| d.join(".config")),
             |p| Some(PathBuf::from(p)),
         );
 
         let global_locations = vec![
+            Some(base_path.join("pixi").join(consts::CONFIG_FILE)),
             xdg_config_home.map(|d| d.join("pixi").join(consts::CONFIG_FILE)),
             dirs::config_dir().map(|d| d.join("pixi").join(consts::CONFIG_FILE)),
             home_path().map(|d| d.join(consts::CONFIG_FILE)),


### PR DESCRIPTION
In some scenarios, you might want to pre-configure pixi but not touch the `$HOME` directory because it belongs to the user using it and not the system administrator.
In these cases, it might be beneficial to have a global system configuration file.