### PR TITLE
fix: automated update of install script in pixi.sh

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,9 @@ on:
       - main
     paths:
       - "docs/**"
+      - ".github/workflows/docs.yml"
       - "mkdocs.yml"
+      - "pixi.*"
     tags:
       - v**
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -119,7 +119,6 @@ jobs:
           git checkout gh-pages
           git checkout main -- install/install.sh install/install.ps1
           mv install/install.sh install/install.ps1 .
-          git restore .
           git restore --staged .
           git add install.sh install.ps1
           # Check diff before committing

--- a/install/docs_hooks.py
+++ b/install/docs_hooks.py
@@ -6,7 +6,7 @@ INSTALL_SCRIPTS = [Path(__file__).parent / "install.sh", Path(__file__).parent /
 
 
 def on_files(files: Files, config: MkDocsConfig):
-    """Copy the install scripts to the site."""
+    """Copy the installation scripts to the site."""
     for script in INSTALL_SCRIPTS:
         files.append(
             File(

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,6 +50,7 @@ build-docs = "mkdocs build --strict"
 docs = "mkdocs serve"
 deploy-latest = "mike deploy --push --update-aliases $RELEASE_VERSION latest"
 deploy-dev = "mike deploy --push dev devel"
+mike-serve = "mike serve"
 
 [feature.schema.tasks]
 generate-schema = { cmd = "python model.py > schema.json", cwd = "schema" }


### PR DESCRIPTION
The `install.sh` and `install.ps1` where significantly outdated because the update mechanism was faulty

Ps. this is not in a rush as I manually updated the upstream. That's why I know this changes works. 