### PR TITLE
feat: Re-add `pixi global upgrade`

### DIFF
--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -11,6 +11,8 @@ mod remove;
 mod sync;
 mod uninstall;
 mod update;
+mod upgrade;
+mod upgrade_all;
 
 #[derive(Debug, Parser)]
 pub enum Command {
@@ -20,10 +22,8 @@ pub enum Command {
     #[clap(visible_alias = "i")]
     Install(install::Args),
     Uninstall(uninstall::Args),
-    // TODO: Needs to adapted
     #[clap(visible_alias = "rm")]
     Remove(remove::Args),
-    // TODO: Needs to adapted
     #[clap(visible_alias = "ls")]
     List(list::Args),
     #[clap(visible_alias = "s")]
@@ -31,8 +31,10 @@ pub enum Command {
     #[clap(visible_alias = "e")]
     #[command(subcommand)]
     Expose(expose::SubCommand),
-    #[clap(visible_alias = "u")]
     Update(update::Args),
+    Upgrade(upgrade::Args),
+    #[clap(visible_alias = "ua")]
+    UpgradeAll(upgrade_all::Args),
 }
 
 /// Subcommand for global package management actions
@@ -58,6 +60,8 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
         Command::Sync(args) => sync::execute(args).await?,
         Command::Expose(subcommand) => expose::execute(subcommand).await?,
         Command::Update(args) => update::execute(args).await?,
+        Command::Upgrade(args) => upgrade::execute(args).await?,
+        Command::UpgradeAll(args) => upgrade_all::execute(args).await?,
     };
     Ok(())
 }

--- a/src/cli/global/mod.rs
+++ b/src/cli/global/mod.rs
@@ -33,7 +33,7 @@ pub enum Command {
     Expose(expose::SubCommand),
     Update(update::Args),
     Upgrade(upgrade::Args),
-    #[clap(visible_alias = "ua")]
+    #[clap(alias = "ua")]
     UpgradeAll(upgrade_all::Args),
 }
 

--- a/src/cli/global/upgrade.rs
+++ b/src/cli/global/upgrade.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+use rattler_conda_types::Platform;
+
+use crate::cli::{cli_config::ChannelsConfig, has_specs::HasSpecs};
+
+/// Upgrade specific package which is installed globally.
+#[derive(Parser, Debug)]
+// TODO: Uncomment as soon we implement this
+//#[clap(arg_required_else_help = true)]
+pub struct Args {
+    /// Specifies the packages to upgrade.
+    // TODO: Uncomment as soon we implement this
+    //#[arg(required = true)]
+    pub specs: Vec<String>,
+
+    #[clap(flatten)]
+    channels: ChannelsConfig,
+
+    /// The platform to install the package for.
+    #[clap(long, default_value_t = Platform::current())]
+    platform: Platform,
+}
+
+impl HasSpecs for Args {
+    fn packages(&self) -> Vec<&str> {
+        self.specs.iter().map(AsRef::as_ref).collect()
+    }
+}
+
+pub async fn execute(_args: Args) -> miette::Result<()> {
+    Err(
+        miette::miette!("You can use `pixi global update` for most use cases").wrap_err(
+            "`pixi global upgrade` has been removed, and will be re-added in future releases",
+        ),
+    )
+}

--- a/src/cli/global/upgrade_all.rs
+++ b/src/cli/global/upgrade_all.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use rattler_conda_types::Platform;
+
+use crate::cli::{cli_config::ChannelsConfig, has_specs::HasSpecs};
+
+/// Upgrade specific package which is installed globally.
+#[derive(Parser, Debug)]
+#[clap(arg_required_else_help = true)]
+pub struct Args {
+    /// Specifies the packages to upgrade.
+    //#[arg(required = true)]
+    pub specs: Vec<String>,
+
+    #[clap(flatten)]
+    channels: ChannelsConfig,
+
+    /// The platform to install the package for.
+    #[clap(long, default_value_t = Platform::current())]
+    platform: Platform,
+}
+
+impl HasSpecs for Args {
+    fn packages(&self) -> Vec<&str> {
+        self.specs.iter().map(AsRef::as_ref).collect()
+    }
+}
+
+pub async fn execute(_args: Args) -> miette::Result<()> {
+    Err(
+        miette::miette!("You can use `pixi global update` for most use cases").wrap_err(
+            "`pixi global upgrade-all` has been removed, and will be re-added in future releases",
+        ),
+    )
+}


### PR DESCRIPTION
Users will get an error message when they attempt to use `pixi global upgrade` or `pixi global upgrade-all`