### PR TITLE
ci: Always run all jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,21 +4,11 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "docs/**"
-      - ".github/workflows/docs.yml"
-      - "mkdocs.yml"
-      - "pixi.*"
     tags:
       - v**
   pull_request:
     branches:
       - main
-    paths:
-      - "docs/**"
-      - ".github/workflows/docs.yml"
-      - "mkdocs.yml"
-      - "pixi.*"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,17 +4,8 @@ on:
       - "v*.*.*"
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "*.md"
   workflow_dispatch:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "*.md"
-
 name: Rust
 
 concurrency:

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -4,16 +4,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "*.md"
   workflow_dispatch:
   pull_request:
-    paths:
-      - "**/pixi.toml"
-      - "schema/**"
-      - "**/schema.yml"
 
 jobs:
   test-schema:


### PR DESCRIPTION
We currently run jobs only if it is necessary.
Unfortunately, this doesn't mix well with required jobs. GitHub patiently waits for them to turn green, but they never start running