### PR TITLE
feat: Auto-prepend 'v' to version numbers during pixi installation

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -158,11 +158,9 @@ $BINARY = "pixi-$ARCH"
 if ($PixiVersion -eq 'latest') {
     $DOWNLOAD_URL = "https://github.com/$REPO/releases/latest/download/$BINARY.zip"
 } else {
-    # Check if version is incorrectly specified without prefix 'v'
+    # Check if version is incorrectly specified without prefix 'v', and prepend 'v' in this case
     if ($PixiVersion -notmatch '^v') {
-        $OriginalVersion = $PixiVersion
         $PixiVersion = "v$PixiVersion"
-        Write-Output "You specified pixi version $OriginalVersion, but version numbers need format v0.0.0, using version $PixiVersion"
     }
     $DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$PixiVersion/$BINARY.zip"
 }

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -158,6 +158,12 @@ $BINARY = "pixi-$ARCH"
 if ($PixiVersion -eq 'latest') {
     $DOWNLOAD_URL = "https://github.com/$REPO/releases/latest/download/$BINARY.zip"
 } else {
+    # Check if version is incorrectly specified without prefix 'v'
+    if ($PixiVersion -notmatch '^v') {
+        $OriginalVersion = $PixiVersion
+        $PixiVersion = "v$PixiVersion"
+        Write-Output "You specified pixi version $OriginalVersion, but version numbers need format v0.0.0, using version $PixiVersion"
+    }
     $DOWNLOAD_URL = "https://github.com/$REPO/releases/download/$PixiVersion/$BINARY.zip"
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -36,11 +36,9 @@ fi
 if [[ $VERSION == "latest" ]]; then
   DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}.${EXTENSION}"
 else
-  # Check if version is incorrectly specified without prefix 'v'
+  # Check if version is incorrectly specified without prefix 'v', and prepend 'v' in this case
   if [[ ! "$VERSION" =~ ^v ]]; then
-    ORIGINAL_VERSION="$VERSION"
     VERSION="v$VERSION"
-    echo "You specified pixi version $ORIGINAL_VERSION, but version numbers need format v0.0.0, using version $VERSION"
   fi
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}.${EXTENSION}"
 fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -36,6 +36,12 @@ fi
 if [[ $VERSION == "latest" ]]; then
   DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}.${EXTENSION}"
 else
+  # Check if version is incorrectly specified without prefix 'v'
+  if [[ ! "$VERSION" =~ ^v ]]; then
+    ORIGINAL_VERSION="$VERSION"
+    VERSION="v$VERSION"
+    echo "You specified pixi version $ORIGINAL_VERSION, but version numbers need format v0.0.0, using version $VERSION"
+  fi
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}.${EXTENSION}"
 fi
 


### PR DESCRIPTION
Trying to install `v0.40.2` using `curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=0.40.2 bash` results in 
```
This script will automatically download and install Pixi (0.40.2) for you.
Getting it from this url: https://github.com/prefix-dev/pixi/releases/download/0.40.2/pixi-x86_64-unknown-linux-musl.tar.gz
error: 'https://github.com/prefix-dev/pixi/releases/download/0.40.2/pixi-x86_64-unknown-linux-musl.tar.gz' is not available
```
which confused me for a second. I hope this auto-prepending the missing `v` makes it smoother. Let me know what you think.