### PR TITLE
test: add alias for `pixi run test-all-fast`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -27,6 +27,7 @@ release = "python scripts/release.py"
 run-all-examples = { cmd = "python tests/scripts/run-all-examples.py --pixi-exec $CARGO_TARGET_DIR/release/pixi", depends-on = [
   "build-release",
 ] }
+test = { depends-on = ["test-all-fast"] }
 test-all-fast = { depends-on = ["test-fast", "test-integration-fast"] }
 test-all-slow = { depends-on = ["test-slow", "test-integration-slow"] }
 test-fast = "cargo nextest run --workspace"


### PR DESCRIPTION
That way developers can just run `pixi run test`