### PR TITLE
feat: extend `pixi lock` with output and with install

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -255,6 +255,24 @@ pixi upgrade --dry-run
     - `url`
     - `subdir`.
 
+## `lock`
+
+The `lock` command can be used to update the `pixi.lock` file without updating the environment.
+It will do the minimal amount of work to make sure the lockfile is in the correct state.
+This means only solving the environment if the lockfile is out of date, or installing only the minimal set of dependencies to solve the lockfile for the PyPI dependencies.
+
+The output is similar to the `update` command to show the changes that are be made to the lockfile.
+
+##### Options
+- `--manifest-path <MANIFEST_PATH>`: the path to [manifest file](pixi_manifest.md), by default it searches for one in the parent directories.
+- `--json` Output the changes in json format.
+
+```shell
+pixi lock
+pixi lock --manifest-path ~/myproject/pixi.toml
+pixi lock --json
+```
+
 ## `run`
 
 The `run` commands first checks if the environment is ready to use.

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -1,9 +1,10 @@
-use clap::Parser;
-
 use crate::cli::cli_config::ProjectConfig;
+use crate::diff::{LockFileDiff, LockFileJsonDiff};
 use crate::environment::LockFileUsage;
 use crate::lock_file::UpdateLockFileOptions;
 use crate::Project;
+use clap::Parser;
+use miette::{Context, IntoDiagnostic};
 
 /// Solve environment and update the lock file
 #[derive(Debug, Parser)]
@@ -11,17 +12,45 @@ use crate::Project;
 pub struct Args {
     #[clap(flatten)]
     pub project_config: ProjectConfig,
+
+    /// Output the changes in JSON format.
+    #[clap(long)]
+    pub json: bool,
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let project = Project::load_or_else_discover(args.project_config.manifest_path.as_deref())?;
 
-    project
+    // Save the original lockfile to compare with the new one.
+    let original_lockfile = project.get_lock_file().await?;
+
+    let new_lockfile = project
         .update_lock_file(UpdateLockFileOptions {
             lock_file_usage: LockFileUsage::Update,
-            no_install: true,
+            no_install: false,
             max_concurrent_solves: project.config().max_concurrent_solves(),
         })
-        .await
-        .map(|_| ())
+        .await?;
+
+    // Determine the diff between the old and new lock-file.
+    let diff = LockFileDiff::from_lock_files(&original_lockfile, &new_lockfile.lock_file);
+
+    // Format as json?
+    if args.json {
+        let diff = LockFileDiff::from_lock_files(&original_lockfile, &new_lockfile.lock_file);
+        let json_diff = LockFileJsonDiff::new(Some(&project), diff);
+        let json = serde_json::to_string_pretty(&json_diff).expect("failed to convert to json");
+        println!("{}", json);
+    } else if diff.is_empty() {
+        eprintln!(
+            "{}Lock-file was already up-to-date",
+            console::style(console::Emoji("✔ ", "")).green()
+        );
+    } else {
+        diff.print()
+            .into_diagnostic()
+            .context("failed to print lock-file diff")?;
+    }
+
+    Ok(())
 }

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -984,7 +984,9 @@ def test_pixi_lock(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -
     shutil.rmtree(dot_pixi)
 
     # Run pixi lock to recreate the lock file
-    verify_cli_command([pixi, "lock", "--manifest-path", manifest_path])
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest_path], stderr_contains=["+", "dummy-a"]
+    )
 
     # Read the recreated lock file content
     recreated_lock_content = lock_file_path.read_text()


### PR DESCRIPTION
Slightly extended the `pixi lock` command and added documentation