### PR TITLE
feat: add pixi run completion for fish shell

### DIFF
--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -129,8 +129,13 @@ $2::task"#;
 
 fn replace_fish_completion(script: &str) -> Cow<str> {
     // Adds tab completion to the pixi run command.
-    let addition = "complete -c pixi -f -n \"__fish_seen_subcommand_from run\" -a \"(string split ' ' (pixi task list --machine-readable  2> /dev/null))\"";
-    format!("{}{}\n", script, addition).into()
+    let addition = "complete -c pixi -n \"__fish_seen_subcommand_from run\" -f -a \"(string split ' ' (pixi task list --machine-readable  2> /dev/null))\"";
+    let new_script = format!("{}{}\n", script, addition);
+    let pattern = r#"-n "__fish_seen_subcommand_from run""#;
+    let replacement = r#"-n "__fish_seen_subcommand_from run; or __fish_seen_subcommand_from r""#;
+    let re = Regex::new(pattern).unwrap();
+    let result = re.replace_all(&new_script, replacement);
+    Cow::Owned(result.into_owned())
 }
 
 /// Replace the parts of the nushell completion script that need different functionality.

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -129,7 +129,7 @@ $2::task"#;
 
 fn replace_fish_completion(script: &str) -> Cow<str> {
     // Adds tab completion to the pixi run command.
-    let addition = "complete -c pixi -f -n \"__fish_seen_subcommand_from run\" -a (pixi task list --machine-readable)";
+    let addition = "complete -c pixi -f -n \"__fish_seen_subcommand_from run\" -a \"(string split ' ' (pixi task list --machine-readable  2> /dev/null))\"";
     format!("{}{}\n", script, addition).into()
 }
 

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -298,7 +298,6 @@ _arguments "${_arguments_options[@]}" \
         let replaced_script = replace_fish_completion(&script);
         // Test if there was a replacement done on the clap generated completions
         assert_ne!(replaced_script, script);
-        assert!(replaced_script.contains(&script));
     }
 
     #[test]


### PR DESCRIPTION
Add one more line to the fish script for code completion to support listing tasks in `pixi run`.

I didn't know how to add description information but as far as I saw for the other shells, it's not yet used there either.

Closes https://github.com/prefix-dev/pixi/issues/1191