### PR TITLE
feat: expose some public API

### DIFF
--- a/crates/pixi_manifest/src/manifests/source.rs
+++ b/crates/pixi_manifest/src/manifests/source.rs
@@ -63,11 +63,17 @@ impl ManifestSource {
         }
     }
 
-    fn manifest(&self) -> &TomlDocument {
+    /// Returns the inner TOML document
+    pub fn manifest(&self) -> &TomlDocument {
         match self {
             ManifestSource::PyProjectToml(document) => document,
             ManifestSource::PixiToml(document) => document,
         }
+    }
+
+    /// Returns `true` if the manifest is a 'pyproject.toml' manifest.
+    pub fn is_pyproject_toml(&self) -> bool {
+        matches!(self, ManifestSource::PyProjectToml(_))
     }
 
     /// Returns a mutable reference to the specified array either in project or


### PR DESCRIPTION
I need to expose these public methods so I could access manifest table from pixi-build-backend.
necessary for this PR: https://github.com/prefix-dev/pixi-build-backends/compare/main...nichmor:pixi-build-backends:fix/add-entry-points-in-recipe?expand=1