### PR TITLE
fix: only uninstall single specified environments, only cleanup on sync

### DIFF
--- a/src/cli/global/uninstall.rs
+++ b/src/cli/global/uninstall.rs
@@ -34,11 +34,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         env_name: &EnvironmentName,
         project_modified: &mut Project,
     ) -> miette::Result<StateChanges> {
-        let mut state_changes = StateChanges::default();
-        project_modified.manifest.remove_environment(env_name)?;
-
-        // Cleanup the project after removing the environments.
-        state_changes |= project_modified.prune_old_environments().await?;
+        let state_changes = project_modified.remove_environment(env_name).await?;
 
         project_modified.manifest.save().await?;
 

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -649,27 +649,39 @@ def test_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     )
 
 
+# Test that we correctly uninstall the required packages
+# - Checking that the binaries are removed
+# - Checking that the non-requested to remove binaries are still there
 def test_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 
-    # Verify empty list
-    verify_cli_command(
-        [pixi, "global", "list"],
-        env=env,
-        stdout_contains="No global environments found.",
-    )
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+    manifest = manifests.joinpath("pixi-global.toml")
+    original_toml = f"""
+version = {MANIFEST_VERSION}
+[envs.dummy-a]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-a = "*" }}
+exposed = {{ dummy-a = "dummy-a", dummy-aa = "dummy-aa" }}
 
-    # Install dummy-b from dummy-channel-1
+[envs.dummy-b]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-b = "*" }}
+exposed = {{ dummy-b = "dummy-b" }}
+
+[envs.dummy-c]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-c = "*" }}
+exposed = {{ dummy-c = "dummy-c" }}
+"""
+    manifest.write_text(original_toml)
+
     verify_cli_command(
         [
             pixi,
             "global",
-            "install",
-            "--channel",
-            dummy_channel_1,
-            "dummy-a",
-            "dummy-b",
-            "dummy-c",
+            "sync",
         ],
         env=env,
     )
@@ -682,7 +694,7 @@ def test_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     assert dummy_b.is_file()
     assert dummy_c.is_file()
 
-    # Uninstall dummy-b
+    # Uninstall dummy-a
     verify_cli_command(
         [pixi, "global", "uninstall", "dummy-a"],
         env=env,
@@ -696,15 +708,27 @@ def test_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     assert tmp_path.joinpath("envs", "dummy-c").is_dir()
     assert not tmp_path.joinpath("envs", "dummy-a").is_dir()
 
-    # Uninstall dummy-b and dummy-c
+    # Remove dummy-b manually from manifest
+    modified_toml = f"""
+version = {MANIFEST_VERSION}
+
+[envs.dummy-c]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-c = "*" }}
+exposed = {{ dummy-c = "dummy-c" }}
+"""
+    manifest.write_text(modified_toml)
+
+    # Uninstall dummy-c
     verify_cli_command(
-        [pixi, "global", "uninstall", "dummy-b", "dummy-c"],
+        [pixi, "global", "uninstall", "dummy-c"],
         env=env,
     )
     assert not dummy_a.is_file()
     assert not dummy_aa.is_file()
-    assert not dummy_b.is_file()
     assert not dummy_c.is_file()
+    # Verify only the dummy-c environment is removed, dummy-b is still there as no sync is run.
+    assert dummy_b.is_file()
 
     # Verify empty list
     verify_cli_command(
@@ -720,6 +744,31 @@ def test_uninstall(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
         env=env,
         stderr_contains="Couldn't remove dummy-a",
     )
+
+    # Uninstall multiple packages
+    manifest.write_text(original_toml)
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "sync",
+        ],
+        env=env,
+    )
+    assert dummy_a.is_file()
+    assert dummy_aa.is_file()
+    assert dummy_b.is_file()
+    assert dummy_c.is_file()
+
+    verify_cli_command(
+        [pixi, "global", "uninstall", "dummy-a", "dummy-b"],
+        env=env,
+    )
+    assert not dummy_a.is_file()
+    assert not dummy_aa.is_file()
+    assert not dummy_b.is_file()
+    assert dummy_c.is_file()
 
 
 def test_uninstall_only_reverts_failing(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:


### PR DESCRIPTION
This fixes the situation where we removed environments that were removed from the manifest on `pixi global uninstall` but it should only uninstall the requested environments.