### PR TITLE
docs: clarify in CLI that run can also take commands

### DIFF
--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -103,7 +103,7 @@ _arguments "${_arguments_options[@]}" \
 '(-v --verbose)*--quiet[Less output per occurrence]' \
 '-h[Print help]' \
 '--help[Print help]' \
-'*::task -- The task you want to run in the projects environment:' \
+'*::task -- The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.:' \
 && ret=0
 ;;
 (add)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -33,7 +33,7 @@ use tracing::Level;
 #[derive(Parser, Debug, Default)]
 #[clap(trailing_var_arg = true, arg_required_else_help = true)]
 pub struct Args {
-    /// The task you want to run in the projects environment.
+    /// The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.
     #[arg(required = true)]
     pub task: Vec<String>,
 

--- a/src/cli/snapshots/pixi__cli__completion__tests__zsh_completion.snap
+++ b/src/cli/snapshots/pixi__cli__completion__tests__zsh_completion.snap
@@ -29,7 +29,7 @@ _arguments "${_arguments_options[@]}" \
 '(-v --verbose)*--quiet[Less output per occurrence]' \
 '-h[Print help]' \
 '--help[Print help]' \
-'::task -- The task you want to run in the projects environment:' \
+'::task -- The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.:' \
 && ret=0
 ;;
 (add)


### PR DESCRIPTION
I didn't realize `pixi run` could also execute arbitrary commands in an environment and thought only pre-defined tasks, based on the CLI help text. This small patch makes this a little clearer for folks not reading the online manual.