### PR TITLE
feat: Allow to upgrade several global packages at once

### DIFF
--- a/src/cli/global/common.rs
+++ b/src/cli/global/common.rs
@@ -125,7 +125,7 @@ pub fn bin_env_dir() -> Option<PathBuf> {
 /// # Returns
 ///
 /// The package name from the given MatchSpec
-pub(super) fn package_name(package_matchspec: &MatchSpec) -> miette::Result<PackageName> {
+fn package_name(package_matchspec: &MatchSpec) -> miette::Result<PackageName> {
     package_matchspec.name.clone().ok_or_else(|| {
         miette::miette!(
             "could not find package name in MatchSpec {}",

--- a/src/cli/global/common.rs
+++ b/src/cli/global/common.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use indexmap::IndexMap;
 use miette::IntoDiagnostic;
 use rattler_conda_types::{
-    Channel, ChannelConfig, MatchSpec, PackageName, Platform, PrefixRecord, RepoDataRecord,
+    Channel, ChannelConfig, MatchSpec, PackageName, ParseStrictness, Platform, PrefixRecord,
+    RepoDataRecord,
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{resolvo, ChannelPriority, SolverImpl, SolverTask};
@@ -16,6 +17,22 @@ use crate::{
     utils::reqwest::build_reqwest_clients,
 };
 
+/// A trait to facilitate extraction of packages data from arguments
+pub(super) trait HasSpecs {
+    /// returns packages passed as arguments to the command
+    fn packages(&self) -> Vec<&str>;
+
+    fn specs(&self) -> miette::Result<IndexMap<PackageName, MatchSpec>> {
+        let mut map = IndexMap::with_capacity(self.packages().len());
+        for package in self.packages() {
+            let spec = MatchSpec::from_str(package, ParseStrictness::Strict).into_diagnostic()?;
+            let name = package_name(&spec)?;
+            map.insert(name, spec);
+        }
+
+        Ok(map)
+    }
+}
 /// Global binaries directory, default to `$HOME/.pixi/bin`
 pub struct BinDir(pub PathBuf);
 

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -10,9 +10,7 @@ use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler::install::Transaction;
 use rattler::package_cache::PackageCache;
-use rattler_conda_types::{
-    MatchSpec, PackageName, ParseStrictness, Platform, PrefixRecord, RepoDataRecord,
-};
+use rattler_conda_types::{PackageName, Platform, PrefixRecord, RepoDataRecord};
 use rattler_shell::{
     activation::{ActivationVariables, Activator, PathModificationBehavior},
     shell::Shell,
@@ -22,7 +20,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use super::common::{
     channel_name_from_prefix, find_designated_package, get_client_and_sparse_repodata,
-    load_package_records, package_name, BinDir, BinEnvDir,
+    load_package_records, BinDir, BinEnvDir, HasSpecs,
 };
 
 /// Installs the defined package in a global accessible location.
@@ -46,6 +44,12 @@ pub struct Args {
 
     #[clap(flatten)]
     config: ConfigCli,
+}
+
+impl HasSpecs for Args {
+    fn packages(&self) -> Vec<&str> {
+        self.package.iter().map(AsRef::as_ref).collect()
+    }
 }
 
 /// Create the environment activation script
@@ -244,22 +248,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = Config::with_cli_config(&args.config);
     let channels = config.compute_channels(&args.channel).into_diagnostic()?;
 
-    // Find the MatchSpec we want to install
-    let specs = args
-        .package
-        .into_iter()
-        .map(|package_str| MatchSpec::from_str(&package_str, ParseStrictness::Strict))
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()?;
-
     // Fetch sparse repodata
     let (authenticated_client, sparse_repodata) =
         get_client_and_sparse_repodata(&channels, &config).await?;
 
     // Install the package(s)
     let mut executables = vec![];
-    for package_matchspec in specs {
-        let package_name = package_name(&package_matchspec)?;
+    for (package_name, package_matchspec) in args.specs()? {
         let records = load_package_records(package_matchspec, &sparse_repodata)?;
 
         let (prefix_package, scripts, _) =

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -148,11 +148,9 @@ pub(super) async fn list_global_packages() -> miette::Result<Vec<PackageName>> {
 
     while let Some(entry) = dir_contents.next_entry().await.into_diagnostic()? {
         if entry.file_type().await.into_diagnostic()?.is_dir() {
-            let Ok(name) = PackageName::from_str(entry.file_name().to_string_lossy().as_ref())
-            else {
-                continue;
-            };
-            packages.push(name);
+            if let Ok(name) = PackageName::from_str(entry.file_name().to_string_lossy().as_ref()) {
+                packages.push(name);
+            }
         }
     }
 

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -1,17 +1,11 @@
-use std::collections::HashMap;
-
 use clap::Parser;
 use itertools::Itertools;
-use miette::IntoDiagnostic;
-use rattler_conda_types::{Channel, MatchSpec, ParseStrictness};
+
+use rattler_conda_types::MatchSpec;
 
 use crate::config::{Config, ConfigCli};
 
-use super::{
-    common::{find_installed_package, get_client_and_sparse_repodata, load_package_records},
-    list::list_global_packages,
-    upgrade::upgrade_package,
-};
+use super::{list::list_global_packages, upgrade::upgrade_packages};
 
 /// Upgrade all globally installed packages
 #[derive(Parser, Debug)]
@@ -33,75 +27,16 @@ pub struct Args {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let packages = list_global_packages().await?;
     let config = Config::with_cli_config(&args.config);
-    let mut channels = config.compute_channels(&args.channel).into_diagnostic()?;
 
-    let mut installed_versions = HashMap::with_capacity(packages.len());
+    let names = list_global_packages().await?;
+    let specs = names
+        .iter()
+        .map(|name| MatchSpec {
+            name: Some(name.clone()),
+            ..Default::default()
+        })
+        .collect_vec();
 
-    for package_name in packages.iter() {
-        let prefix_record = find_installed_package(package_name).await?;
-        let last_installed_channel = Channel::from_str(
-            prefix_record.repodata_record.channel.clone(),
-            config.channel_config(),
-        )
-        .into_diagnostic()?;
-
-        channels.push(last_installed_channel);
-
-        let installed_version = prefix_record
-            .repodata_record
-            .package_record
-            .version
-            .into_version();
-        installed_versions.insert(package_name.as_normalized().to_owned(), installed_version);
-    }
-
-    // Remove possible duplicates
-    channels = channels.into_iter().unique().collect::<Vec<_>>();
-
-    // Fetch sparse repodata
-    let (authenticated_client, sparse_repodata) =
-        get_client_and_sparse_repodata(&channels, &config).await?;
-
-    let mut upgraded = false;
-    for package_name in packages.iter() {
-        let package_matchspec =
-            MatchSpec::from_str(package_name.as_source(), ParseStrictness::Strict)
-                .into_diagnostic()?;
-        let records = load_package_records(package_matchspec, &sparse_repodata)?;
-        let package_record = records
-            .iter()
-            .find(|r| r.package_record.name.as_normalized() == package_name.as_normalized())
-            .ok_or_else(|| {
-                miette::miette!(
-                    "Package {} not found in the specified channels",
-                    package_name.as_normalized()
-                )
-            })?;
-        let toinstall_version = package_record.package_record.version.version().to_owned();
-        let installed_version = installed_versions
-            .get(package_name.as_normalized())
-            .expect("should have the installed version")
-            .to_owned();
-
-        // Prvent downgrades
-        if toinstall_version.cmp(&installed_version) == std::cmp::Ordering::Greater {
-            upgrade_package(
-                package_name,
-                installed_version,
-                toinstall_version,
-                records,
-                authenticated_client.clone(),
-            )
-            .await?;
-            upgraded = true;
-        }
-    }
-
-    if !upgraded {
-        eprintln!("Nothing to upgrade");
-    }
-
-    Ok(())
+    upgrade_packages(names, specs, config, &args.channel).await
 }

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use itertools::Itertools;
+use indexmap::IndexMap;
 
 use rattler_conda_types::MatchSpec;
 
@@ -30,13 +30,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = Config::with_cli_config(&args.config);
 
     let names = list_global_packages().await?;
-    let specs = names
-        .iter()
-        .map(|name| MatchSpec {
-            name: Some(name.clone()),
-            ..Default::default()
-        })
-        .collect_vec();
+    let mut specs = IndexMap::with_capacity(names.len());
+    for name in names {
+        specs.insert(
+            name.clone(),
+            MatchSpec {
+                name: Some(name),
+                ..Default::default()
+            },
+        );
+    }
 
-    upgrade_packages(names, specs, config, &args.channel).await
+    upgrade_packages(specs, config, &args.channel).await
 }


### PR DESCRIPTION
This PR refactors most of `upgrade.rs` and `upgrade_all.rs` into a common `upgrade_packages` function, which upgrades several global packages at once.

Now, several global packages can be upgraded at once.