### PR TITLE
fix: unique exposed name detection

### DIFF
--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -304,16 +304,18 @@ impl Manifest {
         ))
     }
 
-    /// Checks if an exposed name already exists
-    pub fn exposed_name_already_exists(&self, exposed_name: &ExposedName) -> bool {
-        for env in self.parsed.envs.values() {
-            for mapping in &env.exposed {
-                if mapping.exposed_name == *exposed_name {
-                    return false;
-                }
-            }
-        }
-        true
+    /// Checks if an exposed name already exists in other environments
+    pub fn exposed_name_already_exists_in_other_envs(
+        &self,
+        exposed_name: &ExposedName,
+        env_name: &EnvironmentName,
+    ) -> bool {
+        self.parsed
+            .envs
+            .iter()
+            .filter_map(|(name, env)| if name != env_name { Some(env) } else { None })
+            .flat_map(|env| env.exposed.iter())
+            .any(|mapping| mapping.exposed_name == *exposed_name)
     }
 
     /// Adds exposed mapping to the manifest
@@ -328,7 +330,7 @@ impl Manifest {
         }
 
         // Ensure exposed name is unique
-        if !self.exposed_name_already_exists(&mapping.exposed_name) {
+        if self.exposed_name_already_exists_in_other_envs(&mapping.exposed_name, env_name) {
             miette::bail!(
                 "Exposed name {} already exists",
                 mapping.exposed_name.fancy_display()

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -205,7 +205,7 @@ impl<'de> serde::Deserialize<'de> for ParsedManifest {
         }
         if !duplicates.is_empty() {
             return Err(serde::de::Error::custom(format!(
-                "Duplicated exposed names found: '{}'",
+                "Duplicated exposed names found: {}",
                 duplicates
                     .keys()
                     .sorted()

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -193,7 +193,7 @@ exposed = {{ xz = "xz" }}
     assert tomllib.loads(migrated_manifest) == tomllib.loads(original_manifest)
 
 
-def test_sync_duplicated_expose(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+def test_sync_duplicated_expose_error(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
@@ -216,7 +216,7 @@ exposed = {{ dummy-1 = "dummy-b" }}
         [pixi, "global", "sync"],
         ExitCode.FAILURE,
         env=env,
-        stderr_contains="Duplicated exposed names found: 'dummy-1'",
+        stderr_contains="Duplicated exposed names found: dummy-1",
     )
 
 
@@ -347,6 +347,108 @@ dummy-a = "dummy-a"
     print(manifest.read_text())
     # The tables in the manifest have been preserved
     assert manifest.read_text() == original_toml + 'dummy-aa = "dummy-a"\n'
+
+
+def test_expose_duplicated_expose_allow_for_same_env(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+    manifest = manifests.joinpath("pixi-global.toml")
+    toml = f"""
+version = {MANIFEST_VERSION}
+
+[envs.one]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-a = "*", dummy-b = "*" }}
+exposed = {{ dummy-1 = "dummy-a" }}
+
+[envs.two]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-a = "*", dummy-b = "*" }}
+exposed = {{ dummy-2 = "dummy-a" }}
+"""
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "global", "sync"],
+        env=env,
+    )
+
+    # This will not work sinced there would be two times `dummy-2` after this command
+    verify_cli_command(
+        [pixi, "global", "expose", "add", "--environment", "one", "dummy-2=dummy-b"],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="Exposed name dummy-2 already exists",
+    )
+
+    # This should work, since it just overwrites the existing `dummy-2` mapping
+    verify_cli_command(
+        [pixi, "global", "expose", "add", "--environment", "two", "dummy-2=dummy-b"],
+        env=env,
+    )
+    parsed_toml = tomllib.loads(manifest.read_text())
+    assert parsed_toml["envs"]["two"]["exposed"]["dummy-2"] == "dummy-b"
+
+
+def test_install_duplicated_expose_allow_for_same_env(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+    manifest = manifests.joinpath("pixi-global.toml")
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "dummy-a",
+            "--expose",
+            "dummy=dummy-a",
+            "--channel",
+            dummy_channel_1,
+        ],
+        env=env,
+    )
+
+    # This will not work sinced there would be two times `dummy` after this command
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "dummy-b",
+            "--expose",
+            "dummy=dummy-b",
+            "--channel",
+            dummy_channel_1,
+        ],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="Exposed name dummy already exists",
+    )
+
+    # This should work, since it just overwrites the existing properties of environment `dummy-a`
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "dummy-a",
+            "--expose",
+            "dummy=dummy-aa",
+            "--channel",
+            dummy_channel_1,
+            "-vvvv",
+        ],
+        env=env,
+    )
+    parsed_toml = tomllib.loads(manifest.read_text())
+    assert parsed_toml["envs"]["dummy-a"]["exposed"]["dummy"] == "dummy-aa"
 
 
 def test_install_adapts_manifest(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:


### PR DESCRIPTION
Only error on non-unique exposed names when the already existing exposed name is in a different environment