### PR TITLE
fix: attempt copying trampoline when hard-linking fails

### DIFF
--- a/src/global/trampoline.rs
+++ b/src/global/trampoline.rs
@@ -354,9 +354,14 @@ impl Trampoline {
             .into_diagnostic()?;
         }
 
-        // Create a hard link to the shared trampoline binary
-        if !self.path().exists() {
-            tokio::fs::hard_link(self.trampoline_path(), self.path())
+        // If the path doesn't exist yet, create a hard link to the shared trampoline binary
+        // If creating a hard link doesn't succeed, try copying
+        if !self.path().exists()
+            && tokio_fs::hard_link(self.trampoline_path(), self.path())
+                .await
+                .is_err()
+        {
+            tokio_fs::copy(self.trampoline_path(), self.path())
                 .await
                 .into_diagnostic()?;
         }

--- a/src/global/trampoline.rs
+++ b/src/global/trampoline.rs
@@ -356,6 +356,7 @@ impl Trampoline {
 
         // If the path doesn't exist yet, create a hard link to the shared trampoline binary
         // If creating a hard link doesn't succeed, try copying
+        // Hard-linking might for example fail because the file-system enforces a maximum number of hard-links per file
         if !self.path().exists()
             && tokio_fs::hard_link(self.trampoline_path(), self.path())
                 .await


### PR DESCRIPTION
Fixes #2462