### PR TITLE
fix: increase stack size in debug mode on windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,9 @@
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
+
+[target.'cfg(all(windows, debug_assertions))']
+rustflags = [
+  # increase the stack size to prevent overflowing the stack in debug
+  "-C",
+  "link-arg=/STACK:8000000",
+]


### PR DESCRIPTION
Fixes #1414 

When running `pixi` in debug mode on windows you would occasionally encounter a `thread 'main' has overflowed its stack`. This PR increases the stack size on windows in debug mode to fix this issue.

As taken from:

https://users.rust-lang.org/t/stack-overflow-when-compiling-on-windows-10/50818/8