### PR TITLE
fix: do proper sanity check on add and run

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,9 +6,9 @@ use pixi_spec::{GitSpec, SourceSpec};
 use rattler_conda_types::{MatchSpec, PackageName};
 
 use super::has_specs::HasSpecs;
+use crate::environment::sanity_check_project;
 use crate::{
     cli::cli_config::{DependencyConfig, PrefixUpdateConfig, ProjectConfig},
-    environment::verify_prefix_location_unchanged,
     project::{DependencyType, Project},
 };
 
@@ -92,8 +92,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let mut project = Project::load_or_else_discover(project_config.manifest_path.as_deref())?
         .with_cli_config(prefix_update_config.config.clone());
 
-    // Sanity check of prefix location
-    verify_prefix_location_unchanged(project.default_environment().dir().as_path()).await?;
+    sanity_check_project(&project).await?;
 
     // Add the platform if it is not already present
     project

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, string::String};
 
 use crate::cli::cli_config::{PrefixUpdateConfig, ProjectConfig};
-use crate::environment::verify_prefix_location_unchanged;
+use crate::environment::sanity_check_project;
 use crate::lock_file::UpdateLockFileOptions;
 use crate::project::errors::UnsupportedPlatformError;
 use crate::project::virtual_packages::verify_current_platform_has_required_virtual_packages;
@@ -100,7 +100,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     // Sanity check of prefix location
-    verify_prefix_location_unchanged(project.default_environment().dir().as_path()).await?;
+    sanity_check_project(&project).await?;
 
     let best_platform = environment.best_platform();
 


### PR DESCRIPTION
Attempt to fix #3050 

This is not a total fix as there is no guarentee we hit all cases where we write to the .pixi folder. But multiple functions can make this directory. @baszalmstra Do you have a good idea on how to guarentee this `.gitignore` file is written when the `.pixi` folder is made?