### PR TITLE
chore: Rename CLI args from `package` to `packages`

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -29,9 +29,9 @@ use super::common::{
 #[derive(Parser, Debug)]
 #[clap(arg_required_else_help = true)]
 pub struct Args {
-    /// Specifies the package(s) that is to be installed.
+    /// Specifies the packages that are to be installed.
     #[arg(num_args = 1..)]
-    package: Vec<String>,
+    packages: Vec<String>,
 
     /// Represents the channels from which the package will be installed.
     /// Multiple channels can be specified by using this field multiple times.
@@ -53,7 +53,7 @@ pub struct Args {
 
 impl HasSpecs for Args {
     fn packages(&self) -> Vec<&str> {
-        self.package.iter().map(AsRef::as_ref).collect()
+        self.packages.iter().map(AsRef::as_ref).collect()
     }
 }
 

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -16,9 +16,9 @@ use super::install::{find_and_map_executable_scripts, BinScriptMapping};
 #[derive(Parser, Debug)]
 #[clap(arg_required_else_help = true)]
 pub struct Args {
-    /// Specifies the package(s) that is to be removed.
+    /// Specifies the packages that are to be removed.
     #[arg(num_args = 1..)]
-    package: Vec<String>,
+    packages: Vec<String>,
 
     #[command(flatten)]
     verbose: Verbosity,
@@ -26,7 +26,7 @@ pub struct Args {
 
 impl HasSpecs for Args {
     fn packages(&self) -> Vec<&str> {
-        self.package.iter().map(AsRef::as_ref).collect()
+        self.packages.iter().map(AsRef::as_ref).collect()
     }
 }
 


### PR DESCRIPTION
Even though singular might be the most common use case, plural is still the correct one.