### PR TITLE
fix: skip all mapping logic when given empty map.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3881,6 +3881,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/crates/pypi_mapping/Cargo.toml
+++ b/crates/pypi_mapping/Cargo.toml
@@ -26,4 +26,5 @@ reqwest-retry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/pypi_mapping/src/custom_pypi_mapping.rs
+++ b/crates/pypi_mapping/src/custom_pypi_mapping.rs
@@ -52,6 +52,12 @@ pub async fn amend_pypi_purls(
     conda_packages: &mut [RepoDataRecord],
     reporter: Option<Arc<dyn Reporter>>,
 ) -> miette::Result<()> {
+    // If the mapping is empty we don't have to do anything.
+    if mapping_url.mapping.is_empty() {
+        tracing::info!("No custom mapping provided, skipping pypi purl amendment");
+        return Ok(());
+    }
+
     trim_conda_packages_channel_url_suffix(conda_packages);
     let packages_for_prefix_mapping: Vec<RepoDataRecord> = conda_packages
         .iter()


### PR DESCRIPTION
Allow the user to skip mapping logic by adding:
```toml
conda-pypi-map = { }
```