### PR TITLE
feat: allow installing multiple envs at once

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -21,7 +21,7 @@ pub struct Args {
     #[clap(flatten)]
     pub config: ConfigCli,
 
-    #[arg(long, short, conflicts_with = "environments")]
+    #[arg(long, short, conflicts_with = "environment")]
     pub all: bool,
 }
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -56,7 +56,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let s = if installed_envs.len() > 1 { "s" } else { "" };
     // Message what's installed
     eprintln!(
-        "> Installed environment{s}: {}!",
+        "> The following environment{s} are ready to use: \n\t{}",
         installed_envs
             .iter()
             .map(|n| console::style(n).bold())

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -62,7 +62,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     } else {
         eprintln!(
-            "{}The following environments where installed: \n\t{}",
+            "{}The following environments have been installed: \n\t{}",
             console::style(console::Emoji("✔ ", "")).green(),
             installed_envs
                 .iter()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -16,7 +16,7 @@ pub struct Args {
     pub lock_file_usage: super::LockFileUsageArgs,
 
     #[arg(long, short)]
-    pub environments: Option<Vec<String>>,
+    pub environment: Option<Vec<String>>,
 
     #[clap(flatten)]
     pub config: ConfigCli,
@@ -34,7 +34,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // 1. specific environments
     // 2. all environments
     // 3. default environment (if no environments are specified)
-    let envs = if let Some(envs) = args.environments {
+    let envs = if let Some(envs) = args.environment {
         envs
     } else if args.all {
         project

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -56,7 +56,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Message what's installed
     if installed_envs.len() == 1 {
         eprintln!(
-            "{}The {} environment is installed.",
+            "{}The {} environment has been installed.",
             console::style(console::Emoji("✔ ", "")).green(),
             installed_envs[0].fancy_display(),
         );

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -53,19 +53,24 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         installed_envs.push(environment.name().clone());
     }
 
-    let s = if installed_envs.len() > 1 { "s" } else { "" };
     // Message what's installed
-    eprintln!(
-        "> The following environment{s} are ready to use: \n\t{}",
-        installed_envs.iter().map(|n| n.fancy_display()).join(", "),
-    );
+    if installed_envs.len() == 1 {
+        eprintln!(
+            "{}The {} environment is installed.",
+            console::style(console::Emoji("✔ ", "")).green(),
+            installed_envs[0].fancy_display(),
+        );
+    } else {
+        eprintln!(
+            "{}The following environments where installed: \n\t{}",
+            console::style(console::Emoji("✔ ", "")).green(),
+            installed_envs
+                .iter()
+                .map(|n| n.fancy_display())
+                .join("\n\t"),
+        );
+    }
 
-    // Emit success
-    eprintln!(
-        "{}Project in {} is ready to use!",
-        console::style(console::Emoji("✔ ", "")).green(),
-        project.root().display()
-    );
     Project::warn_on_discovered_from_env(args.manifest_path.as_deref());
     Ok(())
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -49,18 +49,15 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let mut installed_envs = Vec::with_capacity(envs.len());
     for env in envs {
         let environment = project.environment_from_name_or_env_var(Some(env))?;
-        installed_envs.push(environment.name().to_string());
         get_up_to_date_prefix(&environment, args.lock_file_usage.into(), false).await?;
+        installed_envs.push(environment.name().clone());
     }
 
     let s = if installed_envs.len() > 1 { "s" } else { "" };
     // Message what's installed
     eprintln!(
         "> The following environment{s} are ready to use: \n\t{}",
-        installed_envs
-            .iter()
-            .map(|n| console::style(n).bold())
-            .join(", "),
+        installed_envs.iter().map(|n| n.fancy_display()).join(", "),
     );
 
     // Emit success

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -370,6 +370,7 @@ impl PixiControl {
                     locked: false,
                 },
                 config: Default::default(),
+                all: false,
             },
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -363,7 +363,7 @@ impl PixiControl {
     pub fn install(&self) -> InstallBuilder {
         InstallBuilder {
             args: Args {
-                environment: None,
+                environments: None,
                 manifest_path: Some(self.manifest_path()),
                 lock_file_usage: LockFileUsageArgs {
                     frozen: false,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -363,7 +363,7 @@ impl PixiControl {
     pub fn install(&self) -> InstallBuilder {
         InstallBuilder {
             args: Args {
-                environments: None,
+                environment: None,
                 manifest_path: Some(self.manifest_path()),
                 lock_file_usage: LockFileUsageArgs {
                     frozen: false,


### PR DESCRIPTION
Allow installation of multiple envs at the same time. Eg:

```bash
pixi install -e default -e other
```