### PR TITLE
test: skip `test_local_source_newer_than_local_metadata`

### DIFF
--- a/src/install_pypi/plan/test/mod.rs
+++ b/src/install_pypi/plan/test/mod.rs
@@ -293,6 +293,12 @@ fn test_installed_local_required_local() {
 }
 /// When requiring a local package and that same local package is installed, we should not reinstall it
 /// except if the pyproject.toml file, or some other source files we won't check here is newer than the cache
+/// NOTE: We are skipping that test since it is flaky on linux
+/// uv checks ctime on unix systems
+/// During debug, we noticed that some times ctime isn't updated, and we couldn't find a relieable way to ensure that
+/// At this time, we believe this to be a problem with our test, not with pixi or uv.
+/// If user encounter this problem we should investigate this again
+#[cfg(not(target_os = "linux"))]
 #[test]
 fn test_local_source_newer_than_local_metadata() {
     let (fake, pyproject) = harness::fake_pyproject_toml(None);


### PR DESCRIPTION
We are skipping that test since it is flaky on linux
uv checks ctime on unix systems
During debug, we noticed that sometimes ctime isn't updated, and we couldn't find a reliable way to ensure that
At this time, we believe this to be a problem with our test, not with pixi or uv.
If user encounter this problem, we should investigate this again
