### PR TITLE
fix: Fix error message for export conda explicit spec

### DIFF
--- a/src/cli/project/export/conda_explicit_spec.rs
+++ b/src/cli/project/export/conda_explicit_spec.rs
@@ -112,8 +112,9 @@ fn render_env_platform(
                     );
                 } else {
                     miette::bail!(
-                        "PyPI packages are not supported. Specify `--ignore-pypi-errors` to ignore this error \
-                        or `--write-pypi-requirements` to write pypi requirements to a separate requirements.txt file"
+                        "PyPI packages are not supported in a conda explicit spec. \
+                        Specify `--ignore-pypi-errors` to ignore this error and create \
+                        a spec file containing only the conda dependencies from the lockfile."
                     );
                 }
             }


### PR DESCRIPTION
This fixes a reference to a flag that was removed from `pixi project export conda-explicit-spec` during the review of PR #1873. 