### PR TITLE
refactor: improve integration tests

### DIFF
--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -149,5 +149,7 @@ jobs:
           echo "Current PATH: $env:PATH"
           pixi --version
         shell: pwsh
+      - name: Typecheck integration tests
+        run: pixi run typecheck-integration
       - name: Run integration tests
         run: pixi run test-integration

--- a/pixi.lock
+++ b/pixi.lock
@@ -82,6 +82,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.3-hd18ef5c_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mimalloc-2.1.7-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mold-2.33.0-h3b4bb38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py312h66e93f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
@@ -89,6 +91,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.3-py312h4b3b743_0.conda
@@ -164,6 +167,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py312hb553811_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
@@ -171,6 +176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-hf7e621a_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.16.3-py312h1b0e595_0.conda
@@ -245,6 +251,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py312h024a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
@@ -252,6 +260,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h7e5086c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.16.3-py312h5280bc4_0.conda
@@ -318,11 +327,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.16.3-py312hfccd98a_0.conda
@@ -1011,10 +1023,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py312h66e93f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.3-py312h4b3b743_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrsistent-0.20.0-py312h98912ed_0.conda
@@ -1047,10 +1062,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py312hb553811_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.16.3-py312h1b0e595_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyrsistent-0.20.0-py312h41838bb_0.conda
@@ -1083,10 +1101,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py312h024a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h7e5086c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.16.3-py312h5280bc4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrsistent-0.20.0-py312he37b823_0.conda
@@ -1119,9 +1140,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.16.3-py312hfccd98a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyrsistent-0.20.0-py312he70551f_0.conda
@@ -4903,6 +4927,101 @@ packages:
   size: 3227
   timestamp: 1608166968312
 - kind: conda
+  name: mypy
+  version: 1.11.2
+  build: py312h024a12e_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py312h024a12e_0.conda
+  sha256: 89303b3e26ff876d40c1c33c96ac3a22023c8244fe48b21f87b264ab35ca5d55
+  md5: e5542c2a7d1f50810ff1b160e5b67e30
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9815300
+  timestamp: 1724602077332
+- kind: conda
+  name: mypy
+  version: 1.11.2
+  build: py312h4389bb4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py312h4389bb4_0.conda
+  sha256: 31d0292518c3c3090af632bc06ffa5f331fa6969ad9ae219e6505a6b2219d0af
+  md5: dd2e469b2e2f8a1cc4ae749a7ed44b7f
+  depends:
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 8560830
+  timestamp: 1724602058839
+- kind: conda
+  name: mypy
+  version: 1.11.2
+  build: py312h66e93f0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py312h66e93f0_0.conda
+  sha256: aadb78145f51b5488806c86e5954cc3cb19b03f2297a464b2a2f27c0340332a8
+  md5: ea315027e648236653f27d3d1ae893f6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 17066588
+  timestamp: 1724602213195
+- kind: conda
+  name: mypy
+  version: 1.11.2
+  build: py312hb553811_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py312hb553811_0.conda
+  sha256: 99eced54663f6cf2b8b924f36bc2fc0317075d8bd3c38c47fff55e463687fb04
+  md5: 4e22f7fed8b0572fa5d1b12e7a39a570
+  depends:
+  - __osx >=10.13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 10502065
+  timestamp: 1724601972090
+- kind: conda
+  name: mypy_extensions
+  version: 1.0.0
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
+  sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+  md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+  depends:
+  - python >=3.5
+  license: MIT
+  license_family: MIT
+  size: 10492
+  timestamp: 1675543414256
+- kind: conda
   name: ncurses
   version: '6.5'
   build: h5846eda_0
