### PR TITLE
ci: adapt test directories

### DIFF
--- a/.github/workflows/test_common_wheels.yml
+++ b/.github/workflows/test_common_wheels.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.arch.name }} - Test Installation of Common Wheels
     runs-on: ${{ matrix.arch.os }}
     env:
-      TARGET_RELEASE: "${{ github.workspace }}/.pixi/target/release"
+      TARGET_RELEASE: "${{ github.workspace }}/target-pixi/release"
       LOGS_DIR: "${{ github.workspace }}/tests/wheel_tests/.logs"
       SUMMARY_FILE: "${{ github.workspace }}/tests/wheel_tests/.summary.md"
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -156,7 +156,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ${{ matrix.arch.os }}
     env:
-      TARGET_RELEASE: "${{ github.workspace }}/.pixi/target/release"
+      TARGET_RELEASE: "${{ github.workspace }}/target-pixi/release"
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 .DS_store
 site/
 .cache
+pytest-temp
+target-pixi

--- a/pixi.toml
+++ b/pixi.toml
@@ -45,9 +45,6 @@ test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose tests
 test-integration-dev = { cmd = "pytest --numprocesses=auto --durations=10 tests/integration", depends-on = [
   "build",
 ] }
-test-integration-global = { cmd = "pytest --numprocesses=auto --durations=10 tests/integration/test_global.py", depends-on = [
-  "build",
-] }
 # pass the file to run as an argument to the task
 # you can also pass a specific test function, like this:
 # /path/to/test.py::test_function

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --basetemp=pytest-temp

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 addopts = --basetemp=pytest-temp
+tmp_path_retention_policy = failed

--- a/scripts/activate.bat
+++ b/scripts/activate.bat
@@ -1,2 +1,2 @@
 @echo off
-set CARGO_TARGET_DIR=.pixi\target
+set CARGO_TARGET_DIR=target-pixi

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -Eeuo pipefail
-export CARGO_TARGET_DIR=".pixi/target"
+export CARGO_TARGET_DIR="target-pixi"
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="clang"
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=$CONDA_PREFIX/bin/mold"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture
 def pixi() -> Path:
-    return Path(__file__).parent.joinpath("../../.pixi/target/release/pixi")
+    return Path(__file__).parent.joinpath("../../target-pixi/release/pixi")
 
 
 @pytest.fixture

--- a/tests/wheel_tests/test_common_wheels.py
+++ b/tests/wheel_tests/test_common_wheels.py
@@ -85,7 +85,7 @@ def pixi(pytestconfig):
     # This assertion is for the type checker
     assert project_root
     project_root = pathlib.Path(project_root)
-    target_dir = project_root.joinpath(".pixi/target/release")
+    target_dir = project_root.joinpath("target-pixi/release")
     if not target_dir.exists():
         pytest.exit("pixi executable not found, run `pixi r build` first")
 


### PR DESCRIPTION
- specify `basetemp` for pytest
  - this avoids the problem that `/tmp` is filling up on Linux which can make problems
  - it is also more convenient to inspect test artifacts
- move target directory from `.pixi/target` to `pixi-target`
  - `setup-pixi` caches the whole `.pixi` which is something we sometimes want to avoid for target