### PR TITLE
chore: use current platform by default

### DIFF
--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -17,7 +17,7 @@ EMPTY_BOILERPLATE_PROJECT = f"""
 [project]
 name = "test"
 channels = []
-platforms = {CURRENT_PLATFORM}
+platforms = ["{CURRENT_PLATFORM}"]
 """
 
 

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -9,13 +9,15 @@ from rattler import Platform
 PIXI_VERSION = "0.39.4"
 
 
-ALL_PLATFORMS = '["linux-64", "osx-64", "win-64", "linux-ppc64le", "linux-aarch64"]'
+ALL_PLATFORMS = '["linux-64", "osx-64", "osx-arm64", "win-64", "linux-ppc64le", "linux-aarch64"]'
+
+CURRENT_PLATFORM = str(Platform.current())
 
 EMPTY_BOILERPLATE_PROJECT = f"""
 [project]
 name = "test"
 channels = []
-platforms = {ALL_PLATFORMS}
+platforms = {CURRENT_PLATFORM}
 """
 
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -571,7 +571,7 @@ test = ["pytest==6"]
 
 [tool.pixi.project]
 channels = ["https://prefix.dev/conda-forge"]
-platforms = {CURRENT_PLATFORM}
+platforms = ["{CURRENT_PLATFORM}"]
 
 [tool.pixi.pypi-dependencies]
 polars = "==0.*"

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from .common import verify_cli_command, ExitCode, PIXI_VERSION, ALL_PLATFORMS
+from .common import verify_cli_command, ExitCode, PIXI_VERSION, CURRENT_PLATFORM
 import tomllib
 import json
 import pytest
@@ -570,8 +570,8 @@ cli = ["rich==12"]
 test = ["pytest==6"]
 
 [tool.pixi.project]
-channels = ["conda-forge"]
-platforms = {ALL_PLATFORMS}
+channels = ["https://prefix.dev/conda-forge"]
+platforms = {CURRENT_PLATFORM}
 
 [tool.pixi.pypi-dependencies]
 polars = "==0.*"


### PR DESCRIPTION
I noticed we use `ALL_PLATFORMS` for the `platforms = [..]` section in a few generated projects. I think this is unnecessary and we should use `CURRENT_PLATFORM` by default. The tests are run on a number of platforms anyway. There was also a tests that wasnt using the prefix.dev conda-forge channel yet which had some failures. 