### PR TITLE
docs: adapt completion instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,32 +109,43 @@ Afterwards, restart the shell or source the shell config file.
 
 #### Bash (default on most Linux systems)
 
+Add the following to the end of `~/.bashrc`:
+
 ```bash
-echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
+# ~/.bashrc
+
+eval "$(pixi completion --shell bash)"
 ```
 #### Zsh (default on macOS)
 
+Add the following to the end of `~/.zshrc`:
+
+
 ```zsh
-echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
+# ~/.zshrc
+
+eval "$(pixi completion --shell zsh)"
 ```
 
 #### PowerShell (pre-installed on all Windows systems)
 
+Add the following to the end of `Microsoft.PowerShell_profile.ps1`.
+You can check the location of this file by querying the `$PROFILE` variable in PowerShell.
+Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or
+`~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix.
+
 ```pwsh
-Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
-```
-
-If this fails with "Failure because no profile file exists", make sure your profile file exists.
-If not, create it with:
-
-```PowerShell
-New-Item -Path $PROFILE -ItemType File -Force
+(& pixi completion --shell powershell) | Out-String | Invoke-Expression
 ```
 
 #### Fish
 
+Add the following to the end of `~/.config/fish/config.fish`:
+
 ```fish
-echo 'pixi completion --shell fish | source' >> ~/.config/fish/config.fish
+# ~/.config/fish/config.fish
+
+pixi completion --shell fish | source
 ```
 
 #### Nushell
@@ -154,8 +165,12 @@ use ~/.cache/pixi/completions.nu *
 
 #### Elvish
 
+Add the following to the end of `~/.elvish/rc.elv`:
+
 ```elv
-echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+# ~/.elvish/rc.elv
+
+eval (pixi completion --shell elvish | slurp)
 ```
 
 ### Distro Packages

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ To get autocompletion follow the instructions for your shell.
 Afterwards, restart the shell or source the shell config file.
 
 
-#### Bash (default on most Linux systems)
+### Bash (default on most Linux systems)
 
 Add the following to the end of `~/.bashrc`:
 
@@ -59,7 +59,7 @@ Add the following to the end of `~/.bashrc`:
 
 eval "$(pixi completion --shell bash)"
 ```
-#### Zsh (default on macOS)
+### Zsh (default on macOS)
 
 Add the following to the end of `~/.zshrc`:
 
@@ -69,7 +69,7 @@ Add the following to the end of `~/.zshrc`:
 eval "$(pixi completion --shell zsh)"
 ```
 
-#### PowerShell (pre-installed on all Windows systems)
+### PowerShell (pre-installed on all Windows systems)
 
 Add the following to the end of `Microsoft.PowerShell_profile.ps1`.
 You can check the location of this file by querying the `$PROFILE` variable in PowerShell.
@@ -80,7 +80,7 @@ Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` 
 (& pixi completion --shell powershell) | Out-String | Invoke-Expression
 ```
 
-#### Fish
+### Fish
 
 Add the following to the end of `~/.config/fish/config.fish`:
 
@@ -89,7 +89,7 @@ Add the following to the end of `~/.config/fish/config.fish`:
 pixi completion --shell fish | source
 ```
 
-#### Nushell
+### Nushell
 
 Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
 
@@ -104,7 +104,7 @@ And add the following to the end of your Nushell configuration (find it by runni
 use ~/.cache/pixi/completions.nu *
 ```
 
-#### Elvish
+### Elvish
 
 Add the following to the end of `~/.elvish/rc.elv`:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,37 +51,45 @@ To get autocompletion follow the instructions for your shell.
 Afterwards, restart the shell or source the shell config file.
 
 
-### Bash (default on most Linux systems)
+#### Bash (default on most Linux systems)
 
-```bash
-echo 'eval "$(pixi completion --shell bash)"' >> ~/.bashrc
+Add the following to the end of `~/.bashrc`:
+
+```bash title="~/.bashrc"
+
+eval "$(pixi completion --shell bash)"
 ```
-### Zsh (default on macOS)
+#### Zsh (default on macOS)
 
-```zsh
-echo 'eval "$(pixi completion --shell zsh)"' >> ~/.zshrc
+Add the following to the end of `~/.zshrc`:
+
+
+```zsh title="~/.zshrc"
+
+eval "$(pixi completion --shell zsh)"
 ```
 
-### PowerShell (pre-installed on all Windows systems)
+#### PowerShell (pre-installed on all Windows systems)
+
+Add the following to the end of `Microsoft.PowerShell_profile.ps1`.
+You can check the location of this file by querying the `$PROFILE` variable in PowerShell.
+Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or
+`~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix.
 
 ```pwsh
-Add-Content -Path $PROFILE -Value '(& pixi completion --shell powershell) | Out-String | Invoke-Expression'
+(& pixi completion --shell powershell) | Out-String | Invoke-Expression
 ```
 
-!!! tip "Failure because no profile file exists"
-    Make sure your profile file exists, otherwise create it with:
-    ```PowerShell
-    New-Item -Path $PROFILE -ItemType File -Force
-    ```
+#### Fish
 
+Add the following to the end of `~/.config/fish/config.fish`:
 
-### Fish
+```fish title="~/.config/fish/config.fish"
 
-```fish
-echo 'pixi completion --shell fish | source' > ~/.config/fish/completions/pixi.fish
+pixi completion --shell fish | source
 ```
 
-### Nushell
+#### Nushell
 
 Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
 
@@ -96,11 +104,15 @@ And add the following to the end of your Nushell configuration (find it by runni
 use ~/.cache/pixi/completions.nu *
 ```
 
-### Elvish
+#### Elvish
 
-```elv
-echo 'eval (pixi completion --shell elvish | slurp)' >> ~/.elvish/rc.elv
+Add the following to the end of `~/.elvish/rc.elv`:
+
+```elv title="~/.elvish/rc.elv"
+
+eval (pixi completion --shell elvish | slurp)
 ```
+
 
 ## Alternative installation methods
 


### PR DESCRIPTION
We currently give people a one-liner to setup completions.

That is convenient, but also fragile.
If people's startup script doesn't end in a newline, it [breaks](https://github.com/panel-extensions/copier-template-panel-extension/issues/4#issuecomment-2495774437).
If people run it multiple times it will be duplicated.

Let's follow https://starship.rs and give users instructions to add it themselves