### PR TITLE
fix: lazy initialize client

### DIFF
--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -99,10 +99,9 @@ impl SpecType {
 pub struct Project {
     /// Root folder of the project
     root: PathBuf,
-    /// Reqwest client shared for this project
-    client: reqwest::Client,
-    /// Authenticated reqwest client shared for this project
-    authenticated_client: ClientWithMiddleware,
+    /// Reqwest client shared for this project.
+    /// This is wrapped in a `OnceLock` to allow for lazy initialization.
+    client: OnceLock<(reqwest::Client, ClientWithMiddleware)>,
     /// The repodata gateway to use for answering queries about repodata.
     /// This is wrapped in a `OnceLock` to allow for lazy initialization.
     repodata_gateway: OnceLock<Gateway>,
@@ -140,12 +139,9 @@ impl Project {
 
         let config = Config::load(&root);
 
-        let (client, authenticated_client) = build_reqwest_clients(Some(&config));
-
         Self {
             root,
-            client,
-            authenticated_client,
+            client: Default::default(),
             manifest,
             env_vars,
             mapping_source: Default::default(),
@@ -228,12 +224,9 @@ impl Project {
         // Load the user configuration from the local project and all default locations
         let config = Config::load(root);
 
-        let (client, authenticated_client) = build_reqwest_clients(Some(&config));
-
         Ok(Self {
             root: root.to_owned(),
-            client,
-            authenticated_client,
+            client: Default::default(),
             manifest,
             env_vars,
             mapping_source: Default::default(),
@@ -500,13 +493,18 @@ impl Project {
 
     /// Returns the reqwest client used for http networking
     pub fn client(&self) -> &reqwest::Client {
-        &self.client
+        &self.client_and_authenticated_client().0
     }
 
     /// Create an authenticated reqwest client for this project
     /// use authentication from `rattler_networking`
     pub fn authenticated_client(&self) -> &ClientWithMiddleware {
-        &self.authenticated_client
+        &self.client_and_authenticated_client().1
+    }
+
+    fn client_and_authenticated_client(&self) -> &(reqwest::Client, ClientWithMiddleware) {
+        self.client
+            .get_or_init(|| build_reqwest_clients(Some(&self.config)))
     }
 
     pub fn config(&self) -> &Config {


### PR DESCRIPTION
Fixes #1499 

The config from the CLI was set *after* the reqwest client was initialized. I modified the initialization to create the client lazily. This ensures that the config is properly set on the project before the client is initialized. 