### PR TITLE
fix: take into account the variants for the source cache

### DIFF
--- a/src/build/cache/source_metadata_cache.rs
+++ b/src/build/cache/source_metadata_cache.rs
@@ -1,9 +1,3 @@
-use std::{
-    hash::{DefaultHasher, Hash, Hasher},
-    io::SeekFrom,
-    path::PathBuf,
-};
-
 use async_fd_lock::{LockWrite, RwLockWriteGuard};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use pixi_build_types::CondaPackageMetadata;
@@ -11,6 +5,12 @@ use pixi_record::InputHash;
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use serde::Deserialize;
 use serde_with::serde_derive::Serialize;
+use std::collections::BTreeMap;
+use std::{
+    hash::{DefaultHasher, Hash, Hasher},
+    io::SeekFrom,
+    path::PathBuf,
+};
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use url::Url;
@@ -52,6 +52,9 @@ pub struct SourceMetadataInput {
     /// The platform on which the package will run
     pub host_platform: Platform,
     pub host_virtual_packages: Vec<GenericVirtualPackage>,
+
+    /// The variants of the build
+    pub build_variants: BTreeMap<String, Vec<String>>,
 }
 
 impl SourceMetadataInput {
@@ -62,6 +65,7 @@ impl SourceMetadataInput {
         self.build_platform.hash(&mut hasher);
         self.build_virtual_packages.hash(&mut hasher);
         self.host_virtual_packages.hash(&mut hasher);
+        self.build_variants.hash(&mut hasher);
         format!(
             "{}-{}",
             self.host_platform,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -190,11 +190,7 @@ impl BuildContext {
             }
         }
 
-        tracing::info!(
-            "resolved variant configuration for {}: {:?}",
-            platform,
-            result
-        );
+        tracing::info!("resolved variant configuration: {:?}", result);
 
         result
     }
@@ -554,6 +550,7 @@ impl BuildContext {
         build_id: usize,
     ) -> Result<Vec<SourceRecord>, BuildError> {
         let channel_urls = channels.iter().cloned().map(Into::into).collect::<Vec<_>>();
+        let variant_configuration = self.resolve_variant(host_platform);
 
         let (cached_metadata, cache_entry) = self
             .source_metadata_cache
@@ -565,6 +562,7 @@ impl BuildContext {
                     build_virtual_packages: build_virtual_packages.clone(),
                     host_platform,
                     host_virtual_packages: host_virtual_packages.clone(),
+                    build_variants: variant_configuration.clone().into_iter().collect(),
                 },
             )
             .await?;
@@ -636,7 +634,7 @@ impl BuildContext {
                         }
                         .key(),
                     ),
-                    variant_configuration: Some(self.resolve_variant(host_platform)),
+                    variant_configuration: Some(variant_configuration),
                 },
                 metadata_reporter.as_conda_metadata_reporter().clone(),
             )


### PR DESCRIPTION
Fixes an issue where the build variants where not included in the source meta cache which caused invalid cache issues.