### PR TITLE
fix: always print a warning when config is invalid

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -666,10 +666,13 @@ impl Config {
         let mut config = Self::load_system();
 
         for p in config_path_global() {
+            if !p.is_file() {
+                continue;
+            }
             match Self::from_path(&p) {
                 Ok(c) => config = config.merge_config(c),
-                Err(e) => tracing::debug!(
-                    "Failed to load global config: {} (error: {})",
+                Err(e) => tracing::warn!(
+                    "Failed to load global config '{}' with error: {}",
                     p.display(),
                     e
                 ),

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -168,6 +168,27 @@ def test_project_commands(pixi: Path, tmp_path: Path) -> None:
     )
 
 
+def test_broken_config(pixi: Path, tmp_path: Path) -> None:
+    env = {"PIXI_HOME": str(tmp_path)}
+    config = tmp_path.joinpath("config.toml")
+    toml = """
+    [repodata-config."https://prefix.dev/"]
+    disable-sharded = false
+    """
+    config.write_text(toml)
+
+    # Test basic commands
+    verify_cli_command([pixi, "info"], env=env)
+
+    toml_invalid = toml + "invalid"
+    config.write_text(toml_invalid)
+    verify_cli_command([pixi, "info"], env=env, stderr_contains="parse error")
+
+    toml_unknown = "invalid-key = true" + toml
+    config.write_text(toml_unknown)
+    verify_cli_command([pixi, "info"], env=env, stderr_contains="Ignoring 'invalid-key'")
+
+
 @pytest.mark.slow
 def test_search(pixi: Path) -> None:
     verify_cli_command(


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/468e31d0-4d80-437b-ade2-73c43c50b18b)

If one of the configs is broken, that's the warning I get with this branch