### PR TITLE
ci: Debug CI timeouts on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,8 @@ jobs:
         run: pixi install -v
 
       - name: Run integration tests
+        env:
+          RUST_LOG: rattler_package_cache=debug,rattler_cache=debug,rattler_repodata_gateway=debug
         run: pixi run --locked test-integration-ci
 
       - name: Test examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,20 +429,20 @@ jobs:
           echo "${{ env.TARGET_RELEASE }}" >> $GITHUB_PATH
       - name: Verify pixi installation
         run: pixi --version
-
-      - name: Install pixi
-        run: pixi install -v
+#
+#      - name: Install pixi
+#        run: pixi install -v
 
       - name: Run integration tests
         env:
           RUST_LOG: rattler_package_cache=debug,rattler_cache=debug,rattler_repodata_gateway=debug
         run: pixi run --locked test-integration-ci
 
-      - name: Test examples
-        run: bash tests/scripts/test-examples.sh
-
-      - name: Test export
-        run: pixi run --locked test-export
+#      - name: Test examples
+#        run: bash tests/scripts/test-examples.sh
+#
+#      - name: Test export
+#        run: pixi run --locked test-export
 
       - name: "Checkout Deltares/Ribasim"
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,162 +85,162 @@ jobs:
         run: rustup component add rustfmt
       - name: "rustfmt"
         run: cargo fmt --all --check
+#
+#  # Check that all the code references are correct.
+#  check-rustdoc-links:
+#    name: "cargo rustdoc | ubuntu"
+#    needs: determine_changes
+#    runs-on: ubuntu-latest
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
+#      - run: |
+#          for package in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .name'); do
+#            cargo rustdoc -p "$package" --all-features -- -D warnings -W unreachable-pub
+#          done
 
