### PR TITLE
ci: Add timeout to job "Rust / Cargo Test"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -98,6 +98,7 @@ jobs:
   cargo-test:
     name: Cargo Test | ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It sometimes gets stuck in an infinite loop.
By timing out after an hour, we improve the situation somewhat.