### PR TITLE
feat: add a source metadata cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -352,7 +352,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -823,7 +823,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1016,7 +1016,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1027,7 +1027,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1125,7 +1125,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1190,7 +1190,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1300,7 +1300,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1333,7 +1333,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2748,7 +2748,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3011,7 +3011,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3022,7 +3022,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3299,7 +3299,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3377,7 +3377,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3563,7 +3563,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "unicase",
 ]
 
@@ -3594,7 +3594,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3626,9 +3626,11 @@ version = "0.29.0"
 dependencies = [
  "ahash 0.8.11",
  "assert_matches",
+ "async-fd-lock",
  "async-once-cell",
  "async-trait",
  "barrier_cell",
+ "base64 0.22.1",
  "cfg-if",
  "chrono",
  "clap",
@@ -3906,6 +3908,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_digest",
  "rattler_lock",
+ "serde",
  "thiserror",
  "typed-path",
  "url",
@@ -4106,7 +4109,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "version_check",
  "yansi",
 ]
@@ -4515,7 +4518,7 @@ version = "1.0.2"
 source = "git+https://github.com/conda/rattler?branch=feat/pixi-build#e6c662e22cd39d8d04c84f9db424b457e787edf1"
 dependencies = [
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4771,7 +4774,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5154,7 +5157,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.72",
+ "syn 2.0.77",
  "unicode-ident",
 ]
 
@@ -5366,7 +5369,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5392,7 +5395,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5515,7 +5518,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5526,7 +5529,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5559,7 +5562,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5610,7 +5613,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5903,7 +5906,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -5952,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6116,7 +6119,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6206,7 +6209,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6374,7 +6377,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6875,7 +6878,7 @@ source = "git+https://github.com/astral-sh/uv?tag=0.4.0#d9bd3bc7a536037ea8645fb7
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "textwrap",
 ]
 
@@ -7170,7 +7173,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -7204,7 +7207,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7377,7 +7380,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7388,7 +7391,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7706,7 +7709,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "zvariant_utils",
 ]
 
@@ -7739,7 +7742,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -7842,7 +7845,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "zvariant_utils",
 ]
 
@@ -7854,5 +7857,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ repository = "https://github.com/prefix-dev/pixi"
 [workspace.dependencies]
 ahash = "0.8.11"
 assert_matches = "1.5.0"
+async-fd-lock = "0.2.0"
 async-once-cell = "0.5.3"
 async-trait = "0.1.82"
+base64 = "0.22.1"
+bincode = ""
 cfg-if = "1.0"
 chrono = "0.4.38"
 clap = { version = "4.5.9", default-features = false }
@@ -177,8 +180,10 @@ slow_integration_tests = []
 [dependencies]
 ahash = { workspace = true }
 assert_matches = { workspace = true }
+async-fd-lock = { workspace = true }
 async-once-cell = { workspace = true }
 barrier_cell = { path = "crates/barrier_cell" }
+base64 = { workspace = true }
 cfg-if = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ async-fd-lock = "0.2.0"
 async-once-cell = "0.5.3"
 async-trait = "0.1.82"
 base64 = "0.22.1"
-bincode = ""
 cfg-if = "1.0"
 chrono = "0.4.38"
 clap = { version = "4.5.9", default-features = false }

