### PR TITLE
test: cover more with downstream tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,7 +640,8 @@ jobs:
           repository: nerfstudio-project/nerfstudio
           path: nerfstudio
       - name: "Install nerfstudio-project/nerfstudio"
-        run: pixi install -vvv --locked
+        # Not using locked as their lockfile is not in sync
+        run: pixi install -vvv
         working-directory: nerfstudio
 
       - name: "Checkout Deltares/Ribasim"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -604,12 +604,9 @@ jobs:
         run: pixi install -vvv --locked
         working-directory: polarify
       - run: pixi info
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
       - run: pixi list
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
       - name: Run downstream polarify environment
         run: pixi run --locked echo "Running downstream polarify environment"
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
 
   test-downstream-linux-x86_64:
     timeout-minutes: 15
@@ -664,12 +661,9 @@ jobs:
         run: pixi install -vvv --locked
         working-directory: polarify
       - run: pixi info
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
       - run: pixi list
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
       - name: Run downstream polarify environment
         run: pixi run --locked echo "Running downstream polarify environment"
-        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
   #
   # Install a number of common wheels on some platforms
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,7 +529,7 @@ jobs:
 
       - name: Install pixi's pixi project
         working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: pixi install -vv
+        run: pixi install -vvv --locked
 
       - name: Checkout Deltares/Ribasim
         uses: actions/checkout@v4
@@ -539,7 +539,7 @@ jobs:
       - name: Copy Deltares/Ribasim to Dev Drive
         run: Copy-Item -Path "${{ github.workspace }}/ribasim" -Destination "${{ env.PIXI_WORKSPACE }}/ribasim" -Recurse
       - name: Install Deltares/Ribasim
-        run: pixi install
+        run: pixi install -vvv --locked
         working-directory: ${{ env.PIXI_WORKSPACE }}/ribasim
 
       - name: Checkout quantco/polarify
@@ -550,7 +550,14 @@ jobs:
       - name: Copy quantco/polarify to Dev Drive
         run: Copy-Item -Path "${{ github.workspace }}/polarify" -Destination "${{ env.PIXI_WORKSPACE }}/polarify" -Recurse
       - name: Install quantco/polarify
-        run: pixi install
+        run: pixi install -vvv --locked
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - run: pixi info
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - run: pixi list
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - name: Run downstream polarify environment
+        run: pixi run --locked echo "Running downstream polarify environment"
         working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
 
   test-downstream-macos-aarch64:
@@ -576,7 +583,8 @@ jobs:
         run: pixi info
 
       - name: Install pixi
-        run: pixi install -v
+        # Using locked to validate that the lock file is correct
+        run: pixi install -vvv --locked
 
       - name: "Checkout Deltares/Ribasim"
         uses: actions/checkout@v4
@@ -584,7 +592,7 @@ jobs:
           repository: Deltares/Ribasim
           path: ribasim
       - name: "Install Deltares/Ribasim"
-        run: pixi install
+        run: pixi install -vvv --locked
         working-directory: ribasim
 
       - name: "Checkout quantco/polarify"
@@ -593,8 +601,15 @@ jobs:
           repository: quantco/polarify
           path: polarify
       - name: "Install quantco/polarify"
-        run: pixi install
+        run: pixi install -vvv --locked
         working-directory: polarify
+      - run: pixi info
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - run: pixi list
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - name: Run downstream polarify environment
+        run: pixi run --locked echo "Running downstream polarify environment"
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
 
   test-downstream-linux-x86_64:
     timeout-minutes: 15
@@ -620,7 +635,7 @@ jobs:
 
       - name: Install pixi
         working-directory: ${{ env.PIXI_WORKSPACE }}
-        run: pixi install -v
+        run: pixi install -vvv --locked
 
       - name: "Checkout nerfstudio-project/nerfstudio"
         uses: actions/checkout@v4
@@ -628,7 +643,7 @@ jobs:
           repository: nerfstudio-project/nerfstudio
           path: nerfstudio
       - name: "Install nerfstudio-project/nerfstudio"
-        run: pixi install
+        run: pixi install -vvv --locked
         working-directory: nerfstudio
 
       - name: "Checkout Deltares/Ribasim"
@@ -637,7 +652,7 @@ jobs:
           repository: Deltares/Ribasim
           path: ribasim
       - name: "Install Deltares/Ribasim"
-        run: pixi install
+        run: pixi install -vvv --locked
         working-directory: ribasim
 
       - name: "Checkout quantco/polarify"
@@ -646,8 +661,15 @@ jobs:
           repository: quantco/polarify
           path: polarify
       - name: "Install quantco/polarify"
-        run: pixi install
+        run: pixi install -vvv --locked
         working-directory: polarify
+      - run: pixi info
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - run: pixi list
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
+      - name: Run downstream polarify environment
+        run: pixi run --locked echo "Running downstream polarify environment"
+        working-directory: ${{ env.PIXI_WORKSPACE }}/polarify
   #
   # Install a number of common wheels on some platforms
   #


### PR DESCRIPTION
This tries to test more on the downstream tests mainly:
- Run the installations with `--locked` to make sure we test satisfiability
- Actually start an environment for `polarify` 
- Getting more info with `pixi info` and `pixi list`
