### PR TITLE
refactor: add to use update code

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1269,6 +1269,7 @@ packages:
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
   license: None
+  purls: []
   size: 2562
   timestamp: 1578324546067
 - kind: conda
@@ -1287,6 +1288,7 @@ packages:
   - openmp_impl 9999
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 23621
   timestamp: 1650670423406
 - kind: conda
@@ -1303,6 +1305,8 @@ packages:
   - typing-extensions >=4.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/annotated-types?source=conda-forge-mapping
   size: 18235
   timestamp: 1716290348421
 - kind: conda
@@ -1318,6 +1322,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/attrs?source=conda-forge-mapping
   size: 54582
   timestamp: 1704011393776
 - kind: conda
@@ -1335,6 +1341,8 @@ packages:
   - setuptools
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/babel?source=conda-forge-mapping
   size: 7609750
   timestamp: 1702422720584
 - kind: conda
@@ -1350,6 +1358,7 @@ packages:
   - binutils_impl_linux-64 >=2.40,<2.41.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 31117
   timestamp: 1717997349555
 - kind: conda
@@ -1366,6 +1375,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 6152532
   timestamp: 1717997325508
 - kind: conda
@@ -1381,6 +1391,7 @@ packages:
   - binutils_impl_linux-64 2.40.*
   - sysroot_linux-64
   license: BSD-3-Clause
+  purls: []
   size: 29991
   timestamp: 1718066171395
 - kind: conda
@@ -1401,6 +1412,8 @@ packages:
   - libbrotlicommon 1.1.0 hd590300_1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 350604
   timestamp: 1695990206327
 - kind: conda
@@ -1422,6 +1435,8 @@ packages:
   - libbrotlicommon 1.1.0 hcfcfb64_1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 322514
   timestamp: 1695991054894
 - kind: conda
@@ -1442,6 +1457,8 @@ packages:
   - libbrotlicommon 1.1.0 hb547adb_1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 343435
   timestamp: 1695990731924
 - kind: conda
@@ -1461,6 +1478,8 @@ packages:
   - libbrotlicommon 1.1.0 h0dc2134_1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 366883
   timestamp: 1695990710194
 - kind: conda
@@ -1474,6 +1493,7 @@ packages:
   md5: 6097a6ca9ada32699b5fc4312dd6ef18
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 127885
   timestamp: 1699280178474
 - kind: conda
@@ -1487,6 +1507,7 @@ packages:
   md5: 1bbc659ca658bfd49a481b5ef7a0f40f
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 122325
   timestamp: 1699280294368
 - kind: conda
@@ -1504,6 +1525,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 124580
   timestamp: 1699280668742
 - kind: conda
@@ -1519,6 +1541,7 @@ packages:
   - libgcc-ng >=12
   license: bzip2-1.0.6
   license_family: BSD
+  purls: []
   size: 254228
   timestamp: 1699279927352
 - kind: conda
@@ -1531,6 +1554,7 @@ packages:
   md5: d5eb7992227254c0e9a0ce71151f0079
   license: MIT
   license_family: MIT
+  purls: []
   size: 152607
   timestamp: 1711819681694
 - kind: conda
@@ -1543,6 +1567,7 @@ packages:
   md5: 04f776a6139f7eafc2f38668570eb7db
   license: MIT
   license_family: MIT
+  purls: []
   size: 150488
   timestamp: 1711819630164
 - kind: conda
@@ -1557,6 +1582,7 @@ packages:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 168875
   timestamp: 1711819445938
 - kind: conda
@@ -1574,6 +1600,7 @@ packages:
   - gcc_linux-64 12.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6324
   timestamp: 1714575511013
 - kind: conda
@@ -1585,6 +1612,7 @@ packages:
   sha256: d872d11558ebeaeb87bcf9086e97c075a1a2dfffed2d0e97570cf197ab29e3d8
   md5: 12a3a2b3a00a21bbb390d4de5ad8dd0f
   license: ISC
+  purls: []
   size: 156530
   timestamp: 1717311907623
 - kind: conda
@@ -1596,6 +1624,7 @@ packages:
   sha256: ba0614477229fcb0f0666356f2c4686caa66f0ed1446e7c9666ce234abe2bacf
   md5: 3c23a8cab15ae51ebc9efdc229fccecf
   license: ISC
+  purls: []
   size: 156145
   timestamp: 1717311781754
 - kind: conda
@@ -1607,6 +1636,7 @@ packages:
   sha256: 979af0932b2a5a26112044891a2d79e402e5ae8166f50fa48b8ebae47c0a2d65
   md5: 847c3c2905cc467cea52c24f9cfa8080
   license: ISC
+  purls: []
   size: 156035
   timestamp: 1717311767102
 - kind: conda
@@ -1618,6 +1648,7 @@ packages:
   sha256: f5fd189d48965df396d060eb48628cbd9f083f1a1ea79c5236f60d655c7b9633
   md5: b534f104f102479402f88f73adf750f5
   license: ISC
+  purls: []
   size: 156299
   timestamp: 1717311742040
 - kind: conda
@@ -1642,6 +1673,7 @@ packages:
   - vc14_runtime >=14.29.30139
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 1520159
   timestamp: 1697029136038
 - kind: conda
@@ -1671,6 +1703,7 @@ packages:
   - xorg-libxrender >=0.9.11,<0.10.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 982351
   timestamp: 1697028423052
 - kind: conda
@@ -1694,6 +1727,7 @@ packages:
   - pixman >=0.42.2,<1.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 885311
   timestamp: 1697028802967
 - kind: conda
@@ -1717,6 +1751,7 @@ packages:
   - pixman >=0.42.2,<1.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
+  purls: []
   size: 897919
   timestamp: 1697028755150
 - kind: conda
@@ -1734,6 +1769,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/cairocffi?source=conda-forge-mapping
   size: 66327
   timestamp: 1690198013914
 - kind: conda
@@ -1754,6 +1791,8 @@ packages:
   - tinycss2
   license: LGPL-3.0
   license_family: LGPL
+  purls:
+  - pkg:pypi/cairosvg?source=conda-forge-mapping
   size: 43857
   timestamp: 1691391975709
 - kind: conda
@@ -1768,6 +1807,8 @@ packages:
   depends:
   - python >=3.7
   license: ISC
+  purls:
+  - pkg:pypi/certifi?source=conda-forge-mapping
   size: 160543
   timestamp: 1718025161969
 - kind: conda
@@ -1788,6 +1829,8 @@ packages:
   - ruamel.yaml >=0.16.0
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/cffconvert?source=conda-forge-mapping
   size: 77728
   timestamp: 1644014985617
 - kind: conda
@@ -1805,6 +1848,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 282370
   timestamp: 1696002004433
 - kind: conda
@@ -1823,6 +1868,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 284245
   timestamp: 1696002181644
 - kind: conda
@@ -1842,6 +1889,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 287805
   timestamp: 1696002408940
 - kind: conda
@@ -1860,6 +1909,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 294523
   timestamp: 1696001868949
 - kind: conda
@@ -1875,6 +1926,8 @@ packages:
   - python >=3.6.1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/cfgv?source=conda-forge-mapping
   size: 10788
   timestamp: 1629909423398
 - kind: conda
@@ -1890,6 +1943,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=conda-forge-mapping
   size: 46597
   timestamp: 1698833765762
 - kind: conda
@@ -1908,6 +1963,8 @@ packages:
   - unidecode >=1.0.23
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/cli-ui?source=conda-forge-mapping
   size: 17216
   timestamp: 1661938037728
 - kind: conda
@@ -1924,6 +1981,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/click?source=conda-forge-mapping
   size: 84437
   timestamp: 1692311973840
 - kind: conda
@@ -1941,6 +2000,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/click?source=conda-forge-mapping
   size: 85051
   timestamp: 1692312207348
 - kind: conda
@@ -1956,6 +2017,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=conda-forge-mapping
   size: 25170
   timestamp: 1666700778190
 - kind: conda
@@ -1973,6 +2036,7 @@ packages:
   - fortran-compiler 1.7.0 heb67821_1
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 7129
   timestamp: 1714575517071
 - kind: conda
@@ -1988,6 +2052,8 @@ packages:
   - python >=3.6
   license: PSF-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/contextlib2?source=conda-forge-mapping
   size: 16367
   timestamp: 1624848715744
 - kind: conda
@@ -2005,6 +2071,8 @@ packages:
   - tinycss2
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/cssselect2?source=conda-forge-mapping
   size: 30243
   timestamp: 1585168847061
 - kind: conda
@@ -2025,6 +2093,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 151678
   timestamp: 1716379050364
 - kind: conda
@@ -2045,6 +2114,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 166948
   timestamp: 1716378571585
 - kind: conda
@@ -2065,6 +2135,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 154052
   timestamp: 1716379053776
 - kind: conda
@@ -2082,6 +2153,7 @@ packages:
   - gxx_linux-64 12.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6283
   timestamp: 1714575513327
 - kind: conda
@@ -2097,6 +2169,8 @@ packages:
   - python >=3.6
   license: PSF-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/defusedxml?source=conda-forge-mapping
   size: 24062
   timestamp: 1615232388757
 - kind: conda
@@ -2112,6 +2186,8 @@ packages:
   - python 2.7|>=3.6
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/distlib?source=conda-forge-mapping
   size: 274915
   timestamp: 1702383349284
 - kind: conda
@@ -2128,6 +2204,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/docopt?source=conda-forge-mapping
   size: 14691
   timestamp: 1530916777462
 - kind: conda
@@ -2143,6 +2221,8 @@ packages:
   depends:
   - python >=3.7
   license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=conda-forge-mapping
   size: 20551
   timestamp: 1704921321122
 - kind: conda
@@ -2158,6 +2238,7 @@ packages:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 137627
   timestamp: 1710362144873
 - kind: conda
@@ -2172,6 +2253,7 @@ packages:
   - libexpat 2.6.2 h63175ca_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 229627
   timestamp: 1710362661692
 - kind: conda
@@ -2186,6 +2268,7 @@ packages:
   - libexpat 2.6.2 h73e2aa4_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 126612
   timestamp: 1710362607162
 - kind: conda
@@ -2200,6 +2283,7 @@ packages:
   - libexpat 2.6.2 hebf3989_0
   license: MIT
   license_family: MIT
+  purls: []
   size: 124594
   timestamp: 1710362455984
 - kind: conda
@@ -2214,6 +2298,8 @@ packages:
   depends:
   - python >=3.7
   license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=conda-forge-mapping
   size: 15902
   timestamp: 1714422911808
 - kind: conda
@@ -2227,6 +2313,7 @@ packages:
   md5: 0c96522c6bdaed4b1566d11387caaf45
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 397370
   timestamp: 1566932522327
 - kind: conda
@@ -2240,6 +2327,7 @@ packages:
   md5: 34893075a5c9e55cdafac56607368fc6
   license: OFL-1.1
   license_family: Other
+  purls: []
   size: 96530
   timestamp: 1620479909603
 - kind: conda
@@ -2253,6 +2341,7 @@ packages:
   md5: 4d59c254e01d9cde7957100457e2d5fb
   license: OFL-1.1
   license_family: Other
+  purls: []
   size: 700814
   timestamp: 1620479612257
 - kind: conda
@@ -2267,6 +2356,7 @@ packages:
   md5: cbbe59391138ea5ad3658c76912e147f
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
+  purls: []
   size: 1622566
   timestamp: 1714483134319
 - kind: conda
@@ -2285,6 +2375,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 272010
   timestamp: 1674828850194
 - kind: conda
@@ -2301,6 +2392,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 237068
   timestamp: 1674829100063
 - kind: conda
@@ -2317,6 +2409,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 237668
   timestamp: 1674829263740
 - kind: conda
@@ -2337,6 +2430,7 @@ packages:
   - vs2015_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls: []
   size: 190111
   timestamp: 1674829354122
 - kind: conda
@@ -2352,6 +2446,7 @@ packages:
   - fonts-conda-forge
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 3667
   timestamp: 1566974674465
 - kind: conda
@@ -2370,6 +2465,7 @@ packages:
   - font-ttf-ubuntu
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 4102
   timestamp: 1566932280397
 - kind: conda
@@ -2388,6 +2484,7 @@ packages:
   - gfortran_linux-64 12.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6300
   timestamp: 1714575515211
 - kind: conda
@@ -2404,6 +2501,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 634972
   timestamp: 1694615932610
 - kind: conda
@@ -2419,6 +2517,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 599300
   timestamp: 1694616137838
 - kind: conda
