### PR TITLE
fix: git dependencies pyproject.toml

### DIFF
--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -336,6 +336,7 @@ mod tests {
         authors = [
             { name = "Author", email = "author@bla.com" }
         ]
+        dependencies = ["attrs @ git+ssh://git@github.com/python-attrs/attrs.git@main"]ck
 
         [tool.pixi.project]
         channels = ["stable"]


### PR DESCRIPTION
Currently only a failing test, that we need to fix. 