### PR TITLE
fix: channel display channels

### DIFF
--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -15,6 +15,7 @@ use tokio::task::spawn_blocking;
 use crate::progress::await_in_progress;
 use crate::project::has_features::HasFeatures;
 use crate::task::TaskName;
+use crate::util::default_channel_config;
 use crate::{config, EnvironmentName, FeatureName, Project};
 
 static WIDTH: usize = 18;
@@ -90,7 +91,7 @@ impl Display for EnvironmentInfo {
             writeln!(f, "{:>WIDTH$}: {}", bold.apply_to("Environment size"), size)?;
         }
         if !self.channels.is_empty() {
-            let channels_list = self.channels.iter().map(|c| c.to_string()).format(", ");
+            let channels_list = self.channels.iter().format(", ");
             writeln!(
                 f,
                 "{:>WIDTH$}: {}",
@@ -347,7 +348,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                         channels: env
                             .channels()
                             .into_iter()
-                            .filter_map(|c| c.name.clone())
+                            .map(|c| {
+                                default_channel_config()
+                                    .canonical_name(c.base_url())
+                                    .to_string()
+                            })
                             .collect(),
                         prefix: env.dir(),
                         tasks,


### PR DESCRIPTION
```toml
channels = ["https://fast.prefix.dev/conda-forge"]
```
Before:
```
> pixi info
...
          Channels: conda-forge
...
```
After:
```
> pixi info
...
          Channels: https://fast.prefix.dev/conda-forge
...
```
