### PR TITLE
fix: `subdirectory` in pypi url

### DIFF
--- a/crates/pixi_manifest/src/pypi/pypi_requirement.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_requirement.rs
@@ -960,7 +960,7 @@ mod tests {
         let parsed = pep508_rs::Requirement::from_str(
             "ribasim@git+https://github.com/Deltares/Ribasim.git#subdirectory=python/ribasim",
         )
-            .unwrap();
+        .unwrap();
         assert_eq!(
             PyPiRequirement::try_from(parsed).unwrap(),
             PyPiRequirement::Git {

--- a/crates/pixi_manifest/src/pypi/pypi_requirement.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_requirement.rs
@@ -34,7 +34,8 @@ impl TryFrom<Url> for ParsedGitUrl {
 
         // Strip the git+ from the url.
         let url_without_git = url.as_str().strip_prefix("git+").unwrap_or(url.as_str());
-        let url = Url::parse(url_without_git)?;
+        let mut url = Url::parse(url_without_git)?;
+        url.set_fragment(None);
 
         // Split the repository url and the rev.
         let (repository_url, rev) = if let Some((prefix, suffix)) = url
@@ -953,6 +954,25 @@ mod tests {
             Err(Pep508ToPyPiRequirementError::ParseGitRev(
                 GitRevParseError::InvalidCharacters(characters)
             )) if characters == "main"
+        );
+
+        // With subdirectory
+        let parsed = pep508_rs::Requirement::from_str(
+            "ribasim@git+https://github.com/Deltares/Ribasim.git#subdirectory=python/ribasim",
+        )
+            .unwrap();
+        assert_eq!(
+            PyPiRequirement::try_from(parsed).unwrap(),
+            PyPiRequirement::Git {
+                url: ParsedGitUrl {
+                    git: Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    subdirectory: Some("python/ribasim".to_string()),
+                },
+                extras: vec![],
+            }
         );
     }
 

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -222,6 +222,7 @@ impl Target {
     ///
     /// This will overwrite any existing dependency of the same name
     pub fn add_pypi_dependency(&mut self, name: PyPiPackageName, requirement: PyPiRequirement) {
+        tracing::info!("Adding pypi dependency: {} {}", name.as_normalized(), requirement);
         self.pypi_dependencies
             .get_or_insert_with(Default::default)
             .insert(name, requirement);

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -222,7 +222,11 @@ impl Target {
     ///
     /// This will overwrite any existing dependency of the same name
     pub fn add_pypi_dependency(&mut self, name: PyPiPackageName, requirement: PyPiRequirement) {
-        tracing::info!("Adding pypi dependency: {} {}", name.as_normalized(), requirement);
+        tracing::info!(
+            "Adding pypi dependency: {} {}",
+            name.as_normalized(),
+            requirement
+        );
         self.pypi_dependencies
             .get_or_insert_with(Default::default)
             .insert(name, requirement);

--- a/schema/examples/valid/full.toml
+++ b/schema/examples/valid/full.toml
@@ -185,6 +185,10 @@ warmup = "python warmup.py"
 [feature.cuda2.target.osx-arm64.dependencies]
 mlx = "x.y.z"
 
+[feature.dev.pypi-dependencies]
+ribasim = { git = "https://github.com/Deltares/Ribasim.git", subdirectory = "python/ribasim" }
+ribasim2 = { path = "test/riba", subdirectory = "python/ribasim" }
+
 # Channels and Platforms are not available as separate tables as they are implemented as lists
 [feature.cuda2]
 channels = ["nvidia"]

--- a/schema/model.py
+++ b/schema/model.py
@@ -24,7 +24,6 @@ CARGO_TOML_DATA = tomllib.loads(CARGO_TOML.read_text(encoding="utf-8"))
 VERSION = CARGO_TOML_DATA["package"]["version"]
 SCHEMA_URI = f"https://pixi.sh/v{VERSION}/schema/manifest/schema.json"
 
-
 NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
 Md5Sum = Annotated[str, StringConstraints(pattern=r"^[a-fA-F0-9]{32}$")]
 Sha256Sum = Annotated[str, StringConstraints(pattern=r"^[a-fA-F0-9]{64}$")]
@@ -194,6 +193,9 @@ class _PyPiGitRequirement(_PyPIRequirement):
         None,
         description="The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
     )
+    subdirectory: NonEmptyStr | None = Field(
+        None, description="The subdirectory in the repo, a path from the root of the repo."
+    )
 
 
 class PyPIGitRevRequirement(_PyPiGitRequirement):
@@ -215,6 +217,9 @@ class PyPIPathRequirement(_PyPIRequirement):
     )
     editable: Optional[bool] = Field(
         None, description="If `true` the package will be installed as editable"
+    )
+    subdirectory: NonEmptyStr | None = Field(
+        None, description="The subdirectory in the repo, a path from the root of the repo."
     )
 
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -852,6 +852,12 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "The subdirectory in the repo, a path from the root of the repo.",
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -880,6 +886,12 @@
           "description": "A `git` SHA revision to use",
           "type": "string",
           "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "The subdirectory in the repo, a path from the root of the repo.",
+          "type": "string",
+          "minLength": 1
         }
       }
     },
@@ -900,6 +912,12 @@
         "git": {
           "title": "Git",
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
+          "type": "string",
+          "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "The subdirectory in the repo, a path from the root of the repo.",
           "type": "string",
           "minLength": 1
         },
@@ -1018,6 +1036,12 @@
         "path": {
           "title": "Path",
           "description": "A path to a local source or wheel",
+          "type": "string",
+          "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "The subdirectory in the repo, a path from the root of the repo.",
           "type": "string",
           "minLength": 1
         }


### PR DESCRIPTION
Fixes the issue in the comment of @evetion in #771: https://github.com/prefix-dev/pixi/issues/771#issuecomment-2346462475

Now you are able to run:
```
pixi add --pypi "ribasim@git+https://github.com/Deltares/Ribasim.git#subdirectory=python/ribasim" 
```