### PR TITLE
ci: run workflow on opened PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     types:
       - labeled
       - synchronize
+      - opened
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
I've noticed that newly opened PRs don't trigger a CI workflow. This change ~~hopefully~~ fixes that