### PR TITLE
perf: significantly speed up conda resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3927,9 +3927,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.27.12"
+version = "0.27.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965ab8331a87c11c00d010c8762f0372ca5164fc48f138c65ad91a2623fed8cc"
+checksum = "e31c7a56e2cc0ceac84c2ae4bd78ab228e2c74e19d89b048d124e59f25a142f9"
 dependencies = [
  "anyhow",
  "clap",
@@ -4149,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.14"
+version = "0.21.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50556663a532a0406e4458bbec71dd96e13a32b2c03a6ac309ad30bf0a44a65"
+checksum = "5e57d793493666d656e264be76b83a24925c095be0c1e5176c65cc1cdaf61c53"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4164,6 +4164,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "file_url",
+ "fs-err",
  "futures",
  "hex",
  "http 1.1.0",
@@ -4221,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3db40d5dee6267798c28c32c002fcc1a0a4de7cd6e13b3a70c2193be2656647"
+checksum = "6c403f3e93a3214f54f2f2ca67c58400f5e860289646b11da39e13eec8c98376"
 dependencies = [
  "chrono",
  "futures",
@@ -4589,15 +4590,16 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a472ebbac5a18c9e235e874df3aa0c8fb0b55611155dd5e5515a55a16520d76"
+checksum = "d68c0ae687bbcd99ab33236c7cbccd2ba1c526a7f7a59743cb991074414c5293"
 dependencies = [
  "ahash 0.8.11",
  "bitvec",
  "elsa",
  "event-listener",
  "futures",
+ "indexmap 2.3.0",
  "itertools 0.13.0",
  "petgraph",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,15 +89,15 @@ typed-path = "0.9.1"
 
 # Rattler crates
 file_url = "0.1.4"
-rattler = { version = "0.27.12", default-features = false }
+rattler = { version = "0.27.13", default-features = false }
 rattler_cache = { version = "0.2.4", default-features = false }
 rattler_conda_types = { version = "0.28.0", default-features = false }
 rattler_digest = { version = "1.0.1", default-features = false }
 rattler_lock = { version = "0.22.25", default-features = false }
 rattler_networking = { version = "0.21.4", default-features = false }
-rattler_repodata_gateway = { version = "0.21.14", default-features = false }
+rattler_repodata_gateway = { version = "0.21.15", default-features = false }
 rattler_shell = { version = "0.22.2", default-features = false }
-rattler_solve = { version = "1.0.8", default-features = false }
+rattler_solve = { version = "1.0.9", default-features = false }
 rattler_virtual_packages = { version = "1.1.5", default-features = false }
 
 # Bumping this to a higher version breaks the Windows path handling.


### PR DESCRIPTION
This PR bumps `rattler_solve` which bumps `resolvo` which includes two important [performance](https://github.com/mamba-org/resolvo/pull/67) [improvements](https://github.com/mamba-org/resolvo/pull/66). This should significantly reduce the number of cases where the solver takes a very long time to solve (minutes plus).

This benchmark image taken [from resolvo](https://github.com/mamba-org/resolvo/pull/67#issuecomment-2382370118) shows that the number of cases that take more than 60 seconds is significantly decreased.

![Resolvo benchmarks](https://github.com/user-attachments/assets/0c89b07f-7e29-430a-b876-a8a5826bbc9d)