### PR TITLE
fix: ensure pinning strategy is not affected by non-semver packages

### DIFF
--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -1461,7 +1461,7 @@ mod tests {
         Ok(())
     }
 
-    #[rstest::rstest]
+    #[rstest]
     #[tokio::test]
     async fn test_good_satisfiability(
         #[files("tests/data/satisfiability/*/pixi.toml")] manifest_path: PathBuf,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -883,9 +883,10 @@ impl Project {
             .flatten()
             .collect_vec();
 
-        let mut pinning_strategy = self.config().pinning_strategy;
         let channel_config = self.channel_config();
         for (name, (spec_type, spec)) in conda_specs_to_add_constraints_for {
+            let mut pinning_strategy = self.config().pinning_strategy;
+
             // Edge case: some packages are a special case where we want to pin the minor
             // version by default. This is done to avoid early user confusion
             // when the minor version changes and environments magically start breaking.

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -470,9 +470,8 @@ async fn add_sdist_functionality() {
         .unwrap();
 }
 
-#[rstest::rstest]
 #[tokio::test]
-async fn add_unconstrainted_dependency() {
+async fn add_unconstrained_dependency() {
     // Create a channel with a single package
     let mut package_database = PackageDatabase::default();
     package_database.add_package(Package::build("foobar", "1").finish());


### PR DESCRIPTION
Fixes #2574.

I added a test as well, but I'm not sure if it follows the project's standards.