### PR TITLE
fix: always overwrite when pixi adding the dependency

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -117,7 +117,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     spec_type,
                     &dependency_config.platform,
                     &dependency_config.feature_name(),
-                    DependencyOverwriteBehavior::OverwriteIfExplicit,
+                    DependencyOverwriteBehavior::Overwrite,
                     &channel_config,
                 )?;
                 if added {
@@ -136,7 +136,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     &dependency_config.platform,
                     &dependency_config.feature_name(),
                     Some(args.editable),
-                    DependencyOverwriteBehavior::OverwriteIfExplicit,
+                    DependencyOverwriteBehavior::Overwrite,
                 )?;
                 if added {
                     if spec.version_or_url.is_none() {

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -500,7 +500,7 @@ async fn minimal_lockfile_update_pypi() {
     assert!(lock.contains_pep508_requirement(
         consts::DEFAULT_ENVIRONMENT_NAME,
         Platform::current(),
-        pep508_rs::Requirement::from_str("click==7.1.2").unwrap()
+        pep508_rs::Requirement::from_str("click>7.1.2").unwrap()
     ));
 }
 


### PR DESCRIPTION
Before:
```
pixi add numpy
pixi add pandas==2.0.1
# fails because of numpy <2 requirement
pixi add numpy panda==2.0.1
# Still fails but it should just resolve the two packages together
```
After this PR
```
pixi add numpy
pixi add pandas==2.0.1
# fails because of numpy <2 requirement
pixi add numpy panda==2.0.1
# Works as numpy is readded to the project without constraints and the solve is rerun for it.
```