### PR TITLE
feat: add `INIT_CWD` to activation env

### DIFF
--- a/docs/features/environment.md
+++ b/docs/features/environment.md
@@ -160,6 +160,7 @@ The following environment variables are set by pixi, when using the `pixi run`, 
 - `CONDA_PREFIX`: The path to the environment. (Used by multiple tools that already understand conda environments)
 - `CONDA_DEFAULT_ENV`: The name of the environment. (Used by multiple tools that already understand conda environments)
 - `PATH`: We prepend the `bin` directory of the environment to the `PATH` variable, so you can use the tools installed in the environment directly.
+- `INIT_CWD`: ONLY IN `pixi run`: The directory where the command was run from.
 
 !!! note
     Even though the variables are environment variables these cannot be overridden. E.g. you can not change the root of the project by setting `PIXI_PROJECT_ROOT` in the environment.

--- a/docs/reference/project_configuration.md
+++ b/docs/reference/project_configuration.md
@@ -217,6 +217,7 @@ alias = { depends-on=["depending"]}
 download = { cmd="curl -o file.txt https://example.com/file.txt" , outputs=["file.txt"]}
 build = { cmd="npm build", cwd="frontend", inputs=["frontend/package.json", "frontend/*.js"]}
 run = { cmd="python run.py $ARGUMENT", env={ ARGUMENT="value" }}
