### PR TITLE
ci: add timeouts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,7 +108,7 @@ jobs:
   cargo-test:
     name: Cargo Test | ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -153,6 +153,7 @@ jobs:
   # pixi interface
   test-integration:
     name: ${{ matrix.arch.name }} - Integration Tests
+    timeout-minutes: 30
     runs-on: ${{ matrix.arch.os }}
     env:
       TARGET_RELEASE: "${{ github.workspace }}/.pixi/target/release"


### PR DESCRIPTION
Especially macOS runners tend to hang.
As far as I can tell 30 minutes should be enough.