### PR TITLE
prototype: `--name` to direct to a project from anywhere

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -409,6 +409,9 @@ pub struct Config {
     /// it back to the .pixi folder.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detached_environments: Option<DetachedEnvironments>,
+
+    /// Registered projects in the config
+    pub registered_projects: HashMap<String, PathBuf>,
 }
 
 impl Default for Config {
@@ -425,6 +428,7 @@ impl Default for Config {
             pypi_config: PyPIConfig::default(),
             detached_environments: Some(DetachedEnvironments::default()),
             pinning_strategy: Default::default(),
+            registered_projects: HashMap::new(),
         }
     }
 }
@@ -668,6 +672,7 @@ impl Config {
     pub fn merge_config(mut self, other: Config) -> Self {
         self.mirrors.extend(other.mirrors);
         self.loaded_from.extend(other.loaded_from);
+        self.registered_projects.extend(other.registered_projects);
 
         Self {
             default_channels: if other.default_channels.is_empty() {
@@ -688,6 +693,7 @@ impl Config {
             pypi_config: other.pypi_config.merge(self.pypi_config),
             detached_environments: other.detached_environments.or(self.detached_environments),
             pinning_strategy: other.pinning_strategy.or(self.pinning_strategy),
+            registered_projects: self.registered_projects,
         }
     }
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -105,8 +105,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         args.project_config,
     );
 
-    let mut project = Project::load_or_else_discover(project_config.manifest_path.as_deref())?
-        .with_cli_config(prefix_update_config.config.clone());
+    let mut project = Project::load_or_else_discover(
+        project_config.manifest_path.as_deref(),
+        project_config.name,
+    )?
+    .with_cli_config(prefix_update_config.config.clone());
 
     // Sanity check of prefix location
     verify_prefix_location_unchanged(project.default_environment().dir().as_path()).await?;

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -72,8 +72,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     match args.command {
         Some(Command::Cache(args)) => clean_cache(args).await?,
         None => {
-            let project =
-                Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?; // Extract the passed in environment name.
+            let project = Project::load_or_else_discover(
+                args.project_config.manifest_path.as_deref(),
+                args.project_config.name,
+            )?; // Extract the passed in environment name.
 
             let explicit_environment = args
                 .environment

--- a/src/cli/cli_config.rs
+++ b/src/cli/cli_config.rs
@@ -21,6 +21,11 @@ pub struct ProjectConfig {
     /// The path to `pixi.toml` or `pyproject.toml`
     #[arg(long)]
     pub manifest_path: Option<PathBuf>,
+
+    /// The name of the project to run the task in.
+    /// If not provided, the project name will be inferred from the current directory.
+    #[arg(long, short)]
+    pub name: Option<String>,
 }
 
 /// Channel configuration

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -345,7 +345,11 @@ fn last_updated(path: impl Into<PathBuf>) -> miette::Result<String> {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref()).ok();
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )
+    .ok();
 
     let (pixi_folder_size, cache_size) = if args.extended {
         let env_dir = project.as_ref().map(|p| p.pixi_dir());

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -27,8 +27,11 @@ pub struct Args {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?
-        .with_cli_config(args.config);
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?
+    .with_cli_config(args.config);
 
     // Install either:
     //

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -108,7 +108,10 @@ where
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
     let environment = project.environment_from_name_or_env_var(args.environment)?;
 
     let lock_file = project

--- a/src/cli/project/channel/mod.rs
+++ b/src/cli/project/channel/mod.rs
@@ -2,19 +2,18 @@ pub mod add;
 pub mod list;
 pub mod remove;
 
+use crate::cli::cli_config::ProjectConfig;
 use crate::Project;
 use clap::Parser;
 use miette::IntoDiagnostic;
 use pixi_manifest::{FeatureName, PrioritizedChannel};
 use rattler_conda_types::{ChannelConfig, NamedChannelOrUrl};
-use std::path::PathBuf;
 
 /// Commands to manage project channels.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to `pixi.toml` or `pyproject.toml`
-    #[clap(long, global = true)]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub project_config: ProjectConfig,
 
     /// The subcommand to execute
     #[clap(subcommand)]
@@ -101,7 +100,10 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
 
     match args.command {
         Command::Add(args) => add::execute(project, args).await,

--- a/src/cli/project/description/mod.rs
+++ b/src/cli/project/description/mod.rs
@@ -1,16 +1,15 @@
 pub mod get;
 pub mod set;
 
+use crate::cli::cli_config::ProjectConfig;
 use crate::Project;
 use clap::Parser;
-use std::path::PathBuf;
 
 /// Commands to manage project description.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to `pixi.toml` or `pyproject.toml`
-    #[clap(long, global = true)]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub project_config: ProjectConfig,
 
     /// The subcommand to execute
     #[clap(subcommand)]
@@ -26,7 +25,10 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
 
     match args.command {
         Command::Get => get::execute(project).await?,

--- a/src/cli/project/environment/mod.rs
+++ b/src/cli/project/environment/mod.rs
@@ -2,16 +2,15 @@ pub mod add;
 pub mod list;
 pub mod remove;
 
+use crate::cli::cli_config::ProjectConfig;
 use crate::Project;
 use clap::Parser;
-use std::path::PathBuf;
 
 /// Commands to manage project environments.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to `pixi.toml` or `pyproject.toml`
-    #[clap(long, global = true)]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub project_config: ProjectConfig,
 
     /// The subcommand to execute
     #[clap(subcommand)]
@@ -32,7 +31,10 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
 
     match args.command {
         Command::Add(args) => add::execute(project, args).await,

--- a/src/cli/project/export/mod.rs
+++ b/src/cli/project/export/mod.rs
@@ -1,16 +1,15 @@
-use std::path::PathBuf;
 pub mod conda_environment;
 pub mod conda_explicit_spec;
 
+use crate::cli::cli_config::ProjectConfig;
 use crate::Project;
 use clap::Parser;
 
 /// Commands to export projects to other formats
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to `pixi.toml` or `pyproject.toml`
-    #[clap(long, global = true)]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub project_config: ProjectConfig,
 
     #[clap(subcommand)]
     pub command: Command,
@@ -26,7 +25,10 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
     match args.command {
         Command::CondaExplicitSpec(args) => conda_explicit_spec::execute(project, args).await?,
         Command::CondaEnvironment(args) => conda_environment::execute(project, args).await?,

--- a/src/cli/project/platform/mod.rs
+++ b/src/cli/project/platform/mod.rs
@@ -2,16 +2,15 @@ pub mod add;
 pub mod list;
 pub mod remove;
 
+use crate::cli::cli_config::ProjectConfig;
 use crate::Project;
 use clap::Parser;
-use std::path::PathBuf;
 
 /// Commands to manage project platforms.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to `pixi.toml` or `pyproject.toml`
-    #[clap(long, global = true)]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub project_config: ProjectConfig,
 
     /// The subcommand to execute
     #[clap(subcommand)]
@@ -32,7 +31,10 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
 
     match args.command {
         Command::Add(args) => add::execute(project, args).await,

--- a/src/cli/project/version/mod.rs
+++ b/src/cli/project/version/mod.rs
@@ -2,17 +2,16 @@ pub mod bump;
 pub mod get;
 pub mod set;
 
+use crate::cli::cli_config::ProjectConfig;
 use crate::Project;
 use clap::Parser;
 use rattler_conda_types::VersionBumpType;
-use std::path::PathBuf;
 
 /// Commands to manage project version.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The path to `pixi.toml` or `pyproject.toml`
-    #[clap(long, global = true)]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(flatten)]
+    pub project_config: ProjectConfig,
 
     /// The subcommand to execute
     #[clap(subcommand)]
@@ -34,7 +33,10 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.manifest_path.as_deref())?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
 
     match args.command {
         Command::Get(args) => get::execute(project, args).await?,

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -35,8 +35,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         args.project_config,
     );
 
-    let mut project = Project::load_or_else_discover(project_config.manifest_path.as_deref())?
-        .with_cli_config(prefix_update_config.config.clone());
+    let mut project = Project::load_or_else_discover(
+        project_config.manifest_path.as_deref(),
+        project_config.name,
+    )?
+    .with_cli_config(prefix_update_config.config.clone());
     let dependency_type = dependency_config.dependency_type();
 
     match dependency_type {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -52,8 +52,11 @@ pub struct Args {
 /// When running the sigints are ignored and child can react to them. As it pleases.
 pub async fn execute(args: Args) -> miette::Result<()> {
     // Load the project
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?
-        .with_cli_config(args.prefix_update_config.config.clone());
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?
+    .with_cli_config(args.prefix_update_config.config.clone());
 
     // Extract the passed in environment name.
     let environment = project.environment_from_name_or_env_var(args.environment.clone())?;

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -99,7 +99,11 @@ where
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let stdout = io::stdout();
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref()).ok();
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )
+    .ok();
 
     // Resolve channels from project / CLI args
     let channels = args.channels.resolve_from_project(project.as_ref())?;

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -225,8 +225,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = args
         .prompt_config
         .merge_with_config(args.prefix_update_config.config.clone().into());
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?
-        .with_cli_config(config);
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?
+    .with_cli_config(config);
     let environment = project.environment_from_name_or_env_var(args.environment)?;
 
     verify_current_platform_has_required_virtual_packages(&environment).into_diagnostic()?;

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -105,8 +105,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = args
         .prompt_config
         .merge_with_config(args.prefix_update_config.config.clone().into());
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?
-        .with_cli_config(config);
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?
+    .with_cli_config(config);
     let environment = project.environment_from_name_or_env_var(args.environment)?;
 
     update_prefix(

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -287,7 +287,10 @@ fn get_tasks_per_env(
 }
 
 pub fn execute(args: Args) -> miette::Result<()> {
-    let mut project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?;
+    let mut project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
     match args.operation {
         Operation::Add(args) => {
             let name = &args.name;

--- a/src/cli/tree.rs
+++ b/src/cli/tree.rs
@@ -70,8 +70,10 @@ static UTF8_SYMBOLS: Symbols = Symbols {
 };
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())
-        .wrap_err("Failed to load project")?;
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?;
 
     let environment = project
         .environment_from_name_or_env_var(args.environment)

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -132,8 +132,11 @@ impl UpdateSpecs {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let config = args.config;
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?
-        .with_cli_config(config);
+    let project = Project::load_or_else_discover(
+        args.project_config.manifest_path.as_deref(),
+        args.project_config.name,
+    )?
+    .with_cli_config(config);
 
     let specs = UpdateSpecs::from(args.specs);
 

--- a/tests/common/builders.rs
+++ b/tests/common/builders.rs
@@ -281,6 +281,7 @@ impl TaskAddBuilder {
             operation: task::Operation::Add(self.args),
             project_config: ProjectConfig {
                 manifest_path: self.manifest_path,
+                name: None,
             },
         })
     }
@@ -304,6 +305,7 @@ impl TaskAliasBuilder {
             operation: task::Operation::Alias(self.args),
             project_config: ProjectConfig {
                 manifest_path: self.manifest_path,
+                name: None,
             },
         })
     }
@@ -340,7 +342,10 @@ impl IntoFuture for ProjectChannelAddBuilder {
 
     fn into_future(self) -> Self::IntoFuture {
         project::channel::execute(project::channel::Args {
-            manifest_path: self.manifest_path,
+            project_config: ProjectConfig {
+                manifest_path: self.manifest_path,
+                name: None,
+            },
             command: project::channel::Command::Add(self.args),
         })
         .boxed_local()
@@ -373,7 +378,10 @@ impl IntoFuture for ProjectChannelRemoveBuilder {
 
     fn into_future(self) -> Self::IntoFuture {
         project::channel::execute(project::channel::Args {
-            manifest_path: self.manifest_path,
+            project_config: ProjectConfig {
+                manifest_path: self.manifest_path,
+                name: None,
+            },
             command: project::channel::Command::Remove(self.args),
         })
         .boxed_local()
@@ -440,7 +448,10 @@ impl IntoFuture for ProjectEnvironmentAddBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
     fn into_future(self) -> Self::IntoFuture {
         project::environment::execute(project::environment::Args {
-            manifest_path: self.manifest_path,
+            project_config: ProjectConfig {
+                manifest_path: self.manifest_path,
+                name: None,
+            },
             command: project::environment::Command::Add(self.args),
         })
         .boxed_local()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -210,7 +210,7 @@ impl PixiControl {
 
     /// Loads the project manifest and returns it.
     pub fn project(&self) -> miette::Result<Project> {
-        Project::load_or_else_discover(Some(&self.manifest_path()))
+        Project::load_or_else_discover(Some(&self.manifest_path()), None)
     }
 
     /// Get the path to the project
@@ -262,6 +262,7 @@ impl PixiControl {
                 format: None,
                 pyproject_toml: false,
                 scm: Some(GitAttributes::Github),
+                register: false,
             },
         }
     }
@@ -280,6 +281,7 @@ impl PixiControl {
                 format: None,
                 pyproject_toml: false,
                 scm: Some(GitAttributes::Github),
+                register: false,
             },
         }
     }
@@ -297,6 +299,7 @@ impl PixiControl {
             args: add::Args {
                 project_config: ProjectConfig {
                     manifest_path: Some(self.manifest_path()),
+                    name: None,
                 },
                 dependency_config: AddBuilder::dependency_config_with_specs(specs),
                 prefix_update_config: PrefixUpdateConfig {
@@ -316,6 +319,7 @@ impl PixiControl {
             args: remove::Args {
                 project_config: ProjectConfig {
                     manifest_path: Some(self.manifest_path()),
+                    name: None,
                 },
                 dependency_config: AddBuilder::dependency_config_with_specs(vec![spec]),
                 prefix_update_config: PrefixUpdateConfig {
@@ -445,6 +449,7 @@ impl PixiControl {
                 environment: None,
                 project_config: ProjectConfig {
                     manifest_path: Some(self.manifest_path()),
+                    name: None,
                 },
                 lock_file_usage: LockFileUsageArgs {
                     frozen: false,
@@ -464,6 +469,7 @@ impl PixiControl {
                 config: Default::default(),
                 project_config: ProjectConfig {
                     manifest_path: Some(self.manifest_path()),
+                    name: None,
                 },
                 no_install: true,
                 dry_run: false,
@@ -478,7 +484,7 @@ impl PixiControl {
     /// If you want to lock-file to be up-to-date with the project call
     /// [`Self::update_lock_file`].
     pub async fn lock_file(&self) -> miette::Result<LockFile> {
-        let project = Project::load_or_else_discover(Some(&self.manifest_path()))?;
+        let project = Project::load_or_else_discover(Some(&self.manifest_path()), None)?;
         pixi::load_lock_file(&project).await
     }
 
@@ -537,6 +543,7 @@ impl TasksControl<'_> {
         task::execute(task::Args {
             project_config: ProjectConfig {
                 manifest_path: Some(self.pixi.manifest_path()),
+                name: None,
             },
             operation: task::Operation::Remove(task::RemoveArgs {
                 names: vec![name],

--- a/tests/install_tests.rs
+++ b/tests/install_tests.rs
@@ -230,6 +230,7 @@ async fn install_locked_with_config() {
             task: vec!["which_python".to_string()],
             project_config: ProjectConfig {
                 manifest_path: None,
+                name: None,
             },
             ..Default::default()
         })

--- a/tests/task_tests.rs
+++ b/tests/task_tests.rs
@@ -114,6 +114,7 @@ async fn test_alias() {
             task: vec!["helloworld".to_string()],
             project_config: ProjectConfig {
                 manifest_path: None,
+                name: None,
             },
             ..Default::default()
         })
@@ -190,6 +191,7 @@ async fn test_cwd() {
             task: vec!["pwd-test".to_string()],
             project_config: ProjectConfig {
                 manifest_path: None,
+                name: None,
             },
             ..Default::default()
         })
@@ -211,7 +213,8 @@ async fn test_cwd() {
         .run(Args {
             task: vec!["unknown-cwd".to_string()],
             project_config: ProjectConfig {
-                manifest_path: None
+                manifest_path: None,
+                name: None
             },
             ..Default::default()
         })
@@ -239,6 +242,7 @@ async fn test_task_with_env() {
             task: vec!["env-test".to_string()],
             project_config: ProjectConfig {
                 manifest_path: None,
+                name: None,
             },
             ..Default::default()
         })
@@ -265,6 +269,7 @@ async fn test_clean_env() {
         task: vec!["env-test".to_string()],
         project_config: ProjectConfig {
             manifest_path: None,
+            name: None,
         },
         clean_env: true,
         ..Default::default()
@@ -284,6 +289,7 @@ async fn test_clean_env() {
             task: vec!["env-test".to_string()],
             project_config: ProjectConfig {
                 manifest_path: None,
+                name: None,
             },
             clean_env: false,
             ..Default::default()


### PR DESCRIPTION
Prototyped this to align more with conda like tools. 

```
~ via 🐍 v3.11.10 via 🦀 v1.80.0 
❯ pixi init registered_project --register
✔ Created /home/rarts/registered_project/pixi.toml
✔ Registered project 'registered_project' to be used from anywhere by name.

~ via 🐍 v3.11.10 via 🦀 v1.80.0 
❯ pixi add python --name registered_project
✔ Added python >=3.13.0,<3.14

~ via 🐍 v3.11.10 via 🦀 v1.80.0 
❯ pixi run --name registered_project "echo \$PIXI_PROJECT_MANIFEST"
/home/rarts/registered_project/pixi.toml

~ via 🐍 v3.11.10 via 🦀 v1.80.0 
❯ pixi shell --name registered_project

~ via 🐍 v3.13.0 via 🦀 v1.80.0 via 🅒 registered_project 
❯ 
```

Let me know what you think of this.