### PR TITLE
feat: change global config to kebab-case

### DIFF
--- a/docs/advanced/global_configuration.md
+++ b/docs/advanced/global_configuration.md
@@ -21,28 +21,41 @@ loaded in the following order:
 
 ## Reference
 
+??? info "Casing In Configuration"
+    In versions of pixi `0.20.1` and older the global configuration used snake_case
+    we've changed to `kebab-case` for consistency with the rest of the configuration.
+    But we still support the old `snake_case` configuration, for older configuration options.
+    These are:
+
+    - `default_channels`
+    - `change_ps1`
+    - `tls_no_verify`
+    - `authentication_override_file`
+    - `mirrors` and sub-options
+    - `repodata-config` and sub-options
+
 The following reference describes all available configuration options.
 
 ```toml
 # The default channels to select when running `pixi init` or `pixi global install`.
 # This defaults to only conda-forge.
-default_channels = ["conda-forge"]
+default-channels = ["conda-forge"]
 
 # When set to false, the `(pixi)` prefix in the shell prompt is removed.
 # This applies to the `pixi shell` subcommand.
 # You can override this from the CLI with `--change-ps1`.
-change_ps1 = true
+change-ps1 = true
 
 # When set to true, the TLS certificates are not verified. Note that this is a
 # security risk and should only be used for testing purposes or internal networks.
 # You can override this from the CLI with `--tls-no-verify`.
-tls_no_verify = false
+tls-no-verify = false
 
 # Override from where the authentication information is loaded.
 # Usually we try to use the keyring to load authentication data from, and only use a JSON
 # file as fallback. This option allows you to force the use of a JSON file.
 # Read more in the authentication section.
-authentication_override_file = "/path/to/your/override.json"
+authentication-override-file = "/path/to/your/override.json"
 
 # configuration for conda channel-mirrors
 [mirrors]
@@ -60,13 +73,13 @@ authentication_override_file = "/path/to/your/override.json"
     "https://prefix.dev/bioconda",
 ]
 
-[repodata_options]
+[repodata-config]
 # disable fetching of jlap, bz2 or zstd repodata files.
 # This should only be used for specific old versions of artifactory and other non-compliant
 # servers.
-disable_jlap = true  # don't try to download repodata.jlap
-disable_bzip2 = true # don't try to download repodata.json.bz2
-disable_zstd = true  # don't try to download repodata.json.zst
+disable-jlap = true  # don't try to download repodata.jlap
+disable-bzip2 = true # don't try to download repodata.json.bz2
+disable-zstd = true  # don't try to download repodata.json.zst
 ```
 
 ## Mirror configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,50 +106,50 @@ pub struct ConfigCliPrompt {
 #[derive(Clone, Default, Debug, Deserialize)]
 pub struct RepodataConfig {
     /// Disable JLAP compression for repodata.
-    #[serde(alias = "disable-jlap")]
+    #[serde(alias = "disable-jlap")] // BREAK: rename instead of alias
     pub disable_jlap: Option<bool>,
     /// Disable bzip2 compression for repodata.
-    #[serde(alias = "disable-bzip2")]
+    #[serde(alias = "disable-bzip2")] // BREAK: rename instead of alias
     pub disable_bzip2: Option<bool>,
     /// Disable zstd compression for repodata.
-    #[serde(alias = "disable-zstd")]
+    #[serde(alias = "disable-zstd")] // BREAK: rename instead of alias
     pub disable_zstd: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     #[serde(default)]
-    #[serde(alias = "default-channels")]
+    #[serde(alias = "default-channels")] // BREAK: rename instead of alias
     pub default_channels: Vec<String>,
 
     /// If set to true, pixi will set the PS1 environment variable to a custom value.
     #[serde(default)]
-    #[serde(alias = "change-ps1")]
+    #[serde(alias = "change-ps1")] // BREAK: rename instead of alias
     change_ps1: Option<bool>,
 
     /// Path to the file containing the authentication token.
     #[serde(default)]
-    #[serde(alias = "authentication-override-file")]
+    #[serde(alias = "authentication-override-file")] // BREAK: rename instead of alias
     authentication_override_file: Option<PathBuf>,
 
     /// If set to true, pixi will not verify the TLS certificate of the server.
     #[serde(default)]
-    #[serde(alias = "tls-no-verify")]
+    #[serde(alias = "tls-no-verify")] // BREAK: rename instead of alias
     tls_no_verify: Option<bool>,
 
     #[serde(default)]
     mirrors: HashMap<Url, Vec<Url>>,
 
     #[serde(skip)]
-    #[serde(alias = "loaded-from")]
+    #[serde(alias = "loaded-from")] // BREAK: rename instead of alias
     pub loaded_from: Vec<PathBuf>,
 
     #[serde(skip, default = "default_channel_config")]
-    #[serde(alias = "channel-config")]
+    #[serde(alias = "channel-config")] // BREAK: rename instead of alias
     pub channel_config: ChannelConfig,
 
     /// Configuration for repodata fetching.
-    #[serde(alias = "repodata-config")]
+    #[serde(alias = "repodata-config")] // BREAK: rename instead of alias
     pub repodata_config: Option<RepodataConfig>,
 }
 


### PR DESCRIPTION
This PR adds the option to use kebab-case in the global config. Which will be the preferred option, for older options we've kept the old way of `snake_case` configuration.

Also, the documentation was updated to reflect this. There was as error in the `repodata-config` in the documentation this was incorrectly named `repodata-options` this has *never* worked. This has also been rectified.