### PR TITLE
feat: use locked pypi indexes during installation

### DIFF
--- a/crates/pixi_manifest/src/pypi/pypi_options.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_options.rs
@@ -1,6 +1,6 @@
 use crate::consts;
 use indexmap::IndexSet;
-use rattler_lock::FindLinksUrlOrPath;
+use rattler_lock::{FindLinksUrlOrPath, PypiIndexes};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{hash::Hash, iter};
@@ -133,6 +133,12 @@ impl From<PypiOptions> for rattler_lock::PypiIndexes {
                 .collect(),
             find_links: value.find_links.into_iter().flatten().collect(),
         }
+    }
+}
+
+impl From<&PypiOptions> for rattler_lock::PypiIndexes {
+    fn from(value: &PypiOptions) -> Self {
+        PypiIndexes::from(value.clone())
     }
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -14,7 +14,7 @@ use crate::{
 use dialoguer::theme::ColorfulTheme;
 use distribution_types::{InstalledDist, Name};
 use miette::{IntoDiagnostic, WrapErr};
-use pixi_manifest::pypi::pypi_options::PypiOptions;
+
 use pixi_manifest::{EnvironmentName, SystemRequirements};
 use rattler::install::{DefaultProgressFormatter, IndicatifReporter, Installer};
 use rattler::{
@@ -22,7 +22,7 @@ use rattler::{
     package_cache::PackageCache,
 };
 use rattler_conda_types::{Platform, PrefixRecord, RepoDataRecord};
-use rattler_lock::{PypiPackageData, PypiPackageEnvironmentData};
+use rattler_lock::{PypiIndexes, PypiPackageData, PypiPackageEnvironmentData};
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 use std::convert::identity;
@@ -294,7 +294,7 @@ pub async fn update_prefix_pypi(
     status: &PythonStatus,
     system_requirements: &SystemRequirements,
     uv_context: &UvResolutionContext,
-    pypi_options: &PypiOptions,
+    pypi_indexes: Option<&PypiIndexes>,
     environment_variables: &HashMap<String, String>,
     lock_file_dir: &Path,
     platform: Platform,
@@ -356,7 +356,7 @@ pub async fn update_prefix_pypi(
                 &python_info.path,
                 system_requirements,
                 uv_context,
-                pypi_options,
+                pypi_indexes,
                 environment_variables,
                 platform,
             )

--- a/src/utils/uv/conversions.rs
+++ b/src/utils/uv/conversions.rs
@@ -51,6 +51,30 @@ pub fn pypi_options_to_index_locations(options: &PypiOptions) -> IndexLocations 
     IndexLocations::new(index, extra_indexes, flat_indexes, false)
 }
 
+/// Convert locked indexes to IndexLocations
+pub fn locked_indexes_to_index_locations(indexes: &rattler_lock::PypiIndexes) -> IndexLocations {
+    let index = indexes
+        .indexes
+        .first()
+        .cloned()
+        .map(VerbatimUrl::from_url)
+        .map(IndexUrl::from);
+    let extra_indexes = indexes
+        .indexes
+        .iter()
+        .skip(1)
+        .cloned()
+        .map(VerbatimUrl::from_url)
+        .map(IndexUrl::from)
+        .collect::<Vec<_>>();
+    let flat_indexes = indexes
+        .find_links
+        .iter()
+        .map(to_flat_index_location)
+        .collect::<Vec<_>>();
+    IndexLocations::new(index, extra_indexes, flat_indexes, false)
+}
+
 pub fn to_git_reference(rev: &GitRev) -> GitReference {
     match rev {
         GitRev::Full(rev) => GitReference::FullCommit(rev.clone()),

--- a/src/utils/uv/conversions.rs
+++ b/src/utils/uv/conversions.rs
@@ -46,9 +46,10 @@ pub fn pypi_options_to_index_locations(options: &PypiOptions) -> IndexLocations 
         })
         .unwrap_or_default();
 
-    // We keep the `no_index` to false for now, because I've not seen a use case for it yet
-    // we could change this later if needed
-    IndexLocations::new(index, extra_indexes, flat_indexes, false)
+    // we don't have support for an explicit `no_index` field in the `PypiOptions`
+    // so we only set it if you want to use flat indexes only
+    let no_index = index.is_none() && !flat_indexes.is_empty();
+    IndexLocations::new(index, extra_indexes, flat_indexes, no_index)
 }
 
 /// Convert locked indexes to IndexLocations
@@ -72,7 +73,11 @@ pub fn locked_indexes_to_index_locations(indexes: &rattler_lock::PypiIndexes) ->
         .iter()
         .map(to_flat_index_location)
         .collect::<Vec<_>>();
-    IndexLocations::new(index, extra_indexes, flat_indexes, false)
+
+    // we don't have support for an explicit `no_index` field in the `PypiIndexes`
+    // so we only set it if you want to use flat indexes only
+    let no_index = index.is_none() && !flat_indexes.is_empty();
+    IndexLocations::new(index, extra_indexes, flat_indexes, no_index)
 }
 
 pub fn to_git_reference(rev: &GitRev) -> GitReference {


### PR DESCRIPTION
When thinking about how install should work off the lock file mostly, I found out that we are using the manifests pypi-options in the installation. I think this can be replaced by the locked indexes, especially as we have the actual url's at hand when making the `Dist`'s.

This implements that refactor, the only assumption I've made is that the first url in the list is the equivalent of the `IndexLocation` `index_url`, this mainly being the main pypi index in most cases.