### PR TITLE
fix: keep the case when getting the executable

### DIFF
--- a/crates/pixi_utils/src/executable_utils.rs
+++ b/crates/pixi_utils/src/executable_utils.rs
@@ -2,46 +2,52 @@ use std::path::Path;
 
 /// Strips known Windows executable extensions from a file name.
 pub(crate) fn strip_windows_executable_extension(file_name: String) -> String {
-    let file_name = file_name.to_lowercase();
-    // Attempt to retrieve the PATHEXT environment variable
+    // Create lowercase version for comparison
+    let lowercase_name = file_name.to_lowercase();
+
+    // Get extensions list
     let extensions_list: Vec<String> = if let Ok(pathext) = std::env::var("PATHEXT") {
         pathext.split(';').map(|s| s.to_lowercase()).collect()
     } else {
-        // Fallback to a default list if PATHEXT is not set
         tracing::debug!("Could not find 'PATHEXT' variable, using a default list");
         [
-            ".COM", ".EXE", ".BAT", ".CMD", ".VBS", ".VBE", ".JS", ".JSE", ".WSF", ".WSH", ".MSC",
-            ".CPL",
+            ".com", ".exe", ".bat", ".cmd", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".msc",
+            ".cpl",
         ]
         .iter()
-        .map(|s| s.to_lowercase())
+        .map(|s| s.to_string())
         .collect()
     };
 
-    // Attempt to strip any known Windows executable extension
-    extensions_list
-        .iter()
-        .find_map(|ext| file_name.strip_suffix(ext))
-        .map(|f| f.to_string())
-        .unwrap_or(file_name)
+    // Check for matches while preserving original case
+    for ext in extensions_list {
+        if lowercase_name.ends_with(&ext) {
+            return file_name[..file_name.len() - ext.len()].to_string();
+        }
+    }
+
+    file_name
 }
 
 /// Strips known Unix executable extensions from a file name.
 pub(crate) fn strip_unix_executable_extension(file_name: String) -> String {
-    let file_name = file_name.to_lowercase();
-
     // Define a list of common Unix executable extensions
     let extensions_list: Vec<&str> = vec![
         ".sh", ".bash", ".zsh", ".csh", ".tcsh", ".ksh", ".fish", ".py", ".pl", ".rb", ".lua",
         ".php", ".tcl", ".awk", ".sed",
     ];
 
+    // Create lowercase version for comparison only
+    let lowercase_name = file_name.to_lowercase();
+
     // Attempt to strip any known Unix executable extension
-    extensions_list
-        .iter()
-        .find_map(|&ext| file_name.strip_suffix(ext))
-        .map(|f| f.to_string())
-        .unwrap_or(file_name)
+    for ext in extensions_list {
+        if lowercase_name.ends_with(ext) {
+            return file_name[..file_name.len() - ext.len()].to_string();
+        }
+    }
+
+    file_name
 }
 
 /// Strips known executable extensions from a file name based on the target operating system.
@@ -50,8 +56,7 @@ pub(crate) fn strip_unix_executable_extension(file_name: String) -> String {
 /// or `strip_unix_executable_extension` depending on the target OS.
 pub fn executable_from_path(path: &Path) -> String {
     let file_name = path
-        .iter()
-        .last()
+        .file_name()
         .unwrap_or(path.as_os_str())
         .to_string_lossy()
         .to_string();
@@ -120,5 +125,43 @@ mod tests {
         // Make sure running it twice doesn't break it
         let result = strip_executable_extension(result);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_unix_extensions() {
+        let test_cases = vec![
+            ("script.sh", "script"),
+            ("MyScript.PY", "MyScript"),
+            ("CamelCase.Sh", "CamelCase"),
+            ("noextension", "noextension"),
+            ("", ""),
+            ("path/to/Script.bash", "path/to/Script"),
+            ("my.script.py", "my.script"),
+        ];
+
+        for (input, expected) in test_cases {
+            assert_eq!(strip_unix_executable_extension(input.to_string()), expected);
+        }
+    }
+
+    #[test]
+    fn test_windows_extensions() {
+        let test_cases = vec![
+            ("program.exe", "program"),
+            ("MyProgram.EXE", "MyProgram"),
+            ("Script.BAT", "Script"),
+            ("noextension", "noextension"),
+            ("", ""),
+            ("C:\\Path\\To\\Program.COM", "C:\\Path\\To\\Program"),
+            ("my.program.exe", "my.program"),
+            ("WeIrDcAsE.ExE", "WeIrDcAsE"),
+        ];
+
+        for (input, expected) in test_cases {
+            assert_eq!(
+                strip_windows_executable_extension(input.to_string()),
+                expected
+            );
+        }
     }
 }


### PR DESCRIPTION
For comparison purposes we were always lower-casing the executable name. However, we also returned the lowercase version and exposed executables as lowercase which doesn't match user expectations.

With this PR we are instead returning the original case. 

I cannot judge if this affects current exposed binaries. However, I assume we would just keep the lower-case exposed binary as written in the global manifest and only change newly installed tools.

fixes https://github.com/prefix-dev/pixi/issues/2478