### PR TITLE
feat: improve expose

### DIFF
--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -41,6 +41,7 @@ lazy_static! {
     pub static ref TASK_STYLE: Style = Style::new().blue();
     pub static ref PLATFORM_STYLE: Style = Style::new().yellow();
     pub static ref ENVIRONMENT_STYLE: Style = Style::new().magenta();
+    pub static ref EXPOSED_NAME_STYLE: Style = Style::new().yellow();
     pub static ref FEATURE_STYLE: Style = Style::new().cyan();
     pub static ref SOLVE_GROUP_STYLE: Style = Style::new().cyan();
     pub static ref DEFAULT_PYPI_INDEX_URL: Url = Url::parse("https://pypi.org/simple").unwrap();

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -48,12 +48,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_cli_config(config.clone());
 
     if let Some(environment) = args.environment {
-        let name = EnvironmentName::from_str(environment.as_str())?;
+        let env_name = EnvironmentName::from_str(environment.as_str())?;
         // Verify that the environment is in sync with the manifest and report to the user otherwise
-        if !project.environment_in_sync(&name).await? {
-            tracing::warn!("The environment '{}' is not in sync with the manifest, to sync run\n\tpixi global sync", name);
+        if !project.environment_in_sync(&env_name).await? {
+            tracing::warn!("The environment {} is not in sync with the manifest, to sync run\n\tpixi global sync", env_name.fancy_display());
         }
-        list_environment(project, &name, args.sort_by).await?;
+        list_environment(project, &env_name, args.sort_by).await?;
     } else {
         // Verify that the environments are in sync with the manifest and report to the user otherwise
         if !project.environments_in_sync().await? {
@@ -135,7 +135,7 @@ async fn list_environment(
         }
     }
     println!(
-        "The '{}' environment has {} packages:",
+        "The {} environment has {} packages:",
         environment_name.fancy_display(),
         console::style(packages_to_output.len()).bold()
     );
@@ -377,7 +377,7 @@ fn format_exposed(env_name: &str, exposed: &IndexSet<Mapping>, last: bool) -> Op
     {
         let content = exposed
             .iter()
-            .map(|mapping| console::style(mapping.exposed_name()).yellow().to_string())
+            .map(|mapping| mapping.exposed_name().fancy_display())
             .join(", ");
         Some(format_asciiart_section("exposes", content, last, false))
     } else {

--- a/src/cli/global/uninstall.rs
+++ b/src/cli/global/uninstall.rs
@@ -51,7 +51,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let mut project = last_updated_project.clone();
         match apply_changes(env_name, &mut project)
             .await
-            .wrap_err_with(|| format!("Couldn't remove {}.", env_name.fancy_display()))
+            .wrap_err_with(|| format!("Couldn't remove {}", env_name.fancy_display()))
         {
             Ok(sc) => {
                 state_changes |= sc;
@@ -62,7 +62,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .await
                     .wrap_err_with(|| {
                         format!(
-                            "Couldn't uninstall environment '{env_name}'. Reverting also failed."
+                            "Couldn't uninstall environment {}. Reverting also failed.",
+                            env_name.fancy_display()
                         )
                     })?;
 

--- a/src/cli/global/update.rs
+++ b/src/cli/global/update.rs
@@ -2,6 +2,7 @@ use crate::cli::global::revert_environment_after_error;
 use crate::global::{self, StateChanges};
 use crate::global::{EnvironmentName, Project};
 use clap::Parser;
+use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use pixi_config::{Config, ConfigCli};
 use pixi_utils::executable_from_path;
@@ -66,9 +67,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         // Remove outdated binaries
         state_changes |= project.prune_exposed(env_name).await?;
         eprintln!(
-            "{}Updated environment: '{}'.",
+            "{}Updated environment: {}.",
             console::style(console::Emoji("✔ ", "")).green(),
-            env_name
+            env_name.fancy_display()
         );
 
         Ok(state_changes)

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -297,7 +297,7 @@ impl StateChanges {
                 StateChange::RemovedExposed(exposed, env_name) => {
                     eprintln!(
                         "{}Removed exposed executable {} from environment {}.",
-                        console::style(console::Emoji("✔ ", "")).red(),
+                        console::style(console::Emoji("✔ ", "")).green(),
                         exposed.fancy_display(),
                         env_name.fancy_display()
                     );
@@ -350,7 +350,7 @@ impl StateChanges {
                 StateChange::RemovedEnvironment(env_name) => {
                     eprintln!(
                         "{}Removed environment {}.",
-                        console::style(console::Emoji("✔ ", "")).red(),
+                        console::style(console::Emoji("✔ ", "")).green(),
                         env_name.fancy_display()
                     );
                 }

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -192,9 +192,9 @@ pub(crate) async fn find_package_records(conda_meta: &Path) -> miette::Result<Ve
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]
 pub(crate) enum StateChange {
-    AddedExposed(String, EnvironmentName),
-    RemovedExposed(String, EnvironmentName),
-    UpdatedExposed(String, EnvironmentName),
+    AddedExposed(ExposedName, EnvironmentName),
+    RemovedExposed(ExposedName, EnvironmentName),
+    UpdatedExposed(ExposedName, EnvironmentName),
     AddedPackage(PackageRecord, EnvironmentName),
     AddedEnvironment(EnvironmentName),
     RemovedEnvironment(EnvironmentName),
@@ -265,12 +265,71 @@ impl StateChanges {
 
         while let Some(change) = iter.next() {
             match change {
-                StateChange::AddedEnvironment(env_name) => {
+                StateChange::AddedExposed(exposed, env_name) => {
+                    let mut exposed_names = vec![exposed.clone()];
+                    while let Some(StateChange::AddedExposed(next_exposed, next_env)) = iter.peek()
+                    {
+                        if next_env == env_name {
+                            exposed_names.push(next_exposed.clone());
+                            iter.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    if exposed_names.len() == 1 {
+                        eprintln!(
+                            "{}Exposed executable {} from environment {}.",
+                            console::style(console::Emoji("✔ ", "")).green(),
+                            exposed_names[0].fancy_display(),
+                            env_name.fancy_display()
+                        );
+                    } else {
+                        eprintln!(
+                            "{}Exposed executables from environment {}:",
+                            console::style(console::Emoji("✔ ", "")).green(),
+                            env_name.fancy_display()
+                        );
+                        for exposed_name in exposed_names {
+                            eprintln!("   - {}", exposed_name.fancy_display());
+                        }
+                    }
+                }
+                StateChange::RemovedExposed(exposed, env_name) => {
                     eprintln!(
-                        "{}Added environment {}.",
-                        console::style(console::Emoji("✔ ", "")).green(),
+                        "{}Removed exposed executable {} from environment {}.",
+                        console::style(console::Emoji("✔ ", "")).red(),
+                        exposed.fancy_display(),
                         env_name.fancy_display()
                     );
+                }
+                StateChange::UpdatedExposed(exposed, env_name) => {
+                    let mut exposed_names = vec![exposed.clone()];
+                    while let Some(StateChange::AddedExposed(next_exposed, next_env)) = iter.peek()
+                    {
+                        if next_env == env_name {
+                            exposed_names.push(next_exposed.clone());
+                            iter.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    if exposed_names.len() == 1 {
+                        eprintln!(
+                            "{}Updated executable {} of environment {}.",
+                            console::style(console::Emoji("✔ ", "")).green(),
+                            exposed_names[0].fancy_display(),
+                            env_name.fancy_display()
+                        );
+                    } else {
+                        eprintln!(
+                            "{}Updated executables of environment {}:",
+                            console::style(console::Emoji("✔ ", "")).green(),
+                            env_name.fancy_display()
+                        );
+                        for exposed_name in exposed_names {
+                            eprintln!("   - {}", exposed_name.fancy_display());
+                        }
+                    }
                 }
                 StateChange::AddedPackage(pkg, env_name) => {
                     eprintln!(
@@ -281,76 +340,17 @@ impl StateChanges {
                         env_name.fancy_display()
                     );
                 }
-                StateChange::AddedExposed(exposed, env_name) => {
-                    let mut executables = vec![exposed.clone()];
-                    while let Some(StateChange::AddedExposed(next_exposed, next_env)) = iter.peek()
-                    {
-                        if next_env == env_name {
-                            executables.push(next_exposed.clone());
-                            iter.next();
-                        } else {
-                            break;
-                        }
-                    }
-                    if executables.len() == 1 {
-                        eprintln!(
-                            "{}Exposed executable {} from environment {}.",
-                            console::style(console::Emoji("✔ ", "")).green(),
-                            executables[0],
-                            env_name.fancy_display()
-                        );
-                    } else {
-                        eprintln!(
-                            "{}Exposed executables from environment {}:",
-                            console::style(console::Emoji("✔ ", "")).green(),
-                            env_name.fancy_display()
-                        );
-                        for executable in executables {
-                            eprintln!("   - {executable}");
-                        }
-                    }
-                }
-                StateChange::UpdatedExposed(exposed, env_name) => {
-                    let mut executables = vec![exposed.clone()];
-                    while let Some(StateChange::AddedExposed(next_exposed, next_env)) = iter.peek()
-                    {
-                        if next_env == env_name {
-                            executables.push(next_exposed.clone());
-                            iter.next();
-                        } else {
-                            break;
-                        }
-                    }
-                    if executables.len() == 1 {
-                        eprintln!(
-                            "{}Updated executable {} of environment {}.",
-                            console::style(console::Emoji("✔ ", "")).green(),
-                            executables[0],
-                            env_name.fancy_display()
-                        );
-                    } else {
-                        eprintln!(
-                            "{}Updated executables of environment {}:",
-                            console::style(console::Emoji("✔ ", "")).green(),
-                            env_name.fancy_display()
-                        );
-                        for executable in executables {
-                            eprintln!("   - {executable}");
-                        }
-                    }
+                StateChange::AddedEnvironment(env_name) => {
+                    eprintln!(
+                        "{}Added environment {}.",
+                        console::style(console::Emoji("✔ ", "")).green(),
+                        env_name.fancy_display()
+                    );
                 }
                 StateChange::RemovedEnvironment(env_name) => {
                     eprintln!(
                         "{}Removed environment {}.",
                         console::style(console::Emoji("✔ ", "")).red(),
-                        env_name.fancy_display()
-                    );
-                }
-                StateChange::RemovedExposed(exposed, env_name) => {
-                    eprintln!(
-                        "{}Removed exposed executable {} from environment {}.",
-                        console::style(console::Emoji("✔ ", "")).red(),
-                        exposed,
                         env_name.fancy_display()
                     );
                 }

--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -171,16 +171,15 @@ pub(crate) async fn create_executable_scripts(
         }
 
         let executable_name = executable_from_path(global_script_path);
+        let exposed_name = ExposedName::from_str(&executable_name)?;
         match added_or_changed {
             AddedOrChanged::Unchanged => {}
             AddedOrChanged::Added => {
                 state_changes
-                    .push_change(StateChange::AddedExposed(executable_name, env_name.clone()));
+                    .push_change(StateChange::AddedExposed(exposed_name, env_name.clone()));
             }
-            AddedOrChanged::Changed => state_changes.push_change(StateChange::UpdatedExposed(
-                executable_name,
-                env_name.clone(),
-            )),
+            AddedOrChanged::Changed => state_changes
+                .push_change(StateChange::UpdatedExposed(exposed_name, env_name.clone())),
         }
     }
     Ok(state_changes)

--- a/src/global/project/environment.rs
+++ b/src/global/project/environment.rs
@@ -48,7 +48,7 @@ impl<'de> Deserialize<'de> for EnvironmentName {
     }
 }
 
-impl FancyDisplay for &EnvironmentName {
+impl FancyDisplay for EnvironmentName {
     fn fancy_display(&self) -> StyledObject<&str> {
         consts::ENVIRONMENT_STYLE.apply_to(self.as_str())
     }

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -241,8 +241,25 @@ impl Manifest {
         // Reinsert unique channels
         *channels_array = existing_channels.iter().collect();
 
-        tracing::debug!("Added channel {channel} for environment {env_name} in toml document",);
+        tracing::debug!("Added channel {channel} for environment {env_name} in toml document");
         Ok(())
+    }
+
+    pub fn match_exposed_name_to_environment(
+        &self,
+        exposed_name: &ExposedName,
+    ) -> miette::Result<EnvironmentName> {
+        for (env_name, env) in &self.parsed.envs {
+            for mapping in &env.exposed {
+                if mapping.exposed_name == *exposed_name {
+                    return Ok(env_name.clone());
+                }
+            }
+        }
+        Err(miette::miette!(
+            "Exposed name {} not found in any environment",
+            exposed_name.fancy_display()
+        ))
     }
 
     /// Adds exposed mapping to the manifest

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -547,7 +547,7 @@ impl Project {
         // Remove all removable binaries
         for exposed_path in to_remove {
             state_changes.push_change(StateChange::RemovedExposed(
-                executable_from_path(&exposed_path),
+                ExposedName::from_str(&executable_from_path(&exposed_path))?,
                 env_name.clone(),
             ));
             tokio_fs::remove_file(&exposed_path)
@@ -950,10 +950,7 @@ mod tests {
         let state_changes = project.prune_exposed(&env_name).await.unwrap();
         assert_eq!(
             state_changes.changes(),
-            vec![StateChange::RemovedExposed(
-                not_python.to_string(),
-                env_name.clone()
-            )]
+            vec![StateChange::RemovedExposed(not_python, env_name.clone())]
         );
 
         // Check if the non-exposed file was removed

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -690,7 +690,10 @@ impl Project {
                 env_name
             ))?;
 
-        tracing::debug!("Exposing executables for environment '{}'", env_name);
+        tracing::debug!(
+            "Exposing executables for environment {}",
+            env_name.fancy_display()
+        );
         state_changes |= create_executable_scripts(
             &script_mapping,
             &prefix,

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
+use console::StyledObject;
+use fancy_display::FancyDisplay;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use miette::Diagnostic;
+use pixi_consts::consts;
 use pixi_manifest::{PrioritizedChannel, TomlError};
 use rattler_conda_types::{NamedChannelOrUrl, PackageName, Platform};
 use serde::de::{Deserialize, Deserializer, Visitor};
@@ -92,10 +95,12 @@ impl<'de> serde::Deserialize<'de> for ParsedManifest {
             }
         }
         if !duplicates.is_empty() {
-            let duplicate_keys = duplicates.keys().map(|k| k.to_string()).collect_vec();
             return Err(serde::de::Error::custom(format!(
-                "Duplicate exposed names found: '{}'",
-                duplicate_keys.into_iter().sorted().join(", ")
+                "Duplicated exposed names found: '{}'",
+                duplicates
+                    .keys()
+                    .map(|exposed_name| exposed_name.fancy_display())
+                    .join(", ")
             )));
         }
 
@@ -185,6 +190,12 @@ pub(crate) struct ExposedName(String);
 impl fmt::Display for ExposedName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl FancyDisplay for ExposedName {
+    fn fancy_display(&self) -> StyledObject<&str> {
+        consts::EXPOSED_NAME_STYLE.apply_to(&self.0)
     }
 }
 

--- a/src/global/project/snapshots/pixi__global__project__parsed_manifest__tests__duplicate_exposed.snap
+++ b/src/global/project/snapshots/pixi__global__project__parsed_manifest__tests__duplicate_exposed.snap
@@ -2,4 +2,4 @@
 source: src/global/project/parsed_manifest.rs
 expression: manifest.unwrap_err()
 ---
-Duplicate exposed names found: 'python, python3'
+Duplicated exposed names found: 'python3, python'

--- a/src/global/project/snapshots/pixi__global__project__parsed_manifest__tests__duplicate_exposed.snap
+++ b/src/global/project/snapshots/pixi__global__project__parsed_manifest__tests__duplicate_exposed.snap
@@ -2,4 +2,4 @@
 source: src/global/project/parsed_manifest.rs
 expression: manifest.unwrap_err()
 ---
-Duplicated exposed names found: 'python3, python'
+Duplicated exposed names found: 'python, python3'


### PR DESCRIPTION
- `pixi global expose remove` doesn't need `--environment` flag anymore
- Move to fancy display for exposed name