### PR TITLE
feat: Add nushell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1accf1b463dee0d3ab2be72591dccdab8bef314958340447c882c4c72acfe2a3"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,6 +3313,7 @@ dependencies = [
  "clap",
  "clap-verbosity-flag",
  "clap_complete",
+ "clap_complete_nushell",
  "concat-idents",
  "console",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ clap = { version = "4.5.4", default-features = false, features = [
 ] }
 clap-verbosity-flag = "2.2.0"
 clap_complete = "4.5.2"
+clap_complete_nushell = "4.5.2"
 concat-idents = "1.1.5"
 console = { version = "0.15.8", features = ["windows-console-colors"] }
 crossbeam-channel = "0.5.12"

--- a/README.md
+++ b/README.md
@@ -110,12 +110,17 @@ winget install prefix-dev.pixi
 To get autocompletion run:
 
 ```shell
-# Pick your shell (The default for macOS is zsh, for Windows PowerShell and for most Linux systems bash):
+# Bash (default on most Linux systems)
 echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
+# Zsh (default on macOS)
 echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
+# Fish
 echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+# Nushell
 pixi completion --shell nushell | save --append $nu.config-path
+# Elvish
 echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+# Powershell (pre-installed on all Windows systems)
 Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,16 +110,12 @@ winget install prefix-dev.pixi
 To get autocompletion run:
 
 ```shell
-# On unix (MacOS or Linux), pick your shell (use `echo $SHELL` to find the shell you are using.):
+# Pick your shell (The default for macOS is zsh, for Windows PowerShell and for most Linux systems bash):
 echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
 echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
 echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+pixi completion --shell nushell | save --append $nu.config-path
 echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
-```
-
-For PowerShell on Windows, run the following command and then restart the shell or source the shell config file:
-
-```pwsh
 Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,24 +107,59 @@ winget install prefix-dev.pixi
 
 ### Autocompletion
 
-To get autocompletion run:
+To get autocompletion follow the instructions for your shell.
+Afterwards, restart the shell or source the shell config file.
 
-```shell
-# Bash (default on most Linux systems)
+#### Bash (default on most Linux systems)
+
+```bash
 echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
-# Zsh (default on macOS)
+```
+#### Zsh (default on macOS)
+
+```zsh
 echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
-# Fish
-echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
-# Nushell
-pixi completion --shell nushell | save --append $nu.config-path
-# Elvish
-echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
-# Powershell (pre-installed on all Windows systems)
+```
+
+#### PowerShell (pre-installed on all Windows systems)
+
+```pwsh
 Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
 ```
 
-And then restart the shell or source the shell config file.
+If this fails with "Failure because no profile file exists", make sure your profile file exists.
+If not, create it with:
+
+```PowerShell
+New-Item -Path $PROFILE -ItemType File -Force
+```
+
+#### Fish
+
+```fish
+echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+```
+
+#### Nushell
+
+Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
+
+```nushell
+mkdir ~/.cache/pixi
+pixi completion --shell nushell | save -f ~/.cache/pixi/completions.nu
+```
+
+And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+
+```nushell
+use ~/.cache/pixi/completions.nu *
+```
+
+#### Elvish
+
+```elv
+echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+```
 
 ### Distro Packages
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,29 +47,60 @@ You can find more options for the installation script [here](#installer-script-o
 
 ## Autocompletion
 
-To get autocompletion run:
+To get autocompletion follow the instructions for your shell.
+Afterwards, restart the shell or source the shell config file.
 
-```shell
-# Bash (default on most Linux systems)
+
+### Bash (default on most Linux systems)
+
+```bash
 echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
-# Zsh (default on macOS)
+```
+### Zsh (default on macOS)
+
+```zsh
 echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
-# Fish
-echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
-# Nushell
-pixi completion --shell nushell | save --append $nu.config-path
-# Elvish
-echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
-# Powershell (pre-installed on all Windows systems)
+```
+
+### PowerShell (pre-installed on all Windows systems)
+
+```pwsh
 Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
 ```
-!!! tip "Failure because no profile file exists" on PowerShell
+
+!!! tip "Failure because no profile file exists"
     Make sure your profile file exists, otherwise create it with:
     ```PowerShell
     New-Item -Path $PROFILE -ItemType File -Force
     ```
 
