### PR TITLE
fix: create missing global manifest folder with pixi global edit

### DIFF
--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -51,6 +51,10 @@ pub const PIXI_DIR: &str = match option_env!("PIXI_DIR") {
     Some(dir) => dir,
     None => ".pixi",
 };
+pub const MANIFEST_DEFAULT_NAME: &str = match option_env!("PIXI_MANIFEST_DEFAULT_NAME") {
+    Some(name) => name,
+    None => "pixi-global.toml",
+};
 
 pub static DEFAULT_CHANNELS: LazyLock<Vec<NamedChannelOrUrl>> =
     LazyLock::new(|| match option_env!("PIXI_DEFAULT_CHANNELS") {

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -55,10 +55,11 @@ pub const PIXI_DIR: &str = match option_env!("PIXI_DIR") {
     None => ".pixi",
 };
 /// The default manifest name for the global manifest file in the pixi config directory.
-pub const GLOBAL_MANIFEST_DEFAULT_NAME: &str = match option_env!("PIXI_GLOBAL_MANIFEST_DEFAULT_NAME") {
-    Some(name) => name,
-    None => "pixi-global.toml",
-};
+pub const GLOBAL_MANIFEST_DEFAULT_NAME: &str =
+    match option_env!("PIXI_GLOBAL_MANIFEST_DEFAULT_NAME") {
+        Some(name) => name,
+        None => "pixi-global.toml",
+    };
 
 pub static DEFAULT_CHANNELS: LazyLock<Vec<NamedChannelOrUrl>> =
     LazyLock::new(|| match option_env!("PIXI_DEFAULT_CHANNELS") {

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -55,7 +55,7 @@ pub const PIXI_DIR: &str = match option_env!("PIXI_DIR") {
     None => ".pixi",
 };
 /// The default manifest name for the global manifest file in the pixi config directory.
-pub const GLOBAL_MANIFEST_DEFAULT_NAME: &str = match option_env!("PIXI_MANIFEST_DEFAULT_NAME") {
+pub const GLOBAL_MANIFEST_DEFAULT_NAME: &str = match option_env!("PIXI_GLOBAL_MANIFEST_DEFAULT_NAME") {
     Some(name) => name,
     None => "pixi-global.toml",
 };

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -39,19 +39,23 @@ pub const _CACHED_BUILD_ENVS_DIR: &str = "cached-build-envs-v0";
 pub const CACHED_BUILD_TOOL_ENVS_DIR: &str = "cached-build-tool-envs-v0";
 pub const CACHED_GIT_DIR: &str = "git-cache-v0";
 
+/// The default config directory for pixi, typically at $XDG_CONFIG_HOME/$PIXI_CONFIG_DIR or $HOME/.config/$PIXI_CONFIG_DIR.
 pub const CONFIG_DIR: &str = match option_env!("PIXI_CONFIG_DIR") {
     Some(dir) => dir,
     None => "pixi",
 };
+/// The default file name for the lock file in a project.
 pub const PROJECT_LOCK_FILE: &str = match option_env!("PIXI_PROJECT_LOCK_FILE") {
     Some(file) => file,
     None => "pixi.lock",
 };
+/// The default directory for the pixi files in a project.
 pub const PIXI_DIR: &str = match option_env!("PIXI_DIR") {
     Some(dir) => dir,
     None => ".pixi",
 };
-pub const MANIFEST_DEFAULT_NAME: &str = match option_env!("PIXI_MANIFEST_DEFAULT_NAME") {
+/// The default manifest name for the global manifest file in the pixi config directory.
+pub const GLOBAL_MANIFEST_DEFAULT_NAME: &str = match option_env!("PIXI_MANIFEST_DEFAULT_NAME") {
     Some(name) => name,
     None => "pixi-global.toml",
 };

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -575,9 +575,7 @@ mod test {
             let result = match spec {
                 Ok(spec) => serde_json::to_value(&spec).unwrap(),
                 Err(e) => {
-                    json!({
-                        "error": format!("ERROR: {e}")
-                    })
+                    json!({ "error": format!("ERROR: {e}") })
                 }
             };
 

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -438,7 +438,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let global_info = Some(GlobalInfo {
         bin_dir: BinDir::from_env().await?.path().to_path_buf(),
         env_dir: EnvRoot::from_env().await?.path().to_path_buf(),
-        manifest: global::Project::manifest_dir()?.join(consts::MANIFEST_DEFAULT_NAME),
+        manifest: global::Project::manifest_dir()?.join(consts::GLOBAL_MANIFEST_DEFAULT_NAME),
     });
 
     let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::from_env())

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -438,7 +438,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let global_info = Some(GlobalInfo {
         bin_dir: BinDir::from_env().await?.path().to_path_buf(),
         env_dir: EnvRoot::from_env().await?.path().to_path_buf(),
-        manifest: global::Project::manifest_dir()?.join(global::project::MANIFEST_DEFAULT_NAME),
+        manifest: global::Project::manifest_dir()?.join(consts::MANIFEST_DEFAULT_NAME),
     });
 
     let virtual_packages = VirtualPackage::detect(&VirtualPackageOverrides::from_env())

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -61,7 +61,7 @@ impl Manifest {
                 .map_err(ManifestParsingError::from)
         }) {
             Ok(result) => result,
-            Err(e) => e.to_fancy(consts::MANIFEST_DEFAULT_NAME, &contents, manifest_path)?,
+            Err(e) => e.to_fancy(consts::GLOBAL_MANIFEST_DEFAULT_NAME, &contents, manifest_path)?,
         };
 
         let manifest = Self {

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -9,6 +9,7 @@ use fs_err::tokio as tokio_fs;
 use indexmap::IndexSet;
 use miette::IntoDiagnostic;
 use pixi_config::Config;
+use pixi_consts::consts;
 use pixi_manifest::{toml::TomlDocument, PrioritizedChannel};
 use pixi_spec::PixiSpec;
 use pixi_toml::TomlIndexMap;
@@ -19,7 +20,7 @@ use toml_span::{DeserError, Value};
 
 use super::{
     parsed_manifest::{ManifestParsingError, ManifestVersion, ParsedManifest},
-    EnvironmentName, ExposedName, MANIFEST_DEFAULT_NAME,
+    EnvironmentName, ExposedName,
 };
 use crate::global::project::ParsedEnvironment;
 
@@ -60,7 +61,7 @@ impl Manifest {
                 .map_err(ManifestParsingError::from)
         }) {
             Ok(result) => result,
-            Err(e) => e.to_fancy(MANIFEST_DEFAULT_NAME, &contents, manifest_path)?,
+            Err(e) => e.to_fancy(consts::MANIFEST_DEFAULT_NAME, &contents, manifest_path)?,
         };
 
         let manifest = Self {

--- a/src/global/project/manifest.rs
+++ b/src/global/project/manifest.rs
@@ -61,7 +61,11 @@ impl Manifest {
                 .map_err(ManifestParsingError::from)
         }) {
             Ok(result) => result,
-            Err(e) => e.to_fancy(consts::GLOBAL_MANIFEST_DEFAULT_NAME, &contents, manifest_path)?,
+            Err(e) => e.to_fancy(
+                consts::GLOBAL_MANIFEST_DEFAULT_NAME,
+                &contents,
+                manifest_path,
+            )?,
         };
 
         let manifest = Self {

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -396,7 +396,7 @@ impl Project {
 
         // First, check if a `pixi-global.toml` already exists
         for dir in &potential_dirs {
-            if dir.join(consts::MANIFEST_DEFAULT_NAME).is_file() {
+            if dir.join(consts::GLOBAL_MANIFEST_DEFAULT_NAME).is_file() {
                 return Ok(dir.clone());
             }
         }
@@ -410,7 +410,7 @@ impl Project {
 
     /// Get the default path to the global manifest file
     pub(crate) fn default_manifest_path() -> miette::Result<PathBuf> {
-        Self::manifest_dir().map(|dir| dir.join(consts::MANIFEST_DEFAULT_NAME))
+        Self::manifest_dir().map(|dir| dir.join(consts::GLOBAL_MANIFEST_DEFAULT_NAME))
     }
 
     /// Loads a project from manifest file.
@@ -1099,7 +1099,7 @@ mod tests {
     #[tokio::test]
     async fn test_project_from_path() {
         let tempdir = tempfile::tempdir().unwrap();
-        let manifest_path = tempdir.path().join(consts::MANIFEST_DEFAULT_NAME);
+        let manifest_path = tempdir.path().join(consts::GLOBAL_MANIFEST_DEFAULT_NAME);
 
         let env_root = EnvRoot::from_env().await.unwrap();
         let bin_dir = BinDir::from_env().await.unwrap();
@@ -1253,7 +1253,7 @@ mod tests {
 
         // Create project with env1 and env3
         let manifest = Manifest::from_str(
-            &env_root.path().join(consts::MANIFEST_DEFAULT_NAME),
+            &env_root.path().join(consts::GLOBAL_MANIFEST_DEFAULT_NAME),
             r#"
             [envs.env1]
             channels = ["conda-forge"]

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -65,7 +65,6 @@ mod environment;
 mod manifest;
 mod parsed_manifest;
 
-pub(crate) const MANIFEST_DEFAULT_NAME: &str = "pixi-global.toml";
 pub(crate) const MANIFESTS_DIR: &str = "manifests";
 
 /// The pixi global project, this main struct to interact with the pixi global
@@ -386,15 +385,18 @@ impl Project {
     /// Get default dir for the pixi global manifest
     pub(crate) fn manifest_dir() -> miette::Result<PathBuf> {
         // Potential directories, with the highest priority coming first
-        let potential_dirs = [pixi_home(), dirs::config_dir().map(|dir| dir.join("pixi"))]
-            .into_iter()
-            .flatten()
-            .map(|dir| dir.join(MANIFESTS_DIR))
-            .collect_vec();
+        let potential_dirs = [
+            pixi_home(),
+            dirs::config_dir().map(|dir| dir.join(consts::CONFIG_DIR)),
+        ]
+        .into_iter()
+        .flatten()
+        .map(|dir| dir.join(MANIFESTS_DIR))
+        .collect_vec();
 
         // First, check if a `pixi-global.toml` already exists
         for dir in &potential_dirs {
-            if dir.join(MANIFEST_DEFAULT_NAME).is_file() {
+            if dir.join(consts::MANIFEST_DEFAULT_NAME).is_file() {
                 return Ok(dir.clone());
             }
         }
@@ -408,7 +410,7 @@ impl Project {
 
     /// Get the default path to the global manifest file
     pub(crate) fn default_manifest_path() -> miette::Result<PathBuf> {
-        Self::manifest_dir().map(|dir| dir.join(MANIFEST_DEFAULT_NAME))
+        Self::manifest_dir().map(|dir| dir.join(consts::MANIFEST_DEFAULT_NAME))
     }
 
     /// Loads a project from manifest file.
@@ -1097,7 +1099,7 @@ mod tests {
     #[tokio::test]
     async fn test_project_from_path() {
         let tempdir = tempfile::tempdir().unwrap();
-        let manifest_path = tempdir.path().join(MANIFEST_DEFAULT_NAME);
+        let manifest_path = tempdir.path().join(consts::MANIFEST_DEFAULT_NAME);
 
         let env_root = EnvRoot::from_env().await.unwrap();
         let bin_dir = BinDir::from_env().await.unwrap();
@@ -1251,7 +1253,7 @@ mod tests {
 
         // Create project with env1 and env3
         let manifest = Manifest::from_str(
-            &env_root.path().join(MANIFEST_DEFAULT_NAME),
+            &env_root.path().join(consts::MANIFEST_DEFAULT_NAME),
             r#"
             [envs.env1]
             channels = ["conda-forge"]


### PR DESCRIPTION
When using pixi global edit, if the manifest folder didn't exist it would throw an error when trying to save. Some EDITORs also will error when trying to open the file. This creates the folder. 

This also cleans up some consts around manifest file and folders and fixes the exposed name error not matching the executable name in the global manifest. 