### PR TITLE
fix: pixi test tasks

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -30,8 +30,8 @@ run-all-examples = { cmd = "python tests/scripts/run-all-examples.py --pixi-exec
 test = { depends-on = ["test-all-fast"] }
 test-all-fast = { depends-on = ["test-fast", "test-integration-fast"] }
 test-all-slow = { depends-on = ["test-slow", "test-integration-slow"] }
-test-fast = "cargo nextest run --workspace"
-test-slow = """cargo nextest run --workspace --retries 2 --features slow_integration_tests
+test-fast = "cargo nextest run --workspace --all-targets"
+test-slow = """cargo nextest run --workspace --all-targets --retries 2 --features slow_integration_tests
               --status-level skip --failure-output immediate-final --no-fail-fast --final-status-level slow"""
 
 


### PR DESCRIPTION
Adds `--all-targets`.
Adding `--all` isn't necessary since it is a deprecated alias for `--workspace`
