### PR TITLE
test: add marker for slow pytest tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = --basetemp=pytest-temp
 tmp_path_retention_policy = failed
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')


### PR DESCRIPTION
Otherwise you get a lot of warnings