### PR TITLE
feat: Follow symlinks while walking files

### DIFF
--- a/src/task/file_hashes.rs
+++ b/src/task/file_hashes.rs
@@ -192,18 +192,17 @@ mod test {
 
         // create symlinked directory
         let symlinked_dir = tempdir().unwrap();
-        std::os::unix::fs::symlink(
-            symlinked_dir.path(),
-            target_dir.path().join("link"),
-        ).unwrap();
+        std::os::unix::fs::symlink(symlinked_dir.path(), target_dir.path().join("link")).unwrap();
 
         write(symlinked_dir.path().join("main.rs"), "fn main() {}").unwrap();
 
         // Compute the hashes of all files in the directory that match a certain set of includes.
-        let hashes =
-            FileHashes::from_files(target_dir.path(), vec!["src/*.rs", "*.toml", "!**/lib.rs", "link/*.rs"])
-                .await
-                .unwrap();
+        let hashes = FileHashes::from_files(
+            target_dir.path(),
+            vec!["src/*.rs", "*.toml", "!**/lib.rs", "link/*.rs"],
+        )
+        .await
+        .unwrap();
 
         assert!(
             !hashes.files.contains_key(Path::new("build.rs")),
@@ -229,7 +228,10 @@ mod test {
         );
 
         assert_matches!(
-            hashes.files.get(Path::new("link/main.rs")).map(String::as_str),
+            hashes
+                .files
+                .get(Path::new("link/main.rs"))
+                .map(String::as_str),
             Some("2c806b6ebece677c")
         );
 

--- a/src/task/file_hashes.rs
+++ b/src/task/file_hashes.rs
@@ -192,7 +192,17 @@ mod test {
 
         // create symlinked directory
         let symlinked_dir = tempdir().unwrap();
-        std::os::unix::fs::symlink(symlinked_dir.path(), target_dir.path().join("link")).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(symlinked_dir.path(), target_dir.path().join("link"))
+                .unwrap();
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_dir(symlinked_dir.path(), target_dir.path().join("link"))
+                .unwrap();
+        }
 
         write(symlinked_dir.path().join("main.rs"), "fn main() {}").unwrap();
 

--- a/src/task/file_hashes.rs
+++ b/src/task/file_hashes.rs
@@ -200,7 +200,7 @@ mod test {
         }
         // On Windows this test can fail, so we need to check if the symlink was created successfully.
         // This works in our CI but might not work on all Windows systems.
-        #[allow(unused_assignments)]
+        #[allow(unused_assignments, unused_mut)]
         let mut symlink_on_windows = false;
         #[cfg(windows)]
         {


### PR DESCRIPTION
I am using `pixi` with detached environments. I have a `postinstall` task that runs `pip install --no-build-isolation --no-deps --disable-pip-version-check -e .`. I want to specify an output for this task that checks if the package is installed in `.pixi/envs/defaults/...` so that I can cache this task. This currently fails because the Walker used does not follow symlinks, and `.pixi` just points to my detached environments via a symlink. This PR enables resolving symlinks and adds a test for that.