### PR TITLE
fix: wrong description on pixi upgrade

### DIFF
--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -19,7 +19,7 @@ use pixi_manifest::SpecType;
 use pixi_spec::PixiSpec;
 use rattler_conda_types::MatchSpec;
 
-/// Update dependencies as recorded in the local lock file
+/// Update the version of packages to the latest possible version, disregarding the manifest version constraints
 #[derive(Parser, Debug, Default)]
 pub struct Args {
     #[clap(flatten)]


### PR DESCRIPTION
Description was duplicate from `update`, it now reflects what it's supposed to do (unless I misunderstood what it does)