### PR TITLE
refactor: clean up workspace methods

### DIFF
--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -27,7 +27,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .locate()?;
 
     // Save the original lockfile to compare with the new one.
-    let original_lock_file = workspace.get_lock_file().await?;
+    let original_lock_file = workspace.load_lock_file().await?;
     let new_lock_file = workspace
         .update_lock_file(UpdateLockFileOptions {
             lock_file_usage: LockFileUsage::Update,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,5 @@ mod build;
 mod rlimit;
 mod utils;
 
-pub use lock_file::{load_lock_file, UpdateLockFileOptions};
+pub use lock_file::UpdateLockFileOptions;
 pub use workspace::{DependencyType, Workspace, WorkspaceLocator};

--- a/src/lock_file/mod.rs
+++ b/src/lock_file/mod.rs
@@ -8,11 +8,9 @@ mod update;
 mod utils;
 
 pub use crate::environment::CondaPrefixUpdater;
-use crate::Workspace;
-use miette::{IntoDiagnostic, WrapErr};
 pub(crate) use package_identifier::PypiPackageIdentifier;
 use pixi_record::PixiRecord;
-use rattler_lock::{LockFile, ParseCondaLockError, PypiPackageData, PypiPackageEnvironmentData};
+use rattler_lock::{PypiPackageData, PypiPackageEnvironmentData};
 pub(crate) use records_by_name::{PixiRecordsByName, PypiRecordsByName};
 pub(crate) use resolve::{
     conda::resolve_conda, pypi::resolve_pypi, uv_resolution_context::UvResolutionContext,
@@ -35,57 +33,26 @@ pub type LockedPypiPackages = Vec<PypiRecord>;
 /// data. In Pixi we basically always need both.
 pub type PypiRecord = (PypiPackageData, PypiPackageEnvironmentData);
 
-/// Loads the lockfile for the specified project or returns a dummy one if none
-/// could be found.
-pub async fn load_lock_file(project: &Workspace) -> miette::Result<LockFile> {
-    let lock_file_path = project.lock_file_path();
-    if lock_file_path.is_file() {
-        // Spawn a background task because loading the file might be IO bound.
-        tokio::task::spawn_blocking(move || {
-            LockFile::from_path(&lock_file_path)
-                .map_err(|err| match err {
-                    ParseCondaLockError::IncompatibleVersion{ lock_file_version, max_supported_version} => {
-                        miette::miette!(
-                            help="Please update pixi to the latest version and try again.",
-                            "The lock file version is {}, but only up to including version {} is supported by the current version.",
-                            lock_file_version, max_supported_version
-                        )
-                    }
-                    _ => miette::miette!(err),
-                })
-                .wrap_err_with(|| {
-                    format!(
-                        "Failed to load lock file from `{}`",
-                        lock_file_path.display()
-                    )
-                })
-        })
-            .await
-            .unwrap_or_else(|e| Err(e).into_diagnostic())
-    } else {
-        Ok(LockFile::default())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::{load_lock_file, Workspace};
+    use crate::Workspace;
 
     #[tokio::test]
     async fn test_load_newer_lock_file() {
         // Test that loading a lock file with a newer version than the current
         // version of pixi will return an error.
         let temp_dir = tempfile::tempdir().unwrap();
-        let project = r#"
+        let manifest_toml = r#"
         [project]
         name = "pixi"
         channels = []
         platforms = []
         "#;
-        let project =
-            Workspace::from_str(temp_dir.path().join("pixi.toml").as_path(), project).unwrap();
+        let workspace =
+            Workspace::from_str(temp_dir.path().join("pixi.toml").as_path(), manifest_toml)
+                .unwrap();
 
-        let lock_file_path = project.lock_file_path();
+        let lock_file_path = workspace.lock_file_path();
         let raw_lock_file = r#"
         version: 9999
         environments:
@@ -99,7 +66,7 @@ mod tests {
             .await
             .unwrap();
 
-        let err = load_lock_file(&project).await.unwrap_err();
+        let err = &workspace.load_lock_file().await.unwrap_err();
         let dbg_err = format!("{:?}", err);
         // Test that the error message contains the correct information.
         assert!(dbg_err.contains("The lock file version is 9999, but only up to including version"));

--- a/src/lock_file/outdated.rs
+++ b/src/lock_file/outdated.rs
@@ -61,8 +61,8 @@ impl<'p> DisregardLockedContent<'p> {
 impl<'p> OutdatedEnvironments<'p> {
     /// Constructs a new instance of this struct by examining the project and
     /// lock-file and finding any mismatches.
-    pub(crate) async fn from_project_and_lock_file(
-        project: &'p Workspace,
+    pub(crate) async fn from_workspace_and_lock_file(
+        workspace: &'p Workspace,
         lock_file: &LockFile,
         glob_hash_cache: GlobHashCache,
     ) -> Self {
@@ -71,7 +71,7 @@ impl<'p> OutdatedEnvironments<'p> {
             mut outdated_conda,
             mut outdated_pypi,
             disregard_locked_content,
-        } = find_unsatisfiable_targets(project, lock_file, glob_hash_cache).await;
+        } = find_unsatisfiable_targets(workspace, lock_file, glob_hash_cache).await;
 
         // Extend the outdated targets to include the solve groups
         let (mut conda_solve_groups_out_of_date, mut pypi_solve_groups_out_of_date) =
@@ -80,7 +80,7 @@ impl<'p> OutdatedEnvironments<'p> {
         // Find all the solve groups that have inconsistent dependencies between
         // environments.
         find_inconsistent_solve_groups(
-            project,
+            workspace,
             lock_file,
             &outdated_conda,
             &mut conda_solve_groups_out_of_date,

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -32,7 +32,9 @@ use pypi_mapping::{self};
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
 use rattler::package_cache::PackageCache;
 use rattler_conda_types::{Arch, MatchSpec, ParseStrictness, Platform};
-use rattler_lock::{LockFile, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData};
+use rattler_lock::{
+    LockFile, ParseCondaLockError, PypiIndexes, PypiPackageData, PypiPackageEnvironmentData,
+};
 use rattler_repodata_gateway::{Gateway, RepoData};
 use reqwest_middleware::ClientWithMiddleware;
 use thiserror::Error;
@@ -52,7 +54,6 @@ use crate::{
         LockedEnvironmentHash, PerEnvironmentAndPlatform, PerGroup, PerGroupAndPlatform,
         PythonStatus,
     },
-    load_lock_file,
     lock_file::{
         self,
         records_by_name::HasNameVersion,
@@ -69,20 +70,121 @@ use crate::{
 };
 
 impl Workspace {
-    /// Ensures that the lock-file is up-to-date with the project information.
+    /// Ensures that the lock-file is up-to-date with the project.
     ///
-    /// Returns the lock-file and any potential derived data that was computed
-    /// as part of this operation.
+    /// This function will return a [`LockFileDerivedData`] struct that contains the
+    /// lock-file and any potential derived data that was computed as part of this
+    /// function. The derived data might be usable by other functions to avoid
+    /// recomputing the same data.
+    ///
+    /// This function starts by checking if the lock-file is up-to-date. If it is
+    /// not up-to-date it will construct a task graph of all the work that needs to
+    /// be done to update the lock-file. The tasks are awaited in a specific order
+    /// to make sure that we can start instantiating prefixes as soon as possible.
     pub async fn update_lock_file(
         &self,
         options: UpdateLockFileOptions,
     ) -> miette::Result<LockFileDerivedData<'_>> {
-        update_lock_file(self, options).await
+        let lock_file = self.load_lock_file().await?;
+        let package_cache =
+            PackageCache::new(pixi_config::get_cache_dir()?.join(consts::CONDA_PACKAGE_CACHE_DIR));
+        let glob_hash_cache = GlobHashCache::default();
+
+        // should we check the lock-file in the first place?
+        if !options.lock_file_usage.should_check_if_out_of_date() {
+            tracing::info!("skipping check if lock-file is up-to-date");
+
+            return Ok(LockFileDerivedData {
+                workspace: self,
+                lock_file,
+                package_cache,
+                updated_conda_prefixes: Default::default(),
+                updated_pypi_prefixes: Default::default(),
+                uv_context: None,
+                io_concurrency_limit: IoConcurrencyLimit::default(),
+                build_context: BuildContext::from_workspace(self)?,
+                glob_hash_cache,
+            });
+        }
+
+        // Check which environments are out of date.
+        let outdated = OutdatedEnvironments::from_workspace_and_lock_file(
+            self,
+            &lock_file,
+            glob_hash_cache.clone(),
+        )
+        .await;
+        if outdated.is_empty() {
+            tracing::info!("the lock-file is up-to-date");
+
+            // If no-environment is outdated we can return early.
+            return Ok(LockFileDerivedData {
+                workspace: self,
+                lock_file,
+                package_cache,
+                updated_conda_prefixes: Default::default(),
+                updated_pypi_prefixes: Default::default(),
+                uv_context: None,
+                io_concurrency_limit: IoConcurrencyLimit::default(),
+                build_context: BuildContext::from_workspace(self)?,
+                glob_hash_cache,
+            });
+        }
+
+        // If the lock-file is out of date, but we're not allowed to update it, we
+        // should exit.
+        if !options.lock_file_usage.allows_lock_file_updates() {
+            miette::bail!("lock-file not up-to-date with the workspace");
+        }
+
+        // Construct an update context and perform the actual update.
+        let lock_file_derived_data = UpdateContext::builder(self)
+            .with_package_cache(package_cache)
+            .with_no_install(options.no_install)
+            .with_outdated_environments(outdated)
+            .with_lock_file(lock_file)
+            .with_glob_hash_cache(glob_hash_cache)
+            .finish()
+            .await?
+            .update()
+            .await?;
+
+        // Write the lock-file to disk
+        lock_file_derived_data.write_to_disk()?;
+
+        Ok(lock_file_derived_data)
     }
 
-    /// Get lockfile without checking
-    pub async fn get_lock_file(&self) -> miette::Result<LockFile> {
-        load_lock_file(self).await
+    /// Loads the lockfile for the workspace or returns `Lockfile::default` if none
+    /// could be found.
+    pub async fn load_lock_file(&self) -> miette::Result<LockFile> {
+        let lock_file_path = self.lock_file_path();
+        if lock_file_path.is_file() {
+            // Spawn a background task because loading the file might be IO bound.
+            tokio::task::spawn_blocking(move || {
+            LockFile::from_path(&lock_file_path)
+                .map_err(|err| match err {
+                    ParseCondaLockError::IncompatibleVersion{ lock_file_version, max_supported_version} => {
+                        miette::miette!(
+                            help="Please update pixi to the latest version and try again.",
+                            "The lock file version is {}, but only up to including version {} is supported by the current version.",
+                            lock_file_version, max_supported_version
+                        )
+                    }
+                    _ => miette::miette!(err),
+                })
+                .wrap_err_with(|| {
+                    format!(
+                        "Failed to load lock file from `{}`",
+                        lock_file_path.display()
+                    )
+                })
+        })
+            .await
+            .unwrap_or_else(|e| Err(e).into_diagnostic())
+        } else {
+            Ok(LockFile::default())
+        }
     }
 }
 
@@ -645,91 +747,6 @@ fn determine_pypi_solve_permits(project: &Workspace) -> usize {
     project.config().max_concurrent_solves()
 }
 
-/// Ensures that the lock-file is up-to-date with the project.
-///
-/// This function will return a [`LockFileDerivedData`] struct that contains the
-/// lock-file and any potential derived data that was computed as part of this
-/// function. The derived data might be usable by other functions to avoid
-/// recomputing the same data.
-///
-/// This function starts by checking if the lock-file is up-to-date. If it is
-/// not up-to-date it will construct a task graph of all the work that needs to
-/// be done to update the lock-file. The tasks are awaited in a specific order
-/// to make sure that we can start instantiating prefixes as soon as possible.
-pub async fn update_lock_file(
-    project: &Workspace,
-    options: UpdateLockFileOptions,
-) -> miette::Result<LockFileDerivedData<'_>> {
-    let lock_file = load_lock_file(project).await?;
-    let package_cache =
-        PackageCache::new(pixi_config::get_cache_dir()?.join(consts::CONDA_PACKAGE_CACHE_DIR));
-    let glob_hash_cache = GlobHashCache::default();
-
-    // should we check the lock-file in the first place?
-    if !options.lock_file_usage.should_check_if_out_of_date() {
-        tracing::info!("skipping check if lock-file is up-to-date");
-
-        return Ok(LockFileDerivedData {
-            workspace: project,
-            lock_file,
-            package_cache,
-            updated_conda_prefixes: Default::default(),
-            updated_pypi_prefixes: Default::default(),
-            uv_context: None,
-            io_concurrency_limit: IoConcurrencyLimit::default(),
-            build_context: BuildContext::from_workspace(project)?,
-            glob_hash_cache,
-        });
-    }
-
-    // Check which environments are out of date.
-    let outdated = OutdatedEnvironments::from_project_and_lock_file(
-        project,
-        &lock_file,
-        glob_hash_cache.clone(),
-    )
-    .await;
-    if outdated.is_empty() {
-        tracing::info!("the lock-file is up-to-date");
-
-        // If no-environment is outdated we can return early.
-        return Ok(LockFileDerivedData {
-            workspace: project,
-            lock_file,
-            package_cache,
-            updated_conda_prefixes: Default::default(),
-            updated_pypi_prefixes: Default::default(),
-            uv_context: None,
-            io_concurrency_limit: IoConcurrencyLimit::default(),
-            build_context: BuildContext::from_workspace(project)?,
-            glob_hash_cache,
-        });
-    }
-
-    // If the lock-file is out of date, but we're not allowed to update it, we
-    // should exit.
-    if !options.lock_file_usage.allows_lock_file_updates() {
-        miette::bail!("lock-file not up-to-date with the project");
-    }
-
-    // Construct an update context and perform the actual update.
-    let lock_file_derived_data = UpdateContext::builder(project)
-        .with_package_cache(package_cache)
-        .with_no_install(options.no_install)
-        .with_outdated_environments(outdated)
-        .with_lock_file(lock_file)
-        .with_glob_hash_cache(glob_hash_cache)
-        .finish()
-        .await?
-        .update()
-        .await?;
-
-    // Write the lock-file to disk
-    lock_file_derived_data.write_to_disk()?;
-
-    Ok(lock_file_derived_data)
-}
-
 pub struct UpdateContextBuilder<'p> {
     /// The project
     project: &'p Workspace,
@@ -827,7 +844,7 @@ impl<'p> UpdateContextBuilder<'p> {
         let outdated = match self.outdated_environments {
             Some(outdated) => outdated,
             None => {
-                OutdatedEnvironments::from_project_and_lock_file(
+                OutdatedEnvironments::from_workspace_and_lock_file(
                     project,
                     &lock_file,
                     glob_hash_cache.clone(),

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -72,7 +72,7 @@ use crate::{
 impl Workspace {
     /// Ensures that the lock-file is up-to-date with the project.
     ///
-    /// This function will return a [`LockFileDerivedData`] struct that contains the
+    /// This function will return a `LockFileDerivedData` struct that contains the
     /// lock-file and any potential derived data that was computed as part of this
     /// function. The derived data might be usable by other functions to avoid
     /// recomputing the same data.

--- a/src/workspace/workspace_mut.rs
+++ b/src/workspace/workspace_mut.rs
@@ -25,7 +25,6 @@ use crate::{
     cli::cli_config::PrefixUpdateConfig,
     diff::LockFileDiff,
     environment::LockFileUsage,
-    load_lock_file,
     lock_file::{LockFileDerivedData, UpdateContext, UpdateMode},
     workspace::{
         grouped_environment::GroupedEnvironment, MatchSpecs, PypiDeps, SourceSpecs, UpdateDeps,
@@ -307,7 +306,7 @@ impl WorkspaceMut {
             return Ok(None);
         }
 
-        let original_lock_file = load_lock_file(self.workspace()).await?;
+        let original_lock_file = self.workspace().load_lock_file().await?;
         let affected_environments = self
             .workspace()
             .environments()

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -568,7 +568,7 @@ impl PixiControl {
     /// [`Self::update_lock_file`].
     pub async fn lock_file(&self) -> miette::Result<LockFile> {
         let workspace = Workspace::from_path(&self.manifest_path())?;
-        pixi::load_lock_file(&workspace).await
+        workspace.load_lock_file().await
     }
 
     /// Load the current lock-file and makes sure that its up to date with the


### PR DESCRIPTION
Follow up to the big workspace refactor.

- Methods were unnecessarily nested
- Updated docstrings
- Fix variable names