### PR TITLE
fix: `test_sync_migrate`

### DIFF
--- a/tests/integration_python/pixi_global/test_global.py
+++ b/tests/integration_python/pixi_global/test_global.py
@@ -186,7 +186,7 @@ exposed = {{ dummy-d = "dummy-d" }}
 [envs.test2]
 channels = ["https://prefix.dev/conda-forge"]
 # Small package with binary for testing purposes
-dependencies = {{ xz = "*" }}
+dependencies = {{ xz-tools = "*" }}
 exposed = {{ xz = "xz" }}
 """
     manifest.write_text(toml)


### PR DESCRIPTION
I am not exactly sure what is going on here, but `xz` is now read as `xz-tools` when migrating
