### PR TITLE
fix: enable use of manylinux wheeltags once again

### DIFF
--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -139,7 +139,7 @@ pub fn get_pypi_tags(
         implementation_name,
         // TODO: This might not be entirely correct..
         (python_version.0 as u8, python_version.1 as u8),
-        false,
+        true,
         // Should revisit this when this lands: https://github.com/conda-forge/python-feedstock/pull/679
         false,
     )

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -595,7 +595,11 @@ async fn test_many_linux_wheel_tag() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
 
-    pixi.add("python==3.12.*").with_install(true).await.unwrap();
+    pixi.add("python==3.12.*").await.unwrap();
     // We know that this package has many linux wheel tags for this version
-    pixi.add("gmsh==4.13.1").await.unwrap();
+    pixi.add("gmsh==4.13.1")
+        .set_type(pixi::DependencyType::PypiDependency)
+        .with_install(true)
+        .await
+        .unwrap();
 }

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -585,3 +585,17 @@ async fn test_old_lock_install() {
         std::fs::read_to_string("tests/satisfiability/old_lock_file/pixi.lock").unwrap()
     );
 }
+
+/// Only run this test on linux
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[serial]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+#[cfg(target_os = "linux")]
+async fn test_many_linux_wheel_tag() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+
+    pixi.add("python==3.12.*").with_install(true).await.unwrap();
+    // We know that this package has many linux wheel tags for this version
+    pixi.add("gmsh==4.13.1").await.unwrap();
+}


### PR DESCRIPTION
This boolean was filtering out the creation of manylinux wheel tags.