@@ -2434,6 +2533,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 596430
   timestamp: 1694616332835
 - kind: conda
@@ -2452,6 +2552,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-2.0-only OR FTL
+  purls: []
   size: 510306
   timestamp: 1694616398888
 - kind: conda
@@ -2467,6 +2568,7 @@ packages:
   - gcc_impl_linux-64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 25966
   timestamp: 1715016817964
 - kind: conda
@@ -2488,6 +2590,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 51128234
   timestamp: 1715016710479
 - kind: conda
@@ -2504,6 +2607,7 @@ packages:
   - gcc_impl_linux-64 12.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
+  purls: []
   size: 32247
   timestamp: 1718066514166
 - kind: conda
@@ -2524,6 +2628,7 @@ packages:
   - libgettextpo-devel 0.22.5 h59595ed_2
   - libstdcxx-ng >=12
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  purls: []
   size: 475058
   timestamp: 1712512357949
 - kind: conda
@@ -2546,6 +2651,7 @@ packages:
   - libintl 0.22.5 h5ff76d1_2
   - libintl-devel 0.22.5 h5ff76d1_2
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  purls: []
   size: 481687
   timestamp: 1712513003915
 - kind: conda
@@ -2568,6 +2674,7 @@ packages:
   - libintl 0.22.5 h8fbad5d_2
   - libintl-devel 0.22.5 h8fbad5d_2
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  purls: []
   size: 482649
   timestamp: 1712512963023
 - kind: conda
@@ -2583,6 +2690,7 @@ packages:
   - libgcc-ng >=12
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 2728420
   timestamp: 1712512328692
 - kind: conda
@@ -2599,6 +2707,7 @@ packages:
   - libintl 0.22.5 h5ff76d1_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 2501207
   timestamp: 1712512940076
 - kind: conda
@@ -2615,6 +2724,7 @@ packages:
   - libintl 0.22.5 h8fbad5d_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 2482262
   timestamp: 1712512901194
 - kind: conda
@@ -2632,6 +2742,7 @@ packages:
   - gfortran_impl_linux-64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 25420
   timestamp: 1715017008409
 - kind: conda
@@ -2652,6 +2763,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 15376006
   timestamp: 1715016903212
 - kind: conda
@@ -2669,6 +2781,7 @@ packages:
   - gfortran_impl_linux-64 12.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
+  purls: []
   size: 30571
   timestamp: 1718066531715
 - kind: conda
@@ -2684,6 +2797,8 @@ packages:
   - python >=3.6
   - python-dateutil >=2.8.1
   license: LicenseRef-Tumbolia-Public
+  purls:
+  - pkg:pypi/ghp-import?source=conda-forge-mapping
   size: 15504
   timestamp: 1651585848291
 - kind: conda
@@ -2696,6 +2811,7 @@ packages:
   sha256: c2e81e48f8a17bb3393a9c413600ee44de34f7be3d8f4a81b3c2deb1da7e620f
   md5: 92bb3d38c5d89465d18d0ccbd7f847cd
   license: GPL-2.0-or-later and LGPL-2.1-or-later
+  purls: []
   size: 116953064
   timestamp: 1701087318572
 - kind: conda
@@ -2717,6 +2833,7 @@ packages:
   - pcre2 >=10.42,<10.43.0a0
   - perl 5.*
   license: GPL-2.0-or-later and LGPL-2.1-or-later
+  purls: []
   size: 8176005
   timestamp: 1701087161334
 - kind: conda
@@ -2739,6 +2856,7 @@ packages:
   - pcre2 >=10.42,<10.43.0a0
   - perl 5.*
   license: GPL-2.0-or-later and LGPL-2.1-or-later
+  purls: []
   size: 9483120
   timestamp: 1701086793863
 - kind: conda
@@ -2761,6 +2879,7 @@ packages:
   - pcre2 >=10.42,<10.43.0a0
   - perl 5.*
   license: GPL-2.0-or-later and LGPL-2.1-or-later
+  purls: []
   size: 7744105
   timestamp: 1701087084155
 - kind: conda
@@ -2777,6 +2896,7 @@ packages:
   - gxx_impl_linux-64 12.3.0.*
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 25402
   timestamp: 1715017020869
 - kind: conda
@@ -2794,6 +2914,7 @@ packages:
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 13036959
   timestamp: 1715016975232
 - kind: conda
@@ -2811,6 +2932,7 @@ packages:
   - gxx_impl_linux-64 12.3.0.*
   - sysroot_linux-64
   license: BSD-3-Clause
+  purls: []
   size: 30576
   timestamp: 1718066536120
 - kind: conda
@@ -2826,6 +2948,7 @@ packages:
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 12089150
   timestamp: 1692900650789
 - kind: conda
@@ -2842,6 +2965,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls: []
   size: 13422193
   timestamp: 1692901469029
 - kind: conda
@@ -2854,6 +2978,7 @@ packages:
   md5: 8521bd47c0e11c5902535bb1a17c565f
   license: MIT
   license_family: MIT
+  purls: []
   size: 11997841
   timestamp: 1692902104771
 - kind: conda
@@ -2866,6 +2991,7 @@ packages:
   md5: 5cc301d759ec03f28328428e28f65591
   license: MIT
   license_family: MIT
+  purls: []
   size: 11787527
   timestamp: 1692901622519
 - kind: conda
@@ -2882,6 +3008,8 @@ packages:
   - ukkonen
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/identify?source=conda-forge-mapping
   size: 78375
   timestamp: 1713673091737
 - kind: conda
@@ -2897,6 +3025,8 @@ packages:
   - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=conda-forge-mapping
   size: 52718
   timestamp: 1713279497047
 - kind: conda
@@ -2913,6 +3043,8 @@ packages:
   - zipp >=0.5
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-metadata?source=conda-forge-mapping
   size: 27043
   timestamp: 1710971498183
 - kind: conda
@@ -2929,6 +3061,8 @@ packages:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-resources?source=conda-forge-mapping
   size: 9657
   timestamp: 1711041029062
 - kind: conda
@@ -2947,6 +3081,8 @@ packages:
   - importlib-resources >=6.4.0,<6.4.1.0a0
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-resources?source=conda-forge-mapping
   size: 33056
   timestamp: 1711041009039
 - kind: conda
@@ -2962,6 +3098,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/iniconfig?source=conda-forge-mapping
   size: 11101
   timestamp: 1673103208955
 - kind: conda
@@ -2978,6 +3116,8 @@ packages:
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=conda-forge-mapping
   size: 111565
   timestamp: 1715127275924
 - kind: conda
@@ -2999,6 +3139,8 @@ packages:
   - six >=1.11.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/jsonschema?source=conda-forge-mapping
   size: 45999
   timestamp: 1614815999960
 - kind: conda
@@ -3015,6 +3157,7 @@ packages:
   - sysroot_linux-64 ==2.12
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 710627
   timestamp: 1708000830116
 - kind: conda
@@ -3028,6 +3171,7 @@ packages:
   depends:
   - libgcc-ng >=10.3.0
   license: LGPL-2.1-or-later
+  purls: []
   size: 117831
   timestamp: 1646151697040
 - kind: conda
@@ -3047,6 +3191,7 @@ packages:
   - openssl >=3.1.2,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1371181
   timestamp: 1692097755782
 - kind: conda
@@ -3064,6 +3209,7 @@ packages:
   - openssl >=3.1.2,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1195575
   timestamp: 1692098070699
 - kind: conda
@@ -3081,6 +3227,7 @@ packages:
   - openssl >=3.1.2,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 1183568
   timestamp: 1692098004387
 - kind: conda
@@ -3099,6 +3246,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls: []
   size: 507632
   timestamp: 1701648249706
 - kind: conda
@@ -3114,6 +3262,7 @@ packages:
   - libtiff >=4.6.0,<4.7.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 211959
   timestamp: 1701647962657
 - kind: conda
@@ -3129,6 +3278,7 @@ packages:
   - libtiff >=4.6.0,<4.7.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 224432
   timestamp: 1701648089496
 - kind: conda
@@ -3145,6 +3295,7 @@ packages:
   - libtiff >=4.6.0,<4.7.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 245247
   timestamp: 1701647787198
 - kind: conda
@@ -3160,6 +3311,7 @@ packages:
   - binutils_impl_linux-64 2.40
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 713873
   timestamp: 1717997303330
 - kind: conda
@@ -3175,6 +3327,7 @@ packages:
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 281798
   timestamp: 1657977462600
 - kind: conda
@@ -3190,6 +3343,7 @@ packages:
   - vs2015_runtime >=14.29.30037
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 194365
   timestamp: 1657977692274
 - kind: conda
@@ -3204,6 +3358,7 @@ packages:
   - libcxx >=13.0.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 215721
   timestamp: 1657977558796
 - kind: conda
@@ -3218,6 +3373,7 @@ packages:
   - libcxx >=13.0.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 290319
   timestamp: 1657977526749
 - kind: conda
@@ -3230,6 +3386,7 @@ packages:
   sha256: 4babb29b8d39ae8b341c094c134a1917c595846e5f974c9d0cb64d3f734b46b1
   md5: ad803793d7168331f1395685cbdae212
   license: LGPL-2.1-or-later
+  purls: []
   size: 40438
   timestamp: 1712512749697
 - kind: conda
@@ -3245,6 +3402,7 @@ packages:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: LGPL-2.1-or-later
+  purls: []
   size: 43226
   timestamp: 1712512265295
 - kind: conda
@@ -3257,6 +3415,7 @@ packages:
   sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
   md5: 1b27402397a76115679c4855ab2ece41
   license: LGPL-2.1-or-later
+  purls: []
   size: 40630
   timestamp: 1712512727388
 - kind: conda
@@ -3271,6 +3430,7 @@ packages:
   depends:
   - libasprintf 0.22.5 h5ff76d1_2
   license: LGPL-2.1-or-later
+  purls: []
   size: 34702
   timestamp: 1712512806211
 - kind: conda
@@ -3286,6 +3446,7 @@ packages:
   - libasprintf 0.22.5 h661eb56_2
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
+  purls: []
   size: 34225
   timestamp: 1712512295117
 - kind: conda
@@ -3300,6 +3461,7 @@ packages:
   depends:
   - libasprintf 0.22.5 h8fbad5d_2
   license: LGPL-2.1-or-later
+  purls: []
   size: 34625
   timestamp: 1712512769736
 - kind: conda
@@ -3319,6 +3481,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 364890
   timestamp: 1716378993833
 - kind: conda
@@ -3339,6 +3502,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 405535
   timestamp: 1716378550673
 - kind: conda
@@ -3358,6 +3522,7 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   license: curl
   license_family: MIT
+  purls: []
   size: 385778
   timestamp: 1716378974624
 - kind: conda
@@ -3372,6 +3537,7 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 1248885
   timestamp: 1715020154867
 - kind: conda
@@ -3386,6 +3552,7 @@ packages:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
+  purls: []
   size: 1249309
   timestamp: 1715020018902
 - kind: conda
@@ -3398,6 +3565,7 @@ packages:
   md5: d46104f6a896a0bc6a1d37b88b2edf5c
   license: MIT
   license_family: MIT
+  purls: []
   size: 70364
   timestamp: 1711196727346
 - kind: conda
@@ -3410,6 +3578,7 @@ packages:
   md5: 97efeaeba2a9a82bdf46fc6d025e3a57
   license: MIT
   license_family: MIT
+  purls: []
   size: 54481
   timestamp: 1711196723486
 - kind: conda
@@ -3426,6 +3595,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls: []
   size: 155358
   timestamp: 1711197066985
 - kind: conda
@@ -3440,6 +3610,7 @@ packages:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 71500
   timestamp: 1711196523408
 - kind: conda
@@ -3455,6 +3626,7 @@ packages:
   - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 105382
   timestamp: 1597616576726
 - kind: conda
@@ -3470,6 +3642,7 @@ packages:
   - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 96607
   timestamp: 1597616630749
 - kind: conda
@@ -3486,6 +3659,7 @@ packages:
   - ncurses >=6.2,<7.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 123878
   timestamp: 1597616541093
 - kind: conda
@@ -3499,6 +3673,7 @@ packages:
   md5: 899db79329439820b7e8f8de41bca902
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 106663
   timestamp: 1702146352558
 - kind: conda
@@ -3512,6 +3687,7 @@ packages:
   md5: 36d33e440c31857372a72137f78bacf5
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 107458
   timestamp: 1702146414478
 - kind: conda
