### PR TITLE
fix: depend on pep440_rs from crates and use replace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ minijinja = "1.0.20"
 nix = { version = "0.28.0", default-features = false }
 once_cell = "1.19.0"
 parking_lot = "0.12.2"
-pep440_rs = { git = "https://github.com/astral-sh/uv", tag = "0.2.18" }
-pep508_rs = { git = "https://github.com/astral-sh/uv", tag = "0.2.18" }
+pep440_rs = "0.6.0"
+pep508_rs = "0.6.0"
 percent-encoding = "2.3.1"
 platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.2.18" }
 pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.2.18" }

--- a/crates/pixi_manifest/src/document.rs
+++ b/crates/pixi_manifest/src/document.rs
@@ -1,6 +1,5 @@
-use std::{fmt, str::FromStr};
+use std::fmt;
 
-use pep508_rs::VerbatimUrl;
 use rattler_conda_types::{ChannelConfig, NamelessMatchSpec, PackageName, Platform};
 use toml_edit::{value, Array, InlineTable, Item, Table, Value};
 
@@ -188,11 +187,12 @@ impl ManifestSource {
         };
         if let Some(array) = array {
             array.retain(|x| {
-                let name = PyPiPackageName::from_normalized(
-                    pep508_rs::Requirement::<VerbatimUrl>::from_str(x.as_str().unwrap_or(""))
-                        .expect("should be a valid pep508 dependency")
-                        .name,
-                );
+                let req: pep508_rs::Requirement = x
+                    .as_str()
+                    .unwrap_or("")
+                    .parse()
+                    .expect("should be a valid pep508 dependency");
+                let name = PyPiPackageName::from_normalized(req.name);
                 name != *dep
             });
         }

--- a/crates/pixi_manifest/src/pypi/pypi_requirement_types.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_requirement_types.rs
@@ -1,8 +1,12 @@
+use std::{
+    borrow::Borrow,
+    fmt::{Display, Formatter, Write},
+    str::FromStr,
+};
+
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::{InvalidNameError, PackageName};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::{Display, Formatter, Write};
-use std::{borrow::Borrow, str::FromStr};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 /// A package name for PyPI that also stores the source version of the name.
@@ -99,7 +103,7 @@ impl From<VersionOrStar> for VersionSpecifiers {
     fn from(value: VersionOrStar) -> Self {
         match value {
             VersionOrStar::Version(v) => v,
-            VersionOrStar::Star => VersionSpecifiers::empty(),
+            VersionOrStar::Star => VersionSpecifiers::from_iter(vec![]),
         }
     }
 }
@@ -188,8 +192,9 @@ impl<'de> Deserialize<'de> for GitRev {
 }
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     #[test]
     fn test_git_rev_from_str_valid_short() {


### PR DESCRIPTION
This PR makes `pixi_manifest` crate compatible with the `pep440_rs` and `pep508_rs` available from crates.io.