### PR TITLE
fix: wrong description on `pixi project help`

### DIFF
--- a/src/cli/project/platform/mod.rs
+++ b/src/cli/project/platform/mod.rs
@@ -6,7 +6,7 @@ use crate::Project;
 use clap::Parser;
 use std::path::PathBuf;
 
-/// Commands to manage project channels.
+/// Commands to manage project platforms.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The path to 'pixi.toml' or 'pyproject.toml'

--- a/src/cli/project/version/mod.rs
+++ b/src/cli/project/version/mod.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use rattler_conda_types::VersionBumpType;
 use std::path::PathBuf;
 
-/// Commands to manage project description.
+/// Commands to manage project version.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The path to 'pixi.toml' or 'pyproject.toml'


### PR DESCRIPTION
`channel` main docstring and `platform` main docstring are the same, same thing with `description` and `version`. Doubt it's intentional, easy change.

Before:
```
Commands:
  channel      Commands to manage project channels
  description  Commands to manage project description
  platform     Commands to manage project channels
  version      Commands to manage project description
  help         Print this message or the help of the given subcommand(s)
```


After:
```
Commands:
  channel      Commands to manage project channels
  description  Commands to manage project description
  platform     Commands to manage project platforms
  version      Commands to manage project version
  help         Print this message or the help of the given subcommand(s)
```