-  # Check that all the code references are correct.
-  check-rustdoc-links:
-    name: "cargo rustdoc | ubuntu"
-    needs: determine_changes
-    runs-on: ubuntu-latest
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: |
-          for package in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .name'); do
-            cargo rustdoc -p "$package" --all-features -- -D warnings -W unreachable-pub
-          done
-
-  # Run `cargo clippy` on the entire codebase.
-  lint:
-    name: "cargo clippy | ubuntu"
-    needs: determine_changes
-    runs-on: ubuntu-latest
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: "Install Rust toolchain"
-        run: rustup component add clippy
-      - name: Run clippy
-        run: cargo clippy --all-targets --workspace --locked
-
-  # Checks for dependencies that are not used in the codebase
-  cargo-machete:
-    name: Cargo Machete
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Machete
-        uses: bnjbvr/cargo-machete@main
-
-
-  #
-  # Run tests on important platforms.
-  #
-
-  cargo-test-linux:
-    name: "cargo test | ubuntu"
-    timeout-minutes: 15
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 8core_ubuntu_latest_runner
-    steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target/pixi"
-          key: ${{ hashFiles('pixi.lock') }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Test pixi
-        run: pixi run test-slow
-
-  cargo-test-macos-aarch64:
-    name: "cargo test | macos aarch64"
-    timeout-minutes: 15
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target/pixi"
-          key: ${{ hashFiles('pixi.lock') }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Test pixi
-        run: pixi run test-slow
-
-  cargo-test-macos-x86_64:
-    name: "cargo test | macos x86_64"
-    timeout-minutes: 15
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target/pixi"
-          key: ${{ hashFiles('pixi.lock') }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Test pixi
-        run: pixi run test-slow
-
-  cargo-test-windows:
-    name: "cargo test | windows"
-    timeout-minutes: 15
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 16core_windows_latest_runner
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
-      - uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          cache: ${{ github.ref == 'refs/heads/main' }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target/pixi"
-          key: ${{ hashFiles('pixi.lock') }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Test pixi
-        run: pixi run test-slow
-
-  #
-  # Builds the binary artifacts on different platforms
-  #
-
-  build-binary-linux-x86_64:
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 8core_ubuntu_latest_runner
-    name: "build binary | linux x86_64"
-    steps:
-        - uses: actions/checkout@v4
-        - uses: rui314/setup-mold@v1
-        - name: "Setup musl"
-          run: |
-            sudo apt-get install musl-tools
-            rustup target add x86_64-unknown-linux-musl
-        - uses: Swatinem/rust-cache@v2
-        - name: "Build"
-          run: >
-            cargo build
-            --locked
-            --target x86_64-unknown-linux-musl
-            --profile $CARGO_BUILD_PROFILE
-            --features self_update
-        - name: "Upload binary"
-          uses: actions/upload-artifact@v4
-          with:
-            name: pixi-linux-x86_64-${{ github.sha }}
-            path: ./target/x86_64-unknown-linux-musl/${{ env.CARGO_BUILD_PROFILE }}/pixi
-            retention-days: 1
+#  # Run `cargo clippy` on the entire codebase.
+#  lint:
+#    name: "cargo clippy | ubuntu"
+#    needs: determine_changes
+#    runs-on: ubuntu-latest
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
+#      - name: "Install Rust toolchain"
+#        run: rustup component add clippy
+#      - name: Run clippy
+#        run: cargo clippy --all-targets --workspace --locked
+#
+#  # Checks for dependencies that are not used in the codebase
+#  cargo-machete:
+#    name: Cargo Machete
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#      - name: Machete
+#        uses: bnjbvr/cargo-machete@main
+#
+#
+#  #
+#  # Run tests on important platforms.
+#  #
+#
+#  cargo-test-linux:
+#    name: "cargo test | ubuntu"
+#    timeout-minutes: 15
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    runs-on: 8core_ubuntu_latest_runner
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: prefix-dev/setup-pixi@v0.8.1
+#        with:
+#          cache: ${{ github.ref == 'refs/heads/main' }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          workspaces: ". -> target/pixi"
+#          key: ${{ hashFiles('pixi.lock') }}
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
+#      - name: Test pixi
+#        run: pixi run test-slow
+#
+#  cargo-test-macos-aarch64:
+#    name: "cargo test | macos aarch64"
+#    timeout-minutes: 15
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    runs-on: macos-14
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: prefix-dev/setup-pixi@v0.8.1
+#        with:
+#          cache: ${{ github.ref == 'refs/heads/main' }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          workspaces: ". -> target/pixi"
+#          key: ${{ hashFiles('pixi.lock') }}
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
+#      - name: Test pixi
+#        run: pixi run test-slow
+#
+#  cargo-test-macos-x86_64:
+#    name: "cargo test | macos x86_64"
+#    timeout-minutes: 15
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
+#    runs-on: macos-13
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: prefix-dev/setup-pixi@v0.8.1
+#        with:
+#          cache: ${{ github.ref == 'refs/heads/main' }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          workspaces: ". -> target/pixi"
+#          key: ${{ hashFiles('pixi.lock') }}
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
+#      - name: Test pixi
+#        run: pixi run test-slow
+#
+#  cargo-test-windows:
+#    name: "cargo test | windows"
+#    timeout-minutes: 15
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    runs-on: 16core_windows_latest_runner
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Create Dev Drive using ReFS
+#        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+#      - uses: prefix-dev/setup-pixi@v0.8.1
+#        with:
+#          cache: ${{ github.ref == 'refs/heads/main' }}
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          workspaces: ". -> target/pixi"
+#          key: ${{ hashFiles('pixi.lock') }}
+#          save-if: ${{ github.ref == 'refs/heads/main' }}
+#      - name: Test pixi
+#        run: pixi run test-slow
+#
+#  #
+#  # Builds the binary artifacts on different platforms
+#  #
+#
+#  build-binary-linux-x86_64:
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    runs-on: 8core_ubuntu_latest_runner
+#    name: "build binary | linux x86_64"
+#    steps:
+#        - uses: actions/checkout@v4
+#        - uses: rui314/setup-mold@v1
+#        - name: "Setup musl"
+#          run: |
+#            sudo apt-get install musl-tools
+#            rustup target add x86_64-unknown-linux-musl
+#        - uses: Swatinem/rust-cache@v2
+#        - name: "Build"
+#          run: >
+#            cargo build
+#            --locked
+#            --target x86_64-unknown-linux-musl
+#            --profile $CARGO_BUILD_PROFILE
+#            --features self_update
+#        - name: "Upload binary"
+#          uses: actions/upload-artifact@v4
+#          with:
+#            name: pixi-linux-x86_64-${{ github.sha }}
+#            path: ./target/x86_64-unknown-linux-musl/${{ env.CARGO_BUILD_PROFILE }}/pixi
+#            retention-days: 1
 
   build-binary-macos-aarch64:
     needs: determine_changes
@@ -263,151 +263,151 @@ jobs:
           name: pixi-macos-aarch64-${{ github.sha }}
           path: ./target/${{ env.CARGO_BUILD_PROFILE }}/pixi
           retention-days: 1
-
-  build-binary-macos-x86_64:
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
-    runs-on: macos-13
-    name: "build binary | macos x86_64"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: rui314/setup-mold@v1
-      - uses: Swatinem/rust-cache@v2
-      - name: "Build"
-        run: >
-          cargo build
-          --locked
-          --profile $CARGO_BUILD_PROFILE
-          --features self_update
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v4
-        with:
-          name: pixi-macos-x86_64-${{ github.sha }}
-          path: ./target/${{ env.CARGO_BUILD_PROFILE }}/pixi
-          retention-days: 1
-
-  build-binary-windows-x86_64:
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 16core_windows_latest_runner
-    name: "build binary | windows x86_64"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
-      - name: Copy Git Repo to Dev Drive
-        run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ env.PIXI_WORKSPACE }}
-      - name: "Build"
-        working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: >
-          cargo build
-          --locked
-          --profile $env:CARGO_BUILD_PROFILE
-          --features self_update
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v4
-        with:
-          name: pixi-windows-x86_64-${{ github.sha }}
-          path: ${{ env.PIXI_WORKSPACE }}/target/${{ env.CARGO_BUILD_PROFILE }}/pixi.exe
-          retention-days: 1
-
-  build-binary-windows-aarch64:
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 16core_windows_latest_runner
-    name: "build binary | windows aarch64"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
-      - name: Copy Git Repo to Dev Drive
-        run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
-      - name: "Install Rust toolchain"
-        run: rustup target add aarch64-pc-windows-msvc
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ env.PIXI_WORKSPACE }}
-      - name: "Build"
-        working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: >
-          cargo build
-          --locked
-          --target aarch64-pc-windows-msvc
-          --profile $env:CARGO_BUILD_PROFILE
-          --features self_update
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v4
-        with:
-          name: pixi-windows-aarch64-${{ github.sha }}
-          path: ${{ env.PIXI_WORKSPACE }}/target/aarch64-pc-windows-msvc/${{ env.CARGO_BUILD_PROFILE }}/pixi.exe
-          retention-days: 1
-
-  #
-  # Run integration tests on important platforms
-  #
-
-  test-integration-windows-x86_64:
-    timeout-minutes: 30
-    name: pytest integration | windows x86_64
-    runs-on: windows-latest
-    needs: build-binary-windows-x86_64
-    env:
-      TARGET_RELEASE: "target/pixi/release"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
-      - name: Copy Git Repo to Dev Drive
-        run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
-          echo "${{ env.PIXI_WORKSPACE }}/${{ env.TARGET_RELEASE }}" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_PATH
-      - name: Download binary from build
-        uses: actions/download-artifact@v4
-        with:
-          name: pixi-windows-x86_64-${{ github.sha }}
-          path: ${{ env.PIXI_WORKSPACE }}/${{ env.TARGET_RELEASE }}
-      - name: Verify pixi installation
-        run: pixi --version
-
-      - name: Install pixi
-        working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: pixi install -v
-
-      - name: Run integration tests
-        working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: pixi run --locked test-integration-ci
-
-      - name: Test examples
-        shell: bash
-        working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: bash tests/scripts/test-examples.sh
-
-      - name: "Checkout Deltares/Ribasim"
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: ribasim
-      - name: "Copy Deltares/Ribasim to Dev Drive"
-        run: Copy-Item -Path "${{ github.workspace }}/ribasim" -Destination "${{ env.PIXI_WORKSPACE }}/ribasim" -Recurse
-      - name: "Install Deltares/Ribasim"
-        run: pixi install
-        working-directory: ${{ env.PIXI_WORKSPACE }}/ribasim
-
-      - name: "Checkout quantco/polarify"
-        uses: actions/checkout@v4
-        with:
-          repository: quantco/polarify
-          path: polarify
-      - name: "Copy quantco/polarify to Dev Drive"
-        run: Copy-Item -Path "${{ github.workspace }}/polarify" -Destination "${{ env.PIXI_WORKSPACE }}/polarify" -Recurse
-      - name: "Install quantco/polarify"
-        run: pixi install
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+#
+#  build-binary-macos-x86_64:
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
+#    runs-on: macos-13
+#    name: "build binary | macos x86_64"
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: rui314/setup-mold@v1
+#      - uses: Swatinem/rust-cache@v2
+#      - name: "Build"
+#        run: >
+#          cargo build
+#          --locked
+#          --profile $CARGO_BUILD_PROFILE
+#          --features self_update
+#      - name: "Upload binary"
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: pixi-macos-x86_64-${{ github.sha }}
+#          path: ./target/${{ env.CARGO_BUILD_PROFILE }}/pixi
+#          retention-days: 1
+#
+#  build-binary-windows-x86_64:
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    runs-on: 16core_windows_latest_runner
+#    name: "build binary | windows x86_64"
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Create Dev Drive using ReFS
+#        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+#      - name: Copy Git Repo to Dev Drive
+#        run: |
+#          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          workspaces: ${{ env.PIXI_WORKSPACE }}
+#      - name: "Build"
+#        working-directory: ${{ env.PIXI_WORKSPACE }}
+#        run: >
+#          cargo build
+#          --locked
+#          --profile $env:CARGO_BUILD_PROFILE
+#          --features self_update
+#      - name: "Upload binary"
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: pixi-windows-x86_64-${{ github.sha }}
+#          path: ${{ env.PIXI_WORKSPACE }}/target/${{ env.CARGO_BUILD_PROFILE }}/pixi.exe
+#          retention-days: 1
+#
+#  build-binary-windows-aarch64:
+#    needs: determine_changes
+#    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+#    runs-on: 16core_windows_latest_runner
+#    name: "build binary | windows aarch64"
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Create Dev Drive using ReFS
+#        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+#      - name: Copy Git Repo to Dev Drive
+#        run: |
+#          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
+#      - name: "Install Rust toolchain"
+#        run: rustup target add aarch64-pc-windows-msvc
+#      - uses: Swatinem/rust-cache@v2
+#        with:
+#          workspaces: ${{ env.PIXI_WORKSPACE }}
+#      - name: "Build"
+#        working-directory: ${{ env.PIXI_WORKSPACE }}
+#        run: >
+#          cargo build
+#          --locked
+#          --target aarch64-pc-windows-msvc
+#          --profile $env:CARGO_BUILD_PROFILE
+#          --features self_update
+#      - name: "Upload binary"
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: pixi-windows-aarch64-${{ github.sha }}
+#          path: ${{ env.PIXI_WORKSPACE }}/target/aarch64-pc-windows-msvc/${{ env.CARGO_BUILD_PROFILE }}/pixi.exe
+#          retention-days: 1
+#
+#  #
+#  # Run integration tests on important platforms
+#  #
+#
+#  test-integration-windows-x86_64:
+#    timeout-minutes: 30
+#    name: pytest integration | windows x86_64
+#    runs-on: windows-latest
+#    needs: build-binary-windows-x86_64
+#    env:
+#      TARGET_RELEASE: "target/pixi/release"
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Create Dev Drive using ReFS
+#        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+#      - name: Copy Git Repo to Dev Drive
+#        run: |
+#          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.PIXI_WORKSPACE }}" -Recurse
+#          echo "${{ env.PIXI_WORKSPACE }}/${{ env.TARGET_RELEASE }}" | Out-File -Append -Encoding utf8 -FilePath $env:GITHUB_PATH
+#      - name: Download binary from build
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: pixi-windows-x86_64-${{ github.sha }}
+#          path: ${{ env.PIXI_WORKSPACE }}/${{ env.TARGET_RELEASE }}
+#      - name: Verify pixi installation
+#        run: pixi --version
+#
+#      - name: Install pixi
+#        working-directory: ${{ env.PIXI_WORKSPACE }}
+#        run: pixi install -v
+#
+#      - name: Run integration tests
+#        working-directory: ${{ env.PIXI_WORKSPACE }}
+#        run: pixi run --locked test-integration-ci
+#
+#      - name: Test examples
+#        shell: bash
+#        working-directory: ${{ env.PIXI_WORKSPACE }}
+#        run: bash tests/scripts/test-examples.sh
+#
+#      - name: "Checkout Deltares/Ribasim"
+#        uses: actions/checkout@v4
+#        with:
+#          repository: Deltares/Ribasim
+#          path: ribasim
+#      - name: "Copy Deltares/Ribasim to Dev Drive"
+#        run: Copy-Item -Path "${{ github.workspace }}/ribasim" -Destination "${{ env.PIXI_WORKSPACE }}/ribasim" -Recurse
+#      - name: "Install Deltares/Ribasim"
+#        run: pixi install
+#        working-directory: ${{ env.PIXI_WORKSPACE }}/ribasim
+#
+#      - name: "Checkout quantco/polarify"
+#        uses: actions/checkout@v4
+#        with:
+#          repository: quantco/polarify
+#          path: polarify
+#      - name: "Copy quantco/polarify to Dev Drive"
+#        run: Copy-Item -Path "${{ github.workspace }}/polarify" -Destination "${{ env.PIXI_WORKSPACE }}/polarify" -Recurse
+#      - name: "Install quantco/polarify"
+#        run: pixi install
+#        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
 
   test-integration-macos-aarch64:
     timeout-minutes: 30
@@ -462,96 +462,96 @@ jobs:
         run: pixi install
         working-directory: polarify
 
-  test-integration-linux-x86_64:
-    timeout-minutes: 30
-    name: pytest integration | linux x86_64
-    runs-on: 8core_ubuntu_latest_runner
-    needs: build-binary-linux-x86_64
-    env:
-      TARGET_RELEASE: "${{ github.workspace }}/target/pixi/release"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download binary from build
-        uses: actions/download-artifact@v4
-        with:
-          name: pixi-linux-x86_64-${{ github.sha }}
-          path: ${{ env.TARGET_RELEASE }}
-      - name: Setup unix binary, add to github path
-        run: |
-          chmod a+x ${{ env.TARGET_RELEASE }}/pixi
-          echo "${{ env.TARGET_RELEASE }}" >> $GITHUB_PATH
-      - name: Verify pixi installation
-        run: pixi --version
-
-      - name: Install pixi
-        run: pixi install -v
-
-      - name: Run integration tests
-        run: pixi run --locked test-integration-ci
-
-      - name: "Test examples"
-        run: bash tests/scripts/test-examples.sh
-
-      - name: "Test export"
-        run: pixi run --locked test-export
-
-      - name: "Checkout nerfstudio-project/nerfstudio"
-        uses: actions/checkout@v4
-        with:
-          repository: nerfstudio-project/nerfstudio
-          path: nerfstudio
-      - name: "Install nerfstudio-project/nerfstudio"
-        run: pixi install
-        working-directory: nerfstudio
-
-      - name: "Checkout Deltares/Ribasim"
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: ribasim
-      - name: "Install Deltares/Ribasim"
-        run: pixi install
-        working-directory: ribasim
-
-      - name: "Checkout quantco/polarify"
-        uses: actions/checkout@v4
-        with:
-          repository: quantco/polarify
-          path: polarify
-      - name: "Install quantco/polarify"
-        run: pixi install
-        working-directory: polarify
-
-  #
-  # Install a number of common wheels on some platforms
-  #
-
-  test-common-wheels-linux-x86_64:
-    name: "test wheel installation | linux x86_64"
-    needs:
-      - build-binary-linux-x86_64
-    uses: ./.github/workflows/test_common_wheels.yml
-    with:
-        sha: ${{ github.sha }}
-        arch: linux-x86_64
-        runs-on: 8core_ubuntu_latest_runner
-
-  test-common-wheels-windows-x86_64:
-    name: "test wheel installation | windows x86_64"
-    needs:
-      - build-binary-windows-x86_64
-    uses: ./.github/workflows/test_common_wheels.yml
-    with:
-      sha: ${{ github.sha }}
-      arch: windows-x86_64
-      runs-on: windows-latest
-
-  test-common-wheels-macos-aarch64:
-    name: "test wheel installation | macos aarch64"
-    needs:
-      - build-binary-macos-aarch64
-    uses: ./.github/workflows/test_common_wheels.yml
-    with:
-      sha: ${{ github.sha }}
-      arch: macos-aarch64
-      runs-on: macos-14
+#  test-integration-linux-x86_64:
+#    timeout-minutes: 30
+#    name: pytest integration | linux x86_64
+#    runs-on: 8core_ubuntu_latest_runner
+#    needs: build-binary-linux-x86_64
+#    env:
+#      TARGET_RELEASE: "${{ github.workspace }}/target/pixi/release"
+#    steps:
+#      - uses: actions/checkout@v4
+#      - name: Download binary from build
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: pixi-linux-x86_64-${{ github.sha }}
+#          path: ${{ env.TARGET_RELEASE }}
+#      - name: Setup unix binary, add to github path
+#        run: |
+#          chmod a+x ${{ env.TARGET_RELEASE }}/pixi
+#          echo "${{ env.TARGET_RELEASE }}" >> $GITHUB_PATH
+#      - name: Verify pixi installation
+#        run: pixi --version
+#
+#      - name: Install pixi
+#        run: pixi install -v
+#
+#      - name: Run integration tests
+#        run: pixi run --locked test-integration-ci
+#
+#      - name: "Test examples"
+#        run: bash tests/scripts/test-examples.sh
+#
+#      - name: "Test export"
+#        run: pixi run --locked test-export
+#
+#      - name: "Checkout nerfstudio-project/nerfstudio"
+#        uses: actions/checkout@v4
+#        with:
+#          repository: nerfstudio-project/nerfstudio
+#          path: nerfstudio
+#      - name: "Install nerfstudio-project/nerfstudio"
+#        run: pixi install
+#        working-directory: nerfstudio
+#
+#      - name: "Checkout Deltares/Ribasim"
+#        uses: actions/checkout@v4
+#        with:
+#          repository: Deltares/Ribasim
+#          path: ribasim
+#      - name: "Install Deltares/Ribasim"
+#        run: pixi install
+#        working-directory: ribasim
+#
+#      - name: "Checkout quantco/polarify"
+#        uses: actions/checkout@v4
+#        with:
+#          repository: quantco/polarify
+#          path: polarify
+#      - name: "Install quantco/polarify"
+#        run: pixi install
+#        working-directory: polarify
+#
+#  #
+#  # Install a number of common wheels on some platforms
+#  #
+#
+#  test-common-wheels-linux-x86_64:
+#    name: "test wheel installation | linux x86_64"
+#    needs:
+#      - build-binary-linux-x86_64
+#    uses: ./.github/workflows/test_common_wheels.yml
+#    with:
+#        sha: ${{ github.sha }}
+#        arch: linux-x86_64
+#        runs-on: 8core_ubuntu_latest_runner
+#
+#  test-common-wheels-windows-x86_64:
+#    name: "test wheel installation | windows x86_64"
+#    needs:
+#      - build-binary-windows-x86_64
+#    uses: ./.github/workflows/test_common_wheels.yml
+#    with:
+#      sha: ${{ github.sha }}
+#      arch: windows-x86_64
+#      runs-on: windows-latest
+#
+#  test-common-wheels-macos-aarch64:
+#    name: "test wheel installation | macos aarch64"
+#    needs:
+#      - build-binary-macos-aarch64
+#    uses: ./.github/workflows/test_common_wheels.yml
+#    with:
+#      sha: ${{ github.sha }}
+#      arch: macos-aarch64
+#      runs-on: macos-14

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,7 +50,7 @@ test-common-wheels = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", de
   "build-release",
 ] }
 test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/wheel_tests/" }
