### PR TITLE
feat: add specialized zsh task completion

### DIFF
--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -60,22 +60,10 @@ fn replace_bash_completion(script: &str) -> Cow<str> {
 
 /// Replace the parts of the bash completion script that need different functionality.
 fn replace_zsh_completion(script: &str) -> Cow<str> {
-    let pattern = r"(?ms)(\(run\))(?:.*?)(_arguments.*?)(\*::task)";
-    // Adds tab completion to the pixi run command.
-    // NOTE THIS IS FORMATTED BY HAND
-    let zsh_replacement = r#"$1
-local tasks
-tasks=("$${(@s/ /)$$(pixi task list --summary 2> /dev/null)}")
-
-if [[ -n "$$tasks" ]]; then
-    _values 'task' "$${tasks[@]}"
-else
-    return 1
-fi
-$2::task"#;
-
-    let re = Regex::new(pattern).unwrap();
-    re.replace(script, zsh_replacement)
+    let mut script = script.to_string();
+    script.push_str("\n");
+    script.push_str(include_str!("./completion_script/postamble.zsh"));
+    Cow::Owned(script)
 }
 
 #[cfg(test)]

--- a/src/cli/completion_script/postamble.zsh
+++ b/src/cli/completion_script/postamble.zsh
@@ -1,0 +1,21 @@
+_pixi_run_inner() {
+    if [[ $words[2] == "run" ]]; then
+        local tasks
+        tasks=("${(@s/ /)$(pixi task list --summary 2> /dev/null)}")
+        tasks=("${(@)tasks:#}")  # Remove empty elements
+
+        if [[ $CURRENT -eq 3 && -n "$tasks" ]]; then
+            _values 'task' "${tasks[@]}"
+        else
+            # Delegate to the completion system of the command after 'pixi run'
+            shift 2 words
+            (( CURRENT -= 2 ))
+            _normal
+        fi
+    else
+        _pixi
+    fi
+}
+
+# Load the completion function
+compdef _pixi_run_inner pixi


### PR DESCRIPTION
This adds some completion for arguments after the task. For example

```
pixi run git chec<TAB>
# completes to `checkout`
pixi run foo ./my-fi<TAB>
# completes to a filename (e.g. `./my-file.txt`)
```

Only works with `zsh` for now but I think we can have a similar approach on `bash`. 

Does not (yet) complete the binaries found in the pixi env (e.g. `$PIXI_ENV/bin/<binary-name>` could also be a nice completion opportunity.

Does not take into account flags like `-e ENV`.
