### PR TITLE
fix: link the SDL library statically

### DIFF
--- a/examples/cpp-sdl/CMakeLists.txt
+++ b/examples/cpp-sdl/CMakeLists.txt
@@ -9,6 +9,6 @@ add_executable(${PROJECT_NAME} src/main.cc)
 
 target_link_libraries(
     ${PROJECT_NAME} PRIVATE
-    SDL2::SDL2
+    SDL2::SDL2-static
     SDL2::SDL2main
 )


### PR DESCRIPTION
This allows to run the executable on windows using:

    .build/bin/sdl_example

Previously it would give an error message that "SDL.dll" was not found.