### PR TITLE
fix: `pixi global list` failing for empty environments

### DIFF
--- a/src/global/list.rs
+++ b/src/global/list.rs
@@ -217,6 +217,18 @@ pub async fn list_global_environments(
     let mut project_envs = project.environments().clone();
     project_envs.sort_by(|a, _, b, _| a.to_string().cmp(&b.to_string()));
 
+    project_envs.retain(|env_name, parsed_environment| {
+        if parsed_environment.dependencies.is_empty() {
+            tracing::warn!(
+                "Environment {} doesn't contain dependencies. Skipping.",
+                env_name.fancy_display()
+            );
+            false
+        } else {
+            true
+        }
+    });
+
     if let Some(regex) = regex {
         let regex = regex::Regex::new(&regex).into_diagnostic()?;
         project_envs.retain(|env_name, _| regex.is_match(env_name.as_str()));
@@ -231,7 +243,8 @@ pub async fn list_global_environments(
     let len = project_envs.len();
     for (idx, (env_name, env)) in project_envs.iter().enumerate() {
         let env_dir = project.env_root.path().join(env_name.as_str());
-        let records = find_package_records(&env_dir.join(consts::CONDA_META_DIR)).await?;
+        let conda_meta = env_dir.join(consts::CONDA_META_DIR);
+        let records = find_package_records(&conda_meta).await?;
 
         let last = (idx + 1) == len;
 

--- a/tests/integration_python/global/test_global.py
+++ b/tests/integration_python/global/test_global.py
@@ -1164,6 +1164,26 @@ def test_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     )
 
 
+def test_list_env_no_dependencies(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+    manifest = manifests.joinpath("pixi-global.toml")
+    toml = f"""
+    [envs.test]
+    channels = ["{dummy_channel_1}"]
+    dependencies = {{}}
+    """
+    manifest.write_text(toml)
+
+    # Verify empty list
+    verify_cli_command(
+        [pixi, "global", "list"],
+        env=env,
+        stderr_contains="Environment test doesn't contain dependencies",
+    )
+
+
 def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")


### PR DESCRIPTION
Fixes #2413
