### PR TITLE
fix: check if files are same in `self-update`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,7 @@ dependencies = [
  "reqwest-retry 0.5.0",
  "rlimit",
  "rstest",
+ "same-file",
  "self-replace",
  "serde",
  "serde_ignored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,8 +253,8 @@ reqwest = { workspace = true, features = [
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
 rlimit = { workspace = true }
-self-replace = { workspace = true }
 same-file = { workspace = true }
+self-replace = { workspace = true }
 serde = { workspace = true }
 serde_ignored = { workspace = true }
 serde_json = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ reqwest-middleware = "0.3.0"
 reqwest-retry = "0.5.0"
 rlimit = "0.10.1"
 rstest = "0.19.0"
+same-file = "1.0.6"
 self-replace = "1.3.7"
 serde = "1.0.198"
 serde-untagged = "0.1.5"
@@ -253,6 +254,7 @@ reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
 rlimit = { workspace = true }
 self-replace = { workspace = true }
+same-file = { workspace = true }
 serde = { workspace = true }
 serde_ignored = { workspace = true }
 serde_json = { workspace = true }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -255,5 +255,6 @@ fn is_pixi_binary_default_location() -> bool {
     same_file::is_same_file(
         std::env::current_exe().expect("Failed to retrieve the current pixi binary path"),
         default_pixi_binary_path(),
-    ).unwrap_or(false)
+    )
+    .unwrap_or(false)
 }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -10,6 +10,7 @@ use miette::{Context, IntoDiagnostic};
 use pixi_consts::consts;
 use reqwest::Client;
 use serde::Deserialize;
+use same_file::is_same_file;
 
 /// Update pixi to the latest version or a specific version.
 ///
@@ -252,9 +253,8 @@ fn default_pixi_binary_path() -> std::path::PathBuf {
 
 // check current binary is in the default pixi location
 fn is_pixi_binary_default_location() -> bool {
-    let default_binary_path = default_pixi_binary_path();
-
-    std::env::current_exe()
-        .expect("Failed to retrieve the current pixi binary path")
-        .starts_with(default_binary_path)
+    same_file::is_same_file(
+        std::env::current_exe().expect("Failed to retrieve the current pixi binary path"),
+        default_pixi_binary_path(),
+    ).unwrap_or(false)
 }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -10,7 +10,6 @@ use miette::{Context, IntoDiagnostic};
 use pixi_consts::consts;
 use reqwest::Client;
 use serde::Deserialize;
-use same_file::is_same_file;
 
 /// Update pixi to the latest version or a specific version.
 ///


### PR DESCRIPTION
`self-update` checks if the Pixi binary matches the default filepath. Instead of checking if paths are equal, we should check if files are same in `self-update`.

This should resolve this issue:
```
  × pixi is not installed in the default location:
  │ 
  │ - Default pixi location: /users/apoorvkh/.pixi/bin/pixi
  │ - Pixi location detected: /nfs/home/apoorvkh/.pixi/bin/pixi
```

which could be caused by using symlinks or case-insensitivity in Windows, etc.

Fixes #1171 and maybe #2059