### PR TITLE
fix: only revert environments we actually modified

### DIFF
--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 
-use crate::global;
+use crate::global::{self, EnvironmentName};
 
 mod expose;
 mod install;
@@ -51,8 +51,11 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
     Ok(())
 }
 
-/// Reverts the changes made to the project after an error occurred.
-async fn revert_after_error(project_original: &global::Project) -> miette::Result<()> {
-    project_original.sync().await?;
+/// Reverts the changes made to the project for a specific environment after an error occurred.
+async fn revert_environment_after_error(
+    project_original: &global::Project,
+    env_name: &EnvironmentName,
+) -> miette::Result<()> {
+    project_original.sync_environment(env_name).await?;
     Ok(())
 }

--- a/src/cli/global/uninstall.rs
+++ b/src/cli/global/uninstall.rs
@@ -1,4 +1,4 @@
-use crate::cli::global::revert_after_error;
+use crate::cli::global::revert_environment_after_error;
 use crate::global;
 use crate::global::{EnvironmentName, Project};
 use clap::Parser;
@@ -62,9 +62,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             project.manifest.path.display()
         ))),
         Err(err) => {
-            revert_after_error(&project_original)
-                .await
-                .wrap_err("Could not uninstall environments. Reverting also failed.")?;
+            for env_name in &args.environment {
+                revert_environment_after_error(&project_original, env_name)
+                    .await
+                    .wrap_err("Could not uninstall environments. Reverting also failed.")?;
+            }
             Err(err)
         }
     }


### PR DESCRIPTION
That way we don't sync changes by accident, just because we need to revert