-test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose --timeout=300 tests/integration_python"
+test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose --timeout=200 -s  tests/integration_python"
 test-integration-fast = { cmd = "pytest -m 'not slow' --pixi-build=debug --numprocesses=auto --durations=10 --timeout=300 tests/integration_python", depends-on = [
   "build-debug",
 ] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,7 +50,7 @@ test-common-wheels = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", de
   "build-release",
 ] }
 test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/wheel_tests/" }
-test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose --timeout=200 -s  tests/integration_python"
+test-integration-ci = "pytest --numprocesses=1 --durations=10 --verbose --timeout=200 -s  tests/integration_python"
 test-integration-fast = { cmd = "pytest -m 'not slow' --pixi-build=debug --numprocesses=auto --durations=10 --timeout=300 tests/integration_python", depends-on = [
   "build-debug",
 ] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,7 +50,7 @@ test-common-wheels = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", de
   "build-release",
 ] }
 test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/wheel_tests/" }
-test-integration-ci = "pytest --numprocesses=1 --durations=10 --verbose --timeout=200 -s  tests/integration_python"
+test-integration-ci = "pytest --numprocesses=auto --durations=10 --verbose --timeout=200 -s  tests/integration_python"
 test-integration-fast = { cmd = "pytest -m 'not slow' --pixi-build=debug --numprocesses=auto --durations=10 --timeout=300 tests/integration_python", depends-on = [
   "build-debug",
 ] }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -108,6 +108,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         })
         .await?;
 
