### PR TITLE
Revert "docs: Update conflict docs for `cargo add` (#1600)"

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -95,17 +95,17 @@ pub struct DependencyConfig {
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
 
-    /// The specified dependencies are host dependencies. Conflicts with `build` and `pypi`
+    /// The specified dependencies are host dependencies. Conflicts with `build`
     /// and `pypi`
     #[arg(long, conflicts_with_all = ["build", "pypi"])]
     pub host: bool,
 
-    /// The specified dependencies are build dependencies. Conflicts with `host` and `pypi`
+    /// The specified dependencies are build dependencies. Conflicts with `host`
     /// and `pypi`
     #[arg(long, conflicts_with_all = ["host", "pypi"])]
     pub build: bool,
 
-    /// The specified dependencies are pypi dependencies. Conflicts with `host` and `build`
+    /// The specified dependencies are pypi dependencies. Conflicts with `host`
     /// and `build`
     #[arg(long, conflicts_with_all = ["host", "build"])]
     pub pypi: bool,


### PR DESCRIPTION
This reverts commit 55281fbe033a46817e5de680b3383ae65236a15e.

As discussed in https://github.com/prefix-dev/pixi/pull/1600#discussion_r1673567300