### PR TITLE
feat: skip dependencies of a task

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -262,6 +262,7 @@ You cannot run `pixi run source setup.bash` as `source` is not available in the 
 - `--revalidate`: Revalidate the full environment, instead of checking the lock file hash. [more info](../features/environment.md#environment-installation-metadata)
 - `--concurrent-downloads`: The number of concurrent downloads to use when installing packages. Defaults to 50.
 - `--concurrent-solves`: The number of concurrent solves to use when installing packages. Defaults to the number of cpu threads.
+- `--skip-deps`: Skip the dependencies of the task, which where defined in the `depends-on` field of the task.
 
 ```shell
 pixi run python
@@ -273,6 +274,8 @@ pixi run --locked python
 pixi run build
 # Extra arguments will be passed to the tasks command.
 pixi run task argument1 argument2
+# Skip dependencies of the task
+pixi run --skip-deps task
 
 # If you have multiple environments you can select the right one with the --environment flag.
 pixi run --environment cuda python
@@ -281,6 +284,7 @@ pixi run --environment cuda python
 # If you want to run a command in a clean environment you can use the --clean-env flag.
 # The PATH should only contain the pixi environment here.
 pixi run --clean-env "echo \$PATH"
+
 ```
 
 !!! info

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -51,6 +51,10 @@ pub struct Args {
     /// minimum environment to activate the pixi environment in.
     #[arg(long)]
     pub clean_env: bool,
+
+    /// Don't run the dependencies of the task ('depends-on' field in the task definition)
+    #[arg(long)]
+    pub skip_deps: bool,
 }
 
 /// CLI entry point for `pixi run`
@@ -116,7 +120,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     )
     .with_disambiguate_fn(disambiguate_task_interactive);
 
-    let task_graph = TaskGraph::from_cmd_args(&project, &search_environment, args.task)?;
+    let task_graph =
+        TaskGraph::from_cmd_args(&project, &search_environment, args.task, args.skip_deps)?;
 
     tracing::info!("Task graph: {}", task_graph);
 

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -478,7 +478,7 @@ impl PixiControl {
                 .map(|e| e.best_platform())
                 .or(Some(Platform::current())),
         );
-        let task_graph = TaskGraph::from_cmd_args(&project, &search_env, args.task)
+        let task_graph = TaskGraph::from_cmd_args(&project, &search_env, args.task, false)
             .map_err(RunError::TaskGraphError)?;
 
         // Iterate over all tasks in the graph and execute them.


### PR DESCRIPTION
I built this because I agree with #2740 

Fixes #2740 

Allows the user to skip the `depends-on` of a task by running:
```
pixi run --skip-deps task-name
```