### PR TITLE
fix: test on macos-13 e.g. x86

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,8 +103,8 @@ jobs:
       matrix:
         include:
           - { name: "Linux",       target: x86_64-unknown-linux-musl,  os: ubuntu-20.04 }
-          - { name: "macOS",       target: x86_64-apple-darwin,        os: macOS-latest }
-          - { name: "macOS-arm",   target: aarch64-apple-darwin,       os: macOS-14 }
+          - { name: "macOS",       target: x86_64-apple-darwin,        os: macos-13 }
+          - { name: "macOS-arm",   target: aarch64-apple-darwin,       os: macos-14 }
           - { name: "Windows",     target: x86_64-pc-windows-msvc,     os: windows-latest }
     steps:
       - uses: actions/checkout@v4
@@ -152,8 +152,8 @@ jobs:
           - { name: "Linux-x86_64",   target: x86_64-unknown-linux-musl,  os: ubuntu-20.04 }
           - { name: "Linux-aarch64",  target: aarch64-unknown-linux-musl, os: ubuntu-latest }
 
-          - { name: "macOS-x86",      target: x86_64-apple-darwin,        os: macOS-latest }
-          - { name: "macOS-arm",      target: aarch64-apple-darwin,       os: macOS-14 }  # macOS-14 is the ARM chipset
+          - { name: "macOS-x86",      target: x86_64-apple-darwin,        os: macos-13 }
+          - { name: "macOS-arm",      target: aarch64-apple-darwin,       os: macos-14 }  # macOS-14 is the ARM chipset
 
           - { name: "Windows",        target: x86_64-pc-windows-msvc,     os: windows-latest }
           - { name: "Windows-arm",    target: aarch64-pc-windows-msvc,    os: windows-latest }
@@ -401,8 +401,8 @@ jobs:
         include:
           - { target: x86_64-unknown-linux-musl,  os: ubuntu-20.04 }
 
-          - { target: x86_64-apple-darwin,        os: macOS-latest }
-          - { target: aarch64-apple-darwin,       os: macOS-14 } # macOS-14 is the ARM chipset
+          - { target: x86_64-apple-darwin,        os: macos-13 }
+          - { target: aarch64-apple-darwin,       os: macos-14 } # macOS-14 is the ARM chipset
 
           - { target: x86_64-pc-windows-msvc,     os: windows-latest , extension: .exe }
     uses: ./.github/workflows/test_downstream.yml


### PR DESCRIPTION
Made it 13 instead of 12 as that was the default setting for pixi's default virtual packages.