### PR TITLE
fix: use `--silent` instead of `--no-progress-meter` for old `curl`

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -61,7 +61,7 @@ trap cleanup EXIT
 
 # Test if stdout is a terminal before showing progress
 if [[ ! -t 1 ]]; then
-  CURL_OPTIONS="--silent"  # --no-progress-bar is better, but only available in 7.67+
+  CURL_OPTIONS="--silent"  # --no-progress-meter is better, but only available in 7.67+
   WGET_OPTIONS="--no-verbose"
 else
   CURL_OPTIONS="--no-silent"

--- a/install/install.sh
+++ b/install/install.sh
@@ -61,10 +61,10 @@ trap cleanup EXIT
 
 # Test if stdout is a terminal before showing progress
 if [[ ! -t 1 ]]; then
-  CURL_OPTIONS="--no-progress-meter"
+  CURL_OPTIONS="--silent"  # --no-progress-bar is better, but only available in 7.67+
   WGET_OPTIONS="--no-verbose"
 else
-  CURL_OPTIONS="--progress-bar"
+  CURL_OPTIONS="--no-silent"
   WGET_OPTIONS="--show-progress"
 fi
 


### PR DESCRIPTION
`--no-progress-meter` was "only" added in 7.67, but centOS 7 only ships til 7.29. Prevents errors in conda-forge's Docker infra.