### PR TITLE
fix: too much shell variables in activation of `pixi shell`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -67,6 +67,6 @@ pyyaml = ">=6.0.1,<6.1"
 taplo = ">=0.9.1,<0.10"
 
 [environments]
-default = { features = ["build", "dev", "docs", "schema"], solve-group = "one"}
-docs = { features = ["docs"], no-default-feature = true, solve-group = "one"}
-schema = { features = ["schema"], no-default-feature = true , solve-group = "one"}
+default = { features = ["build", "dev", "docs", "schema"], solve-group = "default"}
+docs = { features = ["docs"], no-default-feature = true, solve-group = "default"}
+schema = { features = ["schema"], no-default-feature = true , solve-group = "default"}

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -19,7 +19,6 @@ use crate::{
 // Setting a base prefix for the pixi package
 const PROJECT_PREFIX: &str = "PIXI_PROJECT_";
 
-
 pub enum CurrentEnvVarBehavior {
     /// Clean the environment variables of the current shell.
     /// This will return the minimal set of environment variables that are required to run the command.
@@ -143,7 +142,7 @@ pub fn get_activator<'p>(
 /// Runs and caches the activation script.
 pub async fn run_activation(
     environment: &Environment<'_>,
-    env_var_behavior: &CurrentEnvVarBehavior
+    env_var_behavior: &CurrentEnvVarBehavior,
 ) -> miette::Result<HashMap<String, String>> {
     let activator = get_activator(environment, ShellEnum::default()).map_err(|e| {
         miette::miette!(format!(

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -172,8 +172,8 @@ pub async fn run_activation(
             path_modification_behavior,
         })
     })
-    .await
-    .into_diagnostic()?
+        .await
+        .into_diagnostic()?
     {
         Ok(activator) => activator,
         Err(e) => {
@@ -297,10 +297,7 @@ pub(crate) async fn initialize_env_variables(
         CurrentEnvVarBehavior::Exclude => HashMap::new(),
     };
 
-    let all_variables: HashMap<String, String> = activation_env
-        .into_iter()
-        .chain(current_shell_env_vars.into_iter())
-        .collect();
+    let all_variables: HashMap<String, String> = current_shell_env_vars.into_iter().chain(activation_env).collect();
 
     Ok(all_variables)
 }

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -3,21 +3,32 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler_conda_types::Platform;
-use rattler_shell::activation::ActivationError::FailedToRunActivationScript;
 use rattler_shell::{
-    activation::{ActivationError, ActivationVariables, Activator, PathModificationBehavior},
+    activation::{
+        ActivationError, ActivationError::FailedToRunActivationScript, ActivationVariables,
+        Activator, PathModificationBehavior,
+    },
     shell::ShellEnum,
 };
 
-use crate::project::has_features::HasFeatures;
 use crate::{
-    environment::{get_up_to_date_prefix, LockFileUsage},
-    project::{manifest::EnvironmentName, Environment},
+    project::{has_features::HasFeatures, manifest::EnvironmentName, Environment},
     Project,
 };
 
 // Setting a base prefix for the pixi package
 const PROJECT_PREFIX: &str = "PIXI_PROJECT_";
+
+
+pub enum CurrentEnvVarBehavior {
+    /// Clean the environment variables of the current shell.
+    /// This will return the minimal set of environment variables that are required to run the command.
+    Clean,
+    /// Copy the environment variables of the current shell.
+    Include,
+    /// Do not take any environment variables from the current shell.
+    Exclude,
+}
 
 impl Project {
     /// Returns environment variables and their values that should be injected when running a command.
@@ -124,7 +135,7 @@ pub fn get_activator<'p>(
     // Add the environment variables from the project.
     activator
         .env_vars
-        .extend(get_environment_variables(environment));
+        .extend(get_static_environment_variables(environment));
 
     Ok(activator)
 }
@@ -132,7 +143,7 @@ pub fn get_activator<'p>(
 /// Runs and caches the activation script.
 pub async fn run_activation(
     environment: &Environment<'_>,
-    clean_env: bool,
+    env_var_behavior: &CurrentEnvVarBehavior
 ) -> miette::Result<HashMap<String, String>> {
     let activator = get_activator(environment, ShellEnum::default()).map_err(|e| {
         miette::miette!(format!(
@@ -142,10 +153,11 @@ pub async fn run_activation(
         ))
     })?;
 
-    let path_modification_behavior = if clean_env {
-        PathModificationBehavior::Replace
-    } else {
-        PathModificationBehavior::Prepend
+    let path_modification_behavior = match env_var_behavior {
+        // We need to replace the full environment path with the new one.
+        // So only the executables from the pixi environment are available.
+        CurrentEnvVarBehavior::Clean => PathModificationBehavior::Replace,
+        _ => PathModificationBehavior::Prepend,
     };
 
     let activator_result = match tokio::task::spawn_blocking(move || {
@@ -193,51 +205,13 @@ pub async fn run_activation(
         }
     };
 
-    if clean_env && cfg!(windows) {
-        return Err(miette::miette!(
-            format!("It's not possible to run a `clean-env` on Windows as it requires so many non conda specific files that it is basically useless to use. \
-        So pixi currently doesn't support this feature.")));
-    } else if clean_env {
-        let mut cleaned_environment_variables = get_clean_environment_variables();
-
-        // Extend with the original activation environment
-        cleaned_environment_variables.extend(activator_result);
-
-        // Enable this when we found a better way to support windows.
-        // On Windows the path is not completely replace, but we need to strip some paths to keep it as clean as possible.
-        // if cfg!(target_os = "windows") {
-        //     let path = env
-        //         .get("Path")
-        //         .map(|path| {
-        //             // Keep some of the paths
-        //             let win_path = std::env::split_paths(&path).filter(|p| {
-        //                 // Required for base functionalities
-        //                 p.to_string_lossy().contains(":\\Windows")
-        //                     // Required for compilers
-        //                     || p.to_string_lossy().contains("\\Program Files")
-        //                     // Required for pixi environments
-        //                     || p.starts_with(environment.dir())
-        //             });
-        //             // Join back up the paths
-        //             std::env::join_paths(win_path).expect("Could not join paths")
-        //         })
-        //         .expect("Could not find PATH in environment variables");
-        //     // Insert the path back into the env.
-        //     env.insert(
-        //         "Path".to_string(),
-        //         path.to_str()
-        //             .expect("Path contains non-utf8 paths")
-        //             .to_string(),
-        //     );
-        // }
-
-        return Ok(cleaned_environment_variables);
-    }
-    Ok(std::env::vars().chain(activator_result).collect())
+    Ok(activator_result)
 }
 
 /// Get the environment variables that are statically generated from the project and the environment.
-pub fn get_environment_variables<'p>(environment: &'p Environment<'p>) -> HashMap<String, String> {
+pub fn get_static_environment_variables<'p>(
+    environment: &'p Environment<'p>,
+) -> HashMap<String, String> {
     // Get environment variables from the project
     let project_env = environment.project().get_metadata_env();
 
@@ -260,6 +234,8 @@ pub fn get_environment_variables<'p>(environment: &'p Environment<'p>) -> HashMa
         .collect()
 }
 
+/// Get the environment variables that are set in the current shell
+/// and strip them down to the minimal set required to run a command.
 pub fn get_clean_environment_variables() -> HashMap<String, String> {
     let env = std::env::vars().collect::<HashMap<_, _>>();
 
@@ -302,18 +278,32 @@ pub fn get_clean_environment_variables() -> HashMap<String, String> {
 /// Determine the environment variables that need to be set in an interactive shell to make it
 /// function as if the environment has been activated. This method runs the activation scripts from
 /// the environment and stores the environment variables it added, finally it adds environment
-/// variables from the project.
-pub async fn get_activation_env<'p>(
-    environment: &'p Environment<'p>,
-    lock_file_usage: LockFileUsage,
-) -> miette::Result<&HashMap<String, String>> {
-    // Get the prefix which we can then activate.
-    get_up_to_date_prefix(environment, lock_file_usage, false).await?;
+/// variables from the project and based on the clean_env setting it will also add in the current
+/// shell environment variables.
+pub(crate) async fn initialize_env_variables(
+    environment: &Environment<'_>,
+    env_var_behavior: CurrentEnvVarBehavior,
+) -> miette::Result<HashMap<String, String>> {
+    let activation_env = run_activation(environment, &env_var_behavior).await?;
 
-    environment
-        .project()
-        .get_env_variables(environment, false)
-        .await
+    // Get environment variables from the currently activated shell.
+    let current_shell_env_vars = match env_var_behavior {
+        CurrentEnvVarBehavior::Clean if cfg!(windows) => {
+            return Err(miette::miette!(
+                "Currently it's not possible to run a `clean-env` option on Windows."
+            ));
+        }
+        CurrentEnvVarBehavior::Clean => get_clean_environment_variables(),
+        CurrentEnvVarBehavior::Include => std::env::vars().collect(),
+        CurrentEnvVarBehavior::Exclude => HashMap::new(),
+    };
+
+    let all_variables: HashMap<String, String> = activation_env
+        .into_iter()
+        .chain(current_shell_env_vars.into_iter())
+        .collect();
+
+    Ok(all_variables)
 }
 
 #[cfg(test)]

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -172,8 +172,8 @@ pub async fn run_activation(
             path_modification_behavior,
         })
     })
-        .await
-        .into_diagnostic()?
+    .await
+    .into_diagnostic()?
     {
         Ok(activator) => activator,
         Err(e) => {
@@ -297,7 +297,10 @@ pub(crate) async fn initialize_env_variables(
         CurrentEnvVarBehavior::Exclude => HashMap::new(),
     };
 
-    let all_variables: HashMap<String, String> = current_shell_env_vars.into_iter().chain(activation_env).collect();
+    let all_variables: HashMap<String, String> = current_shell_env_vars
+        .into_iter()
+        .chain(activation_env)
+        .collect();
 
     Ok(all_variables)
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -256,7 +256,7 @@ pub async fn get_task_env<'p>(
     let env_var_behavior = if clean_env {
         CurrentEnvVarBehavior::Clean
     } else {
-        CurrentEnvVarBehavior::Exclude
+        CurrentEnvVarBehavior::Include
     };
     let activation_env = await_in_progress("activating environment", |_| {
         environment

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -9,21 +9,21 @@ use dialoguer::theme::ColorfulTheme;
 use itertools::Itertools;
 use miette::{miette, Context, Diagnostic, IntoDiagnostic};
 
+use crate::activation::CurrentEnvVarBehavior;
 use crate::environment::verify_prefix_location_unchanged;
+use crate::lock_file::LockFileDerivedData;
+use crate::lock_file::UpdateLockFileOptions;
+use crate::progress::await_in_progress;
 use crate::project::errors::UnsupportedPlatformError;
+use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
+use crate::project::Environment;
 use crate::task::{
     AmbiguousTask, CanSkip, ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory,
     SearchEnvironments, TaskAndEnvironment, TaskGraph, TaskName,
 };
 use crate::{HasFeatures, Project};
-use crate::lock_file::LockFileDerivedData;
-use crate::lock_file::UpdateLockFileOptions;
-use crate::progress::await_in_progress;
-use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
-use crate::project::Environment;
 use thiserror::Error;
 use tracing::Level;
-use crate::activation::CurrentEnvVarBehavior;
 
 /// Runs task in project.
 #[derive(Parser, Debug, Default)]
@@ -259,7 +259,9 @@ pub async fn get_task_env<'p>(
         CurrentEnvVarBehavior::Exclude
     };
     let activation_env = await_in_progress("activating environment", |_| {
-        environment.project().get_activated_environment_variables(environment, env_var_behavior)
+        environment
+            .project()
+            .get_activated_environment_variables(environment, env_var_behavior)
     })
     .await
     .wrap_err("failed to activate environment")?;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -15,7 +15,7 @@ use crate::task::{
     AmbiguousTask, CanSkip, ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory,
     SearchEnvironments, TaskAndEnvironment, TaskGraph, TaskName,
 };
-use crate::Project;
+use crate::{HasFeatures, Project};
 use crate::lock_file::LockFileDerivedData;
 use crate::lock_file::UpdateLockFileOptions;
 use crate::progress::await_in_progress;
@@ -259,7 +259,7 @@ pub async fn get_task_env<'p>(
         CurrentEnvVarBehavior::Exclude
     };
     let activation_env = await_in_progress("activating environment", |_| {
-        environment.get_activated_env_variables(env_var_behavior)
+        environment.project().get_activated_environment_variables(environment, env_var_behavior)
     })
     .await
     .wrap_err("failed to activate environment")?;

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -14,6 +14,7 @@ use crate::{
     activation::CurrentEnvVarBehavior,
     cli::LockFileUsageArgs,
     config::ConfigCliPrompt,
+    environment::get_up_to_date_prefix,
     project::{
         manifest::EnvironmentName,
         virtual_packages::verify_current_platform_has_required_virtual_packages,
@@ -216,6 +217,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         EnvironmentName::Default => project.name().to_string(),
         EnvironmentName::Named(name) => format!("{}:{}", project.name(), name),
     };
+
+    // Make sure environment is up-to-date, default to install, users can avoid this with frozen or locked.
+    get_up_to_date_prefix(&environment, args.lock_file_usage.into(), false).await?;
 
     // Get the environment variables we need to set activate the environment in the shell.
     let env = project

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -218,8 +218,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     // Get the environment variables we need to set activate the environment in the shell.
-    let env = environment
-        .get_activated_env_variables(CurrentEnvVarBehavior::Exclude)
+    let env = project
+        .get_activated_environment_variables(&environment, CurrentEnvVarBehavior::Exclude)
         .await?;
 
     tracing::debug!("Pixi environment activation:\n{:?}", env);

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -259,12 +259,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     #[cfg(target_family = "unix")]
     let res = match interactive_shell {
-        ShellEnum::NuShell(nushell) => start_nu_shell(nushell, &env, prompt).await,
-        ShellEnum::PowerShell(pwsh) => start_powershell(pwsh, &env, prompt),
-        ShellEnum::Bash(bash) => start_unix_shell(bash, vec!["-l", "-i"], &env, prompt).await,
-        ShellEnum::Zsh(zsh) => start_unix_shell(zsh, vec!["-l", "-i"], &env, prompt).await,
-        ShellEnum::Fish(fish) => start_unix_shell(fish, vec![], &env, prompt).await,
-        ShellEnum::Xonsh(xonsh) => start_unix_shell(xonsh, vec![], &env, prompt).await,
+        ShellEnum::NuShell(nushell) => start_nu_shell(nushell, env, prompt).await,
+        ShellEnum::PowerShell(pwsh) => start_powershell(pwsh, env, prompt),
+        ShellEnum::Bash(bash) => start_unix_shell(bash, vec!["-l", "-i"], env, prompt).await,
+        ShellEnum::Zsh(zsh) => start_unix_shell(zsh, vec!["-l", "-i"], env, prompt).await,
+        ShellEnum::Fish(fish) => start_unix_shell(fish, vec![], env, prompt).await,
+        ShellEnum::Xonsh(xonsh) => start_unix_shell(xonsh, vec![], env, prompt).await,
         _ => {
             miette::bail!("Unsupported shell: {:?}", interactive_shell)
         }

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -15,7 +15,7 @@ use crate::{
     config::ConfigCliPrompt,
     environment::get_up_to_date_prefix,
     project::Environment,
-    Project,
+    HasFeatures, Project,
 };
 
 /// Print the pixi environment activation script.
@@ -89,11 +89,12 @@ async fn generate_activation_script(
 /// activating the provided pixi environment.
 async fn generate_environment_json(environment: &Environment<'_>) -> miette::Result<String> {
     let environment_variables = environment
-        .get_activated_env_variables(CurrentEnvVarBehavior::Exclude)
+        .project()
+        .get_activated_environment_variables(&environment, CurrentEnvVarBehavior::Exclude)
         .await?;
 
     let shell_env = ShellEnv {
-        environment_variables: &environment_variables,
+        environment_variables,
     };
 
     serde_json::to_string(&shell_env).into_diagnostic()

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -90,7 +90,7 @@ async fn generate_activation_script(
 async fn generate_environment_json(environment: &Environment<'_>) -> miette::Result<String> {
     let environment_variables = environment
         .project()
-        .get_activated_environment_variables(&environment, CurrentEnvVarBehavior::Exclude)
+        .get_activated_environment_variables(environment, CurrentEnvVarBehavior::Exclude)
         .await?;
 
     let shell_env = ShellEnv {

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -10,11 +10,11 @@ use serde::Serialize;
 use serde_json;
 
 use crate::{
-    activation::get_activator,
+    activation::{get_activator, CurrentEnvVarBehavior},
     cli::LockFileUsageArgs,
     config::ConfigCliPrompt,
     environment::get_up_to_date_prefix,
-    project::{has_features::HasFeatures, Environment},
+    project::Environment,
     Project,
 };
 
@@ -89,12 +89,13 @@ async fn generate_activation_script(
 /// activating the provided pixi environment.
 async fn generate_environment_json(environment: &Environment<'_>) -> miette::Result<String> {
     let environment_variables = environment
-        .project()
-        .get_env_variables(environment, false)
+        .get_activated_env_variables(CurrentEnvVarBehavior::Exclude)
         .await?;
+
     let shell_env = ShellEnv {
-        environment_variables,
+        environment_variables: &environment_variables,
     };
+
     serde_json::to_string(&shell_env).into_diagnostic()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod activation;
+pub mod activation;
 pub mod cli;
 pub(crate) mod conda_pypi_clobber;
 pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ mod uv_reporter;
 pub mod pypi_mapping;
 mod repodata;
 
-pub use activation::get_activation_env;
 pub use lock_file::load_lock_file;
 pub use lock_file::UpdateLockFileOptions;
 pub use project::{

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -151,8 +151,9 @@ impl<'p> LockFileDerivedData<'p> {
             Some(context) => context.clone(),
         };
 
-        let env_variables = environment
-            .get_activated_env_variables(CurrentEnvVarBehavior::Exclude)
+        let env_variables = self
+            .project
+            .get_activated_environment_variables(environment, CurrentEnvVarBehavior::Exclude)
             .await?;
 
         // Update the prefix with Pypi records
@@ -987,7 +988,7 @@ impl<'p> UpdateContext<'p> {
             .outdated_envs
             .pypi
             .iter()
-            .flat_map(|(env, platforms)| platforms.iter().map(move |p| (env.clone(), *p)))
+            .flat_map(|(env, platforms)| platforms.iter().map(move |p| (env, *p)))
         {
             let group = GroupedEnvironment::from(environment.clone());
 
@@ -1008,8 +1009,8 @@ impl<'p> UpdateContext<'p> {
             }
 
             // Get environment variables from the activation
-            let env_variables = environment
-                .get_activated_env_variables(CurrentEnvVarBehavior::Exclude)
+            let env_variables = project
+                .get_activated_environment_variables(&environment, CurrentEnvVarBehavior::Exclude)
                 .await?;
 
             // Construct a future that will resolve when we have the repodata available
@@ -1044,7 +1045,7 @@ impl<'p> UpdateContext<'p> {
                 platform,
                 repodata_future,
                 prefix_future,
-                &env_variables,
+                env_variables,
                 self.pypi_solve_semaphore.clone(),
                 project.root().to_path_buf(),
                 locked_group_records,

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -167,7 +167,7 @@ impl<'p> LockFileDerivedData<'p> {
             &environment.system_requirements(),
             &uv_context,
             &environment.pypi_options(),
-            &env_variables,
+            env_variables,
             self.project.root(),
             environment.best_platform(),
         )
@@ -1010,7 +1010,7 @@ impl<'p> UpdateContext<'p> {
 
             // Get environment variables from the activation
             let env_variables = project
-                .get_activated_environment_variables(&environment, CurrentEnvVarBehavior::Exclude)
+                .get_activated_environment_variables(environment, CurrentEnvVarBehavior::Exclude)
                 .await?;
 
             // Construct a future that will resolve when we have the repodata available

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -482,14 +482,14 @@ impl Project {
             CurrentEnvVarBehavior::Clean => {
                 vars.clean()
                     .get_or_try_init(async {
-                        initialize_env_variables(&environment, current_env_var_behavior).await
+                        initialize_env_variables(environment, current_env_var_behavior).await
                     })
                     .await
             }
             _ => {
                 vars.normal()
                     .get_or_try_init(async {
-                        initialize_env_variables(&environment, current_env_var_behavior).await
+                        initialize_env_variables(environment, current_env_var_behavior).await
                     })
                     .await
             }

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -239,7 +239,7 @@ impl<'p> ExecutableTask<'p> {
     /// that caused the task to not be skipped - we can use this later to update the cache file quickly.
     pub(crate) async fn can_skip(
         &self,
-        lock_file: &LockFileDerivedData<'_>,
+        lock_file: &LockFileDerivedData<'p>,
     ) -> Result<CanSkip, std::io::Error> {
         tracing::info!("Checking if task can be skipped");
         let cache_name = self.cache_name();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -333,7 +333,7 @@ impl PixiControl {
                 None => {
                     let env =
                         get_task_env(&mut lock_file, &task.run_environment, args.clean_env).await?;
-                    task_env.insert(env) as &_
+                    task_env.insert(env)
                 }
                 Some(task_env) => task_env,
             };

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -20,6 +20,27 @@ async fn test_normal_env_activation() {
 
     assert!(normal_env.get("CONDA_PREFIX").is_some());
     assert!(normal_env.get("DIRTY_VAR").is_none());
+    // Display is not a pixi var, but it is passed into a clean env.
+    assert!(normal_env.get("DISPLAY").is_none());
+}
+
+#[tokio::test]
+async fn test_full_env_activation() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+
+    let project = pixi.project().unwrap();
+    let default_env = project.default_environment();
+
+    std::env::set_var("DIRTY_VAR", "Dookie");
+
+    let full_env = project.get_activated_environment_variables(
+        &default_env,
+        CurrentEnvVarBehavior::Include,
+    ).await.unwrap();
+    assert!(full_env.get("CONDA_PREFIX").is_some());
+    assert!(full_env.get("DIRTY_VAR").is_some());
+    assert!(full_env.get("DISPLAY").is_some());
 }
 
 #[cfg(target_family = "unix")]
@@ -39,4 +60,9 @@ async fn test_clean_env_activation() {
     ).await.unwrap();
     assert!(clean_env.get("CONDA_PREFIX").is_some());
     assert!(clean_env.get("DIRTY_VAR").is_none());
+
+    // Display is not a pixi var, but it is passed into a clean env.
+    assert!(clean_env.get("DISPLAY").is_some());
 }
+
+

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -20,8 +20,8 @@ async fn test_pixi_only_env_activation() {
 
     assert!(pixi_only_env.get("CONDA_PREFIX").is_some());
     assert!(pixi_only_env.get("DIRTY_VAR").is_none());
-    // HOME is not a pixi var, so it is not included in pixi_only.
-    assert!(pixi_only_env.get("HOME").is_none());
+    // PWD is not a pixi var, so it is not included in pixi_only.
+    assert!(pixi_only_env.get("PWD").is_none());
 }
 
 #[tokio::test]
@@ -40,7 +40,7 @@ async fn test_full_env_activation() {
         .unwrap();
     assert!(full_env.get("CONDA_PREFIX").is_some());
     assert!(full_env.get("DIRTY_VAR").is_some());
-    assert!(full_env.get("HOME").is_some());
+    assert!(full_env.get("PWD").is_some());
 }
 
 #[cfg(target_family = "unix")]
@@ -61,6 +61,6 @@ async fn test_clean_env_activation() {
     assert!(clean_env.get("CONDA_PREFIX").is_some());
     assert!(clean_env.get("DIRTY_VAR").is_none());
 
-    // Display is not a pixi var, but it is passed into a clean env.
-    assert!(clean_env.get("HOME").is_some());
+    // PWD is not a pixi var, but it is passed into a clean env.
+    assert!(clean_env.get("PWD").is_some());
 }

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -1,0 +1,52 @@
+use serial_test::serial;
+use pixi::activation::CurrentEnvVarBehavior;
+use crate::common::PixiControl;
+
+mod common;
+
+
+#[tokio::test]
+async fn test_normal_env_activation() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+
+    let project = pixi.project().unwrap();
+    let default_env = project.default_environment();
+
+    let normal_env = project.get_activated_environment_variables(
+        &default_env,
+        CurrentEnvVarBehavior::Exclude,
+    ).await.unwrap();
+
+    std::env::set_var("DIRTY_VAR", "Dookie");
+
+    assert!(normal_env.get("CONDA_PREFIX").is_some());
+    assert!(normal_env.get("DIRTY_VAR").is_none());
+
+    if !cfg!(target_family = "windows") {
+        let clean_env = project.get_activated_environment_variables(
+            &default_env,
+            CurrentEnvVarBehavior::Clean,
+        ).await.unwrap();
+        assert!(clean_env.get("CONDA_PREFIX").is_some());
+    }
+}
+
+#[cfg(target_family = "unix")]
+#[tokio::test]
+async fn test_clean_env_activation() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+
+    let project = pixi.project().unwrap();
+    let default_env = project.default_environment();
+
+    std::env::set_var("DIRTY_VAR", "Dookie");
+
+    let clean_env = project.get_activated_environment_variables(
+        &default_env,
+        CurrentEnvVarBehavior::Clean,
+    ).await.unwrap();
+    assert!(clean_env.get("CONDA_PREFIX").is_some());
+    assert!(clean_env.get("DIRTY_VAR").is_none());
+}

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -4,24 +4,24 @@ use pixi::activation::CurrentEnvVarBehavior;
 mod common;
 
 #[tokio::test]
-async fn test_normal_env_activation() {
+async fn test_pixi_only_env_activation() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
 
     let project = pixi.project().unwrap();
     let default_env = project.default_environment();
 
-    let normal_env = project
+    let pixi_only_env = project
         .get_activated_environment_variables(&default_env, CurrentEnvVarBehavior::Exclude)
         .await
         .unwrap();
 
     std::env::set_var("DIRTY_VAR", "Dookie");
 
-    assert!(normal_env.get("CONDA_PREFIX").is_some());
-    assert!(normal_env.get("DIRTY_VAR").is_none());
-    // HOME is not a pixi var, but it is passed into a clean env.
-    assert!(normal_env.get("HOME").is_none());
+    assert!(pixi_only_env.get("CONDA_PREFIX").is_some());
+    assert!(pixi_only_env.get("DIRTY_VAR").is_none());
+    // HOME is not a pixi var, so it is not included in pixi_only.
+    assert!(pixi_only_env.get("HOME").is_none());
 }
 
 #[tokio::test]

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -3,6 +3,11 @@ use pixi::activation::CurrentEnvVarBehavior;
 
 mod common;
 
+#[cfg(windows)]
+const HOME: &str = "HOMEPATH";
+#[cfg(unix)]
+const HOME: &str = "HOME";
+
 #[tokio::test]
 async fn test_pixi_only_env_activation() {
     let pixi = PixiControl::new().unwrap();
@@ -20,8 +25,8 @@ async fn test_pixi_only_env_activation() {
 
     assert!(pixi_only_env.get("CONDA_PREFIX").is_some());
     assert!(pixi_only_env.get("DIRTY_VAR").is_none());
-    // PWD is not a pixi var, so it is not included in pixi_only.
-    assert!(pixi_only_env.get("PWD").is_none());
+    // This is not a pixi var, so it is not included in pixi_only.
+    assert!(pixi_only_env.get(HOME).is_none());
 }
 
 #[tokio::test]
@@ -40,7 +45,7 @@ async fn test_full_env_activation() {
         .unwrap();
     assert!(full_env.get("CONDA_PREFIX").is_some());
     assert!(full_env.get("DIRTY_VAR").is_some());
-    assert!(full_env.get("PWD").is_some());
+    assert!(full_env.get(HOME).is_some());
 }
 
 #[cfg(target_family = "unix")]
@@ -61,6 +66,6 @@ async fn test_clean_env_activation() {
     assert!(clean_env.get("CONDA_PREFIX").is_some());
     assert!(clean_env.get("DIRTY_VAR").is_none());
 
-    // PWD is not a pixi var, but it is passed into a clean env.
-    assert!(clean_env.get("PWD").is_some());
+    // This is not a pixi var, but it is passed into a clean env.
+    assert!(clean_env.get(HOME).is_some());
 }

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -1,9 +1,7 @@
-use serial_test::serial;
 use pixi::activation::CurrentEnvVarBehavior;
 use crate::common::PixiControl;
 
 mod common;
-
 
 #[tokio::test]
 async fn test_normal_env_activation() {
@@ -22,14 +20,6 @@ async fn test_normal_env_activation() {
 
     assert!(normal_env.get("CONDA_PREFIX").is_some());
     assert!(normal_env.get("DIRTY_VAR").is_none());
-
-    if !cfg!(target_family = "windows") {
-        let clean_env = project.get_activated_environment_variables(
-            &default_env,
-            CurrentEnvVarBehavior::Clean,
-        ).await.unwrap();
-        assert!(clean_env.get("CONDA_PREFIX").is_some());
-    }
 }
 
 #[cfg(target_family = "unix")]

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -20,8 +20,8 @@ async fn test_normal_env_activation() {
 
     assert!(normal_env.get("CONDA_PREFIX").is_some());
     assert!(normal_env.get("DIRTY_VAR").is_none());
-    // Display is not a pixi var, but it is passed into a clean env.
-    assert!(normal_env.get("DISPLAY").is_none());
+    // HOME is not a pixi var, but it is passed into a clean env.
+    assert!(normal_env.get("HOME").is_none());
 }
 
 #[tokio::test]
@@ -40,7 +40,7 @@ async fn test_full_env_activation() {
         .unwrap();
     assert!(full_env.get("CONDA_PREFIX").is_some());
     assert!(full_env.get("DIRTY_VAR").is_some());
-    assert!(full_env.get("DISPLAY").is_some());
+    assert!(full_env.get("HOME").is_some());
 }
 
 #[cfg(target_family = "unix")]
@@ -62,5 +62,5 @@ async fn test_clean_env_activation() {
     assert!(clean_env.get("DIRTY_VAR").is_none());
 
     // Display is not a pixi var, but it is passed into a clean env.
-    assert!(clean_env.get("DISPLAY").is_some());
+    assert!(clean_env.get("HOME").is_some());
 }

--- a/tests/test_activation.rs
+++ b/tests/test_activation.rs
@@ -1,5 +1,5 @@
-use pixi::activation::CurrentEnvVarBehavior;
 use crate::common::PixiControl;
+use pixi::activation::CurrentEnvVarBehavior;
 
 mod common;
 
@@ -11,10 +11,10 @@ async fn test_normal_env_activation() {
     let project = pixi.project().unwrap();
     let default_env = project.default_environment();
 
-    let normal_env = project.get_activated_environment_variables(
-        &default_env,
-        CurrentEnvVarBehavior::Exclude,
-    ).await.unwrap();
+    let normal_env = project
+        .get_activated_environment_variables(&default_env, CurrentEnvVarBehavior::Exclude)
+        .await
+        .unwrap();
 
     std::env::set_var("DIRTY_VAR", "Dookie");
 
@@ -34,10 +34,10 @@ async fn test_full_env_activation() {
 
     std::env::set_var("DIRTY_VAR", "Dookie");
 
-    let full_env = project.get_activated_environment_variables(
-        &default_env,
-        CurrentEnvVarBehavior::Include,
-    ).await.unwrap();
+    let full_env = project
+        .get_activated_environment_variables(&default_env, CurrentEnvVarBehavior::Include)
+        .await
+        .unwrap();
     assert!(full_env.get("CONDA_PREFIX").is_some());
     assert!(full_env.get("DIRTY_VAR").is_some());
     assert!(full_env.get("DISPLAY").is_some());
@@ -54,15 +54,13 @@ async fn test_clean_env_activation() {
 
     std::env::set_var("DIRTY_VAR", "Dookie");
 
-    let clean_env = project.get_activated_environment_variables(
-        &default_env,
-        CurrentEnvVarBehavior::Clean,
-    ).await.unwrap();
+    let clean_env = project
+        .get_activated_environment_variables(&default_env, CurrentEnvVarBehavior::Clean)
+        .await
+        .unwrap();
     assert!(clean_env.get("CONDA_PREFIX").is_some());
     assert!(clean_env.get("DIRTY_VAR").is_none());
 
     // Display is not a pixi var, but it is passed into a clean env.
     assert!(clean_env.get("DISPLAY").is_some());
 }
-
-


### PR DESCRIPTION
Fixes #1503
Fixes #1505

The issue was that the work on the clean-env introduced a situation where all env vars of the current environment are added to the shell activation. This is not what we want, so this pr reverts that behavior.

This pr adds
- Cleanup of the activation code
- Storage of both the clean and normal environment variables when used in the tasks.
- Introduces Environment variable behavior to tell the activator what to do with the current environment
- Removes windows non-sense, I added the possible code to the related issue : #289 for future reference.