### PR TITLE
docs: fix mlx feature in "multiple machines" example

### DIFF
--- a/docs/features/multi_environment.md
+++ b/docs/features/multi_environment.md
@@ -443,13 +443,15 @@ Dev
 
     [feature.mlx]
     platforms = ["osx-arm64"]
+    # MLX is only available on macOS >=13.5 (>14.0 is recommended)
+    system-requirements = {macos = "13.5"}
 
     [feature.mlx.tasks]
     train-model = "python train.py --mlx"
     evaluate-model = "python test.py --mlx"
 
     [feature.mlx.dependencies]
-    mlx = ">=0.5.0,<0.6.0"
+    mlx = ">=0.16.0,<0.17.0"
 
     [feature.cpu]
     platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]

--- a/examples/multi-machine/pixi.lock
+++ b/examples/multi-machine/pixi.lock
@@ -1048,7 +1048,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py311h05b510d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.4-py311h000fb6e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mlx-0.16.0-py311h6ca41e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mlx-0.16.1-py311h025f708_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h91ba8db_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-h41d338b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_0.conda
@@ -6319,12 +6319,12 @@ packages:
   timestamp: 1698350992610
 - kind: conda
   name: mlx
-  version: 0.16.0
-  build: py311h6ca41e1_0
+  version: 0.16.1
+  build: py311h025f708_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mlx-0.16.0-py311h6ca41e1_0.conda
-  sha256: efc6dcd39aa55107a4b8213681473f958a1b34f64cb77ff8fb5db37237594180
-  md5: bf57d24eb407de7f5abe0f5e587dc4ff
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mlx-0.16.1-py311h025f708_0.conda
+  sha256: 4b459c6780641a2347ca68e9c92f212d99c80c9bd444cebba545559dc3885376
+  md5: 1f831c7b7c81db6b0487cc9698b1c45d
   depends:
   - __osx >=13.3
   - libcxx >=16
@@ -6333,8 +6333,8 @@ packages:
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 7655215
-  timestamp: 1720732934647
+  size: 7659235
+  timestamp: 1721961376807
 - kind: conda
   name: mpc
   version: 1.3.1

--- a/examples/multi-machine/pixi.toml
+++ b/examples/multi-machine/pixi.toml
@@ -33,14 +33,14 @@ pytorch-cuda = { version = "12.1.*", channel = "pytorch" }
 
 [feature.mlx]
 platforms = ["osx-arm64"]
-system-requirements = { macos = "13.3" }
+system-requirements = { macos = "13.5" }
+
+[feature.mlx.dependencies]
+mlx = ">=0.16.1,<0.17"
 
 [feature.mlx.tasks]
 test = "python test.py --mlx"
 train = "python train.py --mlx"
-
-[feature.mlx.dependencies]
-mlx = "*"
 
 [environments]
 cuda = ["cuda"]


### PR DESCRIPTION
The example as it was would not solve, it ends with a fairly obscure error:

```
  × failed to solve the conda requirements of 'mlx' 'osx-arm64'
  ╰─▶ Cannot solve the request because of: mlx >=0.5.0,<0.6.0 cannot be installed because there are no viable options:
      └─ mlx 0.5.0 | 0.5.0 | 0.5.0 | 0.5.0 | 0.5.0 | 0.5.1 | 0.5.1 | 0.5.1 | 0.5.1 | 0.5.1 would require
         └─ __osx >=13.3, for which no candidates were found.
```

This was already found previously in https://github.com/prefix-dev/pixi/issues/562#issuecomment-1855847020, and the fix is to add a minimum macOS version. Note that the conda-forge package metadata (saying >=13.3) is also incorrect, the 13.5 minimum added to the example comes from the MLX docs: https://ml-explore.github.io/mlx/build/html/install.html#

While we're at it, also update to a recent MLX version.