### PR TITLE
fix: don't need a python interpreter when not having `pypi` dependencies.

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,3 +1,4 @@
+use crate::consts::PIXI_UV_INSTALLER;
 use crate::lock_file::UvResolutionContext;
 use crate::progress::await_in_progress;
 use crate::project::grouped_environment::GroupedEnvironmentName;
@@ -16,6 +17,7 @@ use crate::{
     Project,
 };
 use dialoguer::theme::ColorfulTheme;
+use distribution_types::{InstalledDist, Name};
 use indexmap::IndexMap;
 use miette::{IntoDiagnostic, WrapErr};
 use rattler::{
@@ -257,7 +259,47 @@ pub async fn update_prefix_pypi(
     lock_file_dir: &Path,
     platform: Platform,
 ) -> miette::Result<()> {
-    // Remove python packages from a previous python distribution if the python version changed.
+    // If we have changed interpreter, we need to uninstall all site-packages from the old interpreter
+    // We need to do this before the pypi prefix update, because that requires a python interpreter.
+    let python_info = match status {
+        // If the python interpreter is removed, we need to uninstall all `pixi-uv` site-packages.
+        // And we don't need to continue with the rest of the pypi prefix update.
+        PythonStatus::Removed { old } => {
+            let site_packages_path = prefix.root().join(&old.site_packages_path);
+            if site_packages_path.exists() {
+                uninstall_outdated_site_packages(&site_packages_path).await?;
+            }
+            return Ok(());
+        }
+        // If the python interpreter is changed, we need to uninstall all site-packages from the old interpreter.
+        // And we continue the function to update the pypi packages.
+        PythonStatus::Changed { old, new } => {
+            // In windows the site-packages path stays the same, so we don't need to uninstall the site-packages ourselves.
+            if old.site_packages_path != new.site_packages_path {
+                let site_packages_path = prefix.root().join(&old.site_packages_path);
+                if site_packages_path.exists() {
+                    uninstall_outdated_site_packages(&site_packages_path).await?;
+                }
+            }
+            new
+        }
+        // If the python interpreter is unchanged, and there are no pypi packages to install, we need to remove the site-packages.
+        // And we don't need to continue with the rest of the pypi prefix update.
+        PythonStatus::Unchanged(info) | PythonStatus::Added { new: info } => {
+            if pypi_records.is_empty() {
+                let site_packages_path = prefix.root().join(&info.site_packages_path);
+                if site_packages_path.exists() {
+                    uninstall_outdated_site_packages(&site_packages_path).await?;
+                }
+                return Ok(());
+            }
+            info
+        }
+        // We can skip the pypi prefix update if there is not python interpreter in the environment.
+        PythonStatus::DoesNotExist => {
+            return Ok(());
+        }
+    };
 
     // Install and/or remove python packages
     progress::await_in_progress(
@@ -271,7 +313,7 @@ pub async fn update_prefix_pypi(
                 prefix,
                 conda_records,
                 pypi_records,
-                status,
+                &python_info.path,
                 system_requirements,
                 uv_context,
                 pypi_options,
@@ -281,6 +323,55 @@ pub async fn update_prefix_pypi(
         },
     )
     .await
+}
+
+/// If the python interpreter is outdated, we need to uninstall all outdated site packages.
+/// from the old interpreter.
+/// TODO: optimize this by recording the installation of the site-packages to check if this is needed.
+async fn uninstall_outdated_site_packages(site_packages: &Path) -> miette::Result<()> {
+    // Check if the old interpreter is outdated
+    let mut installed = vec![];
+    for entry in std::fs::read_dir(site_packages).into_diagnostic()? {
+        let entry = entry.into_diagnostic()?;
+        if entry.file_type().into_diagnostic()?.is_dir() {
+            let path = entry.path();
+
+            let installed_dist = InstalledDist::try_from_path(&path);
+            let Ok(installed_dist) = installed_dist else {
+                continue;
+            };
+
+            if let Some(installed_dist) = installed_dist {
+                // If we can't get the installer, we can't be certain that we have installed it
+                let installer = match installed_dist.installer() {
+                    Ok(installer) => installer,
+                    Err(e) => {
+                        tracing::warn!(
+                            "could not get installer for {}: {}, will not remove distribution",
+                            installed_dist.name(),
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+                // Only remove if have actually installed it
+                // by checking the installer
+                if installer.unwrap_or_default() == PIXI_UV_INSTALLER {
+                    installed.push(installed_dist);
+                }
+            }
+        }
+    }
+
+    // Uninstall all packages in old site-packages directory
+    for dist_info in installed {
+        let _summary = uv_installer::uninstall(&dist_info)
+            .await
+            .expect("uninstallation of old site-packages failed");
+    }
+
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -112,7 +112,6 @@ impl<'p> LockFileDerivedData<'p> {
         let pypi_records = self.pypi_records(environment, platform).unwrap_or_default();
 
         // No `uv` support for WASM right now
-        // TODO - figure out if we can create the `uv` context more lazily
         if platform.arch() == Some(Arch::Wasm32) {
             return Ok(prefix);
         }
@@ -1524,7 +1523,12 @@ async fn spawn_solve_pypi_task(
         let python_path = python_status
             .location()
             .map(|path| prefix.root().join(path))
-            .ok_or_else(|| miette::miette!("missing python interpreter from environment"))?;
+            .ok_or_else(|| {
+                miette::miette!(
+                    help = "Use `pixi add python` to install the latest python interpreter.",
+                    "missing python interpreter from environment"
+                )
+            })?;
 
         let start = Instant::now();
 

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -126,9 +126,11 @@ async fn install_locked() {
     // Add and update lockfile with this version of python
     let python_version = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
         "python==3.10.0"
-    } else {
+    } else if cfg!(target_os = "windows") {
         // Abusing this test to also test the `add` function of older version of python
         // Before this wasn't possible because uv queried the python interpreter, even without pypi dependencies.
+        "python==3.6.0"
+    } else {
         "python==2.7.15"
     };
 

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -124,7 +124,15 @@ async fn install_locked() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
     // Add and update lockfile with this version of python
-    pixi.add("python==3.10.0").await.unwrap();
+    let python_version = if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        "python==3.10.0"
+    } else {
+        // Abusing this test to also test the `add` function of older version of python
+        // Before this wasn't possible because uv queried the python interpreter, even without pypi dependencies.
+        "python==2.7.15"
+    };
+
+    pixi.add(python_version).await.unwrap();
 
     // Add new version of python only to the manifest
     pixi.add("python==3.9.0")
@@ -139,7 +147,7 @@ async fn install_locked() {
     assert!(lock.contains_match_spec(
         DEFAULT_ENVIRONMENT_NAME,
         Platform::current(),
-        "python==3.10.0"
+        python_version
     ));
 
     // After an install with lockfile update the locked install should succeed.


### PR DESCRIPTION
Fixes #1232 

Now we do two things if there is no `pypi-dependencies`:
- Check if we need to remove some `site-packages`.
- Skip everything that requires to call the python interpreter.

To not make the test abonormally slow we "abuse" one of the tests to try to install `python` `2.7` which will not work if we by accident try to run any `uv` related work. 