### PR TITLE
fix: dont use index as a flat index

### DIFF
--- a/src/install_pypi.rs
+++ b/src/install_pypi.rs
@@ -652,7 +652,7 @@ pub async fn update_python_distributions(
     // Resolve the flat indexes from `--find-links`.
     let flat_index = {
         let client = FlatIndexClient::new(&registry_client, &uv_context.cache);
-        let indexes = index_locations.indexes().map(|index| index.url());
+        let indexes = index_locations.flat_indexes().map(|index| index.url());
         let entries = client.fetch(indexes).await.into_diagnostic()?;
         FlatIndex::from_entries(
             entries,


### PR DESCRIPTION
Incorrectly querying the flat indexes, this fixes: https://github.com/prefix-dev/pixi/issues/2445
Should fix: https://github.com/prefix-dev/pixi/issues/2431 (but needs verification)