### PR TITLE
fix: fish prompt display looks wrong in tide

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -19,10 +19,44 @@ pub fn get_zsh_hook(env_name: &str) -> String {
 /// Set default pixi prompt for the fish shell
 pub fn get_fish_prompt(env_name: &str) -> String {
     format!(
-        "functions -c fish_prompt old_fish_prompt; \
-         function fish_prompt; \
-             echo \"({})\" (old_fish_prompt); \
-         end;",
+        r#"
+        function __pixi_add_prompt
+            set_color -o green
+            echo -n "({}) "
+            set_color normal
+        end
+
+        if not functions -q __fish_prompt_orig
+            functions -c fish_prompt __fish_prompt_orig
+        end
+
+        if functions -q fish_right_prompt
+            if not functions -q __fish_right_prompt_orig
+                functions -c fish_right_prompt __fish_right_prompt_orig
+            end
+        else
+            function __fish_right_prompt_orig
+                # Placeholder function for when fish_right_prompt does not exist
+                echo ""
+            end
+        end
+
+        function fish_prompt
+            set -l last_status $status
+            if set -q PIXIE_LEFT_PROMPT
+                __pixi_add_prompt
+            end
+            __fish_prompt_orig
+            return $last_status
+        end
+
+        function fish_right_prompt
+            if not set -q PIXIE_LEFT_PROMPT
+                __pixi_add_prompt
+            end
+            __fish_right_prompt_orig
+        end
+        "#,
         env_name
     )
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -43,7 +43,7 @@ pub fn get_fish_prompt(env_name: &str) -> String {
 
         function fish_prompt
             set -l last_status $status
-            if set -q PIXIE_LEFT_PROMPT
+            if set -q PIXI_LEFT_PROMPT
                 __pixi_add_prompt
             end
             __fish_prompt_orig
@@ -51,7 +51,7 @@ pub fn get_fish_prompt(env_name: &str) -> String {
         end
 
         function fish_right_prompt
-            if not set -q PIXIE_LEFT_PROMPT
+            if not set -q PIXI_LEFT_PROMPT
                 __pixi_add_prompt
             end
             __fish_right_prompt_orig


### PR DESCRIPTION
fixes [prefix-dev/pixi#1407](https://github.com/prefix-dev/pixi/issues/1407)

I adapted the prompt logic from conda and made some small changes for pixi.
The environment name is displayed on the right side per default, but can be moved to the left like this:
```
set -gx CONDA_LEFT_PROMPT 1
```

I have tested it with a vanilla fish theme and my tide prompt. It looks good now.
![grafik](https://github.com/prefix-dev/pixi/assets/1817286/b9302a23-a901-4456-a55c-8c4ddea3fb9e)

![grafik](https://github.com/prefix-dev/pixi/assets/1817286/dd2d0565-e9e7-4c4e-b34a-21239b31f0b4)

I noticed that there's a source /tmp/pixi_env_....fish line printed twice which is not ideal, but out of scope for this PR, as it is not a fish specific issue. 