### PR TITLE
feat: Add support for `gcs://` conda registries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,9 @@ rattler_cache = { version = "0.2.6", default-features = false }
 rattler_conda_types = { version = "0.28.2", default-features = false }
 rattler_digest = { version = "1.0.1", default-features = false }
 rattler_lock = { version = "0.22.27", default-features = false }
-rattler_networking = { version = "0.21.4", default-features = false }
+rattler_networking = { version = "0.21.4", default-features = false, features = [
+  "google-cloud-auth",
+] }
 rattler_repodata_gateway = { version = "0.21.17", default-features = false }
 rattler_shell = { version = "0.22.4", default-features = false }
 rattler_solve = { version = "1.1.0", default-features = false }

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -5,7 +5,8 @@ use rattler_networking::{
     authentication_storage::{self, backends::file::FileStorageError},
     mirror_middleware::Mirror,
     retry_policies::ExponentialBackoff,
-    AuthenticationMiddleware, AuthenticationStorage, MirrorMiddleware, OciMiddleware,
+    AuthenticationMiddleware, AuthenticationStorage, GCSMiddleware, MirrorMiddleware,
+    OciMiddleware,
 };
 
 use reqwest::Client;
@@ -105,6 +106,8 @@ pub fn build_reqwest_clients(config: Option<&Config>) -> (Client, ClientWithMidd
             .with(mirror_middleware(&config))
             .with(oci_middleware());
     }
+
+    client_builder = client_builder.with(GCSMiddleware);
 
     client_builder = client_builder.with_arc(Arc::new(
         auth_middleware(&config).expect("could not create auth middleware"),


### PR DESCRIPTION
Adding gcs auth middleware to pixi

Would need to test it, but currently blocked by : https://github.com/prefix-dev/pixi/issues/1922