### PR TITLE
feat: copy version, description and authors from pyproject

### DIFF
--- a/crates/pixi_manifest/src/metadata.rs
+++ b/crates/pixi_manifest/src/metadata.rs
@@ -26,8 +26,7 @@ pub struct ProjectMetadata {
     pub description: Option<String>,
 
     /// Optional authors
-    #[serde(default)]
-    pub authors: Vec<String>,
+    pub authors: Option<Vec<String>>,
 
     /// The channels used by the project
     #[serde_as(as = "IndexSet<super::channel::TomlPrioritizedChannelStrOrMap>")]

--- a/crates/pixi_manifest/src/parsed_manifest.rs
+++ b/crates/pixi_manifest/src/parsed_manifest.rs
@@ -58,11 +58,6 @@ impl ParsedManifest {
         Ok(manifest)
     }
 
-    /// Set the project name.
-    pub(crate) fn set_project_name(&mut self, name: String) {
-        self.project.name = Some(name);
-    }
-
     /// Returns the default feature.
     ///
     /// This is the feature that is added implicitly by the tables at the root

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -67,9 +67,39 @@ impl From<PyProjectManifest> for ParsedManifest {
             .as_ref()
             .expect("the [project] table should exist");
 
-        // Get tool.pixi.project.name from project.name
-        // TODO: could copy across / convert some other optional fields if relevant
-        manifest.set_project_name(pyproject.name.clone());
+        // Overwrite the project name and version with the ones from the [project] table
+        // of the pyproject.toml if they are not set.
+        if manifest.project.name.is_none() {
+            manifest.project.name = Some(pyproject.name.clone());
+        }
+
+        if manifest.project.version.is_none() {
+            manifest.project.version = pyproject
+                .version
+                .clone()
+                .and_then(|version| version.to_string().parse().ok())
+        }
+
+        if manifest.project.description.is_none() {
+            manifest.project.description = pyproject.description.clone();
+        }
+
+        if manifest.project.authors.is_none() {
+            manifest.project.authors = pyproject.authors.as_ref().map(|authors| {
+                authors
+                    .iter()
+                    .filter_map(|contact| match (&contact.name, &contact.email) {
+                        (Some(name), Some(email)) => Some(format!("{} <{}>", name, email)),
+                        (Some(name), None) => Some(name.clone()),
+                        (None, Some(email)) => Some(email.clone()),
+                        (None, None) => None,
+                    })
+                    .collect()
+            });
+        }
+
+        // TODO: Add license, license-file, readme, homepage, repository, documentation,
+        // etc.
 
         // Add python as dependency based on the project.requires_python property (if
         // any)
@@ -238,20 +268,24 @@ impl PyProjectToml {
 mod tests {
     use std::{path::Path, str::FromStr};
 
-    use crate::manifest::Manifest;
-    use crate::{pypi::PyPiPackageName, DependencyOverwriteBehavior, FeatureName};
     use insta::assert_snapshot;
     use pep440_rs::VersionSpecifiers;
     use rattler_conda_types::{ParseStrictness, VersionSpec};
 
+    use crate::{
+        manifest::Manifest, pypi::PyPiPackageName, DependencyOverwriteBehavior, FeatureName,
+    };
+
     const PYPROJECT_FULL: &str = r#"
         [project]
         name = "project"
-
-        [tool.pixi.project]
         version = "0.1.0"
         description = "A project"
-        authors = ["Author <author@bla.com>"]
+        authors = [
+            { name = "Author", email = "author@bla.com" }
+        ]
+
+        [tool.pixi.project]
         channels = ["stable"]
         platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
         license = "MIT"

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -98,7 +98,9 @@ impl From<PyProjectManifest> for ParsedManifest {
             });
         }
 
-        // TODO: Add license, license-file, readme, homepage, repository, documentation,
+        // TODO:  would be nice to add license, license-file, readme, homepage, repository, documentation,
+        // regarding the above, the types are a bit different than we expect, so the conversion is not straightforward
+        // we could change these types or we can convert. Let's decide when we make it.
         // etc.
 
         // Add python as dependency based on the project.requires_python property (if


### PR DESCRIPTION
Copies the `version`, `description`, and `authors` from the pyproject if they are not explicitly defined in the `[tool.pixi.project]` section.