@@ -5540,6 +5659,73 @@ packages:
   license_family: MIT
   size: 34686
   timestamp: 1712432480698
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h4389bb4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
+  sha256: c9ed9457fa4c4900b7f2fc5e28493bdd3885acb823ed48c01dae59f043a65ad8
+  md5: 86fd428b42be7495c93d0ff837adfc9e
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 509298
+  timestamp: 1719275243368
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h7e5086c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-6.0.0-py312h7e5086c_0.conda
+  sha256: d677457b2ce2e6ef6c2845c653e5bc39be9a59a900d95a5a7771b490f754cb5f
+  md5: e45a140733a4805d80e282c1ede40d0b
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 501703
+  timestamp: 1719274787455
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h9a8786e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
+  sha256: d629363515df957507411fd24db2a0635ac893e5d60b2ee2f656b53be9c70b1d
+  md5: 1aeffa86c55972ca4e88ac843eccedf2
+  depends:
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 493452
+  timestamp: 1719274737481
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
+  sha256: 06e949079497cf8e1c9e253b77be709ec0c11816656814e1ad857ac5cbbea65b
+  md5: db086d71e9be086313110a670b6d549f
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 499307
+  timestamp: 1719274858092
 - kind: conda
   name: pthread-stubs
   version: '0.4'

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,8 +25,8 @@ test = "cargo test"
 test-all = "cargo test --all-features"
 
 [feature.pytest.dependencies]
-pytest = ">=8.0.2,<9"
 mypy = ">=1.11,<1.12"
+pytest = ">=8.0.2,<9"
 
 [feature.pytest.tasks]
 test-integration = "pytest tests/integration"

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,10 +23,14 @@ run-all-examples = "python ./tests/run_all_examples.py"
 run-all-examples-dev = "python ./tests/run_all_examples.py --pixi-exec ./target/debug/pixi"
 test = "cargo test"
 test-all = "cargo test --all-features"
-test-integration = "pytest -s tests/integration"
 
 [feature.pytest.dependencies]
 pytest = ">=8.0.2,<9"
+mypy = ">=1.11,<1.12"
+
+[feature.pytest.tasks]
+test-integration = "pytest tests/integration"
+typecheck-integration = " mypy --strict tests/integration"
 
 [feature.dev.dependencies]
 # Needed for the citation

--- a/tests/integration/test_main_cli.py
+++ b/tests/integration/test_main_cli.py
@@ -1,31 +1,32 @@
+from enum import IntEnum
+from pathlib import Path
 import subprocess
 
 PIXI_VERSION = "0.28.2"
 
 
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    FAILURE = 1
+    INCORRECT_USAGE = 2
+
+
 def verify_cli_command(
     command: str,
-    expected_exit_code: int | None = None,
-    stdout_contains: str | list | None = None,
-    stdout_excludes: str | list | None = None,
-    stderr_contains: str | list | None = None,
-    stderr_excludes: str | list | None = None,
-):
-    process = subprocess.Popen(
-        command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-    )
-    stdout, stderr = process.communicate()
-    print(f"command: {command}, stdout: {stdout}, stderr: {stderr}, code: {process.returncode}")
-
-    if expected_exit_code is not None:
-        assert int(process.returncode) == int(
-            expected_exit_code
-        ), f"Return code was {process.returncode}, stderr: {stderr}"
-
+    expected_exit_code: ExitCode,
+    stdout_contains: str | list[str] | None = None,
+    stdout_excludes: str | list[str] | None = None,
+    stderr_contains: str | list[str] | None = None,
+    stderr_excludes: str | list[str] | None = None,
+) -> None:
+    command_list = command.split()
+    process = subprocess.run(command_list, capture_output=True, text=True)
+    stdout, stderr, returncode = process.stdout, process.stderr, process.returncode
+    print(f"command: {command}, stdout: {stdout}, stderr: {stderr}, code: {returncode}")
     if expected_exit_code is not None:
         assert (
-            process.returncode == expected_exit_code
-        ), f"Return code was {process.returncode}, expected {expected_exit_code}, stderr: {stderr}"
+            returncode == expected_exit_code
+        ), f"Return code was {returncode}, expected {expected_exit_code}, stderr: {stderr}"
 
     if stdout_contains:
         if isinstance(stdout_contains, str):
