### PR TITLE
feat: improve parsing errors of `pypi-dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ is_executable = "1.0.1"
 itertools = "0.13.0"
 lazy_static = "1.4.0"
 libc = { version = "0.2.153", default-features = false }
-miette = "7.2.0"
+miette = { version = "7.2.0", features = ["fancy"] }
 minijinja = "2.1.1"
 nix = { version = "0.29.0", default-features = false }
 once_cell = "1.19.0"

--- a/crates/pixi_manifest/src/pypi/snapshots/pixi_manifest__pypi__pypi_requirement__tests__deserialize_failing.snap
+++ b/crates/pixi_manifest/src/pypi/snapshots/pixi_manifest__pypi__pypi_requirement__tests__deserialize_failing.snap
@@ -1,0 +1,70 @@
+---
+source: crates/pixi_manifest/src/pypi/pypi_requirement.rs
+expression: snapshot
+---
+- input:
+    ver: 1.2.3
+  result:
+    error: "ERROR: unknown field `ver`, expected one of `version`, `extras`, `path`, `editable`, `git`, `branch`, `tag`, `rev`, `url`, `subdirectory`"
+- input:
+    path: foobar
+    version: "==1.2.3"
+  result:
+    error: "ERROR: `version` cannot be used with `path`"
+- input:
+    version: //
+  result:
+    error: "ERROR: Failed to parse version: Unexpected end of version specifier, expected operator:\n//\n^^\n"
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    branch: main
+    tag: v1
+  result:
+    error: "ERROR: Only one of `branch` or `tag` or `rev` can be specified"
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    branch: main
+    tag: v1
+    rev: "123456"
+  result:
+    error: "ERROR: Only one of `branch` or `tag` or `rev` can be specified"
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    branch: main
+    rev: v1
+  result:
+    error: "ERROR: Only one of `branch` or `tag` or `rev` can be specified"
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    tag: v1
+    rev: "123456"
+  result:
+    error: "ERROR: Only one of `branch` or `tag` or `rev` can be specified"
+- input:
+    git: "ssh://github.com:conda-forge/21cmfast-feedstock"
+  result:
+    error: "ERROR: invalid value: string \"ssh://github.com:conda-forge/21cmfast-feedstock\", expected invalid port number"
+- input:
+    branch: main
+    tag: v1
+    rev: "123456"
+  result:
+    error: "ERROR: `branch`, `rev`, and `tag` are only valid when `git` is specified"
+- input: /path/style
+  result:
+    error: "ERROR: it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = \"/path/style\" }'"
+- input: "./path/style"
+  result:
+    error: "ERROR: it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = \"./path/style\" }'"
+- input: "\\path\\style"
+  result:
+    error: "ERROR: it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = \"\\path\\style\" }'"
+- input: ~/path/style
+  result:
+    error: "ERROR: it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = \"~/path/style\" }'"
+- input: "https://example.com"
+  result:
+    error: "ERROR: it seems you're trying to add a url dependency, please specify as a table with a `url` key: '{ url = \"https://example.com\" }'"
+- input: "https://github.com/conda-forge/21cmfast-feedstock"
+  result:
+    error: "ERROR: it seems you're trying to add a git dependency, please specify as a table with a `git` key: '{ git = \"https://github.com/conda-forge/21cmfast-feedstock\" }'"

--- a/crates/pixi_manifest/src/pypi/snapshots/pixi_manifest__pypi__pypi_requirement__tests__deserialize_succeeding.snap
+++ b/crates/pixi_manifest/src/pypi/snapshots/pixi_manifest__pypi__pypi_requirement__tests__deserialize_succeeding.snap
@@ -1,0 +1,70 @@
+---
+source: crates/pixi_manifest/src/pypi/pypi_requirement.rs
+expression: snapshot
+---
+- input: "==1.2.3"
+  result: "==1.2.3"
+- input:
+    version: "==1.2.3"
+  result:
+    version: "==1.2.3"
+    extras: []
+- input: "*"
+  result: "*"
+- input:
+    path: foobar
+  result:
+    path: foobar
+    editable: ~
+    extras: []
+- input:
+    path: ~/.cache
+  result:
+    path: ~/.cache
+    editable: ~
+    extras: []
+- input:
+    url: "https://conda.anaconda.org/conda-forge/linux-64/21cmfast-3.3.1-py38h0db86a8_1.conda"
+  result:
+    url: "https://conda.anaconda.org/conda-forge/linux-64/21cmfast-3.3.1-py38h0db86a8_1.conda"
+    subdirectory: ~
+    extras: []
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+  result:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    branch: ~
+    tag: ~
+    rev: ~
+    subdirectory: ~
+    extras: []
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    branch: main
+  result:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    branch: main
+    tag: ~
+    rev: ~
+    subdirectory: ~
+    extras: []
+- input:
+    git: "ssh://github.com/conda-forge/21cmfast-feedstock"
+    tag: v1.2.3
+  result:
+    git: "ssh://github.com/conda-forge/21cmfast-feedstock"
+    branch: ~
+    tag: v1.2.3
+    rev: ~
+    subdirectory: ~
+    extras: []
+- input:
+    git: "https://github.com/prefix-dev/rattler-build"
+    rev: "123456"
+  result:
+    git: "https://github.com/prefix-dev/rattler-build"
+    branch: ~
+    tag: ~
+    rev: "123456"
+    subdirectory: ~
+    extras: []


### PR DESCRIPTION
Further improves https://github.com/prefix-dev/pixi/issues/1858

Not sure why the formatting is weird but at least it tells you the actual problem:
![image](https://github.com/user-attachments/assets/f856b90d-2bc8-4034-a7da-03e9d3bedd5a)
Custom error:
![image](https://github.com/user-attachments/assets/1348ca9e-ca17-4f5e-a119-8110b617c173)