+    tracing::info!("Before SearchEnvironments::from_opt_env");
     // Construct a task graph from the input arguments
     let search_environment = SearchEnvironments::from_opt_env(
         &project,
@@ -115,6 +116,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         Some(best_platform),
     )
     .with_disambiguate_fn(disambiguate_task_interactive);
+
+    tracing::info!("After SearchEnvironments::from_opt_env");
 
     let task_graph = TaskGraph::from_cmd_args(&project, &search_environment, args.task)?;
 
@@ -321,6 +324,7 @@ async fn execute_task<'p>(
 fn disambiguate_task_interactive<'p>(
     problem: &AmbiguousTask<'p>,
 ) -> Option<TaskAndEnvironment<'p>> {
+    tracing::info!("Disambiguate task interactive");
     let environment_names = problem
         .environments
         .iter()

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -1502,6 +1502,8 @@ impl<'p> UpdateContext<'p> {
                     }
                 }
             }
+
+            tracing::info!("{} futures still pending!", pending_futures.len());
         }
 
         tracing::info!("all tasks have completed");

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -1507,6 +1507,8 @@ impl<'p> UpdateContext<'p> {
         // Construct a new lock-file containing all the updated or old records.
         let mut builder = LockFile::builder();
 
+        tracing::info!("building lock-file");
+
         // Iterate over all environments and add their records to the lock-file.
         for environment in project.environments() {
             let environment_name = environment.name().to_string();
@@ -1554,9 +1556,13 @@ impl<'p> UpdateContext<'p> {
             }
         }
 
+        tracing::info!("lock-file built");
+
         // Store the lock file
         let lock_file = builder.finish();
         top_level_progress.finish_and_clear();
+
+        tracing::info!("lock-file finished");
 
         Ok(LockFileDerivedData {
             project,

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -1504,6 +1504,8 @@ impl<'p> UpdateContext<'p> {
             }
         }
 
+        tracing::info!("all tasks have completed");
+
         // Construct a new lock-file containing all the updated or old records.
         let mut builder = LockFile::builder();
 

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -59,6 +59,10 @@ def verify_cli_command(
     # Set `NO_GRAPHICS` to avoid to have miette splitting up lines
     complete_env |= {"NO_GRAPHICS": "1"}
 
+    # Add -v after the `pixi` command to get verbose output
+    if isinstance(command, list) and "pixi" in str(command[0]):
+        command.insert(1, "-vv")
+
     attempt = 0
     while attempt < retries:
         try:

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -25,20 +25,20 @@ def test_run_in_shell_environment(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
     # Run the default task
     verify_cli_command(
-        [pixi, "run", "--manifest-path", manifest, "--environment", "default", "task"],
+        [pixi, "run", "-vvv", "--manifest-path", manifest, "--environment", "default", "task"],
         stdout_contains="default",
         stderr_excludes="default1",
     )
 
     # Run the a task
     verify_cli_command(
-        [pixi, "run", "--manifest-path", manifest, "--environment", "a", "task"],
+        [pixi, "run", "-vvv", "--manifest-path", manifest, "--environment", "a", "task"],
         stdout_contains=["a", "a1"],
     )
 
     # Error on non-specified environment as ambiguous
     verify_cli_command(
-        [pixi, "run", "--manifest-path", manifest, "task"],
+        [pixi, "run", "-vvv", "--manifest-path", manifest, "task"],
         ExitCode.FAILURE,
         stderr_contains=["ambiguous", "default", "a"],
     )
@@ -46,7 +46,7 @@ def test_run_in_shell_environment(pixi: Path, tmp_pixi_workspace: Path) -> None:
     # Simulate activated shell in environment 'a'
     env = {"PIXI_IN_SHELL": "true", "PIXI_ENVIRONMENT_NAME": "a"}
     verify_cli_command(
-        [pixi, "run", "--manifest-path", manifest, "task"],
+        [pixi, "run", "-vvv", "--manifest-path", manifest, "task"],
         stdout_contains=["a", "a1"],
         env=env,
     )
@@ -87,7 +87,7 @@ def test_run_in_shell_project(pixi: Path) -> None:
 
         # Run task with PIXI_PROJECT_MANIFEST set to manifest_2
         verify_cli_command(
-            [pixi, "run", "task"],
+            [pixi, "run", "-vvv", "task"],
             stdout_contains="manifest_2",
             env=extended_env,
             cwd=tmp_pixi_workspace,
@@ -96,7 +96,7 @@ def test_run_in_shell_project(pixi: Path) -> None:
 
         # Run with working directory at manifest_1_dir
         verify_cli_command(
-            [pixi, "run", "task"],
+            [pixi, "run", "-vvv", "task"],
             stdout_contains="manifest_1",
             env=base_env,
             cwd=manifest_1_dir,
@@ -107,7 +107,7 @@ def test_run_in_shell_project(pixi: Path) -> None:
         # working directory should win
         # pixi should warn that it uses the local manifest rather than PIXI_PROJECT_MANIFEST
         verify_cli_command(
-            [pixi, "run", "task"],
+            [pixi, "run", "-vvv", "task"],
             stdout_contains="manifest_1",
             stderr_contains="manifest_2",
             env=extended_env,
@@ -163,7 +163,7 @@ def test_using_prefix_validation(
 
     # Run an actual re-install
     verify_cli_command(
-        [pixi, "install", "--manifest-path", manifest],
+        [pixi, "install", "-vvv", "--manifest-path", manifest],
     )
 
     # Validate the files are back


### PR DESCRIPTION
This PR tests some assumptions that we have to figure out what the reason could be for the tests on macOS to be so flaky
# Observations:
After adding more information to the pytest output:
### Failed on a test that uses Rosetta:
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34607214712#step:7:320
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34606630544#step:7:316
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34607843181?pr=2729#step:7:376
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34608746636?pr=2729#step:7:367
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34610082003#step:7:525

### No useful info to see why it failed:
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34607499218?pr=2729#step:7:307

### `package.prefix.dev` error:
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34608313648#step:7:419

### :white_check_mark:  Succeed:
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34609165335
- https://github.com/prefix-dev/pixi/actions/runs/12397009022/job/34609459939