### PR TITLE
feat: use rustls-tls instead of native-tls per default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ repository.workspace = true
 version = "0.28.1"
 
 [features]
-default = ["native-tls"]
+default = ["rustls-tls"]
 native-tls = [
   "reqwest/native-tls",
   "reqwest/native-tls-alpn",


### PR DESCRIPTION
This makes it nicer when installing pixi from within a pixi environment. We also have to pay less attention whether uses have a suitable openssl version installed locally