### PR TITLE
fix: update the PATH env var with dynamic elements

### DIFF
--- a/crates/pixi_trampoline/src/main.rs
+++ b/crates/pixi_trampoline/src/main.rs
@@ -1,14 +1,13 @@
+use miette::{Context, IntoDiagnostic};
+use pixi_utils::executable_from_path;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
-use pixi_utils::executable_from_path;
 #[cfg(target_family = "unix")]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use miette::{IntoDiagnostic, Context};
-
 
 // trampoline configuration folder name
 pub const TRAMPOLINE_CONFIGURATION: &str = "trampoline_configuration";
@@ -23,44 +22,76 @@ struct Metadata {
 fn read_metadata(current_exe: &Path) -> miette::Result<Metadata> {
     // the metadata file is next to the current executable parent folder,
     // under trampoline_configuration/current_exe_name.json
-    if let Some(exe_parent) = current_exe.parent(){
-        let metadata_path = exe_parent.join(TRAMPOLINE_CONFIGURATION).join(format!("{}{}", executable_from_path(current_exe), ".json"));
-        let metadata_file = File::open(&metadata_path).into_diagnostic().wrap_err(format!("Couldn't open {:?}", metadata_path))?;
+    if let Some(exe_parent) = current_exe.parent() {
+        let metadata_path = exe_parent.join(TRAMPOLINE_CONFIGURATION).join(format!(
+            "{}{}",
+            executable_from_path(current_exe),
+            ".json"
+        ));
+        let metadata_file = File::open(&metadata_path)
+            .into_diagnostic()
+            .wrap_err(format!("Couldn't open {:?}", metadata_path))?;
         let metadata: Metadata = serde_json::from_reader(metadata_file).into_diagnostic()?;
         return Ok(metadata);
     }
-    miette::bail!("Couldn't get the parent folder of the current executable: {:?}", current_exe);
+    miette::bail!(
+        "Couldn't get the parent folder of the current executable: {:?}",
+        current_exe
+    );
 }
 
-fn prepend_path(extra_path: &str) -> miette::Result<String> {
-    let path = env::var("PATH").into_diagnostic().wrap_err("Couldn't get 'PATH'")?;
-    let mut split_path = env::split_paths(&path).collect::<Vec<_>>();
-    split_path.insert(0, PathBuf::from(extra_path));
-    let new_path = env::join_paths(&split_path).into_diagnostic().wrap_err(format!("Couldn't join PATH's: {:?}", &split_path))?;
-    Ok(new_path.to_string_lossy().into_owned())
+/// Compute the difference between two PATH variables (the entries split by `;` or `:`)
+fn update_path(cached_path: String) -> String {
+    // Get current PATH
+    let current_path = std::env::var("PATH").unwrap_or_default();
+
+    // Split paths into vectors using platform-specific delimiter
+    let current_paths: Vec<PathBuf> = std::env::split_paths(&current_path).collect();
+    let cached_paths: Vec<PathBuf> = std::env::split_paths(&cached_path).collect();
+
+    // Stick all new elements in the front of the cached path
+    let new_elements = current_paths.iter().filter(|p| !cached_paths.contains(p));
+
+    // Join the new elements with the current path
+    let new_path = std::env::join_paths(new_elements.chain(cached_paths.iter()))
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or(cached_path);
+
+    new_path
 }
 
 fn trampoline() -> miette::Result<()> {
     // Get command-line arguments (excluding the program name)
     let args: Vec<String> = env::args().collect();
-    let current_exe = env::current_exe().into_diagnostic().wrap_err("Couldn't get the `env::current_exe`")?;
+    let current_exe = env::current_exe()
+        .into_diagnostic()
+        .wrap_err("Couldn't get the `env::current_exe`")?;
 
     // ignore any ctrl-c signals
-    ctrlc::set_handler(move || {}).into_diagnostic().wrap_err("Couldn't set the ctrl-c handler")?;
+    ctrlc::set_handler(move || {})
+        .into_diagnostic()
+        .wrap_err("Couldn't set the ctrl-c handler")?;
 
     let metadata = read_metadata(&current_exe)?;
 
     // Create a new Command for the specified executable
     let mut cmd = Command::new(metadata.exe);
 
-    let new_path = prepend_path(&metadata.path)?;
-
-    // Set the PATH environment variable
-    cmd.env("PATH", new_path);
-
     // Set any additional environment variables
     for (key, value) in metadata.env.iter() {
         cmd.env(key, value);
+    }
+
+    // Update the PATH environment variable
+    if let Some(path) = metadata
+        .env
+        .iter()
+        .find(|(key, _)| key.to_uppercase() == "PATH")
+        .map(|(_, value)| value.clone())
+    {
+        let new_path = update_path(path);
+        // Set the PATH environment variable
+        cmd.env("PATH", new_path);
     }
 
     // Add any additional arguments
@@ -77,10 +108,16 @@ fn trampoline() -> miette::Result<()> {
 
     #[cfg(target_os = "windows")]
     {
-        let mut child = cmd.spawn().into_diagnostic().wrap_err("Couldn't spawn the child process")?;
+        let mut child = cmd
+            .spawn()
+            .into_diagnostic()
+            .wrap_err("Couldn't spawn the child process")?;
 
         // Wait for the child process to complete
-        let status = child.wait().into_diagnostic().wrap_err("Couldn't wait for the child process")?;
+        let status = child
+            .wait()
+            .into_diagnostic()
+            .wrap_err("Couldn't wait for the child process")?;
 
         // Exit with the same status code as the child process
         std::process::exit(status.code().unwrap_or(1));


### PR DESCRIPTION
This should prepend any new PATH elements that were added after the `pixi global install` was performed to the PATH.