### PR TITLE
fix path variable dynamicism

### DIFF
--- a/crates/pixi_trampoline/src/main.rs
+++ b/crates/pixi_trampoline/src/main.rs
@@ -46,22 +46,23 @@ fn trampoline() -> miette::Result<()> {
     let current_exe = env::current_exe().into_diagnostic().wrap_err("Couldn't get the `env::current_exe`")?;
 
     // ignore any ctrl-c signals
-    ctrlc::set_handler(move || {}).into_diagnostic().wrap_err("Couldn't set the ctrl-c handler")?;
+    ctrlc::set_handler(move || {}).into_diagnostic().wrap_err("Could not unset the ctrl-c handler")?;
 
     let metadata = read_metadata(&current_exe)?;
 
     // Create a new Command for the specified executable
     let mut cmd = Command::new(metadata.exe);
 
-    let new_path = prepend_path(&metadata.path)?;
-
-    // Set the PATH environment variable
-    cmd.env("PATH", new_path);
-
     // Set any additional environment variables
     for (key, value) in metadata.env.iter() {
         cmd.env(key, value);
     }
+
+    // Prepend the specified path to the PATH environment variable
+    let new_path = prepend_path(&metadata.path)?;
+
+    // Set the PATH environment variable
+    cmd.env("PATH", new_path);
 
     // Add any additional arguments
     cmd.args(&args[1..]);


### PR DESCRIPTION
We almost did the right thing, but then the env var was overwritten again because we also store the PATH as part of the `env` vars in the dictionary in JSON trampoline.

However, I am not sure that this works correctly on Windows. On my macBook, the trampoline JSON contains:

```
{
  "exe": "/Users/wolfv/.pixi/envs/coreutils/bin/base32",
  "path": "/Users/wolfv/.pixi/envs/coreutils/bin",
  "env": {
    "PATH": "/Users/wolfv/.pixi/envs/coreutils/bin:/Users/wolfv/.pixi/bin:/Users/wolfv/Library/pnpm:/Users/wolfv/Programs/pixi/target/release/:/Users/wolfv/Programs/rattler-build/target/release:/Users/wolfv/Programs/rattler/target/release:/opt/homebrew/share/google-cloud-sdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/Users/wolfv/.cargo/bin:/Applications/iTerm.app/Contents/Resources/utilities:/Users/wolfv/.pixi/bin",
    "CONDA_PREFIX": "/Users/wolfv/.pixi/envs/coreutils"
  }
}
```

The `path` is the correct, single entry on unix systems. On Windows, we need to add 5 paths to the PATH variable https://github.com/conda/rattler/blob/32eefc87ef0f1bc5bcc0bb65183b97e71808f54c/crates/rattler_shell/src/activation.rs#L277-L290

Maybe @baszalmstra can quickly check if we need to correct the code for Windows?