### PR TITLE
ci: Trigger workflow also when label has been added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
   pull_request:
+    types:
+      - labeled
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
This helps us e.g. when we add the "extra_slow" label