### PR TITLE
fix: constrain feature platforms in schema

### DIFF
--- a/schema/examples/invalid/bad_feature_platform.toml
+++ b/schema/examples/invalid/bad_feature_platform.toml
@@ -1,0 +1,9 @@
+"$schema" = "./../../schema.json"
+
+
+[project]
+name = "badplatform"
+platforms = ["linux-64"]
+
+[feature.foo]
+platforms = ["not-a-platform"]

--- a/schema/model.py
+++ b/schema/model.py
@@ -34,25 +34,31 @@ UnsignedInt = Annotated[int, Field(strict=True, ge=0)]
 GitUrl = Annotated[
     str, StringConstraints(pattern=r"((git|ssh|http(s)?)|(git@[\w\.]+))(:(\/\/)?)([\w\.@:\/\\-~]+)")
 ]
-Platform = (
-    Literal["linux-32"]
-    | Literal["linux-64"]
-    | Literal["linux-aarch64"]
-    | Literal["linux-armv6l"]
-    | Literal["linux-armv7l"]
-    | Literal["linux-ppc64le"]
-    | Literal["linux-ppc64"]
-    | Literal["linux-s390x"]
-    | Literal["linux-riscv32"]
-    | Literal["linux-riscv64"]
-    | Literal["osx-64"]
-    | Literal["osx-arm64"]
-    | Literal["win-32"]
-    | Literal["win-64"]
-    | Literal["win-arm64"]
-    | Literal["emscripten-wasm32"]
-    | Literal["wasi-wasm32"]
-)
+
+
+class Platform(str, Enum):
+    """A supported operating system and processor architecture pair."""
+
+    emscripten_wasm32 = "emscripten-wasm32"
+    linux_32 = "linux-32"
+    linux_64 = "linux-64"
+    linux_aarch64 = "linux-aarch64"
+    linux_armv6l = "linux-armv6l"
+    linux_armv7l = "linux-armv7l"
+    linux_ppc64 = "linux-ppc64"
+    linux_ppc64le = "linux-ppc64le"
+    linux_riscv32 = "linux-riscv32"
+    linux_riscv64 = "linux-riscv64"
+    linux_s390x = "linux-s390x"
+    noarch = "noarch"
+    osx_64 = "osx-64"
+    osx_arm64 = "osx-arm64"
+    unknown = "unknown"
+    wasi_wasm32 = "wasi-wasm32"
+    win_32 = "win-32"
+    win_64 = "win-64"
+    win_arm64 = "win-arm64"
+    zos_z = "zos-z"
 
 
 class StrictBaseModel(BaseModel):
@@ -424,7 +430,7 @@ class Feature(StrictBaseModel):
         "- 'strict': only take the package from the channel it exist in first."
         "- 'disabled': group all dependencies together as if there is no channel difference.",
     )
-    platforms: list[NonEmptyStr] | None = Field(
+    platforms: list[Platform] | None = Field(
         None,
         description="The platforms that the feature supports: a union of all features combined in one environment is used for the environment.",
     )

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -391,8 +391,7 @@
           "description": "The platforms that the feature supports: a union of all features combined in one environment is used for the environment.",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "$ref": "#/$defs/Platform"
           }
         },
         "pypi-dependencies": {
@@ -632,6 +631,33 @@
         }
       }
     },
