### PR TITLE
ci: stop running integration tests in parallel

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -50,7 +50,7 @@ test-common-wheels = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", de
   "build-release",
 ] }
 test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/wheel_tests/" }
-test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose --timeout=300 tests/integration_python"
+test-integration-ci = "pytest --durations=10 --verbose --timeout=300 tests/integration_python"
 test-integration-fast = { cmd = "pytest -m 'not slow' --pixi-build=debug --numprocesses=auto --durations=10 --timeout=300 tests/integration_python", depends-on = [
   "build-debug",
 ] }


### PR DESCRIPTION
The hope is that either we don't see tests timing out anymore, at least see them consistently timing out