### PR TITLE
fix: Print warning when pixi manifest is not parsed in pixi search

### DIFF
--- a/schema/model.py
+++ b/schema/model.py
@@ -637,10 +637,6 @@ class BaseManifest(StrictBaseModel):
     package: Package | None = Field(None, description="The package's metadata information")
     dependencies: Dependencies = DependenciesField
     host_dependencies: Dependencies = HostDependenciesField
-    build_dependencies: Dependencies = BuildDependenciesField
-    run_dependencies: Dependencies = Field(
-        None, description="The run-dependencies for the [package]"
-    )
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
         None, description="The PyPI dependencies"
     )

--- a/schema/model.py
+++ b/schema/model.py
@@ -637,6 +637,7 @@ class BaseManifest(StrictBaseModel):
     package: Package | None = Field(None, description="The package's metadata information")
     dependencies: Dependencies = DependenciesField
     host_dependencies: Dependencies = HostDependenciesField
+    build_dependencies: Dependencies = BuildDependenciesField
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
         None, description="The PyPI dependencies"
     )

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -29,22 +29,6 @@
       "$ref": "#/$defs/Activation",
       "description": "The scripts used on the activation of the project"
     },
-    "build-dependencies": {
-      "title": "Build-Dependencies",
-      "description": "The build `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
-      "type": "object",
-      "additionalProperties": {
-        "anyOf": [
-          {
-            "type": "string",
-            "minLength": 1
-          },
-          {
-            "$ref": "#/$defs/MatchspecTable"
-          }
-        ]
-      }
-    },
     "dependencies": {
       "title": "Dependencies",
       "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
@@ -153,22 +137,6 @@
     "pypi-options": {
       "$ref": "#/$defs/PyPIOptions",
       "description": "Options related to PyPI indexes, on the default feature"
-    },
-    "run-dependencies": {
-      "title": "Run-Dependencies",
-      "description": "The run-dependencies for the [package]",
-      "type": "object",
-      "additionalProperties": {
-        "anyOf": [
-          {
-            "type": "string",
-            "minLength": 1
-          },
-          {
-            "$ref": "#/$defs/MatchspecTable"
-          }
-        ]
-      }
     },
     "system-requirements": {
       "$ref": "#/$defs/SystemRequirements",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -29,6 +29,22 @@
       "$ref": "#/$defs/Activation",
       "description": "The scripts used on the activation of the project"
     },
+    "build-dependencies": {
+      "title": "Build-Dependencies",
+      "description": "The build `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "$ref": "#/$defs/MatchspecTable"
+          }
+        ]
+      }
+    },
     "dependencies": {
       "title": "Dependencies",
       "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -134,8 +134,6 @@ pub async fn execute_impl<W: Write>(
         }
     };
 
