### PR TITLE
fix: use correct directory for build artifact cache

### DIFF
--- a/src/build/cache/mod.rs
+++ b/src/build/cache/mod.rs
@@ -18,7 +18,17 @@ use crate::build::SourceCheckout;
 /// Constructs a name for a cache directory for the given source checkout.
 fn source_checkout_cache_key(source: &SourceCheckout) -> String {
     let mut hasher = Xxh3::new();
-    source.pinned.to_string().hash(&mut hasher);
+
+    // If the source is immutable we use the pinned definition of the source.
+    // If the source is mutable we instead hash the location of the source
+    // checkout on disk. This ensures that we get different cache directories
+    // for different source checkouts with different edits.
+    if source.pinned.is_immutable() {
+        source.pinned.to_string().hash(&mut hasher);
+    } else {
+        source.path.to_string_lossy().hash(&mut hasher);
+    }
+
     let unique_key = URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes());
     match source.path.file_name().and_then(OsStr::to_str) {
         Some(name) => format!("{}-{}", name, unique_key),

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -83,9 +83,6 @@ def test_source_change_trigger_rebuild(
     project = "simple-pyproject"
     test_data = build_data.joinpath(project)
 
-    # TODO: Setting the cache dir shouldn't be necessary!
-    env = {"PIXI_CACHE_DIR": str(tmp_pixi_workspace.joinpath("pixi_cache"))}
-
     target_dir = tmp_pixi_workspace.joinpath(project)
     shutil.copytree(test_data, target_dir)
     manifest_path = target_dir.joinpath("pyproject.toml")
@@ -99,7 +96,6 @@ def test_source_change_trigger_rebuild(
             "get-version",
         ],
         stdout_contains="The version of simple-pyproject is 1.0.0",
-        env=env,
     )
 
     # Bump version from 1.0.0 to 2.0.0
@@ -116,7 +112,6 @@ def test_source_change_trigger_rebuild(
             "get-version",
         ],
         stdout_contains="The version of simple-pyproject is 2.0.0",
-        env=env,
     )
 
 
@@ -124,11 +119,6 @@ def test_source_change_trigger_rebuild(
 def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     project = "editable-pyproject"
     test_data = build_data.joinpath(project)
-
-    # TODO: Setting the cache dir shouldn't be necessary!
-    env = {
-        "PIXI_CACHE_DIR": str(tmp_pixi_workspace.joinpath("pixi_cache")),
-    }
 
     target_dir = tmp_pixi_workspace.joinpath(project)
     shutil.copytree(test_data, target_dir)
@@ -141,7 +131,6 @@ def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Pa
             "--manifest-path",
             manifest_path,
         ],
-        env=env,
     )
 
     # Verify that package is installed as editable
@@ -153,6 +142,5 @@ def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Pa
             manifest_path,
             "check-editable",
         ],
-        env=env,
         stdout_contains="The package is installed as editable.",
     )


### PR DESCRIPTION
There was an issue were the packages in the build-cache were reused for unrelated source checkouts. This is because we bucket the caches based on the pinned source spec but for a lot of examples the pinned path source spec was simply `.`. This caused a lot of examples to reuse the cache entry of another source checkout causing strange behavior.

I fixed this issue by using the pinned source spec as the cache key if the source is immutable (e.g. for git checkouts) and otherwise (e.g. for path source dependencies) use the absolute path on disk as the cache key. I think this makes sense as it creates separate cache entries for packages in different locations on disk (like temporary directories).

Fixes #2792