### PR TITLE
fix: make dashes underscores in python package names

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,10 +1,4 @@
-use std::{
-    cmp::PartialEq,
-    fs,
-    io::{Error, ErrorKind, Write},
-    path::{Path, PathBuf},
-};
-use std::str::FromStr;
+use crate::Project;
 use clap::{Parser, ValueEnum};
 use miette::{Context, IntoDiagnostic};
 use minijinja::{context, Environment};
@@ -15,10 +9,16 @@ use pixi_manifest::{
 };
 use pixi_utils::conda_environment_file::CondaEnvFile;
 use rattler_conda_types::{NamedChannelOrUrl, Platform};
+use std::str::FromStr;
+use std::{
+    cmp::PartialEq,
+    fs,
+    io::{Error, ErrorKind, Write},
+    path::{Path, PathBuf},
+};
 use tokio::fs::OpenOptions;
 use url::Url;
 use uv_normalize::PackageName;
-use crate::Project;
 
 #[derive(Parser, Debug, Clone, PartialEq, ValueEnum)]
 pub enum ManifestFormat {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -137,7 +137,7 @@ platforms = {{ platforms }}
 {%- endif %}
 
 [tool.pixi.pypi-dependencies]
-{{ name }} = { path = ".", editable = true }
+{{ pypi_package_name }} = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 
@@ -334,12 +334,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
             // Create a 'pyproject.toml' manifest
         } else if pyproject {
+            // Python package names cannot contain '-', so we replace them with '_'
+            let pypi_package_name = default_name.replace("-", "_");
+
             let rv = env
                 .render_named_str(
                     consts::PYPROJECT_MANIFEST,
                     NEW_PYROJECT_TEMPLATE,
                     context! {
                         name => default_name,
+                        pypi_package_name,
                         version,
                         author,
                         channels,
@@ -350,7 +354,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 )
                 .unwrap();
             save_manifest_file(&pyproject_manifest_path, rv)?;
-            let src_dir = dir.join("src").join(default_name);
+
+            let src_dir = dir.join("src").join(pypi_package_name);
             tokio::fs::create_dir_all(&src_dir)
                 .await
                 .into_diagnostic()


### PR DESCRIPTION
fixes: #2066 

```bash
$ pixi init --format pyproject test-project
$ tree test-project
test-project/
├── pyproject.toml
└── src
    └── test_project # <<<< This is now an underscore
        └── __init__.py
```