-    println!("adwdwdd: {:?}", project);
-
     // Resolve channels from project / CLI args
     let channels = args.channels.resolve_from_project(project.as_ref())?;
     eprintln!(

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -17,10 +17,11 @@ use rattler_conda_types::{MatchSpec, PackageName, Platform, RepoDataRecord};
 use rattler_repodata_gateway::{GatewayError, RepoData};
 use regex::Regex;
 use strsim::jaro;
+use tracing::{debug, error};
 use url::Url;
 
 use super::cli_config::ChannelsConfig;
-use crate::{cli::cli_config::ProjectConfig, Project};
+use crate::{cli::cli_config::ProjectConfig, project::ProjectError, Project};
 
 /// Search a conda package
 ///
@@ -109,7 +110,31 @@ pub async fn execute_impl<W: Write>(
     args: Args,
     out: &mut W,
 ) -> miette::Result<Option<Vec<RepoDataRecord>>> {
-    let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref()).ok();
+    let project = match Project::load_or_else_discover(args.project_config.manifest_path.as_deref())
+    {
+        Ok(project) => Some(project),
+        Err(e) => {
+            match e {
+                ProjectError::FileNotFound(_)
+                | ProjectError::FileNotFoundInDirectory(_)
+                | ProjectError::NoFileFound => {
+                    debug!(
+                        "No project file found, continuing without project configuration. {}",
+                        e
+                    );
+                }
+                _ => {
+                    error!(
+                        "Error loading project configuration, continuing without: {}",
+                        e
+                    );
+                }
+            };
+            None
+        }
+    };
+
+    println!("adwdwdd: {:?}", project);
 
     // Resolve channels from project / CLI args
     let channels = args.channels.resolve_from_project(project.as_ref())?;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -169,9 +169,11 @@ pub type SourceSpecs = indexmap::IndexMap<PackageName, (SourceSpec, SpecType)>;
 pub enum ProjectError {
     #[error("no file was found at {0}")]
     FileNotFound(PathBuf),
-    #[error("could not find {project_manifest} or {pyproject_manifest} at directory {0}",
-                            project_manifest = consts::PROJECT_MANIFEST,
-                            pyproject_manifest = consts::PYPROJECT_MANIFEST)]
+    #[error(
+        "could not find {project_manifest} or {pyproject_manifest} at directory {0}",
+        project_manifest = consts::PROJECT_MANIFEST,
+        pyproject_manifest = consts::PYPROJECT_MANIFEST
+    )]
     FileNotFoundInDirectory(PathBuf),
     #[error(
         "could not find {} or {} which is configured to use {}",

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -236,7 +236,7 @@ impl Project {
     /// project root.
     pub(crate) fn discover() -> Result<Self, ProjectError> {
         let project_toml =
-            find_project_manifest(std::env::current_dir().map_err(|e| ProjectError::IoError(e))?);
+            find_project_manifest(std::env::current_dir().map_err(ProjectError::IoError)?);
 
         if let Some(project_toml) = project_toml {
             if std::env::var("PIXI_IN_SHELL").is_ok() {

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -163,8 +163,32 @@ pub type PypiDeps = indexmap::IndexMap<
 >;
 
 pub type MatchSpecs = indexmap::IndexMap<PackageName, (MatchSpec, SpecType)>;
-
 pub type SourceSpecs = indexmap::IndexMap<PackageName, (SourceSpec, SpecType)>;
+
+#[derive(thiserror::Error, Debug, miette::Diagnostic)]
+pub enum ProjectError {
+    #[error("no file was found at {0}")]
+    FileNotFound(PathBuf),
+    #[error("could not find {project_manifest} or {pyproject_manifest} at directory {0}",
+                            project_manifest = consts::PROJECT_MANIFEST,
+                            pyproject_manifest = consts::PYPROJECT_MANIFEST)]
+    FileNotFoundInDirectory(PathBuf),
+    #[error(
+        "could not find {} or {} which is configured to use {}",
+        consts::PROJECT_MANIFEST,
+        consts::PYPROJECT_MANIFEST,
+        pixi_utils::executable_name()
+    )]
+    NoFileFound,
+    #[error("failed to read project from '{0}'")]
+    ReadError(std::io::Error),
+    #[error("failed to parse project from {1}: {0}")]
+    ParseErrorWithPathBuf(miette::Report, PathBuf),
+    #[error("failed to parse project: {0}")]
+    ParseError(miette::Report),
+    #[error("io error: {0}")]
+    IoError(std::io::Error),
+}
 
 impl Project {
     /// Constructs a new instance from an internal manifest representation
@@ -208,8 +232,9 @@ impl Project {
     /// the parent directories, or use the manifest specified by the
     /// environment. This will also set the current working directory to the
     /// project root.
-    pub(crate) fn discover() -> miette::Result<Self> {
-        let project_toml = find_project_manifest(std::env::current_dir().into_diagnostic()?);
+    pub(crate) fn discover() -> Result<Self, ProjectError> {
+        let project_toml =
+            find_project_manifest(std::env::current_dir().map_err(|e| ProjectError::IoError(e))?);
 
         if let Some(project_toml) = project_toml {
             if std::env::var("PIXI_IN_SHELL").is_ok() {
@@ -230,37 +255,27 @@ impl Project {
             return Self::from_path(Path::new(env_manifest_path.as_str()));
         }
 
-        miette::bail!(
-            "could not find {} or {} which is configured to use {}",
-            consts::PROJECT_MANIFEST,
-            consts::PYPROJECT_MANIFEST,
-            pixi_utils::executable_name()
-        );
+        Err(ProjectError::NoFileFound)
     }
 
     /// Loads a project from manifest file.
-    pub fn from_path(manifest_path: &Path) -> miette::Result<Self> {
-        let manifest = Manifest::from_path(manifest_path)?;
+    pub fn from_path(manifest_path: &Path) -> Result<Self, ProjectError> {
+        let manifest = Manifest::from_path(manifest_path)
+            .map_err(|e| ProjectError::ParseErrorWithPathBuf(e, manifest_path.into()))?;
         Ok(Project::from_manifest(manifest))
     }
 
     /// Loads a project manifest file or discovers it in the current directory
     /// or any of the parent
-    pub fn load_or_else_discover(manifest_path: Option<&Path>) -> miette::Result<Self> {
+    pub fn load_or_else_discover(manifest_path: Option<&Path>) -> Result<Self, ProjectError> {
         let project = match manifest_path {
             Some(path) => {
                 if !path.exists() {
-                    miette::bail!("manifest path does not exist at {}", path.to_string_lossy());
+                    return Err(ProjectError::FileNotFound(path.to_owned()));
                 }
                 let path = if path.is_dir() {
-                    &find_project_manifest(path).ok_or_else(|| {
-                        miette::miette!(
-                            "could not find {} or {} at directory {}",
-                            consts::PROJECT_MANIFEST,
-                            consts::PYPROJECT_MANIFEST,
-                            path.to_string_lossy()
-                        )
-                    })?
+                    &find_project_manifest(path)
+                        .ok_or_else(|| ProjectError::FileNotFoundInDirectory(path.to_owned()))?
                 } else {
                     path
                 };

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -245,7 +245,7 @@ impl PixiControl {
 
     /// Loads the project manifest and returns it.
     pub fn project(&self) -> miette::Result<Project> {
-        Project::load_or_else_discover(Some(&self.manifest_path()))
+        Project::load_or_else_discover(Some(&self.manifest_path())).into_diagnostic()
     }
 
     /// Get the path to the project


### PR DESCRIPTION
Closes #2887 