### PR TITLE
refactor: Only compile `TaskNode::full_command` for tests

### DIFF
--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -79,7 +79,8 @@ impl<'p> TaskNode<'p> {
     ///
     /// This function returns `None` if the task does not define a command to
     /// execute. This is the case for alias only commands.
-    pub fn full_command(&self) -> Option<String> {
+    #[cfg(test)]
+    pub(crate) fn full_command(&self) -> Option<String> {
         let mut cmd = self.task.as_single_command()?.to_string();
 
         if !self.additional_args.is_empty() {


### PR DESCRIPTION
Only compile `TaskNode::full_command` for tests and make it `pub(crate)`

Saw this trick in a different part of the code base and thought it fit nicely here as well