### PR TITLE
fix: align shell-hook cli with shell

### DIFF
--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -10,11 +10,12 @@ use serde_json;
 use std::collections::HashMap;
 use std::{default::Default, path::PathBuf};
 
+use crate::config::ConfigCliPrompt;
 use crate::{
     activation::get_activator,
     cli::LockFileUsageArgs,
     environment::get_up_to_date_prefix,
-    project::{has_features::HasFeatures, manifest::EnvironmentName, Environment},
+    project::{has_features::HasFeatures, Environment},
     Project,
 };
 
@@ -39,6 +40,9 @@ pub struct Args {
     /// Emit the environment variables set by running the activation as JSON
     #[clap(long, default_value = "false", conflicts_with = "shell")]
     json: bool,
+
+    #[clap(flatten)]
+    config: ConfigCliPrompt,
 }
 
 #[derive(Serialize)]
@@ -88,13 +92,9 @@ async fn generate_environment_json(environment: &Environment<'_>) -> miette::Res
 
 /// Prints the activation script to the stdout.
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
-    let environment_name = args
-        .environment
-        .map_or_else(|| EnvironmentName::Default, EnvironmentName::Named);
-    let environment = project
-        .environment(&environment_name)
-        .ok_or_else(|| miette::miette!("unknown environment '{environment_name}'"))?;
+    let project =
+        Project::load_or_else_discover(args.manifest_path.as_deref())?.with_cli_config(args.config);
+    let environment = project.environment_from_name_or_env_var(args.environment)?;
 
     get_up_to_date_prefix(
         &environment,


### PR DESCRIPTION
fixes #1360 

The problem was that we missed the persistent shell feature in `shell-hook` so it wasn't keeping the correct environment in the restart of the shell after `install, add, remove`