### PR TITLE
fix: skip `test_pixi_install_cleanup`

### DIFF
--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -891,7 +891,7 @@ def test_install_multi_env_install(pixi: Path, tmp_path: Path, dummy_channel_1: 
     )
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Not relieable on Windows")
+@pytest.mark.skipif(platform.system() == "Windows", reason="Not reliable on Windows")
 def test_pixi_install_cleanup(pixi: Path, tmp_path: Path, global_update_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import tomllib
 
+import pytest
 import tomli_w
 from .common import verify_cli_command, ExitCode
 import platform
@@ -890,6 +891,7 @@ def test_install_multi_env_install(pixi: Path, tmp_path: Path, dummy_channel_1: 
     )
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Not relieable on Windows")
 def test_pixi_install_cleanup(pixi: Path, tmp_path: Path, global_update_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
 


### PR DESCRIPTION
It isn't reliable on Windows