### PR TITLE
feat: Set PS1 in shell-hook too

### DIFF
--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -16,7 +16,7 @@ use crate::{
     Project, UpdateLockFileOptions,
 };
 use pixi_config::{ConfigCliActivation, ConfigCliPrompt};
-use pixi_manifest::EnvironmentName;
+
 #[cfg(target_family = "unix")]
 use pixi_pty::unix::PtySession;
 
@@ -238,11 +238,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     verify_current_platform_has_required_virtual_packages(&environment).into_diagnostic()?;
 
-    let prompt_name = match environment.name() {
-        EnvironmentName::Default => project.name().to_string(),
-        EnvironmentName::Named(name) => format!("{}:{}", project.name(), name),
-    };
-
     // Make sure environment is up-to-date, default to install, users can avoid this with frozen or locked.
     let (lock_file_data, _prefix) = get_update_lock_file_and_prefix(
         &environment,
@@ -275,25 +270,22 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     tracing::info!("Starting shell: {:?}", interactive_shell);
 
-    let prompt = if project.config().change_ps1() {
-        match interactive_shell {
-            ShellEnum::NuShell(_) => prompt::get_nu_prompt(prompt_name.as_str()),
-            ShellEnum::PowerShell(_) => prompt::get_powershell_prompt(prompt_name.as_str()),
-            ShellEnum::Bash(_) => prompt::get_bash_hook(prompt_name.as_str()),
-            ShellEnum::Zsh(_) => prompt::get_zsh_hook(prompt_name.as_str()),
-            ShellEnum::Fish(_) => prompt::get_fish_prompt(prompt_name.as_str()),
-            ShellEnum::Xonsh(_) => prompt::get_xonsh_prompt(),
-            ShellEnum::CmdExe(_) => prompt::get_cmd_prompt(prompt_name.as_str()),
-        }
+    let prompt_hook = if project.config().change_ps1() {
+        let prompt_name = prompt::get_prompt_name(project.name(), environment.name());
+        format!(
+            "{}\n{}",
+            prompt::get_prompt_for_shell(&interactive_shell, prompt_name.as_str()),
+            prompt::get_hook_for_shell(&interactive_shell),
+        )
     } else {
         "".to_string()
     };
 
     #[cfg(target_family = "windows")]
     let res = match interactive_shell {
-        ShellEnum::NuShell(nushell) => start_nu_shell(nushell, env, prompt).await,
-        ShellEnum::PowerShell(pwsh) => start_powershell(pwsh, env, prompt),
-        ShellEnum::CmdExe(cmdexe) => start_cmdexe(cmdexe, env, prompt),
+        ShellEnum::NuShell(nushell) => start_nu_shell(nushell, env, prompt_hook).await,
+        ShellEnum::PowerShell(pwsh) => start_powershell(pwsh, env, prompt_hook),
+        ShellEnum::CmdExe(cmdexe) => start_cmdexe(cmdexe, env, prompt_hook),
         _ => {
             miette::bail!("Unsupported shell: {:?}", interactive_shell);
         }
@@ -301,12 +293,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     #[cfg(target_family = "unix")]
     let res = match interactive_shell {
-        ShellEnum::NuShell(nushell) => start_nu_shell(nushell, env, prompt).await,
-        ShellEnum::PowerShell(pwsh) => start_powershell(pwsh, env, prompt),
-        ShellEnum::Bash(bash) => start_unix_shell(bash, vec!["-l", "-i"], env, prompt).await,
-        ShellEnum::Zsh(zsh) => start_unix_shell(zsh, vec!["-l", "-i"], env, prompt).await,
-        ShellEnum::Fish(fish) => start_unix_shell(fish, vec![], env, prompt).await,
-        ShellEnum::Xonsh(xonsh) => start_unix_shell(xonsh, vec![], env, prompt).await,
+        ShellEnum::NuShell(nushell) => start_nu_shell(nushell, env, prompt_hook).await,
+        ShellEnum::PowerShell(pwsh) => start_powershell(pwsh, env, prompt_hook),
+        ShellEnum::Bash(bash) => start_unix_shell(bash, vec!["-l", "-i"], env, prompt_hook).await,
+        ShellEnum::Zsh(zsh) => start_unix_shell(zsh, vec!["-l", "-i"], env, prompt_hook).await,
+        ShellEnum::Fish(fish) => start_unix_shell(fish, vec![], env, prompt_hook).await,
+        ShellEnum::Xonsh(xonsh) => start_unix_shell(xonsh, vec![], env, prompt_hook).await,
         _ => {
             miette::bail!("Unsupported shell: {:?}", interactive_shell)
         }

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -271,14 +271,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     tracing::info!("Starting shell: {:?}", interactive_shell);
 
     let prompt_hook = if project.config().change_ps1() {
-        let prompt_name = prompt::get_prompt_name(project.name(), environment.name());
-        format!(
-            "{}\n{}",
-            prompt::get_prompt_for_shell(&interactive_shell, prompt_name.as_str()),
-            prompt::get_hook_for_shell(&interactive_shell),
-        )
+        let prompt_name = prompt::prompt_name(project.name(), environment.name());
+        [
+            prompt::shell_prompt(&interactive_shell, prompt_name.as_str()),
+            prompt::shell_hook(&interactive_shell)
+                .unwrap_or_default()
+                .to_owned(),
+        ]
+        .join("\n")
     } else {
-        "".to_string()
+        String::new()
     };
 
     #[cfg(target_family = "windows")]

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -17,9 +17,8 @@ use crate::environment::get_update_lock_file_and_prefix;
 use crate::{
     activation::get_activator,
     cli::cli_config::{PrefixUpdateConfig, ProjectConfig},
-    prompt,
     project::{Environment, HasProjectRef},
-    Project, UpdateLockFileOptions,
+    prompt, Project, UpdateLockFileOptions,
 };
 
 /// Print the pixi environment activation script.
@@ -59,7 +58,6 @@ struct ShellEnv<'a> {
     environment_variables: &'a HashMap<String, String>,
 }
 
-
 fn get_shell(shell: Option<ShellEnum>) -> ShellEnum {
     // Get shell from the arguments or from the current process or use default if
     // all fails
@@ -74,7 +72,6 @@ async fn generate_activation_script(
     shell: ShellEnum,
     environment: &Environment<'_>,
 ) -> miette::Result<String> {
-
     let activator = get_activator(environment, shell).into_diagnostic()?;
 
     let path = std::env::var("PATH")
@@ -158,7 +155,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             let shell = get_shell(args.shell);
             let script = generate_activation_script(shell.clone(), &environment).await?;
             let in_shell = match std::env::var("PIXI_IN_SHELL") {
-                Ok(val) => val != "0" && val != "",
+                Ok(val) => val != "0" && !val.is_empty(),
                 Err(_) => false,
             };
             if project.config().change_ps1() && !in_shell {
@@ -179,7 +176,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             } else {
                 script
             }
-        },
+        }
     };
 
     // Print the output - either a JSON object or a shell script
@@ -207,12 +204,10 @@ mod tests {
         assert!(script.contains(&format!("export {path_var_name}=")));
         assert!(script.contains("export CONDA_PREFIX="));
 
-        let script = generate_activation_script(
-            ShellEnum::PowerShell(PowerShell::default()),
-            &environment,
-        )
-        .await
-        .unwrap();
+        let script =
+            generate_activation_script(ShellEnum::PowerShell(PowerShell::default()), &environment)
+                .await
+                .unwrap();
         assert!(script.contains(&format!("${{Env:{path_var_name}}}")));
         assert!(script.contains("${Env:CONDA_PREFIX}"));
 

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -58,21 +58,20 @@ struct ShellEnv<'a> {
     environment_variables: &'a HashMap<String, String>,
 }
 
-fn get_shell(shell: Option<ShellEnum>) -> ShellEnum {
-    // Get shell from the arguments or from the current process or use default if
-    // all fails
-    shell.unwrap_or_else(|| {
-        ShellEnum::from_parent_process()
-            .unwrap_or_else(|| ShellEnum::from_env().unwrap_or_default())
-    })
-}
-
 /// Generates the activation script.
 async fn generate_activation_script(
-    shell: ShellEnum,
+    shell: Option<ShellEnum>,
     environment: &Environment<'_>,
+    project: &Project,
 ) -> miette::Result<String> {
-    let activator = get_activator(environment, shell).into_diagnostic()?;
+    // Get shell from the arguments or from the current process or use default if
+    // all fails
+    let shell = shell.unwrap_or_else(|| {
+        ShellEnum::from_parent_process()
+            .unwrap_or_else(|| ShellEnum::from_env().unwrap_or_default())
+    });
+
+    let activator = get_activator(environment, shell.clone()).into_diagnostic()?;
 
     let path = std::env::var("PATH")
         .ok()
@@ -89,7 +88,26 @@ async fn generate_activation_script(
         })
         .into_diagnostic()?;
 
-    result.script.contents().into_diagnostic()
+    let script = result.script.contents().into_diagnostic();
+
+    if project.config().change_ps1() {
+        let prompt_name = match environment.name() {
+            EnvironmentName::Default => project.name().to_string(),
+            EnvironmentName::Named(name) => format!("{}:{}", project.name(), name),
+        };
+        let prompt = match shell {
+            ShellEnum::NuShell(_) => prompt::get_nu_prompt(prompt_name.as_str()),
+            ShellEnum::PowerShell(_) => prompt::get_powershell_prompt(prompt_name.as_str()),
+            ShellEnum::Bash(_) => prompt::get_posix_prompt(prompt_name.as_str()),
+            ShellEnum::Zsh(_) => prompt::get_posix_prompt(prompt_name.as_str()),
+            ShellEnum::Fish(_) => prompt::get_fish_prompt(prompt_name.as_str()),
+            ShellEnum::Xonsh(_) => prompt::get_xonsh_prompt(),
+            ShellEnum::CmdExe(_) => prompt::get_cmd_prompt(prompt_name.as_str()),
+        };
+        Ok(format!("{}\n{}", script?, prompt))
+    } else {
+        script
+    }
 }
 
 /// Generates a JSON object describing the changes to the shell environment when
@@ -151,32 +169,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
         // Skipping the activated environment caching for the script.
         // As it can still run scripts.
-        false => {
-            let shell = get_shell(args.shell);
-            let script = generate_activation_script(shell.clone(), &environment).await?;
-            let in_shell = match std::env::var("PIXI_IN_SHELL") {
-                Ok(val) => val != "0" && !val.is_empty(),
-                Err(_) => false,
-            };
-            if project.config().change_ps1() && !in_shell {
-                let prompt_name = match environment.name() {
-                    EnvironmentName::Default => project.name().to_string(),
-                    EnvironmentName::Named(name) => format!("{}:{}", project.name(), name),
-                };
-                let prompt = match shell {
-                    ShellEnum::NuShell(_) => prompt::get_nu_prompt(prompt_name.as_str()),
-                    ShellEnum::PowerShell(_) => prompt::get_powershell_prompt(prompt_name.as_str()),
-                    ShellEnum::Bash(_) => prompt::get_posix_prompt(prompt_name.as_str()),
-                    ShellEnum::Zsh(_) => prompt::get_posix_prompt(prompt_name.as_str()),
-                    ShellEnum::Fish(_) => prompt::get_fish_prompt(prompt_name.as_str()),
-                    ShellEnum::Xonsh(_) => prompt::get_xonsh_prompt(),
-                    ShellEnum::CmdExe(_) => prompt::get_cmd_prompt(prompt_name.as_str()),
-                };
-                format!("{}\n{}", script, prompt)
-            } else {
-                script
-            }
-        }
+        false => generate_activation_script(args.shell, &environment, &project).await?,
     };
 
     // Print the output - either a JSON object or a shell script
