### PR TITLE
refactor: Refactor channel add and remove CLI commands

### DIFF
--- a/src/cli/project/channel/add.rs
+++ b/src/cli/project/channel/add.rs
@@ -1,43 +1,15 @@
-use clap::Parser;
-use pixi_manifest::{FeatureName, PrioritizedChannel};
-use rattler_conda_types::NamedChannelOrUrl;
-
 use crate::{
     environment::{get_up_to_date_prefix, LockFileUsage},
     Project,
 };
-#[derive(Parser, Debug, Default)]
-pub struct Args {
-    /// The channel name or URL
-    #[clap(required = true, num_args=1..)]
-    pub channel: Vec<NamedChannelOrUrl>,
 
-    /// Don't update the environment, only add changed packages to the
-    /// lock-file.
-    #[clap(long)]
-    pub no_install: bool,
+use super::AddRemoveArgs;
 
-    /// The name of the feature to add the channel to.
-    #[clap(long, short)]
-    pub feature: Option<String>,
-}
-
-pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
-    let feature_name = args
-        .feature
-        .map_or(FeatureName::Default, FeatureName::Named);
-
+pub async fn execute(mut project: Project, args: AddRemoveArgs) -> miette::Result<()> {
     // Add the channels to the manifest
-    project.manifest.add_channels(
-        args.channel
-            .clone()
-            .into_iter()
-            .map(|channel| PrioritizedChannel {
-                channel,
-                priority: None,
-            }),
-        &feature_name,
-    )?;
+    project
+        .manifest
+        .add_channels(args.prioritized_channels(), &args.feature_name())?;
 
     // TODO: Update all environments touched by the features defined.
     get_up_to_date_prefix(
@@ -47,23 +19,9 @@ pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
     )
     .await?;
     project.save()?;
+
     // Report back to the user
-    let channel_config = project.channel_config();
-    for channel in args.channel {
-        match channel {
-            NamedChannelOrUrl::Name(ref name) => eprintln!(
-                "{}Added {} ({})",
-                console::style(console::Emoji("✔ ", "")).green(),
-                name,
-                channel.clone().into_base_url(&channel_config)
-            ),
-            NamedChannelOrUrl::Url(url) => eprintln!(
-                "{}Added {}",
-                console::style(console::Emoji("✔ ", "")).green(),
-                url
-            ),
-        }
-    }
+    args.report("Added", &project.channel_config());
 
     Ok(())
 }

--- a/src/cli/project/channel/mod.rs
+++ b/src/cli/project/channel/mod.rs
@@ -4,6 +4,8 @@ pub mod remove;
 
 use crate::Project;
 use clap::Parser;
+use pixi_manifest::{FeatureName, PrioritizedChannel};
+use rattler_conda_types::{ChannelConfig, NamedChannelOrUrl};
 use std::path::PathBuf;
 
 /// Commands to manage project channels.
@@ -18,17 +20,63 @@ pub struct Args {
     pub command: Command,
 }
 
