### PR TITLE
fix: channel priority logic

### DIFF
--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -490,6 +490,63 @@ mod tests {
         );
     }
 
+    fn test_channel_feature_priority(){
+        let manifest = Project::from_str(
+            Path::new("pixi.toml"),
+            r#"
+        [project]
+        name = "foobar"
+        channels = ["a", "b"]
+        platforms = ["linux-64", "osx-64"]
+
+        [feature.foo]
+        channels = ["c", "d"]
+
+        [feature.bar]
+        channels = ["e", "f"]
+
+        [feature.barfoo]
+        channels = ["a", "f"]
+
+        [environments]
+        foo = ["foo"]
+        bar = ["bar"]
+        foobar = ["foo", "bar"]
+        barfoo = {features = ["barfoo"], no-default-features=true}
+        "#,
+        )
+            .unwrap();
+
+        let foobar_channels = manifest.environment("foobar").unwrap().channels();
+        assert_eq!(
+            foobar_channels
+                .into_iter()
+                .map(|c| c.name.clone().unwrap())
+                .collect_vec(),
+            vec!["a", "b", "c", "d", "e", "f"]
+        );
+        let foo_channels = manifest.environment("foo").unwrap().channels();
+        assert_eq!(
+            foo_channels
+                .into_iter()
+                .map(|c| c.name.clone().unwrap())
+                .collect_vec(),
+            vec!["a", "b", "c", "d"]
+        );
+
+        let bar_channels = manifest.environment("bar").unwrap().channels();
+        assert_eq!(
+            bar_channels
+                .into_iter()
+                .map(|c| c.name.clone().unwrap())
+                .collect_vec(),
+            vec!["a", "b", "e", "f"]
+        );
+
+        let barfoo_channels = manifest.environment("barfoo").unwrap().channels();
+        assert_eq!(barfoo_channels.into_iter().map(|c| c.name.clone().unwrap()).collect_vec(), vec!["a", "f"])
+    }
+
     #[test]
     fn test_channel_priorities() {
         let manifest = Project::from_str(

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -490,7 +490,8 @@ mod tests {
         );
     }
 
-    fn test_channel_feature_priority(){
+    #[test]
+    fn test_channel_feature_priority() {
         let manifest = Project::from_str(
             Path::new("pixi.toml"),
             r#"
@@ -512,10 +513,10 @@ mod tests {
         foo = ["foo"]
         bar = ["bar"]
         foobar = ["foo", "bar"]
-        barfoo = {features = ["barfoo"], no-default-features=true}
+        barfoo = {features = ["barfoo"], no-default-feature=true}
         "#,
         )
-            .unwrap();
+        .unwrap();
 
         let foobar_channels = manifest.environment("foobar").unwrap().channels();
         assert_eq!(
@@ -523,7 +524,7 @@ mod tests {
                 .into_iter()
                 .map(|c| c.name.clone().unwrap())
                 .collect_vec(),
-            vec!["a", "b", "c", "d", "e", "f"]
+            vec!["c", "d", "e", "f", "a", "b"]
         );
         let foo_channels = manifest.environment("foo").unwrap().channels();
         assert_eq!(
@@ -531,7 +532,7 @@ mod tests {
                 .into_iter()
                 .map(|c| c.name.clone().unwrap())
                 .collect_vec(),
-            vec!["a", "b", "c", "d"]
+            vec!["c", "d", "a", "b"]
         );
 
         let bar_channels = manifest.environment("bar").unwrap().channels();
@@ -540,11 +541,54 @@ mod tests {
                 .into_iter()
                 .map(|c| c.name.clone().unwrap())
                 .collect_vec(),
-            vec!["a", "b", "e", "f"]
+            vec!["e", "f", "a", "b"]
         );
 
         let barfoo_channels = manifest.environment("barfoo").unwrap().channels();
-        assert_eq!(barfoo_channels.into_iter().map(|c| c.name.clone().unwrap()).collect_vec(), vec!["a", "f"])
+        assert_eq!(
+            barfoo_channels
+                .into_iter()
+                .map(|c| c.name.clone().unwrap())
+                .collect_vec(),
+            vec!["a", "f"]
+        )
+    }
+
+    #[test]
+    fn test_channel_feature_priority_with_redifinition() {
+        let manifest = Project::from_str(
+            Path::new("pixi.toml"),
+            r#"
+        [project]
+        name = "holoviews"
+        channels = ["a", "b"]
+        platforms = ["linux-64"]
+
+        [environments]
+        foo = ["foo"]
+
+        [feature.foo]
+        channels = ["a", "c", "b"]
+        "#,
+        )
+        .unwrap();
+
+        let foobar_channels = manifest.environment("default").unwrap().channels();
+        assert_eq!(
+            foobar_channels
+                .into_iter()
+                .map(|c| c.name.clone().unwrap())
+                .collect_vec(),
+            vec!["a", "b"]
+        );
+        let foo_channels = manifest.environment("foo").unwrap().channels();
+        assert_eq!(
+            foo_channels
+                .into_iter()
+                .map(|c| c.name.clone().unwrap())
+                .collect_vec(),
+            vec!["a", "c", "b"]
+        );
     }
 
     #[test]

--- a/src/project/has_features.rs
+++ b/src/project/has_features.rs
@@ -27,15 +27,15 @@ pub trait HasFeatures<'p> {
     fn channels(&self) -> IndexSet<&'p Channel> {
         // We reverse once before collecting into an IndexSet, and once after,
         // to ensure the default channels of the project are added to the end of the list.
-        let mut channels: IndexSet<_> = self
+        let channels: IndexSet<_> = self
             .features()
             .flat_map(|feature| match &feature.channels {
                 Some(channels) => channels,
                 None => &self.project().manifest.parsed.project.channels,
             })
-            .rev()
+            // .rev()
             .collect();
-        channels.reverse();
+        // channels.reverse();
 
         // The prioritized channels contain a priority, sort on this priority.
         // Higher priority comes first. [-10, 1, 0 ,2] -> [2, 1, 0, -10]

--- a/src/project/has_features.rs
+++ b/src/project/has_features.rs
@@ -25,17 +25,15 @@ pub trait HasFeatures<'p> {
     /// If a feature does not specify any channel the default channels from the project metadata are
     /// used instead.
     fn channels(&self) -> IndexSet<&'p Channel> {
-        // We reverse once before collecting into an IndexSet, and once after,
-        // to ensure the default channels of the project are added to the end of the list.
+        // Collect all the channels from the features in one set,
+        // deduplicate them and sort them on feature index, default feature comes last.
         let channels: IndexSet<_> = self
             .features()
             .flat_map(|feature| match &feature.channels {
                 Some(channels) => channels,
                 None => &self.project().manifest.parsed.project.channels,
             })
-            // .rev()
             .collect();
-        // channels.reverse();
 
         // The prioritized channels contain a priority, sort on this priority.
         // Higher priority comes first. [-10, 1, 0 ,2] -> [2, 1, 0, -10]


### PR DESCRIPTION
The issue described in #1331 can be simplified into the added test:
```
[project]
name = "holoviews"
channels = ["a", "b"]
platforms = ["linux-64"]

[environments]
foo = ["foo"]

[feature.foo]
channels = ["a", "c", "b"]
```
The channels for env `foo` should be `["a", "c", "b"]` but the current logic in `v0.21.0` changes it to have the default feature channels always at the end resulting in `["c", "a', "b"]`. 

We changed this back to keep the order of the features, and only add the missing channels from `default` last in the list. 

So this fixes #1331 