### PR TITLE
chore: upgrade zip dependency from alpha to current stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,7 +2279,7 @@ dependencies = [
  "pypi-types",
  "reflink-copy",
  "regex",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "sha2",
@@ -2364,7 +2364,7 @@ checksum = "db2b7379a75544c94b3da32821b0bf41f9062e9970e23b78cc577d0d89676d16"
 dependencies = [
  "jiff-tzdb-platform",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3229,7 +3229,7 @@ dependencies = [
  "pep440_rs",
  "pubgrub",
  "regex",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "schemars",
  "serde",
  "smallvec",
@@ -3453,7 +3453,7 @@ dependencies = [
  "uv-resolver",
  "uv-types",
  "xxhash-rust",
- "zip 0.6.6",
+ "zip 2.2.0",
 ]
 
 [[package]]
@@ -3646,7 +3646,7 @@ name = "platform-tags"
 version = "0.0.1"
 source = "git+https://github.com/astral-sh/uv?tag=0.4.0#d9bd3bc7a536037ea8645fb70f1d35c0bb62b68e"
 dependencies = [
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "thiserror",
 ]
@@ -3770,7 +3770,7 @@ dependencies = [
  "indexmap 2.3.0",
  "log",
  "priority-queue",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "thiserror",
 ]
 
@@ -3881,7 +3881,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.12",
  "socket2",
  "thiserror",
@@ -3898,7 +3898,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.12",
  "slab",
  "thiserror",
@@ -4173,7 +4173,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "zip 2.1.6",
+ "zip 2.2.0",
  "zstd",
 ]
 
@@ -4781,12 +4781,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -6150,7 +6144,7 @@ dependencies = [
  "reqwest 0.12.5",
  "reqwest-middleware",
  "rust-netrc",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "tokio",
  "tracing",
  "url",
@@ -6171,7 +6165,7 @@ dependencies = [
  "pep508_rs",
  "pypi-types",
  "regex",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",
@@ -6199,7 +6193,7 @@ dependencies = [
  "nanoid",
  "pypi-types",
  "rmp-serde",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "tempfile",
  "tracing",
@@ -6266,7 +6260,7 @@ dependencies = [
  "pep508_rs",
  "platform-tags",
  "pypi-types",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
@@ -6288,7 +6282,7 @@ dependencies = [
  "install-wheel-rs",
  "itertools 0.13.0",
  "pypi-types",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "tracing",
  "uv-build",
  "uv-cache",
@@ -6321,7 +6315,7 @@ dependencies = [
  "reqwest 0.12.5",
  "reqwest-middleware",
  "rmp-serde",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "tempfile",
  "thiserror",
@@ -6356,7 +6350,7 @@ dependencies = [
  "pypi-types",
  "rayon",
  "reqwest 0.12.5",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "sha2",
  "thiserror",
  "tokio",
@@ -6427,7 +6421,7 @@ dependencies = [
  "platform-tags",
  "pypi-types",
  "rayon",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "same-file",
  "tempfile",
  "thiserror",
@@ -6558,7 +6552,7 @@ dependencies = [
  "pypi-types",
  "requirements-txt",
  "rkyv",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "same-file",
  "serde",
  "textwrap",
@@ -6604,7 +6598,7 @@ dependencies = [
  "pep440_rs",
  "pep508_rs",
  "pypi-types",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "thiserror",
  "url",
  "uv-cache",
@@ -6643,7 +6637,7 @@ source = "git+https://github.com/astral-sh/uv?tag=0.4.0#d9bd3bc7a536037ea8645fb7
 dependencies = [
  "anstream",
  "owo-colors",
- "rustc-hash 2.0.0",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -6657,7 +6651,7 @@ dependencies = [
  "pep440_rs",
  "pep508_rs",
  "pypi-types",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "thiserror",
  "tokio",
@@ -7322,14 +7316,13 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "time",
 ]
 
 [[package]]
 name = "zip"
-version = "2.1.6"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dd8c92efc296286ce1fbd16657c5dbefff44f1b4ca01cc5f517d8b7b3d3e2e"
+checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.4.0" }
 uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.4.0" }
 winapi = { version = "0.3.9", default-features = false }
 xxhash-rust = "0.8.10"
-zip = { version = "0.6.6", default-features = false }
+zip = { version = "2.2.0", default-features = false }
 
 fancy_display = { path = "crates/fancy_display" }
 pixi_config = { path = "crates/pixi_config" }


### PR DESCRIPTION
Bump zip crate from 0.6.6 to current 2.2.0