### PR TITLE
chore: Update default pixi gitignore and gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-pixi.lock linguist-language=YAML
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 .vscode
 .test-projects
 __pycache__
-**/**/.pixi
-**/**/.build
+**/.pixi/envs
+**/.build
 .DS_store
 site/
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 .vscode
 .test-projects
 __pycache__
-**/.pixi/envs
-**/.build
+.pixi
+.build
 .DS_store
 site/
 .cache

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -123,14 +123,12 @@ platforms = {{ platforms }}
 "#;
 
 const GITIGNORE_TEMPLATE: &str = r#"# pixi environments
-.pixi
+**/.pixi/envs
 *.egg-info
-
 "#;
 
 const GITATTRIBUTES_TEMPLATE: &str = r#"# GitHub syntax highlighting
-pixi.lock linguist-language=YAML
-
+pixi.lock linguist-language=YAML linguist-generated=true
 "#;
 
 pub async fn execute(args: Args) -> miette::Result<()> {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -123,7 +123,7 @@ platforms = {{ platforms }}
 "#;
 
 const GITIGNORE_TEMPLATE: &str = r#"# pixi environments
-**/.pixi/envs
+.pixi
 *.egg-info
 "#;
 


### PR DESCRIPTION
~With `.pixi/config.toml` being a valid configuration place, what do you think about excluding it from .gitignore?~

Also, with pixi.lock file diffs getting very large, especially with multi-envs, I think it makes sense to add `linguist-generated=true` (in some cases, github refused to render the markdown anyway). https://github.com/pavelzw/pixi-diff-to-markdown can generate a bit prettier diffs anyway.

Maybe it makes sense to have a diff mode `pixi diff pixi.lock.old pixi.lock.new` as well that generates the same json output as `pixi update --json` and allow people to configure their git diff to use pixi similar to how [bun does it](https://bun.sh/guides/install/git-diff-bun-lockfile).