### PR TITLE
fix: Add `clap_complete_nushell` to dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "usage", "wrap_help", "std", "color", "error-context", "env"] }
 clap-verbosity-flag = { workspace = true }
 clap_complete = { workspace = true }
+clap_complete_nushell = { workspace = true }
 concat-idents = { workspace = true }
 console = { workspace = true, features = ["windows-console-colors"] }
 crossbeam-channel = { workspace = true }


### PR DESCRIPTION
Adding `clap_complete_nushell` failed after merging since it wasn't in sync with Bas' PR adding workspace dependencies