### PR TITLE
chore: skip building release artifacts on pr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       tag:
@@ -124,10 +123,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist }}
       # Get the dist-manifest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,7 +388,7 @@ github-release = "announce"
 # Whether to auto-include files like READMEs, LICENSEs, and CHANGELOGs (default true)
 auto-includes = false
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "skip"
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["msi"]
 # Whether to sign macOS executables


### PR DESCRIPTION
This PR removes the generation of release artifacts on every PR.