### PR TITLE
refactor: remove ipc override from options and give it manually to test

### DIFF
--- a/crates/pixi_build_frontend/src/lib.rs
+++ b/crates/pixi_build_frontend/src/lib.rs
@@ -5,11 +5,11 @@ mod protocols;
 
 use std::fmt::{Debug, Formatter};
 
-pub(crate) use protocols::builders::{conda_protocol, pixi_protocol, rattler_build_protocol};
+pub use protocols::builders::{conda_protocol, pixi_protocol, rattler_build_protocol};
 
 mod protocol_builder;
 mod reporters;
-mod tool;
+pub mod tool;
 
 use std::path::PathBuf;
 
@@ -32,9 +32,6 @@ pub enum BackendOverride {
 
     /// Overwrite the backend with a executable path.
     System(String),
-
-    /// Override with a specific IPC channel.
-    Io(InProcessBackend),
 }
 
 impl BackendOverride {
@@ -46,18 +43,6 @@ impl BackendOverride {
             }
             Err(_) => None,
         }
-    }
-}
-
-impl From<InProcessBackend> for BackendOverride {
-    fn from(value: InProcessBackend) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl From<InProcessBackend> for Option<BackendOverride> {
-    fn from(value: InProcessBackend) -> Self {
-        Some(value.into())
     }
 }
 

--- a/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
@@ -207,6 +207,8 @@ impl ProtocolBuilder {
         .await?)
     }
 
+    /// Finish the construction of the protocol with the given tool and return the protocol object.
+    /// Note: prefer using `finish` instead of this method.
     pub async fn finish_with_tool(
         self,
         tool: Tool,

--- a/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
@@ -14,6 +14,7 @@ use which::Error;
 
 use crate::{
     protocols::{InitializeError, JsonRPCBuildProtocol},
+    tool::Tool,
     tool::{IsolatedToolSpec, ToolCacheError, ToolSpec},
     BackendOverride, ToolContext,
 };
@@ -74,7 +75,7 @@ impl Display for FinishError {
 
 impl ProtocolBuilder {
     /// Constructs a new instance from a manifest.
-    pub(crate) fn new(
+    pub fn new(
         source_dir: PathBuf,
         manifest_path: PathBuf,
         workspace_manifest: WorkspaceManifest,
@@ -196,6 +197,21 @@ impl ProtocolBuilder {
             .await
             .map_err(FinishError::Tool)?;
 
+        Ok(JsonRPCBuildProtocol::setup(
+            self.source_dir,
+            self.manifest_path,
+            build_id,
+            self.cache_dir,
+            tool,
+        )
+        .await?)
+    }
+
+    pub async fn finish_with_tool(
+        self,
+        tool: Tool,
+        build_id: usize,
+    ) -> Result<JsonRPCBuildProtocol, FinishError> {
         Ok(JsonRPCBuildProtocol::setup(
             self.source_dir,
             self.manifest_path,

--- a/crates/pixi_build_frontend/src/tool/spec.rs
+++ b/crates/pixi_build_frontend/src/tool/spec.rs
@@ -72,7 +72,6 @@ impl BackendOverride {
                 IsolatedToolSpec::from_specs(vec![spec], channels.into_iter().flatten()),
             ),
             BackendOverride::System(command) => ToolSpec::System(SystemToolSpec { command }),
-            BackendOverride::Io(process) => ToolSpec::Io(process),
         }
     }
 }

--- a/crates/pixi_build_frontend/tests/diagnostics.rs
+++ b/crates/pixi_build_frontend/tests/diagnostics.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme};
 use pixi_build_frontend::{BuildFrontend, InProcessBackend, SetupRequest};
+use pixi_manifest::toml::{ExternalWorkspaceProperties, TomlManifest};
 
 fn error_to_snapshot(diag: &impl Diagnostic) -> String {
     let mut report_str = String::new();
@@ -114,24 +115,22 @@ async fn test_invalid_backend() {
     let manifest = source_dir
         .path()
         .join(pixi_consts::consts::PROJECT_MANIFEST);
-    tokio::fs::write(
-        &manifest,
-        r#"
-        [workspace]
-        platforms = []
-        channels = []
-        preview = ['pixi-build']
 
-        [package]
-        version = "0.1.0"
-        name = "project"
+    let toml = r#"
+    [workspace]
+    platforms = []
+    channels = []
+    preview = ['pixi-build']
 
-        [build-system]
-        build-backend = { name = "ipc", version = "*" }
-        "#,
-    )
-    .await
-    .unwrap();
+    [package]
+    version = "0.1.0"
+    name = "project"
+
+    [build-system]
+    build-backend = { name = "ipc", version = "*" }
+    "#;
+
+    tokio::fs::write(&manifest, toml).await.unwrap();
 
     let (in_tx, in_rx) = tokio::io::duplex(1024);
     let (out_tx, _out_rx) = tokio::io::duplex(1024);
@@ -144,12 +143,20 @@ async fn test_invalid_backend() {
     // connection.
     drop(in_tx);
 
-    let err = BuildFrontend::default()
-        .setup_protocol(SetupRequest {
-            source_dir: source_dir.path().to_path_buf(),
-            build_tool_override: ipc.into(),
-            build_id: 0,
-        })
+    let (workspace, package) = TomlManifest::from_toml_str(toml)
+        .unwrap()
+        .into_manifests(ExternalWorkspaceProperties::default())
+        .unwrap();
+    let protocol = pixi_build_frontend::pixi_protocol::ProtocolBuilder::new(
+        source_dir.path().to_path_buf(),
+        manifest.to_path_buf(),
+        workspace,
+        package.unwrap(),
+    )
+    .unwrap();
+
+    let err = protocol
+        .finish_with_tool(pixi_build_frontend::tool::Tool::Io(ipc), 0)
         .await
         .unwrap_err();
 


### PR DESCRIPTION
If I understand correctly, creating the IPC backend from a "string" will not be easily possible, and the types used are not serializable or cloneable. 

I envision a future were we can override build backends selectively, and so it would be good to be able to use a hash map such as:

```
pixi-build-rattler-build: /foo/bar/pixi-build-rattler-build-test
bla: ...
```

But to achieve this, we need a type that is easier to use than the current Io backend. Since that backend override is only used in testing, we can use more direct methods of setting it in the Protocol.

Lmk what you think @tdejager / @baszalmstra 