### PR TITLE
feat: try to speed up `pixi global list`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,6 +325,7 @@ inherits = "release"
 lto = "fat"
 opt-level = 3
 strip = "symbols"
+debug = false
 
 [profile.ci]
 codegen-units = 16
@@ -333,6 +334,8 @@ lto = false
 opt-level = 3
 strip = false
 
+[profile.release]
+debug = true
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -83,7 +83,7 @@ impl Prefix {
                     }
                 }
             }
-
+            tracing::warn!("Parsing '{}'", path.display());
             // Spawn loading on another thread
             let future = tokio::task::spawn_blocking(move || {
                 PrefixRecord::from_path(&path)


### PR DESCRIPTION
I tried to speed up `pixi global list`. My first attempt was to not load all the prefix records, and instead infer name / version / build string from the ".json" filenames in `conda-meta`.

However, this is not the only place where we are loading the PrefixRecords. We are also loading them to validate that environments are in sync. That now takes up the majority (>80%) of the time of `pixi global list`.

Short term: we should also have a "fast-in-sync" function that does not require loading all prefix records. 

Long term: we should serialize PrefixRecords as msgpack and make parsing them really, really fast as this is slowing pixi down in multiple places (e.g. `pixi run`, ...).