### PR TITLE
fix: select correct run environment

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -59,7 +59,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let environment = project.environment_from_name_or_env_var(args.environment.clone())?;
 
     // Find the environment to run the task in, if any were specified.
-    let explicit_environment = if args.environment.is_none() {
+    let explicit_environment = if args.environment.is_none() && environment.is_default() {
         None
     } else {
         Some(environment.clone())

--- a/tests/integration/test_main_cli.py
+++ b/tests/integration/test_main_cli.py
@@ -178,8 +178,9 @@ def test_search(pixi: Path) -> None:
 
 def test_simple_project_setup(pixi: Path, tmp_path: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
+    conda_forge = "https://fast.prefix.dev/conda-forge"
     # Create a new project
-    verify_cli_command([pixi, "init", tmp_path], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", "-c", conda_forge, tmp_path], ExitCode.SUCCESS)
 
     # Add package
     verify_cli_command(
@@ -208,7 +209,7 @@ def test_simple_project_setup(pixi: Path, tmp_path: Path) -> None:
             manifest_path,
             "--platform",
             "linux-64",
-            "conda-forge::_r-mutex",
+            f"{conda_forge}::_r-mutex",
         ],
         ExitCode.SUCCESS,
         stderr_contains=["linux-64", "conda-forge"],
@@ -256,7 +257,7 @@ def test_simple_project_setup(pixi: Path, tmp_path: Path) -> None:
             manifest_path,
             "--platform",
             "linux-64",
-            "conda-forge::_r-mutex",
+            f"{conda_forge}::_r-mutex",
         ],
         ExitCode.SUCCESS,
         stderr_contains=["linux-64", "conda-forge", "Removed"],

--- a/tests/integration/test_run_cli.py
+++ b/tests/integration/test_run_cli.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from .common import verify_cli_command, ExitCode
+
+ALL_PLATFORMS = '["linux-64", "osx-64", "win-64", "linux-ppc64le", "linux-aarch64"]'
+
+EMPTY_BOILERPLATE_PROJECT = f"""
+[project]
+name = "test"
+channels = []
+platforms = {ALL_PLATFORMS}
+"""
+
+
+def test_run_in_shell(pixi: Path, tmp_path: Path) -> None:
+    manifest = tmp_path.joinpath("pixi.toml")
+    toml = f"""
+    {EMPTY_BOILERPLATE_PROJECT}
+    [tasks]
+    task = "echo default"
+    task1 = "echo default1"
+    [feature.a.tasks]
+    task = {{ cmd = "echo a", depends-on = "task1" }}
+    task1 = "echo a1"
+
+    [environments]
+    a = ["a"]
+    """
+    manifest.write_text(toml)
+
+    # Run the default task
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "default", "task"],
+        ExitCode.SUCCESS,
+        stdout_contains="default",
+        stderr_excludes="default1",
+    )
+
+    # Run the a task
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "a", "task"],
+        ExitCode.SUCCESS,
+        stdout_contains=["a", "a1"],
+    )
+
+    # Error on non-specified environment as ambiguous
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "task"],
+        ExitCode.FAILURE,
+        stderr_contains=["ambiguous", "default", "a"],
+    )
+
+    # Simulate activated shell in environment 'a'
+    env = {"PIXI_IN_SHELL": "true", "PIXI_ENVIRONMENT_NAME": "a"}
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "task"],
+        ExitCode.SUCCESS,
+        stdout_contains=["a", "a1"],
+        env=env,
+    )


### PR DESCRIPTION
Fixes: #2299 

Also adds a pytest for this, decided to move it into a pytest as it took me 5 minutes which is much faster. Feel a bit burned by our rust integration test setup, mostly because of the slow compile times for changing text.