### PR TITLE
fix: CI for feature/pixi-build

### DIFF
--- a/crates/pixi_build_frontend/src/protocols/pixi/mod.rs
+++ b/crates/pixi_build_frontend/src/protocols/pixi/mod.rs
@@ -125,10 +125,15 @@ impl ProtocolBuilder {
             .backend_spec
             .ok_or(FinishError::NoBuildSection(self.manifest.path.clone()))?;
 
+        eprintln!("tool spec is {:?}", tool_spec);
+
+        eprintln!("tool contextn  is {:?}", tool.context);
         let tool = tool
             .instantiate(tool_spec)
             .await
             .map_err(FinishError::Tool)?;
+
+        eprintln!("tool is {:?}", tool);
 
         Ok(Protocol::setup(
             self.source_dir,

--- a/crates/pixi_build_frontend/src/protocols/pixi/mod.rs
+++ b/crates/pixi_build_frontend/src/protocols/pixi/mod.rs
@@ -125,15 +125,10 @@ impl ProtocolBuilder {
             .backend_spec
             .ok_or(FinishError::NoBuildSection(self.manifest.path.clone()))?;
 
-        eprintln!("tool spec is {:?}", tool_spec);
-
-        eprintln!("tool contextn  is {:?}", tool.context);
         let tool = tool
             .instantiate(tool_spec)
             .await
             .map_err(FinishError::Tool)?;
-
-        eprintln!("tool is {:?}", tool);
 
         Ok(Protocol::setup(
             self.source_dir,

--- a/crates/pixi_build_frontend/src/tool/cache.rs
+++ b/crates/pixi_build_frontend/src/tool/cache.rs
@@ -187,7 +187,7 @@ impl ToolCache {
         let tool: CachedTool = match spec {
             CacheableToolSpec::Isolated(spec) => CachedTool::Isolated(if spec.specs.is_empty() {
                 return Err(ToolCacheError::Install(miette!(
-                    "No build specs provided for '{}' command.",
+                    "No build match specs provided for '{}' command.",
                     spec.command
                 )));
             } else {

--- a/crates/pixi_build_frontend/src/tool/spec.rs
+++ b/crates/pixi_build_frontend/src/tool/spec.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_consts::consts::CACHED_BUILD_ENVS_DIR;
 use pixi_manifest::BuildSection;
@@ -89,6 +90,14 @@ impl IsolatedToolSpec {
             })
             .into_diagnostic()?;
 
+        eprintln!("spec is {:?}", self.specs);
+        if solved_records.is_empty() {
+            miette::bail!(
+                "could not find {}",
+                self.specs.iter().map(|spec| spec.to_string()).join(",")
+            );
+        }
+
         let cache = EnvironmentHash::new(
             self.command.clone(),
             self.specs.clone(),
@@ -114,7 +123,7 @@ impl IsolatedToolSpec {
             ))
             .install(&cached_dir, solved_records)
             .await
-            .unwrap();
+            .into_diagnostic()?;
 
         // Get the activation scripts
         let activator =

--- a/crates/pixi_build_frontend/src/tool/spec.rs
+++ b/crates/pixi_build_frontend/src/tool/spec.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_consts::consts::CACHED_BUILD_ENVS_DIR;
 use pixi_manifest::BuildSection;
@@ -89,14 +88,6 @@ impl IsolatedToolSpec {
                 ..SolverTask::from_iter(&repodata)
             })
             .into_diagnostic()?;
-
-        eprintln!("spec is {:?}", self.specs);
-        if solved_records.is_empty() {
-            miette::bail!(
-                "could not find {}",
-                self.specs.iter().map(|spec| spec.to_string()).join(",")
-            );
-        }
 
         let cache = EnvironmentHash::new(
             self.command.clone(),

--- a/crates/pixi_build_frontend/tests/snapshots/diagnostics__missing_backend.snap
+++ b/crates/pixi_build_frontend/tests/snapshots/diagnostics__missing_backend.snap
@@ -2,4 +2,4 @@
 source: crates/pixi_build_frontend/tests/diagnostics.rs
 expression: snapshot
 ---
-  × failed to setup a build backend, the backend tool could not be installed: No build specs provided for 'non-existing' command.
+  × failed to setup a build backend, the backend tool could not be installed: No build match specs provided for 'non-existing' command.

--- a/crates/pixi_build_frontend/tests/snapshots/diagnostics__missing_backend.snap
+++ b/crates/pixi_build_frontend/tests/snapshots/diagnostics__missing_backend.snap
@@ -2,4 +2,4 @@
 source: crates/pixi_build_frontend/tests/diagnostics.rs
 expression: snapshot
 ---
-  × failed to setup a build backend, the backend tool 'non-existing' could not be found
+  × failed to setup a build backend, the backend tool could not be installed: No build specs provided for 'non-existing' command.

--- a/examples/cpp-sdl/pixi.lock
+++ b/examples/cpp-sdl/pixi.lock
@@ -598,7 +598,7 @@ packages:
   - libgcc >=14
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
     globs:
     - pixi.toml
 - conda: .
@@ -610,7 +610,7 @@ packages:
   - libcxx >=19
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
     globs:
     - pixi.toml
 - conda: .
@@ -622,7 +622,7 @@ packages:
   - libcxx >=19
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
     globs:
     - pixi.toml
 - conda: .
@@ -635,7 +635,7 @@ packages:
   - vc14_runtime >=14.16.27033
   - sdl2 >=2.30.7,<3.0a0
   input:
-    hash: eff52d96c66ed874d6f943863e7604d2dad918486c4b56c6b72f0d3098d31715
+    hash: e44e13c9ff79a4d053aa32b2bf2d5cea26b3a0337a6a6ca357eb87f27a11b2c2
     globs:
     - pixi.toml
 - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -184,7 +184,6 @@ impl BuildContext {
             path: self.fetch_pinned_source(&source_spec.source).await?,
             pinned: source_spec.source.clone(),
         };
-        eprintln!("passed build channels {:?}", build_channels);
 
         let channels_urls: Vec<Url> = channels.iter().cloned().map(Into::into).collect::<Vec<_>>();
 

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -15,7 +15,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 @pytest.fixture
 def pixi(request: pytest.FixtureRequest) -> Path:
     pixi_build = request.config.getoption("--pixi-build")
-    return Path(__file__).parent.joinpath(f"../../target/{pixi_build}/pixi")
+    return Path(__file__).parent.joinpath(f"../../target-pixi/{pixi_build}/pixi")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Overview
Fix failing CI after *happily* merging isolated tools in `feature/pixi-build`.
This introduced 2 regression:
* unupdated `cpp_sdl/pixi.lock`.
* a missing correct error when user defined only build command without dependencies.