### PR TITLE
fix: don't record purl for non conda-forge channels

### DIFF
--- a/src/pypi_mapping/prefix_pypi_name_mapping.rs
+++ b/src/pypi_mapping/prefix_pypi_name_mapping.rs
@@ -80,7 +80,6 @@ pub async fn conda_pypi_name_mapping(
                 .as_ref()
                 .is_some_and(|p| p.is_empty())
         })
-        .filter(|package| is_conda_forge_record(package))
         .filter_map(|package| {
             package
                 .package_record

--- a/src/pypi_mapping/prefix_pypi_name_mapping.rs
+++ b/src/pypi_mapping/prefix_pypi_name_mapping.rs
@@ -80,6 +80,7 @@ pub async fn conda_pypi_name_mapping(
                 .as_ref()
                 .is_some_and(|p| p.is_empty())
         })
+        .filter(|package| is_conda_forge_record(package))
         .filter_map(|package| {
             package
                 .package_record
@@ -232,7 +233,7 @@ pub fn amend_pypi_purls_for_record(
     if let Some(possible_mapped_name) =
         compressed_mapping.get(record.package_record.name.as_normalized())
     {
-        if !not_a_pypi && purls.is_empty() {
+        if !not_a_pypi && purls.is_empty() && is_conda_forge_record(record) {
             // if we have a pypi name for it
             // we record the purl
             if let Some(mapped_name) = possible_mapped_name {


### PR DESCRIPTION
While trying to reproduce #1230 , I've observed that we record purl for packages even that are not conda-forge but from pytorch.

so by having this example:

```
[dependencies]
captum = {version="*", channel="pytorch"}
boltons = {version = "*"}

[pypi-dependencies]
captum = { version = "*"}
```

we need to have purl only for boltons, and empty purls for captum with a warning that pypi will overwrite it.

<img width="616" alt="Screenshot 2024-05-28 at 14 42 16" src="https://github.com/prefix-dev/pixi/assets/25200469/6f4b6848-c7aa-411c-98c9-4e9ec614247b">
