### PR TITLE
fix: remove debug output

### DIFF
--- a/crates/pixi_build_frontend/src/build_frontend.rs
+++ b/crates/pixi_build_frontend/src/build_frontend.rs
@@ -107,12 +107,10 @@ impl BuildFrontend {
         request: SetupRequest,
     ) -> Result<Protocol, BuildFrontendError> {
         // Determine the build protocol to use for the source directory.
-        eprintln!("before discovering");
         let protocol = ProtocolBuilder::discover(&request.source_dir, &self.enabled_protocols)?
             .with_channel_config(self.channel_config.clone())
             .with_opt_cache_dir(self.cache_dir.clone());
 
-        eprintln!("after discovering");
         tracing::info!(
             "discovered a {} source package at {}",
             protocol.name(),


### PR DESCRIPTION
Removing some debug epritln output.
Other output should be removed only after we upgrade rattler-build here https://github.com/prefix-dev/pixi-build-backends/blob/main/Cargo.toml#L34 to rattler-build/main, which I currently cannot do due to some compiler errors when doing upgrade.
