### PR TITLE
feat: add `description` field to `task`

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -284,6 +284,8 @@ Add a task to the [manifest file](project_configuration.md), use `--depends-on` 
 - `--feature <FEATURE> (-f)`: the feature for which the task is added, if non provided the default tasks will be added.
 - `--depends-on <DEPENDS_ON>`: the task it depends on to be run before the one your adding.
 - `--cwd <CWD>`: the working directory for the task relative to the root of the project.
+- `--env <ENV>`: the environment variables as `key=value` pairs for the task, can be used multiple times, e.g. `--env "VAR1=VALUE1" --env "VAR2=VALUE2"`.
+- `--description <DESCRIPTION>`: a description of the task.
 
 ```shell
 pixi task add cow cowpy "Hello User"
@@ -291,6 +293,7 @@ pixi task add tls ls --cwd tests
 pixi task add test cargo t --depends-on build
 pixi task add build-osx "METAL=1 cargo build" --platform osx-64
 pixi task add train python train.py --feature cuda
+pixi task add publish-pypi "hatch publish --yes --repo main" --feature build --env HATCH_CONFIG=config/hatch.toml --description "Publish the package to pypi"
 ```
 
 This adds the following to the [manifest file](project_configuration.md):
@@ -306,6 +309,9 @@ build-osx = "METAL=1 cargo build"
 
 [feature.cuda.tasks]
 train = "python train.py"
