### PR TITLE
feat: add `pixi run install-as`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -17,7 +17,7 @@ python = "3.12.*"
 [tasks]
 build = "cargo build --release"
 bump = "tbump --only-patch $RELEASE_VERSION"
-install = "cargo install --path . --locked"
+install = { cmd = "python scripts/install.py", depends-on = ["build"] }
 pypi-proxy = "python ./tests/pypi_proxy.py"
 release = "python scripts/release.py"
 run-all-examples = { cmd = "python ./tests/run_all_examples.py --pixi-exec $CARGO_TARGET_DIR/release/pixi", depends-on = [

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,7 +17,8 @@ python = "3.12.*"
 [tasks]
 build = "cargo build --release"
 bump = "tbump --only-patch $RELEASE_VERSION"
-install = { cmd = "python scripts/install.py", depends-on = ["build"] }
+install = "cargo install --path . --locked"
+install-as = { cmd = "python scripts/install.py", depends-on = ["build"] }
 pypi-proxy = "python ./tests/pypi_proxy.py"
 release = "python scripts/release.py"
 run-all-examples = { cmd = "python ./tests/run_all_examples.py --pixi-exec $CARGO_TARGET_DIR/release/pixi", depends-on = [

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -1,0 +1,36 @@
+import argparse
+from pathlib import Path
+import shutil
+import platform
+import os
+
+
+def executable_extension(name: str) -> str:
+    if platform.system() == "Windows":
+        return name + ".exe"
+    else:
+        return name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build pixi and copy the executable to ~/.pixi/bin/"
+    )
+    parser.add_argument(
+        "--name", type=str, default="pixid", help="Name of the executable to copy (default: pixid)"
+    )
+    args = parser.parse_args()
+
+    built_executable_path = Path(os.environ["CARGO_TARGET_DIR"]).joinpath(
+        "release", executable_extension("pixi")
+    )
+    destination_path = Path.home().joinpath(".pixi", "bin", executable_extension(args.name))
+
+    print(f"Copying the executable to {destination_path}")
+    shutil.copy(built_executable_path, destination_path)
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -16,9 +16,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Build pixi and copy the executable to ~/.pixi/bin/"
     )
-    parser.add_argument(
-        "--name", type=str, default="pixid", help="Name of the executable to copy (default: pixid)"
-    )
+    parser.add_argument("name", type=str, help="Name of the executable (e.g. pixid)")
+
     args = parser.parse_args()
 
     built_executable_path = Path(os.environ["CARGO_TARGET_DIR"]).joinpath(


### PR DESCRIPTION
Add a script which installs pixi to `~/.pixi/bin`. Now, people only need pixi, not Rust to install a developer version of pixi. Also the script allows to give pixi a different name, per default `pixid`