### PR TITLE
feat: make concurrency more configurable

### DIFF
--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -1023,9 +1023,11 @@ impl Repodata for Project {
     /// Returns the [`Gateway`] used by this project.
     fn repodata_gateway(&self) -> &Gateway {
         self.repodata_gateway.get_or_init(|| {
+            tracing::info!("Concurrency is set to: {}", self.config().concurrency().network_requests);
             Self::repodata_gateway_init(
                 self.authenticated_client().clone(),
-                self.config(),
+                self.config().into(),
+                self.config().concurrency().network_requests,
             )
         })
     }

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -1025,7 +1025,7 @@ impl Repodata for Project {
         self.repodata_gateway.get_or_init(|| {
             Self::repodata_gateway_init(
                 self.authenticated_client().clone(),
-                self.config().clone().into(),
+                self.config(),
             )
         })
     }

--- a/src/project/repodata.rs
+++ b/src/project/repodata.rs
@@ -8,7 +8,8 @@ impl Repodata for Project {
         self.repodata_gateway.get_or_init(|| {
             Self::repodata_gateway_init(
                 self.authenticated_client().clone(),
-                self.config(),
+                self.config().into(),
+                self.config().concurrency().network_requests,
             )
         })
     }

--- a/src/project/repodata.rs
+++ b/src/project/repodata.rs
@@ -8,7 +8,7 @@ impl Repodata for Project {
         self.repodata_gateway.get_or_init(|| {
             Self::repodata_gateway_init(
                 self.authenticated_client().clone(),
-                self.config().clone().into(),
+                self.config(),
             )
         })
     }

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -6,7 +6,7 @@ pub(crate) trait Repodata {
     /// Initialized the [`Gateway`]
     fn repodata_gateway_init(
         authenticated_client: reqwest_middleware::ClientWithMiddleware,
-        channel_config: ChannelConfig,
+        channel_config: Config,
     ) -> Gateway {
         // Determine the cache directory and fall back to sane defaults otherwise.
         let cache_dir = pixi_config::get_cache_dir().unwrap_or_else(|e| {
@@ -22,6 +22,7 @@ pub(crate) trait Repodata {
             .with_cache_dir(cache_dir.join(pixi_consts::consts::CONDA_REPODATA_CACHE_DIR))
             .with_package_cache(package_cache)
             .with_channel_config(channel_config)
+            .with_max_concurrent_requests(10)
             .finish()
     }
 

--- a/src/repodata.rs
+++ b/src/repodata.rs
@@ -6,7 +6,8 @@ pub(crate) trait Repodata {
     /// Initialized the [`Gateway`]
     fn repodata_gateway_init(
         authenticated_client: reqwest_middleware::ClientWithMiddleware,
-        channel_config: Config,
+        channel_config: ChannelConfig,
+        max_concurrent_requests: usize,
     ) -> Gateway {
         // Determine the cache directory and fall back to sane defaults otherwise.
         let cache_dir = pixi_config::get_cache_dir().unwrap_or_else(|e| {
@@ -22,7 +23,7 @@ pub(crate) trait Repodata {
             .with_cache_dir(cache_dir.join(pixi_consts::consts::CONDA_REPODATA_CACHE_DIR))
             .with_package_cache(package_cache)
             .with_channel_config(channel_config)
-            .with_max_concurrent_requests(10)
+            .with_max_concurrent_requests(max_concurrent_requests)
             .finish()
     }
 


### PR DESCRIPTION
There are some situations with slow network / bad artifactory etc. where setting the concurrency to a lower value might be helpful. 

One problem is that the network concurrency is not currently exposed by the `Installer` in rattler (which is actually where the more problematic code is, for the artifactory case).

Hopefully this would help https://github.com/prefix-dev/pixi/issues/2336