### PR TITLE
refactor: move dependencies to pixi_manifest

### DIFF
--- a/crates/pixi_manifest/src/dependencies.rs
+++ b/crates/pixi_manifest/src/dependencies.rs
@@ -3,7 +3,7 @@ use itertools::Either;
 use rattler_conda_types::{MatchSpec, NamelessMatchSpec, PackageName};
 use std::{borrow::Cow, hash::Hash};
 
-use pixi_manifest::{pypi::PyPiPackageName, PyPiRequirement};
+use crate::{pypi::PyPiPackageName, PyPiRequirement};
 
 pub type PyPiDependencies = Dependencies<PyPiPackageName, PyPiRequirement>;
 pub type CondaDependencies = Dependencies<PackageName, NamelessMatchSpec>;

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -1,6 +1,7 @@
 mod activation;
 pub(crate) mod channel;
 pub mod consts;
+mod dependencies;
 mod document;
 mod environment;
 mod environments;
@@ -19,6 +20,7 @@ mod target;
 pub mod task;
 mod utils;
 mod validation;
+pub use dependencies::{CondaDependencies, Dependencies, PyPiDependencies};
 
 pub use manifest::{Manifest, ManifestKind};
 

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -312,7 +312,7 @@ mod tests {
     use itertools::Itertools;
 
     use super::*;
-    use crate::project::CondaDependencies;
+    use pixi_manifest::CondaDependencies;
 
     #[test]
     fn test_default_channels() {

--- a/src/project/has_features.rs
+++ b/src/project/has_features.rs
@@ -7,8 +7,8 @@ use rattler_solve::ChannelPriority;
 use crate::Project;
 use pixi_manifest::SpecType;
 
-use super::{CondaDependencies, PyPiDependencies};
 use pixi_manifest::{pypi::pypi_options::PypiOptions, Feature, SystemRequirements};
+use pixi_manifest::{CondaDependencies, PyPiDependencies};
 
 /// ChannelPriorityCombination error, thrown when multiple channel priorities are set
 #[derive(Debug, thiserror::Error)]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,4 +1,3 @@
-mod dependencies;
 mod environment;
 pub mod errors;
 pub mod grouped_environment;
@@ -19,7 +18,6 @@ use std::{
 };
 
 use async_once_cell::OnceCell as AsyncCell;
-pub use dependencies::{CondaDependencies, PyPiDependencies};
 pub use environment::Environment;
 use indexmap::Equivalent;
 use miette::{IntoDiagnostic, NamedSource};
@@ -778,7 +776,7 @@ mod tests {
         }
     }
 
-    fn format_dependencies(deps: CondaDependencies) -> String {
+    fn format_dependencies(deps: pixi_manifest::CondaDependencies) -> String {
         deps.iter_specs()
             .map(|(name, spec)| format!("{} = \"{}\"", name.as_source(), spec))
             .join("\n")


### PR DESCRIPTION
Move `Dependencies` to `pixi_manifest`. This is useful to have in `pixi-build`.

**Next**, split `Project` from `HasFeatures` and move `HasFeatures` to `pixi_manifest`.