+    "Platform": {
+      "title": "Platform",
+      "description": "A supported operating system and processor architecture pair.",
+      "type": "string",
+      "enum": [
+        "emscripten-wasm32",
+        "linux-32",
+        "linux-64",
+        "linux-aarch64",
+        "linux-armv6l",
+        "linux-armv7l",
+        "linux-ppc64",
+        "linux-ppc64le",
+        "linux-riscv32",
+        "linux-riscv64",
+        "linux-s390x",
+        "noarch",
+        "osx-64",
+        "osx-arm64",
+        "unknown",
+        "wasi-wasm32",
+        "win-32",
+        "win-64",
+        "win-arm64",
+        "zos-z"
+      ]
+    },
     "Project": {
       "title": "Project",
       "description": "The project's metadata information.",
@@ -744,59 +770,7 @@
           "description": "The platforms that the project supports",
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "const": "linux-32"
-              },
-              {
-                "const": "linux-64"
-              },
-              {
-                "const": "linux-aarch64"
-              },
-              {
-                "const": "linux-armv6l"
-              },
-              {
-                "const": "linux-armv7l"
-              },
-              {
-                "const": "linux-ppc64le"
-              },
-              {
-                "const": "linux-ppc64"
-              },
-              {
-                "const": "linux-s390x"
-              },
-              {
-                "const": "linux-riscv32"
-              },
-              {
-                "const": "linux-riscv64"
-              },
-              {
-                "const": "osx-64"
-              },
-              {
-                "const": "osx-arm64"
-              },
-              {
-                "const": "win-32"
-              },
-              {
-                "const": "win-64"
-              },
-              {
-                "const": "win-arm64"
-              },
-              {
-                "const": "emscripten-wasm32"
-              },
-              {
-                "const": "wasi-wasm32"
-              }
-            ]
+            "$ref": "#/$defs/Platform"
           }
         },
         "pypi-options": {

--- a/schema/test_manifest.py
+++ b/schema/test_manifest.py
@@ -1,18 +1,18 @@
 import glob
 import json
 import tomllib
+from pathlib import Path
 
 import pytest
 import jsonschema
 
+HERE = Path(__file__).parent
+EXAMPLES = HERE / "examples"
+VALID = {ex.stem: ex for ex in (EXAMPLES / "valid").glob("*.toml")}
+INVALID = {ex.stem: ex for ex in (EXAMPLES / "invalid").glob("*.toml")}
 
-@pytest.fixture(
-    scope="module",
-    params=[
-        "minimal",
-        "full",
-    ],
-)
+
+@pytest.fixture(scope="module", params=VALID)
 def valid_manifest(request) -> str:
     manifest_name = request.param
     with open(f"examples/valid/{manifest_name}.toml") as f:
@@ -21,14 +21,7 @@ def valid_manifest(request) -> str:
     return manifest_toml
 
 
-@pytest.fixture(
-    scope="module",
-    params=[
-        "empty",
-        "no_channel",
-        "bad_env_variable",
-    ],
-)
+@pytest.fixture(scope="module", params=INVALID)
 def invalid_manifest(request) -> str:
     manifest_name = request.param
     with open(f"examples/invalid/{manifest_name}.toml") as f:


### PR DESCRIPTION
At present, the following does not raise an error when editing/validating:

```toml
[feature.foo_bar]
platforms = ["garbage"]
```

But does raise an issue when parsed:

```
  × failed to parse project manifest
    ╭─[pixi.toml:10:13]
  9 │ [feature.foo_bar]
 10 │ platforms = ["garbage"]
    ·             ─────┬─────
    ·                  ╰── 'garbage' is not a known platform. Valid platforms are 'noarch', 'unknown', 'linux-32', 'linux-64', 'linux-aarch64', 'linux-armv6l', 'linux-armv7l', 'linux-ppc64le', 'linux-ppc64', 'linux-s390x', 'linux-riscv32', 'linux-riscv64', 'osx-64', 'osx-arm64', 'win-32', 'win-64', 'win-arm64', 'emscripten-wasm32', 'wasi-wasm32', 'zos-z'
    ╰────
```

This PR: 
- [x] makes an enum out of `Platform`
  - [x] updates it to the current list reported by the error
  - [x] sorts the list
- [x] uses `Platform` in `platforms` and `feature.*.platforms`.
- [x] adds a schema test for bad feature platforms
  - [x] reworks schema example finder to glob over `(in)valid/*.toml`

Future work (not on this PR):
- the "true" list of platforms is, of course, whatever the rust code (probably `rattler`?) thinks it is, but apparently, short of creating an error, there is no way to get this list
  - this could perhaps be added to 
    - `pixi info --json` (which, as with #1344, doesn't have a schema) or
    - something like `$PIXI_ENVIRONMENT_PLATFORMS` (not sure how useful that is outside of this case)