### PR TITLE
feat: don't combine build, host, and run when there is a build section

### DIFF
--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -16,8 +16,7 @@ use serde_with::{serde_as, SerializeDisplay};
 use crate::{
     channel::{PrioritizedChannel, TomlPrioritizedChannelStrOrMap},
     consts,
-    parsed_manifest::deserialize_opt_package_map,
-    parsed_manifest::deserialize_package_map,
+    parsed_manifest::{deserialize_opt_package_map, deserialize_package_map},
     pypi::{pypi_options::PypiOptions, PyPiPackageName},
     target::Targets,
     task::{Task, TaskName},
@@ -184,6 +183,48 @@ impl Feature {
         self.channels.get_or_insert_with(Default::default)
     }
 
+    /// Returns the run dependencies of the target for the given `platform`.
+    ///
+    /// If the platform is `None` no platform specific dependencies are
+    /// returned.
+    ///
+    /// This function returns `None` if there is not a single feature that has
+    /// any dependencies defined.
+    pub fn run_dependencies(
+        &self,
+        platform: Option<Platform>,
+    ) -> Option<Cow<'_, IndexMap<PackageName, PixiSpec>>> {
+        self.dependencies(SpecType::Run, platform)
+    }
+
+    /// Returns the host dependencies of the target for the given `platform`.
+    ///
+    /// If the platform is `None` no platform specific dependencies are
+    /// returned.
+    ///
+    /// This function returns `None` if there is not a single feature that has
+    /// any dependencies defined.
+    pub fn host_dependencies(
+        &self,
+        platform: Option<Platform>,
+    ) -> Option<Cow<'_, IndexMap<PackageName, PixiSpec>>> {
+        self.dependencies(SpecType::Host, platform)
+    }
+
+    /// Returns the run dependencies of the target for the given `platform`.
+    ///
+    /// If the platform is `None` no platform specific dependencies are
+    /// returned.
+    ///
+    /// This function returns `None` if there is not a single feature that has
+    /// any dependencies defined.
+    pub fn build_dependencies(
+        &self,
+        platform: Option<Platform>,
+    ) -> Option<Cow<'_, IndexMap<PackageName, PixiSpec>>> {
+        self.dependencies(SpecType::Build, platform)
+    }
+
     /// Returns the dependencies of the feature for a given `spec_type` and
     /// `platform`.
     ///
