### PR TITLE
feat: Align `remove` arguments with `add`

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -163,12 +163,10 @@ impl DependencyConfig {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let editable = args.editable;
-    let (args, config) = (args.dependency_config, args.config);
+    let (args, config, editable) = (args.dependency_config, args.config, args.editable);
     let mut project =
         Project::load_or_else_discover(args.manifest_path.as_deref())?.with_cli_config(config);
     let dependency_type = args.dependency_type();
-    let spec_platforms = &args.platform;
 
     // Sanity check of prefix location
     verify_prefix_location_unchanged(project.default_environment().dir().as_path()).await?;
@@ -176,7 +174,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Add the platform if it is not already present
     project
         .manifest
-        .add_platforms(spec_platforms.iter(), &FeatureName::Default)?;
+        .add_platforms(args.platform.iter(), &FeatureName::Default)?;
 
     match dependency_type {
         DependencyType::CondaDependency(spec_type) => {
@@ -194,7 +192,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 spec_type,
                 args.no_install,
                 args.lock_file_usage(),
-                spec_platforms,
+                &args.platform,
             )
             .await
         }
@@ -213,7 +211,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 &mut project,
                 &args.feature_name(),
                 pep508_requirements,
-                spec_platforms,
+                &args.platform,
                 args.lock_file_usage(),
                 args.no_install,
                 Some(editable),

--- a/src/cli/global/common.rs
+++ b/src/cli/global/common.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use indexmap::IndexMap;
 use miette::IntoDiagnostic;
 use rattler_conda_types::{
-    Channel, ChannelConfig, MatchSpec, PackageName, ParseStrictness, Platform, PrefixRecord,
-    RepoDataRecord,
+    Channel, ChannelConfig, MatchSpec, PackageName, Platform, PrefixRecord, RepoDataRecord,
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{resolvo, ChannelPriority, SolverImpl, SolverTask};
@@ -17,22 +16,6 @@ use crate::{
     utils::reqwest::build_reqwest_clients,
 };
 
-/// A trait to facilitate extraction of packages data from arguments
-pub(super) trait HasSpecs {
-    /// returns packages passed as arguments to the command
-    fn packages(&self) -> Vec<&str>;
-
-    fn specs(&self) -> miette::Result<IndexMap<PackageName, MatchSpec>> {
-        let mut map = IndexMap::with_capacity(self.packages().len());
-        for package in self.packages() {
-            let spec = MatchSpec::from_str(package, ParseStrictness::Strict).into_diagnostic()?;
-            let name = package_name(&spec)?;
-            map.insert(name, spec);
-        }
-
-        Ok(map)
-    }
-}
 /// Global binaries directory, default to `$HOME/.pixi/bin`
 pub struct BinDir(pub PathBuf);
 

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::cli::has_specs::HasSpecs;
 use crate::config::{Config, ConfigCli};
 use crate::install::execute_transaction;
 use crate::{config, prefix::Prefix, progress::await_in_progress};
@@ -20,7 +21,7 @@ use reqwest_middleware::ClientWithMiddleware;
 
 use super::common::{
     channel_name_from_prefix, find_designated_package, get_client_and_sparse_repodata,
-    load_package_records, BinDir, BinEnvDir, HasSpecs,
+    load_package_records, BinDir, BinEnvDir,
 };
 
 /// Installs the defined package in a global accessible location.

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -6,9 +6,10 @@ use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler_conda_types::PackageName;
 
+use crate::cli::has_specs::HasSpecs;
 use crate::prefix::Prefix;
 
-use super::common::{find_designated_package, BinDir, BinEnvDir, HasSpecs};
+use super::common::{find_designated_package, BinDir, BinEnvDir};
 use super::install::{find_and_map_executable_scripts, BinScriptMapping};
 
 /// Removes a package previously installed into a globally accessible location via `pixi global install`.

--- a/src/cli/global/upgrade.rs
+++ b/src/cli/global/upgrade.rs
@@ -10,12 +10,11 @@ use miette::{IntoDiagnostic, Report};
 use rattler_conda_types::{Channel, MatchSpec, PackageName, Platform};
 use tokio::task::JoinSet;
 
+use crate::cli::has_specs::HasSpecs;
 use crate::config::Config;
 use crate::progress::{global_multi_progress, long_running_progress_style};
 
-use super::common::{
-    find_installed_package, get_client_and_sparse_repodata, load_package_records, HasSpecs,
-};
+use super::common::{find_installed_package, get_client_and_sparse_repodata, load_package_records};
 use super::install::globally_install_package;
 
 /// Upgrade specific package which is installed globally.

--- a/src/cli/has_specs.rs
+++ b/src/cli/has_specs.rs
@@ -1,0 +1,37 @@
+use indexmap::IndexMap;
+use miette::IntoDiagnostic;
+use pep508_rs::Requirement;
+use rattler_conda_types::{MatchSpec, PackageName, ParseStrictness};
+
+use crate::{project::manifest::python::PyPiPackageName, Project};
+
+/// A trait to facilitate extraction of packages data from arguments
+pub(crate) trait HasSpecs {
+    /// returns packages passed as arguments to the command
+    fn packages(&self) -> Vec<&str>;
+
+    fn specs(&self) -> miette::Result<IndexMap<PackageName, MatchSpec>> {
+        let mut map = IndexMap::with_capacity(self.packages().len());
+        for package in self.packages() {
+            let spec = MatchSpec::from_str(package, ParseStrictness::Strict).into_diagnostic()?;
+            let name = spec.name.clone().ok_or_else(|| {
+                miette::miette!("could not find package name in MatchSpec {}", spec)
+            })?;
+            map.insert(name, spec);
+        }
+        Ok(map)
+    }
+
+    fn pypi_deps(
+        &self,
+        project: &Project,
+    ) -> miette::Result<IndexMap<PyPiPackageName, Requirement>> {
+        let mut map = IndexMap::with_capacity(self.packages().len());
+        for package in self.packages() {
+            let dep = Requirement::parse(package, project.root()).into_diagnostic()?;
+            let name = PyPiPackageName::from_normalized(dep.clone().name);
+            map.insert(name, dep);
+        }
+        Ok(map)
+    }
+}

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -179,26 +179,26 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             &vec![],
         );
         let mut project = Project::from_str(&pixi_manifest_path, &rv)?;
+        let platforms = platforms
+            .into_iter()
+            .map(|p| p.parse().into_diagnostic())
+            .collect::<Result<Vec<Platform>, _>>()?;
         for spec in conda_deps {
-            for platform in platforms.iter() {
-                // TODO: fix serialization of channels in rattler_conda_types::MatchSpec
-                project.manifest.add_dependency(
-                    &spec,
-                    crate::SpecType::Run,
-                    Some(platform.parse().into_diagnostic()?),
-                    &FeatureName::default(),
-                )?;
-            }
+            // TODO: fix serialization of channels in rattler_conda_types::MatchSpec
+            project.manifest.add_dependency(
+                &spec,
+                crate::SpecType::Run,
+                &platforms,
+                &FeatureName::default(),
+            )?;
         }
         for requirement in pypi_deps {
-            for platform in platforms.iter() {
-                project.manifest.add_pypi_dependency(
-                    &requirement,
-                    Some(platform.parse().into_diagnostic()?),
-                    &FeatureName::default(),
-                    None,
-                )?;
-            }
+            project.manifest.add_pypi_dependency(
+                &requirement,
+                &platforms,
+                &FeatureName::default(),
+                None,
+            )?;
         }
         project.save()?;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@ pub mod add;
 pub mod completion;
 pub mod config;
 pub mod global;
+pub mod has_specs;
 pub mod info;
 pub mod init;
 pub mod install;

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -1,57 +1,29 @@
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use clap::Parser;
+use itertools::Itertools;
 use miette::miette;
 use pep508_rs::Requirement;
-use rattler_conda_types::Platform;
 
 use crate::config::ConfigCli;
-use crate::environment::{get_up_to_date_prefix, LockFileUsage};
+use crate::environment::get_up_to_date_prefix;
 use crate::project::manifest::python::PyPiPackageName;
-use crate::project::manifest::FeatureName;
-use crate::{consts, project::SpecType, Project};
+use crate::DependencyType;
+use crate::{consts, Project};
+
+use super::add::DependencyConfig;
 
 /// Removes dependencies from the project
+///
+///  If the project manifest is a `pyproject.toml`, removing a pypi dependency with the `--pypi` flag will remove it from either
+/// - the native pyproject `project.dependencies` array or, if a feature is specified, the native `project.optional-dependencies` table
+/// - pixi `pypi-dependencies` tables of the default feature or, if a feature is specified, a named feature
+///
 #[derive(Debug, Default, Parser)]
 #[clap(arg_required_else_help = true)]
 pub struct Args {
-    /// Specify the dependencies you wish to remove from the project.
-    ///
-    /// If the project manifest is a `pyproject.toml`, removing a pypi dependency with the `--pypi` flag will remove it from either
-    /// - the native pyproject `project.dependencies` array or, if a feature is specified, the native `project.optional-dependencies` table
-    /// - pixi `pypi-dependencies` tables of the default feature or, if a feature is specified, a named feature
-    ///
-    #[arg(required = true, verbatim_doc_comment)]
-    pub deps: Vec<String>,
-
-    /// The path to 'pixi.toml' or 'pyproject.toml'
-    #[arg(long)]
-    pub manifest_path: Option<PathBuf>,
-
-    /// Whether dependency is a host dependency
-    #[arg(long, conflicts_with = "build")]
-    pub host: bool,
-
-    /// Whether dependency is a build dependency
-    #[arg(long, conflicts_with = "host")]
-    pub build: bool,
-
-    /// Whether the dependency is a pypi package
-    #[arg(long)]
-    pub pypi: bool,
-
-    /// Don't install the environment, only remove the package from the lock-file and manifest.
-    #[arg(long)]
-    pub no_install: bool,
-
-    /// The platform for which the dependency should be removed
-    #[arg(long, short)]
-    pub platform: Option<Platform>,
-
-    /// The feature for which the dependency should be removed
-    #[arg(long, short)]
-    pub feature: Option<String>,
+    #[clap(flatten)]
+    pub dependency_config: DependencyConfig,
 
     #[clap(flatten)]
     pub config: ConfigCli,
@@ -70,72 +42,70 @@ where
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
+    let (args, config) = (args.dependency_config, args.config);
     let mut project =
-        Project::load_or_else_discover(args.manifest_path.as_deref())?.with_cli_config(args.config);
-    let deps = args.deps;
-    let spec_type = if args.host {
-        SpecType::Host
-    } else if args.build {
-        SpecType::Build
-    } else {
-        SpecType::Run
-    };
+        Project::load_or_else_discover(args.manifest_path.as_deref())?.with_cli_config(config);
+    let dependency_type = args.dependency_type();
+    let deps = args.specs.clone();
 
-    let section_name: String = if args.pypi {
-        consts::PYPI_DEPENDENCIES.to_string()
-    } else {
-        spec_type.name().to_string()
+    let section_name = match dependency_type {
+        DependencyType::PypiDependency => consts::PYPI_DEPENDENCIES.to_string(),
+        DependencyType::CondaDependency(spec_type) => spec_type.name().to_string(),
     };
-    let table_name = if let Some(p) = &args.platform {
-        format!("target.{}.{}", p.as_str(), section_name)
+    let table_name = if args.platform.is_empty() {
+        format!("[{section_name}]")
     } else {
-        section_name
+        args.platform
+            .iter()
+            .map(|p| format!("[target.{}.{}]", p.as_str(), section_name))
+            .join(", ")
     };
-    let feature_name = args
-        .feature
-        .map_or(FeatureName::Default, FeatureName::Named);
 
     fn format_ok_message(pkg_name: &str, pkg_extras: &str, table_name: &str) -> String {
         format!(
-            "Removed {} from [{}]",
+            "Removed {} from {}",
             console::style(format!("{pkg_name} {pkg_extras}")).bold(),
             console::style(table_name).bold()
         )
     }
     let mut sucessful_output: Vec<String> = Vec::with_capacity(deps.len());
-    if args.pypi {
-        let all_pkg_name = convert_pkg_name::<Requirement>(&deps)?;
-        for dep in all_pkg_name.iter() {
-            let name = PyPiPackageName::from_normalized(dep.clone().name);
-            let (name, req) =
-                project
-                    .manifest
-                    .remove_pypi_dependency(&name, args.platform, &feature_name)?;
-            sucessful_output.push(format_ok_message(
-                name.as_source(),
-                &req.to_string(),
-                &table_name,
-            ));
+    match dependency_type {
+        DependencyType::PypiDependency => {
+            let all_pkg_name = convert_pkg_name::<Requirement>(&deps)?;
+            for dep in all_pkg_name.iter() {
+                let name = PyPiPackageName::from_normalized(dep.clone().name);
+                let (name, req) = project.manifest.remove_pypi_dependency(
+                    &name,
+                    &args.platform,
+                    &args.feature_name(),
+                )?;
+                sucessful_output.push(format_ok_message(
+                    name.as_source(),
+                    &req.to_string(),
+                    &table_name,
+                ));
+            }
         }
-    } else {
-        let all_pkg_name = convert_pkg_name::<rattler_conda_types::MatchSpec>(&deps)?;
-        for dep in all_pkg_name.iter() {
-            // Get name or error on missing name
-            let name = dep
-                .clone()
-                .name
-                .ok_or_else(|| miette!("Can't remove dependency without a name: {}", dep))?;
-            let (name, req) = project.manifest.remove_dependency(
-                &name,
-                spec_type,
-                args.platform,
-                &feature_name,
-            )?;
-            sucessful_output.push(format_ok_message(
-                name.as_source(),
-                &req.to_string(),
-                &table_name,
-            ));
+        DependencyType::CondaDependency(spec_type) => {
+            let all_pkg_name = convert_pkg_name::<rattler_conda_types::MatchSpec>(&deps)?;
+            for dep in all_pkg_name.iter() {
+                // Get name or error on missing name
+                let name = dep
+                    .clone()
+                    .name
+                    .ok_or_else(|| miette!("Can't remove dependency without a name: {}", dep))?;
+                let (name, req) = project.manifest.remove_dependency(
+                    &name,
+                    spec_type,
+                    &args.platform,
+                    &args.feature_name(),
+                )?;
+                sucessful_output.push(format_ok_message(
+                    name.as_source(),
+                    &req.to_string(),
+                    &table_name,
+                ));
+            }
         }
     };
 
@@ -146,7 +116,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // updating prefix after removing from toml
     get_up_to_date_prefix(
         &project.default_environment(),
-        LockFileUsage::Update,
+        args.lock_file_usage(),
         args.no_install,
     )
     .await?;

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -354,19 +354,16 @@ impl Manifest {
         spec_type: SpecType,
         platforms: &[Platform],
         feature_name: &FeatureName,
-    ) -> miette::Result<(PackageName, NamelessMatchSpec)> {
-        let mut res = None;
+    ) -> miette::Result<()> {
         for platform in to_options(platforms) {
             // Remove the dependency from the manifest
-            res = Some(
-                self.target_mut(platform, feature_name)
-                    .remove_dependency(dep, spec_type),
-            );
+            self.target_mut(platform, feature_name)
+                .remove_dependency(dep, spec_type)?;
             // Remove the dependency from the TOML document
             self.document
                 .remove_dependency(dep, spec_type, platform, feature_name)?;
         }
-        res.unwrap().into_diagnostic()
+        Ok(())
     }
 
     /// Removes a pypi dependency.
@@ -375,19 +372,16 @@ impl Manifest {
         dep: &PyPiPackageName,
         platforms: &[Platform],
         feature_name: &FeatureName,
-    ) -> miette::Result<(PyPiPackageName, PyPiRequirement)> {
-        let mut res = None;
+    ) -> miette::Result<()> {
         for platform in to_options(platforms) {
             // Remove the dependency from the manifest
-            res = Some(
-                self.target_mut(platform, feature_name)
-                    .remove_pypi_dependency(dep),
-            );
+            self.target_mut(platform, feature_name)
+                .remove_pypi_dependency(dep)?;
             // Remove the dependency from the TOML document
             self.document
                 .remove_pypi_dependency(dep, platform, feature_name)?;
         }
-        res.unwrap().into_diagnostic()
+        Ok(())
     }
 
     /// Returns true if any of the features has pypi dependencies defined.

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -310,20 +310,21 @@ impl Manifest {
         &mut self,
         spec: &MatchSpec,
         spec_type: SpecType,
-        platform: Option<Platform>,
+        platforms: &[Platform],
         feature_name: &FeatureName,
     ) -> miette::Result<()> {
         // Determine the name of the package to add
         let (Some(name), spec) = spec.clone().into_nameless() else {
             miette::bail!("pixi does not support wildcard dependencies")
         };
-
-        // Add the dependency to the manifest
-        self.get_or_insert_target_mut(platform, Some(feature_name))
-            .try_add_dependency(&name, &spec, spec_type)?;
-        // and to the TOML document
-        self.document
-            .add_dependency(&name, &spec, spec_type, platform, feature_name)?;
+        for platform in to_options(platforms) {
+            // Add the dependency to the manifest
+            self.get_or_insert_target_mut(platform, Some(feature_name))
+                .try_add_dependency(&name, &spec, spec_type)?;
+            // and to the TOML document
+            self.document
+                .add_dependency(&name, &spec, spec_type, platform, feature_name)?;
+        }
         Ok(())
     }
 
@@ -331,16 +332,18 @@ impl Manifest {
     pub fn add_pypi_dependency(
         &mut self,
         requirement: &pep508_rs::Requirement,
-        platform: Option<Platform>,
+        platforms: &[Platform],
         feature_name: &FeatureName,
         editable: Option<bool>,
     ) -> miette::Result<()> {
-        // Add the pypi dependency to the manifest
-        self.get_or_insert_target_mut(platform, Some(feature_name))
-            .try_add_pypi_dependency(requirement, editable)?;
-        // and to the TOML document
-        self.document
-            .add_pypi_dependency(requirement, platform, feature_name)?;
+        for platform in to_options(platforms) {
+            // Add the pypi dependency to the manifest
+            self.get_or_insert_target_mut(platform, Some(feature_name))
+                .try_add_pypi_dependency(requirement, editable)?;
+            // and to the TOML document
+            self.document
+                .add_pypi_dependency(requirement, platform, feature_name)?;
+        }
         Ok(())
     }
 
@@ -349,34 +352,42 @@ impl Manifest {
         &mut self,
         dep: &PackageName,
         spec_type: SpecType,
-        platform: Option<Platform>,
+        platforms: &[Platform],
         feature_name: &FeatureName,
     ) -> miette::Result<(PackageName, NamelessMatchSpec)> {
-        // Remove the dependency from the manifest
-        let res = self
-            .target_mut(platform, feature_name)
-            .remove_dependency(dep, spec_type);
-        // Remove the dependency from the TOML document
-        self.document
-            .remove_dependency(dep, spec_type, platform, feature_name)?;
-        res.into_diagnostic()
+        let mut res = None;
+        for platform in to_options(platforms) {
+            // Remove the dependency from the manifest
+            res = Some(
+                self.target_mut(platform, feature_name)
+                    .remove_dependency(dep, spec_type),
+            );
+            // Remove the dependency from the TOML document
+            self.document
+                .remove_dependency(dep, spec_type, platform, feature_name)?;
+        }
+        res.unwrap().into_diagnostic()
     }
 
     /// Removes a pypi dependency.
     pub fn remove_pypi_dependency(
         &mut self,
         dep: &PyPiPackageName,
-        platform: Option<Platform>,
+        platforms: &[Platform],
         feature_name: &FeatureName,
     ) -> miette::Result<(PyPiPackageName, PyPiRequirement)> {
-        // Remove the dependency from the manifest
-        let res = self
-            .target_mut(platform, feature_name)
-            .remove_pypi_dependency(dep);
-        // Remove the dependency from the TOML document
-        self.document
-            .remove_pypi_dependency(dep, platform, feature_name)?;
-        res.into_diagnostic()
+        let mut res = None;
+        for platform in to_options(platforms) {
+            // Remove the dependency from the manifest
+            res = Some(
+                self.target_mut(platform, feature_name)
+                    .remove_pypi_dependency(dep),
+            );
+            // Remove the dependency from the TOML document
+            self.document
+                .remove_pypi_dependency(dep, platform, feature_name)?;
+        }
+        res.unwrap().into_diagnostic()
     }
 
     /// Returns true if any of the features has pypi dependencies defined.
@@ -627,6 +638,14 @@ impl Manifest {
         Q: Hash + Equivalent<String>,
     {
         self.parsed.solve_groups.find(name)
+    }
+}
+
+/// Converts an array of Platforms to a non-empty Vec of Option<Platform>
+fn to_options(platforms: &[Platform]) -> Vec<Option<Platform>> {
+    match platforms.is_empty() {
+        true => vec![None],
+        false => platforms.iter().map(|p| Some(*p)).collect_vec(),
     }
 }
 
@@ -1390,46 +1409,50 @@ mod tests {
         file_contents: &str,
         name: &str,
         kind: SpecType,
-        platform: Option<Platform>,
+        platforms: &[Platform],
         feature_name: &FeatureName,
     ) {
         let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
 
         // Initially the dependency should exist
-        assert!(manifest
-            .feature_mut(feature_name)
-            .unwrap()
-            .targets
-            .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
-            .unwrap()
-            .dependencies
-            .get(&kind)
-            .unwrap()
-            .get(name)
-            .is_some());
+        for platform in to_options(platforms) {
+            assert!(manifest
+                .feature_mut(feature_name)
+                .unwrap()
+                .targets
+                .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
+                .unwrap()
+                .dependencies
+                .get(&kind)
+                .unwrap()
+                .get(name)
+                .is_some());
+        }
 
         // Remove the dependency from the manifest
         manifest
             .remove_dependency(
                 &PackageName::new_unchecked(name),
                 kind,
-                platform,
+                platforms,
                 feature_name,
             )
             .unwrap();
 
         // The dependency should no longer exist
-        assert!(manifest
-            .feature_mut(feature_name)
-            .unwrap()
-            .targets
-            .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
-            .unwrap()
-            .dependencies
-            .get(&kind)
-            .unwrap()
-            .get(name)
-            .is_none());
+        for platform in to_options(platforms) {
+            assert!(manifest
+                .feature_mut(feature_name)
+                .unwrap()
+                .targets
+                .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
+                .unwrap()
+                .dependencies
+                .get(&kind)
+                .unwrap()
+                .get(name)
+                .is_none());
+        }
 
         // Write the toml to string and verify the content
         assert_snapshot!(
@@ -1441,7 +1464,7 @@ mod tests {
     fn test_remove_pypi(
         file_contents: &str,
         name: &str,
-        platform: Option<Platform>,
+        platforms: &[Platform],
         feature_name: &FeatureName,
     ) {
         let mut manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
@@ -1449,35 +1472,39 @@ mod tests {
         let package_name = PyPiPackageName::from_str(name).unwrap();
 
         // Initially the dependency should exist
-        assert!(manifest
-            .feature_mut(feature_name)
-            .unwrap()
-            .targets
-            .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
-            .unwrap()
-            .pypi_dependencies
-            .as_ref()
-            .unwrap()
-            .get(&package_name)
-            .is_some());
+        for platform in to_options(platforms) {
+            assert!(manifest
+                .feature_mut(feature_name)
+                .unwrap()
+                .targets
+                .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
+                .unwrap()
+                .pypi_dependencies
+                .as_ref()
+                .unwrap()
+                .get(&package_name)
+                .is_some());
+        }
 
         // Remove the dependency from the manifest
         manifest
-            .remove_pypi_dependency(&package_name, platform, feature_name)
+            .remove_pypi_dependency(&package_name, platforms, feature_name)
             .unwrap();
 
         // The dependency should no longer exist
-        assert!(manifest
-            .feature_mut(feature_name)
-            .unwrap()
-            .targets
-            .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
-            .unwrap()
-            .pypi_dependencies
-            .as_ref()
-            .unwrap()
-            .get(&package_name)
-            .is_none());
+        for platform in to_options(platforms) {
+            assert!(manifest
+                .feature_mut(feature_name)
+                .unwrap()
+                .targets
+                .for_opt_target(platform.map(TargetSelector::Platform).as_ref())
+                .unwrap()
+                .pypi_dependencies
+                .as_ref()
+                .unwrap()
+                .get(&package_name)
+                .is_none());
+        }
 
         // Write the toml to string and verify the content
         assert_snapshot!(
@@ -1487,14 +1514,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case::xpackage("xpackage", Some(Platform::Linux64), FeatureName::Default)]
-    #[case::jax("jax", Some(Platform::Win64), FeatureName::Default)]
-    #[case::requests("requests", None, FeatureName::Default)]
-    #[case::feature_dep("feature_dep", None, FeatureName::Named("test".to_string()))]
-    #[case::feature_target_dep("feature_target_dep", Some(Platform::Linux64), FeatureName::Named("test".to_string()))]
+    #[case::xpackage("xpackage", &[Platform::Linux64], FeatureName::Default)]
+    #[case::jax("jax", &[Platform::Win64], FeatureName::Default)]
+    #[case::requests("requests", &[], FeatureName::Default)]
+    #[case::feature_dep("feature_dep", &[], FeatureName::Named("test".to_string()))]
+    #[case::feature_target_dep("feature_target_dep", &[Platform::Linux64], FeatureName::Named("test".to_string()))]
     fn test_remove_pypi_dependencies(
         #[case] package_name: &str,
-        #[case] platform: Option<Platform>,
+        #[case] platforms: &[Platform],
         #[case] feature_name: FeatureName,
     ) {
         let pixi_cfg = r#"[project]
@@ -1523,7 +1550,7 @@ feature_dep = "*"
 [feature.test.target.linux-64.pypi-dependencies]
 feature_target_dep = "*"
 "#;
-        test_remove_pypi(pixi_cfg, package_name, platform, &feature_name);
+        test_remove_pypi(pixi_cfg, package_name, platforms, &feature_name);
     }
 
     #[test]
@@ -1550,21 +1577,21 @@ feature_target_dep = "*"
             file_contents,
             "baz",
             SpecType::Build,
-            Some(Platform::Linux64),
+            &[Platform::Linux64],
             &FeatureName::Default,
         );
         test_remove(
             file_contents,
             "bar",
             SpecType::Run,
-            Some(Platform::Win64),
+            &[Platform::Win64],
             &FeatureName::Default,
         );
         test_remove(
             file_contents,
             "fooz",
             SpecType::Run,
-            None,
+            &[],
             &FeatureName::Default,
         );
     }
@@ -1595,7 +1622,7 @@ feature_target_dep = "*"
             .remove_dependency(
                 &PackageName::new_unchecked("fooz"),
                 SpecType::Run,
-                None,
+                &[],
                 &FeatureName::Default,
             )
             .unwrap();
@@ -2363,7 +2390,7 @@ bar = "*"
             .add_dependency(
                 &MatchSpec::from_str(" baz >=1.2.3", Strict).unwrap(),
                 SpecType::Run,
-                None,
+                &[],
                 &FeatureName::Default,
             )
             .unwrap();
@@ -2384,7 +2411,7 @@ bar = "*"
             .add_dependency(
                 &MatchSpec::from_str(" bal >=2.3", Strict).unwrap(),
                 SpecType::Run,
-                None,
+                &[],
                 &FeatureName::Named("test".to_string()),
             )
             .unwrap();
@@ -2408,7 +2435,7 @@ bar = "*"
             .add_dependency(
                 &MatchSpec::from_str(" boef >=2.3", Strict).unwrap(),
                 SpecType::Run,
-                Some(Platform::Linux64),
+                &[Platform::Linux64],
                 &FeatureName::Named("extra".to_string()),
             )
             .unwrap();
@@ -2433,7 +2460,7 @@ bar = "*"
             .add_dependency(
                 &MatchSpec::from_str(" cmake >=2.3", ParseStrictness::Strict).unwrap(),
                 SpecType::Build,
-                Some(Platform::Linux64),
+                &[Platform::Linux64],
                 &FeatureName::Named("build".to_string()),
             )
             .unwrap();

--- a/src/project/manifest/pyproject.rs
+++ b/src/project/manifest/pyproject.rs
@@ -409,7 +409,7 @@ mod tests {
         // Add numpy to pyproject
         let requirement = pep508_rs::Requirement::from_str("numpy>=3.12").unwrap();
         manifest
-            .add_pypi_dependency(&requirement, None, &FeatureName::Default, None)
+            .add_pypi_dependency(&requirement, &[], &FeatureName::Default, None)
             .unwrap();
 
         assert!(manifest
@@ -428,7 +428,7 @@ mod tests {
         manifest
             .add_pypi_dependency(
                 &requirement,
-                None,
+                &[],
                 &FeatureName::Named("test".to_string()),
                 None,
             )
@@ -456,7 +456,7 @@ mod tests {
         // Remove flask from pyproject
         let name = PyPiPackageName::from_str("flask").unwrap();
         manifest
-            .remove_pypi_dependency(&name, None, &FeatureName::Default)
+            .remove_pypi_dependency(&name, &[], &FeatureName::Default)
             .unwrap();
 
         assert!(manifest

--- a/tests/add_tests.rs
+++ b/tests/add_tests.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use crate::common::builders::HasDependencyConfig;
 use crate::common::package_database::{Package, PackageDatabase};
 use crate::common::LockFileExt;
 use crate::common::PixiControl;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,7 +36,7 @@ use std::{
 use tempfile::TempDir;
 use thiserror::Error;
 
-use self::builders::RemoveBuilder;
+use self::builders::{HasDependencyConfig, RemoveBuilder};
 
 /// To control the pixi process
 pub struct PixiControl {
@@ -227,21 +227,7 @@ impl PixiControl {
     /// Add a dependency to the project. Returns an [`AddBuilder`].
     /// the command and await the result call `.await` on the return value.
     pub fn add(&self, spec: &str) -> AddBuilder {
-        AddBuilder {
-            args: add::Args {
-                manifest_path: Some(self.manifest_path()),
-                host: false,
-                specs: vec![spec.to_string()],
-                build: false,
-                no_install: true,
-                no_lockfile_update: false,
-                platform: Default::default(),
-                pypi: false,
-                feature: None,
-                config: Default::default(),
-                editable: false,
-            },
-        }
+        self.add_multiple(vec![spec])
     }
 
     /// Add dependencies to the project. Returns an [`AddBuilder`].
@@ -249,15 +235,10 @@ impl PixiControl {
     pub fn add_multiple(&self, specs: Vec<&str>) -> AddBuilder {
         AddBuilder {
             args: add::Args {
-                manifest_path: Some(self.manifest_path()),
-                host: false,
-                specs: specs.iter().map(|s| s.to_string()).collect(),
-                build: false,
-                no_install: true,
-                no_lockfile_update: false,
-                platform: Default::default(),
-                pypi: false,
-                feature: None,
+                dependency_config: AddBuilder::dependency_config_with_specs(
+                    specs,
+                    self.manifest_path(),
+                ),
                 config: Default::default(),
                 editable: false,
             },
@@ -268,15 +249,11 @@ impl PixiControl {
     pub fn remove(&self, spec: &str) -> RemoveBuilder {
         RemoveBuilder {
             args: remove::Args {
-                deps: vec![spec.to_string()],
-                manifest_path: Some(self.manifest_path()),
-                host: false,
-                build: false,
-                pypi: false,
-                platform: Default::default(),
-                feature: None,
+                dependency_config: AddBuilder::dependency_config_with_specs(
+                    vec![spec],
+                    self.manifest_path(),
+                ),
                 config: Default::default(),
-                no_install: true,
             },
         }
     }

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -3,7 +3,7 @@ mod common;
 use std::path::Path;
 use std::str::FromStr;
 
-use crate::common::builders::string_from_iter;
+use crate::common::builders::{string_from_iter, HasDependencyConfig};
 use crate::common::package_database::{Package, PackageDatabase};
 use common::{LockFileExt, PixiControl};
 use pixi::cli::{run, LockFileUsageArgs};

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, str::FromStr};
 
 use crate::common::{
+    builders::HasDependencyConfig,
     package_database::{Package, PackageDatabase},
     LockFileExt, PixiControl,
 };


### PR DESCRIPTION
Refactors Args of `pixi add` and `pixi remove` into a common struct and aligns arguments:

- Like `add`, `remove` now accepts a Vec of platforms
- Like `add`, `remove` now accepts a `no_lockfile_update` argument
- Use same console messages for `remove` as for `add`

In addition,
 - iteration over platforms is pushed down the stack, as it was always wrapping calls to the dependency add / remove methods
 - package & package name extraction is refactored to use the HasSpecs trait