### PR TITLE
fix: `pixi list` should print the git location instead of the wheel

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -345,8 +345,8 @@ fn json_packages(packages: &Vec<PackageToOutput>, json_pretty: bool) {
     println!("{}", json_string);
 }
 
-// Helper function to handle PyPI location logic
-fn handle_pypi_location(location: &UrlOrPath) -> (Option<u64>, Option<String>) {
+/// Return the size and source location of the pypi package
+fn get_pypi_location_information(location: &UrlOrPath) -> (Option<u64>, Option<String>) {
     match location {
         UrlOrPath::Url(url) => (None, Some(url.to_string())),
         UrlOrPath::Path(path) => (
@@ -391,10 +391,10 @@ fn create_package_to_output<'a, 'b>(
                     let name = entry.map(|e| e.dist.filename.to_string());
                     (size, name)
                 } else {
-                    handle_pypi_location(&p.location)
+                    get_pypi_location_information(&p.location)
                 }
             } else {
-                handle_pypi_location(&p.location)
+                get_pypi_location_information(&p.location)
             }
         }
     };


### PR DESCRIPTION
While reviewing #2960 I found that `pixi list` doesn't print the correct information

Before:
```
> pixi list -x
Package      Version  Build               Size      Kind   Source
python       3.12.8   hc22306f_1_cpython  12.4 MiB  conda  python
sphinx_tags  0.4                          19.2 KiB  pypi   sphinx_tags-0.4-py2.py3-none-any.whl
```

After:
```
> pixi list -x
Package      Version  Build               Size      Kind   Source
python       3.12.8   hc22306f_1_cpython  12.4 MiB  conda  python
sphinx_tags  0.4                                    pypi   git+https://github.com/beenje/sphinx-tags.git@490f40f0042792ca410c249e195f29c96e33b25b
```