+format = { cmd="black $INIT_CWD" } # runs black where you run pixi run format
 clean-env = { cmd = "python isolated.py", clean-env = true} # Only on Unix!
 ```
 

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -52,16 +52,6 @@ impl Project {
                     }),
             ),
             (String::from("PIXI_IN_SHELL"), String::from("1")),
-            // Keep INIT_CWD or set to current working directory.
-            (
-                String::from("INIT_CWD"),
-                std::env::var("INIT_CWD").unwrap_or_else(|_| {
-                    std::env::current_dir()
-                        .unwrap()
-                        .to_string_lossy()
-                        .into_owned()
-                }),
-            ),
         ]);
 
         if let Ok(exe_path) = std::env::current_exe() {
@@ -418,29 +408,6 @@ mod tests {
         // Make sure the user defined environment variables are sorted by input order.
         assert!(env.keys().position(|key| key == "ABC") < env.keys().position(|key| key == "ZZZ"));
         assert!(env.keys().position(|key| key == "ZZZ") < env.keys().position(|key| key == "ZAB"));
-    }
-
-    // Test INIT_CWD environment variable
-    #[test]
-    fn test_metadata_project_env_init_cwd() {
-        let project = r#"
-        [project]
-        name = "pixi"
-        channels = [""]
-        platforms = ["linux-64", "osx-64", "win-64"]
-        "#;
-        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
-        let env = project.get_metadata_env();
-
-        assert_eq!(
-            env.get("INIT_CWD").unwrap(),
-            std::env::current_dir().unwrap().to_str().unwrap()
-        );
-
-        // Test if the INIT_CWD is set to the original value if it exists.
-        std::env::set_var("INIT_CWD", "hoi");
-        let env = project.get_metadata_env();
-        assert_eq!(env.get("INIT_CWD").unwrap(), "hoi");
     }
 
     #[test]

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -6,21 +6,18 @@ use std::{collections::HashMap, string::String};
 use clap::Parser;
 use dialoguer::theme::ColorfulTheme;
 use itertools::Itertools;
-use miette::{Context, Diagnostic, IntoDiagnostic};
+use miette::{Diagnostic, IntoDiagnostic};
 use pixi_config::ConfigCli;
-use pixi_progress::await_in_progress;
 
-use crate::activation::CurrentEnvVarBehavior;
 use crate::cli::cli_config::ProjectConfig;
 use crate::environment::verify_prefix_location_unchanged;
-use crate::lock_file::LockFileDerivedData;
 use crate::lock_file::UpdateLockFileOptions;
 use crate::project::errors::UnsupportedPlatformError;
 use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
-use crate::project::{Environment, HasProjectRef};
+use crate::project::Environment;
 use crate::task::{
-    AmbiguousTask, CanSkip, ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory,
-    SearchEnvironments, TaskAndEnvironment, TaskGraph,
+    get_task_env, AmbiguousTask, CanSkip, ExecutableTask, FailedToParseShellScript,
+    InvalidWorkingDirectory, SearchEnvironments, TaskAndEnvironment, TaskGraph,
 };
 use crate::Project;
 use fancy_display::FancyDisplay;
@@ -170,8 +167,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let task_env: &_ = match task_envs.entry(executable_task.run_environment.clone()) {
             Entry::Occupied(env) => env.into_mut(),
             Entry::Vacant(entry) => {
+                // Ensure there is a valid prefix
+                lock_file.prefix(&executable_task.run_environment).await?;
+
                 let command_env = get_task_env(
-                    &mut lock_file,
                     &executable_task.run_environment,
                     args.clean_env || executable_task.task().clean_env(),
                 )
@@ -231,37 +230,6 @@ fn command_not_found<'p>(project: &'p Project, explicit_environment: Option<Envi
                 })
         );
     }
-}
-
-/// Determine the environment variables to use when executing a command. The method combines the
-/// activation environment with the system environment variables.
-pub async fn get_task_env<'p>(
-    lock_file_derived_data: &mut LockFileDerivedData<'p>,
-    environment: &Environment<'p>,
-    clean_env: bool,
-) -> miette::Result<HashMap<String, String>> {
-    // Make sure the system requirements are met
-    verify_current_platform_has_required_virtual_packages(environment).into_diagnostic()?;
-
-    // Ensure there is a valid prefix
-    lock_file_derived_data.prefix(environment).await?;
-
-    // Get environment variables from the activation
-    let env_var_behavior = if clean_env {
-        CurrentEnvVarBehavior::Clean
-    } else {
-        CurrentEnvVarBehavior::Include
-    };
-    let activation_env = await_in_progress("activating environment", |_| {
-        environment
-            .project()
-            .get_activated_environment_variables(environment, env_var_behavior)
-    })
-    .await
-    .wrap_err("failed to activate environment")?;
-
-    // Concatenate with the system environment variables
-    Ok(activation_env.clone())
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -138,7 +138,7 @@ impl Borrow<ParsedManifest> for Project {
 
 impl Project {
     /// Constructs a new instance from an internal manifest representation
-    fn from_manifest(manifest: Manifest) -> Self {
+    pub(crate) fn from_manifest(manifest: Manifest) -> Self {
         let env_vars = Project::init_env_vars(&manifest.parsed.environments);
 
         let root = manifest

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -146,7 +146,7 @@ impl<'p> ExecutableTask<'p> {
         &self,
     ) -> Result<Option<SequentialList>, FailedToParseShellScript> {
         if let Some(full_script) = self.as_script() {
-            tracing::info!("Parsing shell script: {}", full_script);
+            tracing::debug!("Parsing shell script: {}", full_script);
 
             // Parse the shell command
             deno_task_shell::parser::parse(full_script.trim())
@@ -373,14 +373,14 @@ pub async fn get_task_env<'p>(
     .clone();
 
     // Add the current working directory to the environment
-    activation_env.insert(
-        "INIT_CWD".to_string(),
-        std::env::current_dir()
-            .into_diagnostic()
-            .wrap_err("failed to get current working directory")?
-            .to_string_lossy()
-            .to_string(),
-    );
+    if let Ok(init_cwd) = std::env::current_dir() {
+        activation_env.insert(
+            "INIT_CWD".to_string(),
+            init_cwd.to_string_lossy().to_string(),
+        );
+    } else {
+        tracing::warn!("Failed to get the current working directory for INIT_CWD.");
+    }
 
     // Concatenate with the system environment variables
     Ok(activation_env)

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -9,7 +9,7 @@ use deno_task_shell::{
     execute_with_pipes, parser::SequentialList, pipe, ShellPipeWriter, ShellState,
 };
 use itertools::Itertools;
-use miette::Diagnostic;
+use miette::{Context, Diagnostic, IntoDiagnostic};
 use thiserror::Error;
 use tokio::task::JoinHandle;
 
@@ -22,7 +22,11 @@ use crate::{
 };
 use pixi_consts::consts;
 
+use crate::activation::CurrentEnvVarBehavior;
+use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
+use crate::project::HasProjectRef;
 use pixi_manifest::{Task, TaskName};
+use pixi_progress::await_in_progress;
 
 /// Runs task in project.
 #[derive(Default, Debug)]
@@ -116,29 +120,13 @@ impl<'p> ExecutableTask<'p> {
         self.project
     }
 
-    /// Returns a [`SequentialList`] which can be executed by deno task shell.
-    /// Returns `None` if the command is not executable like in the case of
-    /// an alias.
-    pub fn as_deno_script(&self) -> Result<Option<SequentialList>, FailedToParseShellScript> {
+    /// Returns the task as script
+    fn as_script(&self) -> Option<String> {
         // Convert the task into an executable string
-        let Some(task) = self.task.as_single_command() else {
-            return Ok(None);
-        };
+        let task = self.task.as_single_command()?;
 
-        // Append the environment variables if they don't exist
-        let mut export = String::new();
-        if let Some(env) = self.task.env() {
-            for (key, value) in env {
-                if value.contains(format!("${}", key).as_str())
-                    || std::env::var(key.as_str()).is_err()
-                {
-                    tracing::info!("Setting environment variable: {}=\"{}\"", key, value);
-                    export.push_str(&format!("export \"{}={}\";\n", key, value));
-                } else {
-                    tracing::info!("Environment variable {} already set", key);
-                }
-            }
-        }
+        // Get the export specific environment variables
+        let export = get_export_specific_task_env(self.task.as_ref());
 
         // Append the command line arguments verbatim
         let cli_args = self
@@ -153,13 +141,26 @@ impl<'p> ExecutableTask<'p> {
             format!("{export}\n{task} {cli_args}")
         };
 
-        // Parse the shell command
-        deno_task_shell::parser::parse(full_script.trim())
-            .map_err(|e| FailedToParseShellScript {
-                script: full_script,
-                error: e.to_string(),
-            })
-            .map(Some)
+        Some(full_script)
+    }
+
+    /// Returns a [`SequentialList`] which can be executed by deno task shell.
+    /// Returns `None` if the command is not executable like in the case of
+    /// an alias.
+    pub fn as_deno_script(&self) -> Result<Option<SequentialList>, FailedToParseShellScript> {
+        if let Some(full_script) = self.as_script() {
+            tracing::info!("Parsing shell script: {}", full_script);
+
+            // Parse the shell command
+            deno_task_shell::parser::parse(full_script.trim())
+                .map_err(|e| FailedToParseShellScript {
+                    script: full_script,
+                    error: e.to_string(),
+                })
+                .map(Some)
+        } else {
+            Ok(None)
+        }
     }
 
     /// Returns the working directory for this task.
@@ -330,4 +331,156 @@ fn get_output_writer_and_handle() -> (ShellPipeWriter, JoinHandle<String>) {
     let (reader, writer) = pipe();
     let handle = reader.pipe_to_string_handle();
     (writer, handle)
+}
+
+/// Task specific environment variables.
+fn get_export_specific_task_env(task: &Task) -> String {
+    // Append the environment variables if they don't exist
+    let mut export = String::new();
+    if let Some(env) = task.env() {
+        for (key, value) in env {
+            if value.contains(format!("${}", key).as_str()) || std::env::var(key.as_str()).is_err()
+            {
+                tracing::info!("Setting environment variable: {}=\"{}\"", key, value);
+                export.push_str(&format!("export \"{}={}\";\n", key, value));
+            } else {
+                tracing::info!("Environment variable {} already set", key);
+            }
+        }
+    }
+    export
+}
+
+/// Determine the environment variables to use when executing a command. The method combines the
+/// activation environment with the system environment variables.
+pub async fn get_task_env<'p>(
+    environment: &Environment<'p>,
+    clean_env: bool,
+) -> miette::Result<HashMap<String, String>> {
+    // Make sure the system requirements are met
+    verify_current_platform_has_required_virtual_packages(environment).into_diagnostic()?;
+
+    // Get environment variables from the activation
+    let env_var_behavior = if clean_env {
+        CurrentEnvVarBehavior::Clean
+    } else {
+        CurrentEnvVarBehavior::Include
+    };
+    let mut activation_env = await_in_progress("activating environment", |_| {
+        environment
+            .project()
+            .get_activated_environment_variables(environment, env_var_behavior)
+    })
+    .await
+    .wrap_err("failed to activate environment")?
+    .clone();
+
+    // Add the current working directory to the environment
+    activation_env.insert(
+        "INIT_CWD".to_string(),
+        std::env::current_dir()
+            .into_diagnostic()
+            .wrap_err("failed to get current working directory")?
+            .to_string_lossy()
+            .to_string(),
+    );
+
+    // Concatenate with the system environment variables
+    Ok(activation_env)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pixi_manifest::Manifest;
+    use std::path::Path;
+
+    const PROJECT_BOILERPLATE: &str = r#"
+        [project]
+        name = "foo"
+        version = "0.1.0"
+        channels = []
+        # Required to run tests
+        platforms = ["linux-64", "osx-64", "win-64", "osx-arm64", "linux-ppc64le", "linux-aarch64"]
+        "#;
+
+    #[test]
+    fn test_export_specific_task_env() {
+        let file_contents = r#"
+            [tasks]
+            test = {cmd = "test", cwd = "tests", env = {FOO = "bar", BAR = "$FOO"}}
+            "#;
+        let manifest = Manifest::from_str(
+            Path::new("pixi.toml"),
+            format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+        )
+        .unwrap();
+
+        let project = Project::from_manifest(manifest);
+
+        let task = project
+            .default_environment()
+            .task(&TaskName::from("test"), None)
+            .unwrap();
+
+        let export = get_export_specific_task_env(task);
+
+        assert_eq!(export, "export \"FOO=bar\";\nexport \"BAR=$FOO\";\n");
+    }
+
+    #[test]
+    fn test_as_script() {
+        let file_contents = r#"
+            [tasks]
+            test = {cmd = "test", cwd = "tests", env = {FOO = "bar"}}
+            "#;
+        let manifest = Manifest::from_str(
+            Path::new("pixi.toml"),
+            format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+        )
+        .unwrap();
+
+        let project = Project::from_manifest(manifest);
+
+        let task = project
+            .default_environment()
+            .task(&TaskName::from("test"), None)
+            .unwrap();
+
+        let executable_task = ExecutableTask {
+            project: &project,
+            name: Some("test".into()),
+            task: Cow::Borrowed(task),
+            run_environment: project.default_environment(),
+            additional_args: vec![],
+        };
+
+        let script = executable_task.as_script().unwrap();
+        assert_eq!(script, "export \"FOO=bar\";\n\ntest ");
+    }
+
+    #[tokio::test]
+    async fn test_get_task_env() {
+        let file_contents = r#"
+            [tasks]
+            test = {cmd = "test", cwd = "tests", env = {FOO = "bar"}}
+            "#;
+        let manifest = Manifest::from_str(
+            Path::new("pixi.toml"),
+            format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+        )
+        .unwrap();
+
+        let project = Project::from_manifest(manifest);
+
+        let environment = project.default_environment();
+        let env = get_task_env(&environment, false).await.unwrap();
+        assert_eq!(
+            env.get(&"INIT_CWD".to_string()).unwrap(),
+            &std::env::current_dir()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        );
+    }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -10,8 +10,8 @@ pub use pixi_manifest::{Task, TaskName};
 pub use task_hash::{ComputationHash, InputHashes, TaskHash};
 
 pub use executable_task::{
-    CanSkip, ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory, RunOutput,
-    TaskExecutionError,
+    get_task_env, CanSkip, ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory,
+    RunOutput, TaskExecutionError,
 };
 pub use task_environment::{
     AmbiguousTask, FindTaskError, FindTaskSource, SearchEnvironments, TaskAndEnvironment,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,14 +17,14 @@ use crate::common::builders::{
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pixi::cli::cli_config::{PrefixUpdateConfig, ProjectConfig};
 use pixi::task::{
-    ExecutableTask, RunOutput, SearchEnvironments, TaskExecutionError, TaskGraph, TaskGraphError,
+    get_task_env, ExecutableTask, RunOutput, SearchEnvironments, TaskExecutionError, TaskGraph,
+    TaskGraphError,
 };
 use pixi::{
     cli::{
         add, init,
         install::Args,
         project, remove, run,
-        run::get_task_env,
         task::{self, AddArgs, AliasArgs},
         update, LockFileUsageArgs,
     },
@@ -367,8 +367,8 @@ impl PixiControl {
             // Construct the task environment if not already created.
             let task_env = match task_env.as_ref() {
                 None => {
-                    let env =
-                        get_task_env(&mut lock_file, &task.run_environment, args.clean_env).await?;
+                    lock_file.prefix(&task.run_environment).await?;
+                    let env = get_task_env(&task.run_environment, args.clean_env).await?;
                     task_env.insert(env)
                 }
                 Some(task_env) => task_env,


### PR DESCRIPTION
Implement the same behavior as `deno_task_shell`
https://docs.deno.com/runtime/manual/tools/task_runner/#specifying-the-current-working-directory