### PR TITLE
feat: add deprecation notice for `depends_on`

### DIFF
--- a/crates/pixi_build_frontend/tests/diagnostics.rs
+++ b/crates/pixi_build_frontend/tests/diagnostics.rs
@@ -150,7 +150,7 @@ async fn test_invalid_backend() {
     drop(backend_rx);
     drop(backend_tx);
 
-    let (workspace, package) = TomlManifest::from_toml_str(toml)
+    let (workspace, package, _) = TomlManifest::from_toml_str(toml)
         .unwrap()
         .into_manifests(ExternalWorkspaceProperties::default())
         .unwrap();

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -13,7 +13,7 @@ use super::{
     error::{RequirementConversionError, TomlError},
     DependencyOverwriteBehavior, Feature, SpecType, WorkspaceManifest,
 };
-use crate::toml::FromTomlStr;
+use crate::toml::{FromTomlStr, Warning};
 use crate::{
     error::DependencyError,
     manifests::PackageManifest,
@@ -219,7 +219,8 @@ impl PyProjectManifest {
     #[allow(clippy::result_large_err)]
     pub fn into_manifests(
         self,
-    ) -> Result<(WorkspaceManifest, Option<PackageManifest>), PyProjectToManifestError> {
+    ) -> Result<(WorkspaceManifest, Option<PackageManifest>, Vec<Warning>), PyProjectToManifestError>
+    {
         // Load the data nested under '[tool.pixi]' as pixi manifest
         let Some(Tool {
             pixi: Some(pixi),
@@ -246,7 +247,7 @@ impl PyProjectManifest {
         // different than we expect, so the conversion is not straightforward we
         // could change these types or we can convert. Let's decide when we make it.
         // etc.
-        let (mut workspace_manifest, package_manifest) =
+        let (mut workspace_manifest, package_manifest, warnings) =
             pixi.into_manifests(ExternalWorkspaceProperties {
                 name: project.name,
                 version: project
@@ -345,7 +346,7 @@ impl PyProjectManifest {
             }
         }
 
-        Ok((workspace_manifest, package_manifest))
+        Ok((workspace_manifest, package_manifest, warnings))
     }
 }
 

--- a/crates/pixi_manifest/src/toml/deprecation.rs
+++ b/crates/pixi_manifest/src/toml/deprecation.rs
@@ -1,0 +1,45 @@
+use std::{borrow::Cow, fmt::Display};
+
+use miette::{Diagnostic, LabeledSpan, Severity, SourceSpan};
+use thiserror::Error;
+use toml_span::Span;
+
+/// A deprecation message for a field.
+#[derive(Debug, Error)]
+#[error("{message}")]
+pub struct Deprecation {
+    pub message: Cow<'static, str>,
+    pub labels: Vec<LabeledSpan>,
+    pub help: Option<Cow<'static, str>>,
+}
+
+impl Deprecation {
+    pub fn renamed_field(old_name: &str, new_name: &str, span: Span) -> Self {
+        Self {
+            message: format!(
+                "The `{}` field is deprecated. Use `{}` instead.",
+                old_name, new_name
+            )
+            .into(),
+            labels: vec![LabeledSpan::new_primary_with_span(
+                Some(format!("replace this with '{}'", new_name)),
+                SourceSpan::new(span.start.into(), span.end - span.start),
+            )],
+            help: None,
+        }
+    }
+}
+
+impl Diagnostic for Deprecation {
+    fn severity(&self) -> Option<Severity> {
+        Some(Severity::Warning)
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.help.as_ref().map(|h| Box::new(h) as Box<dyn Display>)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        Some(Box::new(self.labels.iter().cloned()))
+    }
+}

--- a/crates/pixi_manifest/src/toml/mod.rs
+++ b/crates/pixi_manifest/src/toml/mod.rs
@@ -1,5 +1,6 @@
 mod build_system;
 mod channel;
+mod deprecation;
 mod document;
 mod environment;
 mod feature;
@@ -13,10 +14,12 @@ mod pyproject;
 mod system_requirements;
 mod target;
 mod task;
+mod warning;
 mod workspace;
 
 pub use build_system::TomlPackageBuild;
 pub use channel::TomlPrioritizedChannel;
+pub use deprecation::Deprecation;
 pub use document::TomlDocument;
 pub use environment::{TomlEnvironment, TomlEnvironmentList};
 pub use feature::TomlFeature;
@@ -25,6 +28,7 @@ pub use package::{ExternalPackageProperties, PackageError, TomlPackage};
 pub use platform::TomlPlatform;
 pub use target::TomlTarget;
 use toml_span::DeserError;
+pub use warning::Warning;
 pub use workspace::{ExternalWorkspaceProperties, TomlWorkspace};
 
 use crate::TomlError;

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__depends_on_deprecation.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__depends_on_deprecation.snap
@@ -1,8 +1,8 @@
 ---
 source: crates/pixi_manifest/src/toml/task.rs
-expression: "format_parse_error(input, result)"
+expression: "format_parse_error(input, parsed.warnings.remove(0))"
 ---
-  × field 'depends_on' is deprecated, 'depends-on' has replaced it
+  ⚠ The `depends_on` field is deprecated. Use `depends-on` instead.
    ╭─[pixi.toml:3:9]
  2 │         cmd = "test"
  3 │         depends_on = ["a", "b"]

--- a/crates/pixi_manifest/src/toml/warning.rs
+++ b/crates/pixi_manifest/src/toml/warning.rs
@@ -1,0 +1,31 @@
+use crate::toml::deprecation::Deprecation;
+use miette::Diagnostic;
+use thiserror::Error;
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum Warning {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Deprecation(#[from] Deprecation),
+}
+
+#[derive(Debug)]
+pub struct WithWarnings<T> {
+    pub value: T,
+    pub warnings: Vec<Warning>,
+}
+
+impl<T> WithWarnings<T> {
+    pub fn with_warnings(self, warnings: Vec<Warning>) -> Self {
+        Self { warnings, ..self }
+    }
+}
+
+impl<T> From<T> for WithWarnings<T> {
+    fn from(value: T) -> Self {
+        Self {
+            value,
+            warnings: Vec::new(),
+        }
+    }
+}

--- a/crates/pixi_manifest/src/utils/test_utils.rs
+++ b/crates/pixi_manifest/src/utils/test_utils.rs
@@ -1,10 +1,7 @@
 use itertools::Itertools;
 use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource, Report};
 
-use crate::{
-    toml::{ExternalWorkspaceProperties, FromTomlStr, TomlManifest},
-    TomlError,
-};
+use crate::toml::{ExternalWorkspaceProperties, FromTomlStr, TomlManifest};
 
 /// A helper function that generates a snapshot of the error message when
 /// parsing a manifest TOML. The error is returned.

--- a/crates/pixi_manifest/src/utils/test_utils.rs
+++ b/crates/pixi_manifest/src/utils/test_utils.rs
@@ -1,9 +1,8 @@
 use itertools::Itertools;
 use miette::{GraphicalReportHandler, GraphicalTheme, NamedSource, Report};
 
-use crate::toml::FromTomlStr;
 use crate::{
-    toml::{ExternalWorkspaceProperties, TomlManifest},
+    toml::{ExternalWorkspaceProperties, FromTomlStr, TomlManifest},
     TomlError,
 };
 
@@ -18,8 +17,9 @@ pub(crate) fn expect_parse_failure(pixi_toml: &str) -> String {
     format_parse_error(pixi_toml, parse_error)
 }
 
-/// Format a TOML parse error into a string that can be used to generate snapshots.
-pub(crate) fn format_parse_error(source: &str, error: TomlError) -> String {
+/// Format a TOML parse error into a string that can be used to generate
+/// snapshots.
+pub(crate) fn format_parse_error(source: &str, error: impl Into<Report>) -> String {
     // Disable colors in tests
     let mut s = String::new();
     let report_handler = GraphicalReportHandler::new()
@@ -29,7 +29,8 @@ pub(crate) fn format_parse_error(source: &str, error: TomlError) -> String {
     report_handler
         .render_report(
             &mut s,
-            Report::from(error)
+            error
+                .into()
                 .with_source_code(NamedSource::new("pixi.toml", source.to_string()))
                 .as_ref(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,14 @@
-#[tokio::main]
-pub async fn main() -> miette::Result<()> {
-    pixi::cli::execute().await
+pub fn main() -> miette::Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed building the Runtime");
+
+    // Box the large main future to avoid stack overflows.
+    let result = runtime.block_on(Box::pin(pixi::cli::execute()));
+
+    // Avoid waiting for pending tasks to complete.
+    runtime.shutdown_background();
+
+    result
 }


### PR DESCRIPTION
This PR reverts the deprecation error on `depends_on` in favor of a deprecation warning. 

We did not really have a way to signal warnings like deprecations in the manifest. This PR adds a simple mechanism to collect warnings during parsing. These warnings are emitted after the project is parsed. Im a little unsure whether it makes sense to just emit them or if we should add a method to emit them. 

An example when running `pixi list --no-install` on the holoviews repository.

```
 WARN Encountered 2 warnings while parsing the manifest:

  ⚠ The `depends_on` field is deprecated. Use `depends-on` instead.
     ╭─[pixi.toml:136:1]
 135 │ cmd = 'pytest holoviews/tests/ui --ui --browser chromium'
 136 │ depends_on = ["_install-ui"]
     · ─────┬────
     ·      ╰── replace this with 'depends-on'
 137 │
     ╰────


  ⚠ The `depends_on` field is deprecated. Use `depends-on` instead.
     ╭─[pixi.toml:180:1]
 179 │ [feature.doc.tasks.docs-build]
 180 │ depends_on = ['_docs-generate-rst', '_docs-refmanual', '_docs-generate']
     · ─────┬────
     ·      ╰── replace this with 'depends-on'
 181 │
     ╰────
```

Fixes: https://github.com/prefix-dev/pixi/issues/2888