### PR TITLE
feat: extract pixi manifest info into protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3741,6 +3741,7 @@ dependencies = [
  "dashmap",
  "fs-err",
  "futures",
+ "indexmap 2.7.0",
  "insta",
  "itertools 0.13.0",
  "jsonrpsee",
@@ -3780,8 +3781,11 @@ dependencies = [
 name = "pixi_build_types"
 version = "0.1.0"
 dependencies = [
+ "indexmap 2.7.0",
  "rattler_conda_types",
+ "rattler_digest",
  "serde",
+ "serde_json",
  "serde_with",
  "url",
 ]

--- a/crates/pixi_build_frontend/Cargo.toml
+++ b/crates/pixi_build_frontend/Cargo.toml
@@ -49,7 +49,7 @@ pixi_build_types = { path = "../pixi_build_types" }
 
 [dev-dependencies]
 bytes = { workspace = true }
-insta = { workspace = true, features = ["yaml", "filters"] }
+insta = { workspace = true, features = ["yaml", "filters", "json"] }
 rstest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [

--- a/crates/pixi_build_frontend/Cargo.toml
+++ b/crates/pixi_build_frontend/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 dashmap = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 jsonrpsee = { workspace = true, features = ["client"] }
 miette = { workspace = true, features = ["fancy", "serde"] }

--- a/crates/pixi_build_frontend/src/into_build_types.rs
+++ b/crates/pixi_build_frontend/src/into_build_types.rs
@@ -31,7 +31,6 @@ fn to_pixi_spec_v1(spec: &PixiSpec) -> pbt::PixiSpecV1 {
                 subdir: detailed_spec.subdir.clone(),
                 md5: detailed_spec.md5.map(Into::into),
                 sha256: detailed_spec.sha256.map(Into::into),
-                url: None,
             })
         }
         PixiSpec::Url(url_spec) => pbt::PixiSpecV1::Url(pbt::UrlSpecV1 {

--- a/crates/pixi_build_frontend/src/into_build_types.rs
+++ b/crates/pixi_build_frontend/src/into_build_types.rs
@@ -18,7 +18,7 @@ fn to_pixi_spec_v1(spec: &PixiSpec) -> pbt::PixiSpecV1 {
         // the NamelessMatchSpecV1 variant
         PixiSpec::Version(version_spec) => pbt::PixiSpecV1::DetailedVersion(version_spec.into()),
         PixiSpec::DetailedVersion(detailed_spec) => {
-            pbt::PixiSpecV1::DetailedVersion(pbt::NamelessMatchSpecV1 {
+            pbt::PixiSpecV1::DetailedVersion(pbt::DependencySpecV1 {
                 version: detailed_spec.version.clone(),
                 build: detailed_spec.build.clone(),
                 build_number: detailed_spec.build_number.clone(),
@@ -29,7 +29,6 @@ fn to_pixi_spec_v1(spec: &PixiSpec) -> pbt::PixiSpecV1 {
                     .map(|c| c.to_string())
                     .clone(),
                 subdir: detailed_spec.subdir.clone(),
-                namespace: None,
                 md5: detailed_spec.md5.map(Into::into),
                 sha256: detailed_spec.sha256.map(Into::into),
                 url: None,
@@ -59,7 +58,7 @@ fn to_pixi_spec_v1(spec: &PixiSpec) -> pbt::PixiSpecV1 {
 /// Converts an iterator of `PackageName` and `PixiSpec` to a `IndexMap<String, pbt::PixiSpecV1>`.
 fn to_pbt_dependencies<'a>(
     iter: impl Iterator<Item = (&'a PackageName, &'a PixiSpec)>,
-) -> IndexMap<String, pbt::PixiSpecV1> {
+) -> IndexMap<pbt::SourcePackageName, pbt::PixiSpecV1> {
     iter.map(|(k, v)| (k.as_source().to_string(), to_pixi_spec_v1(v)))
         .collect()
 }
@@ -155,7 +154,7 @@ mod tests {
                 let mut settings = insta::Settings::clone_current();
                 settings.set_snapshot_suffix(name);
                 settings.bind(|| {
-                    insta::assert_yaml_snapshot!(project_model);
+                    insta::assert_json_snapshot!(project_model);
                 });
             }
         }};

--- a/crates/pixi_build_frontend/src/into_build_types.rs
+++ b/crates/pixi_build_frontend/src/into_build_types.rs
@@ -1,0 +1,127 @@
+//! Conversion functions from `pixi_spec` types to `pixi_build_types` types.
+//! these are used to convert the `pixi_spec` types to the `pixi_build_types` types
+//! we want to keep the conversion here, as we do not want `pixi_build_types` to depend on `pixi_spec`
+//!
+//! This will mostly be boilerplate conversions but some of these are a bit more interesting
+
+// Namespace to pbt, *please use* exclusively so we do not get confused between the two different types
+use indexmap::IndexMap;
+use pixi_build_types as pbt;
+use pixi_manifest::{PackageManifest, PackageTarget, TargetSelector, Targets};
+use pixi_spec::{PixiSpec, Reference};
+use rattler_conda_types::PackageName;
+
+/// Conversion from a `PixiSpec` to a `pbt::PixiSpecV1`.
+fn to_pixi_spec_v1(spec: &PixiSpec) -> pbt::PixiSpecV1 {
+    match spec {
+        // We consider both `Version` and `DetailedVersion` to use
+        // the NamelessMatchSpecV1 variant
+        PixiSpec::Version(version_spec) => pbt::PixiSpecV1::DetailedVersion(version_spec.into()),
+        PixiSpec::DetailedVersion(detailed_spec) => {
+            pbt::PixiSpecV1::DetailedVersion(pbt::NamelessMatchSpecV1 {
+                version: detailed_spec.version.clone(),
+                build: detailed_spec.build.clone(),
+                build_number: detailed_spec.build_number.clone(),
+                file_name: detailed_spec.file_name.clone(),
+                channel: detailed_spec
+                    .channel
+                    .as_ref()
+                    .map(|c| c.to_string())
+                    .clone(),
+                subdir: detailed_spec.subdir.clone(),
+                namespace: None,
+                md5: detailed_spec.md5.map(Into::into),
+                sha256: detailed_spec.sha256.map(Into::into),
+                url: None,
+            })
+        }
+        PixiSpec::Url(url_spec) => pbt::PixiSpecV1::Url(pbt::UrlSpecV1 {
+            url: url_spec.url.clone(),
+            md5: url_spec.md5.map(Into::into),
+            sha256: url_spec.sha256.map(Into::into),
+        }),
+        PixiSpec::Git(git_spec) => pbt::PixiSpecV1::Git(pbt::GitSpecV1 {
+            git: git_spec.git.clone(),
+            rev: git_spec.rev.clone().map(|r| match r {
+                Reference::Branch(b) => pbt::GitReferenceV1::Branch(b.clone()),
+                Reference::Tag(t) => pbt::GitReferenceV1::Tag(t.clone()),
+                Reference::Rev(rev) => pbt::GitReferenceV1::Rev(rev.clone()),
+                Reference::DefaultBranch => pbt::GitReferenceV1::DefaultBranch,
+            }),
+            subdirectory: git_spec.subdirectory.clone(),
+        }),
+        PixiSpec::Path(path_spec) => pbt::PixiSpecV1::Path(pbt::PathSpecV1 {
+            path: path_spec.path.to_string(),
+        }),
+    }
+}
+
+/// Converts an iterator of `PackageName` and `PixiSpec` to a `IndexMap<String, pbt::PixiSpecV1>`.
+fn to_pbt_dependencies<'a>(
+    iter: impl Iterator<Item = (&'a PackageName, &'a PixiSpec)>,
+) -> IndexMap<String, pbt::PixiSpecV1> {
+    iter.map(|(k, v)| (k.as_source().to_string(), to_pixi_spec_v1(v)))
+        .collect()
+}
+
+/// Converts a `PackageTarget` to a `pbt::TargetV1`.
+fn to_target_v1(target: &PackageTarget) -> pbt::TargetV1 {
+    // Difference for us is that [`pbt::TargetV1`] has split the host, run and build dependencies
+    // into separate fields, so we need to split them up here
+    pbt::TargetV1 {
+        host_dependencies: target
+            .host_dependencies()
+            .map(|deps| deps.iter())
+            .map(to_pbt_dependencies)
+            .unwrap_or_default(),
+        build_dependencies: target
+            .build_dependencies()
+            .map(|deps| deps.iter())
+            .map(to_pbt_dependencies)
+            .unwrap_or_default(),
+        run_dependencies: target
+            .run_dependencies()
+            .map(|deps| deps.iter())
+            .map(to_pbt_dependencies)
+            .unwrap_or_default(),
+    }
+}
+
+fn to_target_selector_v1(selector: &TargetSelector) -> pbt::TargetSelectorV1 {
+    match selector {
+        TargetSelector::Platform(platform) => pbt::TargetSelectorV1::Platform(platform.to_string()),
+        TargetSelector::Unix => pbt::TargetSelectorV1::Unix,
+        TargetSelector::Linux => pbt::TargetSelectorV1::Linux,
+        TargetSelector::Win => pbt::TargetSelectorV1::Win,
+        TargetSelector::MacOs => pbt::TargetSelectorV1::MacOs,
+    }
+}
+
+fn to_targets_v1(targets: &Targets<PackageTarget>) -> pbt::TargetsV1 {
+    pbt::TargetsV1 {
+        default_target: to_target_v1(targets.default()),
+        targets: targets
+            .iter()
+            .filter_map(|(k, v)| {
+                v.map(|selector| (to_target_selector_v1(selector), to_target_v1(k)))
+            })
+            .collect(),
+    }
+}
+
+pub fn to_project_model_v1(manifest: &PackageManifest) -> pbt::ProjectModelV1 {
+    pbt::ProjectModelV1 {
+        name: manifest.package.name.clone(),
+        version: manifest.package.version.clone(),
+        description: manifest.package.description.clone(),
+        authors: manifest.package.authors.clone(),
+        license: manifest.package.license.clone(),
+        license_file: manifest.package.license_file.clone(),
+        readme: manifest.package.readme.clone(),
+        homepage: manifest.package.homepage.clone(),
+        repository: manifest.package.repository.clone(),
+        documentation: manifest.package.documentation.clone(),
+        configuration: serde_json::Value::Null,
+        targets: to_targets_v1(&manifest.targets),
+    }
+}

--- a/crates/pixi_build_frontend/src/lib.rs
+++ b/crates/pixi_build_frontend/src/lib.rs
@@ -1,5 +1,6 @@
 mod backend_override;
 mod build_frontend;
+mod into_build_types;
 mod jsonrpc;
 pub mod protocol;
 mod protocols;
@@ -24,6 +25,7 @@ use url::Url;
 pub use crate::protocol::Protocol;
 
 pub use backend_override::BackendOverride;
+pub use into_build_types::to_project_model_v1;
 pub use protocol_builder::EnabledProtocols;
 
 /// A backend communication protocol that can run in the same process.

--- a/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
@@ -205,6 +205,7 @@ impl ProtocolBuilder {
         Ok(JsonRPCBuildProtocol::setup(
             self.source_dir,
             self.manifest_path,
+            Some(&self.package_manifest),
             build_id,
             self.cache_dir,
             tool,
@@ -223,6 +224,7 @@ impl ProtocolBuilder {
             "<IPC>".to_string(),
             self.source_dir,
             self.manifest_path,
+            Some(&self.package_manifest),
             build_id,
             self.cache_dir,
             Sender::from(ipc.rpc_out),

--- a/crates/pixi_build_frontend/src/protocols/builders/rattler_build.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/rattler_build.rs
@@ -145,6 +145,7 @@ impl ProtocolBuilder {
         Ok(JsonRPCBuildProtocol::setup(
             self.source_dir,
             self.recipe_dir.join("recipe.yaml"),
+            None,
             build_id,
             self.cache_dir,
             tool,

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_cpp.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_cpp.snap
@@ -2,68 +2,78 @@
 source: crates/pixi_build_frontend/src/into_build_types.rs
 expression: project_model
 ---
-name: python_bindings
-version: 0.1.0
-description: ~
-authors: ~
-license: ~
-license_file: ~
-readme: ~
-homepage: ~
-repository: ~
-documentation: ~
-configuration: ~
-targets:
-  default_target:
-    host_dependencies:
-      cmake:
-        detailedVersion:
-          version: ">=3.20,<3.27"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-      nanobind:
-        detailedVersion:
-          version: ">=2.4.0,<2.5.0"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-      python_abi:
-        detailedVersion:
-          version: ">=3.12,<3.13"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-    build_dependencies: {}
-    run_dependencies:
-      python:
-        detailedVersion:
-          version: ">=3.12,<3.13"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-  targets: {}
+{
+  "name": "python_bindings",
+  "version": "0.1.0",
+  "description": null,
+  "authors": null,
+  "license": null,
+  "license_file": null,
+  "readme": null,
+  "homepage": null,
+  "repository": null,
+  "documentation": null,
+  "configuration": null,
+  "targets": {
+    "default_target": {
+      "host_dependencies": {
+        "cmake": {
+          "detailedVersion": {
+            "version": ">=3.20,<3.27",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        },
+        "nanobind": {
+          "detailedVersion": {
+            "version": ">=2.4.0,<2.5.0",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        },
+        "python_abi": {
+          "detailedVersion": {
+            "version": ">=3.12,<3.13",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      },
+      "build_dependencies": {},
+      "run_dependencies": {
+        "python": {
+          "detailedVersion": {
+            "version": ">=3.12,<3.13",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      }
+    },
+    "targets": {}
+  }
+}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_cpp.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_cpp.snap
@@ -26,8 +26,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         },
         "nanobind": {
@@ -39,8 +38,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         },
         "python_abi": {
@@ -52,8 +50,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       },
@@ -68,8 +65,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       }

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_cpp.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_cpp.snap
@@ -1,0 +1,69 @@
+---
+source: crates/pixi_build_frontend/src/into_build_types.rs
+expression: project_model
+---
+name: python_bindings
+version: 0.1.0
+description: ~
+authors: ~
+license: ~
+license_file: ~
+readme: ~
+homepage: ~
+repository: ~
+documentation: ~
+configuration: ~
+targets:
+  default_target:
+    host_dependencies:
+      cmake:
+        detailedVersion:
+          version: ">=3.20,<3.27"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+      nanobind:
+        detailedVersion:
+          version: ">=2.4.0,<2.5.0"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+      python_abi:
+        detailedVersion:
+          version: ">=3.12,<3.13"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+    build_dependencies: {}
+    run_dependencies:
+      python:
+        detailedVersion:
+          version: ">=3.12,<3.13"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+  targets: {}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_python.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_python.snap
@@ -26,8 +26,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       },
@@ -42,8 +41,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       }

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_python.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_python.snap
@@ -2,44 +2,52 @@
 source: crates/pixi_build_frontend/src/into_build_types.rs
 expression: project_model
 ---
-name: rich_example
-version: 0.1.0
-description: ~
-authors: ~
-license: ~
-license_file: ~
-readme: ~
-homepage: ~
-repository: ~
-documentation: ~
-configuration: ~
-targets:
-  default_target:
-    host_dependencies:
-      hatchling:
-        detailedVersion:
-          version: "==1.26.3"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-    build_dependencies: {}
-    run_dependencies:
-      rich:
-        detailedVersion:
-          version: ">=13.9.4,<14"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-  targets: {}
+{
+  "name": "rich_example",
+  "version": "0.1.0",
+  "description": null,
+  "authors": null,
+  "license": null,
+  "license_file": null,
+  "readme": null,
+  "homepage": null,
+  "repository": null,
+  "documentation": null,
+  "configuration": null,
+  "targets": {
+    "default_target": {
+      "host_dependencies": {
+        "hatchling": {
+          "detailedVersion": {
+            "version": "==1.26.3",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      },
+      "build_dependencies": {},
+      "run_dependencies": {
+        "rich": {
+          "detailedVersion": {
+            "version": ">=13.9.4,<14",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      }
+    },
+    "targets": {}
+  }
+}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_python.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_python.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pixi_build_frontend/src/into_build_types.rs
+expression: project_model
+---
+name: rich_example
+version: 0.1.0
+description: ~
+authors: ~
+license: ~
+license_file: ~
+readme: ~
+homepage: ~
+repository: ~
+documentation: ~
+configuration: ~
+targets:
+  default_target:
+    host_dependencies:
+      hatchling:
+        detailedVersion:
+          version: "==1.26.3"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+    build_dependencies: {}
+    run_dependencies:
+      rich:
+        detailedVersion:
+          version: ">=13.9.4,<14"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+  targets: {}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_workspace.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_workspace.snap
@@ -26,8 +26,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       },
@@ -42,8 +41,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       }

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_workspace.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_workspace.snap
@@ -2,44 +2,52 @@
 source: crates/pixi_build_frontend/src/into_build_types.rs
 expression: project_model
 ---
-name: rich_example
-version: 0.1.0
-description: ~
-authors: ~
-license: ~
-license_file: ~
-readme: ~
-homepage: ~
-repository: ~
-documentation: ~
-configuration: ~
-targets:
-  default_target:
-    host_dependencies:
-      hatchling:
-        detailedVersion:
-          version: "==1.26.3"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-    build_dependencies: {}
-    run_dependencies:
-      rich:
-        detailedVersion:
-          version: ">=13.9.4,<14"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-  targets: {}
+{
+  "name": "rich_example",
+  "version": "0.1.0",
+  "description": null,
+  "authors": null,
+  "license": null,
+  "license_file": null,
+  "readme": null,
+  "homepage": null,
+  "repository": null,
+  "documentation": null,
+  "configuration": null,
+  "targets": {
+    "default_target": {
+      "host_dependencies": {
+        "hatchling": {
+          "detailedVersion": {
+            "version": "==1.26.3",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      },
+      "build_dependencies": {},
+      "run_dependencies": {
+        "rich": {
+          "detailedVersion": {
+            "version": ">=13.9.4,<14",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      }
+    },
+    "targets": {}
+  }
+}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_workspace.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_docs@pixi_build_workspace.snap
@@ -1,0 +1,45 @@
+---
+source: crates/pixi_build_frontend/src/into_build_types.rs
+expression: project_model
+---
+name: rich_example
+version: 0.1.0
+description: ~
+authors: ~
+license: ~
+license_file: ~
+readme: ~
+homepage: ~
+repository: ~
+documentation: ~
+configuration: ~
+targets:
+  default_target:
+    host_dependencies:
+      hatchling:
+        detailedVersion:
+          version: "==1.26.3"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+    build_dependencies: {}
+    run_dependencies:
+      rich:
+        detailedVersion:
+          version: ">=13.9.4,<14"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+  targets: {}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@boltons.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@boltons.snap
@@ -28,8 +28,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       },

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@boltons.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@boltons.snap
@@ -1,0 +1,34 @@
+---
+source: crates/pixi_build_frontend/src/into_build_types.rs
+expression: project_model
+---
+name: boltons
+version: 0.1.0
+description: Add a short description here
+authors:
+  - nichmor <nmorkotilo@gmail.com>
+license: ~
+license_file: ~
+readme: ~
+homepage: ~
+repository: ~
+documentation: ~
+configuration: ~
+targets:
+  default_target:
+    host_dependencies:
+      hatchling:
+        detailedVersion:
+          version: "*"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+    build_dependencies: {}
+    run_dependencies: {}
+  targets: {}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@boltons.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@boltons.snap
@@ -2,33 +2,40 @@
 source: crates/pixi_build_frontend/src/into_build_types.rs
 expression: project_model
 ---
-name: boltons
-version: 0.1.0
-description: Add a short description here
-authors:
-  - nichmor <nmorkotilo@gmail.com>
-license: ~
-license_file: ~
-readme: ~
-homepage: ~
-repository: ~
-documentation: ~
-configuration: ~
-targets:
-  default_target:
-    host_dependencies:
-      hatchling:
-        detailedVersion:
-          version: "*"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-    build_dependencies: {}
-    run_dependencies: {}
-  targets: {}
+{
+  "name": "boltons",
+  "version": "0.1.0",
+  "description": "Add a short description here",
+  "authors": [
+    "nichmor <nmorkotilo@gmail.com>"
+  ],
+  "license": null,
+  "license_file": null,
+  "readme": null,
+  "homepage": null,
+  "repository": null,
+  "documentation": null,
+  "configuration": null,
+  "targets": {
+    "default_target": {
+      "host_dependencies": {
+        "hatchling": {
+          "detailedVersion": {
+            "version": "*",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      },
+      "build_dependencies": {},
+      "run_dependencies": {}
+    },
+    "targets": {}
+  }
+}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@cpp-sdl.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@cpp-sdl.snap
@@ -1,0 +1,34 @@
+---
+source: crates/pixi_build_frontend/src/into_build_types.rs
+expression: project_model
+---
+name: sdl_example
+version: 0.1.0
+description: Showcases how to create a simple C++ executable with Pixi
+authors:
+  - Bas Zalmstra <bas@prefix.dev>
+license: ~
+license_file: ~
+readme: ~
+homepage: ~
+repository: ~
+documentation: ~
+configuration: ~
+targets:
+  default_target:
+    host_dependencies:
+      sdl2:
+        detailedVersion:
+          version: ">=2.26.5,<3.0"
+          build: ~
+          build_number: ~
+          file_name: ~
+          channel: ~
+          subdir: ~
+          namespace: ~
+          md5: ~
+          sha256: ~
+          url: ~
+    build_dependencies: {}
+    run_dependencies: {}
+  targets: {}

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@cpp-sdl.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@cpp-sdl.snap
@@ -28,8 +28,7 @@ expression: project_model
             "channel": null,
             "subdir": null,
             "md5": null,
-            "sha256": null,
-            "url": null
+            "sha256": null
           }
         }
       },

--- a/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@cpp-sdl.snap
+++ b/crates/pixi_build_frontend/src/snapshots/pixi_build_frontend__into_build_types__tests__conversions_v1_examples@cpp-sdl.snap
@@ -2,33 +2,40 @@
 source: crates/pixi_build_frontend/src/into_build_types.rs
 expression: project_model
 ---
-name: sdl_example
-version: 0.1.0
-description: Showcases how to create a simple C++ executable with Pixi
-authors:
-  - Bas Zalmstra <bas@prefix.dev>
-license: ~
-license_file: ~
-readme: ~
-homepage: ~
-repository: ~
-documentation: ~
-configuration: ~
-targets:
-  default_target:
-    host_dependencies:
-      sdl2:
-        detailedVersion:
-          version: ">=2.26.5,<3.0"
-          build: ~
-          build_number: ~
-          file_name: ~
-          channel: ~
-          subdir: ~
-          namespace: ~
-          md5: ~
-          sha256: ~
-          url: ~
-    build_dependencies: {}
-    run_dependencies: {}
-  targets: {}
+{
+  "name": "sdl_example",
+  "version": "0.1.0",
+  "description": "Showcases how to create a simple C++ executable with Pixi",
+  "authors": [
+    "Bas Zalmstra <bas@prefix.dev>"
+  ],
+  "license": null,
+  "license_file": null,
+  "readme": null,
+  "homepage": null,
+  "repository": null,
+  "documentation": null,
+  "configuration": null,
+  "targets": {
+    "default_target": {
+      "host_dependencies": {
+        "sdl2": {
+          "detailedVersion": {
+            "version": ">=2.26.5,<3.0",
+            "build": null,
+            "build_number": null,
+            "file_name": null,
+            "channel": null,
+            "subdir": null,
+            "md5": null,
+            "sha256": null,
+            "url": null
+          }
+        }
+      },
+      "build_dependencies": {},
+      "run_dependencies": {}
+    },
+    "targets": {}
+  }
+}

--- a/crates/pixi_build_types/Cargo.toml
+++ b/crates/pixi_build_types/Cargo.toml
@@ -10,7 +10,10 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
+indexmap = { workspace = true }
 rattler_conda_types = { workspace = true }
+rattler_digest = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
 url = { workspace = true }

--- a/crates/pixi_build_types/src/capabilities.rs
+++ b/crates/pixi_build_types/src/capabilities.rs
@@ -10,6 +10,9 @@ pub struct BackendCapabilities {
 
     /// Whether the backend provides the ability to build conda packages.
     pub provides_conda_build: Option<bool>,
+
+    /// The highest supported project model version.
+    pub highest_supported_project_model: Option<u32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/pixi_build_types/src/lib.rs
+++ b/crates/pixi_build_types/src/lib.rs
@@ -9,8 +9,8 @@ pub use capabilities::{BackendCapabilities, FrontendCapabilities};
 pub use channel_configuration::ChannelConfiguration;
 pub use conda_package_metadata::CondaPackageMetadata;
 pub use project_model::{
-    GitReferenceV1, GitSpecV1, NamelessMatchSpecV1, PathSpecV1, PixiSpecV1, ProjectModelV1,
-    TargetSelectorV1, TargetV1, TargetsV1, UrlSpecV1, VersionedProjectModel,
+    DependencySpecV1, GitReferenceV1, GitSpecV1, PathSpecV1, PixiSpecV1, ProjectModelV1,
+    SourcePackageName, TargetSelectorV1, TargetV1, TargetsV1, UrlSpecV1, VersionedProjectModel,
 };
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use serde::{Deserialize, Serialize};

--- a/crates/pixi_build_types/src/lib.rs
+++ b/crates/pixi_build_types/src/lib.rs
@@ -3,10 +3,15 @@ mod capabilities;
 mod channel_configuration;
 mod conda_package_metadata;
 pub mod procedures;
+mod project_model;
 
 pub use capabilities::{BackendCapabilities, FrontendCapabilities};
 pub use channel_configuration::ChannelConfiguration;
 pub use conda_package_metadata::CondaPackageMetadata;
+pub use project_model::{
+    GitReferenceV1, GitSpecV1, NamelessMatchSpecV1, PathSpecV1, PixiSpecV1, ProjectModelV1,
+    TargetSelectorV1, TargetV1, TargetsV1, UrlSpecV1, VersionedProjectModel,
+};
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use serde::{Deserialize, Serialize};
 

--- a/crates/pixi_build_types/src/procedures/initialize.rs
+++ b/crates/pixi_build_types/src/procedures/initialize.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use crate::VersionedProjectModel;
 use serde::{Deserialize, Serialize};
 
 pub const METHOD_NAME: &str = "initialize";
@@ -25,6 +26,11 @@ pub struct InitializeParams {
 
     /// Optionally the cache directory to use for any caching activity.
     pub cache_directory: Option<PathBuf>,
+
+    /// Project model that the backend should use
+    /// even though it is an option it is highly recommended to use
+    /// this field. Otherwise it will be very easy to break backwards compatibility.
+    pub project_model: Option<VersionedProjectModel>,
 }
 
 /// The result of the initialize request.

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -82,6 +82,8 @@ pub struct ProjectModelV1 {
     /// Configuration for this specific project model
     pub configuration: serde_json::Value,
 
+    /// The target of the project, this may contain
+    /// platform specific configurations.
     pub targets: TargetsV1,
 }
 
@@ -231,8 +233,6 @@ pub struct DependencySpecV1 {
     pub md5: Option<SerializableHash<Md5>>,
     /// The sha256 hash of the package
     pub sha256: Option<SerializableHash<Sha256>>,
-    /// The url of the package
-    pub url: Option<Url>,
 }
 
 impl From<VersionSpec> for DependencySpecV1 {
@@ -280,9 +280,6 @@ impl std::fmt::Debug for DependencySpecV1 {
         }
         if let Some(sha256) = &self.sha256 {
             debug_struct.field("sha256", &format!("{:x}", sha256.0));
-        }
-        if let Some(url) = &self.url {
-            debug_struct.field("url", url);
         }
 
         debug_struct.finish()

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -1,0 +1,269 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use indexmap::IndexMap;
+use rattler_conda_types::{BuildNumberSpec, StringMatcher, Version, VersionSpec};
+use rattler_digest::{serde::SerializableHash, Md5, Sha256};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use serde_with::DisplayFromStr;
+use url::Url;
+
+/// Enum containing all versions of the project model.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "version")]
+#[serde(rename_all = "camelCase")]
+pub enum VersionedProjectModel {
+    V1(ProjectModelV1),
+}
+
+/// The source package name of a package. Not normalized per se.
+type SourcePackageName = String;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProjectModelV1 {
+    /// The name of the project
+    pub name: String,
+
+    /// The version of the project
+    pub version: Version,
+
+    /// An optional project description
+    pub description: Option<String>,
+
+    /// Optional authors
+    pub authors: Option<Vec<String>>,
+
+    /// The license as a valid SPDX string (e.g. MIT AND Apache-2.0)
+    pub license: Option<String>,
+
+    /// The license file (relative to the project root)
+    pub license_file: Option<PathBuf>,
+
+    /// Path to the README file of the project (relative to the project root)
+    pub readme: Option<PathBuf>,
+
+    /// URL of the project homepage
+    pub homepage: Option<Url>,
+
+    /// URL of the project source repository
+    pub repository: Option<Url>,
+
+    /// URL of the project documentation
+    pub documentation: Option<Url>,
+
+    /// Configuration for this specific project model
+    pub configuration: serde_json::Value,
+
+    pub targets: TargetsV1,
+}
+
+/// Represents a target selector. Currently we only support explicit platform
+/// selection.
+#[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub enum TargetSelectorV1 {
+    // Platform specific configuration
+    Platform(String),
+    Unix,
+    Linux,
+    Win,
+    MacOs,
+    // TODO: Add minijinja coolness here.
+}
+
+/// A collect of targets including a default target.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TargetsV1 {
+    pub default_target: TargetV1,
+
+    /// We use an [`IndexMap`] to preserve the order in which the items where
+    /// defined in the manifest.
+    pub targets: HashMap<TargetSelectorV1, TargetV1>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TargetV1 {
+    /// Host dependencies of the project
+    pub host_dependencies: IndexMap<SourcePackageName, PixiSpecV1>,
+
+    /// Build dependencies of the project
+    pub build_dependencies: IndexMap<SourcePackageName, PixiSpecV1>,
+
+    /// Run dependencies of the project
+    pub run_dependencies: IndexMap<SourcePackageName, PixiSpecV1>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PixiSpecV1 {
+    /// The spec is represented by a detailed version spec. The package should
+    /// be retrieved from a channel.
+    DetailedVersion(NamelessMatchSpecV1),
+
+    /// The spec is represented as an archive that can be downloaded from the
+    /// specified URL. The package should be retrieved from the URL and can
+    /// either represent a source or binary package depending on the archive
+    /// type.
+    Url(UrlSpecV1),
+
+    /// The spec is represented as a git repository. The package represents a
+    /// source distribution of some kind.
+    Git(GitSpecV1),
+
+    /// The spec is represented as a local path. The package should be retrieved
+    /// from the local filesystem. The package can be either a source or binary
+    /// package.
+    Path(PathSpecV1),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UrlSpecV1 {
+    /// The URL of the package
+    pub url: Url,
+
+    /// The md5 hash of the package
+    pub md5: Option<SerializableHash<Md5>>,
+
+    /// The sha256 hash of the package
+    pub sha256: Option<SerializableHash<Sha256>>,
+}
+
+impl std::fmt::Debug for UrlSpecV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_struct("UrlSpecV1");
+
+        debug_struct.field("url", &self.url);
+        if let Some(md5) = &self.md5 {
+            debug_struct.field("md5", &format!("{:x}", md5.0));
+        }
+        if let Some(sha256) = &self.sha256 {
+            debug_struct.field("sha256", &format!("{:x}", sha256.0));
+        }
+        debug_struct.finish()
+    }
+}
+
+/// A specification of a package from a git repository.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitSpecV1 {
+    /// The git url of the package which can contain git+ prefixes.
+    pub git: Url,
+
+    /// The git revision of the package
+    pub rev: Option<GitReferenceV1>,
+
+    /// The git subdirectory of the package
+    pub subdirectory: Option<String>,
+}
+
+/// A specification of a package from a git repository.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PathSpecV1 {
+    /// The path to the package
+    pub path: String,
+}
+
+/// A reference to a specific commit in a git repository.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GitReferenceV1 {
+    /// The HEAD commit of a branch.
+    Branch(String),
+
+    /// A specific tag.
+    Tag(String),
+
+    /// A specific commit.
+    Rev(String),
+
+    /// A default branch.
+    DefaultBranch,
+}
+
+/// Similar to a [`MatchSpec`] but does not include the package name. This is useful in places
+/// where the package name is already known (e.g. `foo = "3.4.1 *cuda"`)
+#[serde_as]
+#[derive(Serialize, Deserialize, Default)]
+pub struct NamelessMatchSpecV1 {
+    /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub version: Option<VersionSpec>,
+    /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub build: Option<StringMatcher>,
+    /// The build number of the package
+    pub build_number: Option<BuildNumberSpec>,
+    /// Match the specific filename of the package
+    pub file_name: Option<String>,
+    /// The channel of the package
+    pub channel: Option<String>,
+    /// The subdir of the channel
+    pub subdir: Option<String>,
+    /// The namespace of the package (currently not used)
+    pub namespace: Option<String>,
+    /// The md5 hash of the package
+    pub md5: Option<SerializableHash<Md5>>,
+    /// The sha256 hash of the package
+    pub sha256: Option<SerializableHash<Sha256>>,
+    /// The url of the package
+    pub url: Option<Url>,
+}
+
+impl From<VersionSpec> for NamelessMatchSpecV1 {
+    fn from(value: VersionSpec) -> Self {
+        Self {
+            version: Some(value),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<&VersionSpec> for NamelessMatchSpecV1 {
+    fn from(value: &VersionSpec) -> Self {
+        Self {
+            version: Some(value.clone()),
+            ..Default::default()
+        }
+    }
+}
+
+impl std::fmt::Debug for NamelessMatchSpecV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug_struct = f.debug_struct("NamelessMatchSpecV1");
+
+        if let Some(version) = &self.version {
+            debug_struct.field("version", version);
+        }
+        if let Some(build) = &self.build {
+            debug_struct.field("build", build);
+        }
+        if let Some(build_number) = &self.build_number {
+            debug_struct.field("build_number", build_number);
+        }
+        if let Some(file_name) = &self.file_name {
+            debug_struct.field("file_name", file_name);
+        }
+        if let Some(channel) = &self.channel {
+            debug_struct.field("channel", channel);
+        }
+        if let Some(subdir) = &self.subdir {
+            debug_struct.field("subdir", subdir);
+        }
+        if let Some(namespace) = &self.namespace {
+            debug_struct.field("namespace", namespace);
+        }
+        if let Some(md5) = &self.md5 {
+            debug_struct.field("md5", &format!("{:x}", md5.0));
+        }
+        if let Some(sha256) = &self.sha256 {
+            debug_struct.field("sha256", &format!("{:x}", sha256.0));
+        }
+        if let Some(url) = &self.url {
+            debug_struct.field("url", url);
+        }
+
+        debug_struct.finish()
+    }
+}

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -1,3 +1,14 @@
+//! This module is a collection of types that represent a pixi package in a protocol
+//! format that can be sent over the wire.
+//!
+//! We need to vendor a lot of the types, and simplify them in some cases, so that
+//! we have a stable protocol that can be used to communicate in the build tasks.
+//!
+//! This is why we append a `V{version}`, to the type names, to indicate the version
+//! of the protocol.
+//!
+//! Only the Whole ProjectModel is versioned explicitly in a enum.
+//! When making a change to one of the types be sure to add another enum declaration, if it is breaking.
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -182,8 +193,7 @@ pub enum GitReferenceV1 {
     DefaultBranch,
 }
 
-/// Similar to a [`MatchSpec`] but does not include the package name. This is useful in places
-/// where the package name is already known (e.g. `foo = "3.4.1 *cuda"`)
+/// Similar to a [`rattler_conda_types::NamelessMatchSpec`]
 #[serde_as]
 #[derive(Serialize, Deserialize, Default)]
 pub struct NamelessMatchSpecV1 {

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -42,7 +42,7 @@ pub use pypi::pypi_requirement::PyPiRequirement;
 use rattler_conda_types::Platform;
 pub use spec_type::SpecType;
 pub use system_requirements::{LibCFamilyAndVersion, LibCSystemRequirement, SystemRequirements};
-pub use target::{TargetSelector, Targets, WorkspaceTarget};
+pub use target::{PackageTarget, TargetSelector, Targets, WorkspaceTarget};
 pub use task::{Task, TaskName};
 use thiserror::Error;
 pub use workspace::{ChannelPriority, Workspace};

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -576,6 +576,11 @@ impl<T> Targets<T> {
         self.targets.keys()
     }
 
+    /// Returns the user defined selectors and their targets
+    pub fn user_defined_targets(&self) -> impl Iterator<Item = (&TargetSelector, &T)> + '_ {
+        self.targets.iter()
+    }
+
     /// Returns the source location of the target selector in the manifest.
     pub fn source_loc(&self, selector: &TargetSelector) -> Option<std::ops::Range<usize>> {
         self.source_locs.get(selector).cloned()


### PR DESCRIPTION
This extracts the required manifest fields into the `initialize` of the build protocol, this has the benefit of allowing the backends to not rely on the `pixi.toml` itself, this is nice because it decouples whatever we do in the `pixi.toml` (like adding extra fields) to whatever the backends need to know. 