### PR TITLE
fix: `pixi install --all` output missing newline 

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -73,10 +73,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         eprintln!(
             "{}The following environments have been installed: {}\t{}",
             console::style(console::Emoji("✔ ", "")).green(),
-            installed_envs
-                .iter()
-                .map(|n| n.fancy_display())
-                .join(", "),
+            installed_envs.iter().map(|n| n.fancy_display()).join(", "),
             detached_envs_message
         );
     }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -71,12 +71,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     } else {
         eprintln!(
-            "{}The following environments have been installed{}: \n\t{}",
+            "{}The following environments have been installed: {}\t{}",
             console::style(console::Emoji("✔ ", "")).green(),
             installed_envs
                 .iter()
                 .map(|n| n.fancy_display())
-                .join("\n\t"),
+                .join(", "),
             detached_envs_message
         );
     }


### PR DESCRIPTION
### Summary

The installed environments are now listed inline similar to the other commands. The formatting of the message has been updated from tab delimited to comma seperated. 

![image](https://github.com/prefix-dev/pixi/assets/62500639/38b61e90-0e8c-417f-a6b9-e0146b887df9)

resolves #1486 
