### PR TITLE
fix: Don't error if no tasks is available on platform

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -277,7 +277,7 @@ fn get_tasks_per_env(
         let mut tasks: HashMap<TaskName, Task> = HashMap::new();
         let this_env_tasks = env
             .tasks(Some(env.best_platform()))
-            .expect("error getting tasks");
+            .unwrap_or_else(|_| HashMap::new());
         for taskname in task_list.iter() {
             // if the task is in the environment, add it to the list
             if let Some(&task) = this_env_tasks.get(taskname) {

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -275,9 +275,7 @@ fn get_tasks_per_env(
     let mut tasks_per_env: HashMap<Environment, HashMap<TaskName, Task>> = HashMap::new();
     for env in environments {
         let mut tasks: HashMap<TaskName, Task> = HashMap::new();
-        let this_env_tasks = env
-            .tasks(Some(env.best_platform()))
-            .unwrap_or_else(|_| HashMap::new());
+        let this_env_tasks = env.tasks(Some(env.best_platform())).unwrap_or_default();
         for taskname in task_list.iter() {
             // if the task is in the environment, add it to the list
             if let Some(&task) = this_env_tasks.get(taskname) {


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi/issues/1547

I have tried some different approaches, and this one was less intrusive. I'm open to suggestions. 

![image](https://github.com/prefix-dev/pixi/assets/19758978/bf8bf6f9-3166-4494-ad68-ef0b6c608bc4)
