### PR TITLE
fix: tiny error in basic_usage.md

### DIFF
--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -55,7 +55,7 @@ Use the `shell` command to activate the environment and start a new shell in the
 ```shell
 pixi shell
 python
-exit
+exit()
 ```
 
 You've just learned the basic features of pixi:


### PR DESCRIPTION
To quit python in terminal use exit() instead of exit