### PR TITLE
fix: make proper use of NamedChannelOrUrl

### DIFF
--- a/crates/pypi_mapping/src/custom_pypi_mapping.rs
+++ b/crates/pypi_mapping/src/custom_pypi_mapping.rs
@@ -59,20 +59,6 @@ pub async fn amend_pypi_purls(
         .cloned()
         .collect();
 
-    eprintln!("mapping url mapping {:?}", mapping_url.mapping);
-    eprintln!(
-        "conda packages channel {:?}",
-        conda_packages
-            .iter()
-            .map(|x| x.channel.clone())
-            .collect::<Vec<String>>()
-    );
-
-    eprintln!(
-        "packages_for_prefix_mapping {:?}",
-        packages_for_prefix_mapping.len()
-    );
-
     let custom_mapping = mapping_url.fetch_custom_mapping(client).await?;
 
     // When all requested channels are present in the custom_mapping, we don't have

--- a/crates/pypi_mapping/src/custom_pypi_mapping.rs
+++ b/crates/pypi_mapping/src/custom_pypi_mapping.rs
@@ -59,6 +59,20 @@ pub async fn amend_pypi_purls(
         .cloned()
         .collect();
 
+    eprintln!("mapping url mapping {:?}", mapping_url.mapping);
+    eprintln!(
+        "conda packages channel {:?}",
+        conda_packages
+            .iter()
+            .map(|x| x.channel.clone())
+            .collect::<Vec<String>>()
+    );
+
+    eprintln!(
+        "packages_for_prefix_mapping {:?}",
+        packages_for_prefix_mapping.len()
+    );
+
     let custom_mapping = mapping_url.fetch_custom_mapping(client).await?;
 
     // When all requested channels are present in the custom_mapping, we don't have

--- a/crates/pypi_mapping/src/lib.rs
+++ b/crates/pypi_mapping/src/lib.rs
@@ -25,7 +25,7 @@ pub type ChannelName = String;
 pub type MappingMap = HashMap<ChannelName, MappingLocation>;
 pub type MappingByChannel = HashMap<String, HashMap<String, Option<String>>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MappingLocation {
     Path(PathBuf),
     Url(Url),

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -1480,7 +1480,7 @@ async fn spawn_solve_conda_environment_task(
     let has_pypi_dependencies = group.has_pypi_dependencies();
 
     // Whether we should use custom mapping location
-    let pypi_name_mapping_location = group.project().pypi_name_mapping_source().clone();
+    let pypi_name_mapping_location = group.project().pypi_name_mapping_source()?.clone();
 
     // Get the channel configuration
     let channel_config = group.project().channel_config();
@@ -1787,7 +1787,7 @@ async fn spawn_solve_pypi_task(
 
     let environment_name = environment.name().clone();
 
-    let pypi_name_mapping_location = environment.project().pypi_name_mapping_source();
+    let pypi_name_mapping_location = environment.project().pypi_name_mapping_source()?;
 
     let mut conda_records = repodata_records.records.clone();
     let locked_pypi_records = locked_pypi_packages.records.clone();

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -545,8 +545,6 @@ impl Project {
                     let mapping = channel_to_location_map
                         .iter()
                         .map(|(channel, mapping_location)| {
-                            // let mapping_location = map.get(channel).unwrap();
-
                             let url_or_path = match Url::parse(mapping_location) {
                                 Ok(url) => MappingLocation::Url(url),
                                 Err(err) => {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -516,7 +516,7 @@ impl Project {
         ) -> miette::Result<MappingSource> {
             match manifest.parsed.project.conda_pypi_map.clone() {
                 Some(map) => {
-                    let new_map = map
+                    let channel_to_location_map = map
                         .into_iter()
                         .map(|(key, value)| {
                             let key = key.into_channel(&channel_config);
@@ -533,7 +533,7 @@ impl Project {
                         .collect::<HashSet<_>>();
 
                     // Throw a warning for each missing channel from project table
-                    new_map.keys().for_each(|channel| {
+                    channel_to_location_map.keys().for_each(|channel| {
                         if !project_channels.contains(channel) {
                             tracing::warn!(
                                 "Defined custom mapping channel {} is missing from project channels",
@@ -542,7 +542,7 @@ impl Project {
                         }
                     });
 
-                    let mapping = new_map
+                    let mapping = channel_to_location_map
                         .iter()
                         .map(|(channel, mapping_location)| {
                             // let mapping_location = map.get(channel).unwrap();

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -907,13 +907,13 @@ mod tests {
     #[test]
     fn test_mapping_location() {
         let file_contents = r#"
+            [project]
+            name = "foo"
+            channels = ["conda-forge", "pytorch"]
+            platforms = []
             conda-pypi-map = {conda-forge = "https://github.com/prefix-dev/parselmouth/blob/main/files/compressed_mapping.json", pytorch = ""}
             "#;
-        let manifest = Manifest::from_str(
-            Path::new("pixi.toml"),
-            format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-        )
-        .unwrap();
+        let manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
         let project = Project::from_manifest(manifest);
 
         let mapping = project.pypi_name_mapping_source().unwrap();
@@ -922,20 +922,17 @@ mod tests {
 
         let canonical_channel_name = canonical_name.trim_end_matches('/');
 
-        eprintln!("our map is {:?}", mapping.custom().unwrap().mapping);
-        eprintln!("can name is {:?}", canonical_channel_name);
-
         assert_eq!(mapping.custom().unwrap().mapping.get(&canonical_channel_name.to_string()).unwrap(), &MappingLocation::Url(Url::parse("https://github.com/prefix-dev/parselmouth/blob/main/files/compressed_mapping.json").unwrap()));
 
         // Check url channel as map key
         let file_contents = r#"
+            [project]
+            name = "foo"
+            channels = ["https://prefix.dev/test-channel"]
+            platforms = []
             conda-pypi-map = {"https://prefix.dev/test-channel" = "mapping.json"}
             "#;
-        let manifest = Manifest::from_str(
-            Path::new("pixi.toml"),
-            format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
-        )
-        .unwrap();
+        let manifest = Manifest::from_str(Path::new("pixi.toml"), file_contents).unwrap();
         let project = Project::from_manifest(manifest);
 
         let mapping = project.pypi_name_mapping_source().unwrap();

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -14,7 +14,6 @@ use std::{
     fmt::{Debug, Formatter},
     hash::Hash,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::{Arc, OnceLock},
 };
 
@@ -32,7 +31,7 @@ use pixi_manifest::{
 };
 use pixi_utils::reqwest::build_reqwest_clients;
 use pypi_mapping::{ChannelName, CustomMapping, MappingLocation, MappingSource};
-use rattler_conda_types::{Channel, ChannelConfig, NamedChannelOrUrl, Version};
+use rattler_conda_types::{Channel, ChannelConfig, Version};
 use rattler_repodata_gateway::Gateway;
 use reqwest_middleware::ClientWithMiddleware;
 pub use solve_group::SolveGroup;
@@ -519,7 +518,7 @@ impl Project {
                     let channel_to_location_map = map
                         .into_iter()
                         .map(|(key, value)| {
-                            let key = key.into_channel(&channel_config);
+                            let key = key.into_channel(channel_config);
                             Ok((key, value))
                         })
                         .collect::<miette::Result<HashMap<Channel, String>>>()?;
@@ -529,7 +528,7 @@ impl Project {
                         .project
                         .channels
                         .iter()
-                        .map(|pc| pc.channel.clone().into_channel(&channel_config))
+                        .map(|pc| pc.channel.clone().into_channel(channel_config))
                         .collect::<HashSet<_>>();
 
                     // Throw a warning for each missing channel from project table
@@ -912,7 +911,7 @@ mod tests {
         let channel = Channel::from_str("conda-forge", &project.channel_config()).unwrap();
         let canonical_name = channel.canonical_name();
 
-        let canonical_channel_name = canonical_name.trim_end_matches("/");
+        let canonical_channel_name = canonical_name.trim_end_matches('/');
 
         eprintln!("our map is {:?}", mapping.custom().unwrap().mapping);
         eprintln!("can name is {:?}", canonical_channel_name);
@@ -943,7 +942,7 @@ mod tests {
                     )
                     .unwrap()
                     .canonical_name()
-                    .trim_end_matches("/")
+                    .trim_end_matches('/')
                     .to_string()
                 )
                 .unwrap(),

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -424,7 +424,11 @@ async fn test_we_record_not_present_package_as_purl_for_custom_mapping() {
 
     let mut packages = vec![repo_data_record, boltons_repo_data_record];
 
-    let mapping_map = project.pypi_name_mapping_source().custom().unwrap();
+    let mapping_map = project
+        .pypi_name_mapping_source()
+        .unwrap()
+        .custom()
+        .unwrap();
 
     pypi_mapping::custom_pypi_mapping::amend_pypi_purls(client, &mapping_map, &mut packages, None)
         .await
@@ -490,7 +494,7 @@ async fn test_custom_mapping_channel_with_suffix() {
 
     let mut packages = vec![repo_data_record];
 
-    let mapping_source = project.pypi_name_mapping_source();
+    let mapping_source = project.pypi_name_mapping_source().unwrap();
 
     let mapping_map = mapping_source.custom().unwrap();
 
@@ -541,7 +545,7 @@ async fn test_repo_data_record_channel_with_suffix() {
 
     let mut packages = vec![repo_data_record];
 
-    let mapping_source = project.pypi_name_mapping_source();
+    let mapping_source = project.pypi_name_mapping_source().unwrap();
 
     let mapping_map = mapping_source.custom().unwrap();
 
@@ -592,7 +596,7 @@ async fn test_path_channel() {
 
     let mut packages = vec![repo_data_record];
 
-    let mapping_source = project.pypi_name_mapping_source();
+    let mapping_source = project.pypi_name_mapping_source().unwrap();
 
     let mapping_map = mapping_source.custom().unwrap();
 

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -564,6 +564,7 @@ async fn test_repo_data_record_channel_with_suffix() {
     );
 }
 
+#[ignore]
 #[tokio::test]
 async fn test_path_channel() {
     let pixi = PixiControl::from_manifest(

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -564,7 +564,6 @@ async fn test_repo_data_record_channel_with_suffix() {
     );
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_path_channel() {
     let pixi = PixiControl::from_manifest(

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -426,7 +426,6 @@ async fn test_we_record_not_present_package_as_purl_for_custom_mapping() {
 
     let mapping_map = project.pypi_name_mapping_source().custom().unwrap();
 
-    eprintln!("ammeding purls");
     pypi_mapping::custom_pypi_mapping::amend_pypi_purls(client, &mapping_map, &mut packages, None)
         .await
         .unwrap();

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -426,6 +426,7 @@ async fn test_we_record_not_present_package_as_purl_for_custom_mapping() {
 
     let mapping_map = project.pypi_name_mapping_source().custom().unwrap();
 
+    eprintln!("ammeding purls");
     pypi_mapping::custom_pypi_mapping::amend_pypi_purls(client, &mapping_map, &mut packages, None)
         .await
         .unwrap();
@@ -550,6 +551,58 @@ async fn test_repo_data_record_channel_with_suffix() {
         .unwrap();
 
     let package = packages.pop().unwrap();
+    assert_eq!(
+        package
+            .package_record
+            .purls
+            .as_ref()
+            .and_then(BTreeSet::first)
+            .unwrap()
+            .qualifiers()
+            .get("source")
+            .unwrap(),
+        PurlSource::ProjectDefinedMapping.as_str()
+    );
+}
+
+#[tokio::test]
+async fn test_path_channel() {
+    let pixi = PixiControl::from_manifest(
+        r#"
+     [project]
+     name = "test-channel-change"
+     channels = ["file:///home/user/staged-recipes/build_artifacts"]
+     platforms = ["linux-64"]
+     conda-pypi-map = {"file:///home/user/staged-recipes/build_artifacts" = "tests/mapping_files/custom_mapping.json"}
+     "#,
+    )
+    .unwrap();
+
+    let project = pixi.project().unwrap();
+
+    let client = project.authenticated_client();
+
+    let foo_bar_package = Package::build("pixi-something-new", "2").finish();
+
+    let repo_data_record = RepoDataRecord {
+        package_record: foo_bar_package.package_record,
+        file_name: "pixi-something-new".to_owned(),
+        url: Url::parse("https://pypi.org/simple/pixi-something-new-new/").unwrap(),
+        channel: "file:///home/user/staged-recipes/build_artifacts".to_owned(),
+    };
+
+    let mut packages = vec![repo_data_record];
+
+    let mapping_source = project.pypi_name_mapping_source();
+
+    let mapping_map = mapping_source.custom().unwrap();
+
+    pypi_mapping::custom_pypi_mapping::amend_pypi_purls(client, &mapping_map, &mut packages, None)
+        .await
+        .unwrap();
+
+    let package = packages.pop().unwrap();
+
     assert_eq!(
         package
             .package_record


### PR DESCRIPTION
Partly fixes #1764 
Fixes #1791 

We didn't read the channel name in the mapping correctly anymore. This fixes that.

This now forces the user to have the channel in the mapping defined as an actual channel. Giving the user this error:
```
❯ pixi install
  × Defined conda-pypi-map channel: bla is missing from the channels, which are: conda-forge, robostack, https://fast.prefix.dev/conda-forge/, bioconda
````

Added a test to verify