### PR TITLE
fix: always fetch the release version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,8 +138,7 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - if: ${{ matrix.os != 'windows-latest' }}
-        uses: rui314/setup-mold@v1
+      - uses: rui314/setup-mold@v1
 
       - name: "Cargo nextest"
         run: >-
@@ -214,7 +213,7 @@ jobs:
 
       - name: Setup | Install cargo-wix [Windows]
         # aarch64 is only supported in wix 4.0 development builds
-        if: startsWith(matrix.os, 'windows') && matrix.target != 'aarch64-pc-windows-msvc'
+        if: startsWith(matrix.name, 'Windows') && matrix.target != 'aarch64-pc-windows-msvc'
         run: cargo install --version 0.3.8 cargo-wix
         env:
           # cargo-wix does not require static crt
@@ -284,7 +283,7 @@ jobs:
           echo "EXE_SUFFIX=${EXE_SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: Build msi Installer
-        if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
+        if: startsWith(matrix.name, 'Windows') && matrix.target != 'aarch64-pc-windows-msvc'
         run: >
           cargo wix -v --no-build --nocapture -I install/windows/main.wxs
           --profile $env:CARGO_PROFILE
@@ -394,7 +393,7 @@ jobs:
           path: ${{ steps.package.outputs.BIN_PATH }}
 
       - name: "Artifact upload: windows installer"
-        if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
+        if: startsWith(matrix.name, 'Windows') && matrix.target != 'aarch64-pc-windows-msvc'
         uses: actions/upload-artifact@v4
         with:
           name: pixi-${{ matrix.target }}.msi

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -77,6 +77,8 @@ def print_summary():
 
 atexit.register(print_summary)
 
+global release_version
+
 
 def main():
     steps = [
@@ -122,10 +124,9 @@ def main():
             )
             status.append("Checked main branch and CI status")
 
-        if start_step <= 3:
-            release_version = get_release_version()
-            os.environ["RELEASE_VERSION"] = release_version
-            status.append(f"Release version set to {release_version}")
+        release_version = get_release_version()
+        os.environ["RELEASE_VERSION"] = release_version
+        status.append(f"Release version set to {release_version}")
 
         if start_step <= 4:
             colored_print("\nCreating a new branch for the release...", "yellow")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -77,7 +77,6 @@ def print_summary():
 
 atexit.register(print_summary)
 
-global release_version
 
 
 def main():

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -78,7 +78,6 @@ def print_summary():
 atexit.register(print_summary)
 
 
-
 def main():
     steps = [
         "Start release process",


### PR DESCRIPTION
This will fix the issue that we don't build `msi` installers.