### PR TITLE
feat: build recipe yaml directly

### DIFF
--- a/crates/pixi_build_frontend/src/protocol.rs
+++ b/crates/pixi_build_frontend/src/protocol.rs
@@ -34,6 +34,7 @@ pub enum DiscoveryError {
     NotADirectory,
     #[error("failed to discover a valid project manifest, the source path '{}' could not be found", .0.display())]
     NotFound(PathBuf),
+
     #[error("unable to discover communication protocol, the source directory does not contain a supported manifest")]
     #[diagnostic(help(
         "Ensure that the source directory contains a valid pixi.toml or meta.yaml file."

--- a/crates/pixi_build_frontend/src/protocols/builders/rattler_build.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/rattler_build.rs
@@ -15,6 +15,8 @@ use crate::{
     BackendOverride,
 };
 
+const DEFAULT_BUILD_TOOL: &str = "pixi-build-rattler-build";
+
 #[derive(Debug, Error, Diagnostic)]
 pub enum FinishError {
     #[error(transparent)]
@@ -138,8 +140,8 @@ impl ProtocolBuilder {
                 .ok_or(FinishError::NoBuildSection(manifest_path.clone()))?
         } else {
             ToolSpec::Isolated(
-                IsolatedToolSpec::from_specs(["pixi-build-rattler-build".parse().unwrap()])
-                    .with_command("pixi-build-rattler-build"),
+                IsolatedToolSpec::from_specs([DEFAULT_BUILD_TOOL.parse().unwrap()])
+                    .with_command(DEFAULT_BUILD_TOOL),
             )
         };
 
@@ -147,13 +149,6 @@ impl ProtocolBuilder {
             .instantiate(tool_spec)
             .await
             .map_err(FinishError::Tool)?;
-
-        if let Some(cache_dir) = self.cache_dir.as_ref() {
-            let _ = std::fs::create_dir_all(cache_dir).map_err(|e| {
-                tracing::warn!("Failed to create cache dir: {:?}", e);
-                e
-            });
-        }
 
         Ok(JsonRPCBuildProtocol::setup(
             self.source_dir,


### PR DESCRIPTION
This adds some "fallback" behavior if a recipe.yaml is found but no `pixi.toml` next to it. 

We just default to the `pixi-build-rattler-build` backend. 

I am currently testing with:

```toml
[project]
authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
channels = ["conda-forge"]
description = "Add a short description here"
name = "build-recipe"
platforms = ["osx-arm64"]
version = "0.1.0"
preview = ["pixi-build"]


[package]

[build-system]
dependencies = []
# note this is unused garbage but currently necessary
build-backend = "bla"
channels = [
    "https://prefix.dev/pixi-build-backends",
    "https://prefix.dev/conda-forge"
]

[tasks]

[dependencies]
bzip-two = { path = "./recipes/bzip-two" }
```

and a `recipe.yaml` that looks like:

```yaml
package:
  name: bzip-two
  version: 1.0.8
```