### PR TITLE
docs: update pixi install output

### DIFF
--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -173,7 +173,7 @@ Now let's `install` the project with `pixi install`:
 
 ```shell
 $ pixi install
-✔ Project in /path/to/pixi-py is ready to use!
+✔ The default environment has been installed.
 ```
 
 We now have a new directory called `.pixi` in the project root.


### PR DESCRIPTION
When running through the tutorial I saw a different output message. Looks like it changed here https://github.com/prefix-dev/pixi/pull/1413