@@ -193,17 +234,55 @@ impl Feature {
     ///
     /// Returns `None` if this feature does not define any target that has any
     /// of the requested dependencies.
+    ///
+    /// If the `platform` is `None` no platform specific dependencies are taken
+    /// into consideration.
     pub fn dependencies(
         &self,
-        spec_type: Option<SpecType>,
+        spec_type: SpecType,
         platform: Option<Platform>,
     ) -> Option<Cow<'_, IndexMap<PackageName, PixiSpec>>> {
         self.targets
             .resolve(platform)
             // Get the targets in reverse order, from least specific to most specific.
-            // This is required because the extend function will overwrite existing keys.
+            // This is required because the extent function will overwrite existing keys.
             .rev()
             .filter_map(|t| t.dependencies(spec_type))
+            .filter(|deps| !deps.is_empty())
+            .fold(None, |acc, deps| match acc {
+                None => Some(Cow::Borrowed(deps)),
+                Some(mut acc) => {
+                    let deps_iter = deps.iter().map(|(name, spec)| (name.clone(), spec.clone()));
+                    acc.to_mut().extend(deps_iter);
+                    Some(acc)
+                }
+            })
+    }
+
+    /// Returns the combined dependencies of the feature and `platform`.
+    ///
+    /// The `build` dependencies overwrite the `host` dependencies which
+    /// overwrite the `run` dependencies.
+    ///
+    /// This function returns a [`Cow`]. If the dependencies are not combined or
+    /// overwritten by multiple targets than this function returns a
+    /// reference to the internal dependencies.
+    ///
+    /// Returns `None` if this feature does not define any target that has any
+    /// of the requested dependencies.
+    ///
+    /// If the `platform` is `None` no platform specific dependencies are taken
+    /// into consideration.
+    pub fn combined_dependencies(
+        &self,
+        platform: Option<Platform>,
+    ) -> Option<Cow<'_, IndexMap<PackageName, PixiSpec>>> {
+        self.targets
+            .resolve(platform)
+            // Get the targets in reverse order, from least specific to most specific.
+            // This is required because the extent function will overwrite existing keys.
+            .rev()
+            .filter_map(|t| t.combined_dependencies())
             .filter(|deps| !deps.is_empty())
             .fold(None, |acc, deps| match acc {
                 None => Some(deps),
@@ -214,7 +293,6 @@ impl Feature {
                         ),
                         Cow::Owned(deps) => Either::Right(deps.into_iter()),
                     };
-
                     acc.to_mut().extend(deps_iter);
                     Some(acc)
                 }

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -485,7 +485,7 @@ mod tests {
         assert_matches!(
             manifest
                 .default_feature()
-                .dependencies(Some(SpecType::Host), None)
+                .dependencies(SpecType::Host, None)
                 .unwrap(),
             Cow::Borrowed(_),
             "[host-dependencies] should be borrowed"
@@ -494,14 +494,17 @@ mod tests {
         assert_matches!(
             manifest
                 .default_feature()
-                .dependencies(Some(SpecType::Run), None)
+                .dependencies(SpecType::Run, None)
                 .unwrap(),
             Cow::Borrowed(_),
             "[dependencies] should be borrowed"
         );
 
         assert_matches!(
-            manifest.default_feature().dependencies(None, None).unwrap(),
+            manifest
+                .default_feature()
+                .combined_dependencies(None)
+                .unwrap(),
             Cow::Owned(_),
             "combined dependencies should be owned"
         );
@@ -512,13 +515,13 @@ mod tests {
             .get(&FeatureName::Named(String::from("bla")))
             .unwrap();
         assert_matches!(
-            bla_feature.dependencies(Some(SpecType::Run), None).unwrap(),
+            bla_feature.dependencies(SpecType::Run, None).unwrap(),
             Cow::Borrowed(_),
             "[feature.bla.dependencies] should be borrowed"
         );
 
         assert_matches!(
-            bla_feature.dependencies(None, None).unwrap(),
+            bla_feature.combined_dependencies(None).unwrap(),
             Cow::Borrowed(_),
             "[feature.bla] combined dependencies should also be borrowed"
         );

--- a/crates/pixi_manifest/src/features_ext.rs
+++ b/crates/pixi_manifest/src/features_ext.rs
@@ -155,13 +155,30 @@ pub trait FeaturesExt<'source>: HasManifestRef<'source> + HasFeaturesIter<'sourc
     /// features define a requirement for the same package that both
     /// requirements are returned. The different requirements per package
     /// are sorted in the same order as the features they came from.
-    fn dependencies(
-        &self,
-        kind: Option<SpecType>,
-        platform: Option<Platform>,
-    ) -> CondaDependencies {
+    ///
+    /// If the `platform` is `None` no platform specific dependencies are taken
+    /// into consideration.
+    fn dependencies(&self, kind: SpecType, platform: Option<Platform>) -> CondaDependencies {
         self.features()
             .filter_map(|f| f.dependencies(kind, platform))
+            .into()
+    }
+
+    /// Returns the combined dependencies to install for this collection.
+    ///
+    /// The `build` dependencies overwrite the `host` dependencies which
+    /// overwrite the `run` dependencies.
+    ///
+    /// The dependencies of all features are combined. This means that if two
+    /// features define a requirement for the same package that both
+    /// requirements are returned. The different requirements per package
+    /// are sorted in the same order as the features they came from.
+    ///
+    /// If the `platform` is `None` no platform specific dependencies are taken
+    /// into consideration.
+    fn combined_dependencies(&self, platform: Option<Platform>) -> CondaDependencies {
+        self.features()
+            .filter_map(|f| f.combined_dependencies(platform))
             .into()
     }
 

--- a/crates/pixi_manifest/src/has_environment_dependencies.rs
+++ b/crates/pixi_manifest/src/has_environment_dependencies.rs
@@ -1,0 +1,36 @@
+use rattler_conda_types::Platform;
+
+use crate::{CondaDependencies, FeaturesExt, HasManifestRef, SpecType};
+
+/// A trait that defines the dependencies of an environment.
+pub trait HasEnvironmentDependencies<'source>:
+    HasManifestRef<'source> + FeaturesExt<'source>
+{
+    /// Returns true if the run, host, and build dependencies of this
+    /// environment should be combined or whether only the run dependencies
+    /// should be used.
+    fn should_combine_dependencies(&self) -> bool {
+        // If the manifest has a build section defined we should not combine.
+        if self.manifest().parsed.build.is_some() {
+            return false;
+        }
+        true
+    }
+
+    /// Returns the dependencies that are requested by the user optionally for a
+    /// specific platform.
+    ///
+    /// The dependencies returned from this function can be either the combined
+    /// (run, host, build) dependencies or only the run dependencies. Which is
+    /// returned is defined by the [`Self::should_combine_dependencies`] method.
+    ///
+    /// If the `platform` is `None` no platform specific dependencies are taken
+    /// into consideration.
+    fn environment_dependencies(&self, platform: Option<Platform>) -> CondaDependencies {
+        if self.should_combine_dependencies() {
+            self.combined_dependencies(platform)
+        } else {
+            self.dependencies(SpecType::Run, platform)
+        }
+    }
+}

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -7,6 +7,7 @@ mod environments;
 mod error;
 mod feature;
 mod features_ext;
+mod has_environment_dependencies;
 mod has_features_iter;
 mod has_manifest_ref;
 mod manifests;
@@ -46,6 +47,7 @@ use thiserror::Error;
 
 pub use build::BuildSection;
 pub use features_ext::FeaturesExt;
+pub use has_environment_dependencies::HasEnvironmentDependencies;
 pub use has_features_iter::HasFeaturesIter;
 pub use has_manifest_ref::HasManifestRef;
 

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -259,14 +259,14 @@ impl TryFrom<PyProjectManifest> for ParsedManifest {
         let python = PackageName::from_str("python").unwrap();
         // If the target doesn't have any python dependency, we add it from the
         // `requires-python`
-        if !target.has_dependency(&python, Some(SpecType::Run), None) {
+        if !target.has_dependency(&python, SpecType::Run, None) {
             target.add_dependency(
                 &python,
                 &version_or_url_to_spec(&python_spec).unwrap(),
                 SpecType::Run,
             );
         } else if let Some(_spec) = python_spec {
-            if target.has_dependency(&python, Some(SpecType::Run), None) {
+            if target.has_dependency(&python, SpecType::Run, None) {
                 // TODO: implement some comparison or spec merging logic here
                 tracing::info!(
                     "Overriding the requires-python with the one defined in pixi dependencies"

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -572,7 +572,7 @@ mod tests {
             .default_feature()
             .targets
             .default()
-            .dependencies(None)
+            .combined_dependencies()
             .unwrap_or_default()
             .iter()
             .map(|(name, spec)| format!("{} = {}", name.as_source(), spec.as_version_spec().unwrap()))

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_config;
 use pixi_consts::consts;
-use pixi_manifest::{EnvironmentName, FeatureName};
+use pixi_manifest::{EnvironmentName, FeatureName, HasEnvironmentDependencies};
 use pixi_manifest::{FeaturesExt, HasFeaturesIter};
 use pixi_progress::await_in_progress;
 use rattler_conda_types::{GenericVirtualPackage, Platform};
@@ -341,7 +341,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                             .map(|solve_group| solve_group.name().to_string()),
                         environment_size: None,
                         dependencies: env
-                            .dependencies(None, Some(env.best_platform()))
+                            .environment_dependencies(Some(env.best_platform()))
                             .names()
                             .map(|p| p.as_source().to_string())
                             .collect(),

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -11,7 +11,7 @@ use crate::cli::cli_config::{PrefixUpdateConfig, ProjectConfig};
 use crate::lock_file::{UpdateLockFileOptions, UvResolutionContext};
 use crate::Project;
 use fancy_display::FancyDisplay;
-use pixi_manifest::FeaturesExt;
+use pixi_manifest::{FeaturesExt, HasEnvironmentDependencies};
 use pixi_uv_conversions::pypi_options_to_index_locations;
 use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record};
 use rattler_conda_types::Platform;
@@ -163,7 +163,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Get the explicit project dependencies
     let mut project_dependency_names = environment
-        .dependencies(None, Some(platform))
+        .environment_dependencies(Some(platform))
         .names()
         .map(|p| p.as_source().to_string())
         .collect_vec();

--- a/src/cli/tree.rs
+++ b/src/cli/tree.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
-use std::io::{StdoutLock, Write};
+use std::{
+    collections::HashMap,
+    io::{StdoutLock, Write},
+};
 
 use ahash::{HashSet, HashSetExt};
 use clap::Parser;
@@ -7,7 +9,7 @@ use console::Color;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use miette::{IntoDiagnostic, WrapErr};
-use pixi_manifest::FeaturesExt;
+use pixi_manifest::{FeaturesExt, HasEnvironmentDependencies};
 use rattler_conda_types::Platform;
 use regex::Regex;
 
@@ -421,7 +423,7 @@ fn direct_dependencies(
     dep_map: &HashMap<String, Package>,
 ) -> HashSet<String> {
     let mut project_dependency_names = environment
-        .dependencies(None, Some(*platform))
+        .environment_dependencies(Some(*platform))
         .names()
         .filter(|p| {
             if let Some(value) = dep_map.get(p.as_source()) {

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -12,7 +12,7 @@ use itertools::{Either, Itertools};
 use miette::{Context, IntoDiagnostic, MietteDiagnostic};
 use pixi_config::ConfigCli;
 use pixi_consts::consts;
-use pixi_manifest::{EnvironmentName, FeaturesExt};
+use pixi_manifest::{EnvironmentName, FeaturesExt, HasEnvironmentDependencies};
 use rattler_conda_types::Platform;
 use rattler_lock::{LockFile, Package};
 use serde::Serialize;
@@ -648,7 +648,7 @@ impl LockFileJsonDiff {
             for (platform, packages_diff) in environment_diff {
                 let conda_dependencies = project
                     .environment(environment_name.as_str())
-                    .map(|env| env.dependencies(None, Some(platform)))
+                    .map(|env| env.environment_dependencies(Some(platform)))
                     .unwrap_or_default();
 
                 let pypi_dependencies = project

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -13,7 +13,7 @@ use miette::Diagnostic;
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::{VerbatimUrl, VersionOrUrl};
 use pixi_glob::{GlobHashCache, GlobHashError, GlobHashKey};
-use pixi_manifest::FeaturesExt;
+use pixi_manifest::{FeaturesExt, HasEnvironmentDependencies};
 use pixi_record::{ParseLockFileError, PixiRecord, SourceMismatchError};
 use pixi_spec::{PixiSpec, SourceSpec, SpecConversionError};
 use pixi_uv_conversions::{as_uv_req, AsPep508Error};
@@ -631,7 +631,7 @@ pub(crate) async fn verify_package_platform_satisfiability(
 
     // Determine the dependencies requested by the environment
     let environment_dependencies = environment
-        .dependencies(None, Some(platform))
+        .environment_dependencies(Some(platform))
         .into_specs()
         .map(|(package_name, spec)| Dependency::Input(package_name, spec, "<environment>".into()))
         .collect_vec();

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use miette::{Diagnostic, IntoDiagnostic, LabeledSpan, MietteDiagnostic, Report, WrapErr};
 use pixi_config::get_cache_dir;
 use pixi_consts::consts;
-use pixi_manifest::{EnvironmentName, FeaturesExt, HasFeaturesIter};
+use pixi_manifest::{EnvironmentName, FeaturesExt, HasEnvironmentDependencies, HasFeaturesIter};
 use pixi_progress::global_multi_progress;
 use pixi_record::{ParseLockFileError, PixiRecord};
 use pypi_mapping::{self};
@@ -1576,7 +1576,7 @@ async fn spawn_solve_conda_environment_task(
     build_context: BuildContext,
 ) -> miette::Result<TaskResult> {
     // Get the dependencies for this platform
-    let dependencies = group.dependencies(None, Some(platform));
+    let dependencies = group.environment_dependencies(Some(platform));
 
     // Get the virtual packages for this platform
     let virtual_packages = group.virtual_packages(platform);
@@ -1801,7 +1801,7 @@ async fn spawn_extract_environment_task(
 
     // Determine the conda packages we need.
     let conda_package_names = environment
-        .dependencies(None, Some(platform))
+        .environment_dependencies(Some(platform))
         .names()
         .cloned()
         .map(PackageName::Conda)

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -1,4 +1,3 @@
-use indexmap::IndexMap;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -7,11 +6,13 @@ use std::{
     sync::Once,
 };
 
+use indexmap::IndexMap;
 use itertools::Either;
 use pixi_consts::consts;
 use pixi_manifest::{
-    self as manifest, EnvironmentName, Feature, FeatureName, FeaturesExt, HasFeaturesIter,
-    HasManifestRef, Manifest, SystemRequirements, Task, TaskName,
+    self as manifest, EnvironmentName, Feature, FeatureName, FeaturesExt,
+    HasEnvironmentDependencies, HasFeaturesIter, HasManifestRef, Manifest, SystemRequirements,
+    Task, TaskName,
 };
 use rattler_conda_types::{Arch, Platform};
 
@@ -268,6 +269,8 @@ impl<'p> Environment<'p> {
     }
 }
 
+impl<'p> HasEnvironmentDependencies<'p> for Environment<'p> {}
+
 impl<'p> HasProjectRef<'p> for Environment<'p> {
     fn project(&self) -> &'p Project {
         self.project
@@ -465,7 +468,7 @@ mod tests {
         let deps = manifest
             .environment("foobar")
             .unwrap()
-            .dependencies(None, None);
+            .environment_dependencies(None);
         assert_snapshot!(format_dependencies(deps));
     }
 

--- a/src/project/grouped_environment.rs
+++ b/src/project/grouped_environment.rs
@@ -8,7 +8,8 @@ use fancy_display::FancyDisplay;
 use itertools::Either;
 use pixi_consts::consts;
 use pixi_manifest::{
-    EnvironmentName, Feature, HasFeaturesIter, HasManifestRef, Manifest, SystemRequirements,
+    EnvironmentName, Feature, HasEnvironmentDependencies, HasFeaturesIter, HasManifestRef,
+    Manifest, SystemRequirements,
 };
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use std::path::PathBuf;
@@ -119,6 +120,8 @@ impl<'p> HasProjectRef<'p> for GroupedEnvironment<'p> {
         }
     }
 }
+
+impl<'p> HasEnvironmentDependencies<'p> for GroupedEnvironment<'p> {}
 
 impl<'p> HasManifestRef<'p> for GroupedEnvironment<'p> {
     fn manifest(&self) -> &'p Manifest {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -722,7 +722,7 @@ mod tests {
 
     use insta::{assert_debug_snapshot, assert_snapshot};
     use itertools::Itertools;
-    use pixi_manifest::{FeatureName, FeaturesExt};
+    use pixi_manifest::{FeatureName, HasEnvironmentDependencies};
     use rattler_conda_types::Platform;
     use rattler_virtual_packages::{LibC, VirtualPackage};
     use tempfile::tempdir;
@@ -807,7 +807,38 @@ mod tests {
         assert_snapshot!(format_dependencies(
             project
                 .default_environment()
-                .dependencies(None, Some(Platform::Linux64))
+                .environment_dependencies(Some(Platform::Linux64))
+        ));
+    }
+
+    #[test]
+    fn test_dependency_set_with_build_section() {
+        let file_contents = r#"
+        [dependencies]
+        foo = "1.0"
+
+        [build]
+        dependencies = []
+        build-backend = "foobar"
+
+        [host-dependencies]
+        libc = "2.12"
+
+        [build-dependencies]
+        bar = "1.0"
+        "#;
+
+        let manifest = Manifest::from_str(
+            Path::new("pixi.toml"),
+            format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+        )
+        .unwrap();
+        let project = Project::from_manifest(manifest);
+
+        assert_snapshot!(format_dependencies(
+            project
+                .default_environment()
+                .environment_dependencies(Some(Platform::Linux64))
         ));
     }
 
@@ -842,7 +873,7 @@ mod tests {
         assert_snapshot!(format_dependencies(
             project
                 .default_environment()
-                .dependencies(None, Some(Platform::Linux64))
+                .environment_dependencies(Some(Platform::Linux64))
         ));
     }
 

--- a/src/project/snapshots/pixi__project__tests__dependency_set_with_build_section.snap
+++ b/src/project/snapshots/pixi__project__tests__dependency_set_with_build_section.snap
@@ -1,0 +1,5 @@
+---
+source: src/project/mod.rs
+expression: "format_dependencies(project.default_environment().environment_dependencies(Some(Platform::Linux64)))"
+---
+foo = "==1.0"

--- a/src/project/solve_group.rs
+++ b/src/project/solve_group.rs
@@ -1,10 +1,13 @@
 use std::{hash::Hash, path::PathBuf};
 
 use itertools::Itertools;
+use pixi_manifest as manifest;
+use pixi_manifest::{
+    FeaturesExt, HasEnvironmentDependencies, HasFeaturesIter, HasManifestRef, Manifest,
+    SystemRequirements,
+};
 
 use super::{Environment, HasProjectRef, Project};
-use pixi_manifest as manifest;
-use pixi_manifest::{FeaturesExt, HasFeaturesIter, HasManifestRef, Manifest, SystemRequirements};
 
 /// A grouping of environments that are solved together.
 #[derive(Debug, Clone)]
@@ -68,6 +71,8 @@ impl<'p> SolveGroup<'p> {
     }
 }
 
+impl<'p> HasEnvironmentDependencies<'p> for SolveGroup<'p> {}
+
 impl<'p> HasManifestRef<'p> for SolveGroup<'p> {
     fn manifest(&self) -> &'p Manifest {
         &self.project().manifest
@@ -96,10 +101,10 @@ mod tests {
     use std::{collections::HashSet, path::Path};
 
     use itertools::Itertools;
+    use pixi_manifest::{FeaturesExt, HasEnvironmentDependencies};
     use rattler_conda_types::PackageName;
 
     use crate::Project;
-    use pixi_manifest::FeaturesExt;
 
     #[test]
     fn test_solve_group() {
@@ -172,7 +177,7 @@ mod tests {
         // Check that the solve group 'group1' contains all the dependencies of its
         // environments
         let package_names: HashSet<_> = solve_group
-            .dependencies(None, None)
+            .environment_dependencies(None)
             .names()
             .cloned()
             .collect();
@@ -189,7 +194,7 @@ mod tests {
         // default environment
         let solve_group = solve_groups[1].clone();
         let package_names: HashSet<_> = solve_group
-            .dependencies(None, None)
+            .environment_dependencies(None)
             .names()
             .cloned()
             .collect();

--- a/tests/add_tests.rs
+++ b/tests/add_tests.rs
@@ -10,7 +10,9 @@ use crate::common::{
 use pixi::{DependencyType, Project};
 use pixi_consts::consts;
 use pixi_manifest::pypi::VersionOrStar;
-use pixi_manifest::{pypi::PyPiPackageName, FeaturesExt, PyPiRequirement, SpecType};
+use pixi_manifest::{
+    pypi::PyPiPackageName, FeaturesExt, HasEnvironmentDependencies, PyPiRequirement, SpecType,
+};
 use rattler_conda_types::{PackageName, Platform};
 use tempfile::TempDir;
 use uv_normalize::ExtraName;
@@ -98,7 +100,7 @@ async fn add_with_channel() {
     let project = Project::from_path(pixi.manifest_path().as_path()).unwrap();
     let mut specs = project
         .default_environment()
-        .dependencies(Some(SpecType::Run), Some(Platform::current()))
+        .environment_dependencies(Some(Platform::current()))
         .into_specs();
 
     let (name, spec) = specs.next().unwrap();
@@ -162,17 +164,17 @@ async fn add_functionality_union() {
     // Should contain all added dependencies
     let dependencies = project
         .default_environment()
-        .dependencies(Some(SpecType::Run), Some(Platform::current()));
+        .dependencies(SpecType::Run, Some(Platform::current()));
     let (name, _) = dependencies.into_specs().next().unwrap();
     assert_eq!(name, PackageName::try_from("rattler").unwrap());
     let host_deps = project
         .default_environment()
-        .dependencies(Some(SpecType::Host), Some(Platform::current()));
+        .dependencies(SpecType::Host, Some(Platform::current()));
     let (name, _) = host_deps.into_specs().next().unwrap();
     assert_eq!(name, PackageName::try_from("libcomputer").unwrap());
     let build_deps = project
         .default_environment()
-        .dependencies(Some(SpecType::Build), Some(Platform::current()));
+        .dependencies(SpecType::Build, Some(Platform::current()));
     let (name, _) = build_deps.into_specs().next().unwrap();
     assert_eq!(name, PackageName::try_from("libidk").unwrap());
 
@@ -489,7 +491,7 @@ async fn add_unconstrainted_dependency() {
     let foo_spec = project
         .manifest()
         .default_feature()
-        .dependencies(None, None)
+        .combined_dependencies(None)
         .unwrap_or_default()
         .get("foobar")
         .cloned()
@@ -502,7 +504,7 @@ async fn add_unconstrainted_dependency() {
         .manifest()
         .feature("unreferenced")
         .expect("feature 'unreferenced' is missing")
-        .dependencies(None, None)
+        .combined_dependencies(None)
         .unwrap_or_default()
         .get("bar")
         .cloned()

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use insta::assert_debug_snapshot;
 use pixi::Project;
-use pixi_manifest::FeaturesExt;
+use pixi_manifest::{FeaturesExt, HasEnvironmentDependencies};
 use rattler_conda_types::{NamedChannelOrUrl, Platform};
 use tempfile::TempDir;
 use url::Url;
@@ -88,7 +88,7 @@ async fn parse_project() {
     fn dependency_names(project: &Project, platform: Platform) -> Vec<String> {
         project
             .default_environment()
-            .dependencies(None, Some(platform))
+            .environment_dependencies(Some(platform))
             .iter()
             .map(|dep| dep.0.as_normalized().to_string())
             .collect()


### PR DESCRIPTION
This PR removes the default behavior that `host-dependencies`, `build-dependencies`, and `dependencies` are combined. This only happens when the project contains a `[build]` section.

Builds on #2251 