### PR TITLE
fix: pixi init

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -565,10 +565,6 @@ mod tests {
             std::env::current_dir().unwrap()
         );
         assert_eq!(
-            get_dir(PathBuf::from("test_folder")).unwrap(),
-            std::env::current_dir().unwrap().join("test_folder")
-        );
-        assert_eq!(
             get_dir(std::env::current_dir().unwrap()).unwrap(),
             std::env::current_dir().unwrap().canonicalize().unwrap()
         );

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -531,7 +531,7 @@ fn create_or_append_file(path: &Path, template: &str) -> std::io::Result<()> {
 }
 
 fn get_dir(path: PathBuf) -> Result<PathBuf, Error> {
-    dunce::canonicalize(&path).map_err(|e| match e.kind() {
+    path.canonicalize().map_err(|e| match e.kind() {
         ErrorKind::NotFound => Error::new(
             ErrorKind::NotFound,
             format!(

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -182,6 +182,8 @@ pixi.lock gitlab-language=yaml gitlab-generated=true
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let env = Environment::new();
+    // Fail silently if the directory already exists or cannot be created.
+    fs_err::create_dir_all(&args.path).ok();
     let dir = get_dir(args.path).into_diagnostic()?;
     let pixi_manifest_path = dir.join(consts::PROJECT_MANIFEST);
     let pyproject_manifest_path = dir.join(consts::PYPROJECT_MANIFEST);
@@ -198,9 +200,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             console::style("--format pyproject").bold().green(),
         );
     }
-
-    // Fail silently if the directory already exists or cannot be created.
-    fs_err::create_dir_all(&dir).ok();
 
     let default_name = get_name_from_dir(&dir).unwrap_or_else(|_| String::from("new_project"));
     let version = "0.1.0";
@@ -532,23 +531,19 @@ fn create_or_append_file(path: &Path, template: &str) -> std::io::Result<()> {
 }
 
 fn get_dir(path: PathBuf) -> Result<PathBuf, Error> {
-    if path.components().count() == 1 {
-        Ok(std::env::current_dir().unwrap_or_default().join(path))
-    } else {
-        path.canonicalize().map_err(|e| match e.kind() {
-            ErrorKind::NotFound => Error::new(
-                ErrorKind::NotFound,
-                format!(
-                    "Cannot find '{}' please make sure the folder is reachable",
-                    path.to_string_lossy()
-                ),
+    dunce::canonicalize(&path).map_err(|e| match e.kind() {
+        ErrorKind::NotFound => Error::new(
+            ErrorKind::NotFound,
+            format!(
+                "Cannot find '{}' please make sure the folder is reachable",
+                path.to_string_lossy()
             ),
-            _ => Error::new(
-                ErrorKind::InvalidInput,
-                "Cannot canonicalize the given path",
-            ),
-        })
-    }
+        ),
+        _ => Error::new(
+            ErrorKind::InvalidInput,
+            "Cannot canonicalize the given path",
+        ),
+    })
 }
 
 #[cfg(test)]
@@ -577,14 +572,6 @@ mod tests {
             get_dir(std::env::current_dir().unwrap()).unwrap(),
             std::env::current_dir().unwrap().canonicalize().unwrap()
         );
-    }
-
-    #[test]
-    fn test_get_name_panic() {
-        match get_dir(PathBuf::from("invalid/path")) {
-            Ok(_) => panic!("Expected error, but got OK"),
-            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
-        }
     }
 
     #[test]

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -1,8 +1,10 @@
+from contextlib import contextmanager
 from enum import IntEnum
 from pathlib import Path
 import platform
 import subprocess
 import os
+from typing import Generator
 
 from rattler import Platform
 
@@ -140,3 +142,13 @@ def get_manifest(directory: Path) -> Path:
         return pyproject_toml
     else:
         raise ValueError("Neither pixi.toml nor pyproject.toml found")
+
+
+@contextmanager
+def cwd(path: str | Path) -> Generator[None, None, None]:
+    oldpwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(oldpwd)

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from .common import verify_cli_command, ExitCode, PIXI_VERSION, CURRENT_PLATFORM
+from .common import cwd, verify_cli_command, ExitCode, PIXI_VERSION, CURRENT_PLATFORM
 import tomllib
 import json
 import pytest
@@ -311,6 +311,37 @@ def test_simple_project_setup(pixi: Path, tmp_pixi_workspace: Path) -> None:
         ExitCode.SUCCESS,
         stderr_contains=["osx-arm64", "test", "Removed"],
     )
+
+
+def test_pixi_init_cwd(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    # Change directory to workspace
+    with cwd(tmp_pixi_workspace):
+        # Create a new project
+        verify_cli_command([pixi, "init", "."], ExitCode.SUCCESS)
+
+        # Verify that the manifest file is created
+        manifest_path = tmp_pixi_workspace / "pixi.toml"
+        assert manifest_path.exists()
+
+        # Verify that the manifest file contains expected content
+        manifest_content = manifest_path.read_text()
+        assert "[project]" in manifest_content
+
+
+def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    # Specify project dir
+    project_dir = tmp_pixi_workspace / "project_dir"
+
+    # Create a new project
+    verify_cli_command([pixi, "init", project_dir], ExitCode.SUCCESS)
+
+    # Verify that the manifest file is created
+    manifest_path = project_dir / "pixi.toml"
+    assert manifest_path.exists()
+
+    # Verify that the manifest file contains expected content
+    manifest_content = manifest_path.read_text()
+    assert "[project]" in manifest_content
 
 
 @pytest.mark.slow


### PR DESCRIPTION
On my system, `pixi init some_folder` didn't work anymore if `some_folder` didn't exist.
I can confirm that `test_pixi_init_non_existing_dir` fails on my machine without the Rust code changes, and works with them.