### PR TITLE
ci: only update one channel when updating test channel

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -59,8 +59,8 @@ test-integration-slow = { cmd = "pytest --numprocesses=auto --durations=10 tests
 # you can also pass a specific test function, like this:
 # /path/to/test.py::test_function
 test-specific-test = { cmd = "pytest", depends-on = ["build-release"] }
-# Update one test channel by passing on key of `mappings.toml`
-# e.g. "trampoline/trampoline_2.yaml"
+# Update one test channel by passing on value of `mappings.toml`
+# e.g. "multiple_versions_channel_1"
 update-test-channel = { cmd = "python update-channels.py", cwd = "tests/data/channels" }
 
 [feature.dev.dependencies]

--- a/tests/data/channels/update-channels.py
+++ b/tests/data/channels/update-channels.py
@@ -2,35 +2,40 @@ import subprocess
 from pathlib import Path
 import shutil
 import tomllib
+import argparse
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Update a single channel.")
+    parser.add_argument("channel", help="The channel to update")
+    args = parser.parse_args()
+
     platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
     mappings = tomllib.loads(Path("mappings.toml").read_text())
-    channels_dir = Path("channels")
+    channels_dir = Path("channels", args.channel)
     shutil.rmtree(channels_dir, ignore_errors=True)
-    channels_dir.mkdir()
 
     for recipe, channel in mappings.items():
-        print(recipe, channel)
-        for platform in platforms:
-            subprocess.run(
-                [
-                    "rattler-build",
-                    "build",
-                    "--target-platform",
-                    platform,
-                    "--no-include-recipe",
-                    "--output-dir",
-                    f"channels/{channel}",
-                    "--recipe",
-                    f"recipes/{recipe}",
-                ],
-                check=True,
-            )
+        if channel == args.channel:
+            print(recipe, channel)
+            for platform in platforms:
+                subprocess.run(
+                    [
+                        "rattler-build",
+                        "build",
+                        "--target-platform",
+                        platform,
+                        "--no-include-recipe",
+                        "--output-dir",
+                        f"channels/{channel}",
+                        "--recipe",
+                        f"recipes/{recipe}",
+                    ],
+                    check=True,
+                )
 
-        # Remove the build directory using shutil
-        shutil.rmtree(Path(channel, "bld"), ignore_errors=True)
+    # Remove the build directory using shutil
+    shutil.rmtree(channels_dir.joinpath("bld"), ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Something similar has been done before, but it has been lost. Probably during git merge conflict resolution