@@ -3527,6 +3703,7 @@ packages:
   - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 112766
   timestamp: 1702146165126
 - kind: conda
@@ -3543,6 +3720,7 @@ packages:
   - expat 2.6.2.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 73730
   timestamp: 1710362120304
 - kind: conda
@@ -3557,6 +3735,7 @@ packages:
   - expat 2.6.2.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 139224
   timestamp: 1710362609641
 - kind: conda
@@ -3571,6 +3750,7 @@ packages:
   - expat 2.6.2.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 69246
   timestamp: 1710362566073
 - kind: conda
@@ -3585,6 +3765,7 @@ packages:
   - expat 2.6.2.*
   license: MIT
   license_family: MIT
+  purls: []
   size: 63655
   timestamp: 1710362424980
 - kind: conda
@@ -3598,6 +3779,7 @@ packages:
   md5: ccb34fb14960ad8b125962d3d79b31a9
   license: MIT
   license_family: MIT
+  purls: []
   size: 51348
   timestamp: 1636488394370
 - kind: conda
@@ -3611,6 +3793,7 @@ packages:
   md5: 086914b672be056eb70fd4285b6783b6
   license: MIT
   license_family: MIT
+  purls: []
   size: 39020
   timestamp: 1636488587153
 - kind: conda
@@ -3626,6 +3809,7 @@ packages:
   - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 58292
   timestamp: 1636488182923
 - kind: conda
@@ -3642,6 +3826,7 @@ packages:
   - vs2015_runtime >=14.16.27012
   license: MIT
   license_family: MIT
+  purls: []
   size: 42063
   timestamp: 1636489106777
 - kind: conda
@@ -3656,6 +3841,7 @@ packages:
   md5: 851e9651c9e4cd5dc19f80398eba9a1c
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 2532549
   timestamp: 1715016464312
 - kind: conda
@@ -3674,6 +3860,7 @@ packages:
   - libgomp 13.2.0 h77fa898_7
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 775806
   timestamp: 1715016057793
 - kind: conda
@@ -3689,6 +3876,7 @@ packages:
   - libgcc-ng >=12
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 170582
   timestamp: 1712512286907
 - kind: conda
@@ -3705,6 +3893,7 @@ packages:
   - libintl 0.22.5 h5ff76d1_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 172506
   timestamp: 1712512827340
 - kind: conda
@@ -3721,6 +3910,7 @@ packages:
   - libintl 0.22.5 h8fbad5d_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 159856
   timestamp: 1712512788407
 - kind: conda
@@ -3737,6 +3927,7 @@ packages:
   - libgettextpo 0.22.5 h59595ed_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 36758
   timestamp: 1712512303244
 - kind: conda
@@ -3754,6 +3945,7 @@ packages:
   - libintl 0.22.5 h5ff76d1_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 37189
   timestamp: 1712512859854
 - kind: conda
@@ -3771,6 +3963,7 @@ packages:
   - libintl 0.22.5 h8fbad5d_2
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 37221
   timestamp: 1712512820461
 - kind: conda
@@ -3788,6 +3981,7 @@ packages:
   - libgfortran-ng 13.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 1441361
   timestamp: 1715016068766
 - kind: conda
@@ -3808,6 +4002,7 @@ packages:
   constrains:
   - glib 2.78.4 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 2437234
   timestamp: 1708285905755
 - kind: conda
@@ -3829,6 +4024,7 @@ packages:
   constrains:
   - glib 2.78.4 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 2692079
   timestamp: 1708284870228
 - kind: conda
@@ -3849,6 +4045,7 @@ packages:
   constrains:
   - glib 2.78.4 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 2474668
   timestamp: 1708285048757
 - kind: conda
@@ -3871,6 +4068,7 @@ packages:
   constrains:
   - glib 2.80.2 *_0
   license: LGPL-2.1-or-later
+  purls: []
   size: 3749179
   timestamp: 1715253077632
 - kind: conda
@@ -3886,6 +4084,7 @@ packages:
   - _libgcc_mutex 0.1 conda_forge
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 422336
   timestamp: 1715015995979
 - kind: conda
@@ -3898,6 +4097,7 @@ packages:
   sha256: bc7de5097b97bcafcf7deaaed505f7ce02f648aac8eccc0d5a47cc599a1d0304
   md5: 69bda57310071cf6d2b86caf11573d2d
   license: LGPL-2.1-only
+  purls: []
   size: 676469
   timestamp: 1702682458114
 - kind: conda
@@ -3914,6 +4114,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-only
+  purls: []
   size: 636146
   timestamp: 1702682547199
 - kind: conda
@@ -3928,6 +4129,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-only
+  purls: []
   size: 705775
   timestamp: 1702682170569
 - kind: conda
@@ -3940,6 +4142,7 @@ packages:
   sha256: 23d4923baeca359423a7347c2ed7aaf48c68603df0cf8b87cc94a10b0d4e9a23
   md5: 6c3628d047e151efba7cf08c5e54d1ca
   license: LGPL-2.1-only
+  purls: []
   size: 666538
   timestamp: 1702682713201
 - kind: conda
@@ -3954,6 +4157,7 @@ packages:
   depends:
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 95745
   timestamp: 1712516102666
 - kind: conda
@@ -3968,6 +4172,7 @@ packages:
   depends:
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 74307
   timestamp: 1712512790983
 - kind: conda
@@ -3982,6 +4187,7 @@ packages:
   depends:
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
+  purls: []
   size: 81206
   timestamp: 1712512755390
 - kind: conda
@@ -3997,6 +4203,7 @@ packages:
   - libiconv >=1.17,<2.0a0
   - libintl 0.22.5 h5ff76d1_2
   license: LGPL-2.1-or-later
+  purls: []
   size: 38422
   timestamp: 1712512843420
 - kind: conda
@@ -4012,6 +4219,7 @@ packages:
   - libiconv >=1.17,<2.0a0
   - libintl 0.22.5 h8fbad5d_2
   license: LGPL-2.1-or-later
+  purls: []
   size: 38616
   timestamp: 1712512805567
 - kind: conda
@@ -4026,6 +4234,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 579748
   timestamp: 1694475265912
 - kind: conda
@@ -4040,6 +4249,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 547541
   timestamp: 1694475104253
 - kind: conda
@@ -4058,6 +4268,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 822966
   timestamp: 1694475223854
 - kind: conda
@@ -4074,6 +4285,7 @@ packages:
   constrains:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
   size: 618575
   timestamp: 1694474974816
 - kind: conda
@@ -4095,6 +4307,7 @@ packages:
   - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 631936
   timestamp: 1702130036271
 - kind: conda
@@ -4116,6 +4329,7 @@ packages:
   - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 599736
   timestamp: 1702130398536
 - kind: conda
@@ -4137,6 +4351,7 @@ packages:
   - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 565451
   timestamp: 1702130473930
 - kind: conda
@@ -4151,6 +4366,7 @@ packages:
   - libgcc-ng >=12
   license: LGPL-2.1-only
   license_family: GPL
+  purls: []
   size: 33408
   timestamp: 1697359010159
 - kind: conda
@@ -4164,6 +4380,7 @@ packages:
   depends:
   - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
+  purls: []
   size: 264177
   timestamp: 1708780447187
 - kind: conda
@@ -4180,6 +4397,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
+  purls: []
   size: 347514
   timestamp: 1708780763195
 - kind: conda
@@ -4194,6 +4412,7 @@ packages:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
+  purls: []
   size: 288221
   timestamp: 1708780443939
 - kind: conda
@@ -4207,6 +4426,7 @@ packages:
   depends:
   - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
+  purls: []
   size: 268524
   timestamp: 1708780496420
 - kind: conda
@@ -4222,6 +4442,7 @@ packages:
   - libgcc-ng >=12.3.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 3939615
   timestamp: 1715016598795
 - kind: conda
@@ -4236,6 +4457,7 @@ packages:
   - __osx >=10.13
   - libzlib >=1.2.13,<2.0a0
   license: Unlicense
+  purls: []
   size: 908643
   timestamp: 1718050720117
 - kind: conda
@@ -4251,6 +4473,7 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
+  purls: []
   size: 876677
   timestamp: 1718051113874
 - kind: conda
@@ -4265,6 +4488,7 @@ packages:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<2.0a0
   license: Unlicense
+  purls: []
   size: 865346
   timestamp: 1718050628718
 - kind: conda
@@ -4279,6 +4503,7 @@ packages:
   - __osx >=11.0
   - libzlib >=1.2.13,<2.0a0
   license: Unlicense
+  purls: []
   size: 830198
   timestamp: 1718050644825
 - kind: conda
@@ -4295,6 +4520,7 @@ packages:
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 271133
   timestamp: 1685837707056
 - kind: conda
@@ -4310,6 +4536,7 @@ packages:
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 255610
   timestamp: 1685837894256
 - kind: conda
@@ -4325,6 +4552,7 @@ packages:
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 259556
   timestamp: 1685837820566
 - kind: conda
@@ -4339,6 +4567,7 @@ packages:
   md5: 167a1f5d77d8f3c2a638f7eb418429f1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 11881031
   timestamp: 1715016519463
 - kind: conda
@@ -4352,6 +4581,7 @@ packages:
   md5: 53ebd4c833fa01cb2c6353e99f905406
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
+  purls: []
   size: 3837704
   timestamp: 1715016117360
 - kind: conda
@@ -4373,6 +4603,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: HPND
+  purls: []
   size: 238349
   timestamp: 1711218119201
 - kind: conda
@@ -4394,6 +4625,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: HPND
+  purls: []
   size: 257489
   timestamp: 1711218113053
 - kind: conda
@@ -4416,6 +4648,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: HPND
+  purls: []
   size: 282688
   timestamp: 1711217970425
 - kind: conda
@@ -4438,6 +4671,7 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: HPND
+  purls: []
   size: 787198
   timestamp: 1711218639912
 - kind: conda
@@ -4452,6 +4686,7 @@ packages:
   - libgcc-ng >=12
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 33601
   timestamp: 1680112270483
 - kind: conda
@@ -4466,6 +4701,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 355099
   timestamp: 1713200298965
 - kind: conda
@@ -4480,6 +4716,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 287750
   timestamp: 1713200194013
 - kind: conda
@@ -4498,6 +4735,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 274359
   timestamp: 1713200524021
 - kind: conda
@@ -4514,6 +4752,7 @@ packages:
   - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 438953
   timestamp: 1713199854503
 - kind: conda
@@ -4531,6 +4770,7 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  purls: []
   size: 384238
   timestamp: 1682082368177
 - kind: conda
@@ -4547,6 +4787,7 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  purls: []
   size: 313793
   timestamp: 1682083036825
 - kind: conda
@@ -4565,6 +4806,7 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  purls: []
   size: 969788
   timestamp: 1682083087243
 - kind: conda
@@ -4581,6 +4823,7 @@ packages:
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
+  purls: []
   size: 334770
   timestamp: 1682082734262
 - kind: conda
@@ -4595,6 +4838,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
+  purls: []
   size: 100393
   timestamp: 1702724383534
 - kind: conda
@@ -4614,6 +4858,7 @@ packages:
   - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 56186
   timestamp: 1716874730539
 - kind: conda
@@ -4631,6 +4876,7 @@ packages:
   - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 61574
   timestamp: 1716874187109
 - kind: conda
@@ -4648,6 +4894,7 @@ packages:
   - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 57372
   timestamp: 1716874211519
 - kind: conda
@@ -4665,6 +4912,7 @@ packages:
   - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 46921
   timestamp: 1716874262512
 - kind: conda
@@ -4680,6 +4928,7 @@ packages:
   - m2w64-gcc-libs-core
   - msys2-conda-epoch ==20160418
   license: GPL, LGPL, FDL, custom
+  purls: []
   size: 350687
   timestamp: 1608163451316
 - kind: conda
@@ -4698,6 +4947,7 @@ packages:
   - m2w64-libwinpthread-git
   - msys2-conda-epoch ==20160418
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  purls: []
   size: 532390
   timestamp: 1608163512830
 - kind: conda
@@ -4714,6 +4964,7 @@ packages:
   - m2w64-libwinpthread-git
   - msys2-conda-epoch ==20160418
   license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  purls: []
   size: 219240
   timestamp: 1608163481341
 - kind: conda
@@ -4728,6 +4979,7 @@ packages:
   depends:
   - msys2-conda-epoch ==20160418
   license: LGPL3
+  purls: []
   size: 743501
   timestamp: 1608163782057
 - kind: conda
@@ -4742,6 +4994,7 @@ packages:
   depends:
   - msys2-conda-epoch ==20160418
   license: MIT, BSD
