### PR TITLE
test: move target folder

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,7 +133,7 @@ jobs:
           cache: true
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ". -> target-pixi"
+          workspaces: ". -> target/pixi"
           key: ${{ hashFiles('pixi.lock') }}
       - name: Test pixi
         run: pixi run test-slow

--- a/.github/workflows/test_common_wheels.yml
+++ b/.github/workflows/test_common_wheels.yml
@@ -8,7 +8,7 @@ jobs:
     name: ${{ matrix.arch.name }} - Test Installation of Common Wheels
     runs-on: ${{ matrix.arch.os }}
     env:
-      TARGET_RELEASE: "${{ github.workspace }}/target-pixi/release"
+      TARGET_RELEASE: "${{ github.workspace }}/target/pixi/release"
       LOGS_DIR: "${{ github.workspace }}/tests/wheel_tests/.logs"
       SUMMARY_FILE: "${{ github.workspace }}/tests/wheel_tests/.summary.md"
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/test_downstream.yml
+++ b/.github/workflows/test_downstream.yml
@@ -156,7 +156,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ${{ matrix.arch.os }}
     env:
-      TARGET_RELEASE: "${{ github.workspace }}/target-pixi/release"
+      TARGET_RELEASE: "${{ github.workspace }}/target/pixi/release"
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ __pycache__
 site/
 .cache
 pytest-temp
-target-pixi

--- a/scripts/activate.bat
+++ b/scripts/activate.bat
@@ -1,2 +1,2 @@
 @echo off
-set CARGO_TARGET_DIR=target-pixi
+set CARGO_TARGET_DIR=target/pixi

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -Eeuo pipefail
-export CARGO_TARGET_DIR="target-pixi"
+export CARGO_TARGET_DIR="target/pixi"
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="clang"
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=$CONDA_PREFIX/bin/mold"

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -15,7 +15,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 @pytest.fixture
 def pixi(request: pytest.FixtureRequest) -> Path:
     pixi_build = request.config.getoption("--pixi-build")
-    return Path(__file__).parent.joinpath(f"../../target-pixi/{pixi_build}/pixi")
+    return Path(__file__).parent.joinpath(f"../../target/pixi/{pixi_build}/pixi")
 
 
 @pytest.fixture

--- a/tests/wheel_tests/test_common_wheels.py
+++ b/tests/wheel_tests/test_common_wheels.py
@@ -85,7 +85,7 @@ def pixi(pytestconfig: pytest.Config) -> pathlib.Path:
     # Check if the target directory exists
     # This assertion is for the type checker
     assert project_root
-    target_dir = pathlib.Path(project_root).joinpath("target-pixi/release")
+    target_dir = pathlib.Path(project_root).joinpath("target/pixi/release")
     if not target_dir.exists():
         pytest.exit("pixi executable not found, run `pixi r build` first")
 


### PR DESCRIPTION
`target-pixi` to `target/pixi`

Fits to convention of rust-analyzer and cargo-nextest. Also this way `cargo clean` removes that directory as well