### PR TITLE
feat: add pixi global list filter

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -45,6 +45,9 @@ test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose tests
 test-integration-dev = { cmd = "pytest --numprocesses=auto --durations=10 tests/integration", depends-on = [
   "build",
 ] }
+test-integration-global = { cmd = "pytest --numprocesses=auto --durations=10 tests/integration/test_global.py", depends-on = [
+  "build",
+] }
 typecheck-integration = "mypy --strict tests/integration"
 
 [feature.dev.dependencies]

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -129,9 +129,15 @@ async fn list_environment(
         })
         .collect();
 
+    // Filter according to the regex
+    if let Some(ref regex) = regex {
+        let regex = regex::Regex::new(regex).into_diagnostic()?;
+        packages_to_output.retain(|package| regex.is_match(package.name.as_normalized()));
+    }
+
     let output_message = if let Some(ref regex) = regex {
         format!(
-            "The {} environment has {} packages filtered by regex {}:",
+            "The {} environment has {} packages filtered by regex `{}`:",
             environment_name.fancy_display(),
             console::style(packages_to_output.len()).bold(),
             regex
@@ -143,13 +149,6 @@ async fn list_environment(
             console::style(packages_to_output.len()).bold()
         )
     };
-
-    // Filter according to the regex
-
-    if let Some(regex) = regex {
-        let regex = regex::Regex::new(&regex).into_diagnostic()?;
-        packages_to_output.retain(|package| regex.is_match(package.name.as_normalized()));
-    }
 
     // Sort according to the sorting strategy
     match sort_by {

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -28,6 +28,11 @@ use std::str::FromStr;
 #[derive(Parser, Debug)]
 #[clap(verbatim_doc_comment)]
 pub struct Args {
+    /// List only packages matching a regular expression.
+    /// Without regex syntax it acts like a `contains` filter.
+    #[arg()]
+    pub regex: Option<String>,
+
     #[clap(flatten)]
     config: ConfigCli,
 
@@ -52,13 +57,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         if !project.environment_in_sync(&env_name).await? {
             tracing::warn!("The environment {} is not in sync with the manifest, to sync run\n\tpixi global sync", env_name.fancy_display());
         }
-        list_environment(project, &env_name, args.sort_by).await?;
+        list_environment(project, &env_name, args.sort_by, args.regex).await?;
     } else {
         // Verify that the environments are in sync with the manifest and report to the user otherwise
         if !project.environments_in_sync().await? {
             tracing::warn!("The environments are not in sync with the manifest, to sync run\n\tpixi global sync");
         }
-        list_global_environments(project).await?;
+        list_global_environments(project, args.regex).await?;
     }
 
     Ok(())
@@ -97,6 +102,7 @@ async fn list_environment(
     project: Project,
     environment_name: &EnvironmentName,
     sort_by: GlobalSortBy,
+    regex: Option<String>,
 ) -> miette::Result<()> {
     let env = project
         .environments()
@@ -123,6 +129,28 @@ async fn list_environment(
         })
         .collect();
 
+    let output_message = if let Some(ref regex) = regex {
+        format!(
+            "The {} environment has {} packages filtered by regex {}:",
+            environment_name.fancy_display(),
+            console::style(packages_to_output.len()).bold(),
+            regex
+        )
+    } else {
+        format!(
+            "The {} environment has {} packages:",
+            environment_name.fancy_display(),
+            console::style(packages_to_output.len()).bold()
+        )
+    };
+
+    // Filter according to the regex
+
+    if let Some(regex) = regex {
+        let regex = regex::Regex::new(&regex).into_diagnostic()?;
+        packages_to_output.retain(|package| regex.is_match(package.name.as_normalized()));
+    }
+
     // Sort according to the sorting strategy
     match sort_by {
         GlobalSortBy::Size => {
@@ -133,11 +161,7 @@ async fn list_environment(
             packages_to_output.sort_by(|a, b| a.name.cmp(&b.name));
         }
     }
-    println!(
-        "The {} environment has {} packages:",
-        environment_name.fancy_display(),
-        console::style(packages_to_output.len()).bold()
-    );
+    println!("{}", output_message);
     print_package_table(packages_to_output).into_diagnostic()?;
     println!();
     print_meta_info(env);
@@ -219,9 +243,14 @@ fn print_package_table(packages: Vec<PackageToOutput>) -> Result<(), std::io::Er
 }
 
 /// List all environments in the global environment
-async fn list_global_environments(project: Project) -> miette::Result<()> {
+async fn list_global_environments(project: Project, regex: Option<String>) -> miette::Result<()> {
     let mut envs = project.environments().clone();
     envs.sort_by(|a, _, b, _| a.to_string().cmp(&b.to_string()));
+
+    if let Some(regex) = regex {
+        let regex = regex::Regex::new(&regex).into_diagnostic()?;
+        envs.retain(|env_name, _| regex.is_match(env_name.as_str()));
+    }
 
     let mut message = String::new();
 

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -882,7 +882,7 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
         env=env,
     )
 
-    # Verify list with dummy-b
+    # Verify list with dummy-a
     verify_cli_command(
         [pixi, "global", "list", "dummy-a"],
         env=env,

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -889,6 +889,15 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
         stdout_contains=["dummy-a: 0.1.0", "dummy-a", "dummy-aa"],
     )
 
+    # Verify list filter for environment dummy-a.
+    # It should not contains dummy-b
+    verify_cli_command(
+        [pixi, "global", "list", "--environment", "dummy-a", "dummy-a"],
+        env=env,
+        stdout_contains=["The dummy-a environment", "dummy-a 0.1.0"],
+        stdout_excludes=["dummy-b"],
+    )
+
 
 # Test that we correctly uninstall the required packages
 # - Checking that the binaries are removed

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -891,9 +891,9 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
     )
 
     # Verify list filter for environment dummy-a.
-    # It should not contains dummy-b
+    # It should not contains dummy-b, but should contain dummy-a
     verify_cli_command(
-        [pixi, "global", "list", "--environment", "dummy-a", "dummy-a"],
+        [pixi, "global", "list", "--environment", "dummy-a", "dummy"],
         env=env,
         stdout_contains=["The dummy-a environment", "dummy-a  0.1.0"],
         stdout_excludes=["dummy-b"],

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -868,7 +868,7 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
     manifests = tmp_path.joinpath("manifests")
     manifests.mkdir()
 
-    # Install dummy-b from dummy-channel-1
+    # Install dummy-a and dummy-b from dummy-channel-1
     verify_cli_command(
         [
             pixi,

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -863,6 +863,33 @@ def test_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     )
 
 
+def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+
+    # Install dummy-b from dummy-channel-1
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--channel",
+            dummy_channel_1,
+            "dummy-b==0.1.0",
+            "dummy-a==0.1.0",
+        ],
+        env=env,
+    )
+
+    # Verify list with dummy-b
+    verify_cli_command(
+        [pixi, "global", "list", "dummy-a"],
+        env=env,
+        stdout_contains=["dummy-a: 0.1.0", "dummy-a", "dummy-aa"],
+    )
+
+
 # Test that we correctly uninstall the required packages
 # - Checking that the binaries are removed
 # - Checking that the non-requested to remove binaries are still there

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -887,6 +887,7 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
         [pixi, "global", "list", "dummy-a"],
         env=env,
         stdout_contains=["dummy-a: 0.1.0", "dummy-a", "dummy-aa"],
+        stdout_excludes=["dummy-b"],
     )
 
     # Verify list filter for environment dummy-a.
@@ -894,7 +895,7 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
     verify_cli_command(
         [pixi, "global", "list", "--environment", "dummy-a", "dummy-a"],
         env=env,
-        stdout_contains=["The dummy-a environment", "dummy-a 0.1.0"],
+        stdout_contains=["The dummy-a environment", "dummy-a  0.1.0"],
         stdout_excludes=["dummy-b"],
     )
 


### PR DESCRIPTION
Add optional `regex` argument for both` pixi global list` and `pixi global list --environment env-name`.


If passed regex string is not a regex syntax, but a simple string - it will act as a contains filter.


Some examples:

Having `nushell`, `python`, `python3-10` as enviroments

`pixi global list py`

![Screenshot 2024-10-14 at 16 49 11](https://github.com/user-attachments/assets/ae16a4a7-0305-4745-8458-b6c78e0fbb24)


`pixi global list --environment python lib`


![Screenshot 2024-10-14 at 16 52 04](https://github.com/user-attachments/assets/529c058c-77bd-4e5f-bf4f-02142934f533)

