### PR TITLE
fix: will also update prefix if there are pypi path dependencies

### DIFF
--- a/crates/pixi_manifest/src/pypi/pypi_requirement.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_requirement.rs
@@ -586,6 +586,40 @@ impl PyPiRequirement {
         )
     }
 
+    /// Returns the path of the requirement if it is a path requirement.
+    pub fn as_path(&self) -> Option<&PathBuf> {
+        match self {
+            PyPiRequirement::Path { path, .. } => Some(path),
+            _ => None,
+        }
+    }
+
+    /// Returns the git spec of the requirement if it is a git requirement.
+    pub fn as_git(&self) -> Option<&GitSpec> {
+        match self {
+            PyPiRequirement::Git { url, .. } => Some(url),
+            _ => None,
+        }
+    }
+
+    /// Returns the url of the requirement if it is a url requirement.
+    pub fn as_url(&self) -> Option<&Url> {
+        match self {
+            PyPiRequirement::Url { url, .. } => Some(url),
+            _ => None,
+        }
+    }
+
+    /// Returns the version of the requirement if it is a version requirement.
+    pub fn as_version(&self) -> Option<&VersionOrStar> {
+        match self {
+            PyPiRequirement::Version { version, .. } | PyPiRequirement::RawVersion(version) => {
+                Some(version)
+            }
+            _ => None,
+        }
+    }
+
     /// Define whether the requirement is editable.
     pub fn set_editable(&mut self, editable: bool) {
         match self {


### PR DESCRIPTION
Attempt to implement: https://github.com/prefix-dev/pixi/issues/1881#issuecomment-2621283703

This will also update the prefix on run when there are pypi path dependencies that are directories, this will typically be source files that we are working with. I think this is in spirit with the wanted behavior, even though the conda filter works a bit differently, as I expect git dependencies to be updated with a `pixi update` instead. And path dependencies which are not directories are either wheels or sdists, and do not change often (if at all)

# How to test?

```bash
pixi init --format=pyproject
#should do a full install
pixi r python
touch pyproject.toml
# should update the prefix (does not happen on main)
pixi r python
````