### PR TITLE
docs: tell cargo install which bin to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,11 @@ apk add pixi
 To start using `pixi` from a source build run:
 
 ```shell
-cargo install --locked pixi
-# Or to use the the latest `main` branch
-cargo install --locked --git https://github.com/prefix-dev/pixi.git
+cargo install --locked --git https://github.com/prefix-dev/pixi.git pixi
 ```
+
+We don't publish to `crates.io` anymore, so you need to install it from the repository.
+The reason for this is that we depend on some unpublished crates which disallows us to publish to `crates.io`.
 
 or when you want to make changes use:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,8 +94,11 @@ pixi is 100% written in Rust, and therefore it can be installed, built and teste
 To start using pixi from a source build run:
 
 ```shell
-cargo install --locked --git https://github.com/prefix-dev/pixi.git
+cargo install --locked --git https://github.com/prefix-dev/pixi.git pixi
 ```
+
+We don't publish to `crates.io` anymore, so you need to install it from the repository.
+The reason for this is that we depend on some unpublished crates which disallows us to publish to `crates.io`.
 
 or when you want to make changes use:
 


### PR DESCRIPTION
fixes #1578 

I can't seem to find other work arounds, if anyone knows a better one please let me know!