### PR TITLE
test: make pixi tests work with local config

### DIFF
--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -501,6 +501,7 @@ mod tests {
     use indexmap::IndexSet;
     use insta::assert_snapshot;
     use itertools::Itertools;
+    use pixi_consts::consts::DEFAULT_CHANNELS;
     use rattler_conda_types::ParseStrictness;
 
     use super::*;
@@ -769,7 +770,17 @@ mod tests {
             MatchSpec::from_str("pythonic ==3.15.0", ParseStrictness::Strict).unwrap();
 
         // Add environment
-        manifest.add_environment(&env_name, None).unwrap();
+        manifest
+            .add_environment(
+                &env_name,
+                Some(
+                    DEFAULT_CHANNELS
+                        .iter()
+                        .map(|&name| NamedChannelOrUrl::Name(name.to_string()))
+                        .collect(),
+                ),
+            )
+            .unwrap();
 
         // Add dependency
         manifest

--- a/tests/integration_rust/init_tests.rs
+++ b/tests/integration_rust/init_tests.rs
@@ -55,26 +55,6 @@ async fn specific_channel() {
     )
 }
 
-/// Tests that when initializing an empty project the default channel
-/// `conda-forge` is used.
-#[tokio::test]
-async fn default_channel() {
-    let pixi = PixiControl::new().unwrap();
-
-    // Init a new project
-    pixi.init().no_fast_prefix_overwrite(true).await.unwrap();
-
-    // Load the project
-    let project = pixi.project().unwrap();
-
-    // The only channel should be the "conda-forge" channel
-    let channels = Vec::from_iter(project.default_environment().channels());
-    assert_eq!(
-        channels,
-        [&NamedChannelOrUrl::Name(String::from("conda-forge"))]
-    )
-}
-
 // Test the initialization from an existing pyproject.toml file without the pixi information
 #[tokio::test]
 async fn init_from_existing_pyproject_toml() {


### PR DESCRIPTION
When I changed the defaults-channel in my config some tests stopped working.

I've adapted `test_add_dependency` accordingly.

I didn't manage to adapt `default_channel` so that it would stop parsing the local config