### PR TITLE
fix: allow for init to pixi.toml when pyproject.toml is available.

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,6 +32,7 @@ It also supports the [`pyproject.toml`](../advanced/pyproject_toml.md) file, if 
 - `--platform <PLATFORM> (-p)`: specify a platform that the project supports. (Allowed to be used more than once)
 - `--import <ENV_FILE> (-i)`: Import an existing conda environment file, e.g. `environment.yml`.
 - `--pyproject`: Create a `pyproject.toml` manifest, rather than a `pixi.toml` manifest. Recommended for a python project.
+- `--pixi`: Create a `pixi.toml` manifest, rather than a `pyproject.toml` manifest. Use when there is already a `pyproject.toml` in the directory.
 
 !!! info "Importing an environment.yml"
   When importing an environment, the `pixi.toml` will be created with the dependencies from the environment file.
@@ -45,6 +46,8 @@ pixi init  # Initializes directly in the current directory.
 pixi init --channel conda-forge --channel bioconda myproject
 pixi init --platform osx-64 --platform linux-64 myproject
 pixi init --import environment.yml
+pixi init --pyproject myproject
+pixi init --pixi myproject # Use when there is already a pyproject.toml in the directory.
 ```
 
 ## `add`

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -34,8 +34,12 @@ pub struct Args {
     pub env_file: Option<PathBuf>,
 
     /// Create a pyproject.toml manifest instead of a pixi.toml manifest
-    #[arg(long, conflicts_with = "env_file")]
+    #[arg(long, conflicts_with_all = ["env_file", "pixi"])]
     pub pyproject: bool,
+
+    /// Create a pixi.toml, even if a pyproject.toml already exists
+    #[arg(long, conflicts_with_all = ["env_file", "pyproject"])]
+    pub pixi: bool,
 }
 
 /// The pixi.toml template
@@ -215,7 +219,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let extra_index_urls = config.pypi_config.extra_index_urls;
 
         // Inject a tool.pixi.project section into an existing pyproject.toml file if there is one without '[tool.pixi.project]'
-        if pyproject_manifest_path.is_file() {
+        if pyproject_manifest_path.is_file() && !args.pixi {
             let file = fs::read_to_string(&pyproject_manifest_path).unwrap();
             let pyproject = PyProjectToml::from_str(&file)?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -206,6 +206,7 @@ impl PixiControl {
                 platforms: Vec::new(),
                 env_file: None,
                 pyproject: false,
+                pixi: false,
             },
         }
     }
@@ -222,6 +223,7 @@ impl PixiControl {
                 platforms,
                 env_file: None,
                 pyproject: false,
+                pixi: false,
             },
         }
     }


### PR DESCRIPTION
fixes #1639 