### PR TITLE
docs: replace discord link with discord.prefix.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Chat
-    url: https://discord.gg/kKV8ZxyzY4
+    url: https://discord.prefix.dev
     about: Engage with the Prefix.dev team and other community members.
 
   - name: Discussions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Before contributing, please read our [Code of Conduct](https://github.com/prefix
 - Explain how the feature would be beneficial to the project.
 
 ## Questions and Discussions
-For general questions, consider using our chat platform: [Discord](https://discord.gg/kKV8ZxyzY4)
+For general questions, consider using our chat platform: [Discord](https://discord.prefix.dev)
 
 ## Acknowledgments
 Your contributions are highly appreciated and will be credited accordingly.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [build-badge]: https://img.shields.io/github/actions/workflow/status/prefix-dev/pixi/rust.yml?style=flat-square&branch=main
 [build]: https://github.com/prefix-dev/pixi/actions/
 [chat-badge]: https://img.shields.io/discord/1082332781146800168.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2&style=flat-square
-[chat-url]: https://discord.gg/kKV8ZxyzY4
+[chat-url]: https://discord.prefix.dev
 [pixi-badge]:https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json&style=flat-square
 [pixi-url]: https://pixi.sh
 

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -418,4 +418,4 @@ Hopefully, this provides a flexible and powerful way to manage your Python proje
 
 Thanks for reading! Happy Coding 🚀
 
-Any questions? Feel free to reach out or share this tutorial on [X](https://twitter.com/prefix_dev), [join our Discord](https://discord.gg/kKV8ZxyzY4), send us an [e-mail](mailto:hi@prefix.dev) or follow our [GitHub](https://github.com/prefix-dev).
+Any questions? Feel free to reach out or share this tutorial on [X](https://twitter.com/prefix_dev), [join our Discord](https://discord.prefix.dev), send us an [e-mail](mailto:hi@prefix.dev) or follow our [GitHub](https://github.com/prefix-dev).

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -56,7 +56,7 @@ Found a Bug or Have a Feature Request?
 Open an issue at: https://github.com/prefix-dev/pixi/issues
 
 Need Help?
-Ask a question on the Prefix Discord server: https://discord.gg/kKV8ZxyzY4
+Ask a question on the Prefix Discord server: https://discord.prefix.dev
 
 For more information, see the documentation at: https://pixi.sh
 "


### PR DESCRIPTION
how about creating a 301 that redirects to the latest discord link in case something happens to your invites?