### PR TITLE
feat: add pixi-build behind preview feature

### DIFF
--- a/crates/pixi_manifest/src/preview.rs
+++ b/crates/pixi_manifest/src/preview.rs
@@ -92,7 +92,8 @@ impl PartialEq<KnownPreviewFeature> for PreviewFeature {
 #[serde(rename_all = "kebab-case")]
 /// Currently supported preview features are listed here
 pub enum KnownPreviewFeature {
-    // Add known features here
+    /// Build feature, to enable conda source builds
+    PixiBuild,
 }
 
 impl<'de> Deserialize<'de> for PreviewFeature {

--- a/crates/pixi_manifest/src/validation.rs
+++ b/crates/pixi_manifest/src/validation.rs
@@ -9,7 +9,8 @@ use std::{
 
 use super::pypi::pypi_options::PypiOptions;
 use crate::{
-    Environment, Feature, FeatureName, SystemRequirements, TargetSelector, WorkspaceManifest,
+    Environment, Feature, FeatureName, KnownPreviewFeature, SystemRequirements, TargetSelector,
+    WorkspaceManifest,
 };
 
 impl WorkspaceManifest {
@@ -148,8 +149,39 @@ impl WorkspaceManifest {
             }
         }
 
-        // If there is a build section, make sure the build-string is not empty
+        // Check if the pixi build feature is enabled
+        let build_enabled = self
+            .workspace
+            .preview
+            .as_ref()
+            .map(|p| p.is_enabled(KnownPreviewFeature::PixiBuild))
+            .unwrap_or(false);
+
+        // Error any conda source dependencies are used and is not set
+        if !build_enabled {
+            let supported_platforms = self.workspace.platforms.as_ref();
+            // Check all features for source dependencies
+            for feature in self.features.values() {
+                if is_using_source_deps(feature, supported_platforms.iter()) {
+                    return Err(miette::miette!(
+                        help = "enable the `build` preview feature to use source dependencies",
+                        "source dependencies are used in the feature '{}', but the `pixi-build` preview feature is not enabled",
+                        feature.name
+                    ));
+                }
+            }
+        }
+
         if let Some(build) = &self.build {
+            // Check if we have enabled the build feature if we have a build section
+            if !build_enabled {
+                return Err(miette::miette!(
+                    help = "enable the `build` preview feature to use the build section",
+                    "the build section is defined, but the `pixi-build` preview feature is not enabled"
+                ));
+            }
+
+            // If there is a build section, make sure the build-string is not empty
             if build.build_backend.is_empty() {
                 return Err(miette::miette!(
                     help = "the build-backend must contain at least one command. e.g `pixi-build-python`",
@@ -242,6 +274,32 @@ impl WorkspaceManifest {
 
         Ok(())
     }
+}
+
+/// Check if any feature is making use of conda source dependencies
+fn is_using_source_deps<'a>(
+    feature: &Feature,
+    supported_platforms: impl IntoIterator<Item = &'a Platform>,
+) -> bool {
+    // List all spec types
+    let spec_types = [
+        crate::SpecType::Build,
+        crate::SpecType::Run,
+        crate::SpecType::Host,
+    ];
+    // Check if any of the spec types have source dependencies
+    for platform in supported_platforms {
+        for spec in spec_types {
+            let deps = feature.dependencies(spec, Some(platform.clone()));
+            if let Some(deps) = deps {
+                if deps.iter().any(|(_, spec)| spec.is_source()) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
 }
 
 // Create an error report for using a platform that is not supported by the


### PR DESCRIPTION
### Description

This PR gates the pixi-build feature behind the recently introduced preview features. This requires the `pixi-build` preview feature to be enabled and this is checked on validation. We've decided on this name with @ruben-arts, but I'm fine changing it if we dont like it.

I thought adding in validation would be the way to go, curious to know if this would miss anything,

### Tests
A couple of automated test have been added to the manifest so that we can check if we properly error when either the `[build]` or a source dependency is used in any feature/platform combination.