### PR TITLE
fix: flaky task test

### DIFF
--- a/tests/task_tests.rs
+++ b/tests/task_tests.rs
@@ -219,9 +219,9 @@ async fn test_task_with_env() {
 
     pixi.tasks()
         .add("env-test".into(), None, FeatureName::Default)
-        .with_commands(["echo From a $HELLO"])
+        .with_commands(["echo From a $HELLO_WORLD"])
         .with_env(vec![(
-            String::from("HELLO"),
+            String::from("HELLO_WORLD"),
             String::from("world with spaces"),
         )])
         .execute()
@@ -246,7 +246,6 @@ async fn test_clean_env() {
     pixi.init().without_channels().await.unwrap();
 
     std::env::set_var("HELLO", "world from env");
-
     pixi.tasks()
         .add("env-test".into(), None, FeatureName::Default)
         .with_commands(["echo Hello is: $HELLO"])
@@ -282,3 +281,6 @@ async fn test_clean_env() {
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout, "Hello is: world from env\n");
 }
+
+// When adding another test with an environment variable, please choose a unique name
+// to avoid collisions


### PR DESCRIPTION
Fix for flaky task test, not using `remove_var` because of: https://doc.rust-lang.org/std/env/fn.remove_var.html


> Even though this function is currently not marked as unsafe, it needs to be because invoking it can cause undefined behaviour. The function will be marked unsafe in a future version of Rust. This is tracked in [rust#27970](https://github.com/rust-lang/rust/issues/27970).

> This function is safe to call in a single-threaded program.

> In multi-threaded programs, you must ensure that are no other threads concurrently writing or reading(!) from the environment through functions other than the ones in this module. You are responsible for figuring out how to achieve this, but we strongly suggest not using set_var or remove_var in multi-threaded programs at all.

