### PR TITLE
docs: fix typo in  project_configuration.md

### DIFF
--- a/docs/reference/project_configuration.md
+++ b/docs/reference/project_configuration.md
@@ -261,7 +261,7 @@ We support:
 - `index-url`: replaces the main index url.
    Only one `index-url` can be defined per environment.
 - `extra-index-urls`: adds an extra index url.
-- `find-links`: which can either be a path `{path: './links'}` or a url `{url: 'https://example.com/links'}`.
+- `find-links`: which can either be a path `{path = './links'}` or a url `{url = 'https://example.com/links'}`.
    This is similar to the `--find-links` option in `pip`.
 
 An example:
@@ -270,7 +270,7 @@ An example:
 [pypi-options]
 index-url = "https://pypi.org/simple"
 extra-index-urls = ["https://example.com/simple"]
-find-links = [{path: './links'}]
+find-links = [{path = './links'}]
 ```
 
 There are some examples in the pixi repository that make use of this feature.


### PR DESCRIPTION
Fix typo in documentation, replace `:` with `=`