### PR TITLE
feat: add short options to config location flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -761,15 +761,21 @@ Use this command to manage the configuration.
 
 ##### Options
 
-- `--system`: Specify management scope to system configuration.
-- `--global`: Specify management scope to global configuration.
-- `--local`: Specify management scope to local configuration.
+- `--system (-s)`: Specify management scope to system configuration.
+- `--global (-g)`: Specify management scope to global configuration.
+- `--local (-l)`: Specify management scope to local configuration.
 
 Checkout the [pixi configuration](./pixi_configuration.md) for more information about the locations.
 
 ### `config edit`
 
 Edit the configuration file in the default editor.
+
+```shell
+pixi config edit --system
+pixi config edit --local
+pixi config edit -g
+```
 
 ### `config list`
 
@@ -786,6 +792,8 @@ List the configuration
 ```shell
 pixi config list default-channels
 pixi config list --json
+pixi config list --system
+pixi config list -g
 ```
 
 ### `config prepend`

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -48,15 +48,15 @@ enum Subcommand {
 #[derive(Parser, Debug, Clone)]
 struct CommonArgs {
     /// Operation on project-local configuration
-    #[arg(long, conflicts_with_all = &["global", "system"])]
+    #[arg(long, short, conflicts_with_all = &["global", "system"])]
     local: bool,
 
     /// Operation on global configuration
-    #[arg(long, conflicts_with_all = &["local", "system"])]
+    #[arg(long, short, conflicts_with_all = &["local", "system"])]
     global: bool,
 
     /// Operation on system configuration
-    #[arg(long, conflicts_with_all = &["local", "global"])]
+    #[arg(long, short, conflicts_with_all = &["local", "global"])]
     system: bool,
 }
 


### PR DESCRIPTION
result of try this issue: https://github.com/prefix-dev/pixi/issues/1557

now you can run 
```
pixi config xxx -g
pixi config xxx -s
pixi config xxx -l
```
for `global` `system` and `local`