### PR TITLE
feat: add target to workspace `[workspace.target.win-64.build-variants]`

### DIFF
--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__build_variants-2.snap
+++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__build_variants-2.snap
@@ -1,0 +1,21 @@
+---
+source: crates/pixi_manifest/src/manifests/workspace.rs
+expression: resolved_win
+---
+[
+    Some(
+        {
+            "python": [
+                "1.0.*",
+            ],
+        },
+    ),
+    Some(
+        {
+            "python": [
+                "3.10.*",
+                "3.11.*",
+            ],
+        },
+    ),
+]

--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__build_variants.snap
+++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__build_variants.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pixi_manifest/src/manifests/workspace.rs
+expression: resolved_linux
+---
+[
+    Some(
+        {
+            "python": [
+                "3.10.*",
+                "3.11.*",
+            ],
+        },
+    ),
+]

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -82,7 +82,7 @@ impl WorkspaceManifest {
 
 #[cfg(test)]
 mod tests {
-    use insta::{assert_snapshot, assert_yaml_snapshot};
+    use insta::{assert_debug_snapshot, assert_snapshot, assert_yaml_snapshot};
     use itertools::Itertools;
     use rattler_conda_types::{NamedChannelOrUrl, Platform};
 
@@ -475,5 +475,36 @@ mod tests {
         test = "test"
         "#;
         let _manifest = WorkspaceManifest::from_toml_str(contents).unwrap();
+    }
+
+    #[test]
+    fn test_build_variants() {
+        let contents = r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = []
+
+        [workspace.build-variants]
+        python = ["3.10.*", "3.11.*"]
+
+        [workspace.target.win-64.build-variants]
+        python = ["1.0.*"]
+        "#;
+        let manifest = WorkspaceManifest::from_toml_str(contents).unwrap();
+        println!("{:?}", manifest.workspace.build_variants);
+        let resolved_linux = manifest
+            .workspace
+            .build_variants
+            .resolve(Some(Platform::Linux64))
+            .collect::<Vec<_>>();
+        assert_debug_snapshot!(resolved_linux);
+
+        let resolved_win = manifest
+            .workspace
+            .build_variants
+            .resolve(Some(Platform::Win64))
+            .collect::<Vec<_>>();
+        assert_debug_snapshot!(resolved_win);
     }
 }

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -267,7 +267,6 @@ impl PyProjectManifest {
                 homepage: None,
                 repository: None,
                 documentation: None,
-                build_variants: None,
             })?;
 
         // Add python as dependency based on the `project.requires_python` property

--- a/crates/pixi_manifest/src/workspace.rs
+++ b/crates/pixi_manifest/src/workspace.rs
@@ -6,7 +6,7 @@ use rattler_solve::ChannelPriority;
 use url::Url;
 
 use super::pypi::pypi_options::PypiOptions;
-use crate::{preview::Preview, utils::PixiSpanned, PrioritizedChannel};
+use crate::{preview::Preview, utils::PixiSpanned, PrioritizedChannel, Targets};
 
 /// Describes the contents of the `[workspace]` section of the project manifest.
 #[derive(Debug, Clone)]
@@ -62,5 +62,5 @@ pub struct Workspace {
     pub preview: Preview,
 
     /// Build variants
-    pub build_variants: Option<HashMap<String, Vec<String>>>,
+    pub build_variants: Targets<Option<HashMap<String, Vec<String>>>>,
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -168,11 +168,15 @@ impl BuildContext {
 
     fn resolve_variant(&self, platform: Platform) -> HashMap<String, Vec<String>> {
         let mut result = HashMap::new();
-        for item in self.variant_config.resolve(Some(platform)) {
-            if let Some(variants) = item {
-                result.extend(variants.clone());
+
+        // Resolves from most specific to least specific.
+        for variants in self.variant_config.resolve(Some(platform)).flatten() {
+            // Update the hash map, but only items that are not already in the map.
+            for (key, value) in variants {
+                result.entry(key.clone()).or_insert_with(|| value.clone());
             }
         }
+
         tracing::info!(
             "resolved variant configuration for {}: {:?}",
             platform,


### PR DESCRIPTION
Adds support for the "`.target`" on the workspace object. 

We then merge the variants (more specific one should win). E.g.:

```
[workspace.build-variants]
foo = ["1.0"]

[workspace.win-64.build-variants]
foo = ["2.0.* *_win"]  # wins on Windows
```