### PR TITLE
fix: remove `description` from `pixi init` template

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -70,7 +70,6 @@ const PROJECT_TEMPLATE: &str = r#"[project]
 authors = ["{{ author[0] }} <{{ author[1] }}>"]
 {%- endif %}
 channels = {{ channels }}
-description = "Add a short description here"
 name = "{{ name }}"
 platforms = {{ platforms }}
 version = "{{ version }}"
@@ -122,7 +121,6 @@ const NEW_PYROJECT_TEMPLATE: &str = r#"[project]
 authors = [{name = "{{ author[0] }}", email = "{{ author[1] }}"}]
 {%- endif %}
 dependencies = []
-description = "Add a short description here"
 name = "{{ name }}"
 requires-python = ">= 3.11"
 version = "{{ version }}"


### PR DESCRIPTION
I always wondered why "description" is generated with `pixi init`. Looking at the code, it doesn't seem like we really do anything with this key. I therefore propose to remove `description` from the template.