@@ -52,132 +53,184 @@ def verify_cli_command(
             assert substring not in stderr, f"'{substring}' unexpectedly found in stderr: {stderr}"
 
 
-def test_pixi():
-    verify_cli_command("pixi", 2, None, f"[version {PIXI_VERSION}]")
-    verify_cli_command("pixi --version", 0, PIXI_VERSION, None)
+def test_pixi() -> None:
+    verify_cli_command(
+        "pixi", ExitCode.INCORRECT_USAGE, stdout_excludes=f"[version {PIXI_VERSION}]"
+    )
+    verify_cli_command("pixi --version", ExitCode.SUCCESS, stdout_contains=PIXI_VERSION)
 
 
-def test_project_commands(tmp_path):
+def test_project_commands(tmp_path: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
     # Create a new project
-    verify_cli_command(f"pixi init {tmp_path}", 0)
+    verify_cli_command(f"pixi init {tmp_path}", ExitCode.SUCCESS)
 
     # Channel commands
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} channel add bioconda", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} channel list", 0, stdout_contains="bioconda"
+        f"pixi project --manifest-path {manifest_path} channel add bioconda", ExitCode.SUCCESS
     )
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} channel remove bioconda", 0)
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} channel list",
+        ExitCode.SUCCESS,
+        stdout_contains="bioconda",
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} channel remove bioconda", ExitCode.SUCCESS
+    )
 
     # Description commands
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} description set blabla", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} description get", 0, stdout_contains="blabla"
+        f"pixi project --manifest-path {manifest_path} description set blabla", ExitCode.SUCCESS
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} description get",
+        ExitCode.SUCCESS,
+        stdout_contains="blabla",
     )
 
     # Environment commands
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} environment add test", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} environment list", 0, stdout_contains="test"
+        f"pixi project --manifest-path {manifest_path} environment add test", ExitCode.SUCCESS
     )
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} environment remove test", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} environment list", 0, stdout_excludes="test"
+        f"pixi project --manifest-path {manifest_path} environment list",
+        ExitCode.SUCCESS,
+        stdout_contains="test",
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} environment remove test", ExitCode.SUCCESS
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} environment list",
+        ExitCode.SUCCESS,
+        stdout_excludes="test",
     )
 
     # Platform commands
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} platform add linux-64", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} platform list", 0, stdout_contains="linux-64"
+        f"pixi project --manifest-path {manifest_path} platform add linux-64", ExitCode.SUCCESS
     )
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} platform remove linux-64", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} platform list", 0, stdout_excludes="linux-64"
+        f"pixi project --manifest-path {manifest_path} platform list",
+        ExitCode.SUCCESS,
+        stdout_contains="linux-64",
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} platform remove linux-64", ExitCode.SUCCESS
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} platform list",
+        ExitCode.SUCCESS,
+        stdout_excludes="linux-64",
     )
 
     # Version commands
-    verify_cli_command(f"pixi project --manifest-path {manifest_path} version set 1.2.3", 0)
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version get", 0, stdout_contains="1.2.3"
+        f"pixi project --manifest-path {manifest_path} version set 1.2.3", ExitCode.SUCCESS
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version major", 0, stderr_contains="2.2.3"
+        f"pixi project --manifest-path {manifest_path} version get",
+        ExitCode.SUCCESS,
+        stdout_contains="1.2.3",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version minor", 0, stderr_contains="2.3.3"
+        f"pixi project --manifest-path {manifest_path} version major",
+        ExitCode.SUCCESS,
+        stderr_contains="2.2.3",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version patch", 0, stderr_contains="2.3.4"
+        f"pixi project --manifest-path {manifest_path} version minor",
+        ExitCode.SUCCESS,
+        stderr_contains="2.3.3",
+    )
+    verify_cli_command(
+        f"pixi project --manifest-path {manifest_path} version patch",
+        ExitCode.SUCCESS,
+        stderr_contains="2.3.4",
     )
 
 
-def test_global_install():
+def test_global_install() -> None:
     # Install
-    verify_cli_command("pixi global install rattler-build", 0, None, "rattler-build")
+    verify_cli_command(
+        "pixi global install rattler-build", ExitCode.SUCCESS, stdout_excludes="rattler-build"
+    )
 
-    # TODO: fix this, not working because of the repodata gateway
-    # verify_cli_command('pixi global install rattler-build -c https://fast.prefix.dev/conda-forge', 0, None, "rattler-build")
+    verify_cli_command(
+        "pixi global install rattler-build -c https://fast.prefix.dev/conda-forge",
+        ExitCode.SUCCESS,
+        stdout_excludes="rattler-build",
+    )
 
     # Upgrade
