### PR TITLE
fix: turn off symlink follow for task cache

### DIFF
--- a/src/task/file_hashes.rs
+++ b/src/task/file_hashes.rs
@@ -193,36 +193,11 @@ mod test {
         write(target_dir.path().join("src/bla/lib.rs"), "fn main() {}").unwrap();
         write(target_dir.path().join("Cargo.toml"), "[package]").unwrap();
 
-        // create symlinked directory
-        let symlinked_dir = tempdir().unwrap();
-
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::symlink(symlinked_dir.path(), target_dir.path().join("link"))
-                .unwrap();
-        }
-        // On Windows this test can fail, so we need to check if the symlink was created successfully.
-        // This works in our CI but might not work on all Windows systems.
-        #[allow(unused_assignments, unused_mut)]
-        let mut symlink_on_windows = false;
-        #[cfg(windows)]
-        {
-            symlink_on_windows = std::os::windows::fs::symlink_dir(
-                symlinked_dir.path(),
-                target_dir.path().join("link"),
-            )
-            .is_ok();
-        }
-
-        write(symlinked_dir.path().join("main.rs"), "fn main() {}").unwrap();
-
         // Compute the hashes of all files in the directory that match a certain set of includes.
-        let hashes = FileHashes::from_files(
-            target_dir.path(),
-            vec!["src/*.rs", "*.toml", "!**/lib.rs", "link/*.rs"],
-        )
-        .await
-        .unwrap();
+        let hashes =
+            FileHashes::from_files(target_dir.path(), vec!["src/*.rs", "*.toml", "!**/lib.rs"])
+                .await
+                .unwrap();
 
         assert!(
             !hashes.files.contains_key(Path::new("build.rs")),
@@ -246,23 +221,12 @@ mod test {
                 .map(String::as_str),
             Some("2c806b6ebece677c")
         );
-
-        if symlink_on_windows || cfg!(unix) {
-            assert_matches!(
-                hashes
-                    .files
-                    .get(Path::new("link/main.rs"))
-                    .map(String::as_str),
-                Some("2c806b6ebece677c")
-            );
-        }
-
         #[cfg(unix)]
         {
             let mut hasher = Xxh3::new();
             hashes.hash(&mut hasher);
             let s = format!("{:x}", hasher.finish());
-            assert_eq!(s, "96308f0071086f62");
+            assert_eq!(s, "be05bb5d7c6e8e6");
         }
 
         let hashes = FileHashes::from_files(target_dir.path(), vec!["src/"])

--- a/src/task/file_hashes.rs
+++ b/src/task/file_hashes.rs
@@ -111,7 +111,10 @@ impl FileHashes {
             .git_ignore(false)
             .git_global(false)
             .git_exclude(false)
-            .follow_links(true)
+            // Turn this back off as it can cause issues with symlinks:
+            // https://github.com/prefix-dev/pixi/issues/2196
+            // TODO: The current idea is to completely reimplement this without the `ignore` crate.
+            // .follow_links(true)
             .build_parallel()
             .run(|| {
                 let tx = tx.clone();


### PR DESCRIPTION
Unfortunately the `.follow_links(true)` created some issues. The idea is to completely redo the file search logic but for now we turn of the breaking option. 

Closes #2196 #2205 