### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,15 @@ Developed with ❤️ at [prefix.dev](https://prefix.dev).
 
 ## Status
 
-Pixi is under active development, and we're planning to add many more features.
+Pixi is ready for production!
 We are working hard to keep file-format changes compatible with the previous
 versions so that you can rely on pixi with peace of mind.
 
-Some notable features we have in the pipeline are:
+Some notable features we envision for upcoming releases are:
 
 - **Build and publish** your project as a Conda package.
-- Support for **PyPi packages**.
 - Support for **dependencies from source**.
-- Improvements to documentation, examples, and user experience.
+- More powerful "global installation" of packages towards a deterministic setup of global packages on multiple machines.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Developed with ❤️ at [prefix.dev](https://prefix.dev).
 
 ## Status
 
-This project is currently in the _alpha stage_. It's actively under development, and we're planning to add many more features. The file formats are still subject to change, and you should expect breaking changes as we work towards a v1.0.
+Pixi is under active development, and we're planning to add many more features.
+We are working hard to keep file-format changes compatible with the previous
+versions so that you can rely on pixi with peace of mind.
 
 Some notable features we have in the pipeline are:
 


### PR DESCRIPTION
Multiple people have notified me that the README still reads "alpha" which is definitely not true. Pixi is used in production by a lot of organizations these days and we are working very hard to not introduce breaking changes in the file format.