### PR TITLE
feat: add explicit flag to CLI list command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -351,6 +351,7 @@ List project's packages. Highlighted packages are explicit dependencies.
 - `--json`: Whether to output in json format.
 - `--json-pretty`: Whether to output in pretty json format
 - `--sort-by <SORT_BY>`: Sorting strategy [default: name] [possible values: size, name, type]
+- `--explicit (-x)`: Only list the packages that are explicitly added to the [manifest file](configuration.md).
 - `--manifest-path <MANIFEST_PATH>`: The path to [manifest file](configuration.md), by default it searches for one in the parent directories.
 - `--environment (-e)`: The environment's packages to list, if non is provided the default environment's packages will be listed.
 - `--frozen`: install the environment as defined in the lock file, doesn't update `pixi.lock` if it isn't up-to-date with [manifest file](configuration.md). It can also be controlled by the `PIXI_FROZEN` environment variable (example: `PIXI_FROZEN=true`).
@@ -360,6 +361,7 @@ List project's packages. Highlighted packages are explicit dependencies.
 ```shell
 pixi list
 pixi list --json-pretty
+pixi list --explicit
 pixi list --sort-by size
 pixi list --platform win-64
 pixi list --environment cuda

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -65,6 +65,10 @@ pub struct Args {
     /// Don't install the environment for pypi solving, only update the lock-file if it can solve without installing.
     #[arg(long)]
     pub no_install: bool,
+
+    /// Only list packages that are explicitly defined in the project.
+    #[arg(short = 'x', long)]
+    pub explicit: bool,
 }
 
 fn serde_skip_is_editable(editable: &bool) -> bool {
@@ -178,6 +182,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         packages_to_output = packages_to_output
             .into_iter()
             .filter(|p| regex.is_match(&p.name))
+            .collect::<Vec<_>>();
+    }
+
+    // Filter packages by explicit if needed
+    if args.explicit {
+        packages_to_output = packages_to_output
+            .into_iter()
+            .filter(|p| p.is_explicit)
             .collect::<Vec<_>>();
     }
 


### PR DESCRIPTION
implements #1372 

feature: add cli flag for `pixi list` so users can filter only for explicit packages using `--explicit` , additionally with `-x` 

```
    -x, --explicit                       Only list packages that are explicitly defined in the project
```

```
List project's packages. Highlighted packages are explicit dependencies

Usage: pixi list [OPTIONS] [REGEX]

Arguments:
  [REGEX]  List only packages matching a regular expression

Options:
      --platform <PLATFORM>            The platform to list packages for. Defaults to the current platform
      --json                           Whether to output in json format
      --json-pretty                    Whether to output in pretty json format
      --sort-by <SORT_BY>              Sorting strategy [default: name] [possible values: size, name, kind]
      --manifest-path <MANIFEST_PATH>  The path to 'pixi.toml' or 'pyproject.toml'
  -e, --environment <ENVIRONMENT>      The environment to list packages for. Defaults to the default environment
      --frozen                         [env: PIXI_FROZEN=]
      --locked                         Check if lockfile is up-to-date before installing the environment, aborts when
                                       lockfile isn't up-to-date with the manifest file [env: PIXI_LOCKED=]
      --no-install                     Don't install the environment for pypi solving, only update the lock-file if it can
                                       solve without installing
  -x, --explicit                       Only list packages that are explicitly defined in the project
  -v, --verbose...                     Increase logging verbosity
  -q, --quiet...                       Decrease logging verbosity
      --color <COLOR>                  Whether the log needs to be colored [env: PIXI_COLOR=] [default: auto] [possible
                                       values: always, never, auto]
      --no-progress                    Hide all progress bars [env: PIXI_NO_PROGRESS=]
  -h, --help                           Print help
```