### PR TITLE
feat: `fs_err` in `pixi global`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,6 +3414,7 @@ dependencies = [
  "fancy_display",
  "fd-lock",
  "flate2",
+ "fs-err",
  "fs_extra",
  "futures",
  "http 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.4.0" }
 dunce = "1.0.4"
 fd-lock = "4.0.2"
 flate2 = "1.0.28"
+fs-err = { version = "2.11.0" }
 fs_extra = "1.3.0"
 futures = "0.3.30"
 http = "1.1.0"
@@ -234,6 +235,7 @@ rattler_repodata_gateway = { workspace = true, features = [
 rattler_shell = { workspace = true, features = ["sysinfo"] }
 rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
 
+fs-err = { workspace = true, features = ["tokio"] }
 pixi_config = { workspace = true, features = ["rattler_repodata_gateway"] }
 pixi_consts = { workspace = true }
 pixi_default_versions = { workspace = true }

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -3,10 +3,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use miette::{Context, IntoDiagnostic};
+use super::{EnvironmentName, ExposedName};
 use fs_err as fs;
 use fs_err::tokio as tokio_fs;
-use super::{EnvironmentName, ExposedName};
+use miette::IntoDiagnostic;
 use pixi_config::home_path;
 use pixi_consts::consts;
 
@@ -22,9 +22,7 @@ impl BinDir {
             .ok_or(miette::miette!(
                 "could not determine global binary executable directory"
             ))?;
-        tokio_fs::create_dir_all(&bin_dir)
-            .await
-            .into_diagnostic()?;
+        tokio_fs::create_dir_all(&bin_dir).await.into_diagnostic()?;
         Ok(Self(bin_dir))
     }
 
@@ -35,9 +33,7 @@ impl BinDir {
     /// vector of file paths or an error if the directory cannot be read.
     pub(crate) async fn files(&self) -> miette::Result<Vec<PathBuf>> {
         let mut files = Vec::new();
-        let mut entries = tokio_fs::read_dir(&self.0)
-            .await
-            .into_diagnostic()?;
+        let mut entries = tokio_fs::read_dir(&self.0).await.into_diagnostic()?;
 
         while let Some(entry) = entries.next_entry().await.into_diagnostic()? {
             let path = entry.path();
@@ -76,9 +72,7 @@ impl EnvRoot {
     /// Create the environment root directory
     #[cfg(test)]
     pub async fn new(path: PathBuf) -> miette::Result<Self> {
-        tokio_fs::create_dir_all(&path)
-            .await
-            .into_diagnostic()?;
+        tokio_fs::create_dir_all(&path).await.into_diagnostic()?;
         Ok(Self(path))
     }
 
@@ -87,9 +81,7 @@ impl EnvRoot {
         let path = home_path()
             .map(|path| path.join("envs"))
             .ok_or_else(|| miette::miette!("Could not get home path"))?;
-        tokio_fs::create_dir_all(&path)
-            .await
-            .into_diagnostic()?;
+        tokio_fs::create_dir_all(&path).await.into_diagnostic()?;
         Ok(Self(path))
     }
 
@@ -100,9 +92,7 @@ impl EnvRoot {
     /// Get all directories in the env root
     pub(crate) async fn directories(&self) -> miette::Result<Vec<PathBuf>> {
         let mut directories = Vec::new();
-        let mut entries = tokio_fs::read_dir(&self.path())
-            .await
-            .into_diagnostic()?;
+        let mut entries = tokio_fs::read_dir(&self.path()).await.into_diagnostic()?;
 
         while let Some(entry) = entries.next_entry().await.into_diagnostic()? {
             let path = entry.path();
@@ -177,12 +167,9 @@ impl EnvDir {
 
 /// Checks if a file is binary by reading the first 1024 bytes and checking for null bytes.
 pub(crate) fn is_binary(file_path: impl AsRef<Path>) -> miette::Result<bool> {
-    let mut file = fs::File::open(&file_path.as_ref())
-        .into_diagnostic()?;
+    let mut file = fs::File::open(file_path.as_ref()).into_diagnostic()?;
     let mut buffer = [0; 1024];
-    let bytes_read = file
-        .read(&mut buffer)
-        .into_diagnostic()?;
+    let bytes_read = file.read(&mut buffer).into_diagnostic()?;
 
     Ok(buffer[..bytes_read].contains(&0))
 }
@@ -196,8 +183,8 @@ pub(crate) fn is_text(file_path: impl AsRef<Path>) -> miette::Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use itertools::Itertools;
     use fs_err::tokio as tokio_fs;
+    use itertools::Itertools;
 
     use tempfile::tempdir;
 

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use miette::{Context, IntoDiagnostic};
-
+use fs_err as fs;
+use fs_err::tokio as tokio_fs;
 use super::{EnvironmentName, ExposedName};
 use pixi_config::home_path;
 use pixi_consts::consts;
@@ -21,7 +22,7 @@ impl BinDir {
             .ok_or(miette::miette!(
                 "could not determine global binary executable directory"
             ))?;
-        tokio::fs::create_dir_all(&bin_dir)
+        tokio_fs::create_dir_all(&bin_dir)
             .await
             .into_diagnostic()?;
         Ok(Self(bin_dir))
@@ -34,10 +35,9 @@ impl BinDir {
     /// vector of file paths or an error if the directory cannot be read.
     pub(crate) async fn files(&self) -> miette::Result<Vec<PathBuf>> {
         let mut files = Vec::new();
-        let mut entries = tokio::fs::read_dir(&self.0)
+        let mut entries = tokio_fs::read_dir(&self.0)
             .await
-            .into_diagnostic()
-            .wrap_err_with(|| format!("Could not read {}", &self.0.display()))?;
+            .into_diagnostic()?;
 
         while let Some(entry) = entries.next_entry().await.into_diagnostic()? {
             let path = entry.path();
@@ -76,10 +76,9 @@ impl EnvRoot {
     /// Create the environment root directory
     #[cfg(test)]
     pub async fn new(path: PathBuf) -> miette::Result<Self> {
-        tokio::fs::create_dir_all(&path)
+        tokio_fs::create_dir_all(&path)
             .await
-            .into_diagnostic()
-            .wrap_err_with(|| format!("Could not create directory {}", path.display()))?;
+            .into_diagnostic()?;
         Ok(Self(path))
     }
 
@@ -88,10 +87,9 @@ impl EnvRoot {
         let path = home_path()
             .map(|path| path.join("envs"))
             .ok_or_else(|| miette::miette!("Could not get home path"))?;
-        tokio::fs::create_dir_all(&path)
+        tokio_fs::create_dir_all(&path)
             .await
-            .into_diagnostic()
-            .wrap_err_with(|| format!("Could not create directory {}", path.display()))?;
+            .into_diagnostic()?;
         Ok(Self(path))
     }
 
@@ -102,10 +100,9 @@ impl EnvRoot {
     /// Get all directories in the env root
     pub(crate) async fn directories(&self) -> miette::Result<Vec<PathBuf>> {
         let mut directories = Vec::new();
-        let mut entries = tokio::fs::read_dir(&self.path())
+        let mut entries = tokio_fs::read_dir(&self.path())
             .await
-            .into_diagnostic()
-            .wrap_err_with(|| format!("Could not read directory {}", self.path().display()))?;
+            .into_diagnostic()?;
 
         while let Some(entry) = entries.next_entry().await.into_diagnostic()? {
             let path = entry.path();
@@ -121,9 +118,10 @@ impl EnvRoot {
     pub(crate) async fn prune(
         &self,
         environments_to_keep: impl IntoIterator<Item = EnvironmentName>,
-    ) -> miette::Result<()> {
+    ) -> miette::Result<Vec<PathBuf>> {
         let env_set: ahash::HashSet<EnvironmentName> = environments_to_keep.into_iter().collect();
 
+        let mut pruned = Vec::new();
         for env_path in self.directories().await? {
             let Some(Ok(env_name)) = env_path
                 .file_name()
@@ -137,12 +135,10 @@ impl EnvRoot {
                 // Test if the environment directory is a conda environment
                 if let Ok(true) = env_path.join(consts::CONDA_META_DIR).try_exists() {
                     // Remove the conda environment
-                    tokio::fs::remove_dir_all(&env_path)
+                    tokio_fs::remove_dir_all(&env_path)
                         .await
-                        .into_diagnostic()
-                        .wrap_err_with(|| {
-                            format!("Could not remove directory {}", env_path.display())
-                        })?;
+                        .into_diagnostic()?;
+                    pruned.push(env_path);
                     eprintln!(
                         "{} Remove environment '{env_name}'",
                         console::style(console::Emoji("✔", " ")).green()
@@ -151,7 +147,7 @@ impl EnvRoot {
             }
         }
 
-        Ok(())
+        Ok(pruned)
     }
 }
 
@@ -167,7 +163,7 @@ impl EnvDir {
         environment_name: EnvironmentName,
     ) -> miette::Result<Self> {
         let path = env_root.path().join(environment_name.as_str());
-        tokio::fs::create_dir_all(&path).await.into_diagnostic()?;
+        tokio_fs::create_dir_all(&path).await.into_diagnostic()?;
 
         Ok(Self { path })
     }
@@ -181,14 +177,12 @@ impl EnvDir {
 
 /// Checks if a file is binary by reading the first 1024 bytes and checking for null bytes.
 pub(crate) fn is_binary(file_path: impl AsRef<Path>) -> miette::Result<bool> {
-    let mut file = std::fs::File::open(&file_path)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Could not open {}", &file_path.as_ref().display()))?;
+    let mut file = fs::File::open(&file_path.as_ref())
+        .into_diagnostic()?;
     let mut buffer = [0; 1024];
     let bytes_read = file
         .read(&mut buffer)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("Could not read {}", &file_path.as_ref().display()))?;
+        .into_diagnostic()?;
 
     Ok(buffer[..bytes_read].contains(&0))
 }
@@ -203,6 +197,7 @@ pub(crate) fn is_text(file_path: impl AsRef<Path>) -> miette::Result<bool> {
 mod tests {
     use super::*;
     use itertools::Itertools;
+    use fs_err::tokio as tokio_fs;
 
     use tempfile::tempdir;
 
@@ -243,7 +238,7 @@ mod tests {
                 .unwrap();
         }
         // Add conda meta data to env2 to make sure it's seen as a conda environment
-        tokio::fs::create_dir_all(env_root.path().join("env2").join(consts::CONDA_META_DIR))
+        tokio_fs::create_dir_all(env_root.path().join("env2").join(consts::CONDA_META_DIR))
             .await
             .unwrap();
 
@@ -254,7 +249,7 @@ mod tests {
             .unwrap();
 
         // Verify that only the specified directories remain
-        let remaining_dirs = std::fs::read_dir(env_root.path())
+        let remaining_dirs = fs::read_dir(env_root.path())
             .unwrap()
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.path().is_dir())

--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -363,7 +363,7 @@ pub(crate) async fn create_executable_scripts(
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(global_script_path, std::fs::Permissions::from_mode(0o755))
+            std::fs::set_permissions(global_script_path, std::fs::Permissions::from_mode(0o755))
                 .into_diagnostic()?;
         }
 

--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -1,4 +1,3 @@
-use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use indexmap::IndexMap;
 use itertools::Itertools;

--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -1,10 +1,5 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ffi::OsStr,
-    path::PathBuf,
-    str::FromStr,
-};
-
+use fs_err as fs;
+use fs_err::tokio as tokio_fs;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
@@ -27,6 +22,12 @@ use rattler_shell::{
 use rattler_solve::{resolvo::Solver, SolverImpl, SolverTask};
 use rattler_virtual_packages::{VirtualPackage, VirtualPackageOverrides};
 use reqwest_middleware::ClientWithMiddleware;
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsStr,
+    path::PathBuf,
+    str::FromStr,
+};
 
 use super::{project::ParsedEnvironment, EnvironmentName, ExposedName};
 use crate::{
@@ -341,7 +342,7 @@ pub(crate) async fn create_executable_scripts(
         }
 
         let added_or_changed = if global_script_path.exists() {
-            match tokio::fs::read_to_string(global_script_path).await {
+            match tokio_fs::read_to_string(global_script_path).await {
                 Ok(previous_script) if previous_script != script => AddedOrChanged::Changed,
                 Ok(_) => AddedOrChanged::Unchanged,
                 Err(_) => AddedOrChanged::Changed,
@@ -354,7 +355,7 @@ pub(crate) async fn create_executable_scripts(
             added_or_changed,
             AddedOrChanged::Changed | AddedOrChanged::Added
         ) {
-            tokio::fs::write(&global_script_path, script)
+            tokio_fs::write(&global_script_path, script)
                 .await
                 .into_diagnostic()?;
             changed = true;
@@ -363,7 +364,7 @@ pub(crate) async fn create_executable_scripts(
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(global_script_path, std::fs::Permissions::from_mode(0o755))
+            fs::set_permissions(global_script_path, std::fs::Permissions::from_mode(0o755))
                 .into_diagnostic()?;
         }
 
@@ -427,16 +428,19 @@ pub(crate) async fn sync(
     project: &global::Project,
     config: &Config,
 ) -> Result<bool, miette::Error> {
+    let mut updated_env = false;
+
     // Fetch the repodata
     let (_, auth_client) = build_reqwest_clients(Some(config));
 
     let gateway = config.gateway(auth_client.clone());
 
     // Prune environments that are not listed
-    project
+    updated_env |= !project
         .env_root
         .prune(project.environments().keys().cloned())
-        .await?;
+        .await?
+        .is_empty();
 
     // Remove binaries that are not listed as exposed
     let exposed_paths = project
@@ -455,18 +459,17 @@ pub(crate) async fn sync(
             .and_then(OsStr::to_str)
             .ok_or_else(|| miette::miette!("Could not get file stem of {}", file.display()))?;
         if !exposed_paths.contains(&file) && file_name != "pixi" {
-            tokio::fs::remove_file(&file)
+            tokio_fs::remove_file(&file)
                 .await
                 .into_diagnostic()
                 .wrap_err_with(|| format!("Could not remove {}", &file.display()))?;
+            updated_env = true;
             eprintln!(
                 "{}Remove executable '{file_name}'.",
                 console::style(console::Emoji("✔ ", "")).green()
             );
         }
     }
-
-    let mut updated_env = false;
 
     for (env_name, parsed_environment) in project.environments() {
         let specs = parsed_environment

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use fs_err as fs;
+use fs_err::tokio as tokio_fs;
 use miette::IntoDiagnostic;
 use pixi_manifest::{TomlError, TomlManifest};
 use toml_edit::{DocumentMut, Item};
-use fs_err as fs;
-use fs_err::tokio as tokio_fs;
 
 use super::parsed_manifest::ParsedManifest;
 use super::{EnvironmentName, ExposedName, MANIFEST_DEFAULT_NAME};

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use miette::IntoDiagnostic;
 use pixi_manifest::{TomlError, TomlManifest};
 use toml_edit::{DocumentMut, Item};
+use fs_err as fs;
+use fs_err::tokio as tokio_fs;
 
 use super::parsed_manifest::ParsedManifest;
 use super::{EnvironmentName, ExposedName, MANIFEST_DEFAULT_NAME};
@@ -29,7 +31,7 @@ impl Manifest {
     /// Create a new manifest from a path
     pub fn from_path(path: impl AsRef<Path>) -> miette::Result<Self> {
         let manifest_path = dunce::canonicalize(path.as_ref()).into_diagnostic()?;
-        let contents = std::fs::read_to_string(path.as_ref()).into_diagnostic()?;
+        let contents = fs::read_to_string(path.as_ref()).into_diagnostic()?;
         Self::from_str(manifest_path.as_ref(), contents)
     }
 
@@ -107,7 +109,7 @@ impl Manifest {
     /// Save the manifest to the file and update the parsed_manifest
     pub async fn save(&mut self) -> miette::Result<()> {
         let contents = self.document.to_string();
-        tokio::fs::write(&self.path, contents)
+        tokio_fs::write(&self.path, contents)
             .await
             .into_diagnostic()?;
         Ok(())

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -179,9 +179,7 @@ async fn package_from_conda_meta(
     executable: &str,
     prefix: &Prefix,
 ) -> miette::Result<(Option<Platform>, PrioritizedChannel, PackageName)> {
-    let mut read_dir = tokio_fs::read_dir(conda_meta)
-        .await
-        .into_diagnostic()?;
+    let mut read_dir = tokio_fs::read_dir(conda_meta).await.into_diagnostic()?;
 
     while let Some(entry) = read_dir.next_entry().await.into_diagnostic()? {
         let path = entry.path();


### PR DESCRIPTION
This just refactors the code to use `fs_err` instead of `std::fs` or `tokio::fs` resulting in the removal of the `.wrap_err`s.

I also changed the `sync` function to have more situation where the env is updated