### PR TITLE
fix: remove or explicitly allow unused functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,6 @@ dependencies = [
 name = "pixi_progress"
 version = "0.1.0"
 dependencies = [
- "console",
  "indicatif",
  "tokio",
 ]

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -995,6 +995,7 @@ impl Config {
         &self.channel_config
     }
 
+    #[cfg(test)]
     pub(crate) fn repodata_config(&self) -> &RepodataConfig {
         &self.repodata_config
     }

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -109,6 +109,7 @@ impl GitResolver {
     /// This method will only return precise URLs for URLs that have already been resolved via
     /// `resolve_precise`, and will return `None` for URLs that have not been resolved _or_
     /// already have a precise reference.
+    #[allow(unused)]
     pub(crate) fn precise(&self, url: GitUrl) -> Option<GitUrl> {
         let reference = RepositoryReference::from(&url);
         let precise = self.get(&reference)?;
@@ -116,6 +117,7 @@ impl GitResolver {
     }
 
     /// Returns `true` if the two Git URLs refer to the same precise commit.
+    #[allow(unused)]
     pub(crate) fn same_ref(&self, a: &GitUrl, b: &GitUrl) -> bool {
         // Convert `a` to a repository URL.
         let a_ref = RepositoryReference::from(a);

--- a/crates/pixi_git/src/sha.rs
+++ b/crates/pixi_git/src/sha.rs
@@ -65,12 +65,6 @@ impl Display for GitOid {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GitSha(GitOid);
 
-impl GitSha {
-    /// Convert the SHA to a truncated representation, i.e., the first 16 characters of the SHA.
-    pub(crate) fn to_short_string(&self) -> String {
-        self.0.to_string()[0..16].to_string()
-    }
-}
 impl Display for GitSha {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -123,11 +123,11 @@ impl Fetch {
         &self.git
     }
 
-    pub(crate) fn path(&self) -> &Path {
+    pub fn path(&self) -> &Path {
         &self.path
     }
 
-    pub(crate) fn into_git(self) -> GitUrl {
+    pub fn into_git(self) -> GitUrl {
         self.git
     }
 

--- a/crates/pixi_git/src/url.rs
+++ b/crates/pixi_git/src/url.rs
@@ -79,6 +79,7 @@ impl CanonicalUrl {
         Self(url)
     }
 
+    #[allow(unused)]
     pub(crate) fn parse(url: &str) -> Result<Self, url::ParseError> {
         Ok(Self::new(&Url::parse(url)?))
     }
@@ -123,7 +124,7 @@ impl RepositoryUrl {
         Self(url)
     }
 
-    pub(crate) fn parse(url: &str) -> Result<Self, url::ParseError> {
+    pub fn parse(url: &str) -> Result<Self, url::ParseError> {
         Ok(Self::new(&Url::parse(url)?))
     }
 }

--- a/crates/pixi_glob/src/glob_mtime.rs
+++ b/crates/pixi_glob/src/glob_mtime.rs
@@ -77,29 +77,6 @@ impl GlobModificationTime {
             None => Ok(Self::NoMatches),
         }
     }
-
-    /// Get the newest modification time, if any.
-    pub(crate) fn newest(&self) -> Option<SystemTime> {
-        match self {
-            Self::MatchesFound { modified_at, .. } => Some(*modified_at),
-            Self::NoMatches => None,
-        }
-    }
-
-    /// Get the designated file with the newest modification time, if any.
-    pub(crate) fn designated_file(&self) -> Option<&Path> {
-        match self {
-            Self::MatchesFound {
-                designated_file, ..
-            } => Some(designated_file.as_path()),
-            Self::NoMatches => None,
-        }
-    }
-
-    /// Returns `true` if there have been any matches found.
-    pub(crate) fn has_matches(&self) -> bool {
-        matches!(self, Self::MatchesFound { .. })
-    }
 }
 
 #[cfg(test)]
@@ -160,7 +137,5 @@ mod tests {
         let glob_mod_time = GlobModificationTime::from_patterns(dir_path, ["*.md"]).unwrap();
 
         assert!(matches!(glob_mod_time, GlobModificationTime::NoMatches));
-        assert_eq!(glob_mod_time.newest(), None);
-        assert_eq!(glob_mod_time.designated_file(), None);
     }
 }

--- a/crates/pixi_progress/Cargo.toml
+++ b/crates/pixi_progress/Cargo.toml
@@ -10,6 +10,5 @@ version = "0.1.0"
 
 
 [dependencies]
-console = { workspace = true }
 indicatif = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }

--- a/crates/pixi_progress/src/lib.rs
+++ b/crates/pixi_progress/src/lib.rs
@@ -44,36 +44,6 @@ pub fn default_progress_style() -> indicatif::ProgressStyle {
         .progress_chars("━━╾─")
 }
 
-/// Returns the style to use for a progressbar that is in Deserializing state.
-pub(crate) fn deserializing_progress_style() -> indicatif::ProgressStyle {
-    indicatif::ProgressStyle::default_bar()
-        .template("  {spinner:.dim} {prefix:20!} [{elapsed_precise}] {wide_msg}")
-        .unwrap()
-        .progress_chars("━━╾─")
-}
-
-/// Returns the style to use for a progressbar that is finished.
-pub(crate) fn finished_progress_style() -> indicatif::ProgressStyle {
-    indicatif::ProgressStyle::default_bar()
-        .template(&format!(
-            "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
-            console::style(console::Emoji("✔", " ")).green()
-        ))
-        .unwrap()
-        .progress_chars("━━╾─")
-}
-
-/// Returns the style to use for a progressbar that is in error state.
-pub(crate) fn errored_progress_style() -> indicatif::ProgressStyle {
-    indicatif::ProgressStyle::default_bar()
-        .template(&format!(
-            "  {} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold.red}}",
-            console::style(console::Emoji("❌", " ")).red()
-        ))
-        .unwrap()
-        .progress_chars("━━╾─")
-}
-
 /// Returns the style to use for a progressbar that is indeterminate and simply shows a spinner.
 pub fn long_running_progress_style() -> indicatif::ProgressStyle {
     indicatif::ProgressStyle::with_template("{prefix}{spinner:.green} {msg}").unwrap()
@@ -159,11 +129,6 @@ impl ScopedTask {
 
 impl ProgressBarMessageFormatter {
     /// Construct a new instance that will update the given progress bar.
-    pub(crate) fn new(progress_bar: ProgressBar) -> Self {
-        Self::new_with_capacity(progress_bar, 50)
-    }
-
-    /// Construct a new instance that will update the given progress bar.
     /// Allows the user to specify a custom capacity for the internal channel.
     pub fn new_with_capacity(progress_bar: ProgressBar, capacity: usize) -> Self {
         let pb = progress_bar.clone();
@@ -195,11 +160,6 @@ impl ProgressBarMessageFormatter {
             }
         });
         Self { sender: tx, pb }
-    }
-
-    /// Returns the associated progress bar
-    pub(crate) fn progress_bar(&self) -> &ProgressBar {
-        &self.pb
     }
 
     /// Adds the start of another task to the progress bar and returns an object that is used to
@@ -238,10 +198,5 @@ impl ProgressBarMessageFormatter {
         let result = fut.await;
         task.finish().await;
         result
-    }
-
-    /// Convert this instance into the underlying progress bar.
-    pub(crate) fn into_progress_bar(self) -> ProgressBar {
-        self.pb
     }
 }

--- a/crates/pixi_pty/src/unix/pty_process.rs
+++ b/crates/pixi_pty/src/unix/pty_process.rs
@@ -132,13 +132,6 @@ impl PtyProcess {
         unsafe { Ok(File::from_raw_fd(fd)) }
     }
 
-    /// At the drop of PtyProcess the running process is killed. This is blocking forever if
-    /// the process does not react to a normal kill. If kill_timeout is set the process is
-    /// `kill -9`ed after duration
-    pub(crate) fn set_kill_timeout(&mut self, timeout_ms: Option<u64>) {
-        self.kill_timeout = timeout_ms.map(time::Duration::from_millis);
-    }
-
     /// Get status of child process, non-blocking.
     ///
     /// This method runs waitpid on the process.
@@ -152,20 +145,9 @@ impl PtyProcess {
         }
     }
 
-    /// Wait until process has exited. This is a blocking call.
-    /// If the process doesn't terminate this will block forever.
-    pub(crate) fn wait(&self) -> nix::Result<wait::WaitStatus> {
-        wait::waitpid(self.child_pid, None)
-    }
-
     /// Regularly exit the process, this method is blocking until the process is dead
     pub(crate) fn exit(&mut self) -> nix::Result<wait::WaitStatus> {
         self.kill(signal::SIGTERM)
-    }
-
-    /// Non-blocking variant of `kill()` (doesn't wait for process to be killed)
-    pub(crate) fn signal(&mut self, sig: signal::Signal) -> nix::Result<()> {
-        signal::kill(self.child_pid, sig)
     }
 
     /// Kill the process with a specific signal. This method blocks, until the process is dead

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -37,6 +37,7 @@ impl PixiRecord {
     }
 
     /// Converts this instance into a binary record if it is a binary record.
+    #[allow(unused)]
     pub(crate) fn into_binary(self) -> Option<RepoDataRecord> {
         match self {
             PixiRecord::Binary(record) => Some(record),
@@ -55,23 +56,6 @@ impl PixiRecord {
 
     /// Returns the source record if it is a source record.
     pub fn as_source(&self) -> Option<&SourceRecord> {
-        match self {
-            PixiRecord::Binary(_) => None,
-            PixiRecord::Source(record) => Some(record),
-        }
-    }
-
-    /// Converts this instance into a source record if it is a source record.
-    pub(crate) fn into_source(self) -> Option<SourceRecord> {
-        match self {
-            PixiRecord::Binary(_) => None,
-            PixiRecord::Source(record) => Some(record),
-        }
-    }
-
-    /// Returns a mutable reference to the source record if it is a source
-    /// record.
-    pub(crate) fn as_source_mut(&mut self) -> Option<&mut SourceRecord> {
         match self {
             PixiRecord::Binary(_) => None,
             PixiRecord::Source(record) => Some(record),

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -47,6 +47,7 @@ impl PinnedSourceSpec {
     }
 
     /// Returns the url spec if this instance is a url spec.
+    #[allow(unused)]
     pub(crate) fn as_url(&self) -> Option<&PinnedUrlSpec> {
         match self {
             PinnedSourceSpec::Url(spec) => Some(spec),
@@ -55,6 +56,7 @@ impl PinnedSourceSpec {
     }
 
     /// Returns the git spec if this instance is a git spec.
+    #[allow(unused)]
     pub(crate) fn as_git(&self) -> Option<&PinnedGitSpec> {
         match self {
             PinnedSourceSpec::Git(spec) => Some(spec),
@@ -63,6 +65,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedPathSpec`] if it is a path spec.
+    #[allow(unused)]
     pub(crate) fn into_path(self) -> Option<PinnedPathSpec> {
         match self {
             PinnedSourceSpec::Path(spec) => Some(spec),
@@ -71,6 +74,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedUrlSpec`] if it is a url spec.
+    #[allow(unused)]
     pub(crate) fn into_url(self) -> Option<PinnedUrlSpec> {
         match self {
             PinnedSourceSpec::Url(spec) => Some(spec),
@@ -79,6 +83,7 @@ impl PinnedSourceSpec {
     }
 
     /// Converts this instance into a [`PinnedGitSpec`] if it is a git spec.
+    #[allow(unused)]
     pub(crate) fn into_git(self) -> Option<PinnedGitSpec> {
         match self {
             PinnedSourceSpec::Git(spec) => Some(spec),
@@ -93,6 +98,7 @@ impl PinnedSourceSpec {
     /// A mutable source is a source that can change over time. For example, a
     /// local path.
     #[allow(clippy::result_large_err)]
+    #[allow(unused)]
     pub(crate) fn into_mutable(self) -> Result<MutablePinnedSourceSpec, PinnedSourceSpec> {
         match self {
             PinnedSourceSpec::Path(spec) => Ok(MutablePinnedSourceSpec::Path(spec)),
@@ -109,6 +115,7 @@ impl PinnedSourceSpec {
 
 impl MutablePinnedSourceSpec {
     /// Returns the path spec if this instance is a path spec.
+    #[allow(unused)]
     pub(crate) fn as_path(&self) -> Option<&PinnedPathSpec> {
         match self {
             MutablePinnedSourceSpec::Path(spec) => Some(spec),
@@ -116,6 +123,7 @@ impl MutablePinnedSourceSpec {
     }
 
     /// Returns the path spec if this instance is a path spec.
+    #[allow(unused)]
     pub(crate) fn into_path(self) -> Option<PinnedPathSpec> {
         match self {
             MutablePinnedSourceSpec::Path(spec) => Some(spec),
@@ -385,6 +393,7 @@ impl LockedGitUrl {
     }
 
     /// Parses a locked git URL from a string.
+    #[allow(unused)]
     pub(crate) fn parse(url: &str) -> miette::Result<Self> {
         let url = Url::parse(url).into_diagnostic()?;
         Ok(Self(url))

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -241,7 +241,7 @@ pub struct PinnedGitSpec {
 
 impl PinnedGitSpec {
     /// Construct the lockfile-compatible [`Url`] from [`PinnedGitSpec`].
-    pub(crate) fn into_locked_git_url(&self) -> LockedGitUrl {
+    pub(crate) fn to_locked_git_url(&self) -> LockedGitUrl {
         let mut url = self.git.clone();
 
         // // Redact the credentials.
@@ -339,7 +339,7 @@ impl From<PinnedPathSpec> for UrlOrPath {
 
 impl From<PinnedGitSpec> for UrlOrPath {
     fn from(value: PinnedGitSpec) -> Self {
-        let url = value.into_locked_git_url();
+        let url = value.to_locked_git_url();
         UrlOrPath::Url(url.into())
     }
 }
@@ -415,7 +415,7 @@ impl TryFrom<LockedGitUrl> for PinnedGitSpec {
 
 impl From<PinnedGitSpec> for LockedGitUrl {
     fn from(value: PinnedGitSpec) -> Self {
-        value.into_locked_git_url()
+        value.to_locked_git_url()
     }
 }
 

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -214,14 +214,6 @@ pub fn to_extra_name(
     )
 }
 
-/// Converts `uv_pep440::Version` to `pep440_rs::Version`
-pub(crate) fn to_version(
-    version: &uv_pep440::Version,
-) -> Result<pep440_rs::Version, ConversionError> {
-    Ok(pep440_rs::Version::from_str(version.to_string().as_str())
-        .map_err(VersionError::PepError)?)
-}
-
 /// Converts `pep440_rs::Version` to `uv_pep440::Version`
 pub fn to_uv_version(version: &pep440_rs::Version) -> Result<uv_pep440::Version, ConversionError> {
     Ok(

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -168,6 +168,7 @@ impl BuildContext {
     }
 
     /// Sets the input hash cache to use for caching input hashes.
+    #[allow(unused)]
     pub(crate) fn with_glob_hash_cache(self, glob_hash_cache: GlobHashCache) -> Self {
         Self {
             glob_hash_cache,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -32,8 +32,8 @@ use pixi_config::{Config, PinningStrategy};
 use pixi_consts::consts;
 use pixi_manifest::{
     pypi::PyPiPackageName, DependencyOverwriteBehavior, EnvironmentName, Environments, FeatureName,
-    FeaturesExt, HasFeaturesIter, HasManifestRef, KnownPreviewFeature, Manifest,
-    PypiDependencyLocation, SpecType, WorkspaceManifest,
+    FeaturesExt, HasFeaturesIter, HasManifestRef, Manifest, PypiDependencyLocation, SpecType,
+    WorkspaceManifest,
 };
 use pixi_utils::reqwest::build_reqwest_clients;
 use pypi_mapping::{ChannelName, CustomMapping, MappingLocation, MappingSource};
@@ -1003,16 +1003,6 @@ impl Project {
         }
 
         Ok(implicit_constraints)
-    }
-
-    /// Returns true if all preview features are enabled
-    pub(crate) fn all_preview_features_enabled(&self) -> bool {
-        self.manifest.preview().all_enabled()
-    }
-
-    /// Returns true if the given preview feature is enabled
-    pub(crate) fn is_preview_feature_enabled(&self, feature: KnownPreviewFeature) -> bool {
-        self.manifest.preview().is_enabled(feature)
     }
 }
 


### PR DESCRIPTION
This should be merged **before** https://github.com/prefix-dev/pixi/pull/2778

Turns out, we have quite a few unused functions. I used my own discretion, how to deal with them. I mostly followed the following rule:
- has something to do with `pixi build`? -> `allow(unused)`
- is used in a test? -> `cfg(test)`
- other reason? -> delete it

Please review carefully and check if we need some of these functions after all.
(Or if they actually should be `pub`, because we will use them soon in other crates)