### PR TITLE
fix: initialized detached envs with None

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -633,7 +633,7 @@ impl Default for Config {
             channel_config: default_channel_config(),
             repodata_config: RepodataConfig::default(),
             pypi_config: PyPIConfig::default(),
-            detached_environments: Some(DetachedEnvironments::default()),
+            detached_environments: None,
             pinning_strategy: None,
             force_activate: None,
             experimental: ExperimentalConfig::default(),


### PR DESCRIPTION
Fixes #2788 

This was a hidden issue until we cleaned up the `merge` function of the configuration. Which had wrong assumptions on the order of importance. 

Thanks for the easy reproducible issue! @moritzwilksch 