### PR TITLE
refactor: Make project manifest loading DRY and consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,6 +3505,7 @@ name = "pixi_manifest"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "dunce",
  "indexmap 2.2.6",
  "insta",
  "itertools 0.12.1",

--- a/crates/pixi_manifest/Cargo.toml
+++ b/crates/pixi_manifest/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
+dunce = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 pep440_rs = { workspace = true }

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -1040,7 +1040,7 @@ mod tests {
             return;
         }
 
-        let project = Project::load(&manifest_path).unwrap();
+        let project = Project::from_path(&manifest_path).unwrap();
         let lock_file = LockFile::from_path(&project.lock_file_path()).unwrap();
         match verify_lockfile_satisfiability(&project, &lock_file).into_diagnostic() {
             Ok(()) => {}
@@ -1050,7 +1050,7 @@ mod tests {
 
     #[rstest]
     fn test_example_satisfiability(#[files("examples/*/pixi.toml")] manifest_path: PathBuf) {
-        let project = Project::load(&manifest_path).unwrap();
+        let project = Project::from_path(&manifest_path).unwrap();
         let lock_file = LockFile::from_path(&project.lock_file_path()).unwrap();
         match verify_lockfile_satisfiability(&project, &lock_file).into_diagnostic() {
             Ok(()) => {}
@@ -1063,7 +1063,7 @@ mod tests {
         let report_handler = NarratableReportHandler::new().with_cause_chain();
 
         insta::glob!("../../tests/non-satisfiability", "*/pixi.toml", |path| {
-            let project = Project::load(path).unwrap();
+            let project = Project::from_path(path).unwrap();
             let lock_file = LockFile::from_path(&project.lock_file_path()).unwrap();
             let err = verify_lockfile_satisfiability(&project, &lock_file)
                 .expect_err("expected failing satisfiability");

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -138,10 +138,14 @@ impl Borrow<ParsedManifest> for Project {
 
 impl Project {
     /// Constructs a new instance from an internal manifest representation
-    pub fn from_manifest(manifest: Manifest) -> Self {
+    fn from_manifest(manifest: Manifest) -> Self {
         let env_vars = Project::init_env_vars(&manifest.parsed.environments);
 
-        let root = manifest.path.parent().unwrap_or(Path::new("")).to_owned();
+        let root = manifest
+            .path
+            .parent()
+            .expect("manifest path should always have a parent")
+            .to_owned();
 
         let config = Config::load(&root);
 
@@ -165,7 +169,6 @@ impl Project {
     }
 
     /// Constructs a project from a manifest.
-    /// Assumes the manifest is a Pixi manifest
     pub fn from_str(manifest_path: &Path, content: &str) -> miette::Result<Self> {
         let manifest = Manifest::from_str(manifest_path, content)?;
         Ok(Self::from_manifest(manifest))
@@ -189,7 +192,7 @@ impl Project {
                         );
                     }
                 }
-                return Self::load(Path::new(env_manifest_path.as_str()));
+                return Self::from_path(Path::new(env_manifest_path.as_str()));
             }
         }
 
@@ -202,7 +205,7 @@ impl Project {
             ),
         };
 
-        Self::load(&project_toml)
+        Self::from_path(&project_toml)
     }
 
     /// Returns the source code of the project as [`NamedSource`].
@@ -212,38 +215,16 @@ impl Project {
     }
 
     /// Loads a project from manifest file.
-    pub fn load(manifest_path: &Path) -> miette::Result<Self> {
-        // Determine the parent directory of the manifest file
-        let full_path = dunce::canonicalize(manifest_path).into_diagnostic()?;
-
-        let root = full_path
-            .parent()
-            .ok_or_else(|| miette::miette!("can not find parent of {}", manifest_path.display()))?;
-
-        // Load the TOML document
-        let manifest = Manifest::from_path(&full_path)?;
-
-        let env_vars = Project::init_env_vars(&manifest.parsed.environments);
-
-        // Load the user configuration from the local project and all default locations
-        let config = Config::load(root);
-
-        Ok(Self {
-            root: root.to_owned(),
-            client: Default::default(),
-            manifest,
-            env_vars,
-            mapping_source: Default::default(),
-            config,
-            repodata_gateway: Default::default(),
-        })
+    pub fn from_path(manifest_path: &Path) -> miette::Result<Self> {
+        let manifest = Manifest::from_path(manifest_path)?;
+        Ok(Project::from_manifest(manifest))
     }
 
     /// Loads a project manifest file or discovers it in the current directory
     /// or any of the parent
     pub fn load_or_else_discover(manifest_path: Option<&Path>) -> miette::Result<Self> {
         let project = match manifest_path {
-            Some(path) => Project::load(path)?,
+            Some(path) => Project::from_path(path)?,
             None => Project::discover()?,
         };
         Ok(project)

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -40,7 +40,7 @@ async fn add_channel() {
         .unwrap();
 
     // There should be a loadable project manifest in the directory
-    let project = Project::load(&pixi.manifest_path()).unwrap();
+    let project = Project::from_path(&pixi.manifest_path()).unwrap();
 
     // Our channel should be in the list of channels
     let local_channel =


### PR DESCRIPTION
I have extracted drive-by refactors from https://github.com/prefix-dev/pixi/pull/1485

- Defer much of `Project::load` to `Project::from_manifest` for consistency, and to avoid repetition.
- Rename `Project::load` to `Project::from_path`, to be consistent with `Manifest::from_path`
- Remove unused method `Manifest::solve_group`, as well as unnecessary collection