@@ -198,46 +191,54 @@ mod tests {
         let path_var_name = default_shell.path_var(&Platform::current());
         let project = Project::discover().unwrap();
         let environment = project.default_environment();
-        let script = generate_activation_script(ShellEnum::Bash(Bash), &environment)
+        let script =
+            generate_activation_script(Some(ShellEnum::Bash(Bash)), &environment, &project)
+                .await
+                .unwrap();
+        assert!(script.contains(&format!("export {path_var_name}=")));
+        assert!(script.contains("export CONDA_PREFIX="));
+
+        let script = generate_activation_script(
+            Some(ShellEnum::PowerShell(PowerShell::default())),
+            &environment,
+            &project,
+        )
+        .await
+        .unwrap();
+        assert!(script.contains(&format!("${{Env:{path_var_name}}}")));
+        assert!(script.contains("${Env:CONDA_PREFIX}"));
+
+        let script = generate_activation_script(Some(ShellEnum::Zsh(Zsh)), &environment, &project)
             .await
             .unwrap();
         assert!(script.contains(&format!("export {path_var_name}=")));
         assert!(script.contains("export CONDA_PREFIX="));
 
         let script =
-            generate_activation_script(ShellEnum::PowerShell(PowerShell::default()), &environment)
+            generate_activation_script(Some(ShellEnum::Fish(Fish)), &environment, &project)
                 .await
                 .unwrap();
-        assert!(script.contains(&format!("${{Env:{path_var_name}}}")));
-        assert!(script.contains("${Env:CONDA_PREFIX}"));
-
-        let script = generate_activation_script(ShellEnum::Zsh(Zsh), &environment)
-            .await
-            .unwrap();
-        assert!(script.contains(&format!("export {path_var_name}=")));
-        assert!(script.contains("export CONDA_PREFIX="));
-
-        let script = generate_activation_script(ShellEnum::Fish(Fish), &environment)
-            .await
-            .unwrap();
         assert!(script.contains(&format!("set -gx {path_var_name} ")));
         assert!(script.contains("set -gx CONDA_PREFIX "));
 
-        let script = generate_activation_script(ShellEnum::Xonsh(Xonsh), &environment)
-            .await
-            .unwrap();
+        let script =
+            generate_activation_script(Some(ShellEnum::Xonsh(Xonsh)), &environment, &project)
+                .await
+                .unwrap();
         assert!(script.contains(&format!("${path_var_name} = ")));
         assert!(script.contains("$CONDA_PREFIX = "));
 
-        let script = generate_activation_script(ShellEnum::CmdExe(CmdExe), &environment)
-            .await
-            .unwrap();
+        let script =
+            generate_activation_script(Some(ShellEnum::CmdExe(CmdExe)), &environment, &project)
+                .await
+                .unwrap();
         assert!(script.contains(&format!("@SET \"{path_var_name}=")));
         assert!(script.contains("@SET \"CONDA_PREFIX="));
 
-        let script = generate_activation_script(ShellEnum::NuShell(NuShell), &environment)
-            .await
-            .unwrap();
+        let script =
+            generate_activation_script(Some(ShellEnum::NuShell(NuShell)), &environment, &project)
+                .await
+                .unwrap();
         assert!(script.contains(&format!("$env.{path_var_name} = ")));
         assert!(script.contains("$env.CONDA_PREFIX = "));
     }

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -90,8 +90,8 @@ async fn generate_activation_script(
     let script = result.script.contents().into_diagnostic();
 
     if project.config().change_ps1() {
-        let prompt_name = prompt::get_prompt_name(project.name(), environment.name());
-        let shell_prompt = prompt::get_prompt_for_shell(&shell, prompt_name.as_str());
+        let prompt_name = prompt::prompt_name(project.name(), environment.name());
+        let shell_prompt = prompt::shell_prompt(&shell, prompt_name.as_str());
         Ok(format!("{}\n{}", script?, shell_prompt))
     } else {
         script

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -87,14 +87,15 @@ async fn generate_activation_script(
         })
         .into_diagnostic()?;
 
-    let script = result.script.contents().into_diagnostic();
+    let script = result.script.contents().into_diagnostic()?;
+    let hook = prompt::shell_hook(&shell).unwrap_or_default().to_owned();
 
     if project.config().change_ps1() {
         let prompt_name = prompt::prompt_name(project.name(), environment.name());
         let shell_prompt = prompt::shell_prompt(&shell, prompt_name.as_str());
-        Ok(format!("{}\n{}", script?, shell_prompt))
+        Ok([script, hook, shell_prompt].join("\n"))
     } else {
-        script
+        Ok([script, hook].join("\n"))
     }
 }
 

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, default::Default};
 use clap::Parser;
 use miette::IntoDiagnostic;
 use pixi_config::{ConfigCliActivation, ConfigCliPrompt};
