### PR TITLE
feat: Add pypi pip requirements export

### DIFF
--- a/src/cli/project/export/mod.rs
+++ b/src/cli/project/export/mod.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 pub mod conda_explicit_spec;
+pub mod pypi_requirements;
 
 use crate::Project;
 use clap::Parser;
@@ -20,12 +21,17 @@ pub enum Command {
     /// Export project environment to a conda explicit specification file
     #[clap(visible_alias = "ces")]
     CondaExplicitSpec(conda_explicit_spec::Args),
+
+    /// Export project environment to a pip requirements file
+    #[clap(visible_alias = "pr")]
+    PyPiRequirements(pypi_requirements::Args),
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
     match args.command {
         Command::CondaExplicitSpec(args) => conda_explicit_spec::execute(project, args).await?,
+        Command::PyPiRequirements(args) => pypi_requirements::execute(project, args).await?,
     };
     Ok(())
 }

--- a/src/cli/project/export/pypi_requirements.rs
+++ b/src/cli/project/export/pypi_requirements.rs
@@ -1,0 +1,256 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::Parser;
+use miette::{Context, IntoDiagnostic};
+
+use crate::cli::cli_config::PrefixUpdateConfig;
+use crate::cli::LockFileUsageArgs;
+use crate::lock_file::UpdateLockFileOptions;
+use crate::Project;
+use rattler_conda_types::Platform;
+use rattler_lock::{Environment, Package, PackageHashes, PypiPackage, PypiPackageData, UrlOrPath};
+
+#[derive(Debug, Parser)]
+#[clap(arg_required_else_help = false)]
+pub struct Args {
+    /// Output directory for rendered requirements files
+    pub output_dir: PathBuf,
+
+    /// Environment to render. Can be repeated for multiple envs. Defaults to all environments
+    #[arg(short, long)]
+    pub environment: Option<Vec<String>>,
+
+    /// The platform to render. Can be repeated for multiple platforms.
+    /// Defaults to all platforms available for selected environments.
+    #[arg(short, long)]
+    pub platform: Option<Vec<Platform>>,
+
+    /// Conda dependencies are not supported in pip requirements files.
+    /// This flag allows creating the requirements file even if Conda dependencies are present.
+    #[arg(long, default_value = "false")]
+    pub ignore_conda_errors: bool,
+
+    #[clap(flatten)]
+    pub lock_file_usage: LockFileUsageArgs,
+
+    #[clap(flatten)]
+    pub prefix_update_config: PrefixUpdateConfig,
+}
+
+#[derive(Debug)]
+struct PypiPackageReqData {
+    source: String,
+    hash_flag: Option<String>,
+    editable: bool,
+}
+
+impl PypiPackageReqData {
+    fn from_pypi_package(p: &PypiPackage) -> Self {
+        // pip --verify-hashes does not accept hashes for local files
+        let (s, include_hash) = match p.url() {
+            UrlOrPath::Url(url) => (url.as_str(), true),
+            UrlOrPath::Path(path) => (
+                path.as_os_str()
+                    .to_str()
+                    .unwrap_or_else(|| panic!("Could not convert {:?} to str", path)),
+                false,
+            ),
+        };
+        //
+        // remove "direct+ since not valid for pip urls"
+        let s = s.trim_start_matches("direct+");
+
+        let hash_flag = if include_hash {
+            get_pypi_hash_str(p.data().package)
+        } else {
+            None
+        };
+
+        Self {
+            source: s.to_string(),
+            hash_flag,
+            editable: p.is_editable(),
+        }
+    }
+
+    fn to_req_entry(&self) -> String {
+        let mut entry = String::new();
+
+        if self.editable {
+            entry.push_str("-e ");
+        }
+        entry.push_str(&self.source);
+
+        if let Some(hash) = &self.hash_flag {
+            entry.push_str(&format!(" {}", hash));
+        }
+
+        entry
+    }
+}
+
+fn get_pypi_hash_str(package_data: &PypiPackageData) -> Option<String> {
+    if let Some(hashes) = &package_data.hash {
+        let h = match hashes {
+            PackageHashes::Sha256(h) => format!("--hash=sha256:{:x}", h).to_string(),
+            PackageHashes::Md5Sha256(_, h) => format!("--hash=sha256:{:x}", h).to_string(),
+            PackageHashes::Md5(h) => format!("--hash=md5:{:x}", h).to_string(),
+        };
+        Some(h)
+    } else {
+        None
+    }
+}
+
+fn render_pypi_requirements(
+    target: impl AsRef<Path>,
+    packages: &[PypiPackageReqData],
+) -> miette::Result<()> {
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    let target = target.as_ref();
+
+    let reqs = packages
+        .iter()
+        .map(|p| p.to_req_entry())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    fs::write(target, reqs)
+        .into_diagnostic()
+        .with_context(|| format!("failed to write requirements file: {}", target.display()))?;
+
+    Ok(())
+}
+
+fn render_env_platform(
+    output_dir: &Path,
+    env_name: &str,
+    env: &Environment,
+    platform: &Platform,
+    ignore_conda_errors: bool,
+) -> miette::Result<()> {
+    let packages = env.packages(*platform).ok_or(miette::miette!(
+        "platform '{platform}' not found for env {}",
+        env_name,
+    ))?;
+
+    let mut pypi_packages: Vec<PypiPackageReqData> = Vec::new();
+
+    for package in packages {
+        match package {
+            Package::Pypi(p) => pypi_packages.push(PypiPackageReqData::from_pypi_package(&p)),
+            Package::Conda(cp) => {
+                if ignore_conda_errors {
+                    tracing::warn!(
+                        "ignoring Conda package {} since Conda packages are not supported in requirements.txt",
+                        cp.package_record().name.as_normalized()
+                    );
+                } else {
+                    miette::bail!(
+                        "Conda packages are not supported. Specify `--ignore-conda-errors` to ignore this error \
+                        and create a requirements file containing only the pypi dependencies from the lockfile."
+                    );
+                }
+            }
+        }
+    }
+
+    // Split package list based on presence of hash since pip currently treats requirements files
+    // containing any hashes as if `--require-hashes` has been supplied. The only known workaround
+    // is to split the dependencies, which are typically from vcs sources into a separate
+    // requirements.txt and to install it separately.
+    let (base, nohash): (Vec<PypiPackageReqData>, Vec<PypiPackageReqData>) = pypi_packages
+        .into_iter()
+        .partition(|p| p.editable || p.hash_flag.is_some());
+
+    tracing::info!("Creating requirements file for env: {env_name} platform: {platform}");
+    let target = output_dir
+        .join(format!("{}_{}_requirements.txt", env_name, platform))
+        .into_os_string();
+
+    render_pypi_requirements(target, &base)?;
+
+    if !nohash.is_empty() {
+        tracing::info!(
+            "Creating secondary requirements file for env: {env_name} platform: {platform} \
+            containing  packages without hashes. This file will have to be installed separately."
+        );
+        let target = output_dir
+            .join(format!("{}_{}_requirements_nohash.txt", env_name, platform))
+            .into_os_string();
+
+        render_pypi_requirements(target, &nohash)?;
+    }
+
+    Ok(())
+}
+
+pub async fn execute(project: Project, args: Args) -> miette::Result<()> {
+    let lockfile = project
+        .update_lock_file(UpdateLockFileOptions {
+            lock_file_usage: args.prefix_update_config.lock_file_usage(),
+            no_install: args.prefix_update_config.no_install,
+            ..UpdateLockFileOptions::default()
+        })
+        .await?
+        .lock_file;
+
+    let mut environments = Vec::new();
+    if let Some(env_names) = args.environment {
+        for env_name in &env_names {
+            environments.push((
+                env_name.to_string(),
+                lockfile
+                    .environment(env_name)
+                    .ok_or(miette::miette!("unknown environment {}", env_name))?,
+            ));
+        }
+    } else {
+        for (env_name, env) in lockfile.environments() {
+            environments.push((env_name.to_string(), env));
+        }
+    };
+
+    let mut env_platform = Vec::new();
+
+    for (env_name, env) in environments {
+        let available_platforms: HashSet<Platform> = HashSet::from_iter(env.platforms());
+
+        if let Some(ref platforms) = args.platform {
+            for plat in platforms {
+                if available_platforms.contains(plat) {
+                    env_platform.push((env_name.clone(), env.clone(), *plat));
+                } else {
+                    tracing::warn!(
+                        "Platform {} not available for environment {}. Skipping...",
+                        plat,
+                        env_name,
+                    );
+                }
+            }
+        } else {
+            for plat in available_platforms {
+                env_platform.push((env_name.clone(), env.clone(), plat));
+            }
+        }
+    }
+
+    fs::create_dir_all(&args.output_dir).ok();
+
+    for (env_name, env, plat) in env_platform {
+        render_env_platform(
+            &args.output_dir,
+            &env_name,
+            &env,
+            &plat,
+            args.ignore_conda_errors,
+        )?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This is a follow-up to #1873 that adds a new `pixi project export pypi-requirements` to export a [pip requirements.txt](https://pip.pypa.io/en/stable/reference/requirements-file-format/) from a pixi lock file. For pixi environments that specify both conda and pypi dependencies, this would allow users to `pixi project export conda-explicit-spec output --ignore-pypi-errors` together with the new command to create a series of files that could then be installed into a conda env using a combination of conda/mamba and pip/uv. 

Since the pip requirements file has many valid ways of representing a package as well as flags, I **think** we side step those complexities by specifying the full url path from the pixi.lock. I'd definitely like feedback from people who work with pip more since typically live fully in conda-land. 

One known complexity is that a `requirements.txt` that contains any package with a hash specified is treated as if the `--require-hashes` flag has been used for the whole file. This means that you can't mix packages with hashes and without in the same `pip install -r ...`. It does appear that `uv` will handle mixed files. To deal with this, I followed the currently recommended workaround and split requirements into two files. There is fix PR in https://github.com/pypa/pip/pull/11968, at least for packages specified from VCS urls, but that's been sitting for a while. As seen for the output of running this on [the pypi-source-deps example](https://github.com/prefix-dev/pixi/tree/main/examples/pypi-source-deps), this produces:

```
$ eza --tree test_output
test_output
├── default_linux-64_requirements.txt
├── default_linux-64_requirements_nohash.txt
├── default_osx-64_requirements.txt
├── default_osx-64_requirements_nohash.txt
├── default_osx-arm64_requirements.txt
├── default_osx-arm64_requirements_nohash.txt
├── default_win-64_requirements.txt
└── default_win-64_requirements_hash.txt
```

and the outputs look like:

```
$cat default_linux-64_requirements.txt
https://files.pythonhosted.org/packages/bb/2a/10164ed1f31196a2f7f3799368a821765c62851ead0e630ab52b8e14b4d0/blinker-1.8.2-py3-none-any.whl --hash=sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01
https://files.pythonhosted.org/packages/1c/d5/c84e1a17bf61d4df64ca866a1c9a913874b4e9bdc131ec689a0ad013fb36/certifi-2024.7.4-py3-none-any.whl --hash=sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
https://files.pythonhosted.org/packages/ee/fb/14d30eb4956408ee3ae09ad34299131fb383c47df355ddb428a7331cfa1e/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl --hash=sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b
https://files.pythonhosted.org/packages/22/7e/d71db821f177828df9dea8c42ac46473366f191be53080e552e628aad991/idna-3.8-py3-none-any.whl --hash=sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac
https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef
https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl --hash=sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1
https://files.pythonhosted.org/packages/0a/0d/2454f072fae3b5a137c119abf15465d1771319dfe9e4acbb31722a0fff91/MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl --hash=sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5
https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
https://files.pythonhosted.org/packages/c7/d9/c2a126eeae791e90ea099d05cb0515feea3688474b978343f3cdcfe04523/rich-13.8.0-py3-none-any.whl --hash=sha256:2e85306a063b9492dffc86278197a60cbece75bcb766022f3436f567cae11bdc
https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472
https://files.pythonhosted.org/packages/4b/84/997bbf7c2bf2dc3f09565c6d0b4959fefe5355c18c4096cfd26d83e0785b/werkzeug-3.0.4-py3-none-any.whl --hash=sha256:02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c
-e ./minimal-project
```

and:

```
$ cat default_linux-64_requirements_nohash.txt
https://github.com/pallets/click/releases/download/8.1.7/click-8.1.7-py3-none-any.whl
git+https://github.com/pallets/flask@f93dd6e826a9bf00bf9e08d9bb3a03abcb1e974c
git+https://github.com/pytest-dev/pytest.git@c947145fbb4aeec810a259b19f70fcb52fd53ad4
git+https://github.com/psf/requests.git@0106aced5faa299e6ede89d1230bd6784f2c3660
```

I'll add tests and docs once I get some feedback on the design. 