### PR TITLE
docs: Fix installation docs mistake in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ To install `pixi` you can run the following command in your terminal:
     The above invocation will automatically download the latest version of `pixi`, extract it, and move the `pixi` binary to `~/.pixi/bin`.
     If this directory does not already exist, the script will create it.
 
-    The script will also update your `~/.bash_profile` to include `~/.pixi/bin` in your PATH, allowing you to invoke the `pixi` command from anywhere.
+    The script will also update your `~/.bashrc` to include `~/.pixi/bin` in your PATH, allowing you to invoke the `pixi` command from anywhere.
 
 === "Windows"
     `PowerShell`:


### PR DESCRIPTION
Fixes an error in the Pixi installation documentation for unix systems.

Pixi adds itself to PATH in ~/.bashrc, NOT ~/.bash_profile.

Not sure if that has always been the case or if it's because that was changed at some point.