### PR TITLE
fix: protocol method names

### DIFF
--- a/crates/pixi_build_frontend/src/protocol.rs
+++ b/crates/pixi_build_frontend/src/protocol.rs
@@ -112,16 +112,16 @@ impl Protocol {
         }
     }
 
-    pub async fn get_conda_metadata(
+    pub async fn conda_get_metadata(
         &self,
         request: &CondaMetadataParams,
         reporter: Arc<dyn CondaMetadataReporter>,
     ) -> miette::Result<CondaMetadataResult> {
         match self {
             Self::PixiBuild(protocol) => Ok(protocol
-                .get_conda_metadata(request, reporter.as_ref())
+                .conda_get_metadata(request, reporter.as_ref())
                 .await?),
-            Self::CondaBuild(protocol) => protocol.get_conda_metadata(request),
+            Self::CondaBuild(protocol) => protocol.conda_get_metadata(request),
         }
     }
 

--- a/crates/pixi_build_frontend/src/protocols/builders/conda_build/protocol.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/conda_build/protocol.rs
@@ -40,7 +40,7 @@ impl Protocol {
     }
 
     // Extract metadata from the recipe.
-    pub fn get_conda_metadata(
+    pub fn conda_get_metadata(
         &self,
         request: &CondaMetadataParams,
     ) -> miette::Result<CondaMetadataResult> {

--- a/crates/pixi_build_frontend/src/protocols/mod.rs
+++ b/crates/pixi_build_frontend/src/protocols/mod.rs
@@ -287,7 +287,7 @@ impl JsonRPCBuildProtocol {
     }
 
     /// Extract metadata from the recipe.
-    pub async fn get_conda_metadata(
+    pub async fn conda_get_metadata(
         &self,
         request: &CondaMetadataParams,
         reporter: &dyn CondaMetadataReporter,

--- a/crates/pixi_build_frontend/src/reporters.rs
+++ b/crates/pixi_build_frontend/src/reporters.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 /// Reporter trait for reporting the progress of metadata operations.
 pub trait CondaMetadataReporter: Send + Sync {
-    /// Reports the start of the get_conda_metadata operation.
+    /// Reports the start of the conda_get_metadata operation.
     /// Returns a unique identifier for the operation.
     fn on_metadata_start(&self, build_id: usize) -> usize;
 
-    /// Reports the end of the get_conda_metadata operation.
+    /// Reports the end of the conda_get_metadata operation.
     fn on_metadata_end(&self, operation: usize);
 }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -631,7 +631,7 @@ impl BuildContext {
 
         // Extract the conda metadata for the package
         let metadata = protocol
-            .get_conda_metadata(
+            .conda_get_metadata(
                 &CondaMetadataParams {
                     build_platform: Some(PlatformAndVirtualPackages {
                         platform: build_platform,


### PR DESCRIPTION
That way they fit with the RPC method names `conda/getMetadata` and `conda/build`