### PR TITLE
fix: `pixi run --help`

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -26,8 +26,7 @@ use tracing::Level;
 
 /// Runs task in project.
 #[derive(Parser, Debug, Default)]
-#[clap(trailing_var_arg = true)]
-#[clap(disable_help_flag = true)]
+#[clap(trailing_var_arg = true, disable_help_flag = true)]
 pub struct Args {
     /// The pixi task or a task shell command you want to run in the project's
     /// environment, which can be an executable in the environment's PATH.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -27,6 +27,7 @@ use tracing::Level;
 /// Runs task in project.
 #[derive(Parser, Debug, Default)]
 #[clap(trailing_var_arg = true)]
+#[clap(disable_help_flag = true)]
 pub struct Args {
     /// The pixi task or a task shell command you want to run in the project's
     /// environment, which can be an executable in the environment's PATH.
@@ -55,6 +56,12 @@ pub struct Args {
     /// Don't run the dependencies of the task ('depends-on' field in the task definition)
     #[arg(long)]
     pub skip_deps: bool,
+
+    #[clap(long, action = clap::ArgAction::HelpLong)]
+    pub help: Option<bool>,
+
+    #[clap(short, action = clap::ArgAction::HelpShort)]
+    pub h: Option<bool>,
 }
 
 /// CLI entry point for `pixi run`

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -341,6 +341,13 @@ def test_run_help(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
     assert len(help_long) > len(help_short)
 
+    help_run = verify_cli_command(
+        [pixi, "help", "run"],
+        stdout_contains="pixi run [OPTIONS]",
+    ).stdout
+
+    assert help_run == help_long
+
     verify_cli_command(
         [pixi, "run", "python", "--help"],
         stdout_contains="python [option]",

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -323,3 +323,25 @@ def test_detached_environments_run(pixi: Path, tmp_path: Path, dummy_channel_1: 
         [pixi, "run", "--manifest-path", manifest, "echo $CONDA_PREFIX"],
         stdout_contains=f"{detached_envs_tmp}",
     )
+
+
+def test_run_help(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    manifest.write_text(EMPTY_BOILERPLATE_PROJECT)
+
+    help_long = verify_cli_command(
+        [pixi, "run", "--help"],
+        stdout_contains="pixi run [OPTIONS]",
+    ).stdout
+
+    help_short = verify_cli_command(
+        [pixi, "run", "-h"],
+        stdout_contains="pixi run [OPTIONS]",
+    ).stdout
+
+    assert len(help_long) > len(help_short)
+
+    verify_cli_command(
+        [pixi, "run", "python", "--help"],
+        stdout_contains="python [option]",
+    )

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -331,24 +331,24 @@ def test_run_help(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
     help_long = verify_cli_command(
         [pixi, "run", "--help"],
-        stdout_contains="pixi run [OPTIONS]",
+        stdout_contains="pixi run",
     ).stdout
 
     help_short = verify_cli_command(
         [pixi, "run", "-h"],
-        stdout_contains="pixi run [OPTIONS]",
+        stdout_contains="pixi run",
     ).stdout
 
     assert len(help_long) > len(help_short)
 
     help_run = verify_cli_command(
         [pixi, "help", "run"],
-        stdout_contains="pixi run [OPTIONS]",
+        stdout_contains="pixi run",
     ).stdout
 
     assert help_run == help_long
 
     verify_cli_command(
         [pixi, "run", "python", "--help"],
-        stdout_contains="python [option]",
+        stdout_contains="python",
     )


### PR DESCRIPTION
`pixi run --help` and `pixi run -h` already worked. However `pixi run python --help` returned the help of `pixi run` instead of the one from python