### PR TITLE
ci: bump timeout for macOS x86_64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
   cargo-test-macos-x86_64:
     name: "cargo test | macos x86_64"
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
     runs-on: macos-13


### PR DESCRIPTION
We noticed that 15 minutes is sometimes not enough for this architecture