### PR TITLE
fix: Move from `pub` to `pub(crate)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,6 @@ dependencies = [
 name = "pixi_progress"
 version = "0.1.0"
 dependencies = [
- "console",
  "indicatif",
  "tokio",
 ]

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -149,14 +149,14 @@ pub struct RepodataConfig {
 }
 
 impl RepodataConfig {
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.default.is_empty() && self.per_channel.is_empty()
     }
 
     /// Merge the given RepodataConfig into the current one.
     /// `other` is mutable to allow for moving the values out of it.
     /// The given config will have higher priority
-    pub fn merge(&self, mut other: Self) -> Self {
+    pub(crate) fn merge(&self, mut other: Self) -> Self {
         let mut per_channel: HashMap<_, _> = self
             .per_channel
             .clone()
@@ -220,14 +220,14 @@ pub struct RepodataChannelConfig {
 }
 
 impl RepodataChannelConfig {
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.disable_jlap.is_none()
             && self.disable_bzip2.is_none()
             && self.disable_zstd.is_none()
             && self.disable_sharded.is_none()
     }
 
-    pub fn merge(&self, other: Self) -> Self {
+    pub(crate) fn merge(&self, other: Self) -> Self {
         Self {
             disable_jlap: self.disable_jlap.or(other.disable_jlap),
             disable_zstd: self.disable_zstd.or(other.disable_zstd),
@@ -319,18 +319,18 @@ pub struct ExperimentalConfig {
 }
 
 impl ExperimentalConfig {
-    pub fn merge(self, other: Self) -> Self {
+    pub(crate) fn merge(self, other: Self) -> Self {
         Self {
             use_environment_activation_cache: other
                 .use_environment_activation_cache
                 .or(self.use_environment_activation_cache),
         }
     }
-    pub fn use_environment_activation_cache(&self) -> bool {
+    pub(crate) fn use_environment_activation_cache(&self) -> bool {
         self.use_environment_activation_cache.unwrap_or(false)
     }
 
-    pub fn is_default(&self) -> bool {
+    pub(crate) fn is_default(&self) -> bool {
         self.use_environment_activation_cache.is_none()
     }
 }
@@ -374,7 +374,7 @@ impl Default for ConcurrencyConfig {
 
 impl ConcurrencyConfig {
     /// Merge the given ConcurrencyConfig into the current one.
-    pub fn merge(self, other: Self) -> Self {
+    pub(crate) fn merge(self, other: Self) -> Self {
         // Merging means using the other value if they are none default.
         Self {
             solves: if other.solves != ConcurrencyConfig::default().solves {
@@ -390,14 +390,14 @@ impl ConcurrencyConfig {
         }
     }
 
-    pub fn is_default(&self) -> bool {
+    pub(crate) fn is_default(&self) -> bool {
         ConcurrencyConfig::default() == *self
     }
 }
 
 impl PyPIConfig {
     /// Merge the given PyPIConfig into the current one.
-    pub fn merge(self, other: Self) -> Self {
+    pub(crate) fn merge(self, other: Self) -> Self {
         let extra_index_urls = self
             .extra_index_urls
             .into_iter()
@@ -416,7 +416,7 @@ impl PyPIConfig {
         }
     }
 
-    pub fn with_keyring(mut self, keyring_provider: KeyringProvider) -> Self {
+    pub(crate) fn with_keyring(mut self, keyring_provider: KeyringProvider) -> Self {
         self.keyring_provider = Some(keyring_provider);
         self
     }
@@ -757,7 +757,7 @@ impl Config {
     /// # Errors
     ///
     /// I/O errors or parsing errors
-    pub fn from_path(path: &Path) -> Result<Config, ConfigError> {
+    pub(crate) fn from_path(path: &Path) -> Result<Config, ConfigError> {
         tracing::debug!("Loading config from {}", path.display());
         let s = match fs_err::read_to_string(path) {
             Ok(content) => content,
@@ -804,7 +804,7 @@ impl Config {
     /// # Errors
     ///
     /// I/O errors or parsing errors
-    pub fn try_load_system() -> Result<Config, ConfigError> {
+    pub(crate) fn try_load_system() -> Result<Config, ConfigError> {
         Self::from_path(&config_path_system())
     }
 
@@ -825,7 +825,7 @@ impl Config {
     }
 
     /// Validate the config file.
-    pub fn validate(&self) -> miette::Result<()> {
+    pub(crate) fn validate(&self) -> miette::Result<()> {
         // Validate the detached environments directory is set correctly
         if let Some(detached_environments) = self.detached_environments.clone() {
             match detached_environments {
@@ -902,7 +902,7 @@ impl Config {
     }
 
     // Get all possible keys of the configuration
-    pub fn get_keys(&self) -> &[&str] {
+    pub(crate) fn get_keys(&self) -> &[&str] {
         &[
             "default-channels",
             "change-ps1",
@@ -995,7 +995,7 @@ impl Config {
         &self.channel_config
     }
 
-    pub fn repodata_config(&self) -> &RepodataConfig {
+    pub(crate) fn repodata_config(&self) -> &RepodataConfig {
         &self.repodata_config
     }
 

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -995,6 +995,7 @@ impl Config {
         &self.channel_config
     }
 
+    #[cfg(test)]
     pub(crate) fn repodata_config(&self) -> &RepodataConfig {
         &self.repodata_config
     }

--- a/crates/pixi_git/src/credentials.rs
+++ b/crates/pixi_git/src/credentials.rs
@@ -20,12 +20,16 @@ pub struct GitStore(RwLock<HashMap<RepositoryUrl, Arc<Credentials>>>);
 
 impl GitStore {
     /// Insert [`Credentials`] for the given URL into the store.
-    pub fn insert(&self, url: RepositoryUrl, credentials: Credentials) -> Option<Arc<Credentials>> {
+    pub(crate) fn insert(
+        &self,
+        url: RepositoryUrl,
+        credentials: Credentials,
+    ) -> Option<Arc<Credentials>> {
         self.0.write().unwrap().insert(url, Arc::new(credentials))
     }
 
     /// Get the [`Credentials`] for the given URL, if they exist.
-    pub fn get(&self, url: &RepositoryUrl) -> Option<Arc<Credentials>> {
+    pub(crate) fn get(&self, url: &RepositoryUrl) -> Option<Arc<Credentials>> {
         self.0.read().unwrap().get(url).cloned()
     }
 }
@@ -89,18 +93,18 @@ impl From<Option<String>> for Username {
 }
 
 impl Credentials {
-    pub fn username(&self) -> Option<&str> {
+    pub(crate) fn username(&self) -> Option<&str> {
         self.username.as_deref()
     }
 
-    pub fn password(&self) -> Option<&str> {
+    pub(crate) fn password(&self) -> Option<&str> {
         self.password.as_deref()
     }
 
     /// Apply the credentials to the given URL.
     ///
     /// Any existing credentials will be overridden.
-    pub fn apply(&self, mut url: Url) -> Url {
+    pub(crate) fn apply(&self, mut url: Url) -> Url {
         if let Some(username) = self.username() {
             let _ = url.set_username(username);
         }
@@ -113,7 +117,7 @@ impl Credentials {
     /// Parse [`Credentials`] from a URL, if any.
     ///
     /// Returns [`None`] if both [`Url::username`] and [`Url::password`] are not populated.
-    pub fn from_url(url: &Url) -> Option<Self> {
+    pub(crate) fn from_url(url: &Url) -> Option<Self> {
         if url.username().is_empty() && url.password().is_none() {
             return None;
         }

--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -75,7 +75,7 @@ pub enum GitReference {
 impl GitReference {
     /// Creates a [`GitReference`] from an arbitrary revision string, which could represent a
     /// branch, tag, commit, or named ref.
-    pub fn from_rev(rev: String) -> Self {
+    pub(crate) fn from_rev(rev: String) -> Self {
         if rev.starts_with("refs/") {
             Self::NamedRef(rev)
         } else if GitReference::looks_like_commit_hash(&rev) {
@@ -90,7 +90,7 @@ impl GitReference {
     }
 
     /// Converts the [`GitReference`] to a `str`.
-    pub fn as_str(&self) -> Option<&str> {
+    pub(crate) fn as_str(&self) -> Option<&str> {
         match self {
             Self::Tag(rev) => Some(rev),
             Self::Branch(rev) => Some(rev),

--- a/crates/pixi_git/src/lib.rs
+++ b/crates/pixi_git/src/lib.rs
@@ -27,7 +27,7 @@ pub struct GitUrl {
 
 impl GitUrl {
     /// Create a new [`GitUrl`] from a repository URL and a reference.
-    pub fn from_reference(repository: Url, reference: GitReference) -> Self {
+    pub(crate) fn from_reference(repository: Url, reference: GitReference) -> Self {
         let precise = reference.as_sha();
         Self {
             repository,
@@ -47,7 +47,7 @@ impl GitUrl {
 
     /// Set the precise [`GitSha`] to use for this Git URL.
     #[must_use]
-    pub fn with_precise(mut self, precise: GitSha) -> Self {
+    pub(crate) fn with_precise(mut self, precise: GitSha) -> Self {
         self.precise = Some(precise);
         self
     }
@@ -65,7 +65,7 @@ impl GitUrl {
     }
 
     /// Return the reference to the commit to use, which could be a branch, tag or revision.
-    pub fn reference(&self) -> &GitReference {
+    pub(crate) fn reference(&self) -> &GitReference {
         &self.reference
     }
 

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -109,6 +109,7 @@ impl GitResolver {
     /// This method will only return precise URLs for URLs that have already been resolved via
     /// `resolve_precise`, and will return `None` for URLs that have not been resolved _or_
     /// already have a precise reference.
+    #[allow(unused)]
     pub(crate) fn precise(&self, url: GitUrl) -> Option<GitUrl> {
         let reference = RepositoryReference::from(&url);
         let precise = self.get(&reference)?;
@@ -116,6 +117,7 @@ impl GitResolver {
     }
 
     /// Returns `true` if the two Git URLs refer to the same precise commit.
+    #[allow(unused)]
     pub(crate) fn same_ref(&self, a: &GitUrl, b: &GitUrl) -> bool {
         // Convert `a` to a repository URL.
         let a_ref = RepositoryReference::from(a);

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -39,7 +39,7 @@ pub struct GitResolver(Arc<DashMap<RepositoryReference, GitSha>>);
 
 impl GitResolver {
     /// Inserts a new [`GitSha`] for the given [`RepositoryReference`].
-    pub fn insert(&self, reference: RepositoryReference, sha: GitSha) {
+    pub(crate) fn insert(&self, reference: RepositoryReference, sha: GitSha) {
         self.0.insert(reference, sha);
     }
 
@@ -109,14 +109,14 @@ impl GitResolver {
     /// This method will only return precise URLs for URLs that have already been resolved via
     /// `resolve_precise`, and will return `None` for URLs that have not been resolved _or_
     /// already have a precise reference.
-    pub fn precise(&self, url: GitUrl) -> Option<GitUrl> {
+    pub(crate) fn precise(&self, url: GitUrl) -> Option<GitUrl> {
         let reference = RepositoryReference::from(&url);
         let precise = self.get(&reference)?;
         Some(url.with_precise(*precise))
     }
 
     /// Returns `true` if the two Git URLs refer to the same precise commit.
-    pub fn same_ref(&self, a: &GitUrl, b: &GitUrl) -> bool {
+    pub(crate) fn same_ref(&self, a: &GitUrl, b: &GitUrl) -> bool {
         // Convert `a` to a repository URL.
         let a_ref = RepositoryReference::from(a);
 

--- a/crates/pixi_git/src/sha.rs
+++ b/crates/pixi_git/src/sha.rs
@@ -67,7 +67,7 @@ pub struct GitSha(GitOid);
 
 impl GitSha {
     /// Convert the SHA to a truncated representation, i.e., the first 16 characters of the SHA.
-    pub fn to_short_string(&self) -> String {
+    pub(crate) fn to_short_string(&self) -> String {
         self.0.to_string()[0..16].to_string()
     }
 }

--- a/crates/pixi_git/src/sha.rs
+++ b/crates/pixi_git/src/sha.rs
@@ -65,12 +65,6 @@ impl Display for GitOid {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GitSha(GitOid);
 
-impl GitSha {
-    /// Convert the SHA to a truncated representation, i.e., the first 16 characters of the SHA.
-    pub(crate) fn to_short_string(&self) -> String {
-        self.0.to_string()[0..16].to_string()
-    }
-}
 impl Display for GitSha {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -123,11 +123,11 @@ impl Fetch {
         &self.git
     }
 
-    pub(crate) fn path(&self) -> &Path {
+    pub fn path(&self) -> &Path {
         &self.path
     }
 
-    pub(crate) fn into_git(self) -> GitUrl {
+    pub fn into_git(self) -> GitUrl {
         self.git
     }
 

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -30,7 +30,7 @@ pub struct GitSource {
 
 impl GitSource {
     /// Initialize a new Git source.
-    pub fn new(
+    pub(crate) fn new(
         git: GitUrl,
         client: impl Into<ClientWithMiddleware>,
         cache: impl Into<PathBuf>,
@@ -44,7 +44,7 @@ impl GitSource {
 
     /// Fetch the underlying Git repository at the given revision.
     #[instrument(skip(self), fields(repository = %self.git.repository, rev = ?self.git.precise))]
-    pub fn fetch(self) -> miette::Result<Fetch> {
+    pub(crate) fn fetch(self) -> miette::Result<Fetch> {
         // Compute the canonical URL for the repository.
         let canonical = RepositoryUrl::new(&self.git.repository);
 
@@ -123,11 +123,11 @@ impl Fetch {
         &self.git
     }
 
-    pub fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> &Path {
         &self.path
     }
 
-    pub fn into_git(self) -> GitUrl {
+    pub(crate) fn into_git(self) -> GitUrl {
         self.git
     }
 
@@ -136,7 +136,7 @@ impl Fetch {
     }
 }
 
-pub fn cache_digest(url: &RepositoryUrl) -> String {
+pub(crate) fn cache_digest(url: &RepositoryUrl) -> String {
     let mut hasher = DefaultHasher::new();
     url.hash(&mut hasher);
     let hash = hasher.finish();

--- a/crates/pixi_git/src/url.rs
+++ b/crates/pixi_git/src/url.rs
@@ -16,7 +16,7 @@ use url::Url;
 pub struct CanonicalUrl(Url);
 
 impl CanonicalUrl {
-    pub fn new(url: &Url) -> Self {
+    pub(crate) fn new(url: &Url) -> Self {
         let mut url = url.clone();
 
         // If the URL cannot be a base, then it's not a valid URL anyway.
@@ -79,7 +79,7 @@ impl CanonicalUrl {
         Self(url)
     }
 
-    pub fn parse(url: &str) -> Result<Self, url::ParseError> {
+    pub(crate) fn parse(url: &str) -> Result<Self, url::ParseError> {
         Ok(Self::new(&Url::parse(url)?))
     }
 }
@@ -123,7 +123,7 @@ impl RepositoryUrl {
         Self(url)
     }
 
-    pub fn parse(url: &str) -> Result<Self, url::ParseError> {
+    pub(crate) fn parse(url: &str) -> Result<Self, url::ParseError> {
         Ok(Self::new(&Url::parse(url)?))
     }
 }

--- a/crates/pixi_git/src/url.rs
+++ b/crates/pixi_git/src/url.rs
@@ -79,6 +79,7 @@ impl CanonicalUrl {
         Self(url)
     }
 
+    #[allow(unused)]
     pub(crate) fn parse(url: &str) -> Result<Self, url::ParseError> {
         Ok(Self::new(&Url::parse(url)?))
     }
@@ -123,7 +124,7 @@ impl RepositoryUrl {
         Self(url)
     }
 
-    pub(crate) fn parse(url: &str) -> Result<Self, url::ParseError> {
+    pub fn parse(url: &str) -> Result<Self, url::ParseError> {
         Ok(Self::new(&Url::parse(url)?))
     }
 }

--- a/crates/pixi_glob/src/glob_hash.rs
+++ b/crates/pixi_glob/src/glob_hash.rs
@@ -38,7 +38,7 @@ pub enum GlobHashError {
 
 impl GlobHash {
     /// Calculate a hash of the files that match the given glob patterns.
-    pub fn from_patterns<'a>(
+    pub(crate) fn from_patterns<'a>(
         root_dir: &Path,
         globs: impl IntoIterator<Item = &'a str>,
     ) -> Result<Self, GlobHashError> {
@@ -168,7 +168,7 @@ mod test {
     use super::*;
 
     #[fixture]
-    pub fn testname() -> String {
+    pub(crate) fn testname() -> String {
         let thread_name = std::thread::current().name().unwrap().to_string();
         let test_name = thread_name.rsplit("::").next().unwrap_or(&thread_name);
         format!("glob_hash_{test_name}")

--- a/crates/pixi_glob/src/glob_mtime.rs
+++ b/crates/pixi_glob/src/glob_mtime.rs
@@ -77,29 +77,6 @@ impl GlobModificationTime {
             None => Ok(Self::NoMatches),
         }
     }
-
-    /// Get the newest modification time, if any.
-    pub(crate) fn newest(&self) -> Option<SystemTime> {
-        match self {
-            Self::MatchesFound { modified_at, .. } => Some(*modified_at),
-            Self::NoMatches => None,
-        }
-    }
-
-    /// Get the designated file with the newest modification time, if any.
-    pub(crate) fn designated_file(&self) -> Option<&Path> {
-        match self {
-            Self::MatchesFound {
-                designated_file, ..
-            } => Some(designated_file.as_path()),
-            Self::NoMatches => None,
-        }
-    }
-
-    /// Returns `true` if there have been any matches found.
-    pub(crate) fn has_matches(&self) -> bool {
-        matches!(self, Self::MatchesFound { .. })
-    }
 }
 
 #[cfg(test)]
@@ -160,7 +137,5 @@ mod tests {
         let glob_mod_time = GlobModificationTime::from_patterns(dir_path, ["*.md"]).unwrap();
 
         assert!(matches!(glob_mod_time, GlobModificationTime::NoMatches));
-        assert_eq!(glob_mod_time.newest(), None);
-        assert_eq!(glob_mod_time.designated_file(), None);
     }
 }

--- a/crates/pixi_glob/src/glob_mtime.rs
+++ b/crates/pixi_glob/src/glob_mtime.rs
@@ -79,7 +79,7 @@ impl GlobModificationTime {
     }
 
     /// Get the newest modification time, if any.
-    pub fn newest(&self) -> Option<SystemTime> {
+    pub(crate) fn newest(&self) -> Option<SystemTime> {
         match self {
             Self::MatchesFound { modified_at, .. } => Some(*modified_at),
             Self::NoMatches => None,
@@ -87,7 +87,7 @@ impl GlobModificationTime {
     }
 
     /// Get the designated file with the newest modification time, if any.
-    pub fn designated_file(&self) -> Option<&Path> {
+    pub(crate) fn designated_file(&self) -> Option<&Path> {
         match self {
             Self::MatchesFound {
                 designated_file, ..
@@ -97,7 +97,7 @@ impl GlobModificationTime {
     }
 
     /// Returns `true` if there have been any matches found.
-    pub fn has_matches(&self) -> bool {
+    pub(crate) fn has_matches(&self) -> bool {
         matches!(self, Self::MatchesFound { .. })
     }
 }

--- a/crates/pixi_glob/src/glob_set.rs
+++ b/crates/pixi_glob/src/glob_set.rs
@@ -30,7 +30,9 @@ pub enum GlobSetError {
 }
 
 impl<'t> GlobSet<'t> {
-    pub fn create(globs: impl IntoIterator<Item = &'t str>) -> Result<GlobSet<'t>, GlobSetError> {
+    pub(crate) fn create(
+        globs: impl IntoIterator<Item = &'t str>,
+    ) -> Result<GlobSet<'t>, GlobSetError> {
         // Split the globs into inclusion and exclusion globs based on whether they
         // start with `!`.
         let (inclusion_globs, exclusion_globs): (Vec<_>, Vec<_>) =
@@ -57,7 +59,7 @@ impl<'t> GlobSet<'t> {
     }
 
     /// Create a function that filters out files that match the globs.
-    pub fn filter_directory(
+    pub(crate) fn filter_directory(
         &'t self,
         root_dir: &Path,
     ) -> impl Iterator<Item = Result<WalkEntry<'static>, GlobSetError>> + 't {

--- a/crates/pixi_progress/Cargo.toml
+++ b/crates/pixi_progress/Cargo.toml
@@ -10,6 +10,5 @@ version = "0.1.0"
 
 
 [dependencies]
-console = { workspace = true }
 indicatif = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }

--- a/crates/pixi_progress/src/lib.rs
+++ b/crates/pixi_progress/src/lib.rs
@@ -45,7 +45,7 @@ pub fn default_progress_style() -> indicatif::ProgressStyle {
 }
 
 /// Returns the style to use for a progressbar that is in Deserializing state.
-pub fn deserializing_progress_style() -> indicatif::ProgressStyle {
+pub(crate) fn deserializing_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
         .template("  {spinner:.dim} {prefix:20!} [{elapsed_precise}] {wide_msg}")
         .unwrap()
@@ -53,7 +53,7 @@ pub fn deserializing_progress_style() -> indicatif::ProgressStyle {
 }
 
 /// Returns the style to use for a progressbar that is finished.
-pub fn finished_progress_style() -> indicatif::ProgressStyle {
+pub(crate) fn finished_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
         .template(&format!(
             "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
@@ -64,7 +64,7 @@ pub fn finished_progress_style() -> indicatif::ProgressStyle {
 }
 
 /// Returns the style to use for a progressbar that is in error state.
-pub fn errored_progress_style() -> indicatif::ProgressStyle {
+pub(crate) fn errored_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::default_bar()
         .template(&format!(
             "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.red}}",
@@ -159,7 +159,7 @@ impl ScopedTask {
 
 impl ProgressBarMessageFormatter {
     /// Construct a new instance that will update the given progress bar.
-    pub fn new(progress_bar: ProgressBar) -> Self {
+    pub(crate) fn new(progress_bar: ProgressBar) -> Self {
         Self::new_with_capacity(progress_bar, 50)
     }
 
@@ -198,7 +198,7 @@ impl ProgressBarMessageFormatter {
     }
 
     /// Returns the associated progress bar
-    pub fn progress_bar(&self) -> &ProgressBar {
+    pub(crate) fn progress_bar(&self) -> &ProgressBar {
         &self.pb
     }
 
@@ -241,7 +241,7 @@ impl ProgressBarMessageFormatter {
     }
 
     /// Convert this instance into the underlying progress bar.
-    pub fn into_progress_bar(self) -> ProgressBar {
+    pub(crate) fn into_progress_bar(self) -> ProgressBar {
         self.pb
     }
 }

--- a/crates/pixi_progress/src/lib.rs
+++ b/crates/pixi_progress/src/lib.rs
@@ -44,36 +44,6 @@ pub fn default_progress_style() -> indicatif::ProgressStyle {
         .progress_chars("━━╾─")
 }
 
-/// Returns the style to use for a progressbar that is in Deserializing state.
-pub(crate) fn deserializing_progress_style() -> indicatif::ProgressStyle {
-    indicatif::ProgressStyle::default_bar()
-        .template("  {spinner:.dim} {prefix:20!} [{elapsed_precise}] {wide_msg}")
-        .unwrap()
-        .progress_chars("━━╾─")
-}
-
-/// Returns the style to use for a progressbar that is finished.
-pub(crate) fn finished_progress_style() -> indicatif::ProgressStyle {
-    indicatif::ProgressStyle::default_bar()
-        .template(&format!(
-            "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
-            console::style(console::Emoji("✔", " ")).green()
-        ))
-        .unwrap()
-        .progress_chars("━━╾─")
-}
-
-/// Returns the style to use for a progressbar that is in error state.
-pub(crate) fn errored_progress_style() -> indicatif::ProgressStyle {
-    indicatif::ProgressStyle::default_bar()
-        .template(&format!(
-            "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.red}}",
-            console::style(console::Emoji("❌", " ")).red()
-        ))
-        .unwrap()
-        .progress_chars("━━╾─")
-}
-
 /// Returns the style to use for a progressbar that is indeterminate and simply shows a spinner.
 pub fn long_running_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::with_template("{prefix}{spinner:.green} {msg}").unwrap()
@@ -159,11 +129,6 @@ impl ScopedTask {
 
 impl ProgressBarMessageFormatter {
     /// Construct a new instance that will update the given progress bar.
-    pub(crate) fn new(progress_bar: ProgressBar) -> Self {
-        Self::new_with_capacity(progress_bar, 50)
-    }
-
-    /// Construct a new instance that will update the given progress bar.
     /// Allows the user to specify a custom capacity for the internal channel.
     pub fn new_with_capacity(progress_bar: ProgressBar, capacity: usize) -> Self {
         let pb = progress_bar.clone();
@@ -195,11 +160,6 @@ impl ProgressBarMessageFormatter {
             }
         });
         Self { sender: tx, pb }
-    }
-
-    /// Returns the associated progress bar
-    pub(crate) fn progress_bar(&self) -> &ProgressBar {
-        &self.pb
     }
 
     /// Adds the start of another task to the progress bar and returns an object that is used to
@@ -238,10 +198,5 @@ impl ProgressBarMessageFormatter {
         let result = fut.await;
         task.finish().await;
         result
-    }
-
-    /// Convert this instance into the underlying progress bar.
-    pub(crate) fn into_progress_bar(self) -> ProgressBar {
-        self.pb
     }
 }

--- a/crates/pixi_pty/src/unix/pty_process.rs
+++ b/crates/pixi_pty/src/unix/pty_process.rs
@@ -132,13 +132,6 @@ impl PtyProcess {
         unsafe { Ok(File::from_raw_fd(fd)) }
     }
 
-    /// At the drop of PtyProcess the running process is killed. This is blocking forever if
-    /// the process does not react to a normal kill. If kill_timeout is set the process is
-    /// `kill -9`ed after duration
-    pub(crate) fn set_kill_timeout(&mut self, timeout_ms: Option<u64>) {
-        self.kill_timeout = timeout_ms.map(time::Duration::from_millis);
-    }
-
     /// Get status of child process, non-blocking.
     ///
     /// This method runs waitpid on the process.
@@ -152,20 +145,9 @@ impl PtyProcess {
         }
     }
 
-    /// Wait until process has exited. This is a blocking call.
-    /// If the process doesn't terminate this will block forever.
-    pub(crate) fn wait(&self) -> nix::Result<wait::WaitStatus> {
-        wait::waitpid(self.child_pid, None)
-    }
-
     /// Regularly exit the process, this method is blocking until the process is dead
     pub(crate) fn exit(&mut self) -> nix::Result<wait::WaitStatus> {
         self.kill(signal::SIGTERM)
-    }
-
-    /// Non-blocking variant of `kill()` (doesn't wait for process to be killed)
-    pub(crate) fn signal(&mut self, sig: signal::Signal) -> nix::Result<()> {
-        signal::kill(self.child_pid, sig)
     }
 
     /// Kill the process with a specific signal. This method blocks, until the process is dead

--- a/crates/pixi_pty/src/unix/pty_session.rs
+++ b/crates/pixi_pty/src/unix/pty_session.rs
@@ -55,7 +55,7 @@ impl PtySession {
     /// need to call `flush()` after `send()` to make the process actually see your input.
     ///
     /// Returns number of written bytes
-    pub fn send<B: AsRef<[u8]>>(&mut self, s: B) -> io::Result<usize> {
+    pub(crate) fn send<B: AsRef<[u8]>>(&mut self, s: B) -> io::Result<usize> {
         self.process_stdin.write(s.as_ref())
     }
 
@@ -68,7 +68,7 @@ impl PtySession {
     }
 
     /// Make sure all bytes written via `send()` are sent to the process
-    pub fn flush(&mut self) -> io::Result<()> {
+    pub(crate) fn flush(&mut self) -> io::Result<()> {
         self.process_stdin.flush()
     }
 

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -37,6 +37,7 @@ impl PixiRecord {
     }
 
     /// Converts this instance into a binary record if it is a binary record.
+    #[allow(unused)]
     pub(crate) fn into_binary(self) -> Option<RepoDataRecord> {
         match self {
             PixiRecord::Binary(record) => Some(record),
@@ -55,23 +56,6 @@ impl PixiRecord {
 
     /// Returns the source record if it is a source record.
     pub fn as_source(&self) -> Option<&SourceRecord> {
-        match self {
-            PixiRecord::Binary(_) => None,
-            PixiRecord::Source(record) => Some(record),
-        }
-    }
-
-    /// Converts this instance into a source record if it is a source record.
-    pub(crate) fn into_source(self) -> Option<SourceRecord> {
-        match self {
-            PixiRecord::Binary(_) => None,
-            PixiRecord::Source(record) => Some(record),
-        }
-    }
-
-    /// Returns a mutable reference to the source record if it is a source
-    /// record.
-    pub(crate) fn as_source_mut(&mut self) -> Option<&mut SourceRecord> {
         match self {
             PixiRecord::Binary(_) => None,
             PixiRecord::Source(record) => Some(record),

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -37,7 +37,7 @@ impl PixiRecord {
     }
 
     /// Converts this instance into a binary record if it is a binary record.
-    pub fn into_binary(self) -> Option<RepoDataRecord> {
+    pub(crate) fn into_binary(self) -> Option<RepoDataRecord> {
         match self {
             PixiRecord::Binary(record) => Some(record),
             PixiRecord::Source(_) => None,
@@ -62,7 +62,7 @@ impl PixiRecord {
     }
 
     /// Converts this instance into a source record if it is a source record.
-    pub fn into_source(self) -> Option<SourceRecord> {
+    pub(crate) fn into_source(self) -> Option<SourceRecord> {
         match self {
             PixiRecord::Binary(_) => None,
             PixiRecord::Source(record) => Some(record),
@@ -71,7 +71,7 @@ impl PixiRecord {
 
     /// Returns a mutable reference to the source record if it is a source
     /// record.
-    pub fn as_source_mut(&mut self) -> Option<&mut SourceRecord> {
+    pub(crate) fn as_source_mut(&mut self) -> Option<&mut SourceRecord> {
         match self {
             PixiRecord::Binary(_) => None,
             PixiRecord::Source(record) => Some(record),

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -47,6 +47,7 @@ impl PinnedSourceSpec {
     }
 
     /// Returns the url spec if this instance is a url spec.
+    #[allow(unused)]
     pub(crate) fn as_url(&self) -> Option<&PinnedUrlSpec> {
         match self {
             PinnedSourceSpec::Url(spec) => Some(spec),
@@ -55,6 +56,7 @@ impl PinnedSourceSpec {
     }
 
     /// Returns the git spec if this instance is a git spec.
+    #[allow(unused)]
     pub(crate) fn as_git(&self) -> Option<&PinnedGitSpec> {
         match self {
             PinnedSourceSpec::Git(spec) => Some(spec),
@@ -63,6 +65,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedPathSpec`] if it is a path spec.
+    #[allow(unused)]
     pub(crate) fn into_path(self) -> Option<PinnedPathSpec> {
         match self {
             PinnedSourceSpec::Path(spec) => Some(spec),
@@ -71,6 +74,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedUrlSpec`] if it is a url spec.
+    #[allow(unused)]
     pub(crate) fn into_url(self) -> Option<PinnedUrlSpec> {
         match self {
             PinnedSourceSpec::Url(spec) => Some(spec),
@@ -79,6 +83,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedGitSpec`] if it is a git spec.
+    #[allow(unused)]
     pub(crate) fn into_git(self) -> Option<PinnedGitSpec> {
         match self {
             PinnedSourceSpec::Git(spec) => Some(spec),
@@ -93,6 +98,7 @@ impl PinnedSourceSpec {
     /// A mutable source is a source that can change over time. For example, a
     /// local path.
     #[allow(clippy::result_large_err)]
+    #[allow(unused)]
     pub(crate) fn into_mutable(self) -> Result<MutablePinnedSourceSpec, PinnedSourceSpec> {
         match self {
             PinnedSourceSpec::Path(spec) => Ok(MutablePinnedSourceSpec::Path(spec)),
@@ -109,6 +115,7 @@ impl PinnedSourceSpec {
 
 impl MutablePinnedSourceSpec {
     /// Returns the path spec if this instance is a path spec.
+    #[allow(unused)]
     pub(crate) fn as_path(&self) -> Option<&PinnedPathSpec> {
         match self {
             MutablePinnedSourceSpec::Path(spec) => Some(spec),
@@ -116,6 +123,7 @@ impl MutablePinnedSourceSpec {
     }
 
     /// Returns the path spec if this instance is a path spec.
+    #[allow(unused)]
     pub(crate) fn into_path(self) -> Option<PinnedPathSpec> {
         match self {
             MutablePinnedSourceSpec::Path(spec) => Some(spec),
@@ -233,7 +241,7 @@ pub struct PinnedGitSpec {
 
 impl PinnedGitSpec {
     /// Construct the lockfile-compatible [`Url`] from [`PinnedGitSpec`].
-    pub(crate) fn into_locked_git_url(&self) -> LockedGitUrl {
+    pub(crate) fn to_locked_git_url(&self) -> LockedGitUrl {
         let mut url = self.git.clone();
 
         // // Redact the credentials.
@@ -331,7 +339,7 @@ impl From<PinnedPathSpec> for UrlOrPath {
 
 impl From<PinnedGitSpec> for UrlOrPath {
     fn from(value: PinnedGitSpec) -> Self {
-        let url = value.into_locked_git_url();
+        let url = value.to_locked_git_url();
         UrlOrPath::Url(url.into())
     }
 }
@@ -385,6 +393,7 @@ impl LockedGitUrl {
     }
 
     /// Parses a locked git URL from a string.
+    #[allow(unused)]
     pub(crate) fn parse(url: &str) -> miette::Result<Self> {
         let url = Url::parse(url).into_diagnostic()?;
         Ok(Self(url))
@@ -406,7 +415,7 @@ impl TryFrom<LockedGitUrl> for PinnedGitSpec {
 
 impl From<PinnedGitSpec> for LockedGitUrl {
     fn from(value: PinnedGitSpec) -> Self {
-        value.into_locked_git_url()
+        value.to_locked_git_url()
     }
 }
 

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -47,7 +47,7 @@ impl PinnedSourceSpec {
     }
 
     /// Returns the url spec if this instance is a url spec.
-    pub fn as_url(&self) -> Option<&PinnedUrlSpec> {
+    pub(crate) fn as_url(&self) -> Option<&PinnedUrlSpec> {
         match self {
             PinnedSourceSpec::Url(spec) => Some(spec),
             _ => None,
@@ -55,7 +55,7 @@ impl PinnedSourceSpec {
     }
 
     /// Returns the git spec if this instance is a git spec.
-    pub fn as_git(&self) -> Option<&PinnedGitSpec> {
+    pub(crate) fn as_git(&self) -> Option<&PinnedGitSpec> {
         match self {
             PinnedSourceSpec::Git(spec) => Some(spec),
             _ => None,
@@ -63,7 +63,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedPathSpec`] if it is a path spec.
-    pub fn into_path(self) -> Option<PinnedPathSpec> {
+    pub(crate) fn into_path(self) -> Option<PinnedPathSpec> {
         match self {
             PinnedSourceSpec::Path(spec) => Some(spec),
             _ => None,
@@ -71,7 +71,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedUrlSpec`] if it is a url spec.
-    pub fn into_url(self) -> Option<PinnedUrlSpec> {
+    pub(crate) fn into_url(self) -> Option<PinnedUrlSpec> {
         match self {
             PinnedSourceSpec::Url(spec) => Some(spec),
             _ => None,
@@ -79,7 +79,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedGitSpec`] if it is a git spec.
-    pub fn into_git(self) -> Option<PinnedGitSpec> {
+    pub(crate) fn into_git(self) -> Option<PinnedGitSpec> {
         match self {
             PinnedSourceSpec::Git(spec) => Some(spec),
             _ => None,
@@ -93,7 +93,7 @@ impl PinnedSourceSpec {
     /// A mutable source is a source that can change over time. For example, a
     /// local path.
     #[allow(clippy::result_large_err)]
-    pub fn into_mutable(self) -> Result<MutablePinnedSourceSpec, PinnedSourceSpec> {
+    pub(crate) fn into_mutable(self) -> Result<MutablePinnedSourceSpec, PinnedSourceSpec> {
         match self {
             PinnedSourceSpec::Path(spec) => Ok(MutablePinnedSourceSpec::Path(spec)),
             _ => Err(self),
@@ -109,14 +109,14 @@ impl PinnedSourceSpec {
 
 impl MutablePinnedSourceSpec {
     /// Returns the path spec if this instance is a path spec.
-    pub fn as_path(&self) -> Option<&PinnedPathSpec> {
+    pub(crate) fn as_path(&self) -> Option<&PinnedPathSpec> {
         match self {
             MutablePinnedSourceSpec::Path(spec) => Some(spec),
         }
     }
 
     /// Returns the path spec if this instance is a path spec.
-    pub fn into_path(self) -> Option<PinnedPathSpec> {
+    pub(crate) fn into_path(self) -> Option<PinnedPathSpec> {
         match self {
             MutablePinnedSourceSpec::Path(spec) => Some(spec),
         }
@@ -233,7 +233,7 @@ pub struct PinnedGitSpec {
 
 impl PinnedGitSpec {
     /// Construct the lockfile-compatible [`Url`] from [`PinnedGitSpec`].
-    pub fn into_locked_git_url(&self) -> LockedGitUrl {
+    pub(crate) fn into_locked_git_url(&self) -> LockedGitUrl {
         let mut url = self.git.clone();
 
         // // Redact the credentials.
@@ -360,12 +360,12 @@ impl LockedGitUrl {
     /// Returns true if the given URL is a locked git URL.
     /// This is used to differentiate between a regular Url and a [`LockedGitUrl`]
     /// that starts with `git+`.
-    pub fn is_locked_git_url(locked_url: &Url) -> bool {
+    pub(crate) fn is_locked_git_url(locked_url: &Url) -> bool {
         locked_url.scheme().starts_with("git+")
     }
 
     /// Converts this [`LockedGitUrl`] into a [`PinnedGitSpec`].
-    pub fn to_pinned_git_spec(&self) -> miette::Result<PinnedGitSpec> {
+    pub(crate) fn to_pinned_git_spec(&self) -> miette::Result<PinnedGitSpec> {
         let git_source = PinnedGitCheckout::from_locked_url(self)?;
 
         let git_url = GitUrl::try_from(self.0.clone()).into_diagnostic()?;
@@ -385,7 +385,7 @@ impl LockedGitUrl {
     }
 
     /// Parses a locked git URL from a string.
-    pub fn parse(url: &str) -> miette::Result<Self> {
+    pub(crate) fn parse(url: &str) -> miette::Result<Self> {
         let url = Url::parse(url).into_diagnostic()?;
         Ok(Self(url))
     }
@@ -499,7 +499,7 @@ pub enum SourceMismatchError {
 impl PinnedPathSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked path satisfies the requested path.
-    pub fn satisfies(&self, spec: &PathSourceSpec) -> Result<(), SourceMismatchError> {
+    pub(crate) fn satisfies(&self, spec: &PathSourceSpec) -> Result<(), SourceMismatchError> {
         if spec.path != self.path {
             return Err(SourceMismatchError::PathMismatch {
                 locked: self.path.clone(),
@@ -513,7 +513,7 @@ impl PinnedPathSpec {
 impl PinnedUrlSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked url satisfies the requested url.
-    pub fn satisfies(&self, spec: &UrlSourceSpec) -> Result<(), SourceMismatchError> {
+    pub(crate) fn satisfies(&self, spec: &UrlSourceSpec) -> Result<(), SourceMismatchError> {
         if spec.url != self.url {
             return Err(SourceMismatchError::UrlMismatch {
                 locked: self.url.clone(),
@@ -549,7 +549,7 @@ impl PinnedUrlSpec {
 impl PinnedGitSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked git url satisfies the requested git url.
-    pub fn satisfies(&self, spec: &GitSpec) -> Result<(), SourceMismatchError> {
+    pub(crate) fn satisfies(&self, spec: &GitSpec) -> Result<(), SourceMismatchError> {
         let mut to_be_redacted = spec.git.clone();
         redact_credentials(&mut to_be_redacted);
 

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -18,7 +18,7 @@ use pixi_config::Config;
 
 /// The default retry policy employed by pixi.
 /// TODO: At some point we might want to make this configurable.
-pub fn default_retry_policy() -> ExponentialBackoff {
+pub(crate) fn default_retry_policy() -> ExponentialBackoff {
     ExponentialBackoff::builder().build_with_max_retries(3)
 }
 
@@ -41,7 +41,7 @@ fn auth_middleware(config: &Config) -> Result<AuthenticationMiddleware, FileStor
     Ok(AuthenticationMiddleware::default())
 }
 
-pub fn mirror_middleware(config: &Config) -> MirrorMiddleware {
+pub(crate) fn mirror_middleware(config: &Config) -> MirrorMiddleware {
     let mut internal_map = HashMap::new();
     tracing::info!("Using mirrors: {:?}", config.mirror_map());
 
@@ -73,7 +73,7 @@ pub fn mirror_middleware(config: &Config) -> MirrorMiddleware {
     MirrorMiddleware::from_map(internal_map)
 }
 
-pub fn oci_middleware() -> OciMiddleware {
+pub(crate) fn oci_middleware() -> OciMiddleware {
     OciMiddleware
 }
 

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -132,7 +132,7 @@ pub fn locked_indexes_to_index_locations(
     Ok(IndexLocations::new(indexes, flat_index, no_index))
 }
 
-pub fn to_git_reference(rev: &GitRev) -> GitReference {
+pub(crate) fn to_git_reference(rev: &GitRev) -> GitReference {
     match rev {
         GitRev::Full(rev) => GitReference::FullCommit(rev.clone()),
         GitRev::Short(rev) => GitReference::BranchOrTagOrCommit(rev.clone()),

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -214,14 +214,6 @@ pub fn to_extra_name(
     )
 }
 
-/// Converts `uv_pep440::Version` to `pep440_rs::Version`
-pub(crate) fn to_version(
-    version: &uv_pep440::Version,
-) -> Result<pep440_rs::Version, ConversionError> {
-    Ok(pep440_rs::Version::from_str(version.to_string().as_str())
-        .map_err(VersionError::PepError)?)
-}
-
 /// Converts `pep440_rs::Version` to `uv_pep440::Version`
 pub fn to_uv_version(version: &pep440_rs::Version) -> Result<uv_pep440::Version, ConversionError> {
     Ok(

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -215,7 +215,9 @@ pub fn to_extra_name(
 }
 
 /// Converts `uv_pep440::Version` to `pep440_rs::Version`
-pub fn to_version(version: &uv_pep440::Version) -> Result<pep440_rs::Version, ConversionError> {
+pub(crate) fn to_version(
+    version: &uv_pep440::Version,
+) -> Result<pep440_rs::Version, ConversionError> {
     Ok(pep440_rs::Version::from_str(version.to_string().as_str())
         .map_err(VersionError::PepError)?)
 }

--- a/crates/pypi_mapping/src/custom_pypi_mapping.rs
+++ b/crates/pypi_mapping/src/custom_pypi_mapping.rs
@@ -45,7 +45,7 @@ pub async fn fetch_mapping_from_url(
     Ok(mapping_by_name)
 }
 
-pub fn fetch_mapping_from_path(path: &Path) -> miette::Result<CompressedMapping> {
+pub(crate) fn fetch_mapping_from_path(path: &Path) -> miette::Result<CompressedMapping> {
     let file = fs_err::File::open(path)
         .into_diagnostic()
         .context(format!("failed to open file {}", path.display()))?;
@@ -181,7 +181,7 @@ fn amend_pypi_purls_for_record(
     Ok(())
 }
 
-pub fn _amend_only_custom_pypi_purls(
+pub(crate) fn _amend_only_custom_pypi_purls(
     conda_packages: &mut [RepoDataRecord],
     custom_mapping: &HashMap<String, CompressedMapping>,
 ) -> miette::Result<()> {

--- a/crates/pypi_mapping/src/lib.rs
+++ b/crates/pypi_mapping/src/lib.rs
@@ -193,14 +193,16 @@ pub fn is_conda_forge_record(record: &RepoDataRecord) -> bool {
 }
 
 /// Returns `true` if the specified url refers to a conda-forge channel.
-pub fn is_conda_forge_url(url: &Url) -> bool {
+pub(crate) fn is_conda_forge_url(url: &Url) -> bool {
     url.path().starts_with("/conda-forge")
 }
 
 /// Build a purl for a `PackageRecord`
 /// it will return a purl in this format
 /// `pkg:pypi/aiofiles`
-pub fn build_pypi_purl_from_package_record(package_record: &PackageRecord) -> Option<PackageUrl> {
+pub(crate) fn build_pypi_purl_from_package_record(
+    package_record: &PackageRecord,
+) -> Option<PackageUrl> {
     let name = pep508_rs::PackageName::from_str(package_record.name.as_source()).ok();
     let version = pep440_rs::Version::from_str(&package_record.version.as_str()).ok();
     if let (Some(name), Some(_)) = (name, version) {

--- a/crates/pypi_mapping/src/prefix_pypi_name_mapping.rs
+++ b/crates/pypi_mapping/src/prefix_pypi_name_mapping.rs
@@ -252,7 +252,7 @@ pub fn amend_pypi_purls_for_record(
 
 /// Try to assume that the conda-forge package is a PyPI package and return a
 /// purl.
-pub fn assume_conda_is_pypi(
+pub(crate) fn assume_conda_is_pypi(
     purls: Option<&Vec<PackageUrl>>,
     record: &RepoDataRecord,
 ) -> Option<PackageUrl> {

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -12,7 +12,7 @@ pub fn is_python_record(record: impl AsRef<PackageRecord>) -> bool {
 
 /// Returns true if the specified name refers to a version/variant of python.
 /// TODO: Add support for more variants.
-pub fn package_name_is_python(record: &rattler_conda_types::PackageName) -> bool {
+pub(crate) fn package_name_is_python(record: &rattler_conda_types::PackageName) -> bool {
     record.as_normalized() == "python"
 }
 

--- a/src/build/cache/build_cache.rs
+++ b/src/build/cache/build_cache.rs
@@ -68,7 +68,7 @@ impl BuildInput {
     /// Computes a unique semi-human-readable hash for this key. Some parts of
     /// the input are hashes and others are included directly in the name this
     /// is to make it easier to identify the cache files.
-    pub fn hash_key(&self) -> String {
+    pub(crate) fn hash_key(&self) -> String {
         let BuildInput {
             channel_urls,
             target_platform,
@@ -99,7 +99,7 @@ impl BuildCache {
     /// An additional directory is created by this cache inside the passed root
     /// which includes a version number. This is to ensure that the cache is
     /// never corrupted if the format changes in the future.
-    pub fn new(root: PathBuf) -> Self {
+    pub(crate) fn new(root: PathBuf) -> Self {
         Self {
             root: root.join("source-builds-v0"),
         }

--- a/src/build/cache/source_metadata_cache.rs
+++ b/src/build/cache/source_metadata_cache.rs
@@ -56,7 +56,7 @@ pub struct SourceMetadataInput {
 
 impl SourceMetadataInput {
     /// Computes a unique semi-human-readable hash for this key.
-    pub fn hash_key(&self) -> String {
+    pub(crate) fn hash_key(&self) -> String {
         let mut hasher = DefaultHasher::new();
         self.channel_urls.hash(&mut hasher);
         self.build_platform.hash(&mut hasher);
@@ -76,7 +76,7 @@ impl SourceMetadataCache {
     /// An additional directory is created by this cache inside the passed root
     /// which includes a version number. This is to ensure that the cache is
     /// never corrupted if the format changes in the future.
-    pub fn new(root: PathBuf) -> Self {
+    pub(crate) fn new(root: PathBuf) -> Self {
         Self {
             root: root.join("source-meta-v0"),
         }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -168,6 +168,7 @@ impl BuildContext {
     }
 
     /// Sets the input hash cache to use for caching input hashes.
+    #[allow(unused)]
     pub(crate) fn with_glob_hash_cache(self, glob_hash_cache: GlobHashCache) -> Self {
         Self {
             glob_hash_cache,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -122,7 +122,7 @@ pub struct SourceMetadata {
 }
 
 impl BuildContext {
-    pub fn new(
+    pub(crate) fn new(
         cache_dir: PathBuf,
         dot_pixi_dir: PathBuf,
         channel_config: ChannelConfig,
@@ -142,7 +142,7 @@ impl BuildContext {
         })
     }
 
-    pub fn from_project(project: &crate::project::Project) -> miette::Result<Self> {
+    pub(crate) fn from_project(project: &crate::project::Project) -> miette::Result<Self> {
         let variant = project
             .manifest()
             .workspace
@@ -160,7 +160,7 @@ impl BuildContext {
         .into_diagnostic()
     }
 
-    pub fn with_tool_context(self, tool_context: Arc<ToolContext>) -> Self {
+    pub(crate) fn with_tool_context(self, tool_context: Arc<ToolContext>) -> Self {
         Self {
             tool_context,
             ..self
@@ -168,7 +168,7 @@ impl BuildContext {
     }
 
     /// Sets the input hash cache to use for caching input hashes.
-    pub fn with_glob_hash_cache(self, glob_hash_cache: GlobHashCache) -> Self {
+    pub(crate) fn with_glob_hash_cache(self, glob_hash_cache: GlobHashCache) -> Self {
         Self {
             glob_hash_cache,
             ..self
@@ -835,7 +835,7 @@ struct WorkDirKey {
 }
 
 impl WorkDirKey {
-    pub fn key(&self) -> String {
+    pub(crate) fn key(&self) -> String {
         let mut hasher = Xxh3::new();
         self.source.pinned.to_string().hash(&mut hasher);
         self.host_platform.hash(&mut hasher);

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -126,7 +126,7 @@ impl PackageExt {
     }
 
     /// Returns the name of the package.
-    pub fn name(&self) -> Cow<'_, str> {
+    pub(crate) fn name(&self) -> Cow<'_, str> {
         match self {
             Self::Conda(value) => value.record().name.as_normalized().into(),
             Self::PyPI(value, _) => value.name.as_dist_info_name(),
@@ -134,7 +134,7 @@ impl PackageExt {
     }
 
     /// Returns the version string of the package
-    pub fn version(&self) -> Cow<'_, str> {
+    pub(crate) fn version(&self) -> Cow<'_, str> {
         match self {
             Self::Conda(value) => value.record().version.as_str(),
             Self::PyPI(value, _) => value.version.to_string().into(),

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -252,7 +252,7 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    pub fn test_unarchive_flat_structure() {
+    pub(crate) fn test_unarchive_flat_structure() {
         // This archive contains a single file named "a_file"
         // So we expect the file to be extracted to the target directory
 
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_unarchive_nested_structure() {
+    pub(crate) fn test_unarchive_nested_structure() {
         // This archive contains following nested structure
         // pixi_nested_archive.tar.gz
         // ├── some_pixi (directory)

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -377,7 +377,7 @@ pub struct LockFileJsonDiff {
 }
 
 impl LockFileJsonDiff {
-    pub fn new(project: &Project, value: LockFileDiff) -> Self {
+    pub(crate) fn new(project: &Project, value: LockFileDiff) -> Self {
         let mut environment = IndexMap::new();
 
         for (environment_name, environment_diff) in value.environment {

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -331,7 +331,7 @@ pub async fn sanity_check_project(project: &Project) -> miette::Result<()> {
 
 /// Extract filtered requirements from the project based on a filter.
 /// The filter allows specifying which subset of requirements to extract.
-pub fn extract_requirements_from_project(project: &Project) -> Vec<PixiSpec> {
+pub(crate) fn extract_requirements_from_project(project: &Project) -> Vec<PixiSpec> {
     let mut requirements = Vec::new();
 
     for env in project.environments() {
@@ -351,7 +351,7 @@ pub fn extract_requirements_from_project(project: &Project) -> Vec<PixiSpec> {
 
 /// Store credentials from the filtered requirements.
 /// This method takes the requirements and processes only `PixiSpec::Git` variants.
-pub fn store_credentials_from_requirements(requirements: Vec<PixiSpec>) {
+pub(crate) fn store_credentials_from_requirements(requirements: Vec<PixiSpec>) {
     for spec in requirements {
         if let PixiSpec::Git(git_spec) = spec {
             store_credentials_from_url(&git_spec.git);
@@ -709,7 +709,7 @@ impl CondaBuildProgress {
 
 impl CondaBuildProgress {
     /// Associate a progress bar with a build identifier, and get a build id back
-    pub fn associate(&self, identifier: &str) -> usize {
+    pub(crate) fn associate(&self, identifier: &str) -> usize {
         let mut locked = self.build_progress.lock();
         let after = if locked.is_empty() {
             &self.main_progress
@@ -723,7 +723,7 @@ impl CondaBuildProgress {
         locked.len() - 1
     }
 
-    pub fn end_progress_for(&self, build_id: usize, alternative_message: Option<String>) {
+    pub(crate) fn end_progress_for(&self, build_id: usize, alternative_message: Option<String>) {
         self.main_progress.inc(1);
         if self.main_progress.position()
             == self

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -37,7 +37,7 @@ pub struct BinDir(PathBuf);
 impl BinDir {
     /// Create the binary executable directory from path
     #[cfg(test)]
-    pub fn new(root: PathBuf) -> miette::Result<Self> {
+    pub(crate) fn new(root: PathBuf) -> miette::Result<Self> {
         let path = root.join("bin");
         fs_err::create_dir_all(&path).into_diagnostic()?;
         Ok(Self(path))
@@ -77,7 +77,7 @@ impl BinDir {
     }
 
     /// Returns the path to the binary directory
-    pub fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> &Path {
         &self.0
     }
 
@@ -105,7 +105,7 @@ pub struct EnvRoot(PathBuf);
 impl EnvRoot {
     /// Create the environment root directory
     #[cfg(test)]
-    pub fn new(root: PathBuf) -> miette::Result<Self> {
+    pub(crate) fn new(root: PathBuf) -> miette::Result<Self> {
         let path = root.join("envs");
         fs_err::create_dir_all(&path).into_diagnostic()?;
         Ok(Self(path))
@@ -120,7 +120,7 @@ impl EnvRoot {
         Ok(Self(path))
     }
 
-    pub fn path(&self) -> &Path {
+    pub(crate) fn path(&self) -> &Path {
         &self.0
     }
 
@@ -219,7 +219,7 @@ impl std::fmt::Display for NotChangedReason {
 
 impl NotChangedReason {
     /// Returns the name of the environment.
-    pub fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         match self {
             NotChangedReason::AlreadyInstalled => "already installed",
         }
@@ -239,7 +239,7 @@ pub(crate) enum EnvState {
 }
 
 impl EnvState {
-    pub fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         match self {
             EnvState::Installed => "installed",
             EnvState::NotChanged(reason) => reason.as_str(),
@@ -271,14 +271,14 @@ pub enum InstallChange {
 }
 
 impl InstallChange {
-    pub fn is_transitive(&self) -> bool {
+    pub(crate) fn is_transitive(&self) -> bool {
         matches!(self, InstallChange::TransitiveUpgraded(_, _))
     }
-    pub fn is_removed(&self) -> bool {
+    pub(crate) fn is_removed(&self) -> bool {
         matches!(self, InstallChange::Removed)
     }
 
-    pub fn version_fancy_display(&self) -> Option<StyledObject<String>> {
+    pub(crate) fn version_fancy_display(&self) -> Option<StyledObject<String>> {
         let version_style = console::Style::new().blue();
         let default_style = console::Style::new();
 
@@ -313,7 +313,7 @@ pub(crate) struct EnvironmentUpdate {
 }
 
 impl EnvironmentUpdate {
-    pub fn new(
+    pub(crate) fn new(
         package_changes: HashMap<PackageName, InstallChange>,
         current_packages: Vec<PackageName>,
     ) -> Self {
@@ -323,19 +323,19 @@ impl EnvironmentUpdate {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.package_changes.is_empty()
     }
 
-    pub fn changes(&self) -> &HashMap<PackageName, InstallChange> {
+    pub(crate) fn changes(&self) -> &HashMap<PackageName, InstallChange> {
         &self.package_changes
     }
 
-    pub fn current_packages(&self) -> &Vec<PackageName> {
+    pub(crate) fn current_packages(&self) -> &Vec<PackageName> {
         &self.current_packages
     }
 
-    pub fn add_removed_packages(&mut self, packages: Vec<PackageName>) {
+    pub(crate) fn add_removed_packages(&mut self, packages: Vec<PackageName>) {
         self.current_packages.extend(packages);
     }
 }
@@ -393,7 +393,7 @@ impl StateChanges {
     }
 
     #[cfg(test)]
-    pub fn changes(self) -> HashMap<EnvironmentName, Vec<StateChange>> {
+    pub(crate) fn changes(self) -> HashMap<EnvironmentName, Vec<StateChange>> {
         self.changes
     }
 
@@ -767,7 +767,7 @@ pub(crate) async fn get_expose_scripts_sync_status(
 }
 
 /// Check if all binaries were exposed, or if the user selected a subset of them.
-pub fn check_all_exposed(
+pub(crate) fn check_all_exposed(
     env_binaries: &IndexMap<PackageName, Vec<Executable>>,
     exposed_mapping_binaries: &IndexSet<Mapping>,
 ) -> bool {

--- a/src/global/list.rs
+++ b/src/global/list.rs
@@ -25,13 +25,18 @@ pub enum GlobalSortBy {
 }
 
 /// Creating the ASCII art representation of a section.
-pub fn format_asciiart_section(label: &str, content: String, last: bool, more: bool) -> String {
+pub(crate) fn format_asciiart_section(
+    label: &str,
+    content: String,
+    last: bool,
+    more: bool,
+) -> String {
     let prefix = if last { " " } else { "│" };
     let symbol = if more { "├" } else { "└" };
     format!("\n{}   {}─ {}: {}", prefix, symbol, label, content)
 }
 
-pub fn format_exposed(exposed: &IndexSet<Mapping>, last: bool) -> Option<String> {
+pub(crate) fn format_exposed(exposed: &IndexSet<Mapping>, last: bool) -> Option<String> {
     if exposed.is_empty() {
         Some(format_asciiart_section(
             "exposes",

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -25,7 +25,7 @@ fn find_executables(prefix: &Prefix, prefix_package: &PrefixRecord) -> Vec<PathB
 
 /// Processes prefix records (that you can get by using `find_installed_packages`)
 /// to filter and collect executable files.
-pub fn find_executables_for_many_records(
+pub(crate) fn find_executables_for_many_records(
     prefix: &Prefix,
     prefix_packages: &[PrefixRecord],
 ) -> Vec<Executable> {

--- a/src/global/project/environment.rs
+++ b/src/global/project/environment.rs
@@ -19,7 +19,7 @@ pub(crate) struct EnvironmentName(String);
 
 impl EnvironmentName {
     /// Returns the name of the environment.
-    pub fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         &self.0
     }
 }

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -38,14 +38,17 @@ pub struct Manifest {
 
 impl Manifest {
     /// Creates a new manifest from a path
-    pub fn from_path(path: impl AsRef<Path>) -> miette::Result<Self> {
+    pub(crate) fn from_path(path: impl AsRef<Path>) -> miette::Result<Self> {
         let manifest_path = dunce::canonicalize(path.as_ref()).into_diagnostic()?;
         let contents = fs_err::read_to_string(path.as_ref()).into_diagnostic()?;
         Self::from_str(manifest_path.as_ref(), contents)
     }
 
     /// Creates a new manifest from a string
-    pub fn from_str(manifest_path: &Path, contents: impl Into<String>) -> miette::Result<Self> {
+    pub(crate) fn from_str(
+        manifest_path: &Path,
+        contents: impl Into<String>,
+    ) -> miette::Result<Self> {
         let contents = contents.into();
         let parsed = ParsedManifest::from_toml_str(&contents);
 
@@ -70,7 +73,7 @@ impl Manifest {
     }
 
     /// Adds an environment to the manifest
-    pub fn add_environment(
+    pub(crate) fn add_environment(
         &mut self,
         env_name: &EnvironmentName,
         channels: Option<Vec<NamedChannelOrUrl>>,
@@ -104,7 +107,7 @@ impl Manifest {
     }
 
     /// Removes a specific environment from the manifest
-    pub fn remove_environment(&mut self, env_name: &EnvironmentName) -> miette::Result<()> {
+    pub(crate) fn remove_environment(&mut self, env_name: &EnvironmentName) -> miette::Result<()> {
         // Update self.parsed
         self.parsed.envs.shift_remove(env_name).ok_or_else(|| {
             miette::miette!("Environment {} doesn't exist.", env_name.fancy_display())
@@ -126,7 +129,7 @@ impl Manifest {
     }
 
     /// Adds a dependency to the manifest
-    pub fn add_dependency(
+    pub(crate) fn add_dependency(
         &mut self,
         env_name: &EnvironmentName,
         spec: &MatchSpec,
@@ -166,7 +169,7 @@ impl Manifest {
     }
 
     /// Removes a dependency from the manifest
-    pub fn remove_dependency(
+    pub(crate) fn remove_dependency(
         &mut self,
         env_name: &EnvironmentName,
         spec: &MatchSpec,
@@ -206,7 +209,7 @@ impl Manifest {
     }
 
     /// Sets the platform of a specific environment in the manifest
-    pub fn set_platform(
+    pub(crate) fn set_platform(
         &mut self,
         env_name: &EnvironmentName,
         platform: Platform,
@@ -244,7 +247,7 @@ impl Manifest {
 
     #[allow(dead_code)]
     /// Adds a channel to the manifest
-    pub fn add_channel(
+    pub(crate) fn add_channel(
         &mut self,
         env_name: &EnvironmentName,
         channel: &NamedChannelOrUrl,
@@ -289,7 +292,7 @@ impl Manifest {
     }
 
     /// Matches an exposed name to its corresponding environment name.
-    pub fn match_exposed_name_to_environment(
+    pub(crate) fn match_exposed_name_to_environment(
         &self,
         exposed_name: &ExposedName,
     ) -> miette::Result<EnvironmentName> {
@@ -307,7 +310,7 @@ impl Manifest {
     }
 
     /// Checks if an exposed name already exists in other environments
-    pub fn exposed_name_already_exists_in_other_envs(
+    pub(crate) fn exposed_name_already_exists_in_other_envs(
         &self,
         exposed_name: &ExposedName,
         env_name: &EnvironmentName,
@@ -321,7 +324,7 @@ impl Manifest {
     }
 
     /// Adds exposed mapping to the manifest
-    pub fn add_exposed_mapping(
+    pub(crate) fn add_exposed_mapping(
         &mut self,
         env_name: &EnvironmentName,
         mapping: &Mapping,
@@ -359,7 +362,7 @@ impl Manifest {
     }
 
     /// Removes exposed mapping from the manifest
-    pub fn remove_exposed_name(
+    pub(crate) fn remove_exposed_name(
         &mut self,
         env_name: &EnvironmentName,
         exposed_name: &ExposedName,
@@ -390,7 +393,7 @@ impl Manifest {
     }
 
     /// Removes all exposed mappings for a specific environment
-    pub fn remove_all_exposed_mappings(
+    pub(crate) fn remove_all_exposed_mappings(
         &mut self,
         env_name: &EnvironmentName,
     ) -> miette::Result<()> {
@@ -439,24 +442,24 @@ pub struct Mapping {
 }
 
 impl Mapping {
-    pub fn new(exposed_name: ExposedName, executable_relname: String) -> Self {
+    pub(crate) fn new(exposed_name: ExposedName, executable_relname: String) -> Self {
         Self {
             exposed_name,
             executable_relname: strip_executable_extension(executable_relname),
         }
     }
 
-    pub fn exposed_name(&self) -> &ExposedName {
+    pub(crate) fn exposed_name(&self) -> &ExposedName {
         &self.exposed_name
     }
 
-    pub fn executable_relname(&self) -> &str {
+    pub(crate) fn executable_relname(&self) -> &str {
         &self.executable_relname
     }
 
     // Splitting the executable_relname by the last '/' and taking the last part
     // e.g. 'nested/test_executable' -> 'test_executable'
-    pub fn executable_name(&self) -> &str {
+    pub(crate) fn executable_name(&self) -> &str {
         Path::new(&self.executable_relname)
             .file_name()
             .and_then(|name| name.to_str())
@@ -495,7 +498,7 @@ pub enum ExposedType {
 }
 
 impl ExposedType {
-    pub fn new(mappings: Vec<Mapping>, filter: Vec<PackageName>) -> Self {
+    pub(crate) fn new(mappings: Vec<Mapping>, filter: Vec<PackageName>) -> Self {
         if !mappings.is_empty() {
             return Self::Mappings(mappings);
         }
@@ -507,7 +510,7 @@ impl ExposedType {
         }
     }
 
-    pub fn subset() -> Self {
+    pub(crate) fn subset() -> Self {
         Self::Mappings(Default::default())
     }
 }

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -455,7 +455,7 @@ impl Project {
 
     /// Create an authenticated reqwest client for this project
     /// use authentication from `rattler_networking`
-    pub fn authenticated_client(&self) -> &ClientWithMiddleware {
+    pub(crate) fn authenticated_client(&self) -> &ClientWithMiddleware {
         &self.client_and_authenticated_client().1
     }
 

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -52,7 +52,7 @@ pub enum ManifestParsingError {
 }
 
 impl ManifestParsingError {
-    pub fn to_fancy<T>(
+    pub(crate) fn to_fancy<T>(
         &self,
         file_name: &str,
         contents: impl Into<String>,

--- a/src/global/trampoline.rs
+++ b/src/global/trampoline.rs
@@ -146,7 +146,7 @@ pub struct Configuration {
 
 impl Configuration {
     /// Create a new configuration of trampoline.
-    pub fn new(exe: PathBuf, path: PathBuf, env: Option<HashMap<String, String>>) -> Self {
+    pub(crate) fn new(exe: PathBuf, path: PathBuf, env: Option<HashMap<String, String>>) -> Self {
         Configuration {
             exe,
             path,
@@ -168,7 +168,7 @@ impl Configuration {
     }
 
     /// Return the configuration file for the trampoline.
-    pub fn path_from_trampoline(root_path: &Path, exposed_name: &ExposedName) -> PathBuf {
+    pub(crate) fn path_from_trampoline(root_path: &Path, exposed_name: &ExposedName) -> PathBuf {
         root_path
             .join(PathBuf::from(TRAMPOLINE_CONFIGURATION))
             .join(format!("{exposed_name}.json"))
@@ -193,7 +193,7 @@ impl GlobalExecutable {
     }
 
     /// Returns exposed name
-    pub fn exposed_name(&self) -> ExposedName {
+    pub(crate) fn exposed_name(&self) -> ExposedName {
         match self {
             GlobalExecutable::Trampoline(trampoline) => trampoline.exposed_name.clone(),
             GlobalExecutable::Script(script) => {
@@ -203,7 +203,7 @@ impl GlobalExecutable {
     }
 
     /// Returns the path to the exposed binary.
-    pub fn path(&self) -> PathBuf {
+    pub(crate) fn path(&self) -> PathBuf {
         match self {
             GlobalExecutable::Trampoline(trampoline) => trampoline.path(),
             GlobalExecutable::Script(script) => script.clone(),
@@ -211,7 +211,7 @@ impl GlobalExecutable {
     }
 
     /// Returns if the exposed global binary is trampoline.
-    pub fn is_trampoline(&self) -> bool {
+    pub(crate) fn is_trampoline(&self) -> bool {
         matches!(self, GlobalExecutable::Trampoline(_))
     }
 
@@ -250,7 +250,7 @@ pub struct Trampoline {
 
 impl Trampoline {
     /// Creates a new trampoline.
-    pub fn new(
+    pub(crate) fn new(
         exposed_name: ExposedName,
         root_path: PathBuf,
         configuration: Configuration,
@@ -281,16 +281,16 @@ impl Trampoline {
     }
 
     /// Returns the path to the trampoline
-    pub fn path(&self) -> PathBuf {
+    pub(crate) fn path(&self) -> PathBuf {
         self.root_path.join(file_name(&self.exposed_name))
     }
 
-    pub fn original_exe(&self) -> PathBuf {
+    pub(crate) fn original_exe(&self) -> PathBuf {
         self.configuration.exe.clone()
     }
 
     /// Returns the path to the trampoline configuration
-    pub fn configuration(&self) -> PathBuf {
+    pub(crate) fn configuration(&self) -> PathBuf {
         self.root_path
             .join(TRAMPOLINE_CONFIGURATION)
             .join(self.exposed_name.to_string() + ".json")
@@ -305,7 +305,7 @@ impl Trampoline {
     }
 
     /// Returns the name of the trampoline
-    pub fn name(trampoline: &Path) -> miette::Result<ExposedName> {
+    pub(crate) fn name(trampoline: &Path) -> miette::Result<ExposedName> {
         let trampoline_name = trampoline.file_name().ok_or_else(|| {
             miette::miette!(
                 "trampoline needs to have a file name {}",
@@ -335,7 +335,7 @@ impl Trampoline {
     }
 
     /// Returns the decompressed trampoline binary
-    pub fn decompressed_trampoline() -> &'static [u8] {
+    pub(crate) fn decompressed_trampoline() -> &'static [u8] {
         // A static variable to hold the cached decompressed trampoline binary
         static DECOMPRESSED_TRAMPOLINE_BIN: LazyLock<Vec<u8>> = LazyLock::new(|| {
             zstd::decode_all(TRAMPOLINE_BIN)

--- a/src/install_pypi/conversions.rs
+++ b/src/install_pypi/conversions.rs
@@ -18,7 +18,7 @@ use uv_pypi_types::{HashAlgorithm, HashDigest, ParsedUrl, ParsedUrlError, Verbat
 use super::utils::{is_direct_url, strip_direct_scheme};
 
 /// Converts our locked data to a file
-pub fn locked_data_to_file(
+pub(crate) fn locked_data_to_file(
     url: &Url,
     hash: Option<&PackageHashes>,
     filename: &str,
@@ -84,7 +84,7 @@ pub enum ConvertToUvDistError {
 }
 
 /// Convert from a PypiPackageData to a uv [`distribution_types::Dist`]
-pub fn convert_to_dist(
+pub(crate) fn convert_to_dist(
     pkg: &PypiPackageData,
     lock_file_dir: &Path,
 ) -> Result<Dist, ConvertToUvDistError> {

--- a/src/install_pypi/plan/mod.rs
+++ b/src/install_pypi/plan/mod.rs
@@ -568,7 +568,7 @@ pub struct InstallPlanner {
 }
 
 impl InstallPlanner {
-    pub fn new(
+    pub(crate) fn new(
         uv_cache: Cache,
         python_version: &uv_pep440::Version,
         lock_file_dir: impl AsRef<Path>,
@@ -626,7 +626,11 @@ impl InstallPlanner {
     ///
     /// All the 'a lifetimes are to to make sure that the names provided to the CachedDistProvider
     /// are valid for the lifetime of the CachedDistProvider and what is passed to the method
-    pub fn plan<'a, Installed: InstalledDistProvider<'a>, Cached: CachedDistProvider<'a> + 'a>(
+    pub(crate) fn plan<
+        'a,
+        Installed: InstalledDistProvider<'a>,
+        Cached: CachedDistProvider<'a> + 'a,
+    >(
         &self,
         site_packages: &'a Installed,
         mut dist_cache: Cached,

--- a/src/install_pypi/plan/test/harness.rs
+++ b/src/install_pypi/plan/test/harness.rs
@@ -19,7 +19,7 @@ use uv_pypi_types::{ArchiveInfo, DirectUrl, VcsInfo, VcsKind};
 struct InstalledDistBuilder;
 
 impl InstalledDistBuilder {
-    pub fn registry<S: AsRef<str>>(name: S, version: S, path: PathBuf) -> InstalledDist {
+    pub(crate) fn registry<S: AsRef<str>>(name: S, version: S, path: PathBuf) -> InstalledDist {
         let name =
             uv_pep508::PackageName::new(name.as_ref().to_owned()).expect("unable to normalize");
         let version =
@@ -34,7 +34,7 @@ impl InstalledDistBuilder {
         InstalledDist::Registry(registry)
     }
 
-    pub fn directory<S: AsRef<str>>(
+    pub(crate) fn directory<S: AsRef<str>>(
         name: S,
         version: S,
         install_path: PathBuf,
@@ -66,7 +66,7 @@ impl InstalledDistBuilder {
         (InstalledDist::Url(installed_direct_url), direct_url)
     }
 
-    pub fn archive<S: AsRef<str>>(
+    pub(crate) fn archive<S: AsRef<str>>(
         name: S,
         version: S,
         install_path: PathBuf,
@@ -98,7 +98,7 @@ impl InstalledDistBuilder {
         (InstalledDist::Url(installed_direct_url), direct_url)
     }
 
-    pub fn git<S: AsRef<str>>(
+    pub(crate) fn git<S: AsRef<str>>(
         name: S,
         version: S,
         install_path: PathBuf,
@@ -144,33 +144,33 @@ pub struct InstalledDistOptions {
 }
 
 impl InstalledDistOptions {
-    pub fn with_installer<S: AsRef<str>>(mut self, installer: S) -> Self {
+    pub(crate) fn with_installer<S: AsRef<str>>(mut self, installer: S) -> Self {
         self.installer = Some(installer.as_ref().to_owned());
         self
     }
 
-    pub fn with_requires_python<S: AsRef<str>>(mut self, requires_python: S) -> Self {
+    pub(crate) fn with_requires_python<S: AsRef<str>>(mut self, requires_python: S) -> Self {
         self.requires_python =
             uv_pep440::VersionSpecifiers::from_str(requires_python.as_ref()).ok();
         self
     }
 
-    pub fn with_metadata_mtime(mut self, metadata_mtime: std::time::SystemTime) -> Self {
+    pub(crate) fn with_metadata_mtime(mut self, metadata_mtime: std::time::SystemTime) -> Self {
         self.metadata_mtime = Some(metadata_mtime);
         self
     }
 
-    pub fn installer(&self) -> &str {
+    pub(crate) fn installer(&self) -> &str {
         self.installer
             .as_deref()
             .unwrap_or(consts::PIXI_UV_INSTALLER)
     }
 
-    pub fn requires_python(&self) -> Option<&uv_pep440::VersionSpecifiers> {
+    pub(crate) fn requires_python(&self) -> Option<&uv_pep440::VersionSpecifiers> {
         self.requires_python.as_ref()
     }
 
-    pub fn metadata_mtime(&self) -> Option<std::time::SystemTime> {
+    pub(crate) fn metadata_mtime(&self) -> Option<std::time::SystemTime> {
         self.metadata_mtime
     }
 }
@@ -183,7 +183,7 @@ pub struct MockedSitePackages {
 }
 
 impl MockedSitePackages {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             installed_dist: vec![],
             fake_site_packages: tempfile::tempdir().expect("should create temp dir"),
@@ -191,7 +191,7 @@ impl MockedSitePackages {
     }
 
     #[allow(dead_code)]
-    pub fn base_dir(&self) -> &Path {
+    pub(crate) fn base_dir(&self) -> &Path {
         self.fake_site_packages.path()
     }
 
@@ -248,7 +248,7 @@ impl MockedSitePackages {
     }
 
     /// Add a registry installed dist to the site packages
-    pub fn add_registry<S: AsRef<str>>(
+    pub(crate) fn add_registry<S: AsRef<str>>(
         mut self,
         name: S,
         version: S,
@@ -261,7 +261,7 @@ impl MockedSitePackages {
     }
 
     /// Add a local directory that serves as an installed dist to the site-packages
-    pub fn add_directory<S: AsRef<str>>(
+    pub(crate) fn add_directory<S: AsRef<str>>(
         mut self,
         name: S,
         version: S,
@@ -283,7 +283,7 @@ impl MockedSitePackages {
     }
 
     /// Add an archive installed dist to the site packages
-    pub fn add_archive<S: AsRef<str>>(
+    pub(crate) fn add_archive<S: AsRef<str>>(
         mut self,
         name: S,
         version: S,
@@ -299,7 +299,7 @@ impl MockedSitePackages {
     }
 
     /// Add a git installed dist to the site packages
-    pub fn add_git<S: AsRef<str>>(
+    pub(crate) fn add_git<S: AsRef<str>>(
         mut self,
         name: S,
         version: S,
@@ -429,12 +429,12 @@ pub struct RequiredPackages {
 }
 
 impl RequiredPackages {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
     /// Add a registry package to the required packages
-    pub fn add_registry<S: AsRef<str>>(mut self, name: S, version: S) -> Self {
+    pub(crate) fn add_registry<S: AsRef<str>>(mut self, name: S, version: S) -> Self {
         let package_name =
             uv_normalize::PackageName::new(name.as_ref().to_owned()).expect("should be correct");
         let data = PyPIPackageDataBuilder::registry(name, version);
@@ -443,7 +443,7 @@ impl RequiredPackages {
     }
 
     /// Add a directory package to the required packages
-    pub fn add_directory<S: AsRef<str>>(
+    pub(crate) fn add_directory<S: AsRef<str>>(
         mut self,
         name: S,
         version: S,
@@ -457,7 +457,7 @@ impl RequiredPackages {
         self
     }
 
-    pub fn add_archive<S: AsRef<str>>(mut self, name: S, version: S, url: Url) -> Self {
+    pub(crate) fn add_archive<S: AsRef<str>>(mut self, name: S, version: S, url: Url) -> Self {
         let package_name =
             uv_normalize::PackageName::new(name.as_ref().to_owned()).expect("should be correct");
         let data = PyPIPackageDataBuilder::url(name, version, url, UrlType::Direct);
@@ -465,7 +465,7 @@ impl RequiredPackages {
         self
     }
 
-    pub fn add_git<S: AsRef<str>>(mut self, name: S, version: S, url: Url) -> Self {
+    pub(crate) fn add_git<S: AsRef<str>>(mut self, name: S, version: S, url: Url) -> Self {
         let package_name =
             uv_normalize::PackageName::new(name.as_ref().to_owned()).expect("should be correct");
         let data = PyPIPackageDataBuilder::url(name, version, url, UrlType::Other);
@@ -475,7 +475,7 @@ impl RequiredPackages {
 
     /// Convert the required packages where the data is borrowed
     /// this is needed to pass it into the [`InstallPlanner`]
-    pub fn to_borrowed(&self) -> HashMap<uv_normalize::PackageName, &PypiPackageData> {
+    pub(crate) fn to_borrowed(&self) -> HashMap<uv_normalize::PackageName, &PypiPackageData> {
         self.required.iter().map(|(k, v)| (k.clone(), v)).collect()
     }
 }
@@ -489,7 +489,7 @@ fn python_version() -> uv_pep440::Version {
 }
 
 /// Simple function to create an installation planner
-pub fn install_planner() -> InstallPlanner {
+pub(crate) fn install_planner() -> InstallPlanner {
     InstallPlanner::new(
         uv_cache::Cache::temp().unwrap(),
         &python_version(),
@@ -499,7 +499,7 @@ pub fn install_planner() -> InstallPlanner {
 
 /// Create a fake pyproject.toml file in a temp dir
 /// return the temp dir
-pub fn fake_pyproject_toml(
+pub(crate) fn fake_pyproject_toml(
     modification_time: Option<std::time::SystemTime>,
 ) -> (TempDir, std::fs::File) {
     let temp_dir = tempfile::tempdir().unwrap();

--- a/src/install_pypi/utils.rs
+++ b/src/install_pypi/utils.rs
@@ -5,7 +5,7 @@ use url::Url;
 use uv_cache::{ArchiveTarget, ArchiveTimestamp};
 use uv_distribution_types::InstalledDist;
 
-pub fn elapsed(duration: Duration) -> String {
+pub(crate) fn elapsed(duration: Duration) -> String {
     let secs = duration.as_secs();
 
     if secs >= 60 {
@@ -21,7 +21,7 @@ pub fn elapsed(duration: Duration) -> String {
 /// Files, git, are direct urls
 /// Direct urls to wheels or sdists are prefixed with a `direct` scheme
 /// by us when resolving the lock file
-pub fn is_direct_url(url_scheme: &str) -> bool {
+pub(crate) fn is_direct_url(url_scheme: &str) -> bool {
     url_scheme == "file"
         || url_scheme == "git+http"
         || url_scheme == "git+https"
@@ -30,7 +30,7 @@ pub fn is_direct_url(url_scheme: &str) -> bool {
 }
 
 /// Strip of the `direct` scheme from the url if it is there
-pub fn strip_direct_scheme(url: &Url) -> Cow<'_, Url> {
+pub(crate) fn strip_direct_scheme(url: &Url) -> Cow<'_, Url> {
     url.as_ref()
         .strip_prefix("direct+")
         .and_then(|str| Url::from_str(str).ok())
@@ -39,7 +39,7 @@ pub fn strip_direct_scheme(url: &Url) -> Cow<'_, Url> {
 }
 
 /// Check freshness of a locked url against an installed dist
-pub fn check_url_freshness(
+pub(crate) fn check_url_freshness(
     locked_url: &Url,
     installed_dist: &InstalledDist,
 ) -> miette::Result<bool> {

--- a/src/lock_file/package_identifier.rs
+++ b/src/lock_file/package_identifier.rs
@@ -29,7 +29,9 @@ impl PypiPackageIdentifier {
         Ok(result)
     }
 
-    pub fn from_package_record(record: &PackageRecord) -> Result<Vec<Self>, ConversionError> {
+    pub(crate) fn from_package_record(
+        record: &PackageRecord,
+    ) -> Result<Vec<Self>, ConversionError> {
         let mut result = Vec::new();
         if let Some(purls) = &record.purls {
             for purl in purls.iter() {

--- a/src/lock_file/reporter/progress_bar.rs
+++ b/src/lock_file/reporter/progress_bar.rs
@@ -129,7 +129,7 @@ impl CondaMetadataProgress {
 impl CondaMetadataProgress {
     /// Use this method to increment the progress bar
     /// It will also check if the progress bar is finished
-    pub fn increment(&self) {
+    pub(crate) fn increment(&self) {
         self.progress_bar.inc(1);
         self.check_finish();
     }

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -828,7 +828,10 @@ impl<'p> UpdateContextBuilder<'p> {
 
     /// Sets the io concurrency semaphore to use when updating environments.
     #[allow(unused)]
-    pub fn with_io_concurrency_semaphore(self, io_concurrency_limit: IoConcurrencyLimit) -> Self {
+    pub(crate) fn with_io_concurrency_semaphore(
+        self,
+        io_concurrency_limit: IoConcurrencyLimit,
+    ) -> Self {
         Self {
             io_concurrency_limit: Some(io_concurrency_limit),
             ..self

--- a/src/lock_file/utils.rs
+++ b/src/lock_file/utils.rs
@@ -28,7 +28,7 @@ impl From<IoConcurrencyLimit> for Arc<Semaphore> {
 }
 
 /// Constructs a new lock-file where some of the packages have been removed
-pub fn filter_lock_file<
+pub(crate) fn filter_lock_file<
     'p,
     'lock,
     F: FnMut(&Environment<'p>, Platform, LockedPackageRef<'lock>) -> bool,

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -47,13 +47,13 @@ impl Prefix {
 
     /// Scans the `conda-meta` directory of an environment and returns all the
     /// [`PrefixRecord`]s found in there.
-    pub fn find_installed_packages(&self) -> miette::Result<Vec<PrefixRecord>> {
+    pub(crate) fn find_installed_packages(&self) -> miette::Result<Vec<PrefixRecord>> {
         PrefixRecord::collect_from_prefix(&self.root).into_diagnostic()
     }
 
     /// Processes prefix records (that you can get by using
     /// `find_installed_packages`) to filter and collect executable files.
-    pub fn find_executables(&self, prefix_packages: &[PrefixRecord]) -> Vec<Executable> {
+    pub(crate) fn find_executables(&self, prefix_packages: &[PrefixRecord]) -> Vec<Executable> {
         let executables = prefix_packages
             .iter()
             .flat_map(|record| {
@@ -122,7 +122,7 @@ pub struct Executable {
 }
 
 impl Executable {
-    pub fn new(name: String, path: PathBuf) -> Self {
+    pub(crate) fn new(name: String, path: PathBuf) -> Self {
         Self { name, path }
     }
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -32,8 +32,8 @@ use pixi_config::{Config, PinningStrategy};
 use pixi_consts::consts;
 use pixi_manifest::{
     pypi::PyPiPackageName, DependencyOverwriteBehavior, EnvironmentName, Environments, FeatureName,
-    FeaturesExt, HasFeaturesIter, HasManifestRef, KnownPreviewFeature, Manifest,
-    PypiDependencyLocation, SpecType, WorkspaceManifest,
+    FeaturesExt, HasFeaturesIter, HasManifestRef, Manifest, PypiDependencyLocation, SpecType,
+    WorkspaceManifest,
 };
 use pixi_utils::reqwest::build_reqwest_clients;
 use pypi_mapping::{ChannelName, CustomMapping, MappingLocation, MappingSource};
@@ -1003,16 +1003,6 @@ impl Project {
         }
 
         Ok(implicit_constraints)
-    }
-
-    /// Returns true if all preview features are enabled
-    pub(crate) fn all_preview_features_enabled(&self) -> bool {
-        self.manifest.preview().all_enabled()
-    }
-
-    /// Returns true if the given preview feature is enabled
-    pub(crate) fn is_preview_feature_enabled(&self, feature: KnownPreviewFeature) -> bool {
-        self.manifest.preview().is_enabled(feature)
     }
 }
 

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1006,12 +1006,12 @@ impl Project {
     }
 
     /// Returns true if all preview features are enabled
-    pub fn all_preview_features_enabled(&self) -> bool {
+    pub(crate) fn all_preview_features_enabled(&self) -> bool {
         self.manifest.preview().all_enabled()
     }
 
     /// Returns true if the given preview feature is enabled
-    pub fn is_preview_feature_enabled(&self, feature: KnownPreviewFeature) -> bool {
+    pub(crate) fn is_preview_feature_enabled(&self, feature: KnownPreviewFeature) -> bool {
         self.manifest.preview().is_enabled(feature)
     }
 }

--- a/src/task/task_hash.rs
+++ b/src/task/task_hash.rs
@@ -139,7 +139,7 @@ impl TaskHash {
     }
 
     /// Computes a single hash for the task.
-    pub fn computation_hash(&self) -> ComputationHash {
+    pub(crate) fn computation_hash(&self) -> ComputationHash {
         let mut hasher = Xxh3::new();
         self.command.hash(&mut hasher);
         self.inputs.hash(&mut hasher);

--- a/src/task/task_hash.rs
+++ b/src/task/task_hash.rs
@@ -139,7 +139,7 @@ impl TaskHash {
     }
 
     /// Computes a single hash for the task.
-    pub(crate) fn computation_hash(&self) -> ComputationHash {
+    pub fn computation_hash(&self) -> ComputationHash {
         let mut hasher = Xxh3::new();
         self.command.hash(&mut hasher);
         self.inputs.hash(&mut hasher);


### PR DESCRIPTION
This should be merged **after** https://github.com/prefix-dev/pixi/pull/2778

I've noticed that we use `pub` for functions in many places, even though `pub(crate)` would suffice.

I wrote a small Python script that tries to change `pub` to `pub(crate)` and see if it `cargo check` is still happy. So kind of like `cargo machete` but for functions instead of dependencies. Is it efficient? No. Does it do the job? Yes!

I excluded crates that are dependencies of `pixi-build-backends`.

In case we want to run this script again in the future:

```python
import subprocess
from pathlib import Path


def run_cargo_check():
    result = subprocess.run(["cargo", "check", "--workspace", "--all-targets"], capture_output=True)
    return result.returncode == 0


def process_file(file_path):
    lines = file_path.read_text().splitlines()

    for i, line in enumerate(lines):
        if "pub fn" in line:
            original_line = line
            # Replace "pub fn" with "pub(crate) fn"
            lines[i] = line.replace("pub fn", "pub(crate) fn")

            file_path.write_text("\n".join(lines) + "\n")

            if run_cargo_check():
                print(f"Change kept in {file_path} at line {i+1}")
            else:
                # Revert the change
                lines[i] = original_line
                file_path.write_text("\n".join(lines) + "\n")


def main():
    directories = ["crates", "src"]

    for directory in directories:
        src_dir = Path(directory)
        for file_path in src_dir.rglob("*.rs"):
            process_file(file_path)


if __name__ == "__main__":
    main()
``` 