### PR TITLE
fix: Change documentation of pixi upload to refer to correct API endpoint

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -768,7 +768,7 @@ Upload a package to a prefix.dev channel
 2. `<PACKAGE_FILE>`: The package file to upload.
 
 ```shell
-pixi upload repo.prefix.dev/my_channel my_package.conda
+pixi upload https://prefix.dev/api/v1/upload/my_channel my_package.conda
 ```
 
 ## `auth`

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -18,7 +18,7 @@ use pixi_progress;
 ///
 /// With this command, you can upload a conda package to a channel.
 /// Example:
-///     pixi upload repo.prefix.dev/my_channel my_package.conda
+///     pixi upload https://prefix.dev/api/v1/upload/my_channel my_package.conda
 ///
 /// Use `pixi auth login` to authenticate with the server.
 #[derive(Parser, Debug)]

--- a/src/cli/upload.rs
+++ b/src/cli/upload.rs
@@ -14,6 +14,7 @@ use tokio_util::io::ReaderStream;
 
 use pixi_progress;
 
+#[allow(rustdoc::bare_urls)]
 /// Upload a conda package
 ///
 /// With this command, you can upload a conda package to a channel.


### PR DESCRIPTION
From what understand eventually the pixi upload UX will be improved (see https://github.com/prefix-dev/pixi/issues/248), in the meanwhile I think it is useful to fix the existing documentation to simplify its use. 

Following the docs, I obtained some enigmatic errors, until I found https://github.com/prefix-dev/pixi/issues/248 that contained the right endpoint to call.