+  purls: []
   size: 31928
   timestamp: 1608166099896
 - kind: conda
@@ -4757,6 +5010,7 @@ packages:
   - libgcc-ng >=7.5.0
   license: GPL-3.0-or-later
   license_family: GPL
+  purls: []
   size: 518896
   timestamp: 1602706451788
 - kind: conda
@@ -4773,6 +5027,8 @@ packages:
   - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markdown?source=conda-forge-mapping
   size: 78331
   timestamp: 1710435316163
 - kind: conda
@@ -4790,6 +5046,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 25742
   timestamp: 1706900456837
 - kind: conda
@@ -4808,6 +5066,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 26685
   timestamp: 1706900070330
 - kind: conda
@@ -4826,6 +5086,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 26382
   timestamp: 1706900495057
 - kind: conda
@@ -4846,6 +5108,8 @@ packages:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 29060
   timestamp: 1706900374745
 - kind: conda
@@ -4862,6 +5126,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mdx-truly-sane-lists?source=conda-forge-mapping
   size: 10480
   timestamp: 1658251565870
 - kind: conda
@@ -4877,6 +5143,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mergedeep?source=conda-forge-mapping
   size: 9598
   timestamp: 1612711404414
 - kind: conda
@@ -4899,6 +5167,8 @@ packages:
   - verspec
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/mike?source=conda-forge-mapping
   size: 31590
   timestamp: 1700921886104
 - kind: conda
@@ -4931,6 +5201,8 @@ packages:
   - babel >=2.9.0
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/mkdocs?source=conda-forge-mapping
   size: 2862150
   timestamp: 1695086687269
 - kind: conda
@@ -4957,6 +5229,8 @@ packages:
   - requests ~=2.26
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-material?source=conda-forge-mapping
   size: 5007228
   timestamp: 1714393800216
 - kind: conda
@@ -4974,6 +5248,8 @@ packages:
   - mkdocs-material >=5.0.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-material-extensions?source=conda-forge-mapping
   size: 16011
   timestamp: 1700695213251
 - kind: conda
@@ -4990,6 +5266,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/mkdocs-redirects?source=conda-forge-mapping
   size: 11691
   timestamp: 1712666138551
 - kind: conda
@@ -5001,6 +5279,7 @@ packages:
   url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
   sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
   md5: b0309b72560df66f71a9d5e34a5efdfa
+  purls: []
   size: 3227
   timestamp: 1608166968312
 - kind: conda
@@ -5012,6 +5291,7 @@ packages:
   sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
   md5: 02a888433d165c99bf09784a7b14d900
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 823601
   timestamp: 1715195267791
 - kind: conda
@@ -5025,6 +5305,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 887465
   timestamp: 1715194722503
 - kind: conda
@@ -5036,6 +5317,7 @@ packages:
   sha256: 87d7cf716d9d930dab682cb57b3b8d3a61940b47d6703f3529a155c938a6990a
   md5: b13ad5724ac9ae98b6b4fd87e4500ba4
   license: X11 AND BSD-3-Clause
+  purls: []
   size: 795131
   timestamp: 1715194898402
 - kind: conda
@@ -5052,6 +5334,8 @@ packages:
   - setuptools
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/nodeenv?source=conda-forge-mapping
   size: 34489
   timestamp: 1717585382642
 - kind: conda
@@ -5071,6 +5355,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 237974
   timestamp: 1709159764160
 - kind: conda
@@ -5089,6 +5374,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 341592
   timestamp: 1709159244431
 - kind: conda
@@ -5106,6 +5392,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 331273
   timestamp: 1709159538792
 - kind: conda
@@ -5123,6 +5410,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
+  purls: []
   size: 316603
   timestamp: 1709159627299
 - kind: conda
@@ -5142,6 +5430,7 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 8383610
   timestamp: 1717550042871
 - kind: conda
@@ -5159,6 +5448,7 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 2896170
   timestamp: 1717546157673
 - kind: conda
@@ -5176,6 +5466,7 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 2547614
   timestamp: 1717546605131
 - kind: conda
@@ -5193,6 +5484,7 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
+  purls: []
   size: 2891941
   timestamp: 1717545846389
 - kind: conda
@@ -5208,6 +5500,8 @@ packages:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/packaging?source=conda-forge-mapping
   size: 49832
   timestamp: 1710076089469
 - kind: conda
@@ -5223,6 +5517,8 @@ packages:
   - python >=3.4
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/paginate?source=conda-forge-mapping
   size: 18537
   timestamp: 1693246970487
 - kind: conda
@@ -5238,6 +5534,8 @@ packages:
   - python >=3.7
   license: MPL-2.0
   license_family: MOZILLA
+  purls:
+  - pkg:pypi/pathspec?source=conda-forge-mapping
   size: 41173
   timestamp: 1702250135032
 - kind: conda
@@ -5253,6 +5551,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 899794
   timestamp: 1698610978148
 - kind: conda
@@ -5268,6 +5567,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 619848
   timestamp: 1698610997157
 - kind: conda
@@ -5284,6 +5584,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 1017235
   timestamp: 1698610864983
 - kind: conda
@@ -5302,6 +5603,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 818317
   timestamp: 1708118868321
 - kind: conda
@@ -5314,6 +5616,7 @@ packages:
   sha256: 8ebd35e2940055a93135b9fd11bef3662cecef72d6ee651f68d64a2f349863c7
   md5: dc442e0885c3a6b65e61c61558161a9e
   license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  purls: []
   size: 12334471
   timestamp: 1703311001432
 - kind: conda
@@ -5326,6 +5629,7 @@ packages:
   sha256: b0c55040d2994fd6bf2f83786561d92f72306d982d6ea12889acad24a9bf43b8
   md5: ba3cbe93f99e896765422cc5f7c3a79e
   license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  purls: []
   size: 14439531
   timestamp: 1703311335652
 - kind: conda
@@ -5341,6 +5645,7 @@ packages:
   - libgcc-ng >=12
   - libxcrypt >=4.4.36
   license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  purls: []
   size: 13344463
   timestamp: 1703310653947
 - kind: conda
@@ -5364,6 +5669,8 @@ packages:
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
+  purls:
+  - pkg:pypi/pillow?source=conda-forge-mapping
   size: 42531277
   timestamp: 1712154782302
 - kind: conda
@@ -5390,6 +5697,8 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: HPND
+  purls:
+  - pkg:pypi/pillow?source=conda-forge-mapping
   size: 42439434
   timestamp: 1712155248737
 - kind: conda
@@ -5414,6 +5723,8 @@ packages:
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
+  purls:
+  - pkg:pypi/pillow?source=conda-forge-mapping
   size: 42729895
   timestamp: 1712155044162
 - kind: conda
@@ -5438,6 +5749,8 @@ packages:
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
+  purls:
+  - pkg:pypi/pillow?source=conda-forge-mapping
   size: 41991755
   timestamp: 1712154634705
 - kind: conda
@@ -5453,6 +5766,7 @@ packages:
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 386826
   timestamp: 1706549500138
 - kind: conda
@@ -5469,6 +5783,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls: []
   size: 461854
   timestamp: 1709239971654
 - kind: conda
@@ -5483,6 +5798,7 @@ packages:
   - libcxx >=16
   license: MIT
   license_family: MIT
+  purls: []
   size: 323904
   timestamp: 1709239931160
 - kind: conda
@@ -5497,6 +5813,7 @@ packages:
   - libcxx >=16
   license: MIT
   license_family: MIT
+  purls: []
   size: 198755
   timestamp: 1709239846651
 - kind: conda
@@ -5514,6 +5831,7 @@ packages:
   - vs2015_runtime >=14.16.27012
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 33990
   timestamp: 1604184834061
 - kind: conda
@@ -5529,6 +5847,7 @@ packages:
   - libgcc-ng >=7.5.0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 123341
   timestamp: 1604184579935
 - kind: conda
@@ -5544,6 +5863,7 @@ packages:
   - libiconv >=1.16,<2.0.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 269087
   timestamp: 1650238856925
 - kind: conda
@@ -5560,6 +5880,7 @@ packages:
   - libiconv >=1.16,<2.0.0a0
   license: GPL-2.0-or-later
   license_family: GPL
+  purls: []
   size: 46049
   timestamp: 1650239029040
 - kind: conda
@@ -5575,6 +5896,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=conda-forge-mapping
   size: 20572
   timestamp: 1715777739019
 - kind: conda
@@ -5590,6 +5913,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=conda-forge-mapping
   size: 23815
   timestamp: 1713667175451
 - kind: conda
@@ -5610,6 +5935,8 @@ packages:
   - virtualenv >=20.10.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pre-commit?source=conda-forge-mapping
   size: 179852
   timestamp: 1686749032780
 - kind: conda
@@ -5623,6 +5950,7 @@ packages:
   md5: d3f26c6494d4105d4ecb85203d687102
   license: MIT
   license_family: MIT
+  purls: []
   size: 5696
   timestamp: 1606147608402
 - kind: conda
@@ -5638,6 +5966,7 @@ packages:
   - libgcc-ng >=7.5.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 5625
   timestamp: 1606147468727
 - kind: conda
@@ -5651,6 +5980,7 @@ packages:
   md5: addd19059de62181cd11ae8f4ef26084
   license: MIT
   license_family: MIT
+  purls: []
   size: 5653
   timestamp: 1606147699844
 - kind: conda
@@ -5666,6 +5996,7 @@ packages:
   - m2w64-gcc-libs
   license: MIT
   license_family: MIT
+  purls: []
   size: 6417
   timestamp: 1606147814351
 - kind: conda
@@ -5681,6 +6012,8 @@ packages:
   - python >=3.8
   - pyyaml
   license: WTFPL
+  purls:
+  - pkg:pypi/pyaml?source=conda-forge-mapping
   size: 27429
   timestamp: 1713456374154
 - kind: conda
@@ -5696,6 +6029,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pycparser?source=conda-forge-mapping
   size: 105098
   timestamp: 1711811634025
 - kind: conda
@@ -5714,6 +6049,8 @@ packages:
   - typing-extensions >=4.6.1
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=conda-forge-mapping
   size: 271508
   timestamp: 1710622392396
 - kind: conda
@@ -5732,6 +6069,8 @@ packages:
   - __osx >=10.12
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
   size: 1571983
   timestamp: 1708701626319
 - kind: conda
@@ -5749,6 +6088,8 @@ packages:
   - typing-extensions >=4.6.0,!=4.7.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
   size: 1638828
   timestamp: 1708701163582
 - kind: conda
@@ -5768,6 +6109,8 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
   size: 1468564
   timestamp: 1708701579683
 - kind: conda
@@ -5787,6 +6130,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
   size: 1617588
   timestamp: 1708701919369
 - kind: conda
@@ -5802,6 +6147,8 @@ packages:
   - python >=3.8
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=conda-forge-mapping
   size: 879295
   timestamp: 1714846885370
 - kind: conda
@@ -5820,6 +6167,8 @@ packages:
   - ruamel.yaml >=0.16.0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pykwalify?source=conda-forge-mapping
   size: 27988
   timestamp: 1701903137868
 - kind: conda
@@ -5837,6 +6186,8 @@ packages:
   - pyyaml
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pymdown-extensions?source=conda-forge-mapping
   size: 158717
   timestamp: 1714261991332
 - kind: conda
@@ -5852,6 +6203,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyparsing?source=conda-forge-mapping
   size: 89455
   timestamp: 1709721146886
 - kind: conda
@@ -5867,6 +6220,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyrsistent?source=conda-forge-mapping
   size: 119154
   timestamp: 1698753368561
 - kind: conda
@@ -5883,6 +6238,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyrsistent?source=conda-forge-mapping
   size: 122192
   timestamp: 1698754175533
 - kind: conda
@@ -5899,6 +6256,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyrsistent?source=conda-forge-mapping
   size: 119500
   timestamp: 1698754330559
 - kind: conda
@@ -5917,6 +6276,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyrsistent?source=conda-forge-mapping
   size: 114503
   timestamp: 1698754544996
 - kind: conda
@@ -5935,6 +6296,8 @@ packages:
   - win_inet_pton
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pysocks?source=conda-forge-mapping
   size: 19348
   timestamp: 1661605138291
 - kind: conda
@@ -5952,6 +6315,8 @@ packages:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/pysocks?source=conda-forge-mapping
   size: 18981
   timestamp: 1661604969727
 - kind: conda
