### PR TITLE
fix: pins python version in add_pypi_functionality

### DIFF
--- a/tests/add_tests.rs
+++ b/tests/add_tests.rs
@@ -245,7 +245,7 @@ async fn add_pypi_functionality() {
     pixi.init().await.unwrap();
 
     // Add python
-    pixi.add("python")
+    pixi.add("python~=3.12.0")
         .set_type(DependencyType::CondaDependency(SpecType::Run))
         .with_install(false)
         .await


### PR DESCRIPTION
Pins the python version in this specific test, so that it keeps working when the platform is added later.