### PR TITLE
fix: pinning logic for minor and major

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -272,6 +272,7 @@ impl PinningStrategy {
     ) -> Option<VersionSpec> {
         let (min_version, max_version) = versions.clone().into_iter().minmax().into_option()?;
         let lower_bound = min_version.clone();
+        let num_segments = max_version.segment_count();
 
         let constraint = match self {
             Self::ExactVersion => VersionSpec::Group(
@@ -285,7 +286,7 @@ impl PinningStrategy {
             Self::Major => {
                 let upper_bound = max_version
                     .clone()
-                    .pop_segments(2)
+                    .pop_segments(num_segments.saturating_sub(1))
                     .unwrap_or(max_version.to_owned())
                     .bump(VersionBumpType::Major)
                     .ok()?;
@@ -300,7 +301,7 @@ impl PinningStrategy {
             Self::Minor => {
                 let upper_bound = max_version
                     .clone()
-                    .pop_segments(1)
+                    .pop_segments(num_segments.saturating_sub(2))
                     .unwrap_or(max_version.to_owned())
                     .bump(VersionBumpType::Minor)
                     .ok()?;
@@ -1293,6 +1294,7 @@ UNUSED = "unused"
             vec!["1.2"],
             vec!["1.2", "2"],
             vec!["1.2", "1!2.0"],
+            vec!["24.2"],
         ];
 
         // We could use `strum` for this, but it requires another dependency

--- a/crates/pixi_config/src/snapshots/pixi_config__tests__version_constraints.snap
+++ b/crates/pixi_config/src/snapshots/pixi_config__tests__version_constraints.snap
@@ -16,6 +16,7 @@ expression: results
 >=1.2,<2 from 1.2
 >=1.2,<3 from 1.2, 2
 >=1.2,<1!3 from 1.2, 1!2.0
+>=24.2,<25 from 24.2
 
 ### Strategy: 'Major'
 >=1.2.3,<2 from 1.2.3
@@ -28,9 +29,10 @@ expression: results
 >=1.2.0,<2 from 1.2.0, 1.3.0
 >=0.2.0,<1 from 0.2.0, 0.3.0
 >=0.2.0,<2 from 0.2.0, 1.3.0
->=1.2,<2.2 from 1.2
+>=1.2,<2 from 1.2
 >=1.2,<3 from 1.2, 2
->=1.2,<1!3.0 from 1.2, 1!2.0
+>=1.2,<1!3 from 1.2, 1!2.0
+>=24.2,<25 from 24.2
 
 ### Strategy: 'Minor'
 >=1.2.3,<1.3 from 1.2.3
@@ -43,9 +45,10 @@ expression: results
 >=1.2.0,<1.4 from 1.2.0, 1.3.0
 >=0.2.0,<0.4 from 0.2.0, 0.3.0
 >=0.2.0,<1.4 from 0.2.0, 1.3.0
->=1.2,<1.1 from 1.2
+>=1.2,<1.3 from 1.2
 >=1.2,<2.1 from 1.2, 2
 >=1.2,<1!2.1 from 1.2, 1!2.0
+>=24.2,<24.3 from 24.2
 
 ### Strategy: 'ExactVersion'
 ==1.2.3 from 1.2.3
@@ -61,6 +64,7 @@ expression: results
 ==1.2 from 1.2
 ==1.2|==2 from 1.2, 2
 ==1.2|==1!2.0 from 1.2, 1!2.0
+==24.2 from 24.2
 
 ### Strategy: 'LatestUp'
 >=1.2.3 from 1.2.3
@@ -76,6 +80,7 @@ expression: results
 >=1.2 from 1.2
 >=1.2 from 1.2, 2
 >=1.2 from 1.2, 1!2.0
+>=24.2 from 24.2
 
 ### Strategy: 'NoPin'
 * from 1.2.3
@@ -91,3 +96,4 @@ expression: results
 * from 1.2
 * from 1.2, 2
 * from 1.2, 1!2.0
+* from 24.2


### PR DESCRIPTION
There was a pinning bug that was caused by versions that did not have 3 segments.

This PR fixes that.

Fixes #1878 