### PR TITLE
refactor: Enhance installation script with custom destination and update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  --dest DEST           Destination directory for the executable, default: ~/.pixi/bin (e.g $PIXI_HOME/bin)
+  --dest DEST           Destination directory for the executable, default: $PIXI_HOME/bin (or ~/.pixi/bin if $PIXI_HOME isn't set)
 ```
 
 ## Get your code ready for a PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,23 @@ pixi run test-all-fast
 pixi run install # only works on unix systems as on windows you can't overwrite the binary while it's running
 ```
 
+### Installing the target binaries to a custom location
+
+Use the pixi task `install-as` which invokes a python script to build the project and copy the executable to a custom location.
+```shell
+$ pixi run install-as
+usage: install.py [-h] [--dest DEST] name
+
+Build pixi and copy the executable to ~/.pixi/bin or a custom destination
+
+positional arguments:
+  name                  Name of the executable (e.g. pixid)
+
+options:
+  -h, --help            show this help message and exit
+  --dest DEST           Destination directory for the executable, default: ~/.pixi/bin (e.g $PIXI_HOME/bin)
+```
+
 ## Get your code ready for a PR
 We use [`pre-commit`](https://pre-commit.com/) to run all the formatters and linters that we use.
 If you have `pre-commit` installed on your system you can run `pre-commit install` to run the tools before you commit or push.

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -3,12 +3,8 @@ from pathlib import Path
 import shutil
 import platform
 import os
-import logging
-import sys
 
-DEFAULT_DESTINATION_DIR = Path.home().joinpath(".pixi", "bin")
-
-logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+DEFAULT_DESTINATION_DIR = Path(os.getenv("PIXI_HOME", Path.home() / ".pixi")) / "bin"
 
 
 def executable_extension(name: str) -> str:
@@ -20,14 +16,14 @@ def executable_extension(name: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=f"Build pixi and copy the executable to {DEFAULT_DESTINATION_DIR} or a custom destination"
+        description=f"Build pixi and copy the executable to {DEFAULT_DESTINATION_DIR} or a custom destination specified by --dest"
     )
     parser.add_argument("name", type=str, help="Name of the executable (e.g. pixid)")
     parser.add_argument(
         "--dest",
         type=Path,
         default=DEFAULT_DESTINATION_DIR,
-        help=f"Destination directory for the executable, default: {DEFAULT_DESTINATION_DIR} (e.g $PIXI_HOME/bin)",
+        help=f"Destination directory for the executable, default: {DEFAULT_DESTINATION_DIR}",
     )
 
     args = parser.parse_args()
@@ -37,14 +33,9 @@ def main() -> None:
     )
     destination_path = args.dest.joinpath(executable_extension(args.name))
 
-    try:
-        logging.info(f"Copying the executable to {destination_path}")
-        destination_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(built_executable_path, destination_path)
-        logging.info("Done!")
-    except Exception as e:
-        logging.error(f"Failed to copy the executable: {e}")
-        sys.exit(1)
+    print(f"Copying the executable to {destination_path}")
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(built_executable_path, destination_path)
 
 
 if __name__ == "__main__":

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -3,6 +3,12 @@ from pathlib import Path
 import shutil
 import platform
 import os
+import logging
+import sys
+
+DEFAULT_DESTINATION_DIR = Path.home().joinpath(".pixi", "bin")
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
 
 def executable_extension(name: str) -> str:
@@ -14,21 +20,31 @@ def executable_extension(name: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Build pixi and copy the executable to ~/.pixi/bin/"
+        description=f"Build pixi and copy the executable to {DEFAULT_DESTINATION_DIR} or a custom destination"
     )
     parser.add_argument("name", type=str, help="Name of the executable (e.g. pixid)")
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=DEFAULT_DESTINATION_DIR,
+        help=f"Destination directory for the executable, default: {DEFAULT_DESTINATION_DIR} (e.g $PIXI_HOME/bin)",
+    )
 
     args = parser.parse_args()
 
     built_executable_path = Path(os.environ["CARGO_TARGET_DIR"]).joinpath(
         "release", executable_extension("pixi")
     )
-    destination_path = Path.home().joinpath(".pixi", "bin", executable_extension(args.name))
+    destination_path = args.dest.joinpath(executable_extension(args.name))
 
-    print(f"Copying the executable to {destination_path}")
-    shutil.copy(built_executable_path, destination_path)
-
-    print("Done!")
+    try:
+        logging.info(f"Copying the executable to {destination_path}")
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(built_executable_path, destination_path)
+        logging.info("Done!")
+    except Exception as e:
+        logging.error(f"Failed to copy the executable: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Found this script useful while working on features for other tooling, i use PIXI_HOME for my binaries so this feature helps write it to the same location. 
+ also wanted to describe how to use it for other devs looking to contribute

- Refactor the installation script to support specifying a custom destination for executables and add logging for better visibility. 
- Update CONTRIBUTING.md to include instructions for the new installation method.