### PR TITLE
feat: Improve integration tests

### DIFF
--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Setup unix binary, add to github path
         if: inputs.os != 'windows-latest'
         run: |
+          mkdir .pixi/target/release
           mv pixi_bin/pixi-${{ inputs.target }} .pixi/target/release/pixi
           chmod a+x .pixi/target/release/pixi
       - name: Create Directory and Move Executable

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -116,6 +116,8 @@ jobs:
   test-integration:
     name: Integration test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
+    env:
+      TARGET_RELEASE: "${{ github.workspace }}/.pixi/target/release"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -130,16 +132,16 @@ jobs:
       - name: Setup unix binary, add to github path
         if: inputs.os != 'windows-latest'
         run: |
-          mkdir .pixi/target/release
-          mv pixi_bin/pixi-${{ inputs.target }} .pixi/target/release/pixi
-          chmod a+x .pixi/target/release/pixi
+          mkdir -p ${{ env.TARGET_RELEASE }}
+          mv pixi_bin/pixi-${{ inputs.target }} ${{ env.TARGET_RELEASE }}/pixi
+          chmod a+x ${{ env.TARGET_RELEASE }}/pixi
       - name: Create Directory and Move Executable
         if: inputs.os == 'windows-latest' && inputs.target == 'x86_64-pc-windows-msvc'
         run: |
-          New-Item -ItemType Directory -Force -Path ".pixi/target/release/"
-          Move-Item -Path "pixi_bin/pixi-${{ inputs.target }}${{ inputs.extension }}" -Destination ".pixi/target/release/pixi.exe"
+          New-Item -ItemType Directory -Force -Path "${{ env.TARGET_RELEASE }}"
+          Move-Item -Path "pixi_bin/pixi-${{ inputs.target }}${{ inputs.extension }}" -Destination "${{ env.TARGET_RELEASE }}/pixi.exe"
         shell: pwsh
       - name: Typecheck integration tests
-        run: ./.pixi/target/release/pixi run typecheck-integration
+        run: ${{ env.TARGET_RELEASE }}/pixi run typecheck-integration
       - name: Run integration tests
-        run: ./.pixi/target/release/pixi run test-integration
+        run: ${{ env.TARGET_RELEASE }}/pixi run test-integration

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -144,4 +144,4 @@ jobs:
       - name: Typecheck integration tests
         run: ${{ env.TARGET_RELEASE }}/pixi run typecheck-integration
       - name: Run integration tests
-        run: ${{ env.TARGET_RELEASE }}/pixi run test-integration
+        run: ${{ env.TARGET_RELEASE }}/pixi run test-integration-ci

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -117,7 +117,7 @@ jobs:
     name: Integration test on ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     steps:
-      - name: checkout repo
+      - name: Checkout repo
         uses: actions/checkout@v4
       - name: Download binary from build
         uses: actions/download-artifact@v4
@@ -130,26 +130,15 @@ jobs:
       - name: Setup unix binary, add to github path
         if: inputs.os != 'windows-latest'
         run: |
-          mv pixi_bin/pixi-${{ inputs.target }} pixi_bin/pixi
-          chmod a+x pixi_bin/pixi
-          echo "$(pwd)/pixi_bin" >> $GITHUB_PATH
+          mv pixi_bin/pixi-${{ inputs.target }} .pixi/target/release/pixi
+          chmod a+x .pixi/target/release/pixi
       - name: Create Directory and Move Executable
         if: inputs.os == 'windows-latest' && inputs.target == 'x86_64-pc-windows-msvc'
         run: |
-          New-Item -ItemType Directory -Force -Path "D:\.pixi"
-          Move-Item -Path "pixi_bin/pixi-${{ inputs.target }}${{ inputs.extension }}" -Destination "D:\.pixi\pixi.exe"
-        shell: pwsh
-      - name: Add to PATH
-        if: inputs.os == 'windows-latest' && inputs.target == 'x86_64-pc-windows-msvc'
-        run: echo "D:\.pixi" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_PATH
-        shell: pwsh
-      - name: Verify and Use Executable
-        if: inputs.os == 'windows-latest' && inputs.target == 'x86_64-pc-windows-msvc'
-        run: |
-          echo "Current PATH: $env:PATH"
-          pixi --version
+          New-Item -ItemType Directory -Force -Path ".pixi/target/release/"
+          Move-Item -Path "pixi_bin/pixi-${{ inputs.target }}${{ inputs.extension }}" -Destination ".pixi/target/release/pixi.exe"
         shell: pwsh
       - name: Typecheck integration tests
-        run: pixi run typecheck-integration
+        run: ./.pixi/target/release/pixi run typecheck-integration
       - name: Run integration tests
