### PR TITLE
fix: give better errors on broken `pyproject.toml`

### DIFF
--- a/crates/pixi_manifest/src/error.rs
+++ b/crates/pixi_manifest/src/error.rs
@@ -34,7 +34,7 @@ pub enum RequirementConversionError {
 pub enum TomlError {
     #[error(transparent)]
     Error(#[from] toml_edit::TomlError),
-    #[error("Missing table `[tool.pixi]`")]
+    #[error("Missing table `[tool.pixi.project]`. Try running `pixi init`")]
     NoPixiTable,
     #[error("Missing field `name`")]
     NoProjectName(Option<std::ops::Range<usize>>),

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -184,7 +184,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 }
 
 fn determine_project_root(common_args: &CommonArgs) -> miette::Result<Option<PathBuf>> {
-    match project::find_project_manifest() {
+    match project::find_project_manifest(std::env::current_dir().into_diagnostic()?) {
         None => {
             if common_args.local {
                 return Err(miette::miette!(

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -229,6 +229,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .or_else(ShellEnum::from_env)
         .unwrap_or_default();
 
+    tracing::info!("Starting shell: {:?}", interactive_shell);
+
     let prompt = if project.config().change_ps1() {
         match interactive_shell {
             ShellEnum::NuShell(_) => prompt::get_nu_prompt(prompt_name.as_str()),


### PR DESCRIPTION
You'll now get:
```
$ pixi install
  × failed to parse project manifest
    ╭─[pyproject.toml:18:12]
 17 │ 
 18 │ [tool.pixi.pypi-depenencies]
    ·            ────────┬───────
    ·                    ╰── unknown field `pypi-depenencies`, expected one of `project`, `system-requirements`, `target`, `dependencies`, `host-dependencies`, `build-dependencies`, `pypi-dependencies`, `activation`, `tasks`, `feature`, `environments`, `pypi-options`, `tool`, `$schema`
 19 │ test_init = { path = ".", editable = true }
    ╰────
```

instead of:
```
❯ ~/.pixi/bin/pixi i
  × could not find pixi.toml or pyproject.toml which is configured to use pixi
```
