### PR TITLE
ci: speed up test workflow

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -45,11 +45,11 @@ test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/whee
 test-common-wheels-dev = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", depends-on = [
   "build",
 ] }
-test-integration-ci = "pytest --runslow --numprocesses=auto --durations=10 --verbose tests/integration"
-test-integration-dev = { cmd = "pytest --runslow --numprocesses=auto --durations=10 tests/integration", depends-on = [
+test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose tests/integration"
+test-integration-dev = { cmd = "pytest --numprocesses=auto --durations=10 tests/integration", depends-on = [
   "build",
 ] }
-test-integration-fast = { cmd = "pytest --pixi-build=debug --numprocesses=auto --durations=10 tests/integration", depends-on = [
+test-integration-fast = { cmd = "pytest -m 'not slow' --pixi-build=debug --numprocesses=auto --durations=10 tests/integration", depends-on = [
   "build-debug",
 ] }
 # pass the file to run as an argument to the task

--- a/pixi.toml
+++ b/pixi.toml
@@ -16,6 +16,7 @@ python = "3.12.*"
 
 [tasks]
 build = "cargo build --release"
+build-debug = "cargo build"
 bump = "tbump --only-patch $RELEASE_VERSION"
 install = "cargo install --path . --locked"
 install-as = { cmd = "python scripts/install.py", depends-on = ["build"] }
@@ -25,6 +26,7 @@ run-all-examples = { cmd = "python ./tests/run_all_examples.py --pixi-exec $CARG
   "build",
 ] }
 test = "cargo nextest run"
+test-all-fast = { depends-on = ["test", "test-integration-fast"] }
 test-workspace = """cargo nextest run --workspace --retries 2 --features slow_integration_tests
               --status-level skip --failure-output immediate-final --no-fail-fast --final-status-level slow"""
 
@@ -43,9 +45,12 @@ test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/whee
 test-common-wheels-dev = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", depends-on = [
   "build",
 ] }
-test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose tests/integration"
-test-integration-dev = { cmd = "pytest --numprocesses=auto --durations=10 tests/integration", depends-on = [
+test-integration-ci = "pytest --runslow --numprocesses=auto --durations=10 --verbose tests/integration"
+test-integration-dev = { cmd = "pytest --runslow --numprocesses=auto --durations=10 tests/integration", depends-on = [
   "build",
+] }
+test-integration-fast = { cmd = "pytest --pixi-build=debug --numprocesses=auto --durations=10 tests/integration", depends-on = [
+  "build-debug",
 ] }
 # pass the file to run as an argument to the task
 # you can also pass a specific test function, like this:

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -1146,6 +1146,7 @@ mod tests {
     }
 
     #[rstest]
+    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     fn test_example_satisfiability(#[files("examples/*/pixi.toml")] manifest_path: PathBuf) {
         let project = Project::from_path(&manifest_path).unwrap();
         let lock_file = LockFile::from_path(&project.lock_file_path()).unwrap();

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -702,6 +702,7 @@ async fn test_many_linux_wheel_tag() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn test_ensure_gitignore_file_creation() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Sequence
 
 import pytest
 
@@ -11,21 +10,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default="release",
         help="Specify the pixi build type (e.g., release or debug)",
     )
-    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: Sequence[pytest.Item]) -> None:
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
 
 
 @pytest.fixture

--- a/tests/integration/test_global.py
+++ b/tests/integration/test_global.py
@@ -18,6 +18,7 @@ def exec_extension(exe_name: str) -> str:
         return exe_name
 
 
+@pytest.mark.slow
 def test_sync_dependencies(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
@@ -61,6 +62,7 @@ def test_sync_dependencies(pixi: Path, tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.slow
 def test_sync_platform(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
@@ -154,6 +156,7 @@ def test_sync_manually_remove_binary(pixi: Path, tmp_path: Path, dummy_channel_1
     assert dummy_a.is_file()
 
 
+@pytest.mark.slow
 def test_sync_migrate(
     pixi: Path, tmp_path: Path, dummy_channel_1: str, dummy_channel_2: str
 ) -> None:
@@ -1007,6 +1010,7 @@ def test_install_only_reverts_failing(pixi: Path, tmp_path: Path, dummy_channel_
     assert not dummy_x.is_file()
 
 
+@pytest.mark.slow
 def test_install_platform(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     # Exists on win-64

--- a/tests/integration/test_main_cli.py
+++ b/tests/integration/test_main_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from .common import verify_cli_command, ExitCode, PIXI_VERSION
+import pytest
 
 
 def test_pixi(pixi: Path) -> None:
@@ -9,6 +10,7 @@ def test_pixi(pixi: Path) -> None:
     verify_cli_command([pixi, "--version"], ExitCode.SUCCESS, stdout_contains=PIXI_VERSION)
 
 
+@pytest.mark.slow
 def test_project_commands(pixi: Path, tmp_path: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
     # Create a new project
@@ -163,6 +165,7 @@ def test_project_commands(pixi: Path, tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.slow
 def test_search(pixi: Path) -> None:
     verify_cli_command(
         [pixi, "search", "rattler-build", "-c", "conda-forge"],
@@ -176,6 +179,7 @@ def test_search(pixi: Path) -> None:
     )
 
 
+@pytest.mark.slow
 def test_simple_project_setup(pixi: Path, tmp_path: Path) -> None:
     manifest_path = tmp_path / "pixi.toml"
     conda_forge = "https://fast.prefix.dev/conda-forge"
@@ -279,6 +283,7 @@ def test_simple_project_setup(pixi: Path, tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.slow
 def test_pixi_init_pyproject(pixi: Path, tmp_path: Path) -> None:
     manifest_path = tmp_path / "pyproject.toml"
     # Create a new project

--- a/tests/solve_group_tests.rs
+++ b/tests/solve_group_tests.rs
@@ -97,6 +97,7 @@ async fn conda_solve_group_functionality() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn test_purl_are_added_for_pypi() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();


### PR DESCRIPTION
- Mark more tests as slow
- Use debug-build for integration tests
- Add `test-integration-fast` and `test-all-fast` for running a great subset of tests without waiting too long