### PR TITLE
feat: prevent line-based 3-way merge on pixi.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-pixi.lock linguist-language=YAML linguist-generated=true
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -166,12 +166,12 @@ impl GitAttributes {
         match self {
             GitAttributes::Github | GitAttributes::Codeberg => {
                 r#"# SCM syntax highlighting
-pixi.lock linguist-language=YAML linguist-generated=true
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true
 "#
             }
             GitAttributes::Gitlab => {
                 r#"# GitLab syntax highlighting
-pixi.lock gitlab-language=yaml gitlab-generated=true
+pixi.lock merge=binary gitlab-language=yaml gitlab-generated=true
 "#
             }
         }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -165,12 +165,12 @@ impl GitAttributes {
     fn template(&self) -> &'static str {
         match self {
             GitAttributes::Github | GitAttributes::Codeberg => {
-                r#"# SCM syntax highlighting
+                r#"# SCM syntax highlighting & preventing 3-way merges
 pixi.lock merge=binary linguist-language=YAML linguist-generated=true
 "#
             }
             GitAttributes::Gitlab => {
-                r#"# GitLab syntax highlighting
+                r#"# GitLab syntax highlighting & preventing 3-way merges
 pixi.lock merge=binary gitlab-language=yaml gitlab-generated=true
 "#
             }


### PR DESCRIPTION
Attempting a three-way file merge doesn't really make sense on pixi.lock, so we could treat it as a binary file (choose either ours or theirs, but don't attempt to manually resolve conflicts into an intermediate. Ultimately in case of lock-file conflicts the user probably almost always wants to resolve conflicts from three-way merging pixi.toml and then regenerate the lock-file.