--- a/crates/pixi_build_frontend/src/protocols/conda_build/mod.rs
+++ b/crates/pixi_build_frontend/src/protocols/conda_build/mod.rs
@@ -69,7 +69,7 @@ impl ProtocolBuilder {
 
     pub fn finish(self, tool: Tool) -> Protocol {
         Protocol {
-            channel_config: self.channel_config,
+            _channel_config: self.channel_config,
             tool,
             source_dir: self.source_dir,
             recipe_dir: self.recipe_dir,

--- a/crates/pixi_build_types/src/conda_package_metadata.rs
+++ b/crates/pixi_build_types/src/conda_package_metadata.rs
@@ -1,9 +1,9 @@
-use rattler_conda_types::{MatchSpec, NoArchType, PackageName, Platform, VersionWithSource};
+use rattler_conda_types::{NoArchType, PackageName, Platform, VersionWithSource};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
+use serde_with::serde_as;
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CondaPackageMetadata {
     /// The name of the package.
@@ -23,13 +23,11 @@ pub struct CondaPackageMetadata {
 
     /// The dependencies of the package
     #[serde(default)]
-    #[serde_as(as = "Vec<DisplayFromStr>")]
-    pub depends: Vec<MatchSpec>,
+    pub depends: Vec<String>,
 
     /// The constrains of the package
     #[serde(default)]
-    #[serde_as(as = "Vec<DisplayFromStr>")]
-    pub constraints: Vec<MatchSpec>,
+    pub constraints: Vec<String>,
 
     /// The license of the package
     pub license: Option<String>,

--- a/crates/pixi_glob/src/glob_hash_cache.rs
+++ b/crates/pixi_glob/src/glob_hash_cache.rs
@@ -55,7 +55,8 @@ impl GlobHashCache {
                 // the map. If another requests comes in for the same hash it will find this
                 // entry.
                 let (tx, _) = broadcast::channel(1);
-                let weak_tx = Arc::downgrade(&Arc::new(tx.clone()));
+                let tx = Arc::new(tx);
+                let weak_tx = Arc::downgrade(&tx);
                 entry.insert(HashCacheEntry::Pending(weak_tx));
 
                 // Spawn the computation of the hash

--- a/crates/pixi_record/Cargo.toml
+++ b/crates/pixi_record/Cargo.toml
@@ -15,6 +15,7 @@ pixi_spec = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true }
 rattler_lock = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 typed-path = { workspace = true }
 url = { workspace = true }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -1,5 +1,5 @@
 use rattler_conda_types::{MatchSpec, Matches, NamelessMatchSpec, PackageRecord};
-use rattler_digest::Sha256Hash;
+use rattler_digest::{Sha256, Sha256Hash};
 use rattler_lock::CondaPackageData;
 use serde::{Deserialize, Serialize};
 
@@ -26,8 +26,12 @@ pub struct SourceRecord {
 /// Defines the hash of the input files that were used to build the metadata of
 /// the record. If reevaluating and hashing the globs results in a different
 /// hash, the metadata is considered invalid.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InputHash {
+    #[serde(
+        serialize_with = "rattler_digest::serde::serialize::<_, Sha256>",
+        deserialize_with = "rattler_digest::serde::deserialize::<_, Sha256>"
+    )]
     pub hash: Sha256Hash,
     pub globs: Vec<String>,
 }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -1,6 +1,7 @@
 use rattler_conda_types::{MatchSpec, Matches, NamelessMatchSpec, PackageRecord};
 use rattler_digest::Sha256Hash;
 use rattler_lock::CondaPackageData;
+use serde::{Deserialize, Serialize};
 
 use crate::{ParseLockFileError, PinnedSourceSpec};
 
@@ -25,7 +26,7 @@ pub struct SourceRecord {
 /// Defines the hash of the input files that were used to build the metadata of
 /// the record. If reevaluating and hashing the globs results in a different
 /// hash, the metadata is considered invalid.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct InputHash {
     pub hash: Sha256Hash,
     pub globs: Vec<String>,

--- a/pixi.lock
+++ b/pixi.lock
@@ -117,8 +117,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.6-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py312h98912ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.81.0-h1a8d7c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.81.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/schema-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -211,8 +211,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.6-py312h41838bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.8-py312h41838bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.80.1-h6c54e5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.80.1-h38e4360_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.81.0-h6c54e5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.81.0-h38e4360_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/schema-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -304,8 +304,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.6-py312he37b823_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py312he37b823_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.80.1-h4ff7c5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.80.1-hf6ec828_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.81.0-h4ff7c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.81.0-hf6ec828_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/schema-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -386,8 +386,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.6-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.8-py312he70551f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.80.1-hf8d6059_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.80.1-h17fc481_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.81.0-hf8d6059_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.81.0-h17fc481_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/schema-0.7.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
@@ -7495,133 +7495,133 @@ packages:
   timestamp: 1718950736324
 - kind: conda
   name: rust
-  version: 1.80.1
-  build: h0a17960_0
+  version: 1.81.0
+  build: h1a8d7c4_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
-  sha256: 7058519747d4b81f3cab23a0d6b4326c80879d38b2a0bf11cade52fc59980b8f
-  md5: dba7ad0d2f707fee5e85c6a19042fdb4
+  url: https://conda.anaconda.org/conda-forge/linux-64/rust-1.81.0-h1a8d7c4_0.conda
+  sha256: 0620c44414d140f63e215b8555770acb94e473787f84cb1ab051bb6ebd3a808f
+  md5: 0e4d3f6598c7b770b1ac73ca8689c300
   depends:
   - __glibc >=2.17,<3.0.a0
   - gcc_impl_linux-64
-  - libgcc-ng >=12
+  - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  - rust-std-x86_64-unknown-linux-gnu 1.80.1 h2c6d0dc_0
+  - rust-std-x86_64-unknown-linux-gnu 1.81.0 h2c6d0dc_0
   - sysroot_linux-64 >=2.17
   license: MIT
   license_family: MIT
-  size: 198885602
-  timestamp: 1723153698032
+  size: 200303283
+  timestamp: 1726504386467
 - kind: conda
   name: rust
-  version: 1.80.1
+  version: 1.81.0
   build: h4ff7c5d_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.80.1-h4ff7c5d_0.conda
-  sha256: 5b296bb663be4c10bf3d07eaaa69c3c5856bd198152a775404e161f6780236bb
-  md5: 76d236abc95f2d77f7a3c16f1b565b3e
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.81.0-h4ff7c5d_0.conda
+  sha256: aa6dffbf4b6441512f9dcce572913b2cfff2a2f71b0ffe9b29c04efa4e1e15d7
+  md5: 9421a9205351eb673c57af9e491dc2bf
   depends:
-  - rust-std-aarch64-apple-darwin 1.80.1 hf6ec828_0
+  - rust-std-aarch64-apple-darwin 1.81.0 hf6ec828_0
   license: MIT
   license_family: MIT
-  size: 197866703
-  timestamp: 1723155024117
+  size: 199771549
+  timestamp: 1726506487060
 - kind: conda
   name: rust
-  version: 1.80.1
+  version: 1.81.0
   build: h6c54e5d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rust-1.80.1-h6c54e5d_0.conda
-  sha256: 8e799c550545a41baef23a543ffd87620cf67c0afd3494ea40b6081cbf8aabe7
-  md5: ecf36b937ded5c641039161f7f5c7f64
+  url: https://conda.anaconda.org/conda-forge/osx-64/rust-1.81.0-h6c54e5d_0.conda
+  sha256: 84e3131a0441e2694849bd0c8de3fd3eac2a1b4e3ae49f37114c2b4c876d4bec
+  md5: ae4382936ab0a7ba617410f3371dba8c
   depends:
-  - rust-std-x86_64-apple-darwin 1.80.1 h38e4360_0
+  - rust-std-x86_64-apple-darwin 1.81.0 h38e4360_0
   license: MIT
   license_family: MIT
-  size: 202606989
-  timestamp: 1723154998091
+  size: 205216960
+  timestamp: 1726505981140
 - kind: conda
   name: rust
-  version: 1.80.1
+  version: 1.81.0
   build: hf8d6059_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rust-1.80.1-hf8d6059_0.conda
-  sha256: 3d8f926d5db03762a1e3ff723295ea18674c29960e2e501a16c9413304698654
-  md5: 385a661cb1746cb6c62eb55712b412dd
+  url: https://conda.anaconda.org/conda-forge/win-64/rust-1.81.0-hf8d6059_0.conda
+  sha256: 47b0f34453bc347739cb1b5eaaefe6a86aff2f4d91a333ecb56075714a188f3f
+  md5: 08ba4c469f11512a07583ace97766ee2
   depends:
-  - rust-std-x86_64-pc-windows-msvc 1.80.1 h17fc481_0
+  - rust-std-x86_64-pc-windows-msvc 1.81.0 h17fc481_0
   license: MIT
   license_family: MIT
-  size: 194534225
-  timestamp: 1723155969495
+  size: 193252613
+  timestamp: 1726506914739
 - kind: conda
   name: rust-std-aarch64-apple-darwin
-  version: 1.80.1
+  version: 1.81.0
   build: hf6ec828_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.80.1-hf6ec828_0.conda
-  sha256: 6cd8c3cf93fb8348c815595eced946316bc81a0bf8c6fc8f6b9f27e270734770
-  md5: b3b07764d1fa59acf5c356bbb727db20
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.81.0-hf6ec828_0.conda
+  sha256: a8a31df1ef430f8dda4689f49e09e43dce333b02cfca39d61281652b950a69da
+  md5: 5f228231eb202cbd06b98e57697c470f
   depends:
   - __unix
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 30991019
-  timestamp: 1723152907303
+  size: 31264180
+  timestamp: 1726503800830
 - kind: conda
   name: rust-std-x86_64-apple-darwin
-  version: 1.80.1
+  version: 1.81.0
   build: h38e4360_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.80.1-h38e4360_0.conda
-  sha256: 56a30b275235975ea4e37f8d703818079601163aca92195a45468b0e7d6beffb
-  md5: b1ce3c6d57f2cf9f5a8b2448e3b6f499
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.81.0-h38e4360_0.conda
+  sha256: 18a2ceedf84a9b002e5bf68db3f9e5a4dd0fcb8c3d6c380004f094a3d0caae9d
+  md5: 37da4f96842452abf1b047a2b4b74893
   depends:
   - __unix
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 31988631
-  timestamp: 1723152891461
+  size: 32202262
+  timestamp: 1726503655773
 - kind: conda
   name: rust-std-x86_64-pc-windows-msvc
-  version: 1.80.1
+  version: 1.81.0
   build: h17fc481_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.80.1-h17fc481_0.conda
-  sha256: a4f118c6211f717846c094e58d3baef32215d1a2414d51c3e08b739dce75c28f
-  md5: f21862b6487af2fe504ca2b78dfec822
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.81.0-h17fc481_0.conda
+  sha256: 2a7d0ac2035c09d31078602e194082e44a641ecfa5ca4edf47c16f25590b4fda
+  md5: 809e64792fbf0bd55fdf9e4577e46bae
   depends:
   - __win
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 25255952
-  timestamp: 1723155705619
+  size: 25578327
+  timestamp: 1726506658685
 - kind: conda
   name: rust-std-x86_64-unknown-linux-gnu
-  version: 1.80.1
+  version: 1.81.0
   build: h2c6d0dc_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
-  sha256: 769cb83291804c9faa0de81534ceb3794cd06efd4d5164872bd5527e511f12a7
-  md5: 0a5b8783d18a253b0812a5501df297af
+  url: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.81.0-h2c6d0dc_0.conda
+  sha256: 6539b9c5f787c9e579d4f0af763527fe890a0935357f99d5410e71fbbb165ee3
+  md5: e6d687c017e8af51a673081a2964ed1c
   depends:
   - __unix
   constrains:
-  - rust >=1.80.1,<1.80.2.0a0
+  - rust >=1.81.0,<1.81.1.0a0
   license: MIT
   license_family: MIT
-  size: 33938994
-  timestamp: 1723153507938
+  size: 34828353
+  timestamp: 1726504171219
 - kind: conda
   name: schema
   version: 0.7.7

--- a/pixi.toml
+++ b/pixi.toml
@@ -73,7 +73,7 @@ toml-lint = "taplo lint --verbose **/pixi.toml"
 git = ">=2.46.0,<3"
 openssl = "3.*"
 pkg-config = "0.29.*"
-rust = "~=1.80.0"
+rust = "~=1.81.0"
 [feature.build.target.linux-64.dependencies]
 clang = ">=18.1.8,<19.0"
 compilers = ">=1.6.0"

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -26,7 +26,7 @@ use typed_path::{Utf8TypedPath, Utf8TypedPathBuf};
 use url::Url;
 
 use crate::build::source_metadata_cache::{
-    CachedCondaMetadata, SourceCacheKey, SourceMetadataCache,
+    CachedCondaMetadata, SourceMetadataCache, SourceMetadataInput,
 };
 
 /// The [`BuildContext`] is used to build packages from source.
@@ -291,7 +291,7 @@ impl BuildContext {
             .source_metadata_cache
             .entry(
                 source,
-                &SourceCacheKey {
+                &SourceMetadataInput {
                     channel_urls: channels.to_vec(),
                     target_platform,
                 },

--- a/src/build/source_metadata_cache.rs
+++ b/src/build/source_metadata_cache.rs
@@ -1,0 +1,185 @@
+use std::{
+    ffi::OsStr,
+    hash::{DefaultHasher, Hash, Hasher},
+    io::SeekFrom,
+    path::PathBuf,
+};
+
+use async_fd_lock::{LockWrite, RwLockWriteGuard};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use pixi_build_types::CondaPackageMetadata;
+use pixi_record::InputHash;
+use rattler_conda_types::Platform;
+use serde::Deserialize;
+use serde_with::serde_derive::Serialize;
+use thiserror::Error;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use url::Url;
+
+use crate::build::SourceCheckout;
+
+#[derive(Debug, Error)]
+pub enum SourceMetadataError {
+    /// An I/O error occurred while reading or writing the cache.
+    #[error("an IO error occurred while {0} {1}")]
+    IoError(String, PathBuf, #[source] std::io::Error),
+}
+
+pub struct SourceCacheKey {
+    /// TODO: I think this should also include the build backend used! Maybe?
+
+    /// The URL of the source.
+    pub channel_urls: Vec<Url>,
+
+    /// The platform for which the metadata was computed.
+    pub target_platform: Platform,
+}
+
+impl SourceCacheKey {
+    /// Computes a unique semi-human-readable hash for this key.
+    pub fn hash_key(&self) -> String {
+        let mut hasher = DefaultHasher::new();
+        self.channel_urls.hash(&mut hasher);
+        format!(
+            "{}-{}",
+            self.target_platform,
+            URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes())
+        )
+    }
+}
+
+pub struct SourceMetadataCache {
+    root: PathBuf,
+}
+
+impl SourceMetadataCache {
+    /// The root directory were the cache is stored. An additional directory is
+    /// created by this cache which includes a version number.
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root: root.join("source-meta-v0"),
+        }
+    }
+
+    /// Determine the path to the cache directory for a given request.
+    fn source_cache_path(&self, source: &SourceCheckout) -> PathBuf {
+        let mut hasher = DefaultHasher::new();
+        source.pinned.to_string().hash(&mut hasher);
+        let unique_key = URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes());
+        let path = match source.path.file_name().and_then(OsStr::to_str) {
+            Some(name) => format!("{}-{}", name, unique_key),
+            None => unique_key,
+        };
+        self.root.join(path)
+    }
+
+    pub async fn entry(
+        &self,
+        source: &SourceCheckout,
+        input: &SourceCacheKey,
+    ) -> Result<(Option<CachedCondaMetadata>, CacheEntry), SourceMetadataError> {
+        // Locate the cache file and lock it.
+        let cache_dir = self.source_cache_path(source);
+        tokio::fs::create_dir_all(&cache_dir).await.map_err(|e| {
+            SourceMetadataError::IoError(
+                "creating cache directory".to_string(),
+                cache_dir.clone(),
+                e,
+            )
+        })?;
+
+        // Try to acquire a lock on the cache file.
+        let cache_file_path = cache_dir.join(input.hash_key()).with_extension("json");
+        let cache_file = tokio::fs::OpenOptions::new()
+            .write(true)
+            .read(true)
+            .truncate(false)
+            .create(true)
+            .open(&cache_file_path)
+            .await
+            .map_err(|e| {
+                SourceMetadataError::IoError(
+                    "opening cache file".to_string(),
+                    cache_file_path.clone(),
+                    e,
+                )
+            })?;
+
+        let mut locked_cache_file = cache_file.lock_write().await.map_err(|e| {
+            SourceMetadataError::IoError(
+                "locking cache file".to_string(),
+                cache_file_path.clone(),
+                e.error,
+            )
+        })?;
+
+        // Try to parse the contents of the file
+        let mut cache_file_contents = String::new();
+        locked_cache_file
+            .read_to_string(&mut cache_file_contents)
+            .await
+            .map_err(|e| {
+                SourceMetadataError::IoError(
+                    "reading cache file".to_string(),
+                    cache_file_path.clone(),
+                    e,
+                )
+            })?;
+
+        let metadata = serde_json::from_str(&cache_file_contents).ok();
+        Ok((
+            metadata,
+            CacheEntry {
+                file: locked_cache_file,
+                path: cache_file_path,
+            },
+        ))
+    }
+}
+
+pub struct CacheEntry {
+    file: RwLockWriteGuard<tokio::fs::File>,
+    path: PathBuf,
+}
+
+impl CacheEntry {
+    pub async fn insert(
+        mut self,
+        metadata: CachedCondaMetadata,
+    ) -> Result<(), SourceMetadataError> {
+        self.file.seek(SeekFrom::Start(0)).await.map_err(|e| {
+            SourceMetadataError::IoError(
+                "seeking to start of cache file".to_string(),
+                self.path.clone(),
+                e,
+            )
+        })?;
+        let bytes = serde_json::to_vec(&metadata).expect("serialization to JSON should not fail");
+        self.file.write_all(&bytes).await.map_err(|e| {
+            SourceMetadataError::IoError(
+                "writing metadata to cache file".to_string(),
+                self.path.clone(),
+                e,
+            )
+        })?;
+        self.file
+            .inner_mut()
+            .set_len(bytes.len() as u64)
+            .await
+            .map_err(|e| {
+                SourceMetadataError::IoError(
+                    "setting length of cache file".to_string(),
+                    self.path.clone(),
+                    e,
+                )
+            })?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CachedCondaMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_hash: Option<InputHash>,
+    pub packages: Vec<CondaPackageMetadata>,
+}


### PR DESCRIPTION
This PR adds a source metadata cache that caches the response from `conda/getMetadata`. 