### PR TITLE
docs: enable autocomplete on Zsh

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ Add the following to the end of `~/.zshrc`:
 
 ```zsh title="~/.zshrc"
 
+autoload -Uz compinit && compinit  # redundant with Oh My Zsh
 eval "$(pixi completion --shell zsh)"
 ```
 


### PR DESCRIPTION
This fixes https://github.com/prefix-dev/pixi/issues/1248

If the user does not have Oh My Zsh they need to add this line for autocomplete to work with Zsh.