### PR TITLE
fix: fixing passing a file as `--manifest-path`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 .idea
 .vscode
 .test-projects

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/target
+target
 .idea
 .vscode
 .test-projects

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,6 +3742,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "dashmap",
+ "dunce",
  "fs-err",
  "futures",
  "insta",

--- a/crates/pixi_build_frontend/Cargo.toml
+++ b/crates/pixi_build_frontend/Cargo.toml
@@ -47,6 +47,7 @@ which = { workspace = true }
 
 [dev-dependencies]
 bytes = { workspace = true }
+dunce = { workspace = true }
 insta = { workspace = true, features = ["yaml", "filters", "json"] }
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/pixi_build_frontend/tests/diagnostics.rs
+++ b/crates/pixi_build_frontend/tests/diagnostics.rs
@@ -71,7 +71,10 @@ async fn test_invalid_manifest() {
         .unwrap_err();
 
     let snapshot = error_to_snapshot(&err);
-    let snapshot = replace_source_dir(&snapshot, source_dir.path());
+    let snapshot = replace_source_dir(
+        &snapshot,
+        dunce::canonicalize(source_dir.path()).unwrap().as_path(),
+    );
 
     insta::assert_snapshot!(snapshot);
 }

--- a/crates/pixi_build_frontend/tests/snapshots/diagnostics__invalid_manifest.snap
+++ b/crates/pixi_build_frontend/tests/snapshots/diagnostics__invalid_manifest.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/pixi_build_frontend/tests/diagnostics.rs
 expression: snapshot
+snapshot_kind: text
 ---
   × missing field 'channels' in table
-   ╭─[pixi.toml:1:1]
+   ╭─[[SOURCE_DIR]/pixi.toml:1:1]
  1 │ [workspace]
    · ───────────
    ╰────

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -517,7 +517,6 @@ mod test {
 
     #[rstest]
     #[case::root("")]
-    #[case::non_existing("non-existing")]
     #[case::empty("empty")]
     #[case::package_a("package_a")]
     #[case::package_b("package_a/package_b")]
@@ -635,5 +634,23 @@ mod test {
         }, {
             insta::assert_snapshot!(snapshot);
         });
