### PR TITLE
docs: add reference documentation for the exec command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -228,6 +228,32 @@ pixi run --clean-env "echo \$PATH"
         pixi run start
         ```
 
+## `exec`
+
+Runs a command in a temporary environment disconnected from any project.
+This can be useful to quickly test out a certain package or version.
+
+Temporary environments are cached. If the same command is run again, the same environment will be reused.
+
+##### Arguments
+
+1. `<COMMAND>`: The command to run.
+
+#### Options:
+* `-s, --spec <SPECS>`: Matchspecs of packages to install. If this is not provided, the package is guessed from the command.
+* `-c, --channel <CHANNELS>`: The channel to install the packages from. If not specified the default channel is used.
+* `--force-reinstall` If specified a new environment is always created even if one already exists.
+
+```shell
+pixi exec python
+
+# Add a constraint to the python version
+pixi exec -s python=3.9 python
+
+# Run ipython and include the py-rattler package in the environment
+pixi exec -s ipython -s py-rattler ipython
+```
+
 ## `remove`
 
 Removes dependencies from the [manifest file](project_configuration.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -252,6 +252,9 @@ pixi exec -s python=3.9 python
 
 # Run ipython and include the py-rattler package in the environment
 pixi exec -s ipython -s py-rattler ipython
+
+# Force reinstall to recreate the environment and get the latest package versions
+pixi exec --force-reinstall -s ipython -s py-rattler ipython
 ```
 
 ## `remove`

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -236,7 +236,7 @@ This can be useful to quickly test out a certain package or version.
 Temporary environments are cached. If the same command is run again, the same environment will be reused.
 
 ??? note "Cleaning temporary environments"
-    Currently, temporary environments can only be cleaned up manually. 
+    Currently, temporary environments can only be cleaned up manually.
     Environments for `pixi exec` are stored under `cached-envs-v0/` in the cache directory.
     Run `pixi info` to find the cache directory.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -240,8 +240,8 @@ Temporary environments are cached. If the same command is run again, the same en
 1. `<COMMAND>`: The command to run.
 
 #### Options:
-* `-s, --spec <SPECS>`: Matchspecs of packages to install. If this is not provided, the package is guessed from the command.
-* `-c, --channel <CHANNELS>`: The channel to install the packages from. If not specified the default channel is used.
+* `--spec <SPECS> (-s)`: Matchspecs of packages to install. If this is not provided, the package is guessed from the command.
+* `--channel <CHANNELS> (-c)`: The channel to install the packages from. If not specified the default channel is used.
 * `--force-reinstall` If specified a new environment is always created even if one already exists.
 
 ```shell

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,6 +235,11 @@ This can be useful to quickly test out a certain package or version.
 
 Temporary environments are cached. If the same command is run again, the same environment will be reused.
 
+??? note "Cleaning temporary environments"
+    Currently, temporary environments can only be cleaned up manually. 
+    Environments for `pixi exec` are stored under `cached-envs-v0/` in the cache directory.
+    Run `pixi info` to find the cache directory.
+
 ##### Arguments
 
 1. `<COMMAND>`: The command to run.


### PR DESCRIPTION
Adds missing reference documentation for the `exec` command.