### PR TITLE
docs: Fix typo in pixi export conda-enviroment

### DIFF
--- a/docs/switching_from/conda.md
+++ b/docs/switching_from/conda.md
@@ -73,7 +73,7 @@ This will create a new project with the dependencies from the `environment.yml` 
 ??? tip "Exporting your environment"
     If you are working with Conda users or systems, you can [export your environment to a `environment.yml`](../reference/cli.md#project-export-conda_environment) file to share them.
     ```shell
-    pixi project export conda
+    pixi project export conda-environment
     ```
     Additionally you can export a [conda explicit specification](../reference/cli.md#project-export-conda_explicit_spec).
 


### PR DESCRIPTION
Hi all,

Just a minor fix regarding the example of exporting a Pixi environment to Conda.
