### PR TITLE
fix: format in docs/features/environment.md

### DIFF
--- a/docs/features/environment.md
+++ b/docs/features/environment.md
@@ -189,8 +189,9 @@ This will always be slower than the pure conda solves. So for the best pixi expe
 Pixi caches all previously downloaded packages in a cache folder.
 This cache folder is shared between all pixi projects and globally installed tools.
 
-Normally the locations would be:
-Platform-specific default cache folder:
+Normally the location would be the following
+platform-specific default cache folder:
+
 - Linux: `$XDG_CACHE_HOME/rattler` or `$HOME/.cache/rattler`
 - macOS: `$HOME/Library/Caches/rattler`
 - Windows: `%LOCALAPPDATA%\rattler`
@@ -200,6 +201,7 @@ This location is configurable by setting the `PIXI_CACHE_DIR` or `RATTLER_CACHE_
 When you want to clean the cache, you can simply delete the cache directory, and pixi will re-create the cache when needed.
 
 The cache contains multiple folders concerning different caches from within pixi.
+
 - `pkgs`: Contains the downloaded/unpacked `conda` packages.
 - `repodata`: Contains the `conda` repodata cache.
 - `uv-cache`: Contains the `uv` cache. This includes multiple caches, e.g. `built-wheels` `wheels` `archives`


### PR DESCRIPTION
Hopefully fixes docs formatting here: https://pixi.sh/latest/features/environment/#caching

<img width="1624" alt="Screenshot 2024-08-20 at 00 23 56" src="https://github.com/user-attachments/assets/0a4fe9f4-ea85-413a-9d03-03ca37f1ea59">