+use pixi_manifest::EnvironmentName;
 use rattler_lock::LockFile;
 use rattler_shell::{
     activation::{ActivationVariables, PathModificationBehavior},
@@ -16,6 +17,7 @@ use crate::environment::get_update_lock_file_and_prefix;
 use crate::{
     activation::get_activator,
     cli::cli_config::{PrefixUpdateConfig, ProjectConfig},
+    prompt,
     project::{Environment, HasProjectRef},
     Project, UpdateLockFileOptions,
 };
@@ -57,17 +59,21 @@ struct ShellEnv<'a> {
     environment_variables: &'a HashMap<String, String>,
 }
 
-/// Generates the activation script.
-async fn generate_activation_script(
-    shell: Option<ShellEnum>,
-    environment: &Environment<'_>,
-) -> miette::Result<String> {
+
+fn get_shell(shell: Option<ShellEnum>) -> ShellEnum {
     // Get shell from the arguments or from the current process or use default if
     // all fails
-    let shell = shell.unwrap_or_else(|| {
+    shell.unwrap_or_else(|| {
         ShellEnum::from_parent_process()
             .unwrap_or_else(|| ShellEnum::from_env().unwrap_or_default())
-    });
+    })
+}
+
+/// Generates the activation script.
+async fn generate_activation_script(
+    shell: ShellEnum,
+    environment: &Environment<'_>,
+) -> miette::Result<String> {
 
     let activator = get_activator(environment, shell).into_diagnostic()?;
 
@@ -148,7 +154,32 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
         // Skipping the activated environment caching for the script.
         // As it can still run scripts.
-        false => generate_activation_script(args.shell, &environment).await?,
+        false => {
+            let shell = get_shell(args.shell);
+            let script = generate_activation_script(shell.clone(), &environment).await?;
+            let in_shell = match std::env::var("PIXI_IN_SHELL") {
+                Ok(val) => val != "0" && val != "",
+                Err(_) => false,
+            };
+            if project.config().change_ps1() && !in_shell {
+                let prompt_name = match environment.name() {
+                    EnvironmentName::Default => project.name().to_string(),
+                    EnvironmentName::Named(name) => format!("{}:{}", project.name(), name),
+                };
+                let prompt = match shell {
+                    ShellEnum::NuShell(_) => prompt::get_nu_prompt(prompt_name.as_str()),
+                    ShellEnum::PowerShell(_) => prompt::get_powershell_prompt(prompt_name.as_str()),
+                    ShellEnum::Bash(_) => prompt::get_posix_prompt(prompt_name.as_str()),
+                    ShellEnum::Zsh(_) => prompt::get_posix_prompt(prompt_name.as_str()),
+                    ShellEnum::Fish(_) => prompt::get_fish_prompt(prompt_name.as_str()),
+                    ShellEnum::Xonsh(_) => prompt::get_xonsh_prompt(),
+                    ShellEnum::CmdExe(_) => prompt::get_cmd_prompt(prompt_name.as_str()),
+                };
+                format!("{}\n{}", script, prompt)
+            } else {
+                script
+            }
+        },
     };
 
     // Print the output - either a JSON object or a shell script
@@ -170,14 +201,14 @@ mod tests {
         let path_var_name = default_shell.path_var(&Platform::current());
         let project = Project::discover().unwrap();
         let environment = project.default_environment();
-        let script = generate_activation_script(Some(ShellEnum::Bash(Bash)), &environment)
+        let script = generate_activation_script(ShellEnum::Bash(Bash), &environment)
             .await
             .unwrap();
         assert!(script.contains(&format!("export {path_var_name}=")));
         assert!(script.contains("export CONDA_PREFIX="));
 
         let script = generate_activation_script(
-            Some(ShellEnum::PowerShell(PowerShell::default())),
+            ShellEnum::PowerShell(PowerShell::default()),
             &environment,
         )
         .await
@@ -185,31 +216,31 @@ mod tests {
         assert!(script.contains(&format!("${{Env:{path_var_name}}}")));
         assert!(script.contains("${Env:CONDA_PREFIX}"));
 
-        let script = generate_activation_script(Some(ShellEnum::Zsh(Zsh)), &environment)
+        let script = generate_activation_script(ShellEnum::Zsh(Zsh), &environment)
             .await
             .unwrap();
         assert!(script.contains(&format!("export {path_var_name}=")));
         assert!(script.contains("export CONDA_PREFIX="));
 
-        let script = generate_activation_script(Some(ShellEnum::Fish(Fish)), &environment)
+        let script = generate_activation_script(ShellEnum::Fish(Fish), &environment)
             .await
             .unwrap();
         assert!(script.contains(&format!("set -gx {path_var_name} ")));
         assert!(script.contains("set -gx CONDA_PREFIX "));
 
-        let script = generate_activation_script(Some(ShellEnum::Xonsh(Xonsh)), &environment)
+        let script = generate_activation_script(ShellEnum::Xonsh(Xonsh), &environment)
             .await
             .unwrap();
         assert!(script.contains(&format!("${path_var_name} = ")));
         assert!(script.contains("$CONDA_PREFIX = "));
 
-        let script = generate_activation_script(Some(ShellEnum::CmdExe(CmdExe)), &environment)
+        let script = generate_activation_script(ShellEnum::CmdExe(CmdExe), &environment)
             .await
             .unwrap();
         assert!(script.contains(&format!("@SET \"{path_var_name}=")));
         assert!(script.contains("@SET \"CONDA_PREFIX="));
 
-        let script = generate_activation_script(Some(ShellEnum::NuShell(NuShell)), &environment)
+        let script = generate_activation_script(ShellEnum::NuShell(NuShell), &environment)
             .await
             .unwrap();
         assert!(script.contains(&format!("$env.{path_var_name} = ")));

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -18,10 +18,7 @@ pub(crate) fn get_zsh_hook(env_name: &str) -> String {
 
 /// Set default pixi prompt for posix shells
 pub(crate) fn get_posix_prompt(env_name: &str) -> String {
-    format!(
-        "export PS1=\"({}) ${{PS1:-}}\"",
-        env_name,
-    )
+    format!("export PS1=\"({}) ${{PS1:-}}\"", env_name,)
 }
 
 /// Set default pixi prompt for the fish shell

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,24 +1,19 @@
+use pixi_manifest::EnvironmentName;
+use rattler_shell::shell::ShellEnum;
+
 /// Set default pixi hook for the bash shell
-pub(crate) fn get_bash_hook(env_name: &str) -> String {
-    format!(
-        "export PS1=\"({}) ${{PS1:-}}\"\n{}",
-        env_name,
-        include_str!("shell_snippets/pixi-bash.sh")
-    )
+pub(crate) fn get_bash_hook() -> &'static str {
+    include_str!("shell_snippets/pixi-bash.sh")
 }
 
 /// Set default pixi hook for the zsh shell
-pub(crate) fn get_zsh_hook(env_name: &str) -> String {
-    format!(
-        "export PS1=\"({}) ${{PS1:-}}\"\n{}",
-        env_name,
-        include_str!("shell_snippets/pixi-zsh.sh")
-    )
+pub(crate) fn get_zsh_hook() -> &'static str {
+    include_str!("shell_snippets/pixi-zsh.sh")
 }
 
 /// Set default pixi prompt for posix shells
 pub(crate) fn get_posix_prompt(env_name: &str) -> String {
-    format!("export PS1=\"({}) ${{PS1:-}}\"", env_name,)
+    format!("export PS1=\"({}) ${{PS1:-}}\"", env_name)
 }
 
 /// Set default pixi prompt for the fish shell
@@ -93,4 +88,34 @@ pub(crate) fn get_nu_prompt(env_name: &str) -> String {
 /// Set default pixi prompt for the cmd.exe command prompt
 pub(crate) fn get_cmd_prompt(env_name: &str) -> String {
     format!(r"@PROMPT ({}) $P$G", env_name)
+}
+
+/// Get appropriate hook function for configured shell
+pub(crate) fn get_hook_for_shell(shell: &ShellEnum) -> &str {
+    match shell {
+        ShellEnum::Bash(_) => get_bash_hook(),
+        ShellEnum::Zsh(_) => get_zsh_hook(),
+        _ => "",
+    }
+}
+
+/// Get appropriate prompt (without hook) for configured shell
+pub(crate) fn get_prompt_for_shell(shell: &ShellEnum, prompt_name: &str) -> String {
+    match shell {
+        ShellEnum::NuShell(_) => get_nu_prompt(prompt_name),
+        ShellEnum::PowerShell(_) => get_powershell_prompt(prompt_name),
+        ShellEnum::Bash(_) => get_posix_prompt(prompt_name),
+        ShellEnum::Zsh(_) => get_posix_prompt(prompt_name),
+        ShellEnum::Fish(_) => get_fish_prompt(prompt_name),
+        ShellEnum::Xonsh(_) => get_xonsh_prompt(),
+        ShellEnum::CmdExe(_) => get_cmd_prompt(prompt_name),
+    }
+}
+
+/// Get prompt name for given project and environment
+pub(crate) fn get_prompt_name(project_name: &str, environment_name: &EnvironmentName) -> String {
+    match environment_name {
+        EnvironmentName::Default => project_name.to_string(),
+        EnvironmentName::Named(name) => format!("{}:{}", project_name, name),
+    }
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,7 +1,7 @@
 /// Set default pixi hook for the bash shell
 pub(crate) fn get_bash_hook(env_name: &str) -> String {
     format!(
-        "export PS1=\"({}) $PS1\"\n{}",
+        "export PS1=\"({}) ${{PS1:-}}\"\n{}",
         env_name,
         include_str!("shell_snippets/pixi-bash.sh")
     )
@@ -10,7 +10,7 @@ pub(crate) fn get_bash_hook(env_name: &str) -> String {
 /// Set default pixi hook for the zsh shell
 pub(crate) fn get_zsh_hook(env_name: &str) -> String {
     format!(
-        "export PS1=\"({}) $PS1\"\n{}",
+        "export PS1=\"({}) ${{PS1:-}}\"\n{}",
         env_name,
         include_str!("shell_snippets/pixi-zsh.sh")
     )
@@ -19,7 +19,7 @@ pub(crate) fn get_zsh_hook(env_name: &str) -> String {
 /// Set default pixi prompt for posix shells
 pub(crate) fn get_posix_prompt(env_name: &str) -> String {
     format!(
-        "export PS1=\"({}) $PS1\"",
+        "export PS1=\"({}) ${{PS1:-}}\"",
         env_name,
     )
 }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,4 +1,4 @@
-/// Set default pixi prompt for the bash shell
+/// Set default pixi hook for the bash shell
 pub(crate) fn get_bash_hook(env_name: &str) -> String {
     format!(
         "export PS1=\"({}) $PS1\"\n{}",
@@ -7,12 +7,20 @@ pub(crate) fn get_bash_hook(env_name: &str) -> String {
     )
 }
 
-/// Set default pixi prompt for the zsh shell
+/// Set default pixi hook for the zsh shell
 pub(crate) fn get_zsh_hook(env_name: &str) -> String {
     format!(
         "export PS1=\"({}) $PS1\"\n{}",
         env_name,
         include_str!("shell_snippets/pixi-zsh.sh")
+    )
+}
+
+/// Set default pixi prompt for posix shells
+pub(crate) fn get_posix_prompt(env_name: &str) -> String {
+    format!(
+        "export PS1=\"({}) $PS1\"",
+        env_name,
     )
 }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,23 +1,23 @@
 use pixi_manifest::EnvironmentName;
 use rattler_shell::shell::ShellEnum;
 
-/// Set default pixi hook for the bash shell
-pub(crate) fn get_bash_hook() -> &'static str {
+/// Sets default pixi hook for the bash shell
+pub(crate) fn bash_hook() -> &'static str {
     include_str!("shell_snippets/pixi-bash.sh")
 }
 
-/// Set default pixi hook for the zsh shell
-pub(crate) fn get_zsh_hook() -> &'static str {
+/// Sets default pixi hook for the zsh shell
+pub(crate) fn zsh_hook() -> &'static str {
     include_str!("shell_snippets/pixi-zsh.sh")
 }
 
-/// Set default pixi prompt for posix shells
-pub(crate) fn get_posix_prompt(env_name: &str) -> String {
+/// Sets default pixi prompt for posix shells
+pub(crate) fn posix_prompt(env_name: &str) -> String {
     format!("export PS1=\"({}) ${{PS1:-}}\"", env_name)
 }
 
-/// Set default pixi prompt for the fish shell
-pub(crate) fn get_fish_prompt(env_name: &str) -> String {
+/// Sets default pixi prompt for the fish shell
+pub(crate) fn fish_prompt(env_name: &str) -> String {
     format!(
         r#"
         function __pixi_add_prompt
@@ -61,14 +61,14 @@ pub(crate) fn get_fish_prompt(env_name: &str) -> String {
     )
 }
 
-/// Set default pixi prompt for the xonsh shell
-pub(crate) fn get_xonsh_prompt() -> String {
+/// Sets default pixi prompt for the xonsh shell
+pub(crate) fn xonsh_prompt() -> String {
     // Xonsh' default prompt can find the environment for some reason.
     "".to_string()
 }
 
-/// Set default pixi prompt for the powershell
-pub(crate) fn get_powershell_prompt(env_name: &str) -> String {
+/// Sets default pixi prompt for the powershell
+pub(crate) fn powershell_prompt(env_name: &str) -> String {
     format!(
         "$old_prompt = $function:prompt\n\
          function prompt {{\"({}) $($old_prompt.Invoke())\"}}",
@@ -76,8 +76,8 @@ pub(crate) fn get_powershell_prompt(env_name: &str) -> String {
     )
 }
 
-/// Set default pixi prompt for the Nu shell
-pub(crate) fn get_nu_prompt(env_name: &str) -> String {
+/// Sets default pixi prompt for the Nu shell
+pub(crate) fn nu_prompt(env_name: &str) -> String {
     format!(
         "let old_prompt = $env.PROMPT_COMMAND; \
          $env.PROMPT_COMMAND = {{|| echo $\"\\({}\\) (do $old_prompt)\"}}",
@@ -85,35 +85,35 @@ pub(crate) fn get_nu_prompt(env_name: &str) -> String {
     )
 }
 
-/// Set default pixi prompt for the cmd.exe command prompt
-pub(crate) fn get_cmd_prompt(env_name: &str) -> String {
+/// Sets default pixi prompt for the cmd.exe command prompt
+pub(crate) fn cmd_prompt(env_name: &str) -> String {
     format!(r"@PROMPT ({}) $P$G", env_name)
 }
 
-/// Get appropriate hook function for configured shell
-pub(crate) fn get_hook_for_shell(shell: &ShellEnum) -> &str {
+/// Returns appropriate hook function for configured shell
+pub(crate) fn shell_hook(shell: &ShellEnum) -> Option<&str> {
     match shell {
-        ShellEnum::Bash(_) => get_bash_hook(),
-        ShellEnum::Zsh(_) => get_zsh_hook(),
-        _ => "",
+        ShellEnum::Bash(_) => Some(bash_hook()),
+        ShellEnum::Zsh(_) => Some(zsh_hook()),
+        _ => None,
     }
 }
 
-/// Get appropriate prompt (without hook) for configured shell
-pub(crate) fn get_prompt_for_shell(shell: &ShellEnum, prompt_name: &str) -> String {
+/// Returns appropriate prompt (without hook) for configured shell
+pub(crate) fn shell_prompt(shell: &ShellEnum, prompt_name: &str) -> String {
     match shell {
-        ShellEnum::NuShell(_) => get_nu_prompt(prompt_name),
-        ShellEnum::PowerShell(_) => get_powershell_prompt(prompt_name),
-        ShellEnum::Bash(_) => get_posix_prompt(prompt_name),
-        ShellEnum::Zsh(_) => get_posix_prompt(prompt_name),
-        ShellEnum::Fish(_) => get_fish_prompt(prompt_name),
-        ShellEnum::Xonsh(_) => get_xonsh_prompt(),
-        ShellEnum::CmdExe(_) => get_cmd_prompt(prompt_name),
+        ShellEnum::NuShell(_) => nu_prompt(prompt_name),
+        ShellEnum::PowerShell(_) => powershell_prompt(prompt_name),
+        ShellEnum::Bash(_) => posix_prompt(prompt_name),
+        ShellEnum::Zsh(_) => posix_prompt(prompt_name),
+        ShellEnum::Fish(_) => fish_prompt(prompt_name),
+        ShellEnum::Xonsh(_) => xonsh_prompt(),
+        ShellEnum::CmdExe(_) => cmd_prompt(prompt_name),
     }
 }
 
-/// Get prompt name for given project and environment
-pub(crate) fn get_prompt_name(project_name: &str, environment_name: &EnvironmentName) -> String {
+/// Returns prompt name for given project and environment
+pub(crate) fn prompt_name(project_name: &str, environment_name: &EnvironmentName) -> String {
     match environment_name {
         EnvironmentName::Default => project_name.to_string(),
         EnvironmentName::Named(name) => format!("{}:{}", project_name, name),


### PR DESCRIPTION
- Closes https://github.com/prefix-dev/pixi/issues/1275

Made some choices that can be discussed:

- Had to copy things form `shell.rs`, not sure if a refactor is expected here.
- Detect if we are already in a pixi shell so we don't duplicate the PS1 recursively
- Do not add the shell function for reactivation
- The shell syntax used for `$PS1` makes it vulnerable to `set -u` errors if not set, I added a fix here too. Is that ok?

Not particularly proud of that `shell.clone()` either. Maybe there's a better way?