### PR TITLE
fix: align aliases and add missing

### DIFF
--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -9,15 +9,17 @@ mod upgrade_all;
 
 #[derive(Debug, Parser)]
 pub enum Command {
-    #[clap(alias = "a")]
+    // BREAK: This should only have the `i` as an alias
+    #[clap(visible_alias = "i", alias = "a")]
     Install(install::Args),
-    #[clap(alias = "r")]
+    // BREAK: This should only have the `rm` as an alias
+    #[clap(visible_alias = "rm", alias = "r")]
     Remove(remove::Args),
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List(list::Args),
-    #[clap(alias = "u")]
+    #[clap(visible_alias = "u")]
     Upgrade(upgrade::Args),
-    #[clap(alias = "ua")]
+    #[clap(visible_alias = "ua")]
     UpgradeAll(upgrade_all::Args),
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -61,27 +61,29 @@ pub struct CompletionCommand {
 pub enum Command {
     Completion(CompletionCommand),
     Init(init::Args),
-    #[clap(alias = "a")]
+    #[clap(visible_alias = "a")]
     Add(add::Args),
-    #[clap(alias = "r")]
+    #[clap(visible_alias = "r")]
     Run(run::Args),
-    #[clap(alias = "s")]
+    #[clap(visible_alias = "s")]
     Shell(shell::Args),
     ShellHook(shell_hook::Args),
-    #[clap(alias = "g")]
+    #[clap(visible_alias = "g")]
     Global(global::Args),
     Auth(rattler::cli::auth::Args),
-    #[clap(alias = "i")]
+    #[clap(visible_alias = "i")]
     Install(install::Args),
     Task(task::Args),
     Info(info::Args),
     Upload(upload::Args),
     Search(search::Args),
     Project(project::Args),
-    #[clap(alias = "rm")]
+    #[clap(visible_alias = "rm")]
     Remove(remove::Args),
     SelfUpdate(self_update::Args),
+    #[clap(visible_alias = "ls")]
     List(list::Args),
+    #[clap(visible_alias = "t")]
     Tree(tree::Args),
 }
 

--- a/src/cli/project/channel/mod.rs
+++ b/src/cli/project/channel/mod.rs
@@ -21,10 +21,13 @@ pub struct Args {
 #[derive(Parser, Debug)]
 pub enum Command {
     /// Adds a channel to the project file and updates the lockfile.
+    #[clap(visible_alias = "a")]
     Add(add::Args),
     /// List the channels in the project file.
+    #[clap(visible_alias = "ls")]
     List(list::Args),
     /// Remove channel(s) from the project file and updates the lockfile.
+    #[clap(visible_alias = "rm")]
     Remove(remove::Args),
 }
 

--- a/src/cli/project/platform/mod.rs
+++ b/src/cli/project/platform/mod.rs
@@ -21,10 +21,13 @@ pub struct Args {
 #[derive(Parser, Debug)]
 pub enum Command {
     /// Adds a platform(s) to the project file and updates the lockfile.
+    #[clap(visible_alias = "a")]
     Add(add::Args),
     /// List the platforms in the project file.
+    #[clap(visible_alias = "ls")]
     List,
     /// Remove platform(s) from the project file and updates the lockfile.
+    #[clap(visible_alias = "rm")]
     Remove(remove::Args),
 }
 

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -16,7 +16,7 @@ use toml_edit::{Array, Item, Table, Value};
 #[derive(Parser, Debug)]
 pub enum Operation {
     /// Add a command to the project
-    #[clap(alias = "a")]
+    #[clap(visible_alias = "a")]
     Add(AddArgs),
 
     /// Remove a command from the project
@@ -29,7 +29,7 @@ pub enum Operation {
     Alias(AliasArgs),
 
     /// List all tasks
-    #[clap(alias = "l")]
+    #[clap(visible_alias = "ls", alias = "l")]
     List(ListArgs),
 }
 

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -20,7 +20,8 @@ pub enum Operation {
     Add(AddArgs),
 
     /// Remove a command from the project
-    #[clap(alias = "r")]
+    // BREAK: This should only have the `rm` alias
+    #[clap(visible_alias = "rm", alias = "r")]
     Remove(RemoveArgs),
 
     /// Alias another specific command


### PR DESCRIPTION
This aligns aliases, e.g.:
- Remove should have `rm`  as an alias
- List should have `ls` as an alias
- Install should have `i` as an alias.

I found that we aliased `global install` to `g a` which I hate. So I made the correct aliases visible in the help command and we can hopefully later remove them when we break. 