### PR TITLE
docs: Do not depend on gxx in pixi build docs

### DIFF
--- a/docs/build/dependency_types.md
+++ b/docs/build/dependency_types.md
@@ -9,7 +9,7 @@ Here you can see the three types of dependencies for a simple C++ package.
 ```
 
 Each dependency is used at a different step of the package building process.
-`gxx` is used to build the package, `catch` will be linked into the package and `git` will be available during runtime.
+`cxx-compiler` is used to build the package, `catch` will be linked into the package and `git` will be available during runtime.
 
 Let's delve deeper into the various types of package dependencies and their specific roles in the build process.
 

--- a/docs/source_files/pixi_tomls/dependency_types.toml
+++ b/docs/source_files/pixi_tomls/dependency_types.toml
@@ -15,7 +15,7 @@ channels = [
 ]
 # --8<-- [start:dependencies]
 [build-dependencies]
-gxx = "*"
+cxx-compiler = "*"
 
 [host-dependencies]
 catch = "*"


### PR DESCRIPTION
The `gxx` package is not a valid dependency if one wants to build a C++ package, as it is missing the required activation scripts, and this can easily confuse users, see https://github.com/RoboStack/ros-humble/issues/119#issuecomment-2568849121 . 

While I understand that this is just a minimal example, I am quite afraid that more and more users will may misunderstand this, so I think it may be better to just depend on `cxx-compiler` that is the conda-forge-documented way of getting a C++ compiler. Any other solution that does not depend simply on the "incomplete" gxx package is perfectly fine for me as well.