### PR TITLE
fix: `pixi run test`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -52,15 +52,15 @@ test-common-wheels = { cmd = "pytest --numprocesses=auto tests/wheel_tests/", de
   "build-release",
 ] }
 test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/wheel_tests/" }
-test-integration-ci = "pytest --numprocesses=auto --durations=0 --timeout=100 --verbose tests/integration_python"
-test-integration-extra-slow = { cmd = "pytest --numprocesses=auto --durations=0 --timeout=300 tests/integration_python -m ''", depends-on = [
+test-integration-ci = "pytest --numprocesses=auto --durations=0 --timeout=100 --verbose -m 'not extra_slow' tests/integration_python"
+test-integration-extra-slow = { cmd = "pytest --numprocesses=auto --durations=0 --timeout=300 tests/integration_python", depends-on = [
   "build-release",
 ] }
-test-integration-extra-slow-ci = "pytest --numprocesses=auto --durations=0 --timeout=300 tests/integration_python -m 'extra_slow'"
-test-integration-fast = { cmd = "pytest -m 'not slow' --pixi-build=debug --numprocesses=auto --durations=0 --timeout=100 tests/integration_python", depends-on = [
+test-integration-extra-slow-ci = "pytest --numprocesses=auto --durations=0 --timeout=300 -m 'extra_slow' tests/integration_python"
+test-integration-fast = { cmd = "pytest --pixi-build=debug --numprocesses=auto --durations=0 --timeout=100 -m 'not slow and not extra_slow' tests/integration_python", depends-on = [
   "build-debug",
 ] }
-test-integration-slow = { cmd = "pytest --numprocesses=auto --durations=0 --timeout=100 tests/integration_python", depends-on = [
+test-integration-slow = { cmd = "pytest --numprocesses=auto --durations=0 --timeout=100 -m 'not extra_slow' tests/integration_python", depends-on = [
   "build-release",
 ] }
 # pass the file to run as an argument to the task

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,5 @@ addopts = --basetemp=pytest-temp
 tmp_path_retention_policy = failed
 testpaths = tests/integration_python
 markers =
-    slow: marks tests as slow (select with '-m slow')
-    extra_slow: marks tests as extra slow (select with '-m extra_slow')
+    slow: marks tests as slow
+    extra_slow: marks tests as extra slow

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
-addopts = --basetemp=pytest-temp -m "not extra_slow"
+addopts = --basetemp=pytest-temp
 tmp_path_retention_policy = failed
 testpaths = tests/integration_python
 markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')
-    extra_slow: marks tests as nightly (select with '-m "extra_slow"')
+    slow: marks tests as slow (select with '-m slow')
+    extra_slow: marks tests as extra slow (select with '-m extra_slow')


### PR DESCRIPTION
When we pass `-m` to `pytest` multiple times, only the last one is used.
This results in the fast tests to run also the extra slow tests.
This times out with a debug build