### PR TITLE
refactor: spawn main entrypoint in box

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,14 @@
-#[tokio::main]
-pub async fn main() -> miette::Result<()> {
-    pixi::cli::execute().await
+pub fn main() -> miette::Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("Failed building the Runtime");
+
+    // Box the large main future to avoid stack overflows.
+    let result = runtime.block_on(Box::pin(pixi::cli::execute()));
+
+    // Avoid waiting for pending tasks to complete.
+    runtime.shutdown_background();
+
+    result
 }


### PR DESCRIPTION
When running a debug build on windows you often get "stackoverflow" errors when starting pixi. This is because the default stacksize on windows is smaller than on other operating systems. This PR works around this issue by boxing the main entrypoint future instead which effectively moves it to the heap.