### PR TITLE
fix: enforce rust-tls for reqwest

### DIFF
--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -96,6 +96,7 @@ pub fn build_reqwest_clients(config: Option<&Config>) -> (Client, ClientWithMidd
         .user_agent(app_user_agent)
         .danger_accept_invalid_certs(config.tls_no_verify())
         .read_timeout(Duration::from_secs(timeout))
+        .use_rustls_tls()
         .build()
         .expect("failed to create reqwest Client");
 


### PR DESCRIPTION
We expect that `native-tls` is still used for `reqwest` and that this is the reason we see this error message on CI on Windows

```
Failed to resolve dependencies: error sending request for url (https://prefix.dev/conda-forge/noarch/repodata_shards.msgpack.zst)
    Diagnostic severity: error
    Caused by: An existing connection was forcibly closed by the remote host. (os error 10054)
    Caused by: client error (Connect)
    Caused by: error sending request for url (https://prefix.dev/conda-forge/noarch/repodata_shards.msgpack.zst)
```