### PR TITLE
feat: add channels for build section

### DIFF
--- a/crates/pixi_manifest/src/build.rs
+++ b/crates/pixi_manifest/src/build.rs
@@ -1,5 +1,6 @@
 //! Defines the build section for the pixi manifest.
 use rattler_conda_types::MatchSpec;
+use rattler_conda_types::NamedChannelOrUrl;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::DisplayFromStr;
@@ -17,6 +18,9 @@ pub struct BuildSection {
 
     /// The command to start the build backend
     pub build_backend: String,
+
+    /// The channels to use for fetching build tools
+    pub channels: Vec<NamedChannelOrUrl>,
 }
 
 #[cfg(test)]
@@ -26,6 +30,7 @@ mod tests {
     #[test]
     fn deserialize_build() {
         let toml = r#"
+            channels = ["conda-forge"]
             dependencies = ["pixi-build-python > 12"]
             build-backend = "pixi-build-python"
             "#;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1183,6 +1183,7 @@ mod tests {
         foo = "1.0"
 
         [build]
+        channels = []
         dependencies = []
         build-backend = "foobar"
 


### PR DESCRIPTION
This PR aims to make easier to integrate isolated build tools https://github.com/prefix-dev/pixi/pull/2479 .

After merging we can also refer to `feature/pixi-build` from pixi-build-backend tools, so it will not fail on deser when reading manifest with `channels` field 