### PR TITLE
fix: remove double manifest warning

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -307,7 +307,7 @@ pub(crate) async fn initialize_env_variables(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use super::*;
 
@@ -354,7 +354,7 @@ mod tests {
         channels = ["conda-forge"]
         platforms = ["linux-64", "osx-64", "win-64"]
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
+        let project = Project::from_str(Path::new("/tmp/test/pixi.toml"), project).unwrap();
         let env = project.get_metadata_env();
 
         assert_eq!(env.get("PIXI_PROJECT_NAME").unwrap(), project.name());
@@ -365,6 +365,12 @@ mod tests {
         assert_eq!(
             env.get("PIXI_PROJECT_MANIFEST").unwrap(),
             project.manifest_path().to_str().unwrap()
+        );
+        let project_path: PathBuf = env.get("PIXI_PROJECT_MANIFEST").unwrap().parse().unwrap();
+        assert!(
+            project_path.is_absolute(),
+            "Path is not absolute {}",
+            project_path.display()
         );
         assert_eq!(
             env.get("PIXI_PROJECT_VERSION").unwrap(),

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -307,7 +307,7 @@ pub(crate) async fn initialize_env_variables(
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     use super::*;
 
@@ -354,7 +354,7 @@ mod tests {
         channels = ["conda-forge"]
         platforms = ["linux-64", "osx-64", "win-64"]
         "#;
-        let project = Project::from_str(Path::new("/tmp/test/pixi.toml"), project).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
         let env = project.get_metadata_env();
 
         assert_eq!(env.get("PIXI_PROJECT_NAME").unwrap(), project.name());
@@ -365,12 +365,6 @@ mod tests {
         assert_eq!(
             env.get("PIXI_PROJECT_MANIFEST").unwrap(),
             project.manifest_path().to_str().unwrap()
-        );
-        let project_path: PathBuf = env.get("PIXI_PROJECT_MANIFEST").unwrap().parse().unwrap();
-        assert!(
-            project_path.is_absolute(),
-            "Path is not absolute {}",
-            project_path.display()
         );
         assert_eq!(
             env.get("PIXI_PROJECT_VERSION").unwrap(),

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -254,7 +254,7 @@ impl Project {
             .ok_or_else(|| miette::miette!("can not find parent of {}", manifest_path.display()))?;
 
         // Load the TOML document
-        let manifest = Manifest::from_path(manifest_path)?;
+        let manifest = Manifest::from_path(&full_path)?;
 
         let env_vars = Project::init_env_vars(&manifest.parsed.environments);
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -209,11 +209,6 @@ impl Project {
         if std::env::var("PIXI_IN_SHELL").is_ok() {
             if let Ok(env_manifest_path) = std::env::var("PIXI_PROJECT_MANIFEST") {
                 if let Some(project_toml) = project_toml {
-                    tracing::warn!(
-                        "compare {} == {}",
-                        &env_manifest_path,
-                        project_toml.display()
-                    );
                     if env_manifest_path != project_toml.to_string_lossy() {
                         tracing::warn!(
                             "Using manifest {} from `PIXI_PROJECT_MANIFEST` rather than local {}",

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -209,6 +209,11 @@ impl Project {
         if std::env::var("PIXI_IN_SHELL").is_ok() {
             if let Ok(env_manifest_path) = std::env::var("PIXI_PROJECT_MANIFEST") {
                 if let Some(project_toml) = project_toml {
+                    tracing::warn!(
+                        "compare {} == {}",
+                        &env_manifest_path,
+                        project_toml.display()
+                    );
                     if env_manifest_path != project_toml.to_string_lossy() {
                         tracing::warn!(
                             "Using manifest {} from `PIXI_PROJECT_MANIFEST` rather than local {}",


### PR DESCRIPTION
I think this will fix: #1480 

@baszalmstra any idea how I could make a test for it? The problem is that the test should happen relative to the cwd, because of the relative loading of the toml. But setting cwd is a pretty bad idea in tests I think..