### PR TITLE
chore: update rattler for macOS speedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
@@ -432,7 +432,7 @@ name = "barrier_cell"
 version = "0.1.0"
 dependencies = [
  "parking_lot 0.12.3",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
 ]
 
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
  "jobserver",
  "libc",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4db298d517d5fa00b2b84bbe044efd3fde43874a41db0d46f91994646a2da4"
+checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
 dependencies = [
  "clap",
 ]
@@ -1295,6 +1295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +1400,7 @@ checksum = "95ad84121770c9766a67e4dd0a96b0467c6a5a2c43e873bf853aeaa6632b687c"
 dependencies = [
  "itertools 0.13.0",
  "percent-encoding",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "typed-path",
  "url",
 ]
@@ -1444,9 +1450,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -2082,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http",
@@ -2706,7 +2712,7 @@ dependencies = [
  "log",
  "secret-service",
  "security-framework 2.11.1",
- "security-framework 3.0.1",
+ "security-framework 3.1.0",
  "windows-sys 0.59.0",
  "zbus",
 ]
@@ -2758,9 +2764,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libdbus-sys"
@@ -3000,9 +3006,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef2593ffb6958c941575cee70c8e257438749971869c4ae5acf6f91a168a61"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -3235,9 +3241,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -3683,13 +3689,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sha2",
  "shlex",
  "signal-hook",
  "strsim",
  "tabwriter",
  "tar",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -3755,7 +3762,7 @@ dependencies = [
  "serde_yaml",
  "sha1",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3795,7 +3802,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml_edit",
  "tracing",
  "url",
@@ -3830,7 +3837,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -3850,7 +3857,7 @@ dependencies = [
  "rattler_digest",
  "rstest",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "wax",
 ]
@@ -3888,7 +3895,7 @@ dependencies = [
  "spdx",
  "strsim",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml_edit",
  "tracing",
  "url",
@@ -3924,7 +3931,7 @@ dependencies = [
  "rattler_digest",
  "rattler_lock",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "typed-path",
  "url",
 ]
@@ -3944,7 +3951,7 @@ dependencies = [
  "serde-untagged",
  "serde_json",
  "serde_with",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml_edit",
  "typed-path",
  "url",
@@ -3973,7 +3980,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3989,7 +3996,7 @@ dependencies = [
  "pixi_manifest",
  "rattler_lock",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "url",
  "uv-configuration",
  "uv-distribution-filename",
@@ -4017,9 +4024,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platform-info"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91077ffd05d058d70d79eefcd7d7f6aac34980860a7519960f7913b6563a8c3a"
+checksum = "7539aeb3fdd8cb4f6a331307cf71a1039cee75e94e8a71725b9484f4a0d9451a"
 dependencies = [
  "libc",
  "winapi",
@@ -4177,15 +4184,15 @@ dependencies = [
  "log",
  "priority-queue",
  "rustc-hash",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=57832d0588fbb7aab824813481104761dc1c7740)",
 ]
 
 [[package]]
 name = "purl"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14fe28c8495f7eaf77a6e6106966f95211c0a2404b9da50d248fc32af3a3f14"
+checksum = "f112b0e2a9bca03924c39166775b74fec9a831f7d4d8fa539dee0e565f403a0e"
 dependencies = [
  "hex",
  "percent-encoding",
@@ -4269,7 +4276,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -4288,7 +4295,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4296,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4370,9 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.28.8"
+version = "0.28.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6b55310ef1c0479d8ec23bdaf4f243cad29c7b0e4a855c72e6b2e51bd649e0"
+checksum = "c90d5a0dd356a4b2289752dd738d5597348d616a7797ec045209c4cc8b65bb9b"
 dependencies = [
  "anyhow",
  "clap",
@@ -4403,7 +4410,7 @@ dependencies = [
  "simple_spawn_blocking",
  "smallvec",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -4412,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c21d2868933899284c54f0336269dd1e8f63b979c9a8256020f166cea176b3"
+checksum = "266a244026ae404be929fa7cdb36761848dadc238868448d0fcb6c900522ee72"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -4434,7 +4441,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "simple_spawn_blocking",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -4442,9 +4449,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.29.6"
+version = "0.29.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13391d33d1511153902d8e512a5c84c1f4e84a389fcb6ad650e7909408cf544"
+checksum = "d5f01db87a34cb9fc92d7be8a8789c79a567c8738a535f3cb79779a8580c33d6"
 dependencies = [
  "chrono",
  "dirs",
@@ -4472,7 +4479,7 @@ dependencies = [
  "simd-json",
  "smallvec",
  "strum",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "typed-path",
  "url",
@@ -4497,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.35"
+version = "0.22.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b54218759724416f1456e3e3e459dcd507690f0b59b4fb2fa158530647bf1f7"
+checksum = "f02009a673daea8bdf12d8ed4a3ad6a91a837db21b4e2bbe8389b8af97fc3ef0"
 dependencies = [
  "chrono",
  "file_url",
@@ -4515,7 +4522,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "serde_yaml",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "typed-path",
  "url",
 ]
@@ -4554,16 +4561,16 @@ dependencies = [
  "retry-policies",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.19"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b7f8d479f3e1e9fe5eaa6ccb8cf296258f9d56cb0423baced7720fe9512e6b"
+checksum = "24a505f4ed90ca9c4eed477d3184bc38621c5d2c334be28bcdde7f16e7c4ef0c"
 dependencies = [
  "bzip2 0.5.0",
  "chrono",
@@ -4579,7 +4586,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4601,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.28"
+version = "0.21.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24b5beea6fbf6b76356e361897c919abc4bf7db706ae5f5868a24815f2ff711"
+checksum = "9ef851fac32e22323c735e5eda2f966687902f595ab3d6f25cf28e2f89e16ced"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4645,7 +4652,7 @@ dependencies = [
  "simple_spawn_blocking",
  "superslice",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4656,9 +4663,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.11"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06401300c3f5718abb5c3ed1c66f9837c5cac5879c33a440d6bf95f4336ba38d"
+checksum = "39e4f21b5783b0ce087d816669a4539add1ce5c076050856e350435a9a27c61f"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -4669,15 +4676,15 @@ dependencies = [
  "shlex",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
 ]
 
 [[package]]
 name = "rattler_solve"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896a10d47c9a24f9274f9e54cda3721aa92b316a09a066a7e8aad372d1cd6d28"
+checksum = "fa4c73c74bd7747ebe16607055eaa74c2daad359514a0765994642d6fa446193"
 dependencies = [
  "chrono",
  "futures",
@@ -4687,16 +4694,16 @@ dependencies = [
  "resolvo",
  "serde",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb283545cf1241c2ee61d72c2149a3f32f856ebfa1440ea913c71d438247c7e"
+checksum = "f0e792417bd869e30b9ff9611dd56664de1352c810fb88c53ea4bb543ef6e8fe"
 dependencies = [
  "archspec",
  "libloading",
@@ -4706,7 +4713,7 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
 ]
 
@@ -5163,7 +5170,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.0.1",
+ "security-framework 3.1.0",
 ]
 
 [[package]]
@@ -5344,9 +5351,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.10.0",
@@ -5357,9 +5364,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5451,9 +5458,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
@@ -5568,6 +5575,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -5854,9 +5871,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6019,11 +6036,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.7"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.7",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -6039,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.7"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6101,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6508,7 +6525,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "toml_edit",
  "tracing",
@@ -6557,7 +6574,7 @@ dependencies = [
  "fs-err",
  "globwalk",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml",
  "tracing",
 ]
@@ -6596,7 +6613,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sys-info",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tl",
  "tokio",
  "tokio-util",
@@ -6633,7 +6650,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "url",
  "uv-auth",
@@ -6708,7 +6725,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6743,7 +6760,7 @@ source = "git+https://github.com/wolfv/uv?branch=ignore-rayon-init#878234ba6b9a3
 dependencies = [
  "rkyv",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "url",
  "uv-normalize",
  "uv-pep440",
@@ -6765,7 +6782,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "url",
  "urlencoding",
@@ -6798,7 +6815,7 @@ dependencies = [
  "reqwest",
  "rustc-hash",
  "sha2",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -6845,7 +6862,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -6877,7 +6894,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "uv-cache-info",
  "uv-distribution-filename",
@@ -6906,7 +6923,7 @@ dependencies = [
  "rustc-hash",
  "same-file",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -6949,7 +6966,7 @@ dependencies = [
  "async_zip",
  "fs-err",
  "futures",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "uv-distribution-filename",
@@ -7012,7 +7029,7 @@ dependencies = [
  "schemars",
  "serde",
  "smallvec",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "unicode-width 0.1.14",
  "url",
  "uv-fs",
@@ -7028,7 +7045,7 @@ source = "git+https://github.com/wolfv/uv?branch=ignore-rayon-init#878234ba6b9a3
 dependencies = [
  "rustc-hash",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -7046,7 +7063,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde-untagged",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml",
  "toml_edit",
  "tracing",
@@ -7082,7 +7099,7 @@ dependencies = [
  "serde_json",
  "target-lexicon",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -7122,7 +7139,7 @@ dependencies = [
  "futures",
  "rustc-hash",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "toml",
  "tracing",
  "url",
@@ -7154,7 +7171,7 @@ dependencies = [
  "regex",
  "reqwest",
  "reqwest-middleware",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "unscanny",
  "url",
@@ -7189,7 +7206,7 @@ dependencies = [
  "same-file",
  "serde",
  "textwrap",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tokio-stream",
  "toml",
@@ -7257,7 +7274,7 @@ version = "0.0.1"
 source = "git+https://github.com/wolfv/uv?branch=ignore-rayon-init#878234ba6b9a3b143e079ca9baa4bec99af93600"
 dependencies = [
  "fs-err",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "uv-fs",
  "zip 0.6.6",
 ]
@@ -7269,7 +7286,7 @@ source = "git+https://github.com/wolfv/uv?branch=ignore-rayon-init#878234ba6b9a3
 dependencies = [
  "anyhow",
  "rustc-hash",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "url",
  "uv-cache",
  "uv-configuration",
@@ -7296,7 +7313,7 @@ dependencies = [
  "fs-err",
  "itertools 0.13.0",
  "pathdiff",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tracing",
  "uv-fs",
  "uv-platform-tags",
@@ -7328,7 +7345,7 @@ dependencies = [
  "rustc-hash",
  "same-file",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "toml",
  "toml_edit",
@@ -7561,12 +7578,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cad3279ade7346b96e38731a641d7343dd6a53d55083dd54eadfa5a1b38c6b"
+checksum = "fb4a9e33648339dc1642b0e36e21b3385e6148e289226f657c809dee59df5028"
 dependencies = [
  "either",
- "home",
+ "env_home",
  "regex",
  "rustix",
  "winsafe 0.0.19",
@@ -7983,9 +8000,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "a08fd76779ae1883bbf1e46c2c46a75a0c4e37c445e68a24b01479d438f26ae6"
 
 [[package]]
 name = "xz2"
@@ -8183,7 +8200,7 @@ dependencies = [
  "flate2",
  "indexmap 2.7.0",
  "memchr",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "time",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,8 +313,8 @@ zstd = { workspace = true }
 libc = { workspace = true, default-features = false }
 nix = { workspace = true, features = ["poll", "term"] }
 pixi_pty = { path = "crates/pixi_pty" }
-signal-hook = { workspace = true }
 sha2 = { workspace = true, features = ["asm"] }
+signal-hook = { workspace = true }
 
 [profile.dist]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1.9.0"
 chrono = "0.4.39"
 clap = { version = "4.5.23", default-features = false }
 clap-verbosity-flag = "3.0.2"
-clap_complete = "4.5.39"
+clap_complete = "4.5.40"
 clap_complete_nushell = "4.5.4"
 concat-idents = "1.1.5"
 console = "0.15.10"
@@ -48,7 +48,7 @@ is_executable = "1.0.4"
 itertools = "0.13.0"
 jsonrpsee = "=0.24.2"
 lazy_static = "1.5.0"
-libc = { version = "0.2.168", default-features = false }
+libc = { version = "0.2.169", default-features = false }
 memchr = "2.7.4"
 miette = { version = "7.4.0", features = ["fancy"] }
 minijinja = "2.5.0"
@@ -70,10 +70,11 @@ serde = "1.0.216"
 serde-untagged = "0.1.6"
 serde-value = "0.7.0"
 serde_ignored = "0.1.10"
-serde_json = "1.0.133"
+serde_json = "1.0.134"
 serde_with = "3.11.0"
 serde_yaml = "0.9.34"
 sha1 = "0.10.6"
+sha2 = "0.10.6"
 shlex = "1.3.0"
 signal-hook = "0.3.17"
 spdx = "0.10.7"
@@ -81,7 +82,7 @@ strsim = "0.11.1"
 tabwriter = "1.4.0"
 tar = "0.4.43"
 tempfile = "3.14.0"
-thiserror = "2.0.7"
+thiserror = "2.0.9"
 tokio = "1.42.0"
 tokio-stream = "0.1.17"
 tokio-util = "0.7.13"
@@ -98,24 +99,24 @@ uv-platform-tags = { git = "https://github.com/wolfv/uv", branch = "ignore-rayon
 uv-pypi-types = { git = "https://github.com/wolfv/uv", branch = "ignore-rayon-init" }
 uv-requirements-txt = { git = "https://github.com/wolfv/uv", branch = "ignore-rayon-init" }
 wax = "0.6.0"
-which = "7.0.0"
+which = "7.0.1"
 
 # Rattler crates
 file_url = "0.2.1"
-rattler = { version = "0.28.8", default-features = false }
-rattler_cache = { version = "0.3.0", default-features = false }
-rattler_conda_types = { version = "0.29.6", default-features = false, features = [
+rattler = { version = "0.28.9", default-features = false }
+rattler_cache = { version = "0.3.1", default-features = false }
+rattler_conda_types = { version = "0.29.7", default-features = false, features = [
   "rayon",
 ] }
 rattler_digest = { version = "1.0.4", default-features = false }
-rattler_lock = { version = "0.22.35", default-features = false }
+rattler_lock = { version = "0.22.36", default-features = false }
 rattler_networking = { version = "0.21.9", default-features = false, features = [
   "google-cloud-auth",
 ] }
-rattler_repodata_gateway = { version = "0.21.28", default-features = false }
-rattler_shell = { version = "0.22.11", default-features = false }
-rattler_solve = { version = "1.3.0", default-features = false }
-rattler_virtual_packages = { version = "1.1.14", default-features = false }
+rattler_repodata_gateway = { version = "0.21.29", default-features = false }
+rattler_shell = { version = "0.22.12", default-features = false }
+rattler_solve = { version = "1.3.1", default-features = false }
+rattler_virtual_packages = { version = "1.1.15", default-features = false }
 
 
 # Bumping this to a higher version breaks the Windows path handling.
@@ -134,7 +135,7 @@ uv-requirements = { git = "https://github.com/wolfv/uv", branch = "ignore-rayon-
 uv-resolver = { git = "https://github.com/wolfv/uv", branch = "ignore-rayon-init" }
 uv-types = { git = "https://github.com/wolfv/uv", branch = "ignore-rayon-init" }
 winapi = { version = "0.3.9", default-features = false }
-xxhash-rust = "0.8.12"
+xxhash-rust = "0.8.13"
 zip = { version = "2.2.2", default-features = false }
 zstd = { version = "0.13.2", default-features = false }
 
@@ -313,6 +314,7 @@ libc = { workspace = true, default-features = false }
 nix = { workspace = true, features = ["poll", "term"] }
 pixi_pty = { path = "crates/pixi_pty" }
 signal-hook = { workspace = true }
+sha2 = { workspace = true, features = ["asm"] }
 
 [profile.dist]
 codegen-units = 1


### PR DESCRIPTION
After running:
```
pixi add rust scipy
```
This is the result, `pixi` is this branch vs the latest release. On `osx-arm64`
```
hyperfine -p "pixi clean" "pixi install" "pixi39_3 install" -r 5
Benchmark 1: pixi install
  Time (mean ± σ):      2.558 s ±  0.116 s    [User: 0.432 s, System: 1.895 s]
  Range (min … max):    2.400 s …  2.651 s    5 runs
 
Benchmark 2: pixi39_3 install
  Time (mean ± σ):     12.199 s ±  0.700 s    [User: 4.337 s, System: 44.407 s]
  Range (min … max):   11.053 s … 12.887 s    5 runs
 
Summary
  pixi install ran
    4.77 ± 0.35 times faster than pixi39_3 install
```
