### PR TITLE
fix: Make sure we also build the msi installer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -200,7 +200,6 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Setup | Install cargo-wix [Windows]
-        continue-on-error: ${{ !steps.is-release.outputs.IS_RELEASE }}
         # aarch64 is only supported in wix 4.0 development builds
         if: startsWith(matrix.os, 'windows') && matrix.target != 'aarch64-pc-windows-msvc'
         run: cargo install --version 0.3.4 cargo-wix
@@ -263,7 +262,6 @@ jobs:
           echo "EXE_SUFFIX=${EXE_SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: Build msi Installer
-        continue-on-error: ${{ !steps.is-release.outputs.IS_RELEASE }}
         if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
         run: >
           cargo wix -v --no-build --nocapture -I install/windows/main.wxs
@@ -374,7 +372,6 @@ jobs:
           path: ${{ steps.package.outputs.BIN_PATH }}
 
       - name: "Artifact upload: windows installer"
-        continue-on-error: ${{ !steps.is-release.outputs.IS_RELEASE }}
         if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -393,13 +393,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: pixi-${{ matrix.target }}${{ steps.bin.outputs.EXE_SUFFIX }}
-
-
-
   downstream_tests:
     needs:
         - build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -200,7 +200,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Setup | Install cargo-wix [Windows]
-        continue-on-error: true
+        continue-on-error: ${{ !steps.is-release.outputs.IS_RELEASE }}
         # aarch64 is only supported in wix 4.0 development builds
         if: startsWith(matrix.os, 'windows') && matrix.target != 'aarch64-pc-windows-msvc'
         run: cargo install --version 0.3.4 cargo-wix
@@ -262,11 +262,12 @@ jobs:
           echo "BIN_NAME=${BIN_NAME}" >> $GITHUB_OUTPUT
           echo "EXE_SUFFIX=${EXE_SUFFIX}" >> $GITHUB_OUTPUT
 
-      - name: Build Installer
-        continue-on-error: true
+      - name: Build msi Installer
+        continue-on-error: ${{ !steps.is-release.outputs.IS_RELEASE }}
         if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
         run: >
           cargo wix -v --no-build --nocapture -I install/windows/main.wxs
+          --package pixi
           --target ${{ matrix.target }}
           --output target/wix/pixi-${{ matrix.target }}.msi
 
@@ -373,7 +374,7 @@ jobs:
           path: ${{ steps.package.outputs.BIN_PATH }}
 
       - name: "Artifact upload: windows installer"
-        continue-on-error: true
+        continue-on-error: ${{ !steps.is-release.outputs.IS_RELEASE }}
         if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
         uses: actions/upload-artifact@v4
         with:
@@ -391,6 +392,13 @@ jobs:
             target/wix/pixi-${{ matrix.target }}.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: pixi-${{ matrix.target }}${{ steps.bin.outputs.EXE_SUFFIX }}
+
+
 
   downstream_tests:
     needs:


### PR DESCRIPTION
On the release `v0.26.0` build we missed the build for the MSI installer as it was set to `continue-on-error`.