### PR TITLE
docs: add section on aws codeartifact

### DIFF
--- a/docs/advanced/authentication.md
+++ b/docs/advanced/authentication.md
@@ -131,6 +131,10 @@ To install keyring you can use pixi global install:
     ```shell
     pixi global install keyring --with keyring.artifacts
     ```
+=== "AWS CodeArtifact"
+    ```shell
+    pixi global install keyring --with keyrings.codeartifact
+    ```
 
 For other registries, you will need to adapt these instructions to add the right keyring backend.
 
@@ -172,6 +176,14 @@ For other registries, you will need to adapt these instructions to add the right
     ```toml
     [pypi-options]
     extra-index-urls = ["https://VssSessionToken@pkgs.dev.azure.com/{organization}/{project}/_packaging/{feed}/pypi/simple/"]
+    ```
+
+=== "AWS CodeArtifact"
+    Ensure you are logged in e.g via `aws sso login` and add the following configuration to your pixi manifest:
+
+    ```toml
+    [pypi-options]
+    extra-index-urls = ["https://aws@<your-domain>-<your-account>.d.codeartifact.<your-region>.amazonaws.com/pypi/<your-repository>/simple/"]
     ```
 
 #### Installing your environment


### PR DESCRIPTION
In the documentation, there isn't a tab for authenticating to AWS codeartifact, but I stumbled upon the relevant issue https://github.com/prefix-dev/pixi/issues/1783 and the linked blog post.

I managed to set up keyring authentication using the newer `pixi global install` method (as opposed to the `pipx` workaround in the older blog post). In my case, I have left `keyringrc.cfg` empty (there are good defaults as [mentioned in the docs](https://github.com/jmkeyes/keyrings.codeartifact)) so it wasn't a necessary step.

I hope this will help others who are using codeartifact too.