### PR TITLE
feat: Create `.pixi/.gitignore` containing `*`

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -223,7 +223,7 @@ pub async fn sanity_check_project(project: &Project) -> miette::Result<()> {
 /// Ensure that the `.pixi/` directory exists and contains a `.gitignore` file.
 /// If the directory doesn't exist, create it.
 /// If the `.gitignore` file doesn't exist, create it with a '*' pattern.
-async fn ensure_pixi_directory_and_gitignore(project: &Project) -> miette::Result<()> {
+async fn ensure_pixi_directory_and_gitignore(pixi_dir: &Path) -> miette::Result<()> {
     let pixi_dir = project.pixi_dir();
     let gitignore_path = pixi_dir.join(".gitignore");
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -232,11 +232,10 @@ async fn ensure_pixi_directory_and_gitignore(pixi_dir: &Path) -> miette::Result<
         match tokio::fs::create_dir_all(&pixi_dir).await {
             Ok(_) => tracing::info!("Created .pixi/ directory at {}", pixi_dir.display()),
             Err(e) => {
-                return Err(miette::miette!(
-                    "Failed to create .pixi/ directory at {}: {}",
-                    pixi_dir.display(),
-                    e
-                ))
+                return Err(e).into_diagnostic().wrap_err(format!(
+                    "Failed to create .pixi/ directory at {}",
+                    gitignore_path.display()
+                ));
             }
         }
     }

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -700,3 +700,54 @@ async fn test_many_linux_wheel_tag() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn test_ensure_gitignore_file_creation() {
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().await.unwrap();
+    let gitignore_path = pixi.project().unwrap().pixi_dir().join(".gitignore");
+    assert!(
+        !gitignore_path.exists(),
+        ".pixi/.gitignore file should not exist"
+    );
+
+    // Check that .gitignore is created after the first install and contains '*'
+    pixi.install().await.unwrap();
+    assert!(
+        gitignore_path.exists(),
+        ".pixi/.gitignore file was not created"
+    );
+    let contents = tokio::fs::read_to_string(&gitignore_path).await.unwrap();
+    assert_eq!(
+        contents, "*\n",
+        ".pixi/.gitignore file does not contain the expected content"
+    );
+
+    // Modify the .gitignore file and check that it is preserved after reinstall
+    tokio::fs::write(&gitignore_path, "*\nsome_file\n")
+        .await
+        .unwrap();
+    pixi.install().await.unwrap();
+    let contents = tokio::fs::read_to_string(&gitignore_path).await.unwrap();
+    assert_eq!(
+        contents, "*\nsome_file\n",
+        ".pixi/.gitignore file does not contain the expected content"
+    );
+
+    // Remove the .gitignore file and check that it is recreated
+    tokio::fs::remove_file(&gitignore_path).await.unwrap();
+    assert!(
+        !gitignore_path.exists(),
+        ".pixi/.gitignore file should not exist"
+    );
+    pixi.install().await.unwrap();
+    assert!(
+        gitignore_path.exists(),
+        ".pixi/.gitignore file was not recreated"
+    );
+    let contents = tokio::fs::read_to_string(&gitignore_path).await.unwrap();
+    assert_eq!(
+        contents, "*\n",
+        ".pixi/.gitignore file does not contain the expected content"
+    );
+}


### PR DESCRIPTION
Closes #2115

**Implementation note**: I wasn't so sure where's the best location in the code to create `.pixi/.gitignore`, and I ended up adding it to the `sanity_check_project` part of `update_prefix`. This means that `.pixi/` will be created slightly more eagerly than before (e.g. if there aren't yet any environments defined). Please let me know in case there's a better way.

**Brief why?**: Adding a `.gitignore` under `.pixi/` has the advantage that `.pixi/` will be ignored in a self-contained way without requiring modification of the project-level `.gitignore`. This ignore is mostly redundant with the rule defined in `GITIGNORE_TEMPLATE`, but retaining them both for the moment ensures that edge cases are better handled. See the discussion in <https://github.com/prefix-dev/pixi/issues/2115>.

Please review this harshly. I don't actually know Rust so this was AI-assisted. Be merciless so that I can learn for myself. :smile: Thanks!

Test summary:
* `pixi init`
* `pixi install`, check that `.pixi/.gitignore` was created
* modify `.pixi/.gitignore`
* `pixi install`, check that `.pixi/.gitignore` was not modified (just in case someone wants to modify it, but I can't think of any real use case for this)
* remove `.pixi/.gitignore`
* `pixi install`, check that `.pixi/.gitignore` was recreated