### PR TITLE
test: stop testing rich example

### DIFF
--- a/tests/scripts/test-examples.sh
+++ b/tests/scripts/test-examples.sh
@@ -9,7 +9,6 @@ pixi run -v --manifest-path examples/polarify/pixi.toml -e pl020 test
 
 echo "Running the pypi example:"
 pixi run -v --manifest-path examples/pypi/pixi.toml test
-# pixi run -v --manifest-path examples/pypi-source-deps/pixi.toml test
 
 echo "Running the conda_mapping example:"
 pixi run -v --manifest-path examples/conda_mapping/pixi.toml test
@@ -17,6 +16,3 @@ pixi run -v --manifest-path examples/conda_mapping/pixi.toml test
 echo "Running the solve-groups example:"
 pixi run -v --manifest-path examples/solve-groups/pixi.toml -e min-py38 test
 pixi run -v --manifest-path examples/solve-groups/pixi.toml -e max-py310 test
-
-echo "Running the rich example:"
-pixi run -v --manifest-path examples/rich_example/pyproject.toml test


### PR DESCRIPTION
It fails on CI, but @tdejager and I cannot reproduce the error locally