### PR TITLE
fix(install_pypi): wrong path passed to dynamic check

### DIFF
--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -660,7 +660,7 @@ async fn resolve_editables(
                 if ArchiveTimestamp::up_to_date_with(&editable.path, ArchiveTarget::Install(dist))
                     .into_diagnostic()?
                     // If the editable is dynamic, we need to rebuild it
-                    && !uv_installer::is_dynamic(dist.path())
+                    && !uv_installer::is_dynamic(&editable.path)
                     // And the dist is already editable
                     && dist.is_editable()
                 {


### PR DESCRIPTION
Wrong path was passed to the dynamic check. This made the editable be re-installed each time.

Fixes: https://github.com/prefix-dev/pixi/issues/1526 