### PR TITLE
docs: Add whitespace between text and images

### DIFF
--- a/docs/examples/cpp-sdl.md
+++ b/docs/examples/cpp-sdl.md
@@ -5,6 +5,7 @@ description: How to build and run an SDL application in C++
 ---
 
 ![](https://storage.googleapis.com/prefix-cms-images/docs/sdl_examle.png)
+
 The `cpp-sdl` example is located in the pixi repository.
 
 ```shell

--- a/docs/examples/opencv.md
+++ b/docs/examples/opencv.md
@@ -25,6 +25,7 @@ pixi run start
 ```
 
 The screen that starts should look like this:
+
 ![](https://storage.googleapis.com/prefix-cms-images/docs/opencv_face_recognition.png)
 
 Check out the `webcame_capture.py` to see how we detect a face.
@@ -34,7 +35,9 @@ Check out the `webcame_capture.py` to see how we detect a face.
 Next to face recognition, a camera calibration example is also included.
 
 You'll need a checkerboard for this to work.
-Print this: [![chessboard](https://github.com/opencv/opencv/blob/4.x/doc/pattern.png?raw=true)](https://github.com/opencv/opencv/blob/4.x/doc/pattern.png)
+Print this:
+
+[![chessboard](https://github.com/opencv/opencv/blob/4.x/doc/pattern.png?raw=true)](https://github.com/opencv/opencv/blob/4.x/doc/pattern.png)
 
 Then run
 


### PR DESCRIPTION
That way, you avoid situations like this one:

![grafik](https://github.com/user-attachments/assets/4e9c5745-b44d-4fe7-8f9d-6d54498e459f)