-        run: pixi run test-integration
+        run: ./.pixi/target/release/pixi run test-integration

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,8 +19,7 @@ build = "cargo build --release"
 bump = "tbump --only-patch $RELEASE_VERSION"
 install = "cargo install --path . --locked"
 pypi-proxy = "python ./tests/pypi_proxy.py"
-run-all-examples = "python ./tests/run_all_examples.py"
-run-all-examples-dev = { cmd = "python ./tests/run_all_examples.py --pixi-exec .pixi/target/release/pixi", depends-on = [
+run-all-examples = { cmd = "python ./tests/run_all_examples.py --pixi-exec .pixi/target/release/pixi", depends-on = [
   "build",
 ] }
 test = "cargo test"
@@ -31,7 +30,10 @@ mypy = ">=1.11,<1.12"
 pytest = ">=8.0.2,<9"
 
 [feature.pytest.tasks]
-test-integration = "pytest tests/integration"
+test-integration-ci = "pytest tests/integration"
+test-integration-dev = { cmd = "pytest tests/integration", depends-on = [
+  "build",
+] }
 typecheck-integration = "mypy --strict tests/integration"
 
 [feature.dev.dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,9 @@ bump = "tbump --only-patch $RELEASE_VERSION"
 install = "cargo install --path . --locked"
 pypi-proxy = "python ./tests/pypi_proxy.py"
 run-all-examples = "python ./tests/run_all_examples.py"
-run-all-examples-dev = "python ./tests/run_all_examples.py --pixi-exec ./target/debug/pixi"
+run-all-examples-dev = { cmd = "python ./tests/run_all_examples.py --pixi-exec .pixi/target/release/pixi", depends-on = [
+  "build",
+] }
 test = "cargo test"
 test-all = "cargo test --all-features"
 
@@ -30,7 +32,10 @@ pytest = ">=8.0.2,<9"
 
 [feature.pytest.tasks]
 test-integration = "pytest tests/integration"
-typecheck-integration = " mypy --strict tests/integration"
+test-integration-dev = { cmd = "pytest tests/integration", depends-on = [
+  "build",
+], env = { PIXI_PATH = "$PIXI_PROJECT_ROOT/.pixi/target/release/pixi" } }
+typecheck-integration = "mypy --strict tests/integration"
 
 [feature.dev.dependencies]
 # Needed for the citation

--- a/pixi.toml
+++ b/pixi.toml
@@ -32,9 +32,6 @@ pytest = ">=8.0.2,<9"
 
 [feature.pytest.tasks]
 test-integration = "pytest tests/integration"
-test-integration-dev = { cmd = "pytest tests/integration", depends-on = [
-  "build",
-], env = { PIXI_PATH = "$PIXI_PROJECT_ROOT/.pixi/target/release/pixi" } }
 typecheck-integration = "mypy --strict tests/integration"
 
 [feature.dev.dependencies]

--- a/tests/integration/test_main_cli.py
+++ b/tests/integration/test_main_cli.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
 from pathlib import Path
 import subprocess
+import pytest
 
 PIXI_VERSION = "0.28.2"
 
@@ -11,16 +12,20 @@ class ExitCode(IntEnum):
     INCORRECT_USAGE = 2
 
 
+@pytest.fixture
+def pixi() -> Path:
+    return Path(__file__).parent.joinpath("../../.pixi/target/release/pixi")
+
+
 def verify_cli_command(
-    command: str,
+    command: list[Path | str],
     expected_exit_code: ExitCode,
     stdout_contains: str | list[str] | None = None,
     stdout_excludes: str | list[str] | None = None,
     stderr_contains: str | list[str] | None = None,
     stderr_excludes: str | list[str] | None = None,
 ) -> None:
-    command_list = command.split()
-    process = subprocess.run(command_list, capture_output=True, text=True)
+    process = subprocess.run(command, capture_output=True, text=True)
     stdout, stderr, returncode = process.stdout, process.stderr, process.returncode
     print(f"command: {command}, stdout: {stdout}, stderr: {stderr}, code: {returncode}")
     if expected_exit_code is not None:
@@ -53,184 +58,309 @@ def verify_cli_command(
             assert substring not in stderr, f"'{substring}' unexpectedly found in stderr: {stderr}"
 
 
-def test_pixi() -> None:
+def test_pixi(pixi: Path) -> None:
     verify_cli_command(
-        "pixi", ExitCode.INCORRECT_USAGE, stdout_excludes=f"[version {PIXI_VERSION}]"
+        [pixi], ExitCode.INCORRECT_USAGE, stdout_excludes=f"[version {PIXI_VERSION}]"
     )
-    verify_cli_command("pixi --version", ExitCode.SUCCESS, stdout_contains=PIXI_VERSION)
+    verify_cli_command([pixi, "--version"], ExitCode.SUCCESS, stdout_contains=PIXI_VERSION)
 
 
-def test_project_commands(tmp_path: Path) -> None:
+def test_project_commands(tmp_path: Path, pixi: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
     # Create a new project
-    verify_cli_command(f"pixi init {tmp_path}", ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", tmp_path], ExitCode.SUCCESS)
 
     # Channel commands
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} channel add bioconda", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "channel",
+            "add",
+            "bioconda",
+        ],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} channel list",
+        [pixi, "project", "--manifest-path", manifest_path, "channel", "list"],
         ExitCode.SUCCESS,
         stdout_contains="bioconda",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} channel remove bioconda", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "channel",
+            "remove",
+            "bioconda",
+        ],
+        ExitCode.SUCCESS,
     )
 
     # Description commands
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} description set blabla", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "description",
+            "set",
+            "blabla",
+        ],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} description get",
+        [pixi, "project", "--manifest-path", manifest_path, "description", "get"],
         ExitCode.SUCCESS,
         stdout_contains="blabla",
     )
 
     # Environment commands
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} environment add test", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "environment",
+            "add",
+            "test",
+        ],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} environment list",
+        [pixi, "project", "--manifest-path", manifest_path, "environment", "list"],
         ExitCode.SUCCESS,
         stdout_contains="test",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} environment remove test", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "environment",
