### PR TITLE
refactor: move config to repodata functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,6 +3525,7 @@ dependencies = [
  "pixi_consts",
  "rattler",
  "rattler_conda_types",
+ "rattler_repodata_gateway",
  "rstest",
  "serde",
  "serde_ignored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ rattler_repodata_gateway = { workspace = true, features = [
 rattler_shell = { workspace = true, features = ["sysinfo"] }
 rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
 
-pixi_config = { workspace = true, features = ["gateway-conversion"] }
+pixi_config = { workspace = true, features = ["rattler_repodata_gateway"] }
 pixi_consts = { workspace = true }
 pixi_default_versions = { workspace = true }
 pixi_manifest = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ rattler_repodata_gateway = { workspace = true, features = [
 rattler_shell = { workspace = true, features = ["sysinfo"] }
 rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
 
-pixi_config = { workspace = true }
+pixi_config = { workspace = true, features = ["gateway-conversion"] }
 pixi_consts = { workspace = true }
 pixi_default_versions = { workspace = true }
 pixi_manifest = { workspace = true }

--- a/crates/pixi_config/Cargo.toml
+++ b/crates/pixi_config/Cargo.toml
@@ -18,7 +18,9 @@ miette = { workspace = true }
 pixi_consts = { workspace = true }
 rattler = { workspace = true }
 rattler_conda_types = { workspace = true }
-rattler_repodata_gateway = { workspace = true, optional = true }
+rattler_repodata_gateway = { workspace = true, optional = true, features = [
+  "gateway",
+] }
 serde = { workspace = true }
 serde_ignored = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/pixi_config/Cargo.toml
+++ b/crates/pixi_config/Cargo.toml
@@ -9,9 +9,6 @@ readme.workspace = true
 repository.workspace = true
 version = "0.1.0"
 
-[features]
-gateway-conversion = ["dep:rattler_repodata_gateway"]
-
 [dependencies]
 clap = { workspace = true, features = ["std", "derive", "env"] }
 console = { workspace = true }

--- a/crates/pixi_config/Cargo.toml
+++ b/crates/pixi_config/Cargo.toml
@@ -9,6 +9,9 @@ readme.workspace = true
 repository.workspace = true
 version = "0.1.0"
 
+[features]
+gateway-conversion = ["dep:rattler_repodata_gateway"]
+
 [dependencies]
 clap = { workspace = true, features = ["std", "derive", "env"] }
 console = { workspace = true }
@@ -18,6 +21,7 @@ miette = { workspace = true }
 pixi_consts = { workspace = true }
 rattler = { workspace = true }
 rattler_conda_types = { workspace = true }
+rattler_repodata_gateway = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_ignored = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/pixi_config/src/gateway.rs
+++ b/crates/pixi_config/src/gateway.rs
@@ -1,4 +1,4 @@
-use pixi_config::Config;
+use crate::Config;
 use rattler_repodata_gateway::{ChannelConfig, SourceConfig};
 
 /// Converts a [`Config`] into a rattler [`ChannelConfig`]

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -18,6 +18,9 @@ use rattler_conda_types::{
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use url::Url;
 
+#[cfg(feature = "gateway-conversion")]
+pub mod gateway;
+
 /// TODO: maybe remove this duplicate from `src/util.rs` at some point
 pub fn default_channel_config() -> ChannelConfig {
     ChannelConfig::default_with_root_dir(

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -18,7 +18,7 @@ use rattler_conda_types::{
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use url::Url;
 
-#[cfg(feature = "gateway-conversion")]
+#[cfg(feature = "rattler_repodata_gateway")]
 pub mod gateway;
 
 /// TODO: maybe remove this duplicate from `src/util.rs` at some point

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -18,12 +18,12 @@ use rattler_solve::{resolvo::Solver, SolverImpl, SolverTask};
 use rattler_virtual_packages::VirtualPackage;
 use reqwest_middleware::ClientWithMiddleware;
 
-use crate::utils::config::from_pixi_config;
 use crate::{
     prefix::Prefix,
     progress::{await_in_progress, global_multi_progress, wrap_in_progress},
     utils::{reqwest::build_reqwest_clients, PrefixGuard},
 };
+use pixi_config::gateway::from_pixi_config;
 use pixi_config::{self, Config, ConfigCli};
 
 /// Run a command in a temporary environment.

--- a/src/project/repodata.rs
+++ b/src/project/repodata.rs
@@ -1,6 +1,6 @@
 use crate::project::Project;
 
-use crate::utils::config::from_pixi_config;
+use pixi_config::gateway::from_pixi_config;
 use rattler_repodata_gateway::Gateway;
 use std::path::PathBuf;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,4 @@
 pub mod conda_environment_file;
-pub(crate) mod config;
 mod defaults;
 pub mod indicatif;
 mod prefix_guard;


### PR DESCRIPTION
This continue to make the `project` module entirely independent of anything in the main pixi crate.

This makes moving a lot simpler, which allows us to use it in pixi build

I've put the repodata conversion behind a feature, because not everything might need it :)