### PR TITLE
fix: make sure pixi vars are available before activation.env vars are…

### DIFF
--- a/src/activation.rs
+++ b/src/activation.rs
@@ -214,7 +214,7 @@ pub async fn run_activation(
 }
 
 /// Get the environment variables that are statically generated from the project and the environment.
-/// Returns IndexMap to stay sorted, as pixi should export the metadata before exporting variables that could depend on it. 
+/// Returns IndexMap to stay sorted, as pixi should export the metadata before exporting variables that could depend on it.
 pub fn get_static_environment_variables<'p>(
     environment: &'p Environment<'p>,
 ) -> IndexMap<String, String> {

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -214,7 +214,7 @@ pub async fn run_activation(
 }
 
 /// Get the environment variables that are statically generated from the project and the environment.
-/// This returns an IndexMap to make sure they get exported in the correct order.
+/// Returns IndexMap to stay sorted, as pixi should export the metadata before exporting variables that could depend on it. 
 pub fn get_static_environment_variables<'p>(
     environment: &'p Environment<'p>,
 ) -> IndexMap<String, String> {

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use indexmap::IndexMap;
+use std::collections::HashMap;
 
 use itertools::Itertools;
 use miette::IntoDiagnostic;
@@ -231,7 +231,6 @@ pub fn get_static_environment_variables<'p>(
 
     // Get environment variables from the pixi environment
     let environment_env = environment.get_metadata_env();
-
 
     // Combine the environments
     project_env

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -380,6 +380,37 @@ mod tests {
     }
 
     #[test]
+    fn test_metadata_project_env_order() {
+        let project = r#"
+        [project]
+        name = "pixi"
+        channels = [""]
+        platforms = ["linux-64", "osx-64", "win-64"]
+
+        [activation.env]
+        ABC = "123test123"
+        ZZZ = "123test123"
+        ZAB = "123test123"
+        "#;
+        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
+        let env = get_static_environment_variables(&project.default_environment());
+
+        // Make sure the user defined environment variables are at the end.
+        assert!(
+            env.keys().position(|key| key == "PIXI_PROJECT_NAME")
+                < env.keys().position(|key| key == "ABC")
+        );
+        assert!(
+            env.keys().position(|key| key == "PIXI_PROJECT_NAME")
+                < env.keys().position(|key| key == "ZZZ")
+        );
+
+        // Make sure the user defined environment variables are sorted by input order.
+        assert!(env.keys().position(|key| key == "ABC") < env.keys().position(|key| key == "ZZZ"));
+        assert!(env.keys().position(|key| key == "ZZZ") < env.keys().position(|key| key == "ZAB"));
+    }
+
+    #[test]
     #[cfg(target_os = "unix")]
     fn test_get_linux_clean_environment_variables() {
         let env = get_clean_environment_variables();

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -246,10 +247,10 @@ impl<'p> Environment<'p> {
     ///
     /// The environment variables of all features are combined in the order they
     /// are defined for the environment.
-    pub fn activation_env(&self, platform: Option<Platform>) -> HashMap<String, String> {
+    pub fn activation_env(&self, platform: Option<Platform>) -> IndexMap<String, String> {
         self.features()
             .filter_map(|f| f.activation_env(platform))
-            .fold(HashMap::new(), |mut acc, env| {
+            .fold(IndexMap::new(), |mut acc, env| {
                 acc.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
                 acc
             })


### PR DESCRIPTION
fixes: #1726 

`pixi shell-hook` before:
```bash
export ABC="$PIXI_PROJECT_ROOT/test"
...
export PIXI_PROJECT_ROOT="/home/rarts/dev/pixi"
```

`pixi shell-hook` after:
```bash
...
export PIXI_PROJECT_ROOT="/home/rarts/dev/pixi"
...
export ABC="$PIXI_PROJECT_ROOT/test"
```
