### PR TITLE
docs: add more activation documentation

### DIFF
--- a/docs/features/environment.md
+++ b/docs/features/environment.md
@@ -120,6 +120,12 @@ It sets the `PATH` and some more environment variables. But more importantly it 
 An example of this would be the [`libglib_activate.sh`](https://github.com/conda-forge/glib-feedstock/blob/52ba1944dffdb2d882d824d6548325155b58819b/recipe/scripts/activate.sh) script.
 Thus, just adding the `bin` directory to the `PATH` is not enough.
 
+You can modify the activation with the `activation` table in the manifest, you can add more activation scripts or inject environment variables into the activation scripts.
+```toml
+--8<-- "docs/source_files/pixi_tomls/activation.toml:activation"
+```
+Find the reference for the `activation` table [here](../reference/pixi_manifest.md#the-activation-table).
+
 ## Traditional `conda activate`-like activation
 
 If you prefer to use the traditional `conda activate`-like activation, you could use the `pixi shell-hook` command.

--- a/docs/source_files/pixi_tomls/activation.toml
+++ b/docs/source_files/pixi_tomls/activation.toml
@@ -1,0 +1,29 @@
+[project]
+channels = []
+name = "activation"
+platforms = ["linux-64"]
+
+# --8<-- [start:activation]
+[activation.env]
+# Python users often set:
+PYTHONIOENCODING = "utf-8"
+PYTHONNOUSERSITE = "1"
+# R users often set:
+PIXI_R_LIBS = "$CONDA_PREFIX/lib/R/library"
+R_LIBS = "$PIXI_R_LIBS"
+R_LIBS_USER = "$PIXI_R_LIBS"
+
+
+[activation]
+# Use sh scripts on unix
+scripts = [
+  # Common in the ROS workspaces
+  "install/setup.sh",
+  # Want to add some personall scripts to the activation:
+  "activation.sh",
+]
+
+# Use batch scripts on windows
+[target.win.activation]
+scripts = ["install/setup.bat"]
+# --8<-- [end:activation]


### PR DESCRIPTION
Triggered by https://github.com/prefix-dev/pixi/issues/2859

Thought this might be missing from the activation story in that file