### PR TITLE
feat: serialize system requirements

### DIFF
--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__system_requirements__tests__serialization.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__system_requirements__tests__serialization.snap
@@ -1,0 +1,10 @@
+---
+source: crates/pixi_manifest/src/system_requirements.rs
+expression: serialized
+snapshot_kind: text
+---
+macos = "10.15"
+linux = "5.11"
+cuda = "12.2"
+libc = "2.12"
+archspec = "x86_64"

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__system_requirements__tests__serialization_other_family.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__system_requirements__tests__serialization_other_family.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_manifest/src/system_requirements.rs
+expression: serialized
+snapshot_kind: text
+---
+macos = "10.15"
+linux = "5.11"
+cuda = "12.2"
+archspec = "x86_64"
+
+[libc]
+family = "glibc"
+version = "2.12"

--- a/crates/pixi_manifest/src/system_requirements.rs
+++ b/crates/pixi_manifest/src/system_requirements.rs
@@ -522,18 +522,7 @@ mod tests {
         };
 
         let serialized = to_string_pretty(&system_requirements).unwrap();
-
-        let expected = r#"
-        macos = "10.15"
-        linux = "5.11"
-        cuda = "12.2"
-        libc = "2.12"
-        archspec = "x86_64"
-        "#;
-        assert_eq!(
-            serialized.replace("\n", "").replace(" ", ""),
-            expected.replace("\n", "").replace(" ", "")
-        );
+        assert_snapshot!(serialized);
     }
 
     #[test]
@@ -550,19 +539,6 @@ mod tests {
         };
 
         let serialized = to_string_pretty(&system_requirements).unwrap();
-        let expected = r#"
-        macos = "10.15"
-        linux = "5.11"
-        cuda = "12.2"
-        archspec = "x86_64"
-
-        [libc]
-        family = "glibc"
-        version = "2.12"
-        "#;
-        assert_eq!(
-            serialized.replace("\n", "").replace(" ", ""),
-            expected.replace("\n", "").replace(" ", "")
-        );
+        assert_snapshot!(serialized);
     }
 }


### PR DESCRIPTION
This allows us to add it to `pixi info` which I did:
```
        Environment: img2txt
           Features: img2txt, img2txt_base
        Solve group: img2txt
           Channels: pytorch, conda-forge, bioconda, anaconda
   Dependency count: 1
       Dependencies: python
  PyPI Dependencies: paddlepaddle, layoutparser, easyocr
   Target platforms: win-64, linux-aarch64, osx-arm64, osx-64, linux-64
System requirements: cuda = "12"
                     libc = "2.27"
```            
Printing only if it is defined by the user       