### PR TITLE
refactor: reimplement barrier cell on OnceLock

### DIFF
--- a/crates/barrier_cell/src/lib.rs
+++ b/crates/barrier_cell/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::OnceLock;
 use thiserror::Error;
 use tokio::sync::Notify;
 
-/// A synchronization primitive, around [OnceCell] that can be used to wait for a value to become available.
+/// A synchronization primitive, around [`OnceLock`] that can be used to wait for a value to become available.
 ///
 /// The [`BarrierCell`] is initially empty, requesters can wait for a value to become available
 /// using the `wait` method. Once a value is available, the `set` method can be used to set the

--- a/crates/barrier_cell/src/lib.rs
+++ b/crates/barrier_cell/src/lib.rs
@@ -1,40 +1,16 @@
-use std::{
-    cell::UnsafeCell,
-    mem::MaybeUninit,
-    sync::atomic::{AtomicU8, Ordering},
-};
+use std::sync::OnceLock;
 use thiserror::Error;
 use tokio::sync::Notify;
 
-/// A synchronization primitive that can be used to wait for a value to become available.
+/// A synchronization primitive, around [OnceCell] that can be used to wait for a value to become available.
 ///
 /// The [`BarrierCell`] is initially empty, requesters can wait for a value to become available
 /// using the `wait` method. Once a value is available, the `set` method can be used to set the
 /// value in the cell. The `set` method can only be called once. If the `set` method is called
-/// multiple times, it will return an error. When `set` is called all waiters will be notified.
+/// multiple times, it will return an error. When `set` is called successfully all waiters will be notified.
 pub struct BarrierCell<T> {
-    state: AtomicU8,
-    value: UnsafeCell<MaybeUninit<T>>,
+    value: OnceLock<T>,
     notify: Notify,
-}
-
-unsafe impl<T: Sync> Sync for BarrierCell<T> {}
-
-unsafe impl<T: Send> Send for BarrierCell<T> {}
-
-impl<T> Drop for BarrierCell<T> {
-    fn drop(&mut self) {
-        if self.state.load(Ordering::Acquire) == BarrierCellState::Initialized as u8 {
-            unsafe { self.value.get_mut().assume_init_drop() }
-        }
-    }
-}
-
-#[repr(u8)]
-enum BarrierCellState {
-    Uninitialized,
-    Initializing,
-    Initialized,
 }
 
 impl<T> Default for BarrierCell<T> {
@@ -53,8 +29,7 @@ impl<T> BarrierCell<T> {
     /// Constructs a new instance.
     pub fn new() -> Self {
         Self {
-            state: AtomicU8::new(BarrierCellState::Uninitialized as u8),
-            value: UnsafeCell::new(MaybeUninit::uninit()),
+            value: OnceLock::new(),
             notify: Notify::new(),
         }
     }
@@ -62,41 +37,20 @@ impl<T> BarrierCell<T> {
     /// Wait for a value to become available in the cell
     pub async fn wait(&self) -> &T {
         self.notify.notified().await;
-        unsafe { (*self.value.get()).assume_init_ref() }
+        // safe, as notification only occurs after setting the value
+        unsafe { self.value.get().unwrap_unchecked() }
     }
 
     /// Set the value in the cell, if the cell was already initialized this will return an error.
     pub fn set(&self, value: T) -> Result<(), SetError> {
-        let state = self
-            .state
-            .fetch_max(BarrierCellState::Initializing as u8, Ordering::SeqCst);
-
-        // If the state is larger than started writing, then either there is an active writer or
-        // the cell has already been initialized.
-        if state == BarrierCellState::Initialized as u8 {
-            return Err(SetError::AlreadySet);
-        } else {
-            unsafe { *self.value.get() = MaybeUninit::new(value) };
-            self.state
-                .store(BarrierCellState::Initialized as u8, Ordering::Release);
-            self.notify.notify_waiters();
-        }
+        self.value.set(value).map_err(|_| SetError::AlreadySet)?;
+        self.notify.notify_waiters();
 
         Ok(())
     }
 
     /// Consumes this instance and converts it into the inner value if it has been initialized.
-    pub fn into_inner(mut self) -> Option<T> {
-        if self.state.compare_exchange(
-            BarrierCellState::Initialized as u8,
-            BarrierCellState::Uninitialized as u8,
-            Ordering::Acquire,
-            Ordering::Acquire,
-        ) == Ok(BarrierCellState::Initialized as u8)
-        {
-            Some(unsafe { self.value.get_mut().assume_init_read() })
-        } else {
-            None
-        }
+    pub fn into_inner(self) -> Option<T> {
+        self.value.into_inner()
     }
 }


### PR DESCRIPTION
As OnceLock is now in std, reimplement BarrierCell with the OnceLock primitive (simplifying the unsafe code to one instance, and making it easier to maintain)