+    }
+
+    #[test]
+    fn test_non_existing_discovery() {
+        // Split from the previous rstests, to avoid insta snapshot path conflicts in the error.
+        let test_data_root = dunce::canonicalize(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery"),
+        )
+        .unwrap();
+
+        let err = WorkspaceDiscoverer::new(DiscoveryStart::SearchRoot(
+            test_data_root.join("non-existing"),
+        ))
+        .with_closest_package(true)
+        .discover()
+        .expect_err("Expected an error");
+
+        assert!(matches!(err, WorkspaceDiscoveryError::Canonicalize(_, _)));
     }
 }

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -520,8 +520,10 @@ mod test {
     #[case::non_pixi_build("non-pixi-build")]
     #[case::non_pixi_build_project("non-pixi-build/project")]
     fn test_workspace_discoverer(#[case] subdir: &str) {
-        let test_data_root =
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery");
+        let test_data_root = dunce::canonicalize(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery"),
+        )
+        .unwrap();
 
         let snapshot =
             match WorkspaceDiscoverer::new(DiscoveryStart::SearchRoot(test_data_root.join(subdir)))
@@ -535,7 +537,7 @@ mod test {
                     let rel_path =
                         pathdiff::diff_paths(&discovered.workspace.provenance.path, test_data_root)
                             .unwrap_or(discovered.workspace.provenance.path);
-
+                    dbg!(&rel_path);
                     let mut snapshot = String::new();
                     writeln!(
                         &mut snapshot,
@@ -572,8 +574,10 @@ mod test {
     #[case::empty("empty")]
     #[case::package_specific("package_a/pixi.toml")]
     fn test_explicit_workspace_discoverer(#[case] subdir: &str) {
-        let test_data_root =
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery");
+        let test_data_root = dunce::canonicalize(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery"),
+        )
+        .unwrap();
 
         let snapshot = match WorkspaceDiscoverer::new(DiscoveryStart::ExplicitManifest(
             test_data_root.join(subdir),
@@ -585,6 +589,8 @@ mod test {
             Ok(Some(WithWarnings {
                 value: discovered, ..
             })) => {
+                dbg!(&discovered.workspace.provenance.path);
+                dbg!(&test_data_root);
                 let rel_path =
                     pathdiff::diff_paths(&discovered.workspace.provenance.path, test_data_root)
                         .unwrap_or(discovered.workspace.provenance.path);

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -119,7 +119,7 @@ impl ManifestDocument {
             Err(err) => {
                 return Err(Box::new(WithSourceCode {
                     source: NamedSource::new(
-                        provenance.path.to_string_lossy(),
+                        provenance.absolute_path().to_string_lossy(),
                         Arc::from(contents),
                     ),
                     error: TomlError::from(err),

--- a/crates/pixi_manifest/src/manifests/provenance.rs
+++ b/crates/pixi_manifest/src/manifests/provenance.rs
@@ -58,6 +58,11 @@ impl ManifestProvenance {
             ManifestKind::Pyproject => Ok(ManifestSource::PyProjectToml(contents)),
         }
     }
+
+    /// Returns the absolute path to the manifest file.
+    pub fn absolute_path(&self) -> PathBuf {
+        dunce::canonicalize(self.path.clone()).unwrap_or(self.path.to_path_buf())
+    }
 }
 
 impl From<ManifestKind> for ManifestProvenance {

--- a/crates/pixi_manifest/src/pypi/snapshots/pixi_manifest__pypi__pypi_requirement__tests__deserialize_failing.snap
+++ b/crates/pixi_manifest/src/pypi/snapshots/pixi_manifest__pypi__pypi_requirement__tests__deserialize_failing.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/pixi_manifest/src/pypi/pypi_requirement.rs
 expression: "snapshot.into_iter().map(|Snapshot { input, result }|\nformat!(\"input: {input}\\nresult: {} \",\nresult.as_object().unwrap().get(\"error\").unwrap().as_str().unwrap())).join(\"\\n\")"
+snapshot_kind: text
 ---
 input: pkg = { ver = "1.2.3" }
 result: 
@@ -86,9 +87,9 @@ result:
    ╰──── 
 input: pkg = "\\path\\style"
 result: 
-  × it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = "\path\style" }'
+  × it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = "/path/style" }'
    ╭─[pixi.toml:1:8]
- 1 │ pkg = "\\path\\style"
+ 1 │ pkg = "//path//style"
    ·        ─────────────
    ╰──── 
 input: pkg = "~/path/style"

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@non-existing.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@non-existing.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/pixi_manifest/src/discovery.rs
 expression: snapshot
+snapshot_kind: text
 ---
-Discovered workspace at: pixi.toml
-- Name: workspace-discovery
-Package: workspace-discovery @ 0.1.0
+  × cannot canonicalize path '/Users/rubenarts/dev/pixi/tests/data/workspace-discovery/non-existing' while searching for a manifest.
+  ╰─▶ No such file or directory (os error 2)

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@non-existing.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@non-existing.snap
@@ -3,5 +3,5 @@ source: crates/pixi_manifest/src/discovery.rs
 expression: snapshot
 snapshot_kind: text
 ---
-  × cannot canonicalize path '/Users/rubenarts/dev/pixi/tests/data/workspace-discovery/non-existing' while searching for a manifest.
+  × cannot canonicalize path '<CARGO_ROOT>/tests/data/workspace-discovery/non-existing' while searching for a manifest.
   ╰─▶ No such file or directory (os error 2)

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@non-pixi-build_project.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@non-pixi-build_project.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/pixi_manifest/src/discovery.rs
 expression: snapshot
+snapshot_kind: text
 ---
   × [package] section is only allowed when the `pixi-build` feature is enabled
-   ╭─[pixi.toml:1:1]
+   ╭─[<CARGO_ROOT>/tests/data/workspace-discovery/non-pixi-build/project/pixi.toml:1:1]
  1 │ ╭─▶ [package]
  2 │ │   name = "package"
  3 │ ╰─▶ version = "0.1.0"

--- a/crates/pixi_manifest/src/utils/test_utils.rs
+++ b/crates/pixi_manifest/src/utils/test_utils.rs
@@ -49,6 +49,9 @@ pub(crate) fn format_diagnostic(error: &dyn Diagnostic) -> String {
         .to_string();
     s = s.replace(&cargo_root, "<CARGO_ROOT>");
 
+    // Replace backslashes with forward slashes
+    s = s.replace("\\", "/");
+
     // Remove trailing whitespace in the error message.
     s.lines()
         .map(|line| line.trim_end())

--- a/crates/pixi_manifest/src/utils/test_utils.rs
+++ b/crates/pixi_manifest/src/utils/test_utils.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme, NamedSource, Report};
+use std::path::Path;
 
 use crate::toml::ExternalWorkspaceProperties;
 use crate::toml::{FromTomlStr, TomlManifest};
@@ -37,6 +38,16 @@ pub(crate) fn format_diagnostic(error: &dyn Diagnostic) -> String {
         .with_break_words(false)
         .with_theme(GraphicalTheme::unicode_nocolor());
     report_handler.render_report(&mut s, error).unwrap();
+
+    // Strip machine specific paths
+    let cargo_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    s = s.replace(&cargo_root, "<CARGO_ROOT>");
 
     // Remove trailing whitespace in the error message.
     s.lines()

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -65,6 +65,13 @@ pub enum WorkspaceLocatorError {
     )]
     WorkspaceNotFound(PathBuf),
 
+    #[error("unable to canonicalize '{}'", .path.display())]
+    Canonicalize {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     /// The manifest file could not be loaded.
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -124,7 +131,7 @@ impl WorkspaceLocator {
             DiscoveryStart::SearchRoot(path) => pixi_manifest::DiscoveryStart::SearchRoot(path),
         };
 
-        let root = discovery_start.root().to_path_buf();
+        let discovery_source = discovery_start.root().to_path_buf();
 
         // Discover the workspace manifest for the current path.
         let workspace_manifests = match pixi_manifest::WorkspaceDiscoverer::new(discovery_start)
@@ -165,7 +172,7 @@ impl WorkspaceLocator {
 
         // Early out if discovery failed.
         let Some(discovered_manifests) = workspace_manifests else {
-            return Err(WorkspaceLocatorError::WorkspaceNotFound(root));
+            return Err(WorkspaceLocatorError::WorkspaceNotFound(discovery_source));
         };
 
         // Emit any warnings that were encountered during the discovery process.
@@ -222,5 +229,62 @@ impl WorkspaceLocator {
         }
 
         Ok(discovered_workspace.map(WithWarnings::from))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn test_workspace_locator() {
+        let workspace_locator = WorkspaceLocator::default();
+        let workspace = workspace_locator.locate().unwrap();
+        let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        assert_eq!(workspace.root, PathBuf::from(project_root));
+    }
+
+    #[test]
+    fn test_workspace_locator_cli() {
+        // Equivalent to `pixi xxx` where xxx is any command
+        let workspace_locator = WorkspaceLocator::for_cli();
+        let workspace = workspace_locator.locate().unwrap();
+        let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        assert_eq!(workspace.root, PathBuf::from(project_root));
+    }
+
+    #[test]
+    fn test_workspace_locator_explicit() {
+        // Equivalent to `pixi xxx --manifest /absolute/path/to/pixi.toml`
+        let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let workspace_locator =
+            WorkspaceLocator::default().with_search_start(DiscoveryStart::ExplicitManifest(
+                Path::new(&project_root).join("pixi.toml").to_path_buf(),
+            ));
+        let workspace = workspace_locator.locate().unwrap();
+        assert_eq!(workspace.root, PathBuf::from(project_root));
+    }
+
+    #[test]
+    fn test_workspace_locator_explicit_simple() {
+        // Equivalent to `pixi xxx --manifest pixi.toml`
+        let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let workspace_locator = WorkspaceLocator::default().with_search_start(
+            DiscoveryStart::ExplicitManifest(Path::new("pixi.toml").to_path_buf()),
+        );
+        let workspace = workspace_locator.locate().unwrap();
+        assert_eq!(workspace.root, PathBuf::from(project_root));
+    }
+
+    #[test]
+    fn test_workspace_locator_explicit_path() {
+        // Equivalent to `pixi xxx --manifest /absolute/path/to/folder`
+        let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let workspace_locator = WorkspaceLocator::default().with_search_start(
+            DiscoveryStart::ExplicitManifest(Path::new(&project_root).to_path_buf()),
+        );
+        let workspace = workspace_locator.locate().unwrap();
+        assert_eq!(workspace.root, PathBuf::from(project_root));
     }
 }

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -146,6 +146,9 @@ impl WorkspaceLocator {
             Err(WorkspaceDiscoveryError::ExplicitManifestError(err)) => {
                 return Err(WorkspaceLocatorError::ExplicitManifestError(err))
             }
+            Err(WorkspaceDiscoveryError::Canonicalize(source, path)) => {
+                return Err(WorkspaceLocatorError::Canonicalize { path, source })
+            }
         };
 
         // Extract the warnings from the discovered workspace.

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -174,19 +174,18 @@ impl Workspace {
     /// Constructs a new instance from an internal manifest representation
     pub(crate) fn from_manifests(manifest: Manifests) -> Self {
         let env_vars = Workspace::init_env_vars(&manifest.workspace.value.environments);
-
-        let root = manifest
-            .workspace
-            .provenance
-            .path
+        // Canonicalize the root path
+        let root = &manifest.workspace.provenance.path;
+        let root = dunce::canonicalize(root).unwrap_or(root.to_path_buf());
+        // Take the parent after conicalizing to ensure this works even when the manifest
+        let root = root
             .parent()
             .expect("manifest path should always have a parent")
             .to_owned();
 
         let config = Config::load(&root);
-
         Self {
-            root: dunce::canonicalize(&root).unwrap_or(root),
+            root,
             client: Default::default(),
             workspace: manifest.workspace,
             package: manifest.package,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -177,7 +177,7 @@ impl Workspace {
         // Canonicalize the root path
         let root = &manifest.workspace.provenance.path;
         let root = dunce::canonicalize(root).unwrap_or(root.to_path_buf());
-        // Take the parent after conicalizing to ensure this works even when the manifest
+        // Take the parent after canonicalizing to ensure this works even when the manifest
         let root = root
             .parent()
             .expect("manifest path should always have a parent")


### PR DESCRIPTION
There was a failure when running the list command with a `--manifest-path pixi.toml` instead of using `./pixi.toml`. What happened is that the discovery found `pyproject.toml` but when creating the workspace path it tried to use the parent of a file which was basically empty, and making the `workspace.root` be an empty path.

Resulting in failures if this was being passed around. As can be seen:

- `× base path is not absolute:` https://github.com/prefix-dev/setup-pixi/actions/runs/13088235283/job/37021990108
- `× lock-file not up-to-date with the project`: https://github.com/Hofer-Julian/Ribasim/actions/runs/13266269616/job/37034421343#step:6:18

This should resolve that.