### PR TITLE
docs: Expands the environment variable examples in the reference section

### DIFF
--- a/docs/reference/project_configuration.md
+++ b/docs/reference/project_configuration.md
@@ -578,6 +578,14 @@ scripts = ["env_setup.bat"]
 
 [target.linux-64.activation.env]
 ENV_VAR = "linux-value"
+
+# You can also reference existing environment variables, but this has
+# to be done separately for unix-like operating systems and Windows
+[target.unix.activation.env]
+ENV_VAR = "$OTHER_ENV_VAR/unix-value"
+
+[target.win.activation.env]
+ENV_VAR = "%OTHER_ENV_VAR%\\windows-value"
 ```
 
 ## The `target` table


### PR DESCRIPTION
This adds another example to the reference showing how to use existing environment variables in the env definition section.