### PR TITLE
Show suggestions if `pixi add` was executed with a non-existing package name

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -448,7 +448,7 @@ fn print_package_info<W: Write>(
     Ok(())
 }
 
-async fn search_package_by_wildcard<W: Write, QF, FR>(
+pub async fn search_package_by_wildcard<W: Write, QF, FR>(
     package_name: PackageName,
     package_name_filter: &str,
     all_package_names: Vec<PackageName>,


### PR DESCRIPTION
Related to #3026 