-And then restart the shell or source the shell config file.
+
+### Fish
+
+```fish
+echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+```
+
+### Nushell
+
+Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
+
+```nushell
+mkdir ~/.cache/pixi
+pixi completion --shell nushell | save -f ~/.cache/pixi/completions.nu
+```
+
+And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+
+```nushell
+use ~/.cache/pixi/completions.nu *
+```
+
+### Elvish
+
+```elv
+echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+```
 
 ## Alternative installation methods
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,12 +50,17 @@ You can find more options for the installation script [here](#installer-script-o
 To get autocompletion run:
 
 ```shell
-# Pick your shell (The default for macOS is zsh, for Windows PowerShell and for most Linux systems bash):
+# Bash (default on most Linux systems)
 echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
+# Zsh (default on macOS)
 echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
+# Fish
 echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+# Nushell
 pixi completion --shell nushell | save --append $nu.config-path
+# Elvish
 echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+# Powershell (pre-installed on all Windows systems)
 Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
 ```
 !!! tip "Failure because no profile file exists" on PowerShell

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,25 +49,20 @@ You can find more options for the installation script [here](#installer-script-o
 
 To get autocompletion run:
 
-=== "Linux & macOS"
-    ```shell
-    # Pick your shell (use `echo $SHELL` to find the shell you are using.):
-    echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
-    echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
-    echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
-    echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+```shell
+# Pick your shell (The default for macOS is zsh, for Windows PowerShell and for most Linux systems bash):
+echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
+echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
+echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+pixi completion --shell nushell | save --append $nu.config-path
+echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
+```
+!!! tip "Failure because no profile file exists" on PowerShell
+    Make sure your profile file exists, otherwise create it with:
+    ```PowerShell
+    New-Item -Path $PROFILE -ItemType File -Force
     ```
-=== "Windows"
-
-    PowerShell:
-    ```powershell
-    Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
-    ```
-    !!! tip "Failure because no profile file exists"
-        Make sure your profile file exists, otherwise create it with:
-        ```PowerShell
-        New-Item -Path $PROFILE -ItemType File -Force
-        ```
 
 And then restart the shell or source the shell config file.
 

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -15,6 +15,7 @@ pub struct Args {
     shell: Shell,
 }
 
+/// Defines the shells for which we can provide completions
 #[allow(clippy::enum_variant_names)]
 #[derive(ValueEnum, Clone, Debug, Copy, Eq, Hash, PartialEq)]
 enum Shell {

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -28,7 +28,7 @@ enum Shell {
     /// Nushell
     Nushell,
     /// PowerShell
-    PowerShell,
+    Powershell,
     /// Z SHell (zsh)
     Zsh,
 }
@@ -40,7 +40,7 @@ impl Generator for Shell {
             Shell::Elvish => shells::Elvish.file_name(name),
             Shell::Fish => shells::Fish.file_name(name),
             Shell::Nushell => Nushell.file_name(name),
-            Shell::PowerShell => shells::PowerShell.file_name(name),
+            Shell::Powershell => shells::PowerShell.file_name(name),
             Shell::Zsh => shells::Zsh.file_name(name),
         }
     }
@@ -51,7 +51,7 @@ impl Generator for Shell {
             Shell::Elvish => shells::Elvish.generate(cmd, buf),
             Shell::Fish => shells::Fish.generate(cmd, buf),
             Shell::Nushell => Nushell.generate(cmd, buf),
-            Shell::PowerShell => shells::PowerShell.generate(cmd, buf),
+            Shell::Powershell => shells::PowerShell.generate(cmd, buf),
             Shell::Zsh => shells::Zsh.generate(cmd, buf),
         }
     }


### PR DESCRIPTION
- Add nushell completion
- Stop guessing shell, and make `--shell` required
- Adapt instructions

I have a version local that still tries to guess the shell from the `$SHELL` env var. But it made the code much more verbose, and I am not a fan of that behavior. On my system, `$SHELL` gives `/bin/bash` even though I use nushell.

I also adapted the instructions to stop suggesting that your choice of shell is platform dependent. Every listed shell can be used on Windows and vice versa.