### PR TITLE
test: run tests in parallel again on CI

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -65,10 +65,6 @@ test-specific-test = { cmd = "pytest", depends-on = ["build-release"] }
 # e.g. "multiple_versions_channel_1"
 update-test-channel = { cmd = "python update-channels.py", cwd = "tests/data/channels" }
 
-[feature.pytest.target.osx.tasks]
-# Running integration tests in parallel sometimes fails for macOS
-test-integration-ci = "pytest --durations=10 --verbose --timeout=300 tests/integration_python"
-
 
 [feature.dev.dependencies]
 # Needed for the citation


### PR DESCRIPTION
We hoped that this would avoid osx freezing, but it didn't
