### PR TITLE
fix: ensure tasks are fetched for the best platform

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -423,7 +423,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
                     let tasks: HashMap<TaskName, Task> = task_names
                         .into_iter()
                         .filter_map(|task_name| {
-                            env.task(&task_name, None)
+                            env.task(&task_name, Some(env.best_platform()))
                                 .ok()
                                 .map(|task| (task_name, task.clone()))
                         })


### PR DESCRIPTION
`task list` was not displaying when targets were specified


**manifest-path**

```toml
[project]
channels = ["https://fast.prefix.dev/conda-forge"]
name = "pixi"
platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]

[tasks]
make.cmd = "command_1"
generate_keymap.cmd = "command_2"
svg.cmd = "command_3"

[target.osx.tasks]
flash.cmd = "command_4"
port.cmd = "command_5"
port_right.cmd = "command_6"
```

### on `osx-arm64`

**before**
```console
> pixi task --manifest-path target/pixi.toml ls -s
Tasks per environment:
----------------------
default: generate_keymap, make, svg
```

**after**
```console
> pixi task --manifest-path target/pixi.toml ls -s
Tasks per environment:
----------------------
default: flash, generate_keymap, make, port, port_right, svg
```