### PR TITLE
chore!: Remove deprecated CLI aliases

### DIFF
--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -9,11 +9,9 @@ mod upgrade_all;
 
 #[derive(Debug, Parser)]
 pub enum Command {
-    // BREAK: This should only have the `i` as an alias
-    #[clap(visible_alias = "i", alias = "a")]
+    #[clap(visible_alias = "i")]
     Install(install::Args),
-    // BREAK: This should only have the `rm` as an alias
-    #[clap(visible_alias = "rm", alias = "r")]
+    #[clap(visible_alias = "rm")]
     Remove(remove::Args),
     #[clap(visible_alias = "ls")]
     List(list::Args),

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -22,8 +22,6 @@ use crate::Project;
 pub enum SortBy {
     Size,
     Name,
-    // BREAK: remove the alias
-    #[value(alias = "type")]
     Kind,
 }
 

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -22,8 +22,7 @@ pub enum Operation {
     Add(AddArgs),
 
     /// Remove a command from the project
-    // BREAK: This should only have the `rm` alias
-    #[clap(visible_alias = "rm", alias = "r")]
+    #[clap(visible_alias = "rm")]
     Remove(RemoveArgs),
 
     /// Alias another specific command


### PR DESCRIPTION
⚠️Breaking change ⚠️

Now that we touch the CLI, let's also remove the deprecated aliases