### PR TITLE
refactor: `pixi global add` follow up

### DIFF
--- a/src/cli/global/expose.rs
+++ b/src/cli/global/expose.rs
@@ -13,8 +13,8 @@ use crate::{
 /// will expose the `python3.10` executable as `python310` and the `python3` executable as `python3`
 #[derive(Parser, Debug)]
 pub struct AddArgs {
-    /// Add one or more `MAPPING` for environment `ENV` which describe which executables are exposed.
-    /// The syntax for `MAPPING` is `exposed_name=executable_name`, so for example `python3.10=python`.
+    /// Add one or more mapping which describe which executables are exposed.
+    /// The syntax is `exposed_name=executable_name`, so for example `python3.10=python`.
     mappings: Vec<global::Mapping>,
 
     /// The environment to which the binaries should be exposed

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -7,7 +7,7 @@ use rattler_conda_types::{MatchSpec, NamedChannelOrUrl, PackageName, Platform};
 
 use crate::{
     cli::{global::revert_environment_after_error, has_specs::HasSpecs},
-    global::{self, EnvDir, EnvironmentName, ExposedName, Mapping, Project},
+    global::{self, EnvironmentName, ExposedName, Mapping, Project},
     prefix::Prefix,
 };
 use pixi_config::{self, Config, ConfigCli};
@@ -37,8 +37,8 @@ pub struct Args {
     #[clap(short, long)]
     environment: Option<EnvironmentName>,
 
-    /// Add one or more `MAPPING` for environment `ENV` which describe which executables are exposed.
-    /// The syntax for `MAPPING` is `exposed_name=executable_name`, so for example `python3.10=python`.
+    /// Add one or more mapping which describe which executables are exposed.
+    /// The syntax is `exposed_name=executable_name`, so for example `python3.10=python`.
     #[arg(long)]
     expose: Vec<Mapping>,
 
@@ -142,8 +142,7 @@ async fn setup_environment(
     if args.expose.is_empty() {
         // Add the expose binaries for all the packages that were requested to the manifest
         for (package_name, _spec) in &specs {
-            let env_dir = EnvDir::from_env_root(project.env_root.clone(), env_name.clone()).await?;
-            let prefix = Prefix::new(env_dir.path());
+            let prefix = project.environment_prefix(env_name.clone()).await?;
             let prefix_package = prefix.find_designated_package(package_name).await?;
             let package_executables = prefix.find_executables(&[prefix_package]);
             for (executable_name, _) in &package_executables {

--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -169,12 +169,12 @@ pub(crate) async fn create_executable_scripts(
         let executable_name = executable_from_path(global_script_path);
         match added_or_changed {
             AddedOrChanged::Unchanged => {}
-            AddedOrChanged::Added => println!(
+            AddedOrChanged::Added => eprintln!(
                 "{}Added executable '{}'.",
                 console::style(console::Emoji("✔ ", "")).green(),
                 executable_name
             ),
-            AddedOrChanged::Changed => println!(
+            AddedOrChanged::Changed => eprintln!(
                 "{}Updated executable '{}'.",
                 console::style(console::Emoji("~ ", "")).yellow(),
                 executable_name

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -375,9 +375,9 @@ impl Project {
     /// Returns the prefix of the environment with the given name.
     pub(crate) async fn environment_prefix(
         &self,
-        name: &EnvironmentName,
+        env_name: EnvironmentName,
     ) -> miette::Result<Prefix> {
-        let env_dir = EnvDir::from_env_root(self.env_root.clone(), name.clone()).await?;
+        let env_dir = EnvDir::from_env_root(self.env_root.clone(), env_name).await?;
         Ok(Prefix::new(env_dir.path()))
     }
 
@@ -473,11 +473,7 @@ impl Project {
 
         // Install the environment
         let package_cache = PackageCache::new(pixi_config::get_cache_dir()?.join("pkgs"));
-        let prefix = Prefix::new(
-            EnvDir::from_env_root(self.env_root.clone(), env_name.clone())
-                .await?
-                .path(),
-        );
+        let prefix = self.environment_prefix(env_name.clone()).await?;
         await_in_progress("creating virtual environment", |pb| {
             Installer::new()
                 .with_download_client(self.authenticated_client().clone())

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -13,7 +13,7 @@ def exec_extension(exe_name: str) -> str:
         return exe_name
 
 
-def test_global_sync_dependencies(pixi: Path, tmp_path: Path) -> None:
+def test_sync_dependencies(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -61,7 +61,7 @@ def test_global_sync_dependencies(pixi: Path, tmp_path: Path) -> None:
     )
 
 
-def test_global_sync_platform(pixi: Path, tmp_path: Path) -> None:
+def test_sync_platform(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -89,7 +89,7 @@ def test_global_sync_platform(pixi: Path, tmp_path: Path) -> None:
     )
 
 
-def test_global_sync_change_expose(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_sync_change_expose(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -126,9 +126,7 @@ def test_global_sync_change_expose(pixi: Path, tmp_path: Path, dummy_channel_1: 
     assert not dummy_in_disguise.is_file()
 
 
-def test_global_sync_manually_remove_binary(
-    pixi: Path, tmp_path: Path, dummy_channel_1: str
-) -> None:
+def test_sync_manually_remove_binary(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -157,7 +155,7 @@ def test_global_sync_manually_remove_binary(
     assert dummy_a.is_file()
 
 
-def test_global_sync_migrate(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_sync_migrate(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -180,7 +178,7 @@ exposed = {{ dummy-1 = "dummy-a", dummy-2 = "dummy-a", dummy-3 = "dummy-b", dumm
     assert tomllib.loads(original_manifest) == tomllib.loads(migrated_manifest)
 
 
-def test_global_expose_basic(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_expose_basic(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -227,7 +225,7 @@ def test_global_expose_basic(pixi: Path, tmp_path: Path, dummy_channel_1: str) -
     )
 
 
-def test_global_expose_revert_working(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_expose_revert_working(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -251,7 +249,7 @@ def test_global_expose_revert_working(pixi: Path, tmp_path: Path, dummy_channel_
     assert manifest.read_text() == original_toml
 
 
-def test_global_expose_revert_failure(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_expose_revert_failure(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -277,9 +275,7 @@ def test_global_expose_revert_failure(pixi: Path, tmp_path: Path, dummy_channel_
     )
 
 
-def test_global_expose_preserves_table_format(
-    pixi: Path, tmp_path: Path, dummy_channel_1: str
-) -> None:
+def test_expose_preserves_table_format(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -304,7 +300,7 @@ def test_global_expose_preserves_table_format(
     assert manifest.read_text() == original_toml
 
 
-def test_global_install_adapts_manifest(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_install_adapts_manifest(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifest = manifests.joinpath("pixi-global.toml")
@@ -334,7 +330,7 @@ exposed = {{ dummy-a = "dummy-a", dummy-aa = "dummy-aa" }}
     assert actual_manifest == expected_manifest
 
 
-def test_global_install_multiple_packages(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_install_multiple_packages(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
     dummy_a = tmp_path / "bin" / exec_extension("dummy-a")
@@ -363,7 +359,7 @@ def test_global_install_multiple_packages(pixi: Path, tmp_path: Path, dummy_chan
     assert not dummy_c.is_file()
 
 
-def test_global_install_expose(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_install_expose(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
     dummy_a = tmp_path / "bin" / exec_extension("dummy-a")
@@ -469,9 +465,7 @@ def test_global_install_expose(pixi: Path, tmp_path: Path, dummy_channel_1: str)
     )
 
 
-def test_global_install_only_reverts_failing(
-    pixi: Path, tmp_path: Path, dummy_channel_1: str
-) -> None:
+def test_install_only_reverts_failing(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
     dummy_a = tmp_path / "bin" / exec_extension("dummy-a")
@@ -492,7 +486,7 @@ def test_global_install_only_reverts_failing(
     assert not dummy_x.is_file()
 
 
-def test_global_install_platform(pixi: Path, tmp_path: Path) -> None:
+def test_install_platform(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     # Exists on win-64
     verify_cli_command(
@@ -510,7 +504,7 @@ def test_global_install_platform(pixi: Path, tmp_path: Path) -> None:
     )
 
 
-def test_global_install_channels(
+def test_install_channels(
     pixi: Path, tmp_path: Path, dummy_channel_1: str, dummy_channel_2: str
 ) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
@@ -567,7 +561,7 @@ def test_global_install_channels(
     assert dummy_x.is_file()
 
 
-def test_global_install_multi_env_install(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_install_multi_env_install(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
     # Install dummy-a and dummy-b from dummy-channel-1 this will fail if both environment contains the same package as spec.
@@ -586,7 +580,7 @@ def test_global_install_multi_env_install(pixi: Path, tmp_path: Path, dummy_chan
     )
 
 
-def test_global_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -623,7 +617,7 @@ def test_global_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     )
 
 
-def test_global_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
     # Verify empty list
@@ -701,9 +695,7 @@ def test_global_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
     )
 
 
-def test_global_uninstall_only_reverts_failing(
-    pixi: Path, tmp_path: Path, dummy_channel_1: str
-) -> None:
+def test_uninstall_only_reverts_failing(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
     dummy_a = tmp_path / "bin" / exec_extension("dummy-a")
@@ -746,6 +738,14 @@ def test_auto_self_expose(pixi: Path, tmp_path: Path, non_self_expose_channel: s
 def test_add(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
+    # Cannot add package to environment that doesn't exist
+    verify_cli_command(
+        [pixi, "global", "add", "--environment", "dummy-a", "dummy-b"],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="Environment dummy-a doesn't exist",
+    )
+
     verify_cli_command(
         [pixi, "global", "install", "--channel", dummy_channel_1, "dummy-a"],
         ExitCode.SUCCESS,
@@ -755,21 +755,30 @@ def test_add(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     assert dummy_a.is_file()
 
     verify_cli_command(
-        [pixi, "global", "add", "-e" "dummy-a", "dummy-b"],
+        [pixi, "global", "add", "--environment", "dummy-a", "dummy-b"],
         ExitCode.SUCCESS,
         env=env,
-        stdout_contains=["Added", "dummy-b", "0.1.0"],
+        stderr_contains="Added package 'dummy-b",
     )
     # Make sure it doesn't expose a binary from this package
     dummy_b = tmp_path / "bin" / exec_extension("dummy-b")
     assert not dummy_b.is_file()
 
     verify_cli_command(
-        [pixi, "global", "add", "-e" "dummy-a", "dummy-b", "--expose", "dummy-b=dummy-b"],
+        [
+            pixi,
+            "global",
+            "add",
+            "--environment",
+            "dummy-a",
+            "dummy-b",
+            "--expose",
+            "dummy-b=dummy-b",
+        ],
         ExitCode.SUCCESS,
         env=env,
-        stdout_contains=["Added", "executable", "dummy-b", "0.1.0"],
+        stderr_contains=["Added executable 'dummy-b"],
     )
-    # Make sure it doesn't expose a binary from this package
+    # Make sure it now exposes the binary
     dummy_b = tmp_path / "bin" / exec_extension("dummy-b")
     assert dummy_b.is_file()


### PR DESCRIPTION
- Use long form CLI commands. They are preferable in scripts and docs.
- Require parameter `packages`
- Use `HasSpecs` trait
- Fail if environment doesn't exist
- Use `environment_prefix` in more places
- Take ownership of `env_name` in `environment_prefix`
- Use stderr for messages as described in https://clig.dev/#the-basics
- Adapt mapping docs
- Dropped `global` namespace in integration test naming for consistency
- Extended integration tests