### PR TITLE
fix: macos activation cargo vars

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -103,9 +103,7 @@ clang = ">=18.1.8,<19.0"
 compilers = ">=1.6.0"
 make = ">=4.3,<5"
 mold = ">=2.33.0,<3.0"
-[feature.build.target.linux-64.activation]
-scripts = ["scripts/activate.sh"]
-[feature.build.target.osx-arm64.activation]
+[feature.build.target.unix.activation]
 scripts = ["scripts/activate.sh"]
 [feature.build.target.win-64.activation]
 scripts = ["scripts/activate.bat"]

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -Eeuo pipefail
 export CARGO_TARGET_DIR="target/pixi"
+
+# on linux we need to set these rust flags
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="clang"
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=$CONDA_PREFIX/bin/mold"
+
+# on macOS we need to set these rust flags
+export CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-Wl,-rpath,$CONDA_PREFIX/lib"
+export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-Wl,-rpath,$CONDA_PREFIX/lib"


### PR DESCRIPTION
Fixes using `pixi` to build `pixi`. e.g.: `pixi run install`. On macos. 

Without these environment variables you'll get:
```
pixi/examples/flask-hello-world on  main [?⇡] via 🐍 v3.13.0 on ☁️   
❯ ../../target-pixi/release/pixi build
dyld[98511]: Library not loaded: @rpath/liblzma.5.dylib
  Referenced from: <E86679E3-7383-3039-9E4A-031C60A071A5> /Users/hadim/Code/libs/pixi/pixi/target-pixi/release/pixi
  Reason: no LC_RPATH's found
zsh: abort      ../../target-pixi/release/pixi build
```