### PR TITLE
fix: logic was backward for creating missing .bashrc

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -132,7 +132,7 @@ update_shell() {
     [[ -n "${PIXI_NO_PATH_UPDATE:-}" ]] && echo "No path update because PIXI_NO_PATH_UPDATE has a value" && return
 
     # Create the file if it doesn't exist
-    if [ -f "$FILE" ]; then
+    if [ ! -f "$FILE" ]; then
         touch "$FILE"
     fi
 


### PR DESCRIPTION
If the ${HOME}/.bashrc file does not exist, create it with the `touch` command.

File was touched only if it already existed.