### PR TITLE
feat: (simple) build tool override

### DIFF
--- a/crates/pixi_build_frontend/src/build_frontend.rs
+++ b/crates/pixi_build_frontend/src/build_frontend.rs
@@ -112,10 +112,6 @@ impl BuildFrontend {
             request.source_dir.display()
         );
 
-        if let Some(tool_override) = &request.build_tool_override {
-            tracing::info!("overriding the backend with {:?}", tool_override);
-        }
-
         protocol
             .with_backend_override(request.build_tool_override)
             .finish(self.tool_context.clone(), request.build_id)

--- a/crates/pixi_build_frontend/src/build_frontend.rs
+++ b/crates/pixi_build_frontend/src/build_frontend.rs
@@ -112,6 +112,10 @@ impl BuildFrontend {
             request.source_dir.display()
         );
 
+        if let Some(tool_override) = &request.build_tool_override {
+            tracing::info!("overriding the backend with {:?}", tool_override);
+        }
+
         protocol
             .with_backend_override(request.build_tool_override)
             .finish(self.tool_context.clone(), request.build_id)

--- a/crates/pixi_build_frontend/src/lib.rs
+++ b/crates/pixi_build_frontend/src/lib.rs
@@ -41,7 +41,7 @@ impl BackendOverride {
     pub fn from_env() -> Option<Self> {
         match std::env::var("PIXI_BUILD_BACKEND_OVERRIDE") {
             Ok(spec) => {
-                tracing::warn!("Overriding build backend with: {}", spec);
+                tracing::warn!("overriding build backend with: {}", spec);
                 Some(Self::System(spec))
             }
             Err(_) => None,

--- a/crates/pixi_build_frontend/src/lib.rs
+++ b/crates/pixi_build_frontend/src/lib.rs
@@ -27,14 +27,26 @@ pub use protocol_builder::EnabledProtocols;
 
 #[derive(Debug)]
 pub enum BackendOverride {
-    /// Overrwide the backend with a specific tool.
+    /// Override the backend with a specific tool.
     Spec(MatchSpec, Option<Vec<NamedChannelOrUrl>>),
 
-    /// Overwrite the backend with a specific tool.
+    /// Overwrite the backend with a executable path.
     System(String),
 
-    /// Use the given IO for the backend.
+    /// Override with a specific IPC channel.
     Io(InProcessBackend),
+}
+
+impl BackendOverride {
+    pub fn from_env() -> Option<Self> {
+        match std::env::var("PIXI_BUILD_BACKEND_OVERRIDE") {
+            Ok(spec) => {
+                tracing::warn!("Overriding build backend with: {}", spec);
+                Some(Self::System(spec))
+            }
+            Err(_) => None,
+        }
+    }
 }
 
 impl From<InProcessBackend> for BackendOverride {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -14,7 +14,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use chrono::Utc;
 use itertools::Itertools;
 use miette::Diagnostic;
-use pixi_build_frontend::{SetupRequest, ToolContext};
+use pixi_build_frontend::{BackendOverride, SetupRequest, ToolContext};
 use pixi_build_types::{
     procedures::{
         conda_build::{CondaBuildParams, CondaOutputIdentifier},
@@ -258,7 +258,7 @@ impl BuildContext {
             .with_tool_context(self.tool_context.clone())
             .setup_protocol(SetupRequest {
                 source_dir: source_checkout.path.clone(),
-                build_tool_override: Default::default(),
+                build_tool_override: BackendOverride::from_env(),
                 build_id,
             })
             .await
@@ -492,6 +492,7 @@ impl BuildContext {
                 ));
             }
         }
+        tracing::warn!("extracting metadata for {}", source.pinned);
 
         // Instantiate a protocol for the source directory.
         let protocol = pixi_build_frontend::BuildFrontend::default()
@@ -499,7 +500,7 @@ impl BuildContext {
             .with_tool_context(self.tool_context.clone())
             .setup_protocol(SetupRequest {
                 source_dir: source.path.clone(),
-                build_tool_override: Default::default(),
+                build_tool_override: BackendOverride::from_env(),
                 build_id,
             })
             .await

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -492,7 +492,6 @@ impl BuildContext {
                 ));
             }
         }
-        tracing::warn!("extracting metadata for {}", source.pinned);
 
         // Instantiate a protocol for the source directory.
         let protocol = pixi_build_frontend::BuildFrontend::default()

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc, time::Duration};
 use clap::{ArgAction, Parser};
 use indicatif::ProgressBar;
 use miette::{Context, IntoDiagnostic};
-use pixi_build_frontend::{CondaBuildReporter, SetupRequest};
+use pixi_build_frontend::{BackendOverride, CondaBuildReporter, SetupRequest};
 use pixi_build_types::{
     procedures::conda_build::CondaBuildParams, ChannelConfiguration, PlatformAndVirtualPackages,
 };
@@ -100,7 +100,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_tool_context(Arc::new(tool_context))
         .setup_protocol(SetupRequest {
             source_dir: project.root().to_path_buf(),
-            build_tool_override: None,
+            build_tool_override: BackendOverride::from_env(),
             build_id: 0,
         })
         .await


### PR DESCRIPTION
This allows us to set a `PIXI_BUILD_BACKEND_OVERRIDE=/foo/bar/...` so that we can test more easily.