### PR TITLE
fix: edit cli on windows and for both config and global

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -829,10 +829,17 @@ Checkout the [pixi configuration](./pixi_configuration.md) for more information 
 
 Edit the configuration file in the default editor.
 
+
+##### Arguments
+
+1. `[EDITOR]`: The editor to use, defaults to `EDITOR` environment variable or `nano` on Unix and `notepad` on Windows
+
 ```shell
 pixi config edit --system
 pixi config edit --local
 pixi config edit -g
+pixi config edit --global code
+pixi config edit --system vim
 ```
 
 ### `config list`

--- a/src/cli/global/edit.rs
+++ b/src/cli/global/edit.rs
@@ -24,11 +24,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
     });
 
-    let mut child = std::process::Command::new(editor.as_str())
-        .arg(&manifest_path)
-        .spawn()
-        .into_diagnostic()?;
+    let mut child = if cfg!(windows) {
+        std::process::Command::new("cmd")
+            .arg("/C")
+            .arg(editor.as_str())
+            .arg(&manifest_path)
+            .spawn()
+            .into_diagnostic()?
+    } else {
+        std::process::Command::new(editor.as_str())
+            .arg(&manifest_path)
+            .spawn()
+            .into_diagnostic()?
+    };
     child.wait().into_diagnostic()?;
-
     Ok(())
 }


### PR DESCRIPTION
Fixes on windows:
```
pixi global edit code
```


Aligns `edit` cli:
```
pixi config edit -g code
```