@@ -5975,6 +6340,8 @@ packages:
   - pytest-faulthandler >=2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pytest?source=conda-forge-mapping
   size: 251895
   timestamp: 1708821744729
 - kind: conda
@@ -6001,6 +6368,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 14557341
   timestamp: 1713208068012
 - kind: conda
@@ -6027,6 +6395,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 16179248
   timestamp: 1713205644673
 - kind: conda
@@ -6053,6 +6422,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 13207557
   timestamp: 1713206576646
 - kind: conda
@@ -6083,6 +6453,7 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
+  purls: []
   size: 31991381
   timestamp: 1713208036041
 - kind: conda
@@ -6099,6 +6470,8 @@ packages:
   - six >=1.5
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/python-dateutil?source=conda-forge-mapping
   size: 222742
   timestamp: 1709299922152
 - kind: conda
@@ -6114,6 +6487,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6385
   timestamp: 1695147396604
 - kind: conda
@@ -6129,6 +6503,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6496
   timestamp: 1695147498447
 - kind: conda
@@ -6144,6 +6519,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6508
   timestamp: 1695147497048
 - kind: conda
@@ -6159,6 +6535,7 @@ packages:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 6785
   timestamp: 1695147430513
 - kind: conda
@@ -6174,6 +6551,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pytz?source=conda-forge-mapping
   size: 188538
   timestamp: 1706886944988
 - kind: conda
@@ -6192,6 +6571,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 182705
   timestamp: 1695373895409
 - kind: conda
@@ -6209,6 +6590,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 185636
   timestamp: 1695373742454
 - kind: conda
@@ -6227,6 +6610,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 196583
   timestamp: 1695373632212
 - kind: conda
@@ -6247,6 +6632,8 @@ packages:
   - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 167932
   timestamp: 1695374097139
 - kind: conda
@@ -6263,6 +6650,8 @@ packages:
   - pyyaml
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml-env-tag?source=conda-forge-mapping
   size: 7473
   timestamp: 1624389117412
 - kind: conda
@@ -6279,6 +6668,7 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 281456
   timestamp: 1679532220005
 - kind: conda
@@ -6294,6 +6684,7 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 250351
   timestamp: 1679532511311
 - kind: conda
@@ -6309,6 +6700,7 @@ packages:
   - ncurses >=6.3,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
+  purls: []
   size: 255870
   timestamp: 1679532707590
 - kind: conda
@@ -6327,6 +6719,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Python-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=conda-forge-mapping
   size: 358496
   timestamp: 1715829078813
 - kind: conda
@@ -6344,6 +6738,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=conda-forge-mapping
   size: 360656
   timestamp: 1715828723075
 - kind: conda
@@ -6360,6 +6756,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=conda-forge-mapping
   size: 398199
   timestamp: 1715828558963
 - kind: conda
@@ -6376,6 +6774,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=conda-forge-mapping
   size: 366823
   timestamp: 1715828565789
 - kind: conda
@@ -6397,6 +6797,8 @@ packages:
   - chardet >=3.0.2,<6
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/requests?source=conda-forge-mapping
   size: 58810
   timestamp: 1717057174842
 - kind: conda
@@ -6413,6 +6815,8 @@ packages:
   - ruamel.yaml.clib >=0.1.2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=conda-forge-mapping
   size: 268460
   timestamp: 1707298596313
 - kind: conda
@@ -6430,6 +6834,8 @@ packages:
   - ruamel.yaml.clib >=0.1.2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=conda-forge-mapping
   size: 268015
   timestamp: 1707298336196
 - kind: conda
@@ -6447,6 +6853,8 @@ packages:
   - ruamel.yaml.clib >=0.1.2
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=conda-forge-mapping
   size: 268637
   timestamp: 1707298502612
 - kind: conda
@@ -6466,6 +6874,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml?source=conda-forge-mapping
   size: 267762
   timestamp: 1707298539404
 - kind: conda
@@ -6481,6 +6891,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=conda-forge-mapping
   size: 118650
   timestamp: 1707314908121
 - kind: conda
@@ -6497,6 +6909,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=conda-forge-mapping
   size: 135640
   timestamp: 1707314642857
 - kind: conda
@@ -6513,6 +6927,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=conda-forge-mapping
   size: 111221
   timestamp: 1707315016121
 - kind: conda
@@ -6531,6 +6947,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ruamel-yaml-clib?source=conda-forge-mapping
   size: 96333
   timestamp: 1707315306489
 - kind: conda
@@ -6546,6 +6964,7 @@ packages:
   - rust-std-aarch64-apple-darwin 1.77.2 hf6ec828_1
   license: MIT
   license_family: MIT
+  purls: []
   size: 147205067
   timestamp: 1715155248202
 - kind: conda
@@ -6564,6 +6983,7 @@ packages:
   - rust-std-x86_64-unknown-linux-gnu 1.77.2 h2c6d0dc_1
   license: MIT
   license_family: MIT
+  purls: []
   size: 186692944
   timestamp: 1715154179188
 - kind: conda
@@ -6579,6 +6999,7 @@ packages:
   - rust-std-x86_64-apple-darwin 1.77.2 h38e4360_1
   license: MIT
   license_family: MIT
+  purls: []
   size: 192556912
   timestamp: 1715155429820
 - kind: conda
@@ -6594,6 +7015,7 @@ packages:
   - rust-std-x86_64-pc-windows-msvc 1.77.2 h17fc481_1
   license: MIT
   license_family: MIT
+  purls: []
   size: 186782410
   timestamp: 1715157050370
 - kind: conda
@@ -6612,6 +7034,7 @@ packages:
   - rust >=1.77.2,<1.77.3.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 30979017
   timestamp: 1715153523506
 - kind: conda
@@ -6630,6 +7053,7 @@ packages:
   - rust >=1.77.2,<1.77.3.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 31784306
   timestamp: 1715153497698
 - kind: conda
@@ -6648,6 +7072,7 @@ packages:
   - rust >=1.77.2,<1.77.3.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 25155888
   timestamp: 1715156710925
 - kind: conda
@@ -6666,6 +7091,7 @@ packages:
   - rust >=1.77.2,<1.77.3.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 33923495
   timestamp: 1715154009471
 - kind: conda
@@ -6682,6 +7108,8 @@ packages:
   - python >=3.6
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/schema?source=conda-forge-mapping
   size: 23534
   timestamp: 1714829277138
 - kind: conda
@@ -6697,6 +7125,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=conda-forge-mapping
   size: 483015
   timestamp: 1716368141661
 - kind: conda
@@ -6712,6 +7142,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/six?source=conda-forge-mapping
   size: 14259
   timestamp: 1620240338595
 - kind: conda
@@ -6728,6 +7160,7 @@ packages:
   - kernel-headers_linux-64 2.6.32 he073ed8_17
   license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later AND MPL-2.0
   license_family: GPL
+  purls: []
   size: 15127123
   timestamp: 1708000843849
 - kind: conda
@@ -6744,6 +7177,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tabulate?source=conda-forge-mapping
   size: 35912
   timestamp: 1665138565317
 - kind: conda
@@ -6760,6 +7195,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 3560280
   timestamp: 1710793219601
 - kind: conda
@@ -6775,6 +7211,7 @@ packages:
   - openssl >=3.2.1,<4.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 3877123
   timestamp: 1710792099600
 - kind: conda
@@ -6791,6 +7228,7 @@ packages:
   - __osx >=10.12
   license: MIT
   license_family: MIT
+  purls: []
   size: 3773670
   timestamp: 1710793055293
 - kind: conda
@@ -6806,6 +7244,7 @@ packages:
   - m2w64-gcc-libs-core
   license: MIT
   license_family: MIT
+  purls: []
   size: 3924159
   timestamp: 1710794002174
 - kind: conda
@@ -6825,6 +7264,8 @@ packages:
   - tomlkit >=0.5.8
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/tbump?source=conda-forge-mapping
   size: 28785
   timestamp: 1652622787739
 - kind: conda
@@ -6841,6 +7282,8 @@ packages:
   - webencodings >=0.4
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/tinycss2?source=conda-forge-mapping
   size: 25405
   timestamp: 1713975078735
 - kind: conda
@@ -6856,6 +7299,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3270220
   timestamp: 1699202389792
 - kind: conda
@@ -6871,6 +7315,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3145523
   timestamp: 1699202432999
 - kind: conda
@@ -6888,6 +7333,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: TCL
   license_family: BSD
+  purls: []
   size: 3503410
   timestamp: 1699202577803
 - kind: conda
@@ -6904,6 +7350,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
+  purls: []
   size: 3318875
   timestamp: 1699202167581
 - kind: conda
@@ -6919,6 +7366,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=conda-forge-mapping
   size: 15940
   timestamp: 1644342331069
 - kind: conda
@@ -6934,6 +7383,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/tomlkit?source=conda-forge-mapping
   size: 37297
   timestamp: 1715185504185
 - kind: conda
@@ -6949,6 +7400,7 @@ packages:
   - typing_extensions 4.12.2 pyha770c72_0
   license: PSF-2.0
   license_family: PSF
+  purls: []
   size: 10097
   timestamp: 1717802659025
 - kind: conda
@@ -6964,6 +7416,8 @@ packages:
   - python >=3.8
   license: PSF-2.0
   license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=conda-forge-mapping
   size: 39888
   timestamp: 1717802653893
 - kind: conda
@@ -6976,6 +7430,7 @@ packages:
   sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
   md5: 161081fc7cec0bfda0d86d7cb595f8d8
   license: LicenseRef-Public-Domain
+  purls: []
   size: 119815
   timestamp: 1706886945727
 - kind: conda
@@ -6990,6 +7445,7 @@ packages:
   - vs2015_runtime >=14.29.30037
   license: LicenseRef-Proprietary
   license_family: PROPRIETARY
+  purls: []
   size: 1283972
   timestamp: 1666630199266
 - kind: conda
@@ -7010,6 +7466,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 17235
   timestamp: 1695549871621
 - kind: conda
@@ -7029,6 +7487,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 13948
   timestamp: 1695549890285
 - kind: conda
@@ -7047,6 +7507,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 13246
   timestamp: 1695549689363
 - kind: conda
@@ -7066,6 +7528,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 14050
   timestamp: 1695549556745
 - kind: conda
@@ -7081,6 +7545,8 @@ packages:
   - python >=3.5
   license: GPL-2.0-or-later
   license_family: GPL
+  purls:
+  - pkg:pypi/unidecode?source=conda-forge-mapping
   size: 173788
   timestamp: 1704986523363
 - kind: conda
@@ -7098,6 +7564,8 @@ packages:
   - python >=3.7
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/urllib3?source=conda-forge-mapping
   size: 94669
   timestamp: 1708239595549
 - kind: conda
@@ -7115,6 +7583,7 @@ packages:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 17391
   timestamp: 1717709040616
 - kind: conda
@@ -7132,6 +7601,7 @@ packages:
   - vs2015_runtime 14.40.33810.* *_20
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
+  purls: []
   size: 751934
   timestamp: 1717709031266
 - kind: conda
@@ -7147,6 +7617,8 @@ packages:
   - python >=3.6
   license: BSD-2-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/verspec?source=conda-forge-mapping
   size: 19929
   timestamp: 1618150464786
 - kind: conda
@@ -7165,6 +7637,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/virtualenv?source=conda-forge-mapping
   size: 3458445
   timestamp: 1715681264937
 - kind: conda
@@ -7180,6 +7654,7 @@ packages:
   - vc14_runtime >=14.40.33810
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 17395
   timestamp: 1717709043353
 - kind: conda
@@ -7196,6 +7671,8 @@ packages:
   - pyyaml >=3.10
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/watchdog?source=conda-forge-mapping
   size: 162034
   timestamp: 1716562347718
 - kind: conda
@@ -7212,6 +7689,8 @@ packages:
   - pyyaml >=3.10
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/watchdog?source=conda-forge-mapping
   size: 136444
   timestamp: 1716561872155
 - kind: conda
@@ -7230,6 +7709,8 @@ packages:
   - pyyaml >=3.10
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/watchdog?source=conda-forge-mapping
   size: 145420
   timestamp: 1716562106758
 - kind: conda
@@ -7247,6 +7728,8 @@ packages:
   - pyyaml >=3.10
   license: Apache-2.0
   license_family: APACHE
+  purls:
+  - pkg:pypi/watchdog?source=conda-forge-mapping
   size: 144881
   timestamp: 1716561920161
 - kind: conda
@@ -7263,6 +7746,8 @@ packages:
   - python >=2.6
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/webencodings?source=conda-forge-mapping
   size: 15600
   timestamp: 1694681458271
 - kind: conda
