### PR TITLE
feat: improve global install reporting

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -127,7 +127,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                         EnvState::NotChanged(NotChangedReason::AlreadyInstalled),
                     ),
                 };
-                state_changes.report();
             }
             Err(err) => {
                 revert_environment_after_error(env_name, &last_updated_project)

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -118,14 +118,15 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             .wrap_err_with(|| format!("Couldn't install {}", env_name.fancy_display()))
         {
             Ok(state_changes) => {
-                match state_changes.has_changed() {
-                    true => env_changes
+                if state_changes.has_changed() {
+                    env_changes
                         .changes
-                        .insert(env_name.clone(), EnvState::Installed),
-                    false => env_changes.changes.insert(
+                        .insert(env_name.clone(), EnvState::Installed)
+                } else {
+                    env_changes.changes.insert(
                         env_name.clone(),
                         EnvState::NotChanged(NotChangedReason::AlreadyInstalled),
-                    ),
+                    )
                 };
             }
             Err(err) => {


### PR DESCRIPTION
Stop reporting state changes for `pixi global install`.
We already have the list view for that.