+            "remove",
+            "test",
+        ],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} environment list",
+        [pixi, "project", "--manifest-path", manifest_path, "environment", "list"],
         ExitCode.SUCCESS,
         stdout_excludes="test",
     )
 
     # Platform commands
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} platform add linux-64", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "platform",
+            "add",
+            "linux-64",
+        ],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} platform list",
+        [pixi, "project", "--manifest-path", manifest_path, "platform", "list"],
         ExitCode.SUCCESS,
         stdout_contains="linux-64",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} platform remove linux-64", ExitCode.SUCCESS
+        [
+            pixi,
+            "project",
+            "--manifest-path",
+            manifest_path,
+            "platform",
+            "remove",
+            "linux-64",
+        ],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} platform list",
+        [pixi, "project", "--manifest-path", manifest_path, "platform", "list"],
         ExitCode.SUCCESS,
         stdout_excludes="linux-64",
     )
 
     # Version commands
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version set 1.2.3", ExitCode.SUCCESS
+        [pixi, "project", "--manifest-path", manifest_path, "version", "set", "1.2.3"],
+        ExitCode.SUCCESS,
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version get",
+        [pixi, "project", "--manifest-path", manifest_path, "version", "get"],
         ExitCode.SUCCESS,
         stdout_contains="1.2.3",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version major",
+        [pixi, "project", "--manifest-path", manifest_path, "version", "major"],
         ExitCode.SUCCESS,
         stderr_contains="2.2.3",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version minor",
+        [pixi, "project", "--manifest-path", manifest_path, "version", "minor"],
         ExitCode.SUCCESS,
         stderr_contains="2.3.3",
     )
     verify_cli_command(
-        f"pixi project --manifest-path {manifest_path} version patch",
+        [pixi, "project", "--manifest-path", manifest_path, "version", "patch"],
         ExitCode.SUCCESS,
         stderr_contains="2.3.4",
     )
 
 
-def test_global_install() -> None:
+def test_global_install(pixi: Path) -> None:
     # Install
     verify_cli_command(
-        "pixi global install rattler-build", ExitCode.SUCCESS, stdout_excludes="rattler-build"
+        [pixi, "global", "install", "rattler-build"],
+        ExitCode.SUCCESS,
+        stdout_excludes="rattler-build",
     )
 
     verify_cli_command(
-        "pixi global install rattler-build -c https://fast.prefix.dev/conda-forge",
+        [
+            pixi,
+            "global",
+            "install",
+            "rattler-build",
+            "-c",
+            "https://fast.prefix.dev/conda-forge",
+        ],
         ExitCode.SUCCESS,
         stdout_excludes="rattler-build",
     )
 
     # Upgrade
-    verify_cli_command("pixi global upgrade rattler-build", ExitCode.SUCCESS)
+    verify_cli_command([pixi, "global", "upgrade", "rattler-build"], ExitCode.SUCCESS)
 
     # List
-    verify_cli_command("pixi global list", ExitCode.SUCCESS, stderr_contains="rattler-build")
+    verify_cli_command([pixi, "global", "list"], ExitCode.SUCCESS, stderr_contains="rattler-build")
 
     # Remove
