### PR TITLE
fix: create a GUI application on Windows, not Console

### DIFF
--- a/examples/cpp-sdl/CMakeLists.txt
+++ b/examples/cpp-sdl/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 add_executable(${PROJECT_NAME} src/main.cc)
 
+if (MSVC)
+    set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
+endif()
+
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
     SDL2::SDL2


### PR DESCRIPTION
This prevents an empty console to be opened when we launch this program from Windows Explorer.

Note that this change makes `std::cout` not work anymore (if launched from a console). This is fixed in a separate PR: https://github.com/prefix-dev/pixi/pull/2070.