### PR TITLE
fix: Write to `stdout` for machine readable output

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -163,9 +163,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
             if out.is_empty() {
                 eprintln!("Configuration not set");
-            } else {
-                eprintln!("{}", out);
             }
+            println!("{}", out);
         }
         Subcommand::Prepend(args) => alter_config(
             &args.common,

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -423,7 +423,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
                     .sorted()
                     .map(|name| name.as_str())
                     .join(" ");
-                eprintln!("{}", unformatted);
+                println!("{}", unformatted);
                 return Ok(());
             }
 


### PR DESCRIPTION
Fixes #1638