### PR TITLE
feat: minimal pre-commit task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,19 +58,21 @@ repos:
       - id: fmt
         name: fmt
         language: system
+        stages: [push, manual]
         types: [file, rust]
         entry: cargo fmt
         pass_filenames: false
       - id: clippy
         name: clippy
         language: system
+        stages: [push, manual]
         types: [file, rust]
         entry: cargo clippy --all-targets --workspace -- -D warnings -Dclippy::dbg_macro # Use -D warnings option to ensure the job fails when encountering warnings
         pass_filenames: false
       - id: test
         name: test
         language: system
-        stages: [push]
+        stages: [push, manual]
         types: [file, rust]
         entry: cargo test
         pass_filenames: false

--- a/pixi.toml
+++ b/pixi.toml
@@ -52,7 +52,8 @@ typos = ">=1.23.1,<2"
 [feature.lint.tasks]
 lint = { depends-on = ["pre-commit-run"] }
 pre-commit-install = "pre-commit install"
-pre-commit-run = "pre-commit run --all"
+pre-commit-install-minimal = "pre-commit install -t=pre-commit"
+pre-commit-run = "pre-commit run --all-files"
 toml-format = { cmd = "taplo fmt", env = { RUST_LOG = "warn" } }
 toml-lint = "taplo lint --verbose **/pixi.toml"
 


### PR DESCRIPTION
By running `pixi run pre-commit-install-minimal`, only the pre-commit hooks are installed, which don't include rust anymore. With `pixi run pre-commit-install` rust lints are also run before pushing.