### PR TITLE
fix: stackoverflow when running pixi in debug mode on windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,57 @@
-// This forces the crate to be compiled even though the crate is not used in the project.
-// https://github.com/rust-lang/rust/issues/64402
+// This forces the crate to be compiled even though the crate is not used in the
+// project. https://github.com/rust-lang/rust/issues/64402
 #[cfg(feature = "pixi_allocator")]
 extern crate pixi_allocator;
 
 pub fn main() -> miette::Result<()> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("Failed building the Runtime");
+    // We often run out of stack space when running the CLI. This is especially an
+    // issue for debug builds.
+    //
+    // Non-main threads should all have 2MB, as Rust forces platform consistency.
+    // The default can be overridden with the RUST_MIN_STACK environment variable if
+    // you need more.
+    //
+    // However, the real issue is the main thread. There is a large variety here
+    // across platforms and it's harder to control (which is why Rust doesn't
+    // normalize is by default). Notably on macOS and Linux you will typically get
+    // 8MB for the main thread, while on Windows we only get 1MB, which is tiny in
+    // comparison:
+    // https://learn.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=msvc-170
+    //
+    // To normalize this we spawn an additional thread called `main2` with a size we
+    // can set ourselves. 2MB tends to be too small (especially for debug builds).
+    // 4MB seems fine. The code also tries to respect RUST_MIN_STACK if it is set,
+    // which allows overriding the defaults. We don't allow stack sizes smaller than
+    // 4MB to avoid misconfiguration since we know we use quite a bit of stack
+    // space.
+    let main_stack_size = std::env::var("RUST_MIN_STACK")
+        .ok()
+        .and_then(|var| var.parse::<usize>().ok())
+        .unwrap_or(0)
+        .max(4 * 1024 * 1024);
 
-    // Box the large main future to avoid stack overflows.
-    let result = runtime.block_on(Box::pin(pixi::cli::execute()));
+    let main2 = move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed building the Runtime");
 
-    // Avoid waiting for pending tasks to complete.
-    runtime.shutdown_background();
+        // Box the large main future to avoid stack overflows.
+        let result = runtime.block_on(Box::pin(pixi::cli::execute()));
+
+        // Avoid waiting for pending tasks to complete.
+        runtime.shutdown_background();
+
+        result
+    };
+
+    let result = std::thread::Builder::new()
+        .name("main2".to_string())
+        .stack_size(main_stack_size)
+        .spawn(main2)
+        .expect("Tokio executor failed, was there a panic?")
+        .join()
+        .expect("Tokio executor failed, was there a panic?");
 
     result
 }


### PR DESCRIPTION
I'm still running into stack overflow issues when running pixi in debug mode on windows. This is mostly caused by the fact that windows has a 1MB stack size for the main thread. Which is relatively small to the 8MB on macOS and Linux.

Apparently, there is a not very well-documented environment variable to set the stack size of threads called `RUST_MIN_STACK`. But this only sets the stack-size for newly spawned threads while the issues happens on the main thread. I noticed uv very recently worked around this issue to spawn an additional main thread from which the entire application is ran. Pretty clever, so I implemented the same behavior for pixi. 

Now I can finally run pixi again in debug mode. 🥳 