### PR TITLE
fix: hash pypi mapping wasnt used

### DIFF
--- a/src/pypi_mapping/custom_pypi_mapping.rs
+++ b/src/pypi_mapping/custom_pypi_mapping.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::{
     build_pypi_purl_from_package_record, is_conda_forge_record, prefix_pypi_name_mapping,
-    CustomMapping, Reporter,
+    CustomMapping, PurlSource, Reporter,
 };
 
 pub async fn fetch_mapping_from_url<T>(
@@ -120,7 +120,7 @@ fn amend_pypi_purls_for_record(
             // we have a pypi name for it so we record a purl
             if let Some(name) = mapped_name {
                 let purl = PackageUrl::builder(String::from("pypi"), name.to_string())
-                    .with_qualifier("source", "project-defined-mapping")
+                    .with_qualifier("source", PurlSource::ProjectDefinedMapping.as_str())
                     .expect("valid qualifier");
 
                 purls.push(purl.build().expect("valid pypi package url"));

--- a/src/pypi_mapping/mod.rs
+++ b/src/pypi_mapping/mod.rs
@@ -126,6 +126,26 @@ impl MappingSource {
     }
 }
 
+/// This enum represents the source of mapping
+/// it can be user-defined ( custom )
+/// or from prefix.dev ( prefix )
+#[derive(Debug, Clone)]
+pub enum PurlSource {
+    HashMapping,
+    CompressedMapping,
+    ProjectDefinedMapping,
+}
+
+impl PurlSource {
+    pub fn as_str(&self) -> &str {
+        match self {
+            PurlSource::HashMapping => "hash-mapping",
+            PurlSource::CompressedMapping => "compressed-mapping",
+            PurlSource::ProjectDefinedMapping => "project-defined-mapping",
+        }
+    }
+}
+
 pub async fn amend_pypi_purls(
     client: reqwest::Client,
     mapping_source: &MappingSource,

--- a/src/pypi_mapping/prefix_pypi_name_mapping.rs
+++ b/src/pypi_mapping/prefix_pypi_name_mapping.rs
@@ -15,7 +15,8 @@ use tokio::sync::Semaphore;
 use url::Url;
 
 use super::{
-    build_pypi_purl_from_package_record, custom_pypi_mapping, is_conda_forge_record, Reporter,
+    build_pypi_purl_from_package_record, custom_pypi_mapping, is_conda_forge_record, PurlSource,
+    Reporter,
 };
 
 const STORAGE_URL: &str = "https://conda-mapping.prefix.dev";
@@ -200,7 +201,7 @@ pub fn amend_pypi_purls_for_record(
             if let Some(pypi_names) = &mapped_name.pypi_normalized_names {
                 for pypi_name in pypi_names {
                     let purl = PackageUrl::builder(String::from("pypi"), pypi_name)
-                        .with_qualifier("source", "hash-mapping")
+                        .with_qualifier("source", PurlSource::HashMapping.as_str())
                         .expect("valid qualifier");
                     let built_purl = purl.build().expect("valid pypi package url");
                     // Push the value into the vector
@@ -225,7 +226,7 @@ pub fn amend_pypi_purls_for_record(
             // we record the purl
             if let Some(mapped_name) = possible_mapped_name {
                 let purl = PackageUrl::builder(String::from("pypi"), mapped_name)
-                    .with_qualifier("source", "compressed-mapping")
+                    .with_qualifier("source", PurlSource::CompressedMapping.as_str())
                     .expect("valid qualifier");
                 let built_purl = purl.build().expect("valid pypi package url");
                 purls.push(built_purl);

--- a/src/pypi_mapping/prefix_pypi_name_mapping.rs
+++ b/src/pypi_mapping/prefix_pypi_name_mapping.rs
@@ -73,13 +73,7 @@ pub async fn conda_pypi_name_mapping(
         // that have purls
         // here we only filter packages that don't them
         // to save some requests
-        .filter(|package| {
-            package
-                .package_record
-                .purls
-                .as_ref()
-                .is_some_and(|p| p.is_empty())
-        })
+        .filter(|package| package.package_record.purls.is_none())
         .filter_map(|package| {
             package
                 .package_record
@@ -185,41 +179,33 @@ pub async fn amend_pypi_purls(
 ///    a PyPI package.
 pub fn amend_pypi_purls_for_record(
     record: &mut RepoDataRecord,
-    conda_forge_mapping: &HashMap<Sha256Hash, Package>,
+    mapping_by_hash: &HashMap<Sha256Hash, Package>,
     compressed_mapping: &HashMap<String, Option<String>>,
 ) -> miette::Result<()> {
-    // If the package already has a pypi name we can stop here.
-    if record
-        .package_record
-        .purls
-        .as_ref()
-        .is_some_and(|vec| vec.iter().any(|p| p.package_type() == "pypi"))
-    {
+    // If we already figured out the pypi purls, we can skip this record.
+    if record.package_record.purls.is_some() {
         return Ok(());
     }
 
-    let mut purls = Vec::new();
-
-    let mut not_a_pypi = false;
+    let mut purls = None;
 
     // if package have a hash
     if let Some(sha256) = record.package_record.sha256 {
         // we look into our mapping by it's hash
-        if let Some(mapped_name) = conda_forge_mapping.get(&sha256) {
+        if let Some(mapped_name) = mapping_by_hash.get(&sha256) {
+            let purls = purls.get_or_insert_with(Vec::new);
+
             // if we have pypi names in mapping
             // we populate purls for it
             if let Some(pypi_names) = &mapped_name.pypi_normalized_names {
                 for pypi_name in pypi_names {
                     let purl = PackageUrl::builder(String::from("pypi"), pypi_name)
-                        .with_qualifier("source", "conda-forge-mapping")
+                        .with_qualifier("source", "hash-mapping")
                         .expect("valid qualifier");
                     let built_purl = purl.build().expect("valid pypi package url");
                     // Push the value into the vector
                     purls.push(built_purl);
                 }
-            } else {
-                // it's not a pypi name
-                not_a_pypi = true;
             }
             // we don't have a mapping for it's hash yet
             // so we are looking into our .json map by name
@@ -232,37 +218,35 @@ pub fn amend_pypi_purls_for_record(
     if let Some(possible_mapped_name) =
         compressed_mapping.get(record.package_record.name.as_normalized())
     {
-        if !not_a_pypi && purls.is_empty() && is_conda_forge_record(record) {
+        if purls.is_none() && is_conda_forge_record(record) {
+            let purls = purls.get_or_insert_with(Vec::new);
+
             // if we have a pypi name for it
             // we record the purl
             if let Some(mapped_name) = possible_mapped_name {
                 let purl = PackageUrl::builder(String::from("pypi"), mapped_name)
-                    .with_qualifier("source", "conda-forge-mapping")
+                    .with_qualifier("source", "compressed-mapping")
                     .expect("valid qualifier");
                 let built_purl = purl.build().expect("valid pypi package url");
                 purls.push(built_purl);
-            } else {
-                // it's not a pypi name
-                not_a_pypi = true;
             }
         }
     }
 
     // package is not in our mapping yet
     // so we assume that it is the same as the one from conda-forge
-    if !not_a_pypi && purls.is_empty() && is_conda_forge_record(record) {
+    if purls.is_none() && is_conda_forge_record(record) {
         // Convert the conda package names to pypi package names. If the conversion
         // fails we just assume that its not a valid python package.
         if let Some(purl) = build_pypi_purl_from_package_record(&record.package_record) {
-            purls.push(purl);
+            purls.get_or_insert_with(Vec::new).push(purl);
         }
     }
 
-    let package_purls = record
-        .package_record
-        .purls
-        .get_or_insert_with(BTreeSet::new);
-    package_purls.extend(purls);
+    // If we have found some purls we overwrite whatever was there before.
+    if let Some(purls) = purls {
+        record.package_record.purls = Some(BTreeSet::from_iter(purls));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
While debugging the `opencv-headless` issue from #771 I noticed that the most accurate mapping (the hash based mapping) wasn't actually used! This PR fixes the logic.