### PR TITLE
refactor: rename `[build]` to `[build-system]`

### DIFF
--- a/crates/pixi_build_frontend/src/protocols/pixi/mod.rs
+++ b/crates/pixi_build_frontend/src/protocols/pixi/mod.rs
@@ -51,7 +51,7 @@ impl Display for FinishError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             FinishError::Init(init) => write!(f, "{init}"),
-            FinishError::NoBuildSection(_) => write!(f, "failed to setup a build backend, the project manifest does not contain a [build] section"),
+            FinishError::NoBuildSection(_) => write!(f, "failed to setup a build backend, the project manifest does not contain a [build-system] section"),
             FinishError::Tool(ToolCacheError::Instantiate(tool, err)) => match err {
                 Error::CannotGetCurrentDirAndPathListEmpty|Error::CannotFindBinaryPath => write!(f, "failed to setup a build backend, the backend tool '{}' could not be found", tool.display()),
                 Error::CannotCanonicalize => write!(f, "failed to setup a build backend, although the backend tool  '{}' can be resolved it could not be canonicalized", tool.display()),

--- a/crates/pixi_build_frontend/src/protocols/pixi/protocol.rs
+++ b/crates/pixi_build_frontend/src/protocols/pixi/protocol.rs
@@ -35,7 +35,9 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 pub enum InitializeError {
     #[error("failed to setup communication with the build backend, an unexpected io error occurred while communicating with the pixi build backend")]
-    #[diagnostic(help("Ensure that the project manifest contains a valid [build] section."))]
+    #[diagnostic(help(
+        "Ensure that the project manifest contains a valid [build-system] section."
+    ))]
     Io(#[from] std::io::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/crates/pixi_build_frontend/src/tool/spec.rs
+++ b/crates/pixi_build_frontend/src/tool/spec.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use pixi_manifest::BuildSection;
+use pixi_manifest::BuildSystem;
 use rattler_conda_types::MatchSpec;
 
 use crate::{BackendOverride, InProcessBackend};
@@ -34,7 +34,7 @@ impl IsolatedToolSpec {
     }
 
     /// Construct a new instance from a build section
-    pub fn from_build_section(build_section: &BuildSection) -> Self {
+    pub fn from_build_section(build_section: &BuildSystem) -> Self {
         Self {
             specs: build_section.dependencies.clone(),
             command: build_section.build_backend.clone(),

--- a/crates/pixi_build_frontend/tests/basic/pixi.toml
+++ b/crates/pixi_build_frontend/tests/basic/pixi.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 
 [tasks]
 
-[build]
+[build-system]
 build-backend = "pixi-build-python"
 dependencies = []
 

--- a/crates/pixi_build_frontend/tests/diagnostics.rs
+++ b/crates/pixi_build_frontend/tests/diagnostics.rs
@@ -105,7 +105,7 @@ async fn test_missing_backend() {
         platforms = []
         channels = []
 
-        [build]
+        [build-system]
         dependencies = []
         build-backend = "non-existing"
         channels = []

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -10,7 +10,7 @@ use serde_with::DisplayFromStr;
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
-pub struct BuildSection {
+pub struct BuildSystem {
     /// The dependencies for the build tools which will be installed in the build environment.
     /// These need to be conda packages
     #[serde_as(as = "Vec<DisplayFromStr>")]
@@ -35,7 +35,7 @@ mod tests {
             build-backend = "pixi-build-python"
             "#;
 
-        let build: BuildSection = toml_edit::de::from_str(toml).unwrap();
+        let build: BuildSystem = toml_edit::de::from_str(toml).unwrap();
         assert_eq!(build.dependencies.len(), 1);
         assert_eq!(
             build.dependencies[0].to_string(),

--- a/crates/pixi_manifest/src/has_environment_dependencies.rs
+++ b/crates/pixi_manifest/src/has_environment_dependencies.rs
@@ -11,7 +11,7 @@ pub trait HasEnvironmentDependencies<'source>:
     /// should be used.
     fn should_combine_dependencies(&self) -> bool {
         // If the manifest has a build section defined we should not combine.
-        if self.manifest().workspace.build.is_some() {
+        if self.manifest().workspace.build_system.is_some() {
             return false;
         }
         true

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -1,5 +1,5 @@
 mod activation;
-mod build;
+mod build_system;
 pub(crate) mod channel;
 mod dependencies;
 mod environment;
@@ -24,7 +24,7 @@ mod validation;
 mod workspace;
 
 pub use activation::Activation;
-pub use build::BuildSection;
+pub use build_system::BuildSystem;
 pub use channel::{PrioritizedChannel, TomlPrioritizedChannelStrOrMap};
 pub use dependencies::{CondaDependencies, Dependencies, PyPiDependencies};
 pub use environment::{Environment, EnvironmentName};

--- a/crates/pixi_manifest/src/manifests/manifest.rs
+++ b/crates/pixi_manifest/src/manifests/manifest.rs
@@ -22,7 +22,7 @@ use crate::{
     preview::Preview,
     pypi::PyPiPackageName,
     pyproject::PyProjectManifest,
-    to_options, BuildSection, DependencyOverwriteBehavior, Environment, EnvironmentName, Feature,
+    to_options, BuildSystem, DependencyOverwriteBehavior, Environment, EnvironmentName, Feature,
     FeatureName, GetFeatureError, PrioritizedChannel, PypiDependencyLocation, SpecType, Target,
     TargetSelector, Task, TaskName, WorkspaceManifest,
 };
@@ -738,8 +738,8 @@ impl Manifest {
     }
 
     /// Return the build section from the parsed manifest
-    pub fn build_section(&self) -> Option<&BuildSection> {
-        self.workspace.build.as_ref()
+    pub fn build_section(&self) -> Option<&BuildSystem> {
+        self.workspace.build_system.as_ref()
     }
 }
 

--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_key.snap
+++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_key.snap
@@ -6,7 +6,7 @@ TOML parse error at line 8, column 2
   |
 8 | [foobar]
   |  ^^^^^^
-unknown field `foobar`, expected one of `project`, `workspace`, `system-requirements`, `target`, `dependencies`, `host-dependencies`, `build-dependencies`, `pypi-dependencies`, `activation`, `tasks`, `feature`, `environments`, `pypi-options`, `tool`, `build`, `$schema`
+unknown field `foobar`, expected one of `project`, `workspace`, `system-requirements`, `target`, `dependencies`, `host-dependencies`, `build-dependencies`, `pypi-dependencies`, `activation`, `tasks`, `feature`, `environments`, `pypi-options`, `tool`, `build-system`, `$schema`
 
 TOML parse error at line 8, column 16
   |

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -25,7 +25,7 @@ use crate::{
     task::{Task, TaskName},
     utils::PixiSpanned,
     workspace::Workspace,
-    BuildSection,
+    BuildSystem,
 };
 
 /// Holds the parsed content of the workspace part of a pixi manifest. This
@@ -45,7 +45,7 @@ pub struct WorkspaceManifest {
     pub solve_groups: SolveGroups,
 
     /// The build section of the project.
-    pub build: Option<BuildSection>,
+    pub build_system: Option<BuildSystem>,
 }
 
 impl WorkspaceManifest {
@@ -175,7 +175,7 @@ impl<'de> Deserialize<'de> for WorkspaceManifest {
 
             /// The build section
             #[serde(default)]
-            build: Option<BuildSection>,
+            build_system: Option<BuildSystem>,
 
             /// The URI for the manifest schema which is unused by pixi
             #[allow(dead_code)]
@@ -272,14 +272,14 @@ impl<'de> Deserialize<'de> for WorkspaceManifest {
             }));
         }
 
-        let build = toml_manifest.build;
+        let build = toml_manifest.build_system;
 
         Ok(Self {
             workspace: toml_manifest.workspace,
             features,
             environments,
             solve_groups,
-            build,
+            build_system: build,
         })
     }
 }
@@ -695,7 +695,7 @@ mod tests {
         channels = []
         platforms = []
 
-        [build]
+        [build-system]
         dependencies = ["python-build-backend > 12"]
         build-backend = "python-build-backend"
         channels = []
@@ -703,7 +703,7 @@ mod tests {
         .to_string();
         let manifest = toml_edit::de::from_str::<WorkspaceManifest>(&contents)
             .expect("parsing should succeed!");
-        assert_yaml_snapshot!(manifest.build.clone().unwrap());
+        assert_yaml_snapshot!(manifest.build_system.clone().unwrap());
     }
 
     #[test]
@@ -714,7 +714,7 @@ mod tests {
         channels = []
         platforms = []
 
-        [build]
+        [build-system]
         dependencies = ["python-build-backend > > 12"]
         build-backend = "python-build-backend"
         channels = []

--- a/crates/pixi_manifest/src/validation.rs
+++ b/crates/pixi_manifest/src/validation.rs
@@ -149,7 +149,7 @@ impl WorkspaceManifest {
         }
 
         // If there is a build section, make sure the build-string is not empty
-        if let Some(build) = &self.build {
+        if let Some(build) = &self.build_system {
             if build.build_backend.is_empty() {
                 return Err(miette::miette!(
                     help = "the build-backend must contain at least one command. e.g `pixi-build-python`",

--- a/examples/cpp-sdl/pixi.lock
+++ b/examples/cpp-sdl/pixi.lock
@@ -598,7 +598,7 @@ packages:
   - libgcc >=14
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: 8fe88cb413ec9dcc95f35ab7b0e49f404290867442a1160385ccf131215b4614
     globs:
     - pixi.toml
 - conda: .
@@ -610,7 +610,7 @@ packages:
   - libcxx >=19
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: 8fe88cb413ec9dcc95f35ab7b0e49f404290867442a1160385ccf131215b4614
     globs:
     - pixi.toml
 - conda: .
@@ -622,7 +622,7 @@ packages:
   - libcxx >=19
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: 8fe88cb413ec9dcc95f35ab7b0e49f404290867442a1160385ccf131215b4614
     globs:
     - pixi.toml
 - conda: .
@@ -635,7 +635,7 @@ packages:
   - vc14_runtime >=14.16.27033
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: 8fe88cb413ec9dcc95f35ab7b0e49f404290867442a1160385ccf131215b4614
     globs:
     - pixi.toml
 - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda

--- a/examples/cpp-sdl/pixi.lock
+++ b/examples/cpp-sdl/pixi.lock
@@ -598,7 +598,7 @@ packages:
   - libgcc >=14
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
+    hash: 5abe578bb48a8ee24adc82a49cfe96c89dcac6a00d7f36ab86b5f602bb65bd42
     globs:
     - pixi.toml
 - conda: .
@@ -610,7 +610,7 @@ packages:
   - libcxx >=19
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
+    hash: 5abe578bb48a8ee24adc82a49cfe96c89dcac6a00d7f36ab86b5f602bb65bd42
     globs:
     - pixi.toml
 - conda: .
@@ -622,7 +622,7 @@ packages:
   - libcxx >=19
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
+    hash: 5abe578bb48a8ee24adc82a49cfe96c89dcac6a00d7f36ab86b5f602bb65bd42
     globs:
     - pixi.toml
 - conda: .
@@ -635,7 +635,7 @@ packages:
   - vc14_runtime >=14.16.27033
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
+    hash: 5abe578bb48a8ee24adc82a49cfe96c89dcac6a00d7f36ab86b5f602bb65bd42
     globs:
     - pixi.toml
 - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda

--- a/examples/cpp-sdl/pixi.toml
+++ b/examples/cpp-sdl/pixi.toml
@@ -5,7 +5,7 @@ description = "Showcases how to create a simple C++ executable with Pixi"
 name = "sdl_example"
 platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
 
-[build]
+[build-system]
 build-backend = "pixi-build-cmake"
 channels = [
   "https://prefix.dev/pixi-build-backends",

--- a/examples/flask-hello-world-pyproject/pyproject.toml
+++ b/examples/flask-hello-world-pyproject/pyproject.toml
@@ -38,7 +38,7 @@ test = ["pytest>=8.3.3,<9"]
 hatchling = "*"
 
 
-[tool.pixi.build]
+[tool.pixi.build-system]
 build-backend = "pixi-build-python"
 channels = [
   "https://repo.prefix.dev/pixi-build-backends",

--- a/examples/flask-hello-world/pixi.toml
+++ b/examples/flask-hello-world/pixi.toml
@@ -12,7 +12,7 @@ start = "python -m flask run --port=5050"
 [dependencies]
 flask = "2.*"
 
-[build]
+[build-system]
 build-backend = "pixi-build-python"
 channels = [
   "https://fast.prefix.dev/pixi-build-backends",

--- a/schema/examples/valid/full.toml
+++ b/schema/examples/valid/full.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 repository = "https://github.com/author/project"
 version = "0.1.0"
 
-[build]
+[build-system]
 build-backend = "pixi-build-python"
 channels = [
   "https://prefix.dev/pixi-build-backends",

--- a/schema/model.py
+++ b/schema/model.py
@@ -35,6 +35,10 @@ GitUrl = Annotated[
 ]
 
 
+def hyphenize(field: str):
+    return field.replace("_", "-")
+
+
 class Platform(str, Enum):
     """A supported operating system and processor architecture pair."""
 
@@ -63,6 +67,7 @@ class Platform(str, Enum):
 class StrictBaseModel(BaseModel):
     class Config:
         extra = "forbid"
+        alias_generator = hyphenize
 
 
 ###################
@@ -113,7 +118,6 @@ class Project(StrictBaseModel):
     )
     channel_priority: ChannelPriority | None = Field(
         None,
-        alias="channel-priority",
         examples=["strict", "disabled"],
         description="The type of channel priority that is used in the solve."
         "- 'strict': only take the package from the channel it exist in first."
@@ -125,7 +129,7 @@ class Project(StrictBaseModel):
         description="The license of the project; we advise using an [SPDX](https://spdx.org/licenses/) identifier.",
     )
     license_file: PathNoBackslash | None = Field(
-        None, alias="license-file", description="The path to the license file of the project"
+        None, description="The path to the license file of the project"
     )
     readme: PathNoBackslash | None = Field(
         None, description="The path to the readme file of the project"
@@ -138,13 +142,13 @@ class Project(StrictBaseModel):
         None, description="The URL of the documentation of the project"
     )
     conda_pypi_map: dict[ChannelName, AnyHttpUrl | NonEmptyStr] | None = Field(
-        None, alias="conda-pypi-map", description="The `conda` to PyPI mapping configuration"
+        None, description="The `conda` to PyPI mapping configuration"
     )
     pypi_options: PyPIOptions | None = Field(
-        None, alias="pypi-options", description="Options related to PyPI indexes for this project"
+        None, description="Options related to PyPI indexes for this project"
     )
     preview: list[KnownPreviewFeature | str] | bool | None = Field(
-        None, alias="preview", description="Defines the enabling of preview features of the project"
+        None, description="Defines the enabling of preview features of the project"
     )
 
 
@@ -163,12 +167,9 @@ class MatchspecTable(StrictBaseModel):
     build: NonEmptyStr | None = Field(None, description="The build string of the package")
     build_number: NonEmptyStr | None = Field(
         None,
-        alias="build-number",
         description="The build number of the package, can be a spec like `>=1` or `<=10` or `1`",
     )
-    file_name: NonEmptyStr | None = Field(
-        None, alias="file-name", description="The file name of the package"
-    )
+    file_name: NonEmptyStr | None = Field(None, description="The file name of the package")
     channel: NonEmptyStr | None = Field(
         None,
         description="The channel the packages needs to be fetched from",
@@ -197,13 +198,11 @@ CondaPackageName = NonEmptyStr
 #####################
 # The Build section #
 #####################
-class BuildSection(StrictBaseModel):
+class BuildSystem(StrictBaseModel):
     dependencies: list[MatchSpec] = Field(
         None, description="The dependencies for the build backend"
     )
-    build_backend: NonEmptyStr = Field(
-        None, alias="build-backend", description="The build executable to call"
-    )
+    build_backend: NonEmptyStr = Field(None, description="The build executable to call")
     channels: list[Channel] = Field(
         None, description="The `conda` channels that are used to fetch the build backend from"
     )
@@ -282,13 +281,11 @@ DependenciesField = Field(
 )
 HostDependenciesField = Field(
     None,
-    alias="host-dependencies",
     description="The host `conda` dependencies, used in the build process",
     examples=[{"python": ">=3.8"}],
 )
 BuildDependenciesField = Field(
     None,
-    alias="build-dependencies",
     description="The build `conda` dependencies, used in the build process",
 )
 Dependencies = dict[CondaPackageName, MatchSpec] | None
@@ -315,7 +312,6 @@ class TaskInlineTable(StrictBaseModel):
     )
     depends_on: list[TaskName] | TaskName | None = Field(
         None,
-        alias="depends-on",
         description="The tasks that this task depends on. Environment variables will **not** be expanded.",
     )
     inputs: list[Glob] | None = Field(
@@ -338,7 +334,6 @@ class TaskInlineTable(StrictBaseModel):
     )
     clean_env: bool | None = Field(
         None,
-        alias="clean-env",
         description="Whether to run in a clean environment, removing all environment variables except those defined in `env` and by pixi itself.",
     )
 
@@ -388,12 +383,10 @@ class Environment(StrictBaseModel):
     )
     solve_group: SolveGroupName | None = Field(
         None,
-        alias="solve-group",
         description="The group name for environments that should be solved together",
     )
     no_default_feature: Optional[bool] = Field(
         False,
-        alias="no-default-feature",
         description="Whether to add the default feature to this environment",
     )
 
@@ -429,7 +422,7 @@ class Target(StrictBaseModel):
     host_dependencies: Dependencies = HostDependenciesField
     build_dependencies: Dependencies = BuildDependenciesField
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
-        None, alias="pypi-dependencies", description="The PyPI dependencies for this target"
+        None, description="The PyPI dependencies for this target"
     )
     tasks: dict[TaskName, TaskInlineTable | NonEmptyStr] | None = Field(
         None, description="The tasks of the target"
@@ -451,7 +444,6 @@ class Feature(StrictBaseModel):
     )
     channel_priority: ChannelPriority | None = Field(
         None,
-        alias="channel-priority",
         examples=["strict", "disabled"],
         description="The type of channel priority that is used in the solve."
         "- 'strict': only take the package from the channel it exist in first."
@@ -465,7 +457,7 @@ class Feature(StrictBaseModel):
     host_dependencies: Dependencies = HostDependenciesField
     build_dependencies: Dependencies = BuildDependenciesField
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
-        None, alias="pypi-dependencies", description="The PyPI dependencies of this feature"
+        None, description="The PyPI dependencies of this feature"
     )
     tasks: dict[TaskName, TaskInlineTable | NonEmptyStr] | None = Field(
         None, description="The tasks provided by this feature"
@@ -474,7 +466,7 @@ class Feature(StrictBaseModel):
         None, description="The scripts used on the activation of environments using this feature"
     )
     system_requirements: SystemRequirements | None = Field(
-        None, alias="system-requirements", description="The system requirements of this feature"
+        None, description="The system requirements of this feature"
     )
     target: dict[TargetName, Target] | None = Field(
         None,
@@ -482,7 +474,7 @@ class Feature(StrictBaseModel):
         examples=[{"linux": {"dependencies": {"python": "3.8"}}}],
     )
     pypi_options: PyPIOptions | None = Field(
-        None, alias="pypi-options", description="Options related to PyPI indexes for this feature"
+        None, description="Options related to PyPI indexes for this feature"
     )
 
 
@@ -514,25 +506,21 @@ class PyPIOptions(StrictBaseModel):
 
     index_url: NonEmptyStr | None = Field(
         None,
-        alias="index-url",
         description="PyPI registry that should be used as the primary index",
         examples=["https://pypi.org/simple"],
     )
     extra_index_urls: list[NonEmptyStr] | None = Field(
         None,
-        alias="extra-index-urls",
         description="Additional PyPI registries that should be used as extra indexes",
         examples=[["https://pypi.org/simple"]],
     )
     find_links: list[FindLinksPath | FindLinksURL] = Field(
         None,
-        alias="find-links",
         description="Paths to directory containing",
         examples=[["https://pypi.org/simple"]],
     )
     no_build_isolation: list[PyPIPackageName] = Field(
         None,
-        alias="no-build-isolation",
         description="Packages that should NOT be isolated during the build process",
         examples=[["numpy"]],
     )
@@ -540,7 +528,6 @@ class PyPIOptions(StrictBaseModel):
         Literal["first-index"] | Literal["unsafe-first-match"] | Literal["unsafe-best-match"] | None
     ) = Field(
         None,
-        alias="index-strategy",
         description="The strategy to use when resolving packages from multiple indexes",
         examples=["first-index", "unsafe-first-match", "unsafe-best-match"],
     )
@@ -574,16 +561,14 @@ class BaseManifest(StrictBaseModel):
     host_dependencies: Dependencies = HostDependenciesField
     build_dependencies: Dependencies = BuildDependenciesField
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
-        None, alias="pypi-dependencies", description="The PyPI dependencies"
+        None, description="The PyPI dependencies"
     )
-    pypi_options: PyPIOptions | None = Field(
-        None, alias="pypi-options", description="Options related to PyPI indexes"
-    )
+    pypi_options: PyPIOptions | None = Field(None, description="Options related to PyPI indexes")
     tasks: dict[TaskName, TaskInlineTable | NonEmptyStr] | None = Field(
         None, description="The tasks of the project"
     )
     system_requirements: SystemRequirements | None = Field(
-        None, alias="system-requirements", description="The system requirements of the project"
+        None, description="The system requirements of the project"
     )
     environments: dict[EnvironmentName, Environment | list[FeatureName]] | None = Field(
         None,
@@ -605,10 +590,11 @@ class BaseManifest(StrictBaseModel):
     )
     pypi_options: PyPIOptions | None = Field(
         None,
-        alias="pypi-options",
         description="Options related to PyPI indexes, on the default feature",
     )
-    build: BuildSection | None = Field(None, description="The build section of the project")
+    build_system: BuildSystem | None = Field(
+        None, description="The build-system used to build the package."
+    )
 
 
 #########################

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -20,10 +20,6 @@
       "$ref": "#/$defs/Activation",
       "description": "The scripts used on the activation of the project"
     },
-    "build": {
-      "$ref": "#/$defs/BuildSection",
-      "description": "The build section of the project"
-    },
     "build-dependencies": {
       "title": "Build-Dependencies",
       "description": "The build `conda` dependencies, used in the build process",
@@ -39,6 +35,10 @@
           }
         ]
       }
+    },
+    "build-system": {
+      "$ref": "#/$defs/BuildSystem",
+      "description": "The build-system used to build the package."
     },
     "dependencies": {
       "title": "Dependencies",
@@ -229,8 +229,8 @@
         }
       }
     },
-    "BuildSection": {
-      "title": "BuildSection",
+    "BuildSystem": {
+      "title": "BuildSystem",
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1203,7 +1203,7 @@ mod tests {
         [dependencies]
         foo = "1.0"
 
-        [build]
+        [build-system]
         channels = []
         dependencies = []
         build-backend = "foobar"


### PR DESCRIPTION
We decided to rename `[build]` to `[build-system]`. This change takes care of that.

I also took the liberty to remove most `alias`es from `model.py` and use an `alias_generator` instead. Less code is better!