### PR TITLE
doc: fix small screen by removing getting started section.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ part: pixi
 title: Getting Started
 description: Package management made easy
 ---
-
+# Getting Started
 ![Pixi with magic wand](assets/pixi.webp)
 
 Pixi is a package management tool for developers.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,13 +96,12 @@ extra:
     provider: mike
 
 nav:
-  - Getting Started:
-      - Installation: index.md
-      - Basic Usage: basic_usage.md
-      - IDE Integration:
-          - JupyterLab: ide_integration/jupyterlab.md
-          - PyCharm: ide_integration/pycharm.md
-          - RStudio: ide_integration/r_studio.md
+  - Installation: index.md
+  - Basic Usage: basic_usage.md
+  - IDE Integration:
+      - JupyterLab: ide_integration/jupyterlab.md
+      - PyCharm: ide_integration/pycharm.md
+      - RStudio: ide_integration/r_studio.md
   - Tutorials:
       - Python: tutorials/python.md
       - ROS 2: tutorials/ros2.md


### PR DESCRIPTION
The navigation would now look like:
![image](https://github.com/prefix-dev/pixi/assets/12893423/75691a4a-6314-4e63-9594-d856c945f7cd)


instead of the one in #1392 

fixes #1392 