### PR TITLE
build: add release mode to cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ pixi_progress = { path = "crates/pixi_progress" }
 pypi_mapping = { path = "crates/pypi_mapping" }
 pypi_modifiers = { path = "crates/pypi_modifiers" }
 
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true
 
 [package]
 authors.workspace = true


### PR DESCRIPTION
This modifies Cargo.toml to release with LTO and one CGU whilst also stripping the binary for release size. Significant hit to release comp time (4m46s vs 1m26s on my machine)  but a smaller end product which should be faster (32 MB down from 56 MB). With just LTO and 1 CGU (but no strip) still significant decrease in size down to 37 MB.