### PR TITLE
fix: dont enfore system requirements for task tests

### DIFF
--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -347,12 +347,13 @@ pub enum TaskGraphError {
 mod test {
     use std::path::Path;
 
+    use pixi_manifest::EnvironmentName;
+    use rattler_conda_types::Platform;
+
     use crate::{
         task::{task_environment::SearchEnvironments, task_graph::TaskGraph},
         Project,
     };
-    use pixi_manifest::EnvironmentName;
-    use rattler_conda_types::Platform;
 
     fn commands_in_order(
         project_str: &str,
@@ -363,7 +364,8 @@ mod test {
         let project = Project::from_str(Path::new("pixi.toml"), project_str).unwrap();
 
         let environment = environment_name.map(|name| project.environment(&name).unwrap());
-        let search_envs = SearchEnvironments::from_opt_env(&project, environment, platform);
+        let search_envs = SearchEnvironments::from_opt_env(&project, environment, platform)
+            .with_ignore_system_requirements(true);
 
         let graph = TaskGraph::from_cmd_args(
             &project,


### PR DESCRIPTION
This PR removes the system requirements check for some of the tests. Checking the system requirements is not required for these tests.

Fixes https://github.com/prefix-dev/pixi/issues/1738