### PR TITLE
feat: no project table required in manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "miette 7.2.0",
  "pep440_rs",
  "pep508_rs",
+ "pixi_config",
  "pixi_consts",
  "pixi_spec",
  "pyproject-toml",

--- a/crates/pixi_manifest/Cargo.toml
+++ b/crates/pixi_manifest/Cargo.toml
@@ -40,6 +40,7 @@ rattler_virtual_packages = { workspace = true }
 # TODO: Remove these dependencies
 console = { workspace = true }
 miette = { workspace = true }
+pixi_config.workspace = true
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -401,6 +401,7 @@ mod tests {
         [feature.bla.host-dependencies]
         # empty on purpose
         "#,
+            None,
         )
         .unwrap();
 
@@ -462,6 +463,7 @@ mod tests {
         [target.linux-64.activation]
         scripts = ["linux-64.bat"]
         "#,
+            None,
         )
         .unwrap();
 
@@ -496,6 +498,7 @@ mod tests {
         [pypi-options]
         extra-index-urls = ["https://mypypi.org/simple"]
         "#,
+            None,
         )
         .unwrap();
 

--- a/crates/pixi_manifest/src/metadata.rs
+++ b/crates/pixi_manifest/src/metadata.rs
@@ -12,7 +12,7 @@ use crate::utils::PixiSpanned;
 
 /// Describes the contents of the `[package]` section of the project manifest.
 #[serde_as]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ProjectMetadata {
     /// The name of the project
@@ -29,6 +29,7 @@ pub struct ProjectMetadata {
     pub authors: Option<Vec<String>>,
 
     /// The channels used by the project
+    #[serde(default)]
     #[serde_as(as = "IndexSet<super::channel::TomlPrioritizedChannelStrOrMap>")]
     pub channels: IndexSet<super::channel::PrioritizedChannel>,
 
@@ -39,6 +40,7 @@ pub struct ProjectMetadata {
     /// The platforms this project supports
     // TODO: This is actually slightly different from the rattler_conda_types::Platform because it
     //     should not include noarch.
+    #[serde(default)]
     pub platforms: PixiSpanned<IndexSet<Platform>>,
 
     /// The license as a valid SPDX string (e.g. MIT AND Apache-2.0)

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -517,13 +517,14 @@ mod tests {
 
     #[test]
     fn test_build_manifest() {
-        let _manifest = Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_FULL).unwrap();
+        let _manifest =
+            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_FULL, None).unwrap();
     }
 
     #[test]
     fn test_add_pypi_dependency() {
         let mut manifest =
-            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_BOILERPLATE).unwrap();
+            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_BOILERPLATE, None).unwrap();
 
         // Add numpy to pyproject
         let requirement = pep508_rs::Requirement::from_str("numpy>=3.12").unwrap();
@@ -577,7 +578,7 @@ mod tests {
     #[test]
     fn test_remove_pypi_dependency() {
         let mut manifest =
-            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_BOILERPLATE).unwrap();
+            Manifest::from_str(Path::new("pyproject.toml"), PYPROJECT_BOILERPLATE, None).unwrap();
 
         // Remove flask from pyproject
         let name = PyPiPackageName::from_str("flask").unwrap();

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -582,6 +582,7 @@ mod tests {
         run = "3.0"
         host = "1.0"
         "#,
+            None,
         )
         .unwrap();
 

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -334,7 +334,7 @@ mod tests {
         [environments]
         test = ["test"]
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), multi_env_project).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), multi_env_project, None).unwrap();
 
         let default_env = project.default_environment();
         let env = default_env.get_metadata_env();
@@ -361,7 +361,7 @@ mod tests {
         channels = ["conda-forge"]
         platforms = ["linux-64", "osx-64", "win-64"]
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), project, None).unwrap();
         let env = project.get_metadata_env();
 
         assert_eq!(env.get("PIXI_PROJECT_NAME").unwrap(), project.name());
