### PR TITLE
ci: fix clippy and fmt check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,22 +74,6 @@ jobs:
           environments: lint
       - name: pre-commit
         run: pixi run pre-commit-run --color=always --show-diff-on-failure
-        env:
-          # As the rust GitHub action is better at the rust jobs it can be skipped in this job.
-          SKIP: clippy,fmt
-
-  # Format the all rust code and make sure it's formatted correctly.
-  format:
-    name: "cargo fmt | ubuntu"
-    needs: determine_changes
-    runs-on: ubuntu-latest
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Install Rustfmt"
-        run: rustup component add rustfmt
-      - name: "rustfmt"
-        run: cargo fmt --all --check
 
   # Check that all the code references are correct.
   check-rustdoc-links:
@@ -106,22 +90,6 @@ jobs:
           for package in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .name'); do
             cargo rustdoc -p "$package" --all-features -- -D warnings -W unreachable-pub
           done
-
-  # Run `cargo clippy` on the entire codebase.
-  lint:
-    name: "cargo clippy | ubuntu"
-    needs: determine_changes
-    runs-on: ubuntu-latest
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: "Install Rust toolchain"
-        run: rustup component add clippy
-      - name: Run clippy
-        run: cargo clippy --all-targets --workspace --locked
 
   # Checks for dependencies that are not used in the codebase
   cargo-machete:

--- a/pixi.toml
+++ b/pixi.toml
@@ -91,7 +91,7 @@ typos = ">=1.23.1,<2"
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086" } }
 cargo-clippy = "cargo clippy --all-targets --workspace -- -D warnings -Dclippy::dbg_macro"
-cargo-fmt = "cargo fmt"
+cargo-fmt = "cargo fmt --all"
 check-openssl = "python tests/scripts/check-openssl.py"
 lint = "pre-commit run --all-files --hook-stage=manual"
 pre-commit-install = "pre-commit install --install-hooks"


### PR DESCRIPTION
Clippy and fmt is currently run twice, since the skip on pre-commit didn't work, since the IDs changed. I don't see how running them separately improves things, so I put it all on pre-commit