### PR TITLE
fix: log config parsing errors as errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,6 +3793,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "thiserror 2.0.7",
  "toml_edit",
  "tracing",
  "url",

--- a/crates/pixi_config/Cargo.toml
+++ b/crates/pixi_config/Cargo.toml
@@ -24,6 +24,7 @@ reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 serde_ignored = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 toml_edit = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -11,8 +11,6 @@ use reqwest_middleware::ClientWithMiddleware;
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use std::{
     collections::{BTreeSet as Set, HashMap},
-    error::Error,
-    fmt,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     str::FromStr,


### PR DESCRIPTION
Fixes # 2720

We used to log on debug level when we couldn't parse a config file