@@ -7279,6 +7764,8 @@ packages:
   - __win
   - python >=3.6
   license: PUBLIC-DOMAIN
+  purls:
+  - pkg:pypi/win-inet-pton?source=conda-forge-mapping
   size: 8191
   timestamp: 1667051294134
 - kind: conda
@@ -7294,6 +7781,7 @@ packages:
   - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 27338
   timestamp: 1610027759842
 - kind: conda
@@ -7308,6 +7796,7 @@ packages:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 58469
   timestamp: 1685307573114
 - kind: conda
@@ -7324,6 +7813,7 @@ packages:
   - xorg-libice >=1.1.1,<2.0a0
   license: MIT
   license_family: MIT
+  purls: []
   size: 27433
   timestamp: 1685453649160
 - kind: conda
@@ -7342,6 +7832,7 @@ packages:
   - xorg-xproto
   license: MIT
   license_family: MIT
+  purls: []
   size: 828060
   timestamp: 1712415742569
 - kind: conda
@@ -7354,6 +7845,7 @@ packages:
   md5: 9566b4c29274125b0266d0177b5eb97b
   license: MIT
   license_family: MIT
+  purls: []
   size: 13071
   timestamp: 1684638167647
 - kind: conda
@@ -7366,6 +7858,7 @@ packages:
   md5: ca73dc4f01ea91e44e3ed76602c5ea61
   license: MIT
   license_family: MIT
+  purls: []
   size: 13667
   timestamp: 1684638272445
 - kind: conda
@@ -7381,6 +7874,7 @@ packages:
   - m2w64-gcc-libs-core
   license: MIT
   license_family: MIT
+  purls: []
   size: 51297
   timestamp: 1684638355740
 - kind: conda
@@ -7395,6 +7889,7 @@ packages:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 14468
   timestamp: 1684637984591
 - kind: conda
@@ -7407,6 +7902,7 @@ packages:
   md5: 6738b13f7fadc18725965abdd4129c36
   license: MIT
   license_family: MIT
+  purls: []
   size: 18164
   timestamp: 1610071737668
 - kind: conda
@@ -7419,6 +7915,7 @@ packages:
   md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
   license: MIT
   license_family: MIT
+  purls: []
   size: 17225
   timestamp: 1610071995461
 - kind: conda
@@ -7433,6 +7930,7 @@ packages:
   - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 19126
   timestamp: 1610071769228
 - kind: conda
@@ -7447,6 +7945,7 @@ packages:
   - m2w64-gcc-libs
   license: MIT
   license_family: MIT
+  purls: []
   size: 67908
   timestamp: 1610072296570
 - kind: conda
@@ -7464,6 +7963,7 @@ packages:
   - xorg-xextproto
   license: MIT
   license_family: MIT
+  purls: []
   size: 50143
   timestamp: 1677036907815
 - kind: conda
@@ -7480,6 +7980,7 @@ packages:
   - xorg-renderproto
   license: MIT
   license_family: MIT
+  purls: []
   size: 37770
   timestamp: 1688300707994
 - kind: conda
@@ -7495,6 +7996,7 @@ packages:
   - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 9621
   timestamp: 1614866326326
 - kind: conda
@@ -7510,6 +8012,7 @@ packages:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
+  purls: []
   size: 30270
   timestamp: 1677036833037
 - kind: conda
@@ -7525,6 +8028,7 @@ packages:
   - libgcc-ng >=9.3.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 74922
   timestamp: 1607291557628
 - kind: conda
@@ -7538,6 +8042,7 @@ packages:
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 418368
   timestamp: 1660346797927
 - kind: conda
@@ -7549,6 +8054,7 @@ packages:
   sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   md5: 39c6b54e94014701dd157f4f576ed211
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 235693
   timestamp: 1660346961024
 - kind: conda
@@ -7560,6 +8066,7 @@ packages:
   sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
   md5: a72f9d4ea13d55d745ff1ed594747f10
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 238119
   timestamp: 1660346964847
 - kind: conda
@@ -7574,6 +8081,7 @@ packages:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
   license: LGPL-2.1 and GPL-2.0
+  purls: []
   size: 217804
   timestamp: 1660346976440
 - kind: conda
@@ -7587,6 +8095,7 @@ packages:
   md5: d7e08fcf8259d742156188e8762b4d20
   license: MIT
   license_family: MIT
+  purls: []
   size: 84237
   timestamp: 1641347062780
 - kind: conda
@@ -7600,6 +8109,7 @@ packages:
   md5: 4bb3f014845110883a3c5ee811fd84b4
   license: MIT
   license_family: MIT
+  purls: []
   size: 88016
   timestamp: 1641347076660
 - kind: conda
@@ -7615,6 +8125,7 @@ packages:
   - libgcc-ng >=9.4.0
   license: MIT
   license_family: MIT
+  purls: []
   size: 89141
   timestamp: 1641346969816
 - kind: conda
@@ -7631,6 +8142,7 @@ packages:
   - vs2015_runtime >=14.16.27012
   license: MIT
   license_family: MIT
+  purls: []
   size: 63274
   timestamp: 1641347623319
 - kind: conda
@@ -7646,6 +8158,8 @@ packages:
   - python >=3.8
   license: MIT
   license_family: MIT
+  purls:
+  - pkg:pypi/zipp?source=conda-forge-mapping
   size: 20917
   timestamp: 1718013395428
 - kind: conda
@@ -7664,6 +8178,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Zlib
   license_family: Other
+  purls: []
   size: 108081
   timestamp: 1716874767420
 - kind: conda
@@ -7680,6 +8195,7 @@ packages:
   - libzlib 1.3.1 h4ab18f5_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 93004
   timestamp: 1716874213487
 - kind: conda
@@ -7696,6 +8212,7 @@ packages:
   - libzlib 1.3.1 h87427d6_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 88782
   timestamp: 1716874245467
 - kind: conda
@@ -7712,6 +8229,7 @@ packages:
   - libzlib 1.3.1 hfb2fe0b_1
   license: Zlib
   license_family: Other
+  purls: []
   size: 78260
   timestamp: 1716874280334
 - kind: conda
@@ -7729,6 +8247,7 @@ packages:
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 349143
   timestamp: 1714723445995
 - kind: conda
@@ -7744,6 +8263,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 498900
   timestamp: 1714723303098
 - kind: conda
@@ -7760,6 +8280,7 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 554846
   timestamp: 1714722996770
 - kind: conda
@@ -7775,5 +8296,6 @@ packages:
   - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
+  purls: []
   size: 405089
   timestamp: 1714723101397

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,62 +1,76 @@
-use crate::{
-    config::ConfigCli,
-    environment::{get_up_to_date_prefix, verify_prefix_location_unchanged, LockFileUsage},
-    project::{has_features::HasFeatures, DependencyType, Project, SpecType},
-    FeatureName,
-};
-use clap::Parser;
-use indexmap::IndexMap;
-use itertools::{Either, Itertools};
-
-use crate::project::grouped_environment::GroupedEnvironment;
-use miette::{IntoDiagnostic, WrapErr};
-use rattler_conda_types::{
-    version_spec::{LogicalOperator, RangeOperator},
-    Channel, MatchSpec, NamelessMatchSpec, PackageName, Platform, Version, VersionBumpType,
-    VersionSpec,
-};
-use rattler_repodata_gateway::{Gateway, RepoData};
-use rattler_solve::{resolvo, SolverImpl};
-use std::time::Instant;
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
+    str::FromStr,
 };
 
+use clap::Parser;
+use indexmap::IndexMap;
+use itertools::Itertools;
+use miette::{IntoDiagnostic, WrapErr};
+use pep440_rs::VersionSpecifiers;
+use pep508_rs::{Requirement, VersionOrUrl::VersionSpecifier};
+use rattler_conda_types::{
+    version_spec::{LogicalOperator, RangeOperator},
+    MatchSpec, NamelessMatchSpec, PackageName, Platform, Version, VersionBumpType, VersionSpec,
+};
+use rattler_lock::{LockFile, Package};
+
 use super::has_specs::HasSpecs;
+use crate::{
+    config::ConfigCli,
+    environment::{verify_prefix_location_unchanged, LockFileUsage},
+    load_lock_file,
+    lock_file::{filter_lock_file, UpdateContext},
+    project::{
+        grouped_environment::GroupedEnvironment, has_features::HasFeatures,
+        manifest::python::PyPiPackageName, DependencyType, Project, SpecType,
+    },
+    FeatureName,
+};
 
 /// Adds dependencies to the project
 ///
-/// The dependencies should be defined as MatchSpec for conda package, or a PyPI requirement
-/// for the --pypi dependencies. If no specific version is provided, the latest version
-/// compatible with your project will be chosen automatically or a * will be used.
+/// The dependencies should be defined as MatchSpec for conda package, or a PyPI
+/// requirement for the --pypi dependencies. If no specific version is provided,
+/// the latest version compatible with your project will be chosen automatically
+/// or a * will be used.
 ///
 /// Example usage:
 ///
-/// - `pixi add python=3.9`: This will select the latest minor version that complies with 3.9.*, i.e.,
-///   python version 3.9.0, 3.9.1, 3.9.2, etc.
-/// - `pixi add python`: In absence of a specified version, the latest version will be chosen.
-///   For instance, this could resolve to python version 3.11.3.* at the time of writing.
+/// - `pixi add python=3.9`: This will select the latest minor version that
+///   complies with 3.9.*, i.e., python version 3.9.0, 3.9.1, 3.9.2, etc.
+/// - `pixi add python`: In absence of a specified version, the latest version
+///   will be chosen. For instance, this could resolve to python version
+///   3.11.3.* at the time of writing.
 ///
 /// Adding multiple dependencies at once is also supported:
-/// - `pixi add python pytest`: This will add both `python` and `pytest` to the project's dependencies.
+/// - `pixi add python pytest`: This will add both `python` and `pytest` to the
+///   project's dependencies.
 ///
-/// The `--platform` and `--build/--host` flags make the dependency target specific.
-/// - `pixi add python --platform linux-64 --platform osx-arm64`: Will add the latest version of python for linux-64 and osx-arm64 platforms.
-/// - `pixi add python --build`: Will add the latest version of python for as a build dependency.
+/// The `--platform` and `--build/--host` flags make the dependency target
+/// specific.
+/// - `pixi add python --platform linux-64 --platform osx-arm64`: Will add the
+///   latest version of python for linux-64 and osx-arm64 platforms.
+/// - `pixi add python --build`: Will add the latest version of python for as a
+///   build dependency.
 ///
 /// Mixing `--platform` and `--build`/`--host` flags is supported
 ///
-/// The `--pypi` option will add the package as a pypi dependency. This can not be mixed with the conda dependencies
+/// The `--pypi` option will add the package as a pypi dependency. This can not
+/// be mixed with the conda dependencies
 /// - `pixi add --pypi boto3`
 /// - `pixi add --pypi "boto3==version"
 ///
