### PR TITLE
chore: pixi build manifest error print full path

### DIFF
--- a/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
@@ -34,8 +34,7 @@ pub struct ProtocolBuilder {
 
 #[derive(thiserror::Error, Debug, Diagnostic)]
 pub enum ProtocolBuildError {
-    #[error("failed to setup a build backend, the {} could not be parsed", .0.file_name().and_then(std::ffi::OsStr::to_str).unwrap_or("manifest")
-    )]
+    #[error("failed to setup a build backend, the {0} could not be parsed")]
     #[diagnostic(help("Ensure that the manifest at '{}' is a valid pixi project manifest", .0.display()
     ))]
     FailedToParseManifest(PathBuf, #[diagnostic_source] miette::Report),

--- a/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/pixi.rs
@@ -34,7 +34,7 @@ pub struct ProtocolBuilder {
 
 #[derive(thiserror::Error, Debug, Diagnostic)]
 pub enum ProtocolBuildError {
-    #[error("failed to setup a build backend, the {0} could not be parsed")]
+    #[error("failed to setup a build backend, failed to parse {0}")]
     #[diagnostic(help("Ensure that the manifest at '{}' is a valid pixi project manifest", .0.display()
     ))]
     FailedToParseManifest(PathBuf, #[diagnostic_source] miette::Report),

--- a/crates/pixi_build_frontend/tests/snapshots/diagnostics__invalid_manifest.snap
+++ b/crates/pixi_build_frontend/tests/snapshots/diagnostics__invalid_manifest.snap
@@ -2,7 +2,7 @@
 source: crates/pixi_build_frontend/tests/diagnostics.rs
 expression: snapshot
 ---
-  × failed to setup a build backend, the pixi.toml could not be parsed
+  × failed to setup a build backend, failed to parse [SOURCE_DIR]/pixi.toml
   ╰─▶   × missing field 'channels' in table
          ╭─[pixi.toml:1:1]
        1 │ [workspace]


### PR DESCRIPTION
I spend too much time on finding the file from the error. This will avoid that lost time, next time.

From:
```
  × failed to setup a build backend, the pyproject.toml could not be parsed
```

To:
```
  × failed to setup a build backend, the /Users/rubenarts/examples/ros_workspace/src/talker/pyproject.toml could not be parsed
```