### PR TITLE
feat: Add environment variables to `init --import`

### DIFF
--- a/crates/pixi_utils/src/conda_environment_file.rs
+++ b/crates/pixi_utils/src/conda_environment_file.rs
@@ -344,10 +344,7 @@ mod tests {
 
         let empty_map = HashMap::<String, String>::new();
 
-        assert_eq!(
-            vars,
-            empty_map
-        );
+        assert_eq!(vars, empty_map);
     }
 
     #[test]

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -497,12 +497,8 @@ fn render_project(
         } else {String::new()}},
     };
 
-    env.render_named_str(
-        consts::PROJECT_MANIFEST,
-        PROJECT_TEMPLATE,
-        ctx,
-    )
-    .expect("should be able to render the template")
+    env.render_named_str(consts::PROJECT_MANIFEST, PROJECT_TEMPLATE, ctx)
+        .expect("should be able to render the template")
 }
 
 /// Save the rendered template to a file, and print a message to the user.


### PR DESCRIPTION
This adds transfer of the `variables` section in an imported environment file to a corresponding `activation` section in the new `pixi.toml` file.

Closes #2007