### PR TITLE
feat: bump system requirements

### DIFF
--- a/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.linux-64.snap
+++ b/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.linux-64.snap
@@ -1,6 +1,5 @@
 ---
 source: src/project/virtual_packages.rs
-assertion_line: 226
 expression: packages
 ---
 [
@@ -32,7 +31,7 @@ expression: packages
             source: "__glibc",
         },
         version: Version {
-            version: [[0], [2], [17]],
+            version: [[0], [2], [28]],
             local: [],
         },
         build_string: "0",

--- a/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.linux-aarch64.snap
+++ b/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.linux-aarch64.snap
@@ -31,7 +31,7 @@ expression: packages
             source: "__glibc",
         },
         version: Version {
-            version: [[0], [2], [17]],
+            version: [[0], [2], [28]],
             local: [],
         },
         build_string: "0",

--- a/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.linux-ppc64le.snap
+++ b/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.linux-ppc64le.snap
@@ -31,7 +31,7 @@ expression: packages
             source: "__glibc",
         },
         version: Version {
-            version: [[0], [2], [17]],
+            version: [[0], [2], [28]],
             local: [],
         },
         build_string: "0",

--- a/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.osx-64.snap
+++ b/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.osx-64.snap
@@ -20,7 +20,7 @@ expression: packages
             source: "__osx",
         },
         version: Version {
-            version: [[0], [10], [15]],
+            version: [[0], [13], [0]],
             local: [],
         },
         build_string: "0",

--- a/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.osx-arm64.snap
+++ b/src/project/snapshots/pixi__project__virtual_packages__tests__test_get_minimal_virtual_packages.osx-arm64.snap
@@ -20,7 +20,7 @@ expression: packages
             source: "__osx",
         },
         version: Version {
-            version: [[0], [11], [0]],
+            version: [[0], [13], [0]],
             local: [],
         },
         build_string: "0",

--- a/src/project/virtual_packages.rs
+++ b/src/project/virtual_packages.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 
 /// The default GLIBC version to use. This is used when no system requirements are specified.
 pub fn default_glibc_version() -> Version {
-    "2.17".parse().unwrap()
+    "2.28".parse().unwrap()
 }
 
 /// The default linux version to use. This is used when no system requirements are specified.
@@ -27,8 +27,8 @@ pub fn default_linux_version() -> Version {
 /// MacOS platform.
 pub fn default_mac_os_version(platform: Platform) -> Version {
     match platform {
-        Platform::OsxArm64 => "11.0".parse().unwrap(),
-        Platform::Osx64 => "10.15".parse().unwrap(),
+        Platform::OsxArm64 => "13.0".parse().unwrap(),
+        Platform::Osx64 => "13.0".parse().unwrap(),
         _ => panic!(
             "default_mac_os_version() called with non-osx platform: {}",
             platform


### PR DESCRIPTION
This PR bumps the system requirements to be more in line with current `manylinux2_28` and minimum macOS versions. 

While conda-forge is very conservative with the default system requirements, we can be a bit more bold. We based our first set of defaults on `conda-forge` defaults, but the aims are somewhat different: conda-forge tries to build packages for maximum compatibility while we are developing a software that is modern and probably mostly used on recent machines. 

There is some pain with wheels that are only available for macOS 13.0+ which have become somewhat common on PyPI. Users would then receive `sdists` with all of their problems. Therefore I think it would be good to bump the minimum here. Users that want to support older systems or RedHat style Linux versions can always set different values in the `pixi.toml`.