@@ -392,7 +392,7 @@ mod tests {
         ZZZ = "123test123"
         ZAB = "123test123"
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), project).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), project, None).unwrap();
         let env = get_static_environment_variables(&project.default_environment());
 
         // Make sure the user defined environment variables are at the end.

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -212,7 +212,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             None,
             &vec![],
         );
-        let mut project = Project::from_str(&pixi_manifest_path, &rv)?;
+        let mut project = Project::from_str(&pixi_manifest_path, &rv, Some(config.clone()))?;
         let channel_config = project.channel_config();
         for spec in conda_deps {
             project.manifest.add_dependency(

--- a/src/cli/project/export/conda_environment.rs
+++ b/src/cli/project/export/conda_environment.rs
@@ -407,7 +407,7 @@ mod tests {
             [dependencies]
             python = "3.9"
            "#;
-        let project = Project::from_str(Path::new("pixi.toml"), toml).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), toml, None).unwrap();
         let args = Args {
             output_path: None,
             platform: Some(Platform::Osx64),

--- a/src/project/environment.rs
+++ b/src/project/environment.rs
@@ -326,6 +326,7 @@ mod tests {
         channels = ["foo", "bar"]
         platforms = []
         "#,
+            None,
         )
         .unwrap();
 
@@ -348,6 +349,7 @@ mod tests {
         channels = []
         platforms = ["linux-64", "osx-64"]
         "#,
+            None,
         )
         .unwrap();
 
@@ -374,6 +376,7 @@ mod tests {
         [target.linux-64.tasks]
         foo = "echo linux"
         "#,
+            None,
         )
         .unwrap();
 
@@ -414,6 +417,7 @@ mod tests {
         foo = "echo foo"
         _bar = "echo bar"
         "#,
+            None,
         )
         .unwrap();
 
@@ -459,6 +463,7 @@ mod tests {
         [environments]
         foobar = ["foo", "bar"]
         "#,
+            None,
         )
         .unwrap();
 
@@ -491,6 +496,7 @@ mod tests {
         [environments]
         foo = ["foo"]
                 "#,
+            None,
         )
         .unwrap();
 
@@ -529,6 +535,7 @@ mod tests {
         foobar = ["foo", "bar"]
         barfoo = {features = ["barfoo"], no-default-feature=true}
         "#,
+            None,
         )
         .unwrap();
 
@@ -580,6 +587,7 @@ mod tests {
         channels = ["a", "c", "b"]
 
         "#,
+            None,
         )
         .unwrap();
 
@@ -625,6 +633,7 @@ mod tests {
         bar = ["bar"]
         foobar = ["foo", "bar"]
         "#,
+            None,
         )
         .unwrap();
 
@@ -675,7 +684,7 @@ mod tests {
         foo = ["foo"]
         bar = ["bar"]
         foobar = ["foo", "bar"]
-        "#,
+        "#, None
         )
         .unwrap();
 
@@ -743,7 +752,7 @@ mod tests {
             bar = { features = ["foo"], no-default-feature = true }
             "##;
 
-        let manifest = Project::from_str(Path::new("pixi.toml"), contents).unwrap();
+        let manifest = Project::from_str(Path::new("pixi.toml"), contents, None).unwrap();
         assert_eq!(
             manifest
                 .default_environment()
@@ -771,6 +780,7 @@ mod tests {
         channels = ["conda-forge"]
         platforms = ["osx-64", "linux-64", "win-64"]
         "#,
+            None,
         )
         .unwrap();
         let env = manifest.default_environment();
@@ -785,6 +795,7 @@ mod tests {
         channels = ["conda-forge"]
         platforms = ["emscripten-wasm32"]
         "#,
+            None,
         )
         .unwrap();
         let env = manifest.default_environment();

--- a/src/project/solve_group.rs
+++ b/src/project/solve_group.rs
@@ -131,6 +131,7 @@ mod tests {
         bar = { features=["bar"], solve-group="group1" }
         baz = { features=["bar"], solve-group="group2", no-default-feature=true }
         "#,
+            None,
         )
         .unwrap();
 

--- a/src/task/executable_task.rs
+++ b/src/task/executable_task.rs
@@ -410,6 +410,7 @@ mod tests {
         let manifest = Manifest::from_str(
             Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+            None,
         )
         .unwrap();
 
@@ -434,6 +435,7 @@ mod tests {
         let manifest = Manifest::from_str(
             Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+            None,
         )
         .unwrap();
 
@@ -465,6 +467,7 @@ mod tests {
         let manifest = Manifest::from_str(
             Path::new("pixi.toml"),
             format!("{PROJECT_BOILERPLATE}\n{file_contents}").as_str(),
+            None,
         )
         .unwrap();
 

--- a/src/task/task_environment.rs
+++ b/src/task/task_environment.rs
@@ -239,7 +239,7 @@ mod tests {
             [environments]
             test = ["test"]
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str, None).unwrap();
         let env = project.default_environment();
         let search = SearchEnvironments::from_opt_env(&project, None, Some(env.best_platform()));
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
@@ -264,7 +264,7 @@ mod tests {
             [environments]
             test = ["test"]
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str, None).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(matches!(result, Err(FindTaskError::AmbiguousTask(_))));
@@ -293,7 +293,7 @@ mod tests {
             [system-requirements]
             macos = "10.6"
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str, None).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None)
             .with_ignore_system_requirements(true);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
@@ -329,7 +329,7 @@ mod tests {
             [system-requirements]
             macos = "10.6"
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str, None).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let result = search.find_task("test".into(), FindTaskSource::CmdArgs);
         assert!(result.unwrap().0.name().is_default());
@@ -362,7 +362,7 @@ mod tests {
             [environments]
             other = ["other"]
         "#;
-        let project = Project::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), manifest_str, None).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None)
             .with_ignore_system_requirements(true);
         let result = search.find_task("bla".into(), FindTaskSource::CmdArgs);

--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -361,7 +361,7 @@ mod test {
         platform: Option<Platform>,
         environment_name: Option<EnvironmentName>,
     ) -> Vec<String> {
-        let project = Project::from_str(Path::new("pixi.toml"), project_str).unwrap();
+        let project = Project::from_str(Path::new("pixi.toml"), project_str, None).unwrap();
 
         let environment = environment_name.map(|name| project.environment(&name).unwrap());
         let search_envs = SearchEnvironments::from_opt_env(&project, environment, platform)

--- a/tests/project_tests.rs
+++ b/tests/project_tests.rs
@@ -95,7 +95,7 @@ async fn parse_project() {
     }
 
     let pixi_toml = include_str!("./pixi_tomls/many_targets.toml");
-    let project = Project::from_str(&PathBuf::from("./many/pixi.toml"), pixi_toml).unwrap();
+    let project = Project::from_str(&PathBuf::from("./many/pixi.toml"), pixi_toml, None).unwrap();
     assert_debug_snapshot!(dependency_names(&project, Platform::Linux64));
     assert_debug_snapshot!(dependency_names(&project, Platform::OsxArm64));
     assert_debug_snapshot!(dependency_names(&project, Platform::Win64));
@@ -110,7 +110,8 @@ async fn parse_valid_schema_projects() {
         let path = entry.path();
         if path.extension().map(|ext| ext == "toml").unwrap_or(false) {
             let pixi_toml = std::fs::read_to_string(&path).unwrap();
-            let _project = Project::from_str(&PathBuf::from("pixi.toml"), &pixi_toml).unwrap();
+            let _project =
+                Project::from_str(&PathBuf::from("pixi.toml"), &pixi_toml, None).unwrap();
         }
     }
 }


### PR DESCRIPTION
Tried this for fun. 

This would then be allowed as a `pixi.toml`
```toml
[dependencies]
python = "*"
```

Defaulting to global config and current platform.