+#[derive(Parser, Debug, Default)]
+pub struct AddRemoveArgs {
+    /// The channel name or URL
+    #[clap(required = true, num_args=1..)]
+    pub channel: Vec<NamedChannelOrUrl>,
+
+    /// Don't update the environment, only modify the manifest and the
+    /// lock-file.
+    #[clap(long)]
+    pub no_install: bool,
+
+    /// The name of the feature to modify.
+    #[clap(long, short)]
+    pub feature: Option<String>,
+}
+
+impl AddRemoveArgs {
+    fn prioritized_channels(&self) -> impl IntoIterator<Item = PrioritizedChannel> + '_ {
+        self.channel.iter().cloned().map(PrioritizedChannel::from)
+    }
+
+    fn feature_name(&self) -> FeatureName {
+        self.feature
+            .clone()
+            .map_or(FeatureName::Default, FeatureName::Named)
+    }
+
+    fn report(self, operation: &str, channel_config: &ChannelConfig) {
+        for channel in self.channel {
+            match channel {
+                NamedChannelOrUrl::Name(ref name) => eprintln!(
+                    "{}{operation} {} ({})",
+                    console::style(console::Emoji("✔ ", "")).green(),
+                    name,
+                    channel.clone().into_base_url(channel_config)
+                ),
+                NamedChannelOrUrl::Url(url) => eprintln!(
+                    "{}{operation} {}",
+                    console::style(console::Emoji("✔ ", "")).green(),
+                    url
+                ),
+            }
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 pub enum Command {
     /// Adds a channel to the project file and updates the lockfile.
     #[clap(visible_alias = "a")]
-    Add(add::Args),
+    Add(AddRemoveArgs),
     /// List the channels in the project file.
     #[clap(visible_alias = "ls")]
     List(list::Args),
     /// Remove channel(s) from the project file and updates the lockfile.
     #[clap(visible_alias = "rm")]
-    Remove(remove::Args),
+    Remove(AddRemoveArgs),
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {

--- a/src/cli/project/channel/remove.rs
+++ b/src/cli/project/channel/remove.rs
@@ -1,38 +1,15 @@
-use clap::Parser;
-use pixi_manifest::{FeatureName, PrioritizedChannel};
-use rattler_conda_types::NamedChannelOrUrl;
-
 use crate::{
     environment::{get_up_to_date_prefix, LockFileUsage},
     Project,
 };
 
-#[derive(Parser, Debug, Default)]
-pub struct Args {
-    /// The channel name(s) or URL
-    #[clap(required = true, num_args=1..)]
-    pub channel: Vec<NamedChannelOrUrl>,
+use super::AddRemoveArgs;
 
-    /// Don't update the environment, only remove the channel(s) from the
-    /// lock-file.
-    #[clap(long)]
-    pub no_install: bool,
-
-    /// The name of the feature to remove the channel from.
-    #[clap(long, short)]
-    pub feature: Option<String>,
-}
-
-pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
-    let feature_name = args
-        .feature
-        .map_or(FeatureName::Default, FeatureName::Named);
-
+pub async fn execute(mut project: Project, args: AddRemoveArgs) -> miette::Result<()> {
     // Remove the channels from the manifest
-    project.manifest.remove_channels(
-        args.channel.iter().cloned().map(PrioritizedChannel::from),
-        &feature_name,
-    )?;
+    project
+        .manifest
+        .remove_channels(args.prioritized_channels(), &args.feature_name())?;
 
     // Try to update the lock-file without the removed channels
     get_up_to_date_prefix(
@@ -44,22 +21,7 @@ pub async fn execute(mut project: Project, args: Args) -> miette::Result<()> {
     project.save()?;
 
     // Report back to the user
-    let channel_config = project.channel_config();
-    for channel in args.channel {
-        match channel {
-            NamedChannelOrUrl::Name(ref name) => eprintln!(
-                "{}Removed {} ({})",
-                console::style(console::Emoji("✔ ", "")).green(),
-                name,
-                channel.clone().into_base_url(&channel_config)
-            ),
-            NamedChannelOrUrl::Url(url) => eprintln!(
-                "{}Removed {}",
-                console::style(console::Emoji("✔ ", "")).green(),
-                url
-            ),
-        }
-    }
+    args.report("Removed", &project.channel_config());
 
     Ok(())
 }

--- a/tests/common/builders.rs
+++ b/tests/common/builders.rs
@@ -287,7 +287,7 @@ impl TaskAliasBuilder {
 
 pub struct ProjectChannelAddBuilder {
     pub manifest_path: Option<PathBuf>,
-    pub args: project::channel::add::Args,
+    pub args: project::channel::AddRemoveArgs,
 }
 
 impl ProjectChannelAddBuilder {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -266,7 +266,7 @@ impl PixiControl {
     pub fn project_channel_add(&self) -> ProjectChannelAddBuilder {
         ProjectChannelAddBuilder {
             manifest_path: Some(self.manifest_path()),
-            args: project::channel::add::Args {
+            args: project::channel::AddRemoveArgs {
                 channel: vec![],
                 no_install: true,
                 feature: None,


### PR DESCRIPTION
Refactor channel add and remove CLI command into a common `AddRemoveArgs` struct with helper methods