### PR TITLE
feat: Make project table optional for `pyproject.toml` manifests

### DIFF
--- a/crates/pixi_manifest/src/error.rs
+++ b/crates/pixi_manifest/src/error.rs
@@ -32,8 +32,8 @@ pub enum RequirementConversionError {
 pub enum TomlError {
     #[error("{0}")]
     Error(#[from] toml_edit::TomlError),
-    #[error("Missing field `project`")]
-    NoProjectTable,
+    #[error("Missing table `[tool.pixi.project]`")]
+    NoPixiProjectTable,
     #[error("Missing field `name`")]
     NoProjectName(Option<std::ops::Range<usize>>),
     #[error("Could not find or access the part '{part}' in the path '[{table_name}]'")]
@@ -63,7 +63,7 @@ impl TomlError {
     fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             TomlError::Error(e) => e.span(),
-            TomlError::NoProjectTable => Some(0..1),
+            TomlError::NoPixiProjectTable => Some(0..1),
             TomlError::NoProjectName(span) => span.clone(),
             _ => None,
         }
@@ -71,7 +71,7 @@ impl TomlError {
     fn message(&self) -> &str {
         match self {
             TomlError::Error(e) => e.message(),
-            TomlError::NoProjectTable => "Missing field `project`",
+            TomlError::NoPixiProjectTable => "Missing table `[tool.pixi.project]`",
             TomlError::NoProjectName(_) => "Missing field `name`",
             _ => "",
         }

--- a/crates/pixi_manifest/src/error.rs
+++ b/crates/pixi_manifest/src/error.rs
@@ -33,7 +33,7 @@ pub enum TomlError {
     #[error("{0}")]
     Error(#[from] toml_edit::TomlError),
     #[error("Missing table `[tool.pixi.project]`")]
-    NoPixiProjectTable,
+    NoPixiTable,
     #[error("Missing field `name`")]
     NoProjectName(Option<std::ops::Range<usize>>),
     #[error("Could not find or access the part '{part}' in the path '[{table_name}]'")]
@@ -63,7 +63,7 @@ impl TomlError {
     fn span(&self) -> Option<std::ops::Range<usize>> {
         match self {
             TomlError::Error(e) => e.span(),
-            TomlError::NoPixiProjectTable => Some(0..1),
+            TomlError::NoPixiTable => Some(0..1),
             TomlError::NoProjectName(span) => span.clone(),
             _ => None,
         }
@@ -71,7 +71,7 @@ impl TomlError {
     fn message(&self) -> &str {
         match self {
             TomlError::Error(e) => e.message(),
-            TomlError::NoPixiProjectTable => "Missing table `[tool.pixi.project]`",
+            TomlError::NoPixiTable => "Missing table `[tool.pixi.project]`",
             TomlError::NoProjectName(_) => "Missing field `name`",
             _ => "",
         }

--- a/crates/pixi_manifest/src/error.rs
+++ b/crates/pixi_manifest/src/error.rs
@@ -30,9 +30,9 @@ pub enum RequirementConversionError {
 
 #[derive(Error, Debug, Clone, Diagnostic)]
 pub enum TomlError {
-    #[error("{0}")]
+    #[error(transparent)]
     Error(#[from] toml_edit::TomlError),
-    #[error("Missing table `[tool.pixi.project]`")]
+    #[error("Missing table `[tool.pixi]`")]
     NoPixiTable,
     #[error("Missing field `name`")]
     NoProjectName(Option<std::ops::Range<usize>>),
@@ -68,12 +68,10 @@ impl TomlError {
             _ => None,
         }
     }
-    fn message(&self) -> &str {
+    fn message(&self) -> String {
         match self {
-            TomlError::Error(e) => e.message(),
-            TomlError::NoPixiTable => "Missing table `[tool.pixi.project]`",
-            TomlError::NoProjectName(_) => "Missing field `name`",
-            _ => "",
+            TomlError::Error(e) => e.message().to_owned(),
+            _ => self.to_string(),
         }
     }
 

--- a/crates/pixi_manifest/src/manifest.rs
+++ b/crates/pixi_manifest/src/manifest.rs
@@ -92,7 +92,9 @@ impl Manifest {
         let (parsed, file_name) = match manifest_kind {
             ManifestKind::Pixi => (ParsedManifest::from_toml_str(&contents), "pixi.toml"),
             ManifestKind::Pyproject => (
-                PyProjectManifest::from_pixi_pyproject_toml_str(&contents).map(|x| x.into()),
+                PyProjectManifest::from_toml_str(&contents)
+                    .and_then(|m| m.ensure_pixi(&contents))
+                    .map(|x| x.into()),
                 "pyproject.toml",
             ),
         };

--- a/crates/pixi_manifest/src/manifest.rs
+++ b/crates/pixi_manifest/src/manifest.rs
@@ -92,7 +92,7 @@ impl Manifest {
         let (parsed, file_name) = match manifest_kind {
             ManifestKind::Pixi => (ParsedManifest::from_toml_str(&contents), "pixi.toml"),
             ManifestKind::Pyproject => (
-                PyProjectManifest::from_toml_str(&contents).map(|x| x.into()),
+                PyProjectManifest::from_pixi_pyproject_toml_str(&contents).map(|x| x.into()),
                 "pyproject.toml",
             ),
         };

--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -916,11 +916,9 @@ fn is_dynamic(path: &Path) -> bool {
         return true;
     };
     // // If `[project]` is not present, we assume it's dynamic.
-    let Some(project) = &pyproject_toml.project else {
+    let Some(project) = pyproject_toml.project() else {
         // ...unless it appears to be a Poetry project.
-        return pyproject_toml
-            .tool
-            .map_or(true, |tool| tool.poetry.is_none());
+        return pyproject_toml.poetry().is_none();
     };
     // `[project.dynamic]` must be present and non-empty.
     project

--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use miette::{IntoDiagnostic, WrapErr};
 use pep440_rs::Version;
 use pep508_rs::{VerbatimUrl, VerbatimUrlError};
-use pixi_manifest::{pyproject::PyProjectToml, SystemRequirements};
+use pixi_manifest::{pyproject::PyProjectManifest, SystemRequirements};
 use pypi_types::{
     HashAlgorithm, HashDigest, ParsedDirectoryUrl, ParsedGitUrl, ParsedPathUrl, ParsedUrl,
     ParsedUrlError, VerbatimParsedUrl,
@@ -912,18 +912,21 @@ fn is_dynamic(path: &Path) -> bool {
     let Ok(contents) = fs::read_to_string(path.join("pyproject.toml")) else {
         return true;
     };
-    let Ok(pyproject_toml) = PyProjectToml::from_toml_str(&contents) else {
+    let Ok(pyproject_toml) = PyProjectManifest::from_toml_str(&contents) else {
         return true;
     };
     // // If `[project]` is not present, we assume it's dynamic.
-    let Some(project) = pyproject_toml.project else {
+    let Some(project) = &pyproject_toml.project else {
         // ...unless it appears to be a Poetry project.
         return pyproject_toml
             .tool
             .map_or(true, |tool| tool.poetry.is_none());
     };
     // `[project.dynamic]` must be present and non-empty.
-    project.dynamic.is_some_and(|dynamic| !dynamic.is_empty())
+    project
+        .dynamic
+        .as_ref()
+        .is_some_and(|dynamic| !dynamic.is_empty())
 }
 
 #[cfg(test)]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -23,7 +23,7 @@ use indexmap::Equivalent;
 use miette::{IntoDiagnostic, NamedSource};
 use once_cell::sync::OnceCell;
 use pixi_manifest::{
-    pyproject::PyProjectToml, EnvironmentName, Environments, Manifest, ParsedManifest, SpecType,
+    pyproject::PyProjectManifest, EnvironmentName, Environments, Manifest, ParsedManifest, SpecType,
 };
 use rattler_conda_types::{ChannelConfig, Version};
 use rattler_repodata_gateway::Gateway;
@@ -628,7 +628,7 @@ pub fn find_project_manifest() -> Option<PathBuf> {
                     match *manifest {
                         consts::PROJECT_MANIFEST => Some(path.to_path_buf()),
                         consts::PYPROJECT_MANIFEST
-                            if PyProjectToml::from_path(&path)
+                            if PyProjectManifest::from_path(&path)
                                 .is_ok_and(|project| project.is_pixi()) =>
                         {
                             Some(path.to_path_buf())


### PR DESCRIPTION
This Fixes https://github.com/prefix-dev/pixi/issues/1687 and https://github.com/prefix-dev/pixi/issues/1207 by keeping the `[project]` table optional in `pyproject.toml`.

The `[project]` table had been made mandatory to make sure a name was defined. Now, the project name is read from, in order of priority
 - the `[tool.pixi.project]` table
 - the `[project]` table
 - the `[tool.poetry]` table

The same is done for project description, version and authors.

During init, if the name cannot be read from the `[project]` table or the `[tool.poetry]` table, a default name (inferred from the directory name) is added to the `[tool.pixi.project]`

This PR also refactors handling of `pyproject.toml`: both pixi and non-pixi `pyproject.toml` are now read into the same `PyProjectManifest` struct, with existence checking of the `[tool.pixi.project]` table managed outside of serde when necessary.
