### PR TITLE
feat: suggest fix in platform error message

### DIFF
--- a/src/project/errors.rs
+++ b/src/project/errors.rs
@@ -29,7 +29,12 @@ impl Display for UnsupportedPlatformError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self.environment {
             EnvironmentName::Default => {
-                write!(f, "the project does not support '{}'", self.platform)
+                write!(
+                    f,
+                    "The project does not support '{}'.\n\
+                    Add it with 'pixi project platform add {}'.",
+                    self.platform, self.platform
+                )
             }
             EnvironmentName::Named(name) => write!(
                 f,


### PR DESCRIPTION
Suggest to run `pixi project platform add {platform}` when the current platform is not supported.

For the following `pixi.toml`:

```toml
[project]
channels = ["https://fast.prefix.dev/conda-forge"]
name = "error-messages"
platforms = []
```

Before:
```
> pixi run echo hello

× The current platform does not satisfy the minimal virtual package requirements
╰─▶ The project does not support 'osx-arm64'.
```

Now:
```
> pixi run echo hello

× The current platform does not satisfy the minimal virtual package requirements
╰─▶ The project does not support 'osx-arm64'.
    Add it with 'pixi project platform add osx-arm64'.
```