### PR TITLE
fix: run cargo clippy on push and on pixi lint task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,6 @@ exclude: (^.pixi/|.snap)
 repos:
   - repo: local
     hooks:
-      - id: pixi-install
-        name: pixi-install
-        entry: pixi install -e lint
-        language: system
-        always_run: true
-        require_serial: true
-        pass_filenames: false
-      # pre-commit-hooks
       - id: check-yaml
         name: check-yaml
         entry: pixi run -e lint check-yaml
@@ -58,14 +50,14 @@ repos:
       - id: fmt
         name: fmt
         language: system
-        stages: [pre-commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
         types: [file, rust]
         entry: cargo fmt
         pass_filenames: false
       - id: clippy
         name: clippy
         language: system
-        stages: [push, manual]
+        stages: [pre-push, manual]
         types: [file, rust]
         entry: cargo clippy --all-targets --workspace -- -D warnings -Dclippy::dbg_macro # Use -D warnings option to ensure the job fails when encountering warnings
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
       - id: fmt
         name: fmt
         language: system
-        stages: [push, manual]
+        stages: [pre-commit, push, manual]
         types: [file, rust]
         entry: cargo fmt
         pass_filenames: false
@@ -68,11 +68,4 @@ repos:
         stages: [push, manual]
         types: [file, rust]
         entry: cargo clippy --all-targets --workspace -- -D warnings -Dclippy::dbg_macro # Use -D warnings option to ensure the job fails when encountering warnings
-        pass_filenames: false
-      - id: test
-        name: test
-        language: system
-        stages: [push, manual]
-        types: [file, rust]
-        entry: cargo test
         pass_filenames: false

--- a/pixi.toml
+++ b/pixi.toml
@@ -59,7 +59,7 @@ taplo = ">=0.9.1,<0.10"
 typos = ">=1.23.1,<2"
 
 [feature.lint.tasks]
-lint = { depends-on = ["pre-commit-run"] }
+lint = "pre-commit run --all-files --hook-stage=manual"
 pre-commit-install = "pre-commit install"
 pre-commit-install-minimal = "pre-commit install -t=pre-commit"
 pre-commit-run = "pre-commit run --all-files"

--- a/pixi.toml
+++ b/pixi.toml
@@ -60,7 +60,7 @@ typos = ">=1.23.1,<2"
 
 [feature.lint.tasks]
 lint = "pre-commit run --all-files --hook-stage=manual"
-pre-commit-install = "pre-commit install"
+pre-commit-install = "pre-commit install --install-hooks -t=pre-commit -t=pre-push"
 pre-commit-install-minimal = "pre-commit install -t=pre-commit"
 pre-commit-run = "pre-commit run --all-files"
 toml-format = { cmd = "taplo fmt", env = { RUST_LOG = "warn" } }


### PR DESCRIPTION
Changed it so that `pixi run lint` will run the cargo parts to. And so that you also format before committing.