### PR TITLE
fix: pixi add creates a project

### DIFF
--- a/crates/pixi_manifest/src/manifests/source.rs
+++ b/crates/pixi_manifest/src/manifests/source.rs
@@ -104,6 +104,15 @@ impl ManifestSource {
         matches!(self, ManifestSource::PyProjectToml(_))
     }
 
+    /// Detect the table name to use when querying elements of the manifest.
+    fn detect_table_name(&self) -> &'static str {
+        if self.manifest().as_table().contains_key("workspace") {
+            "workspace"
+        } else {
+            "project"
+        }
+    }
+
     /// Returns a mutable reference to the specified array either in project or
     /// feature.
     pub fn get_array_mut(
@@ -116,7 +125,7 @@ impl ManifestSource {
         // The spec is described here:
         // https://github.com/prefix-dev/pixi/issues/2807#issuecomment-2577826553
         let table = match feature_name {
-            FeatureName::Default => Some("workspace"),
+            FeatureName::Default => Some(self.detect_table_name()),
             FeatureName::Named(_) => None,
         };
 

--- a/crates/pixi_manifest/src/manifests/source.rs
+++ b/crates/pixi_manifest/src/manifests/source.rs
@@ -111,8 +111,12 @@ impl ManifestSource {
         array_name: &str,
         feature_name: &FeatureName,
     ) -> Result<&mut Array, TomlError> {
+        // TODO: When `[package]` will become a standalone table, this method
+        // should be refactored to determine the priority of the table to use
+        // The spec is described here:
+        // https://github.com/prefix-dev/pixi/issues/2807#issuecomment-2577826553
         let table = match feature_name {
-            FeatureName::Default => Some("project"),
+            FeatureName::Default => Some("workspace"),
             FeatureName::Named(_) => None,
         };
 

--- a/crates/pixi_manifest/src/toml/document.rs
+++ b/crates/pixi_manifest/src/toml/document.rs
@@ -31,6 +31,11 @@ impl TomlDocument {
         self.0.as_table_mut()
     }
 
+    /// Returns the manifest as a mutable table
+    pub fn as_table(&self) -> &Table {
+        self.0.as_table()
+    }
+
     /// Get or insert a top-level item
     pub fn get_or_insert<'a>(&'a mut self, key: &str, item: Item) -> &'a Item {
         self.0.entry(key).or_insert(item)

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -657,6 +657,8 @@ async fn add_dependency_dont_create_project() {
 
     let local_channel = package_database.into_channel().await.unwrap();
 
+    let local_channel_str = format!("{}", local_channel.url());
+
     // Initialize a new pixi project using the above channel
     let pixi = PixiControl::from_manifest(&format!(
         r#"
@@ -666,7 +668,7 @@ platforms = []
 channels = ['{local_channel}']
 preview = ['pixi-build']
 "#,
-        local_channel = local_channel.url()
+        local_channel = local_channel_str
     ))
     .unwrap();
 
@@ -675,5 +677,10 @@ preview = ['pixi-build']
 
     let project = pixi.project().unwrap();
 
-    insta::assert_snapshot!(project.manifest().source.to_string());
+    // filter out local channels from the insta
+    insta::with_settings!({filters => vec![
+        (local_channel_str.as_str(), "file://<LOCAL_CHANNEL>/"),
+    ]}, {
+        insta::assert_snapshot!(project.manifest().source.to_string());
+    });
 }

--- a/tests/integration_rust/snapshots/integration_rust__add_tests__add_dependency_dont_create_project.snap
+++ b/tests/integration_rust/snapshots/integration_rust__add_tests__add_dependency_dont_create_project.snap
@@ -5,7 +5,7 @@ expression: project.manifest().source.to_string()
 [workspace]
 name = "some-workspace"
 platforms = []
-channels = ['file:///var/folders/rf/kyk8v0zd3993kvjg2p373plm0000gn/T/.tmp38YpY6']
+channels = ['file://<LOCAL_CHANNEL>/']
 preview = ['pixi-build']
 
 [dependencies]

--- a/tests/integration_rust/snapshots/integration_rust__add_tests__add_dependency_dont_create_project.snap
+++ b/tests/integration_rust/snapshots/integration_rust__add_tests__add_dependency_dont_create_project.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_rust/add_tests.rs
+expression: project.manifest().source.to_string()
+---
+[workspace]
+name = "some-workspace"
+platforms = []
+channels = ['file:///var/folders/rf/kyk8v0zd3993kvjg2p373plm0000gn/T/.tmp38YpY6']
+preview = ['pixi-build']
+
+[dependencies]
+foo = "*"


### PR DESCRIPTION
## Overview

previously if `pixi.toml` contained a `[workspace]` and you runned `pixi add` it would create a `[project]` table because we always verify if we need to add platforms, and do it with a hardcoded `project` key. 
Now we will have a small logic to find the table name.