+
+[feature.build.tasks]
+publish-pypi = { cmd = "hatch publish --yes --repo main", env = { HATCH_CONFIG = "config/hatch.toml" }, description = "Publish the package to pypi" }
 ```
 
 Which you can then run with the `run` command:

--- a/schema/examples/valid/full.toml
+++ b/schema/examples/valid/full.toml
@@ -13,46 +13,52 @@ readme = "README.md"
 homepage = "https://project.com"
 repository = "https://github.com/author/project"
 documentation = "https://docs.project.com"
-conda-pypi-map = {"robostack" = "robostack_mapping.json", "conda-forge" = "https://repo.prefix.dev/conda-forge"}
+conda-pypi-map = { "robostack" = "robostack_mapping.json", "conda-forge" = "https://repo.prefix.dev/conda-forge" }
 
 [dependencies]
 test = "*"
 test1 = "*"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
-package1 = { version = ">=1.2.3", build="py34_0" }
-
+package1 = { version = ">=1.2.3", build = "py34_0" }
 
 [pypi-dependencies]
 testpypi = "*"
 testpypi1 = "*"
-requests = {version = ">= 2.8.1, ==2.8.*", extras=["security", "tests"]} # Using the map allows the user to add `extras`
+requests = { version = ">= 2.8.1, ==2.8.*", extras = [
+  "security",
+  "tests",
+] } # Using the map allows the user to add `extras`
 
 [host-dependencies]
 test = "*"
 test1 = "*"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
-package1 = { version = ">=1.2.3", build="py34_0" }
+package1 = { version = ">=1.2.3", build = "py34_0" }
 
 [build-dependencies]
 test = "*"
 test1 = "*"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
-package1 = { version = ">=1.2.3", build="py34_0" }
+package1 = { version = ">=1.2.3", build = "py34_0" }
 
 [tasks]
 build = "conda build ."
 # deprecated depends_on
-test = { cmd = "pytest", cwd = "tests", depends_on = ["build"] }
-test2 = { cmd = "pytest", cwd = "tests"}
+test = { cmd = "pytest", cwd = "tests", depends_on = [
+  "build",
+], description = "Run tests using pytests after building." }
+test2 = { cmd = "pytest", cwd = "tests" }
 test3 = { cmd = "pytest", depends-on = ["test2"] }
 test4 = { cmd = "pytest", cwd = "tests", depends-on = ["test2"] }
 test5 = { cmd = "pytest" }
 test6 = { depends-on = ["test5"] }
-test7 = { cmd = "pytest", cwd = "tests", depends-on = ["test5"], env = {PYTHONPATH = "bla", "WEIRD_STRING" = "blu"}}
+test7 = { cmd = "pytest", cwd = "tests", depends-on = [
+  "test5",
+], env = { PYTHONPATH = "bla", "WEIRD_STRING" = "blu" } }
 
 [system-requirements]
 linux = "5.10"
-libc = { family="glibc", version="2.17" }
+libc = { family = "glibc", version = "2.17" }
 cuda = "10.1"
 
 [feature.test.dependencies]
@@ -62,18 +68,18 @@ test = "*"
 test = "*"
 
 [feature.prod]
-activation = {scripts = ["activate.sh", "deactivate.sh"]}
+activation = { scripts = ["activate.sh", "deactivate.sh"] }
 
 [feature.lint]
-dependencies = {flake8 = "3.7.9", black = "19.10b0"}
+dependencies = { flake8 = "3.7.9", black = "19.10b0" }
 
 [environments]
-test = {features = ["test"], solve-group = "test"}
-prod = {features = ["test2"], solve-group = "test"}
+test = { features = ["test"], solve-group = "test" }
+prod = { features = ["test2"], solve-group = "test" }
 
 [activation]
 scripts = ["activate.sh", "deactivate.sh"]
-env = { TEST = "bla"}
+env = { TEST = "bla" }
 
 [target.unix.activation.env]
 TEST2 = "bla2"
@@ -85,30 +91,32 @@ scripts = ["env_setup.bat"]
 test = "*"
 test1 = "*"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
-package1 = { version = ">=1.2.3", build="py34_0" }
-
+package1 = { version = ">=1.2.3", build = "py34_0" }
 
 [target.osx-arm64.pypi-dependencies]
 testpypi = "*"
 testpypi1 = "*"
-requests = {version = ">= 2.8.1, ==2.8.*", extras=["security", "tests"]} # Using the map allows the user to add `extras`
+requests = { version = ">= 2.8.1, ==2.8.*", extras = [
+  "security",
+  "tests",
+] } # Using the map allows the user to add `extras`
 
 [target.osx-64.host-dependencies]
 test = "*"
 test1 = "*"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
-package1 = { version = ">=1.2.3", build="py34_0" }
+package1 = { version = ">=1.2.3", build = "py34_0" }
 
 [target.linux-64.build-dependencies]
 test = "*"
 test1 = "*"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
-package1 = { version = ">=1.2.3", build="py34_0" }
+package1 = { version = ">=1.2.3", build = "py34_0" }
 
 [target.linux-64.tasks]
 build = "conda build ."
 test = { cmd = "pytest", cwd = "tests", depends-on = ["build"] }
-test2 = { cmd = "pytest", cwd = "tests"}
+test2 = { cmd = "pytest", cwd = "tests" }
 test3 = { cmd = "pytest", depends-on = ["test2"] }
 test4 = { cmd = "pytest", cwd = "tests", depends-on = ["test2"] }
 test5 = { cmd = "pytest" }
@@ -118,14 +126,17 @@ test6 = { depends-on = ["test5"] }
 test = "*"
 
 [feature.cuda]
-activation = {scripts = ["cuda_activation.sh"]}
-channels = ["nvidia" , { channel = "pytorch", priority = -1}] # Results in:  ["nvidia", "conda-forge"] when the default is `conda-forge`
-dependencies = {cuda = "x.y.z", cudnn = "12.0"}
-pypi-dependencies = {torch = "==1.9.0"}
+activation = { scripts = ["cuda_activation.sh"] }
+channels = [
+  "nvidia",
+  { channel = "pytorch", priority = -1 },
+] # Results in:  ["nvidia", "conda-forge"] when the default is `conda-forge`
+dependencies = { cuda = "x.y.z", cudnn = "12.0" }
+pypi-dependencies = { torch = "==1.9.0" }
 platforms = ["linux-64", "osx-arm64"]
-system-requirements = {cuda = "12"}
-tasks = { warmup = "python warmup.py" }
-target.osx-arm64 = {dependencies = {mlx = "x.y.z"}}
+system-requirements = { cuda = "12" }
+tasks = { warmup = { cmd = "python warmup.py", description = "Warmup the GPU" } }
+target.osx-arm64 = { dependencies = { mlx = "x.y.z" } }
 
 [feature.cuda2.activation]
 scripts = ["cuda_activation.sh"]
@@ -151,11 +162,10 @@ mlx = "x.y.z"
 channels = ["nvidia"]
 platforms = ["linux-64", "osx-arm64"]
 
-
 [tool.poetry]
 test = "bla"
 test1 = ["bla", "bli"]
-test2= { version = "~=1.1", channel = "test" }
+test2 = { version = "~=1.1", channel = "test" }
 
 [tool.poetry.dependencies]
 test = "bla"

--- a/schema/model.py
+++ b/schema/model.py
@@ -240,7 +240,7 @@ class TaskInlineTable(StrictBaseModel):
     # BREAK: `depends_on` is deprecated, use `depends-on`
     depends_on_deprecated: list[TaskName] | TaskName | None = Field(
         None,
-        alias = "depends_on",
+        alias="depends_on",
         description="The tasks that this task depends on. Environment variables will **not** be expanded. Deprecated in favor of `depends-on` from v0.21.0 onward.",
     )
     depends_on: list[TaskName] | TaskName | None = Field(
@@ -260,6 +260,11 @@ class TaskInlineTable(StrictBaseModel):
         None,
         description="A map of environment variables to values, used in the task, these will be overwritten by the shell.",
         examples=[{"key": "value"}, {"ARGUMENT": "value"}],
+    )
+    description: NonEmptyStr | None = Field(
+        None,
+        description="A short description of the task",
+        examples=["Build the project"],
     )
 
 
@@ -393,25 +398,56 @@ class Feature(StrictBaseModel):
         description="Machine-specific aspects of this feature",
         examples=[{"linux": {"dependencies": {"python": "3.8"}}}],
     )
-    pypi_options: PyPIOptions | None = Field(None, alias="pypi-options", description="Options related to PyPI indexes for this feature")
+    pypi_options: PyPIOptions | None = Field(
+        None, alias="pypi-options", description="Options related to PyPI indexes for this feature"
+    )
+
 
 ###################
 # PyPI section #
 ###################
 
+
 class FindLinksPath(StrictBaseModel):
     """The path to the directory containing packages"""
-    path: NonEmptyStr | None = Field(None, description="Path to the directory of packages", examples=["./links"])
+
+    path: NonEmptyStr | None = Field(
+        None, description="Path to the directory of packages", examples=["./links"]
+    )
+
 
 class FindLinksURL(StrictBaseModel):
     """The URL to the html file containing href-links to packages"""
-    url: NonEmptyStr | None = Field(None, description="URL to html file with href-links to packages", examples=["https://simple-index-is-here.com"])
+
+    url: NonEmptyStr | None = Field(
+        None,
+        description="URL to html file with href-links to packages",
+        examples=["https://simple-index-is-here.com"],
+    )
+
 
 class PyPIOptions(StrictBaseModel):
     """Options related to PyPI indexes"""
-    index_url: NonEmptyStr | None = Field(None, alias="index-url", description="Alternative PyPI registry that should be used as the main index", examples=["https://pypi.org/simple"])
-    extra_index_urls: list[NonEmptyStr] | None = Field(None, alias="extra-index-urls", description="Additional PyPI registries that should be used as extra indexes", examples=[["https://pypi.org/simple"]])
-    find_links: list[FindLinksPath | FindLinksURL] = Field(None, alias="find-links", description="Paths to directory containing", examples=[["https://pypi.org/simple"]])
+
+    index_url: NonEmptyStr | None = Field(
+        None,
+        alias="index-url",
+        description="Alternative PyPI registry that should be used as the main index",
+        examples=["https://pypi.org/simple"],
+    )
+    extra_index_urls: list[NonEmptyStr] | None = Field(
+        None,
+        alias="extra-index-urls",
+        description="Additional PyPI registries that should be used as extra indexes",
+        examples=[["https://pypi.org/simple"]],
+    )
+    find_links: list[FindLinksPath | FindLinksURL] = Field(
+        None,
+        alias="find-links",
+        description="Paths to directory containing",
+        examples=[["https://pypi.org/simple"]],
+    )
+
 
 #######################
 # The Manifest itself #
@@ -443,7 +479,9 @@ class BaseManifest(StrictBaseModel):
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
         None, alias="pypi-dependencies", description="The PyPI dependencies"
     )
-    pypi_options: PyPIOptions | None = Field(None, alias="pypi-options", description="Options related to PyPI indexes")
+    pypi_options: PyPIOptions | None = Field(
+        None, alias="pypi-options", description="Options related to PyPI indexes"
+    )
     tasks: dict[TaskName, TaskInlineTable | NonEmptyStr] | None = Field(
         None, description="The tasks of the project"
     )

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1206,6 +1206,15 @@
             }
           ]
         },
+        "description": {
+          "title": "Description",
+          "description": "A short description of the task",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "Build the project"
+          ]
+        },
         "env": {
           "title": "Env",
           "description": "A map of environment variables to values, used in the task, these will be overwritten by the shell.",

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -128,7 +128,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 eprintln!();
             }
             eprintln!(
-                "{}{}{} in {}{}{}",
+                "{}{}{} in {}{}{}{}",
                 console::Emoji("✨ ", ""),
                 console::style("Pixi task (").bold(),
                 console::style(executable_task.name().unwrap_or("unnamed"))
@@ -141,6 +141,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .bold(),
                 console::style("): ").bold(),
                 executable_task.display_command(),
+                if let Some(description) = executable_task.task().description() {
+                    console::style(format!(": ({})", description)).yellow()
+                } else {
+                    console::style("".to_string()).yellow()
+                }
             );
         }
 

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -84,7 +84,7 @@ pub struct AddArgs {
     /// A description of the task to be added.
     #[arg(long)]
     pub description: Option<String>,
-    
+
     /// Isolate the task from the shell environment, and only use the pixi environment to run the task
     #[arg(long)]
     pub clean_env: bool,

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -245,7 +245,7 @@ fn list_tasks(
                     format!(
                         " - {:<15} {}",
                         taskname.fancy_display(),
-                        console::style(description).italic().to_string()
+                        console::style(description).italic()
                     ),
                 );
             }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -264,6 +264,9 @@ pub struct Alias {
     #[serde(alias = "depends-on")]
     #[serde_as(deserialize_as = "OneOrMany<_, PreferMany>")]
     pub depends_on: Vec<TaskName>,
+
+    /// A description of the task.
+    pub description: Option<String>,
 }
 
 impl Display for Task {

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -150,6 +150,16 @@ impl Task {
         }
     }
 
+    /// Returns the description of the task.
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Task::Plain(_) => None,
+            Task::Custom(_) => None,
+            Task::Execute(exe) => exe.description.as_deref(),
+            Task::Alias(_) => None,
+        }
+    }
+
     /// True if this task is a custom task instead of something defined in a project.
     pub fn is_custom(&self) -> bool {
         matches!(self, Task::Custom(_))
@@ -182,6 +192,9 @@ pub struct Execute {
 
     /// A list of environment variables to set before running the command
     pub env: Option<IndexMap<String, String>>,
+
+    /// A description of the task
+    pub description: Option<String>,
 }
 
 impl From<Execute> for Task {
@@ -288,6 +301,10 @@ impl Display for Task {
             if !env.is_empty() {
                 write!(f, ", env = {:?}", env)?;
             }
+        }
+        let description = self.description();
+        if let Some(description) = description {
+            write!(f, ", description = {:?}", description)?;
         }
 
         Ok(())

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -205,7 +205,7 @@ pub struct Execute {
 
     /// A description of the task
     pub description: Option<String>,
-    
+
     /// Isolate the task from the running machine
     #[serde(default)]
     pub clean_env: bool,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -428,6 +428,7 @@ impl TasksControl<'_> {
                 feature,
                 cwd: None,
                 env: Default::default(),
+                description: None,
             },
         }
     }
@@ -457,6 +458,7 @@ impl TasksControl<'_> {
                 platform,
                 alias: name,
                 depends_on: vec![],
+                description: None,
             },
         }
     }


### PR DESCRIPTION
first PR for the work for #1113 and part of #1434 

I believe next missing work would be some tests and I'm not entirely certain on how to update the `schema`. 

- [ ] Add tests 
- [ ] Update schema

note: I realized that the output for `task list` is now in a single line, so the description only prints after the `run` command if a description exists. 

![image](https://github.com/prefix-dev/pixi/assets/44614774/a54529a4-c434-42fb-b875-a32c9a7cfd21)
