### PR TITLE
docs: fix ambiguous version specifiers

### DIFF
--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -105,10 +105,10 @@ mod tests {
         {PROJECT_BOILERPLATE}
 
         [target.win-64.dependencies]
-        foo = "3.4.5"
+        foo = "==3.4.5"
 
         [target.osx-64.dependencies]
-        foo = "1.2.3"
+        foo = "==1.2.3"
         "#
         );
 

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -370,7 +370,7 @@ Some examples are:
 
 ```toml
 # Use this exact package version
-package0 = "1.2.3"
+package0 = "==1.2.3"
 # Use 1.2.3 up to 1.3.0
 package1 = "~=1.2.3"
 # Use larger than 1.2 lower and equal to 1.4
@@ -402,7 +402,7 @@ Even if the dependency defines a channel that channel should be added to the `pr
 ```toml
 [dependencies]
 python = ">3.9,<=3.11"
-rust = "1.72"
+rust = "==1.72"
 pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
 ```
 


### PR DESCRIPTION
As discussed in https://github.com/prefix-dev/pixi/issues/2964#issuecomment-2604253502