### PR TITLE
ci: downstream test improvement

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -413,7 +413,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   downstream_tests:
-    name: "Test downstream projects"
+    name: "Test examples, downstream projects and integration"
     needs:
       - build
     uses: ./.github/workflows/test_downstream.yml

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -1,4 +1,4 @@
-name: "Test examples and Downstream projects"
+name: "Test examples, downstream projects and integration"
 
 on:
   workflow_call:
@@ -200,6 +200,7 @@ jobs:
           Move-Item -Path "pixi_bin/pixi-${{ matrix.arch.target }}${{ matrix.arch.extension }}" -Destination "${{ env.TARGET_RELEASE }}/pixi.exe"
         shell: pwsh
       - name: Typecheck integration tests
+        if: runner.os == 'Linux'
         run: ${{ env.TARGET_RELEASE }}/pixi${{ matrix.arch.extension }} run typecheck-integration
       - name: Run integration tests
         run: ${{ env.TARGET_RELEASE }}/pixi${{ matrix.arch.extension }} run test-integration-ci


### PR DESCRIPTION
- Typecheck takes 22 s on linux and 3 minutes on Windows. One platform is enough, so let's only run it on linux
- Adapt the naming of the workflow