### PR TITLE
test: add `online_tests` feature to control Internet use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ repository.workspace = true
 version = "0.40.0"
 
 [features]
-default = ["rustls-tls"]
+default = ["online_tests", "rustls-tls"]
 native-tls = [
   "reqwest/native-tls",
   "reqwest/native-tls-alpn",
@@ -182,6 +182,8 @@ native-tls = [
   "rattler/native-tls",
   "pixi_utils/native-tls",
 ]
+# run tests connecting to remote Internet services
+online_tests = []
 rustls-tls = [
   "reqwest/rustls-tls",
   "reqwest/rustls-tls-native-roots",

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -650,6 +650,7 @@ async fn add_dependency_pinning_strategy() {
 
 /// Test adding a git dependency with a specific branch
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn add_git_deps() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -686,6 +687,7 @@ preview = ['pixi-build']
 /// during the CI run
 #[cfg(not(windows))]
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn add_git_deps_with_creds() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -722,6 +724,7 @@ preview = ['pixi-build']
 
 /// Test adding a git dependency with a specific commit
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn add_git_with_specific_commit() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -755,6 +758,7 @@ preview = ['pixi-build']"#,
 
 /// Test adding a git dependency with a specific tag
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn add_git_with_tag() {
     let pixi = PixiControl::from_manifest(
         r#"

--- a/tests/integration_rust/solve_group_tests.rs
+++ b/tests/integration_rust/solve_group_tests.rs
@@ -163,6 +163,7 @@ async fn test_purl_are_added_for_pypi() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_purl_are_missing_for_non_conda_forge() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
@@ -206,6 +207,7 @@ async fn test_purl_are_missing_for_non_conda_forge() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_purl_are_generated_using_custom_mapping() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
@@ -250,6 +252,7 @@ async fn test_purl_are_generated_using_custom_mapping() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_compressed_mapping_catch_not_pandoc_not_a_python_package() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();
@@ -290,6 +293,7 @@ async fn test_compressed_mapping_catch_not_pandoc_not_a_python_package() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_dont_record_not_present_package_as_purl() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();


### PR DESCRIPTION
Add an `online_tests` feature that specifically covers tests accessing the Internet.  It is enabled by default to preserve the existing behavior, but can be explicitly disabled when running the test suite entirely offline.

I have not added the respective feature checks to
`slow_integration_tests`, as they all seem to require Internet, so that seems redundant.

Fixes #2880