-/// If the project manifest is a `pyproject.toml`, adding a pypi dependency will add it to the native pyproject `project.dependencies` array
-/// or to the native `project.optional-dependencies` table if a feature is specified:
-/// - `pixi add --pypi boto3` will add `boto3` to the `project.dependencies` array
-/// - `pixi add --pypi boto3 --feature aws` will add `boto3` to the `project.dependencies.aws` array
-/// These dependencies will then be read by pixi as if they had been added to the pixi `pypi-dependencies` tables of the default or of a named feature.
-///
+/// If the project manifest is a `pyproject.toml`, adding a pypi dependency will
+/// add it to the native pyproject `project.dependencies` array or to the native
+/// `project.optional-dependencies` table if a feature is specified:
+/// - `pixi add --pypi boto3` will add `boto3` to the `project.dependencies`
+///   array
+/// - `pixi add --pypi boto3 --feature aws` will add `boto3` to the
+///   `project.dependencies.aws` array
+/// These dependencies will then be read by pixi as if they had been added to
+/// the pixi `pypi-dependencies` tables of the default or of a named feature.
 #[derive(Parser, Debug, Default)]
 #[clap(arg_required_else_help = true, verbatim_doc_comment)]
 pub struct Args {
@@ -80,15 +94,18 @@ pub struct DependencyConfig {
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 
-    /// The specified dependencies are host dependencies. Conflicts with `build` and `pypi`
+    /// The specified dependencies are host dependencies. Conflicts with `build`
+    /// and `pypi`
     #[arg(long, conflicts_with_all = ["build", "pypi"])]
     pub host: bool,
 
-    /// The specified dependencies are build dependencies. Conflicts with `host` and `pypi`
+    /// The specified dependencies are build dependencies. Conflicts with `host`
+    /// and `pypi`
     #[arg(long, conflicts_with_all = ["host", "pypi"])]
     pub build: bool,
 
-    /// The specified dependencies are pypi dependencies. Conflicts with `host` and `build`
+    /// The specified dependencies are pypi dependencies. Conflicts with `host`
+    /// and `build`
     #[arg(long, conflicts_with_all = ["host", "build"])]
     pub pypi: bool,
 
@@ -133,12 +150,17 @@ impl DependencyConfig {
             .clone()
             .map_or(FeatureName::Default, FeatureName::Named)
     }
-    pub fn display_success(&self, operation: &str) {
+    pub fn display_success(&self, operation: &str, implicit_constraints: HashMap<String, String>) {
         for package in self.specs.clone() {
             eprintln!(
-                "{}{operation} {}",
+                "{}{operation} {}{}",
                 console::style(console::Emoji("✔ ", "")).green(),
-                console::style(package).bold(),
+                console::style(&package).bold(),
+                if let Some(constraint) = implicit_constraints.get(&package) {
+                    format!(" {}", console::style(constraint).dim())
+                } else {
+                    "".to_string()
+                }
             );
         }
 
@@ -174,296 +196,265 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let (args, config, editable) = (args.dependency_config, args.config, args.editable);
     let mut project =
         Project::load_or_else_discover(args.manifest_path.as_deref())?.with_cli_config(config);
-    let dependency_type = args.dependency_type();
 
     // Sanity check of prefix location
     verify_prefix_location_unchanged(project.default_environment().dir().as_path()).await?;
+
+    // Load the current lock-file
+    let lock_file = load_lock_file(&project).await?;
 
     // Add the platform if it is not already present
     project
         .manifest
         .add_platforms(args.platform.iter(), &FeatureName::Default)?;
 
-    match dependency_type {
+    // Add the individual specs to the project.
+    let mut conda_specs_to_add_constraints_for = IndexMap::new();
+    let mut pypi_specs_to_add_constraints_for = IndexMap::new();
+    let mut conda_packages = HashSet::new();
+    let mut pypi_packages = HashSet::new();
+    match args.dependency_type() {
         DependencyType::CondaDependency(spec_type) => {
             let specs = args.specs()?;
-            add_conda_specs_to_project(
-                &mut project,
-                &args.feature_name(),
-                specs,
-                spec_type,
-                args.no_install,
-                args.lock_file_usage(),
-                &args.platform,
-            )
-            .await
+            for (name, spec) in specs {
+                project.manifest.add_dependency(
+                    &spec,
+                    spec_type,
+                    &args.platform,
+                    &args.feature_name(),
+                )?;
+                if spec.version.is_none() {
+                    conda_specs_to_add_constraints_for.insert(name.clone(), (spec_type, spec));
+                }
+                conda_packages.insert(name);
+            }
         }
         DependencyType::PypiDependency => {
-            let specs = args.pypi_deps(&project)?.values().cloned().collect_vec();
-            add_pypi_requirements_to_project(
-                &mut project,
-                &args.feature_name(),
-                specs,
-                &args.platform,
-                args.lock_file_usage(),
-                args.no_install,
-                Some(editable),
-            )
-            .await
+            let specs = args.pypi_deps(&project)?;
+            for (name, spec) in specs {
+                project.manifest.add_pypi_dependency(
+                    &spec,
+                    &args.platform,
+                    &args.feature_name(),
+                    Some(editable),
+                )?;
+                if spec.version_or_url.is_none() {
+                    pypi_specs_to_add_constraints_for.insert(name.clone(), spec);
+                }
+                pypi_packages.insert(name.as_normalized().clone());
+            }
         }
-    }?;
+    }
 
-    args.display_success("Added");
+    // Determine the environments that are affected by the change.
+    let feature_name = args.feature_name();
+    let affected_environments = project
+        .environments()
+        .iter()
+        // Filter out any environment that does not contain the feature we modified
+        .filter(|e| e.features().any(|f| f.name == feature_name))
+        // Expand the selection to also included any environment that shares the same solve
+        // group
+        .flat_map(|e| {
+            GroupedEnvironment::from(e.clone())
+                .environments()
+                .collect_vec()
+        })
+        .unique()
+        .collect_vec();
+
+    tracing::debug!(
+        "environments affected by the add command: {}",
+        affected_environments.iter().map(|e| e.name()).format(", ")
+    );
+
+    // Determine the combination of platforms and environments that are affected by
+    // the command
+    let affect_environment_and_platforms = affected_environments
+        .into_iter()
+        // Create an iterator over all environment and platform combinations
+        .flat_map(|e| e.platforms().into_iter().map(move |p| (e.clone(), p)))
+        // Filter out any platform that is not affected by the changes.
+        .filter(|(_, platform)| args.platform.is_empty() || args.platform.contains(platform))
+        .map(|(e, p)| (e.name().to_string(), p))
+        .collect_vec();
+
+    // Create an updated lock-file where the dependencies to be added are removed
+    // from the lock-file.
+    let unlocked_lock_file = unlock_packages(
+        &project,
+        &lock_file,
+        conda_packages,
+        pypi_packages,
+        affect_environment_and_platforms
+            .iter()
+            .map(|(e, p)| (e.as_str(), *p))
+            .collect(),
+    );
+
+    // Solve the updated project.
+    let updated_lock_file = UpdateContext::builder(&project)
+        .with_lock_file(unlocked_lock_file)
+        .with_no_install(args.no_install || args.no_lockfile_update)
+        .finish()?
+        .update()
+        .await?
+        .lock_file;
+
+    // Update the constraints of specs that didn't have a version constraint based
+    // on the contents of the lock-file.
+    let implicit_constraints = if !conda_specs_to_add_constraints_for.is_empty() {
+        update_conda_specs_from_lock_file(
+            &mut project,
+            &updated_lock_file,
+            conda_specs_to_add_constraints_for,
+            affect_environment_and_platforms,
+            &feature_name,
+            &args.platform,
+        )?
+    } else if !pypi_specs_to_add_constraints_for.is_empty() {
+        update_pypi_specs_from_lock_file(
+            &mut project,
+            &updated_lock_file,
+            pypi_specs_to_add_constraints_for,
+            affect_environment_and_platforms,
+            &feature_name,
+            &args.platform,
+            editable,
+        )?
+    } else {
+        HashMap::new()
+    };
+
+    // Write the lock-file and the project to disk
+    updated_lock_file
+        .to_path(&project.lock_file_path())
+        .into_diagnostic()
+        .context("failed to write lock-file to disk")?;
+    project.save()?;
+
+    // Notify the user we succeeded.
+    args.display_success("Added", implicit_constraints);
 
     Project::warn_on_discovered_from_env(args.manifest_path.as_deref());
     Ok(())
 }
 
-pub async fn add_pypi_requirements_to_project(
+/// Update the pypi specs of newly added packages based on the contents of the
+/// updated lock-file.
+fn update_pypi_specs_from_lock_file(
     project: &mut Project,
+    updated_lock_file: &LockFile,
+    pypi_specs_to_add_constraints_for: IndexMap<PyPiPackageName, Requirement>,
+    affect_environment_and_platforms: Vec<(String, Platform)>,
     feature_name: &FeatureName,
-    requirements: Vec<pep508_rs::Requirement>,
     platforms: &[Platform],
-    lock_file_usage: LockFileUsage,
-    no_install: bool,
-    editable: Option<bool>,
-) -> miette::Result<()> {
-    for requirement in &requirements {
-        // TODO: Get best version
-        // Add the dependency to the project
-        project
-            .manifest
-            .add_pypi_dependency(requirement, platforms, feature_name, editable)?;
-    }
+    editable: bool,
+) -> miette::Result<HashMap<String, String>> {
+    let mut implicit_constraints = HashMap::new();
 
-    get_up_to_date_prefix(&project.default_environment(), lock_file_usage, no_install).await?;
-
-    project.save()?;
-
-    Ok(())
-}
-
-pub async fn add_conda_specs_to_project(
-    project: &mut Project,
-    feature_name: &FeatureName,
-    specs: IndexMap<PackageName, MatchSpec>,
-    spec_type: SpecType,
-    no_install: bool,
-    lock_file_usage: LockFileUsage,
-    specs_platforms: &[Platform],
-) -> miette::Result<()> {
-    // Determine the best version per platform
-    let mut package_versions = HashMap::<PackageName, HashSet<Version>>::new();
-
-    // Get the grouped environments that contain the feature
-    let grouped_environments: Vec<GroupedEnvironment> = project
-        .grouped_environments()
-        .iter()
-        .filter(|env| {
-            env.features()
-                .map(|feat| &feat.name)
-                .contains(&feature_name)
+    let pypi_records = affect_environment_and_platforms
+        .into_iter()
+        // Get all the conda and pypi records for the combination of environments and
+        // platforms
+        .filter_map(|(env, platform)| {
+            let locked_env = updated_lock_file.environment(&env)?;
+            locked_env.pypi_packages_for_platform(platform)
         })
-        .cloned()
-        .collect();
+        .flatten()
+        .collect_vec();
 
-    // TODO: show progress of this set of solves
-    // TODO: Make this parallel
-    // TODO: Make this more efficient by reusing the solves in the get_up_to_date_prefix
-    for grouped_environment in grouped_environments {
-        let platforms = if specs_platforms.is_empty() {
-            Either::Left(grouped_environment.platforms().into_iter())
-        } else {
-            Either::Right(specs_platforms.iter().copied())
-        };
+    // Determine the versions of the packages in the lock-file
+    for (name, _) in pypi_specs_to_add_constraints_for {
+        let version_constraint = determine_version_constraint(
+            pypi_records
+                .iter()
+                .filter_map(|(data, _)| Version::from_str(&data.version.to_string()).ok())
+                .collect_vec()
+                .iter(),
+        );
 
-        for platform in platforms {
-            // Solve the environment with the new specs added
-            let solved_versions = match determine_best_version(
-                &grouped_environment,
-                &specs,
-                spec_type,
-                platform,
-                grouped_environment.channels(),
-                project.repodata_gateway(),
-            )
-            .await
-            {
-                Ok(versions) => versions,
-                Err(err) => {
-                    return Err(err).wrap_err_with(|| miette::miette!(
-                        "could not determine any available versions for {} on {platform}. Either the package could not be found or version constraints on other dependencies result in a conflict.",
-                        specs.keys().map(|s| s.as_source()).join(", ")
-                    ));
-                }
-            };
-
-            // Collect all the versions seen.
-            for (name, version) in solved_versions {
-                package_versions.entry(name).or_default().insert(version);
-            }
+        let version_spec =
+            version_constraint.and_then(|spec| VersionSpecifiers::from_str(&spec.to_string()).ok());
+        if let Some(version_spec) = version_spec {
+            implicit_constraints.insert(name.as_source().to_string(), version_spec.to_string());
+            project.manifest.add_pypi_dependency(
+                &Requirement {
+                    name: name.as_normalized().clone(),
+                    extras: vec![],
+                    version_or_url: Some(VersionSpecifier(version_spec)),
+                    marker: None,
+                    origin: None,
+                },
+                platforms,
+                feature_name,
+                Some(editable),
+            )?;
         }
     }
 
-    // Update the specs passed on the command line with the best available versions.
-    for (name, spec) in specs {
-        let updated_spec = if spec.version.is_none() {
-            let mut updated_spec = NamelessMatchSpec::from(spec.clone());
-            if let Some(versions_seen) = package_versions.get(&name).cloned() {
-                updated_spec.version = determine_version_constraint(&versions_seen);
-            } else {
-                updated_spec.version = determine_version_constraint(
-                    &determine_latest_versions(project, specs_platforms, &name).await?,
-                );
-            }
-            updated_spec
-        } else {
-            spec.into()
-        };
-        let spec = MatchSpec::from_nameless(updated_spec, Some(name));
-
-        // Add the dependency to the project
-        project
-            .manifest
-            .add_dependency(&spec, spec_type, specs_platforms, feature_name)?;
-    }
-
-    // Update the prefix
-    get_up_to_date_prefix(&project.default_environment(), lock_file_usage, no_install).await?;
-
-    project.save()?;
-
-    Ok(())
+    Ok(implicit_constraints)
 }
 
-/// Get all the latest versions found in the platforms repodata.
-async fn determine_latest_versions(
-    project: &Project,
+/// Update the conda specs of newly added packages based on the contents of the
+/// updated lock-file.
+fn update_conda_specs_from_lock_file(
+    project: &mut Project,
+    updated_lock_file: &LockFile,
+    conda_specs_to_add_constraints_for: IndexMap<PackageName, (SpecType, MatchSpec)>,
+    affect_environment_and_platforms: Vec<(String, Platform)>,
+    feature_name: &FeatureName,
     platforms: &[Platform],
-    name: &PackageName,
-) -> miette::Result<Vec<Version>> {
-    // Get platforms to search for including NoArch
-    let platforms = if platforms.is_empty() {
-        let mut temp = project
-            .default_environment()
-            .platforms()
-            .into_iter()
-            .collect_vec();
-        temp.push(Platform::NoArch);
-        temp
-    } else {
-        let mut temp = platforms.to_vec();
-        temp.push(Platform::NoArch);
-        temp
-    };
+) -> miette::Result<HashMap<String, String>> {
+    let mut implicit_constraints = HashMap::new();
 
-    // Get the records for the package
-    let records = project
-        .repodata_gateway()
-        .query(
-            project
-                .default_environment()
-                .channels()
-                .into_iter()
-                .cloned(),
-            platforms,
-            [name.clone()],
-        )
-        .recursive(false)
-        .await
-        .into_diagnostic()?;
+    // Determine the conda records that were affected by the add.
+    let conda_records = affect_environment_and_platforms
+        .into_iter()
+        // Get all the conda and pypi records for the combination of environments and
+        // platforms
+        .filter_map(|(env, platform)| {
+            let locked_env = updated_lock_file.environment(&env)?;
+            locked_env
+                .conda_repodata_records_for_platform(platform)
+                .ok()?
+        })
+        .flatten()
+        .collect_vec();
 
-    // Find the first non-empty channel
-    let Some(priority_records) = records.into_iter().find(|records| !records.is_empty()) else {
-        return Ok(vec![]);
-    };
-
-    // Find the maximum versions per platform
-    let mut found_records: HashMap<String, Version> = HashMap::new();
-    for record in priority_records.iter() {
-        let version = record.package_record.version.version().clone();
-        let platform = &record.package_record.subdir;
-        found_records
-            .entry(platform.clone())
-            .and_modify(|max| {
-                if &version > max {
-                    *max = version.clone();
+    for (name, (spec_type, _)) in conda_specs_to_add_constraints_for {
+        let version_constraint =
+            determine_version_constraint(conda_records.iter().filter_map(|record| {
+                if record.package_record.name == name {
+                    Some(record.package_record.version.version())
+                } else {
+                    None
                 }
-            })
-            .or_insert(version);
+            }));
+
+        if let Some(version_constraint) = version_constraint {
+            implicit_constraints
+                .insert(name.as_source().to_string(), version_constraint.to_string());
+            project.manifest.add_dependency(
+                &MatchSpec::from_nameless(
+                    NamelessMatchSpec {
+                        version: Some(version_constraint),
+                        ..NamelessMatchSpec::default()
+                    },
+                    Some(name),
+                ),
+                spec_type,
+                platforms,
+                feature_name,
+            )?;
+        }
     }
 
-    // Determine the version constraint based on the max of every channel and platform.
-    Ok(found_records.into_values().collect())
-}
-/// Given several specs determines the highest installable version for them.
-pub async fn determine_best_version<'p>(
-    environment: &GroupedEnvironment<'p>,
-    new_specs: &IndexMap<PackageName, MatchSpec>,
-    new_specs_type: SpecType,
-    platform: Platform,
-    channels: impl IntoIterator<Item = &'p Channel>,
-    repodata_gateway: &Gateway,
-) -> miette::Result<HashMap<PackageName, Version>> {
-    // Build the combined set of specs while updating the dependencies with the new specs.
-    let dependencies = SpecType::all()
-        .map(|spec_type| {
-            let mut deps = environment.dependencies(Some(spec_type), Some(platform));
-            if spec_type == new_specs_type {
-                for (new_name, new_spec) in new_specs.iter() {
-                    deps.remove(new_name); // Remove any existing specs
-                    deps.insert(new_name.clone(), NamelessMatchSpec::from(new_spec.clone()));
-                    // Add the new specs
-                }
-            }
-            deps
-        })
-        .reduce(|acc, deps| acc.overwrite(&deps))
-        .unwrap_or_default();
-
-    // Extract the package names from all the dependencies
-    let fetch_repodata_start = Instant::now();
-    let available_packages = repodata_gateway
-        .query(
-            channels.into_iter().cloned(),
-            [platform, Platform::NoArch],
-            dependencies.clone().into_match_specs(),
-        )
-        .recursive(true)
-        .await
-        .into_diagnostic()?;
-    let total_records = available_packages.iter().map(RepoData::len).sum::<usize>();
-    tracing::info!(
-        "fetched {total_records} records in {:?}",
-        fetch_repodata_start.elapsed()
-    );
-
-    // Construct a solver task to start solving.
-    let task = rattler_solve::SolverTask {
-        specs: dependencies
-            .iter_specs()
-            .map(|(name, spec)| MatchSpec::from_nameless(spec.clone(), Some(name.clone())))
-            .collect(),
-        virtual_packages: environment.virtual_packages(platform),
-        ..rattler_solve::SolverTask::from_iter(&available_packages)
-    };
-
-    let records = resolvo::Solver.solve(task).into_diagnostic()?;
-
-    // Determine the versions of the new packages
-    Ok(records
-        .into_iter()
-        .filter(|record| new_specs.contains_key(&record.package_record.name))
-        .map(|record| {
-            (
-                record.package_record.name,
-                record.package_record.version.into(),
-            )
-        })
-        .collect())
+    Ok(implicit_constraints)
 }
 
-/// Given a set of versions, determines the best version constraint to use that captures all of them.
+/// Given a set of versions, determines the best version constraint to use that
+/// captures all of them.
 fn determine_version_constraint<'a>(
     versions: impl IntoIterator<Item = &'a Version>,
 ) -> Option<VersionSpec> {
@@ -481,6 +472,26 @@ fn determine_version_constraint<'a>(
             VersionSpec::Range(RangeOperator::Less, upper_bound),
         ],
     ))
+}
+
+/// Constructs a new lock-file where some of the constraints have been removed.
+fn unlock_packages(
+    project: &Project,
+    lock_file: &LockFile,
+    conda_packages: HashSet<PackageName>,
+    pypi_packages: HashSet<uv_normalize::PackageName>,
+    affected_environments: HashSet<(&str, Platform)>,
+) -> LockFile {
+    filter_lock_file(project, lock_file, |env, platform, package| {
+        if affected_environments.contains(&(env.name().as_str(), platform)) {
+            match package {
+                Package::Conda(package) => !conda_packages.contains(&package.package_record().name),
+                Package::Pypi(package) => !pypi_packages.contains(&package.data().package.name),
+            }
+        } else {
+            true
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -63,7 +63,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     )
     .await?;
 
-    args.display_success("Removed");
+    args.display_success("Removed", Default::default());
 
     Project::warn_on_discovered_from_env(args.manifest_path.as_deref());
     Ok(())

--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -4,20 +4,22 @@ mod records_by_name;
 mod resolve;
 mod satisfiability;
 mod update;
+mod utils;
 
-use crate::Project;
 use miette::{IntoDiagnostic, WrapErr};
-use rattler_conda_types::RepoDataRecord;
-use rattler_lock::{LockFile, PypiPackageData, PypiPackageEnvironmentData};
-
 pub use outdated::OutdatedEnvironments;
 pub use package_identifier::PypiPackageIdentifier;
+use rattler_conda_types::RepoDataRecord;
+use rattler_lock::{LockFile, PypiPackageData, PypiPackageEnvironmentData};
 pub use records_by_name::{PypiRecordsByName, RepoDataRecordsByName};
 pub use resolve::{
     conda::resolve_conda, pypi::resolve_pypi, uv_resolution_context::UvResolutionContext,
 };
 pub use satisfiability::{verify_environment_satisfiability, verify_platform_satisfiability};
 pub use update::{LockFileDerivedData, UpdateContext, UpdateLockFileOptions};
+pub use utils::filter_lock_file;
+
+use crate::Project;
 
 /// A list of conda packages that are locked for a specific platform.
 pub type LockedCondaPackages = Vec<RepoDataRecord>;
@@ -25,11 +27,12 @@ pub type LockedCondaPackages = Vec<RepoDataRecord>;
 /// A list of Pypi packages that are locked for a specific platform.
 pub type LockedPypiPackages = Vec<PypiRecord>;
 
-/// A single Pypi record that contains both the package data and the environment data. In Pixi we
-/// basically always need both.
+/// A single Pypi record that contains both the package data and the environment
+/// data. In Pixi we basically always need both.
 pub type PypiRecord = (PypiPackageData, PypiPackageEnvironmentData);
 
-/// Loads the lockfile for the specified project or returns a dummy one if none could be found.
+/// Loads the lockfile for the specified project or returns a dummy one if none
+/// could be found.
 pub async fn load_lock_file(project: &Project) -> miette::Result<LockFile> {
     let lock_file_path = project.lock_file_path();
     if lock_file_path.is_file() {

--- a/src/lock_file/utils.rs
+++ b/src/lock_file/utils.rs
@@ -1,0 +1,45 @@
+use rattler_conda_types::Platform;
+use rattler_lock::{LockFile, LockFileBuilder, Package};
+
+use crate::{
+    project::{grouped_environment::GroupedEnvironment, Environment},
+    HasFeatures, Project,
+};
+
+/// Constructs a new lock-file where some of the packages have been removed
+pub fn filter_lock_file<'p, F: FnMut(&Environment<'p>, Platform, &Package) -> bool>(
+    project: &'p Project,
+    lock_file: &LockFile,
+    mut filter: F,
+) -> LockFile {
+    let mut builder = LockFileBuilder::new();
+
+    for (environment_name, environment) in lock_file.environments() {
+        // Find the environment in the project
+        let Some(project_env) = project.environment(environment_name) else {
+            continue;
+        };
+
+        // Copy the channels
+        builder.set_channels(environment_name, environment.channels().to_vec());
+
+        // Copy the indexes
+        let indexes = environment.pypi_indexes().cloned().unwrap_or_else(|| {
+            GroupedEnvironment::from(project_env.clone())
+                .pypi_options()
+                .into()
+        });
+        builder.set_pypi_indexes(environment_name, indexes);
+
+        // Copy all packages that don't need to be relaxed
+        for (platform, packages) in environment.packages_by_platform() {
+            for package in packages {
+                if filter(&project_env, platform, &package) {
+                    builder.add_package(environment_name, platform, package);
+                }
+            }
+        }
+    }
+
+    builder.finish()
+}

--- a/src/project/manifest/document.rs
+++ b/src/project/manifest/document.rs
@@ -251,6 +251,7 @@ impl ManifestSource {
         requirement: &pep508_rs::Requirement,
         platform: Option<Platform>,
         feature_name: &FeatureName,
+        editable: Option<bool>,
     ) -> Result<(), TomlError> {
         match self {
             ManifestSource::PyProjectToml(_) => {
@@ -270,10 +271,15 @@ impl ManifestSource {
                 }
             }
             ManifestSource::PixiToml(_) => {
+                let mut pypi_requirement = PyPiRequirement::from(requirement.clone());
+                if let Some(editable) = editable {
+                    pypi_requirement.set_editable(editable);
+                }
+
                 self.get_or_insert_toml_table(platform, feature_name, consts::PYPI_DEPENDENCIES)?
                     .insert(
                         requirement.name.as_ref(),
-                        Item::Value(PyPiRequirement::from(requirement.clone()).into()),
+                        Item::Value(pypi_requirement.into()),
                     );
             }
         };

--- a/src/project/manifest/mod.rs
+++ b/src/project/manifest/mod.rs
@@ -438,7 +438,7 @@ impl Manifest {
             };
             // and to the TOML document
             self.document
-                .add_pypi_dependency(requirement, platform, feature_name)?;
+                .add_pypi_dependency(requirement, platform, feature_name, editable)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Refactors the `pixi add` code to use the same code path as `update` and `install`. This provides:

* a more correct result
* speeeeeed because now everything is done in parallel
* progress reporting!
* version caps for pypi deps: https://github.com/prefix-dev/pixi/issues/639

Fixes https://github.com/prefix-dev/pixi/issues/639
Fixes https://github.com/prefix-dev/pixi/issues/1506