### PR TITLE
fix: pixi global required args

### DIFF
--- a/src/cli/global/add.rs
+++ b/src/cli/global/add.rs
@@ -16,7 +16,7 @@ use rattler_conda_types::MatchSpec;
 #[clap(arg_required_else_help = true, verbatim_doc_comment)]
 pub struct Args {
     /// Specifies the packages that are to be added to the environment.
-    #[arg(num_args = 1..)]
+    #[arg(num_args = 1.., required = true)]
     packages: Vec<String>,
 
     /// Specifies the environment that the dependencies need to be added to.
@@ -97,7 +97,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     )
     .await
     {
-        Ok(state_changes) => {
+        Ok(ref mut state_changes) => {
             state_changes.report();
             Ok(())
         }

--- a/src/cli/global/expose.rs
+++ b/src/cli/global/expose.rs
@@ -91,7 +91,7 @@ pub async fn add(args: AddArgs) -> miette::Result<()> {
 
     let mut project_modified = project_original.clone();
     match apply_changes(&args, &mut project_modified).await {
-        Ok(state_changes) => {
+        Ok(mut state_changes) => {
             project_modified.manifest.save().await?;
             state_changes.report();
             Ok(())

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -24,7 +24,7 @@ use pixi_config::{self, Config, ConfigCli};
 #[clap(arg_required_else_help = true, verbatim_doc_comment)]
 pub struct Args {
     /// Specifies the packages that are to be installed.
-    #[arg(num_args = 1..)]
+    #[arg(num_args = 1.., required = true)]
     packages: Vec<String>,
 
     /// The channels to consider as a name or a url.

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 #[clap(arg_required_else_help = true, verbatim_doc_comment)]
 pub struct Args {
     /// Specifies the packages that are to be removed.
-    #[arg(num_args = 1..)]
+    #[arg(num_args = 1.., required = true)]
     packages: Vec<String>,
 
     /// Specifies the environment that the dependencies need to be removed from.
@@ -94,7 +94,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             "Couldn't remove packages from {}",
             &args.environment
         )) {
-        Ok(state_changes) => {
+        Ok(ref mut state_changes) => {
             state_changes.report();
         }
         Err(err) => {

--- a/src/cli/global/sync.rs
+++ b/src/cli/global/sync.rs
@@ -16,7 +16,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .with_cli_config(config.clone());
 
-    let state_changes = project.sync().await?;
+    let mut state_changes = project.sync().await?;
 
     if state_changes.has_changed() {
         state_changes.report();

--- a/src/cli/global/uninstall.rs
+++ b/src/cli/global/uninstall.rs
@@ -14,7 +14,7 @@ use pixi_config::{Config, ConfigCli};
 #[clap(arg_required_else_help = true, verbatim_doc_comment)]
 pub struct Args {
     /// Specifies the environments that are to be removed.
-    #[arg(num_args = 1..)]
+    #[arg(num_args = 1.., required = true)]
     environment: Vec<EnvironmentName>,
 
     #[clap(flatten)]

--- a/src/cli/global/update.rs
+++ b/src/cli/global/update.rs
@@ -2,6 +2,7 @@ use crate::cli::global::revert_environment_after_error;
 use crate::global::{self, StateChanges};
 use crate::global::{EnvironmentName, Project};
 use clap::Parser;
+use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use pixi_config::{Config, ConfigCli};
 use pixi_utils::executable_from_path;
@@ -66,7 +67,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         // Remove outdated binaries
         state_changes |= project.prune_exposed(env_name).await?;
 
-        state_changes.report();
+        eprintln!(
+            "{}Updated environment: {}.",
+            console::style(console::Emoji("✔ ", "")).green(),
+            env_name.fancy_display()
+        );
 
         Ok(state_changes)
     }

--- a/src/cli/global/update.rs
+++ b/src/cli/global/update.rs
@@ -2,7 +2,6 @@ use crate::cli::global::revert_environment_after_error;
 use crate::global::{self, StateChanges};
 use crate::global::{EnvironmentName, Project};
 use clap::Parser;
-use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use pixi_config::{Config, ConfigCli};
 use pixi_utils::executable_from_path;
@@ -66,11 +65,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // Remove outdated binaries
         state_changes |= project.prune_exposed(env_name).await?;
-        eprintln!(
-            "{}Updated environment: {}.",
-            console::style(console::Emoji("✔ ", "")).green(),
-            env_name.fancy_display()
-        );
+
+        state_changes.report();
 
         Ok(state_changes)
     }

--- a/src/cli/global/update.rs
+++ b/src/cli/global/update.rs
@@ -66,7 +66,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // Remove outdated binaries
         state_changes |= project.prune_exposed(env_name).await?;
-
         eprintln!(
             "{}Updated environment: {}.",
             console::style(console::Emoji("✔ ", "")).green(),

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -252,8 +252,6 @@ impl StateChanges {
 
     /// Remove changes that cancel each other out
     fn prune(&mut self) {
-        eprintln!("changes are {:?}", self.changes);
-
         self.changes = self
             .changes
             .iter()

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -252,6 +252,8 @@ impl StateChanges {
 
     /// Remove changes that cancel each other out
     fn prune(&mut self) {
+        eprintln!("changes are {:?}", self.changes);
+
         self.changes = self
             .changes
             .iter()
@@ -269,10 +271,10 @@ impl StateChanges {
             .collect()
     }
 
-    pub(crate) fn report(mut self) {
+    pub(crate) fn report(&mut self) {
         self.prune();
 
-        for (env_name, changes_for_env) in self.changes {
+        for (env_name, changes_for_env) in &self.changes {
             if changes_for_env.is_empty() {
                 eprintln!(
                     "{}The environment {} was already up-to-date",


### PR DESCRIPTION
https://github.com/clap-rs/clap/issues/4507#issuecomment-1372250231
`num_args = 1.. ` don't make packages a mandatory argument.
This PR aims to fix this, and some other stylistic usage of report instead of computing println message