### PR TITLE
fix: use default indexes if non where given by the lockfile

### DIFF
--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -4,7 +4,7 @@ use std::{
 
 use distribution_filename::{DistExtension, ExtensionError, SourceDistExtension, WheelFilename};
 use distribution_types::{
-    BuiltDist, CachedDist, Dist, IndexUrl, InstalledDist, Name, RegistryBuiltDist,
+    BuiltDist, CachedDist, Dist, IndexLocations, IndexUrl, InstalledDist, Name, RegistryBuiltDist,
     RegistryBuiltWheel, RegistrySourceDist, SourceDist, UrlString,
 };
 use install_wheel_rs::linker::LinkMode;
@@ -608,7 +608,7 @@ pub async fn update_python_distributions(
 
     let index_locations = pypi_indexes
         .map(|indexes| locked_indexes_to_index_locations(indexes, lock_file_dir))
-        .unwrap()
+        .unwrap_or_else(|| Ok(IndexLocations::default()))
         .into_diagnostic()?;
 
     let registry_client = Arc::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod activation;
 pub mod cli;
 pub(crate) mod conda_pypi_clobber;
-mod environment;
+pub mod environment;
 mod install_pypi;
 mod install_wheel;
 mod lock_file;

--- a/tests/satisfiability/old_lock_file/pixi.lock
+++ b/tests/satisfiability/old_lock_file/pixi.lock
@@ -1,0 +1,1098 @@
+version: 4
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+        - pypi: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        - pypi: https://files.pythonhosted.org/packages/e3/23/c9843d7550092ae7ad380611c238f44afef66f58f76c1dab7dcf313e4339/werkzeug-3.0.2-py3-none-any.whl
+      osx-64:
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+        - pypi: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl
+        - pypi: https://files.pythonhosted.org/packages/e3/23/c9843d7550092ae7ad380611c238f44afef66f58f76c1dab7dcf313e4339/werkzeug-3.0.2-py3-none-any.whl
+      osx-arm64:
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+        - pypi: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl
+        - pypi: https://files.pythonhosted.org/packages/e3/23/c9843d7550092ae7ad380611c238f44afef66f58f76c1dab7dcf313e4339/werkzeug-3.0.2-py3-none-any.whl
+      win-64:
+        - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+        - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+        - pypi: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl
+        - pypi: https://files.pythonhosted.org/packages/e3/23/c9843d7550092ae7ad380611c238f44afef66f58f76c1dab7dcf313e4339/werkzeug-3.0.2-py3-none-any.whl
+packages:
+  - kind: conda
+    name: _libgcc_mutex
+    version: '0.1'
+    build: conda_forge
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+    md5: d7c89558ba9fa0495403155b64376d81
+    license: None
+    size: 2562
+    timestamp: 1578324546067
+  - kind: conda
+    name: _openmp_mutex
+    version: '4.5'
+    build: 2_gnu
+    build_number: 16
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+    sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+    md5: 73aaf86a425cc6e73fcf236a5a46396d
+    depends:
+      - _libgcc_mutex 0.1 conda_forge
+      - libgomp >=7.5.0
+    constrains:
+      - openmp_impl 9999
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 23621
+    timestamp: 1650670423406
+  - kind: pypi
+    name: blinker
+    version: 1.7.0
+    url: https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl
+    sha256: c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9
+    requires_python: '>=3.8'
+  - kind: pypi
+    name: boltons
+    version: 24.0.0
+    url: https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl
+    sha256: 9618695a6ec4f50412e7072e5d78910a00b4111d0b9b549e4a3d60bc321e7807
+    requires_python: '>=3.7'
+  - kind: conda
+    name: bzip2
+    version: 1.0.8
+    build: h10d778d_5
+    build_number: 5
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
+    sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
+    md5: 6097a6ca9ada32699b5fc4312dd6ef18
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 127885
+    timestamp: 1699280178474
+  - kind: conda
+    name: bzip2
+    version: 1.0.8
+    build: h93a5062_5
+    build_number: 5
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+    sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+    md5: 1bbc659ca658bfd49a481b5ef7a0f40f
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 122325
+    timestamp: 1699280294368
+  - kind: conda
+    name: bzip2
+    version: 1.0.8
+    build: hcfcfb64_5
+    build_number: 5
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
+    sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
+    md5: 26eb8ca6ea332b675e11704cce84a3be
+    depends:
+      - ucrt >=10.0.20348.0
+      - vc >=14.2,<15
+      - vc14_runtime >=14.29.30139
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 124580
+    timestamp: 1699280668742
+  - kind: conda
+    name: bzip2
+    version: 1.0.8
+    build: hd590300_5
+    build_number: 5
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+    md5: 69b8b6202a07720f448be700e300ccf4
+    depends:
+      - libgcc-ng >=12
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 254228
+    timestamp: 1699279927352
+  - kind: conda
+    name: ca-certificates
+    version: 2024.2.2
+    build: h56e8100_0
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+    sha256: 4d587088ecccd393fec3420b64f1af4ee1a0e6897a45cfd5ef38055322cea5d0
+    md5: 63da060240ab8087b60d1357051ea7d6
+    license: ISC
+    size: 155886
+    timestamp: 1706843918052
+  - kind: conda
+    name: ca-certificates
+    version: 2024.2.2
+    build: h8857fd0_0
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+    sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
+    md5: f2eacee8c33c43692f1ccfd33d0f50b1
+    license: ISC
+    size: 155665
+    timestamp: 1706843838227
+  - kind: conda
+    name: ca-certificates
+    version: 2024.2.2
+    build: hbcca054_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+    sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
+    md5: 2f4327a1cbe7f022401b236e915a5fef
+    license: ISC
+    size: 155432
+    timestamp: 1706843687645
+  - kind: conda
+    name: ca-certificates
+    version: 2024.2.2
+    build: hf0a4a13_0
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+    sha256: 49bc3439816ac72d0c0e0f144b8cc870fdcc4adec2e861407ec818d8116b2204
+    md5: fb416a1795f18dcc5a038bc2dc54edf9
+    license: ISC
+    size: 155725
+    timestamp: 1706844034242
+  - kind: pypi
+    name: click
+    version: 8.1.7
+    url: https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl
+    sha256: ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28
+    requires_dist:
+      - colorama ; platform_system == 'Windows'
+      - importlib-metadata ; python_version < '3.8'
+    requires_python: '>=3.7'
+  - kind: pypi
+    name: colorama
+    version: 0.4.6
+    url: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+    sha256: 4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
+    requires_python: '!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7'
+  - kind: pypi
+    name: flask
+    version: 2.3.3
+    url: https://files.pythonhosted.org/packages/fd/56/26f0be8adc2b4257df20c1c4260ddd0aa396cf8e75d90ab2f7ff99bc34f9/flask-2.3.3-py3-none-any.whl
+    sha256: f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b
+    requires_dist:
+      - werkzeug >=2.3.7
+      - jinja2 >=3.1.2
+      - itsdangerous >=2.1.2
+      - click >=8.1.3
+      - blinker >=1.6.2
+      - importlib-metadata >=3.6.0 ; python_version < '3.10'
+      - asgiref >=3.2 ; extra == 'async'
+      - python-dotenv ; extra == 'dotenv'
+    requires_python: '>=3.8'
+  - kind: pypi
+    name: itsdangerous
+    version: 2.1.2
+    url: https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl
+    sha256: 2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44
+    requires_python: '>=3.7'
+  - kind: pypi
+    name: jinja2
+    version: 3.1.3
+    url: https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl
+    sha256: 7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa
+    requires_dist:
+      - markupsafe >=2.0
+      - babel >=2.7 ; extra == 'i18n'
+    requires_python: '>=3.7'
+  - kind: conda
+    name: ld_impl_linux-64
+    version: '2.40'
+    build: h41732ed_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+    md5: 7aca3059a1729aa76c597603f10b0dd3
+    constrains:
+      - binutils_impl_linux-64 2.40
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 704696
+    timestamp: 1674833944779
+  - kind: conda
+    name: libexpat
+    version: 2.6.2
+    build: h59595ed_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+    sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+    md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+    depends:
+      - libgcc-ng >=12
+    constrains:
+      - expat 2.6.2.*
+    license: MIT
+    license_family: MIT
+    size: 73730
+    timestamp: 1710362120304
+  - kind: conda
+    name: libexpat
+    version: 2.6.2
+    build: h63175ca_0
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+    sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
+    md5: bc592d03f62779511d392c175dcece64
+    constrains:
+      - expat 2.6.2.*
+    license: MIT
+    license_family: MIT
+    size: 139224
+    timestamp: 1710362609641
+  - kind: conda
+    name: libexpat
+    version: 2.6.2
+    build: h73e2aa4_0
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+    sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
+    md5: 3d1d51c8f716d97c864d12f7af329526
+    constrains:
+      - expat 2.6.2.*
+    license: MIT
+    license_family: MIT
+    size: 69246
+    timestamp: 1710362566073
+  - kind: conda
+    name: libexpat
+    version: 2.6.2
+    build: hebf3989_0
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+    sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+    md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+    constrains:
+      - expat 2.6.2.*
+    license: MIT
+    license_family: MIT
+    size: 63655
+    timestamp: 1710362424980
+  - kind: conda
+    name: libffi
+    version: 3.4.2
+    build: h0d85af4_5
+    build_number: 5
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+    sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+    md5: ccb34fb14960ad8b125962d3d79b31a9
+    license: MIT
+    license_family: MIT
+    size: 51348
+    timestamp: 1636488394370
+  - kind: conda
+    name: libffi
+    version: 3.4.2
+    build: h3422bc3_5
+    build_number: 5
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+    md5: 086914b672be056eb70fd4285b6783b6
+    license: MIT
+    license_family: MIT
+    size: 39020
+    timestamp: 1636488587153
+  - kind: conda
+    name: libffi
+    version: 3.4.2
+    build: h7f98852_5
+    build_number: 5
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+    depends:
+      - libgcc-ng >=9.4.0
+    license: MIT
+    license_family: MIT
+    size: 58292
+    timestamp: 1636488182923
+  - kind: conda
+    name: libffi
+    version: 3.4.2
+    build: h8ffe710_5
+    build_number: 5
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+    sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+    md5: 2c96d1b6915b408893f9472569dee135
+    depends:
+      - vc >=14.1,<15.0a0
+      - vs2015_runtime >=14.16.27012
+    license: MIT
+    license_family: MIT
+    size: 42063
+    timestamp: 1636489106777
+  - kind: conda
+    name: libgcc-ng
+    version: 13.2.0
+    build: h807b86a_5
+    build_number: 5
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
+    sha256: d32f78bfaac282cfe5205f46d558704ad737b8dbf71f9227788a5ca80facaba4
+    md5: d4ff227c46917d3b4565302a2bbb276b
+    depends:
+      - _libgcc_mutex 0.1 conda_forge
+      - _openmp_mutex >=4.5
+    constrains:
+      - libgomp 13.2.0 h807b86a_5
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 770506
+    timestamp: 1706819192021
+  - kind: conda
+    name: libgomp
+    version: 13.2.0
+    build: h807b86a_5
+    build_number: 5
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
+    sha256: 0d3d4b1b0134283ea02d58e8eb5accf3655464cf7159abf098cc694002f8d34e
+    md5: d211c42b9ce49aee3734fdc828731689
+    depends:
+      - _libgcc_mutex 0.1 conda_forge
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 419751
+    timestamp: 1706819107383
+  - kind: conda
+    name: libnsl
+    version: 2.0.1
+    build: hd590300_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+    depends:
+      - libgcc-ng >=12
+    license: LGPL-2.1-only
+    license_family: GPL
+    size: 33408
+    timestamp: 1697359010159
+  - kind: conda
+    name: libsqlite
+    version: 3.45.2
+    build: h091b4b1_0
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
+    sha256: 7c234320a1a2132b9cc972aaa06bb215bb220a5b1addb0bed7a5a321c805920e
+    md5: 9d07427ee5bd9afd1e11ce14368a48d6
+    depends:
+      - libzlib >=1.2.13,<1.3.0a0
+    license: Unlicense
+    size: 825300
+    timestamp: 1710255078823
+  - kind: conda
+    name: libsqlite
+    version: 3.45.2
+    build: h2797004_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+    sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
+    md5: 866983a220e27a80cb75e85cb30466a1
+    depends:
+      - libgcc-ng >=12
+      - libzlib >=1.2.13,<1.3.0a0
+    license: Unlicense
+    size: 857489
+    timestamp: 1710254744982
+  - kind: conda
+    name: libsqlite
+    version: 3.45.2
+    build: h92b6c6a_0
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
+    sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
+    md5: 086f56e13a96a6cfb1bf640505ae6b70
+    depends:
+      - libzlib >=1.2.13,<1.3.0a0
+    license: Unlicense
+    size: 902355
+    timestamp: 1710254991672
+  - kind: conda
+    name: libsqlite
+    version: 3.45.2
+    build: hcfcfb64_0
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
+    sha256: 4bb24b986550275a6d02835150d943c4c675808d05c0efc5c2a22154d007a69f
+    md5: f95359f8dc5abf7da7776ece9ef10bc5
+    depends:
+      - ucrt >=10.0.20348.0
+      - vc >=14.2,<15
+      - vc14_runtime >=14.29.30139
+    license: Unlicense
+    size: 869606
+    timestamp: 1710255095740
+  - kind: conda
+    name: libuuid
+    version: 2.38.1
+    build: h0b41bf4_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+    depends:
+      - libgcc-ng >=12
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 33601
+    timestamp: 1680112270483
+  - kind: conda
+    name: libxcrypt
+    version: 4.4.36
+    build: hd590300_1
+    build_number: 1
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+    sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+    md5: 5aa797f8787fe7a17d1b0821485b5adc
+    depends:
+      - libgcc-ng >=12
+    license: LGPL-2.1-or-later
+    size: 100393
+    timestamp: 1702724383534
+  - kind: conda
+    name: libzlib
+    version: 1.2.13
+    build: h53f4e23_5
+    build_number: 5
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+    sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+    md5: 1a47f5236db2e06a320ffa0392f81bd8
+    constrains:
+      - zlib 1.2.13 *_5
+    license: Zlib
+    license_family: Other
+    size: 48102
+    timestamp: 1686575426584
+  - kind: conda
+    name: libzlib
+    version: 1.2.13
+    build: h8a1eda9_5
+    build_number: 5
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+    sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
+    md5: 4a3ad23f6e16f99c04e166767193d700
+    constrains:
+      - zlib 1.2.13 *_5
+    license: Zlib
+    license_family: Other
+    size: 59404
+    timestamp: 1686575566695
+  - kind: conda
+    name: libzlib
+    version: 1.2.13
+    build: hcfcfb64_5
+    build_number: 5
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+    sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
+    md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+    depends:
+      - ucrt >=10.0.20348.0
+      - vc >=14.2,<15
+      - vc14_runtime >=14.29.30139
+    constrains:
+      - zlib 1.2.13 *_5
+    license: Zlib
+    license_family: Other
+    size: 55800
+    timestamp: 1686575452215
+  - kind: conda
+    name: libzlib
+    version: 1.2.13
+    build: hd590300_5
+    build_number: 5
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+    md5: f36c115f1ee199da648e0597ec2047ad
+    depends:
+      - libgcc-ng >=12
+    constrains:
+      - zlib 1.2.13 *_5
+    license: Zlib
+    license_family: Other
+    size: 61588
+    timestamp: 1686575217516
+  - kind: pypi
+    name: markupsafe
+    version: 2.1.5
+    url: https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    sha256: f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5
+    requires_python: '>=3.7'
+  - kind: pypi
+    name: markupsafe
+    version: 2.1.5
+    url: https://files.pythonhosted.org/packages/48/d6/e7cd795fc710292c3af3a06d80868ce4b02bfbbf370b7cee11d282815a2a/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl
+    sha256: 3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4
+    requires_python: '>=3.7'
+  - kind: pypi
+    name: markupsafe
+    version: 2.1.5
+    url: https://files.pythonhosted.org/packages/53/bd/583bf3e4c8d6a321938c13f49d44024dbe5ed63e0a7ba127e454a66da974/MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl
+    sha256: 8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1
+    requires_python: '>=3.7'
+  - kind: pypi
+    name: markupsafe
+    version: 2.1.5
+    url: https://files.pythonhosted.org/packages/3f/14/c3554d512d5f9100a95e737502f4a2323a1959f6d0d01e0d0997b35f7b10/MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl
+    sha256: 823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb
+    requires_python: '>=3.7'
+  - kind: conda
+    name: ncurses
+    version: 6.4.20240210
+    build: h078ce10_0
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
+    sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
+    md5: 616ae8691e6608527d0071e6766dcb81
+    license: X11 AND BSD-3-Clause
+    size: 820249
+    timestamp: 1710866874348
+  - kind: conda
+    name: ncurses
+    version: 6.4.20240210
+    build: h59595ed_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
+    sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
+    md5: 97da8860a0da5413c7c98a3b3838a645
+    depends:
+      - libgcc-ng >=12
+    license: X11 AND BSD-3-Clause
+    size: 895669
+    timestamp: 1710866638986
+  - kind: conda
+    name: ncurses
+    version: 6.4.20240210
+    build: h73e2aa4_0
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
+    sha256: 50b72acf08acbc4e5332807653e2ca6b26d4326e8af16fad1fd3f2ce9ea55503
+    md5: 50f28c512e9ad78589e3eab34833f762
+    license: X11 AND BSD-3-Clause
+    size: 823010
+    timestamp: 1710866856626
+  - kind: conda
+    name: openssl
+    version: 3.2.1
+    build: h0d3ecfb_1
+    build_number: 1
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+    sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
+    md5: eb580fb888d93d5d550c557323ac5cee
+    depends:
+      - ca-certificates
+    constrains:
+      - pyopenssl >=22.1
+    license: Apache-2.0
+    license_family: Apache
+    size: 2855250
+    timestamp: 1710793435903
+  - kind: conda
+    name: openssl
+    version: 3.2.1
+    build: hcfcfb64_1
+    build_number: 1
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
+    sha256: 61ce4e11c3c26ed4e4d9b7e7e2483121a1741ad0f9c8db0a91a28b6e05182ce6
+    md5: 958e0418e93e50c575bff70fbcaa12d8
+    depends:
+      - ca-certificates
+      - ucrt >=10.0.20348.0
+      - vc >=14.2,<15
+      - vc14_runtime >=14.29.30139
+    constrains:
+      - pyopenssl >=22.1
+    license: Apache-2.0
+    license_family: Apache
+    size: 8230112
+    timestamp: 1710796158475
+  - kind: conda
+    name: openssl
+    version: 3.2.1
+    build: hd590300_1
+    build_number: 1
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+    sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
+    md5: 9d731343cff6ee2e5a25c4a091bf8e2a
+    depends:
+      - ca-certificates
+      - libgcc-ng >=12
+    constrains:
+      - pyopenssl >=22.1
+    license: Apache-2.0
+    license_family: Apache
+    size: 2865379
+    timestamp: 1710793235846
+  - kind: conda
+    name: openssl
+    version: 3.2.1
+    build: hd75f5a5_1
+    build_number: 1
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+    sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
+    md5: 570a6f04802df580be529f3a72d2bbf7
+    depends:
+      - ca-certificates
+    constrains:
+      - pyopenssl >=22.1
+    license: Apache-2.0
+    license_family: Apache
+    size: 2506344
+    timestamp: 1710793930515
+  - kind: conda
+    name: python
+    version: 3.12.2
+    build: h2628c8c_0_cpython
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
+    sha256: b8eda863b48ae4531635e23fd15e759d93212b6204c6847d591e25fa5fd67477
+    md5: be8803e9f75a477df61d4aabea3c1246
+    depends:
+      - bzip2 >=1.0.8,<2.0a0
+      - libexpat >=2.5.0,<3.0a0
+      - libffi >=3.4,<4.0a0
+      - libsqlite >=3.45.1,<4.0a0
+      - libzlib >=1.2.13,<1.3.0a0
+      - openssl >=3.2.1,<4.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+      - ucrt >=10.0.20348.0
+      - vc >=14.2,<15
+      - vc14_runtime >=14.29.30139
+      - xz >=5.2.6,<6.0a0
+    constrains:
+      - python_abi 3.12.* *_cp312
+    license: Python-2.0
+    size: 16083296
+    timestamp: 1708116662336
+  - kind: conda
+    name: python
+    version: 3.12.2
+    build: h9f0c242_0_cpython
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
+    sha256: 7647ac06c3798a182a4bcb1ff58864f1ef81eb3acea6971295304c23e43252fb
+    md5: 0179b8007ba008cf5bec11f3b3853902
+    depends:
+      - bzip2 >=1.0.8,<2.0a0
+      - libexpat >=2.5.0,<3.0a0
+      - libffi >=3.4,<4.0a0
+      - libsqlite >=3.45.1,<4.0a0
+      - libzlib >=1.2.13,<1.3.0a0
+      - ncurses >=6.4,<7.0a0
+      - openssl >=3.2.1,<4.0a0
+      - readline >=8.2,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+      - xz >=5.2.6,<6.0a0
+    constrains:
+      - python_abi 3.12.* *_cp312
+    license: Python-2.0
+    size: 14596811
+    timestamp: 1708118065292
+  - kind: conda
+    name: python
+    version: 3.12.2
+    build: hab00c5b_0_cpython
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
+    sha256: ddb7a2d8d78046bda5d7631e6814f9468d2eb054e10f86f4648c9d1fdaa30c0f
+    md5: ad7b68400f3a6ebe72b00be093c7f301
+    depends:
+      - bzip2 >=1.0.8,<2.0a0
+      - ld_impl_linux-64 >=2.36.1
+      - libexpat >=2.5.0,<3.0a0
+      - libffi >=3.4,<4.0a0
+      - libgcc-ng >=12
+      - libnsl >=2.0.1,<2.1.0a0
+      - libsqlite >=3.45.1,<4.0a0
+      - libuuid >=2.38.1,<3.0a0
+      - libxcrypt >=4.4.36
+      - libzlib >=1.2.13,<1.3.0a0
+      - ncurses >=6.4,<7.0a0
+      - openssl >=3.2.1,<4.0a0
+      - readline >=8.2,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+      - xz >=5.2.6,<6.0a0
+    constrains:
+      - python_abi 3.12.* *_cp312
+    license: Python-2.0
+    size: 32312631
+    timestamp: 1708118077305
+  - kind: conda
+    name: python
+    version: 3.12.2
+    build: hdf0ec26_0_cpython
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
+    sha256: ccd6c55a286d51d907c878ed2bfa7d1becce0fee71374a9386c5eb90d803ac72
+    md5: 85e91138ae921a2771f57a50120272bd
+    depends:
+      - bzip2 >=1.0.8,<2.0a0
+      - libexpat >=2.5.0,<3.0a0
+      - libffi >=3.4,<4.0a0
+      - libsqlite >=3.45.1,<4.0a0
+      - libzlib >=1.2.13,<1.3.0a0
+      - ncurses >=6.4,<7.0a0
+      - openssl >=3.2.1,<4.0a0
+      - readline >=8.2,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+      - xz >=5.2.6,<6.0a0
+    constrains:
+      - python_abi 3.12.* *_cp312
+    license: Python-2.0
+    size: 13085901
+    timestamp: 1708117361381
+  - kind: conda
+    name: readline
+    version: '8.2'
+    build: h8228510_1
+    build_number: 1
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+    md5: 47d31b792659ce70f470b5c82fdfb7a4
+    depends:
+      - libgcc-ng >=12
+      - ncurses >=6.3,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 281456
+    timestamp: 1679532220005
+  - kind: conda
+    name: readline
+    version: '8.2'
+    build: h92ec313_1
+    build_number: 1
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+    sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+    md5: 8cbb776a2f641b943d413b3e19df71f4
+    depends:
+      - ncurses >=6.3,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 250351
+    timestamp: 1679532511311
+  - kind: conda
+    name: readline
+    version: '8.2'
+    build: h9e318b2_1
+    build_number: 1
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+    sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
+    md5: f17f77f2acf4d344734bda76829ce14e
+    depends:
+      - ncurses >=6.3,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 255870
+    timestamp: 1679532707590
+  - kind: conda
+    name: tk
+    version: 8.6.13
+    build: h1abcd95_1
+    build_number: 1
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
+    sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
+    md5: bf830ba5afc507c6232d4ef0fb1a882d
+    depends:
+      - libzlib >=1.2.13,<1.3.0a0
+    license: TCL
+    license_family: BSD
+    size: 3270220
+    timestamp: 1699202389792
+  - kind: conda
+    name: tk
+    version: 8.6.13
+    build: h5083fa2_1
+    build_number: 1
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+    md5: b50a57ba89c32b62428b71a875291c9b
+    depends:
+      - libzlib >=1.2.13,<1.3.0a0
+    license: TCL
+    license_family: BSD
+    size: 3145523
+    timestamp: 1699202432999
+  - kind: conda
+    name: tk
+    version: 8.6.13
+    build: h5226925_1
+    build_number: 1
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+    sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
+    md5: fc048363eb8f03cd1737600a5d08aafe
+    depends:
+      - ucrt >=10.0.20348.0
+      - vc >=14.2,<15
+      - vc14_runtime >=14.29.30139
+    license: TCL
+    license_family: BSD
+    size: 3503410
+    timestamp: 1699202577803
+  - kind: conda
+    name: tk
+    version: 8.6.13
+    build: noxft_h4845f30_101
+    build_number: 101
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+    md5: d453b98d9c83e71da0741bb0ff4d76bc
+    depends:
+      - libgcc-ng >=12
+      - libzlib >=1.2.13,<1.3.0a0
+    license: TCL
+    license_family: BSD
+    size: 3318875
+    timestamp: 1699202167581
+  - kind: conda
+    name: tzdata
+    version: 2024a
+    build: h0c530f3_0
+    subdir: noarch
+    noarch: generic
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+    md5: 161081fc7cec0bfda0d86d7cb595f8d8
+    license: LicenseRef-Public-Domain
+    size: 119815
+    timestamp: 1706886945727
+  - kind: conda
+    name: ucrt
+    version: 10.0.22621.0
+    build: h57928b3_0
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+    sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
+    md5: 72608f6cd3e5898229c3ea16deb1ac43
+    constrains:
+      - vs2015_runtime >=14.29.30037
+    license: LicenseRef-Proprietary
+    license_family: PROPRIETARY
+    size: 1283972
+    timestamp: 1666630199266
+  - kind: conda
+    name: vc
+    version: '14.3'
+    build: hcf57466_18
+    build_number: 18
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
+    sha256: 447a8d8292a7b2107dcc18afb67f046824711a652725fc0f522c368e7a7b8318
+    md5: 20e1e652a4c740fa719002a8449994a2
+    depends:
+      - vc14_runtime >=14.38.33130
+    track_features:
+      - vc14
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 16977
+    timestamp: 1702511255313
+  - kind: conda
+    name: vc14_runtime
+    version: 14.38.33130
+    build: h82b7239_18
+    build_number: 18
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+    sha256: bf94c9af4b2e9cba88207001197e695934eadc96a5c5e4cd7597e950aae3d8ff
+    md5: 8be79fdd2725ddf7bbf8a27a4c1f79ba
+    depends:
+      - ucrt >=10.0.20348.0
+    constrains:
+      - vs2015_runtime 14.38.33130.* *_18
+    license: LicenseRef-ProprietaryMicrosoft
+    license_family: Proprietary
+    size: 749868
+    timestamp: 1702511239004
+  - kind: conda
+    name: vs2015_runtime
+    version: 14.38.33130
+    build: hcb4865c_18
+    build_number: 18
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
+    sha256: a2fec221f361d6263c117f4ea6d772b21c90a2f8edc6f3eb0eadec6bfe8843db
+    md5: 10d42885e3ed84e575b454db30f1aa93
+    depends:
+      - vc14_runtime >=14.38.33130
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 16988
+    timestamp: 1702511261442
+  - kind: pypi
+    name: werkzeug
+    version: 3.0.2
+    url: https://files.pythonhosted.org/packages/e3/23/c9843d7550092ae7ad380611c238f44afef66f58f76c1dab7dcf313e4339/werkzeug-3.0.2-py3-none-any.whl
+    sha256: 3aac3f5da756f93030740bc235d3e09449efcf65f2f55e3602e1d851b8f48795
+    requires_dist:
+      - markupsafe >=2.1.1
+      - watchdog >=2.3 ; extra == 'watchdog'
+    requires_python: '>=3.8'
+  - kind: conda
+    name: xz
+    version: 5.2.6
+    build: h166bdaf_0
+    subdir: linux-64
+    url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+    md5: 2161070d867d1b1204ea749c8eec4ef0
+    depends:
+      - libgcc-ng >=12
+    license: LGPL-2.1 and GPL-2.0
+    size: 418368
+    timestamp: 1660346797927
+  - kind: conda
+    name: xz
+    version: 5.2.6
+    build: h57fd34a_0
+    subdir: osx-arm64
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+    sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+    md5: 39c6b54e94014701dd157f4f576ed211
+    license: LGPL-2.1 and GPL-2.0
+    size: 235693
+    timestamp: 1660346961024
+  - kind: conda
+    name: xz
+    version: 5.2.6
+    build: h775f41a_0
+    subdir: osx-64
+    url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+    sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+    md5: a72f9d4ea13d55d745ff1ed594747f10
+    license: LGPL-2.1 and GPL-2.0
+    size: 238119
+    timestamp: 1660346964847
+  - kind: conda
+    name: xz
+    version: 5.2.6
+    build: h8d14728_0
+    subdir: win-64
+    url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+    sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
+    md5: 515d77642eaa3639413c6b1bc3f94219
+    depends:
+      - vc >=14.1,<15
+      - vs2015_runtime >=14.16.27033
+    license: LGPL-2.1 and GPL-2.0
+    size: 217804
+    timestamp: 1660346976440

--- a/tests/satisfiability/old_lock_file/pyproject.toml
+++ b/tests/satisfiability/old_lock_file/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+dependencies = ["flask==2.*"]
+description = "Testing pyproject-manifest."
+name = "pyproject-manifest"
+readme = "README.md"
+requires-python = ">=3.11"
+version = "0.1.0"
+
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools", "wheel"]
+
+[tool.pixi.project]
+channels = ["conda-forge"]
+name = "pyproject-manifest"
+platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
+
+[tool.pixi]
+# This dotted inline table fails with the `toml` parser, but works with `@iarna/toml`.
+pypi-dependencies.boltons = "*"
+
+[tool.pixi.tasks]
+test = "echo 'Running tests...'"


### PR DESCRIPTION
Fixes:
```
/home/runner/.pixi/bin/pixi install --locked --manifest-path pyproject.toml --color always
  thread 'main' panicked at /home/runner/work/pixi/pixi/src/install_pypi.rs:611:10:
  called `Option::unwrap()` on a `None` value
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: The process '/home/runner/.pixi/bin/pixi' failed with exit code 101
```

