### PR TITLE
fix: use best_platform to verify the run platform

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -8,7 +8,6 @@ use clap::Parser;
 use dialoguer::theme::ColorfulTheme;
 use itertools::Itertools;
 use miette::{miette, Context, Diagnostic, IntoDiagnostic};
-use rattler_conda_types::Platform;
 
 use crate::activation::get_environment_variables;
 use crate::environment::verify_prefix_location_unchanged;
@@ -62,6 +61,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Extract the passed in environment name.
     let environment = project.environment_from_name_or_env_var(args.environment.clone())?;
+
+    let best_platform = environment.best_platform();
+
     // Find the environment to run the task in, if any were specified.
     let explicit_environment = if environment.is_default() {
         None
@@ -99,10 +101,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let search_environment = SearchEnvironments::from_opt_env(
         &project,
         explicit_environment.clone(),
-        explicit_environment
-            .as_ref()
-            .map(|e| e.best_platform())
-            .or(Some(Platform::current())),
+        Some(best_platform),
     )
     .with_disambiguate_fn(disambiguate_task_interactive);
 

--- a/src/task/task_environment.rs
+++ b/src/task/task_environment.rs
@@ -206,7 +206,7 @@ mod tests {
             [project]
             name = "foo"
             channels = ["foo"]
-            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64"]
+            platforms = ["linux-64", "win-64", "osx-64"]
 
             [tasks]
             test = "cargo test"
@@ -216,7 +216,8 @@ mod tests {
             test = ["test"]
         "#;
         let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
-        let search = SearchEnvironments::from_opt_env(&project, None, None);
+        let env = project.default_environment();
+        let search = SearchEnvironments::from_opt_env(&project, None, Some(env.best_platform()));
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(result.is_ok());
         assert!(result.unwrap().0.name().is_default());


### PR DESCRIPTION
I believe this allows `osx-64` only environments' tasks to run on osx-arm64. @wolfv Could you verify. I only checked with faking the current platform on my machine.

e.g. this should work on `osx-arm64`:
```toml
[project]
name = "foo"
channels = ["foo"]
platforms = ["linux-64", "win-64", "osx-64"]

[tasks]
test = "echo test"
```

```
pixi run test
```

Fixes #1404 