-    verify_cli_command("pixi global upgrade rattler-build", 0)
+    verify_cli_command("pixi global upgrade rattler-build", ExitCode.SUCCESS)
 
     # List
-    verify_cli_command("pixi global list", 0, stderr_contains="rattler-build")
+    verify_cli_command("pixi global list", ExitCode.SUCCESS, stderr_contains="rattler-build")
 
     # Remove
-    verify_cli_command("pixi global remove rattler-build", 0)
-    verify_cli_command("pixi global remove rattler-build", 1)
+    verify_cli_command("pixi global remove rattler-build", ExitCode.SUCCESS)
+    verify_cli_command("pixi global remove rattler-build", ExitCode.FAILURE)
 
 
-def test_search():
+def test_search() -> None:
     verify_cli_command(
-        "pixi search rattler-build -c conda-forge", 0, stdout_contains="rattler-build"
+        "pixi search rattler-build -c conda-forge",
+        ExitCode.SUCCESS,
+        stdout_contains="rattler-build",
     )
-    # TODO: fix this, not working because of the repodata gateway
-    # verify_cli_command('pixi search rattler-build -c https://fast.prefix.dev/conda-forge', 0, stdout_contains="rattler-build")
+    verify_cli_command(
+        "pixi search rattler-build -c https://fast.prefix.dev/conda-forge",
+        ExitCode.SUCCESS,
+        stdout_contains="rattler-build",
+    )
 
 
-def test_simple_project_setup(tmp_path):
+def test_simple_project_setup(tmp_path: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
     # Create a new project
-    verify_cli_command(f"pixi init {tmp_path}", 0)
+    verify_cli_command(f"pixi init {tmp_path}", ExitCode.SUCCESS)
 
     # Add package
     verify_cli_command(
-        f"pixi add --manifest-path {manifest_path}  _r-mutex", 0, stderr_contains="Added"
+        f"pixi add --manifest-path {manifest_path} _r-mutex",
+        ExitCode.SUCCESS,
+        stderr_contains="Added",
     )
     verify_cli_command(
         f"pixi add --manifest-path {manifest_path} --feature test _r-mutex==1.0.1",
-        0,
+        ExitCode.SUCCESS,
         stderr_contains=["test", "==1.0.1"],
     )
     verify_cli_command(
         f"pixi add --manifest-path {manifest_path} --platform linux-64 conda-forge::_r-mutex",
-        0,
+        ExitCode.SUCCESS,
         stderr_contains=["linux-64", "conda-forge"],
     )
     verify_cli_command(
         f"pixi add --manifest-path {manifest_path} -f test -p osx-arm64 _r-mutex",
-        0,
+        ExitCode.SUCCESS,
         stderr_contains=["osx-arm64", "test"],
     )
 
     # Remove package
     verify_cli_command(
-        f"pixi remove --manifest-path {manifest_path} _r-mutex", 0, stderr_contains="Removed"
+        f"pixi remove --manifest-path {manifest_path} _r-mutex",
+        ExitCode.SUCCESS,
+        stderr_contains="Removed",
     )
     verify_cli_command(
         f"pixi remove --manifest-path {manifest_path} --feature test _r-mutex",
-        0,
+        ExitCode.SUCCESS,
         stderr_contains=["test", "Removed"],
     )
     verify_cli_command(
         f"pixi remove --manifest-path {manifest_path} --platform linux-64 conda-forge::_r-mutex",
-        0,
+        ExitCode.SUCCESS,
         stderr_contains=["linux-64", "conda-forge", "Removed"],
     )
     verify_cli_command(
         f"pixi remove --manifest-path {manifest_path} -f test -p osx-arm64 _r-mutex",
-        0,
+        ExitCode.SUCCESS,
         stderr_contains=["osx-arm64", "test", "Removed"],
     )


### PR DESCRIPTION
- Use explicit enum for exit codes
- Use modern subprocess usage
- Extend type hints
- Check type hints