-    verify_cli_command("pixi global remove rattler-build", ExitCode.SUCCESS)
-    verify_cli_command("pixi global remove rattler-build", ExitCode.FAILURE)
+    verify_cli_command([pixi, "global", "remove", "rattler-build"], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "global", "remove", "rattler-build"], ExitCode.FAILURE)
 
 
-def test_search() -> None:
+def test_search(pixi: Path) -> None:
     verify_cli_command(
-        "pixi search rattler-build -c conda-forge",
+        [pixi, "search", "rattler-build", "-c", "conda-forge"],
         ExitCode.SUCCESS,
         stdout_contains="rattler-build",
     )
     verify_cli_command(
-        "pixi search rattler-build -c https://fast.prefix.dev/conda-forge",
+        [pixi, "search", "rattler-build", "-c", "https://fast.prefix.dev/conda-forge"],
         ExitCode.SUCCESS,
         stdout_contains="rattler-build",
     )
 
 
-def test_simple_project_setup(tmp_path: Path) -> None:
+def test_simple_project_setup(tmp_path: Path, pixi: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
     # Create a new project
-    verify_cli_command(f"pixi init {tmp_path}", ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", tmp_path], ExitCode.SUCCESS)
 
     # Add package
     verify_cli_command(
-        f"pixi add --manifest-path {manifest_path} _r-mutex",
+        [pixi, "add", "--manifest-path", manifest_path, "_r-mutex"],
         ExitCode.SUCCESS,
         stderr_contains="Added",
     )
     verify_cli_command(
-        f"pixi add --manifest-path {manifest_path} --feature test _r-mutex==1.0.1",
+        [
+            pixi,
+            "add",
+            "--manifest-path",
+            manifest_path,
+            "--feature",
+            "test",
+            "_r-mutex==1.0.1",
+        ],
         ExitCode.SUCCESS,
         stderr_contains=["test", "==1.0.1"],
     )
     verify_cli_command(
-        f"pixi add --manifest-path {manifest_path} --platform linux-64 conda-forge::_r-mutex",
+        [
+            pixi,
+            "add",
+            "--manifest-path",
+            manifest_path,
+            "--platform",
+            "linux-64",
+            "conda-forge::_r-mutex",
+        ],
         ExitCode.SUCCESS,
         stderr_contains=["linux-64", "conda-forge"],
     )
     verify_cli_command(
-        f"pixi add --manifest-path {manifest_path} -f test -p osx-arm64 _r-mutex",
+        [
+            pixi,
+            "add",
+            "--manifest-path",
+            manifest_path,
+            "-f",
+            "test",
+            "-p",
+            "osx-arm64",
+            "_r-mutex",
+        ],
         ExitCode.SUCCESS,
         stderr_contains=["osx-arm64", "test"],
     )
 
     # Remove package
     verify_cli_command(
-        f"pixi remove --manifest-path {manifest_path} _r-mutex",
+        [pixi, "remove", "--manifest-path", manifest_path, "_r-mutex"],
         ExitCode.SUCCESS,
         stderr_contains="Removed",
     )
     verify_cli_command(
-        f"pixi remove --manifest-path {manifest_path} --feature test _r-mutex",
+        [
+            pixi,
+            "remove",
+            "--manifest-path",
+            manifest_path,
+            "--feature",
+            "test",
+            "_r-mutex",
+        ],
         ExitCode.SUCCESS,
         stderr_contains=["test", "Removed"],
     )
     verify_cli_command(
-        f"pixi remove --manifest-path {manifest_path} --platform linux-64 conda-forge::_r-mutex",
+        [
+            pixi,
+            "remove",
+            "--manifest-path",
+            manifest_path,
+            "--platform",
+            "linux-64",
+            "conda-forge::_r-mutex",
+        ],
         ExitCode.SUCCESS,
         stderr_contains=["linux-64", "conda-forge", "Removed"],
     )
     verify_cli_command(
-        f"pixi remove --manifest-path {manifest_path} -f test -p osx-arm64 _r-mutex",
+        [
+            pixi,
+            "remove",
+            "--manifest-path",
+            manifest_path,
+            "-f",
+            "test",
+            "-p",
+            "osx-arm64",
+            "_r-mutex",
+        ],
         ExitCode.SUCCESS,
         stderr_contains=["osx-arm64", "test", "Removed"],
     )


### PR DESCRIPTION
- Test locally build pixi, instead of installed one
- Add task `test-integration-dev` with dependency on task `build`
- Use list instead of strings for commands, so that it also works if the paths contain spaces