### PR TITLE
fix: improve test speed and support win-arm64

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -151,10 +151,10 @@ impl ConfigCliPrompt {
 #[serde(rename_all = "kebab-case")]
 pub struct RepodataConfig {
     #[serde(flatten)]
-    default: RepodataChannelConfig,
+    pub default: RepodataChannelConfig,
 
     #[serde(flatten)]
-    per_channel: HashMap<Url, RepodataChannelConfig>,
+    pub per_channel: HashMap<Url, RepodataChannelConfig>,
 }
 
 impl RepodataConfig {
@@ -696,6 +696,23 @@ impl From<&Config> for rattler_repodata_gateway::ChannelConfig {
 }
 
 impl Config {
+    /// Constructs a new config that is optimized to be used in tests.
+    ///
+    /// This instance is optimized to provide the fastest experience for tests.
+    pub fn for_tests() -> Self {
+        let mut config = Config::default();
+        // Use prefix.dev as the default channel alias
+        config.channel_config.channel_alias = Url::parse("https://prefix.dev").unwrap();
+
+        // Use conda-forge as the default channel
+        config.default_channels = vec![NamedChannelOrUrl::Name("conda-forge".into())];
+
+        // Enable sharded repodata by default.
+        config.repodata_config.default.disable_sharded = Some(false);
+
+        config
+    }
+
     /// Parse the given toml string and return a Config instance.
     ///
     /// # Returns

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -585,7 +585,6 @@ pub struct Config {
     pub loaded_from: Vec<PathBuf>,
 
     #[serde(skip, default = "default_channel_config")]
-    #[serde(alias = "channel_config")] // BREAK: remove to stop supporting snake_case alias
     channel_config: ChannelConfig,
 
     /// Configuration for repodata fetching.

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -552,7 +552,7 @@ mod tests {
         dependencies = ["flask==2.*"]
 
         [tool.pixi.project]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
         platforms = ["linux-64"]
 
         [tool.pixi.tasks]

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__pyproject__tests__add_pypi_dependency.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__pyproject__tests__add_pypi_dependency.snap
@@ -13,7 +13,7 @@ expression: manifest.document.to_string()
         dependencies = ["flask==2.*", "numpy>=3.12"]
 
         [tool.pixi.project]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
         platforms = ["linux-64"]
 
         [tool.pixi.tasks]

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__pyproject__tests__remove_pypi_dependency.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__pyproject__tests__remove_pypi_dependency.snap
@@ -12,7 +12,7 @@ expression: manifest.document.to_string()
         requires-python = ">=3.11"
 
         [tool.pixi.project]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
         platforms = ["linux-64"]
 
         [tool.pixi.tasks]

--- a/crates/pixi_utils/src/cache.rs
+++ b/crates/pixi_utils/src/cache.rs
@@ -13,12 +13,17 @@ pub struct EnvironmentHash {
 
 impl EnvironmentHash {
     /// Creates a new environment hash.
-    pub fn new(command: String, specs: Vec<MatchSpec>, channels: Vec<String>, platform: Platform) -> Self {
+    pub fn new(
+        command: String,
+        specs: Vec<MatchSpec>,
+        channels: Vec<String>,
+        platform: Platform,
+    ) -> Self {
         Self {
             command,
             specs,
             channels,
-            platform
+            platform,
         }
     }
 

--- a/crates/pixi_utils/src/cache.rs
+++ b/crates/pixi_utils/src/cache.rs
@@ -1,6 +1,6 @@
 use std::hash::{DefaultHasher, Hash, Hasher};
 
-use rattler_conda_types::MatchSpec;
+use rattler_conda_types::{MatchSpec, Platform};
 
 /// A hash that uniquely identifies an environment.
 #[derive(Hash)]
@@ -8,15 +8,17 @@ pub struct EnvironmentHash {
     pub command: String,
     pub specs: Vec<MatchSpec>,
     pub channels: Vec<String>,
+    pub platform: Platform,
 }
 
 impl EnvironmentHash {
     /// Creates a new environment hash.
-    pub fn new(command: String, specs: Vec<MatchSpec>, channels: Vec<String>) -> Self {
+    pub fn new(command: String, specs: Vec<MatchSpec>, channels: Vec<String>, platform: Platform) -> Self {
         Self {
             command,
             specs,
             channels,
+            platform
         }
     }
 

--- a/crates/pixi_utils/src/conda_environment_file.rs
+++ b/crates/pixi_utils/src/conda_environment_file.rs
@@ -131,6 +131,8 @@ impl CondaEnvFile {
             channels = config.default_channels();
         }
 
+        dbg!(&channels);
+
         Ok((conda_deps, pip_deps, channels))
     }
 }

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -636,50 +636,27 @@ mod tests {
         .unwrap();
         assert_eq!(env.get("TEST").unwrap(), "ACTIVATION456");
 
-        // Verify that the cache is not used when the hash is different
-        let mock_lock = r#"
-version: 5
+        // Verify that the cache is not used when the hash is different.
+        //
+        // We change the hash by modifying the lock-file. This should invalidate the cache and thus
+        // result in the activation script being run again.
+        let mock_lock = &format!(r#"
+version: 6
 environments:
   default:
     channels:
-    - url: https://fast.prefix.dev/conda-forge/
+    - url: https://prefix.dev/conda-forge/
     packages:
-      linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
-      osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
-      osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
-      win-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+      {platform}:
+      - conda: https://prefix.dev/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
 packages:
-- kind: conda
-  name: _r-mutex
-  version: 1.0.1
-  build: anacondar_1
-  build_number: 1
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+- conda: https://prefix.dev/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
   sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
   md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
   license: BSD
   size: 3566
   timestamp: 1562343890778
-- kind: conda
-  name: _r-mutex
-  version: 1.0.1
-  build: anacondar_1
-  build_number: 1
-  subdir: noarch
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
-  sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
-  md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
-  license: BSD
-  size: 3566
-  timestamp: 1562343890778
-"#;
+"#, platform=Platform::current());
         let lock_file = LockFile::from_str(mock_lock).unwrap();
         let env = run_activation(
             &default_env,

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -640,7 +640,8 @@ mod tests {
         //
         // We change the hash by modifying the lock-file. This should invalidate the cache and thus
         // result in the activation script being run again.
-        let mock_lock = &format!(r#"
+        let mock_lock = &format!(
+            r#"
 version: 6
 environments:
   default:
@@ -656,7 +657,9 @@ packages:
   license: BSD
   size: 3566
   timestamp: 1562343890778
-"#, platform=Platform::current());
+"#,
+            platform = Platform::current()
+        );
         let lock_file = LockFile::from_str(mock_lock).unwrap();
         let env = run_activation(
             &default_env,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -30,9 +30,7 @@ use rattler_conda_types::{
     ChannelConfig, ChannelUrl, GenericVirtualPackage, PackageRecord, Platform, RepoDataRecord,
 };
 use rattler_digest::Sha256;
-use rattler_repodata_gateway::Gateway;
 pub use reporters::{BuildMetadataReporter, BuildReporter};
-use reqwest_middleware::ClientWithMiddleware;
 use thiserror::Error;
 use tracing::instrument;
 use typed_path::{Utf8TypedPath, Utf8TypedPathBuf};
@@ -179,8 +177,6 @@ impl BuildContext {
         build_virtual_packages: Vec<GenericVirtualPackage>,
         build_reporter: Arc<dyn BuildReporter>,
         build_id: usize,
-        authenticated_client: ClientWithMiddleware,
-        gateway: Gateway,
     ) -> Result<RepoDataRecord, BuildError> {
         let source_checkout = SourceCheckout {
             path: self.fetch_pinned_source(&source_spec.source).await?,
@@ -255,16 +251,11 @@ impl BuildContext {
             }
         }
 
-        let tool_context = ToolContext::builder()
-            .with_gateway(gateway.clone())
-            .with_client(authenticated_client.clone())
-            .build();
-
         // Instantiate a protocol for the source directory.
         let protocol = pixi_build_frontend::BuildFrontend::default()
             .with_channel_config(self.channel_config.clone())
             .with_cache_dir(self.cache_dir.clone())
-            .with_tool_context(tool_context.into())
+            .with_tool_context(self.tool_context.clone())
             .setup_protocol(SetupRequest {
                 source_dir: source_checkout.path.clone(),
                 build_tool_override: Default::default(),

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -18,7 +18,7 @@ use super::cli_config::ChannelsConfig;
 use crate::prefix::Prefix;
 
 /// Run a command in a temporary environment.
-#[derive(Parser, Debug, Default)]
+#[derive(Parser, Debug)]
 #[clap(trailing_var_arg = true, arg_required_else_help = true)]
 pub struct Args {
     /// The executable to run.
@@ -32,6 +32,10 @@ pub struct Args {
 
     #[clap(flatten)]
     channels: ChannelsConfig,
+
+    /// The platform to create the environment for.
+    #[clap(long, short, default_value_t = Platform::current())]
+    pub platform: Platform,
 
     /// If specified a new environment is always created even if one already
     /// exists.
@@ -88,7 +92,7 @@ pub async fn create_exec_prefix(
         .map(|c| c.base_url.to_string())
         .collect();
 
-    let environment_hash = EnvironmentHash::new(command.clone(), specs, channels);
+    let environment_hash = EnvironmentHash::new(command.clone(), specs, channels, args.platform);
 
     let prefix = Prefix::new(
         cache_dir
@@ -146,7 +150,7 @@ pub async fn create_exec_prefix(
         gateway
             .query(
                 channels,
-                [Platform::current(), Platform::NoArch],
+                [args.platform, Platform::NoArch],
                 specs.clone(),
             )
             .recursive(true)
@@ -154,8 +158,8 @@ pub async fn create_exec_prefix(
             .await
             .into_diagnostic()
     })
-    .await
-    .context("failed to get repodata")?;
+        .await
+        .context("failed to get repodata")?;
 
     // Determine virtual packages of the current platform
     let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::from_env())
@@ -181,11 +185,12 @@ pub async fn create_exec_prefix(
             ..SolverTask::from_iter(&repodata)
         })
     })
-    .into_diagnostic()
-    .context("failed to solve environment")?;
+        .into_diagnostic()
+        .context("failed to solve environment")?;
 
     // Install the environment
     Installer::new()
+        .with_target_platform(args.platform)
         .with_download_client(client.clone())
         .with_reporter(
             IndicatifReporter::builder()

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -148,18 +148,14 @@ pub async fn create_exec_prefix(
     // Get the repodata for the specs
     let repodata = await_in_progress("fetching repodata for environment", |_| async {
         gateway
-            .query(
-                channels,
-                [args.platform, Platform::NoArch],
-                specs.clone(),
-            )
+            .query(channels, [args.platform, Platform::NoArch], specs.clone())
             .recursive(true)
             .execute()
             .await
             .into_diagnostic()
     })
-        .await
-        .context("failed to get repodata")?;
+    .await
+    .context("failed to get repodata")?;
 
     // Determine virtual packages of the current platform
     let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::from_env())
@@ -185,8 +181,8 @@ pub async fn create_exec_prefix(
             ..SolverTask::from_iter(&repodata)
         })
     })
-        .into_diagnostic()
-        .context("failed to solve environment")?;
+    .into_diagnostic()
+    .context("failed to solve environment")?;
 
     // Install the environment
     Installer::new()

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -471,7 +471,7 @@ mod tests {
 
         # The name of the environment is `python3-10`
         [envs.python3-10]
-        channels = ["https://fast.prefix.dev/conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
         # It will expose python3.10
         [envs.python3-10.dependencies]
         python = "3.10.*"

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -388,7 +388,6 @@ impl<'p> LockFileDerivedData<'p> {
         // Update the prefix with conda packages.
         let has_existing_packages = !installed_packages.is_empty();
         let env_name = GroupedEnvironmentName::Environment(environment.name().clone());
-        let gateway = environment.project().repodata_gateway().clone();
         let python_status = environment::update_prefix_conda(
             &prefix,
             self.package_cache.clone(),
@@ -414,7 +413,6 @@ impl<'p> LockFileDerivedData<'p> {
             "",
             self.io_concurrency_limit.clone().into(),
             self.build_context.clone(),
-            gateway,
         )
         .await?;
 
@@ -2233,12 +2231,9 @@ async fn spawn_create_prefix_task(
 
     let build_virtual_packages = group.virtual_packages(Platform::current());
 
-    let gateway = group.project().repodata_gateway();
-
     // Spawn a background task to update the prefix
     let (python_status, duration) = tokio::spawn({
         let prefix = prefix.clone();
-        let gateway = gateway.clone();
         let group_name = group_name.clone();
         async move {
             let start = Instant::now();
@@ -2264,7 +2259,6 @@ async fn spawn_create_prefix_task(
                 "  ",
                 io_concurrency_limit.into(),
                 build_context,
-                gateway.clone(),
             )
             .await?;
             let end = Instant::now();

--- a/tests/integration_rust/common/builders.rs
+++ b/tests/integration_rust/common/builders.rs
@@ -57,7 +57,7 @@ pub struct InitBuilder {
 }
 
 impl InitBuilder {
-    /// Disable using `https://fast.prefix.dev` as the default channel.
+    /// Disable using `https://prefix.dev` as the default channel.
     pub fn no_fast_prefix_overwrite(self, no_fast_prefix: bool) -> Self {
         Self {
             no_fast_prefix,
@@ -98,7 +98,7 @@ impl IntoFuture for InitBuilder {
             channels: if !self.no_fast_prefix {
                 self.args.channels.or_else(|| {
                     Some(vec![NamedChannelOrUrl::from_str(
-                        "https://fast.prefix.dev/conda-forge",
+                        "https://prefix.dev/conda-forge",
                     )
                     .unwrap()])
                 })

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -44,6 +44,11 @@ use crate::common::builders::{
     ProjectEnvironmentAddBuilder, TaskAddBuilder, TaskAliasBuilder, UpdateBuilder,
 };
 
+const DEFAULT_PROJECT_CONFIG: &str = r#"
+[repodata-config."https://prefix.dev"]
+disable-sharded = false
+"#;
+
 /// To control the pixi process
 pub struct PixiControl {
     /// The path to the project working file
@@ -209,6 +214,12 @@ impl PixiControl {
     /// Create a new PixiControl instance
     pub fn new() -> miette::Result<PixiControl> {
         let tempdir = tempfile::tempdir().into_diagnostic()?;
+
+        // Add default project config
+        let pixi_path = tempdir.path().join(".pixi");
+        std::fs::create_dir_all(&pixi_path).unwrap();
+        std::fs::write(pixi_path.join("config.toml"), DEFAULT_PROJECT_CONFIG).unwrap();
+
         // Hide the progress bars for the tests
         // Otherwise the override the test output
         hide_progress_bars();

--- a/tests/integration_rust/install_tests.rs
+++ b/tests/integration_rust/install_tests.rs
@@ -18,7 +18,6 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-
 use tempfile::TempDir;
 use uv_python::PythonEnvironment;
 
@@ -307,7 +306,7 @@ async fn pypi_reinstall_python() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
     // Add and update lockfile with this version of python
-    pixi.add("python==3.11").with_install(true).await.unwrap();
+    pixi.add("python==3.11").await.unwrap();
 
     // Add flask from pypi
     pixi.add("flask")

--- a/tests/integration_rust/pypi_tests.rs
+++ b/tests/integration_rust/pypi_tests.rs
@@ -15,7 +15,7 @@ async fn test_flat_links_based_index_returns_path() {
         [project]
         name = "pypi-extra-index-url"
         platforms = ["{platform}"]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
 
         [dependencies]
         python = "~=3.12.0"
@@ -55,7 +55,7 @@ async fn test_file_based_index_returns_path() {
         [project]
         name = "pypi-extra-index-url"
         platforms = ["{platform}"]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
 
         [dependencies]
         python = "~=3.12.0"
@@ -97,7 +97,7 @@ async fn test_index_strategy() {
         [project]
         name = "pypi-extra-index-url"
         platforms = ["{platform}"]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
 
         [dependencies]
         python = "~=3.12.0"
@@ -178,7 +178,7 @@ async fn test_pinning_index() {
         [project]
         name = "pypi-pinning-index"
         platforms = ["{platform}"]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
 
         [dependencies]
         python = "~=3.12.0"
@@ -221,7 +221,7 @@ async fn pin_torch() {
         [project]
         name = "pypi-pinning-index"
         platforms = [{platforms}]
-        channels = ["conda-forge"]
+        channels = ["https://prefix.dev/conda-forge"]
 
         [dependencies]
         python = "~=3.12.0"

--- a/tests/integration_rust/solve_group_tests.rs
+++ b/tests/integration_rust/solve_group_tests.rs
@@ -100,8 +100,7 @@ async fn test_purl_are_added_for_pypi() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
     // Add and update lockfile with this version of python
-    pixi.add("boltons").with_install(true).await.unwrap();
-
+    pixi.add("boltons").await.unwrap();
     let lock_file = pixi.update_lock_file().await.unwrap();
 
     // Check if boltons has a purl


### PR DESCRIPTION
### Description

I couldnt run some tests on my local arm64 windows machine because some packages are not available for arm64 (yet). 

### Solution

I added a platform to the toolcache to allow installing tools for other platforms than the current one. 

I also found that the toolcache was instantiated on each build invocation which effectively removes all caching. 

Finally I sped up the toolcache tests by using sharded repodata and changing the tool that was installed to something more lightweight.

@nichmor This touches some of your code, please review. 