### PR TITLE
fix: use read timeout, not global timeout

### DIFF
--- a/src/utils/reqwest.rs
+++ b/src/utils/reqwest.rs
@@ -88,12 +88,12 @@ pub(crate) fn build_reqwest_clients(config: Option<&Config>) -> (Client, ClientW
         tracing::warn!("TLS verification is disabled. This is insecure and should only be used for testing or internal networks.");
     }
 
-    let timeout = 100 * 60;
+    let timeout = 5 * 60;
     let client = Client::builder()
         .pool_max_idle_per_host(20)
         .user_agent(APP_USER_AGENT)
         .danger_accept_invalid_certs(config.tls_no_verify())
-        .timeout(Duration::from_secs(timeout))
+        .read_timeout(Duration::from_secs(timeout))
         .build()
         .expect("failed to create reqwest Client");
 

--- a/src/utils/reqwest.rs
+++ b/src/utils/reqwest.rs
@@ -88,7 +88,7 @@ pub(crate) fn build_reqwest_clients(config: Option<&Config>) -> (Client, ClientW
         tracing::warn!("TLS verification is disabled. This is insecure and should only be used for testing or internal networks.");
     }
 
-    let timeout = 5 * 60;
+    let timeout = 100 * 60;
     let client = Client::builder()
         .pool_max_idle_per_host(20)
         .user_agent(APP_USER_AGENT)


### PR DESCRIPTION
This should fix users with slower internet connection. Currently, a package can download only for 5 minutes - which is definitely not appropriate for some larger ones.

With the `read_timeout` this value is reset at every read so only really stalled connections will time out.