### PR TITLE
fix: improve install.sh PATH handling and general robustness

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 
 __wrap__() {
 
-VERSION=${PIXI_VERSION:-latest}
-PIXI_HOME=${PIXI_HOME:-"$HOME/.pixi"}
+VERSION="${PIXI_VERSION:-latest}"
+PIXI_HOME="${PIXI_HOME:-$HOME/.pixi}"
+PIXI_HOME="${PIXI_HOME/#\~/$HOME}"
 BIN_DIR="$PIXI_HOME/bin"
 
-REPO=prefix-dev/pixi
-PLATFORM=$(uname -s)
-ARCH=${PIXI_ARCH:-$(uname -m)}
+REPO="prefix-dev/pixi"
+PLATFORM="$(uname -s)"
+ARCH="${PIXI_ARCH:-$(uname -m)}"
 
 if [[ $PLATFORM == "Darwin" ]]; then
   PLATFORM="apple-darwin"
@@ -33,9 +34,9 @@ if [[ $(uname -o) == "Msys" ]]; then
 fi
 
 if [[ $VERSION == "latest" ]]; then
-  DOWNLOAD_URL=https://github.com/${REPO}/releases/latest/download/${BINARY}.${EXTENSION}
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}.${EXTENSION}"
 else
-  DOWNLOAD_URL=https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}.${EXTENSION}
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}.${EXTENSION}"
 fi
 
 printf "This script will automatically download and install Pixi (${VERSION}) for you.\nGetting it from this url: $DOWNLOAD_URL\n"
@@ -50,7 +51,7 @@ if ! hash tar 2> /dev/null; then
   exit 1
 fi
 
-TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/.pixi_install.XXXXXXXX")
+TEMP_FILE="$(mktemp "${TMPDIR:-/tmp}/.pixi_install.XXXXXXXX")"
 
 cleanup() {
   rm -f "$TEMP_FILE"
@@ -59,8 +60,8 @@ cleanup() {
 trap cleanup EXIT
 
 if hash curl 2> /dev/null; then
-  HTTP_CODE=$(curl -SL --progress-bar "$DOWNLOAD_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
-  if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]]; then
+  HTTP_CODE="$(curl -SL --progress-bar "$DOWNLOAD_URL" --output "$TEMP_FILE" --write-out "%{http_code}")"
+  if [[ "${HTTP_CODE}" -lt 200 || "${HTTP_CODE}" -gt 299 ]]; then
     echo "error: '${DOWNLOAD_URL}' is not available"
     exit 1
   fi
@@ -72,7 +73,7 @@ elif hash wget 2> /dev/null; then
 fi
 
 # Check that file was correctly created (https://github.com/prefix-dev/pixi/issues/446)
-if [[ ! -s $TEMP_FILE ]]; then
+if [[ ! -s "$TEMP_FILE" ]]; then
   echo "error: temporary file ${TEMP_FILE} not correctly created."
   echo "       As a workaround, you can try set TMPDIR env variable to directory with write permissions."
   exit 1
@@ -80,7 +81,7 @@ fi
 
 # Extract pixi from the downloaded file
 mkdir -p "$BIN_DIR"
-if [[ $(uname -o) == "Msys" ]]; then
+if [[ "$(uname -o)" == "Msys" ]]; then
   unzip "$TEMP_FILE" -d "$BIN_DIR"
 else
   tar -xzf "$TEMP_FILE" -C "$BIN_DIR"
@@ -90,11 +91,11 @@ fi
 echo "The 'pixi' binary is installed into '${BIN_DIR}'"
 
 update_shell() {
-    FILE=$1
-    LINE=$2
+    FILE="$1"
+    LINE="$2"
 
     # shell update can be suppressed by `PIXI_NO_PATH_UPDATE` env var
-    [[ ! -z "${PIXI_NO_PATH_UPDATE-}" ]] && echo "No path update because PIXI_NO_PATH_UPDATE has a value" && return
+    [[ ! -z "${PIXI_NO_PATH_UPDATE:-}" ]] && echo "No path update because PIXI_NO_PATH_UPDATE has a value" && return
 
     # Create the file if it doesn't exist
     if [ -f "$FILE" ]; then
@@ -113,7 +114,7 @@ update_shell() {
 case "$(basename "$SHELL")" in
     bash)
         # Default to bashrc as that is used in non login shells instead of the profile.
-        LINE="export PATH=${BIN_DIR}:\$PATH"
+        LINE="export PATH=\"${BIN_DIR}:\$PATH\""
         update_shell ~/.bashrc "$LINE"
         ;;
 
@@ -123,7 +124,7 @@ case "$(basename "$SHELL")" in
         ;;
 
     zsh)
-        LINE="export PATH=${BIN_DIR}:\$PATH"
+        LINE="export PATH=\"${BIN_DIR}:\$PATH\""
         update_shell ~/.zshrc "$LINE"
         ;;
 


### PR DESCRIPTION
- Exported paths for Bash and ZSH are now surrounded by double quotes, which is necessary to avoid breaking user systems where the existing `PATH` contains spaces.

- The `PIXI_HOME` environment variable now resolves incoming `~/` prefixes to the actual user's `$HOME` value. Otherwise we would generate invalid paths, since `~/` is not a valid prefix in `PATH`. It also fixes the fact that the old code installed into a literal sub-directory of the current working dir, named `~/.pixi` (a literal `~`), instead of into the user's home directory, whenever users tried to provide a custom `env PIXI_HOME=~/.pixi` variable themselves.

- We now use double quotes around all variables. This is required for two reasons. It ensures that arguments with spaces are supported. And it prevents Bash from breaking when a variable contains an empty string. Otherwise, various tests such as `[[ $HTTP_CODE -lt 200 ]]` would break with errors about not providing enough parameters.

- The `PIXI_NO_PATH_UPDATE` syntax has been clarified to use `:-` to clearly show that it's using an empty default. The old `-` syntax looks more like a typo.

Closes #2188