### PR TITLE
chore: improve error messages on prefix issues

### DIFF
--- a/src/environment/conda_prefix.rs
+++ b/src/environment/conda_prefix.rs
@@ -192,9 +192,7 @@ impl CondaPrefixUpdater {
                     tokio::task::spawn_blocking(move || prefix_clone.find_installed_packages())
                         .unwrap_or_else(|e| match e.try_into_panic() {
                             Ok(panic) => std::panic::resume_unwind(panic),
-                            Err(e) => {
-                                std::panic::resume_unwind(Box::new(PrefixError::JoinError(e)))
-                            }
+                            Err(_e) => Err(PrefixError::JoinError),
                         });
 
                 // Wait until the conda records are available and until the installed packages

--- a/src/environment/conda_prefix.rs
+++ b/src/environment/conda_prefix.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, LazyLock};
 use crate::build::{BuildContext, SourceCheckoutReporter};
 use crate::environment::PythonStatus;
 use crate::lock_file::IoConcurrencyLimit;
-use crate::prefix::Prefix;
+use crate::prefix::{Prefix, PrefixError};
 use crate::workspace::grouped_environment::{GroupedEnvironment, GroupedEnvironmentName};
 use crate::workspace::HasWorkspaceRef;
 use futures::{stream, StreamExt, TryFutureExt, TryStreamExt};
@@ -192,7 +192,9 @@ impl CondaPrefixUpdater {
                     tokio::task::spawn_blocking(move || prefix_clone.find_installed_packages())
                         .unwrap_or_else(|e| match e.try_into_panic() {
                             Ok(panic) => std::panic::resume_unwind(panic),
-                            Err(_err) => Err(miette::miette!("the operation was cancelled")),
+                            Err(e) => {
+                                std::panic::resume_unwind(Box::new(PrefixError::JoinError(e)))
+                            }
                         });
 
                 // Wait until the conda records are available and until the installed packages

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use miette::{Context, IntoDiagnostic};
+use miette::{Context, Diagnostic, IntoDiagnostic};
 use pixi_utils::{is_binary_folder, strip_executable_extension};
 use rattler_conda_types::{PackageName, Platform, PrefixRecord};
 use rattler_shell::{
@@ -12,7 +12,21 @@ use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
 };
+use thiserror::Error;
 use uv_configuration::RAYON_INITIALIZE;
+
+#[derive(Error, Debug, Diagnostic)]
+pub enum PrefixError {
+    #[error("failed to collect prefix records from '{1}'")]
+    PrefixRecordCollectionError(#[source] std::io::Error, PathBuf),
+
+    #[error("failed to find the designated package '{0}' in the prefix: '{1}'")]
+    DesignatedPackageNotFound(String, PathBuf),
+
+    #[error("executing prefix related task failed")]
+    #[diagnostic(help("try running the command again, or `pixi clean` to reset the environment"))]
+    JoinError(#[from] tokio::task::JoinError),
+}
 
 /// Points to a directory that serves as a Conda prefix.
 #[derive(Debug, Clone)]
@@ -48,11 +62,12 @@ impl Prefix {
 
     /// Scans the `conda-meta` directory of an environment and returns all the
     /// [`PrefixRecord`]s found in there.
-    pub fn find_installed_packages(&self) -> miette::Result<Vec<PrefixRecord>> {
+    pub fn find_installed_packages(&self) -> Result<Vec<PrefixRecord>, PrefixError> {
         // Initialize rayon explicitly to avoid implicit initialization.
         LazyLock::force(&RAYON_INITIALIZE);
 
-        PrefixRecord::collect_from_prefix(&self.root).into_diagnostic()
+        PrefixRecord::collect_from_prefix(&self.root)
+            .map_err(|err| PrefixError::PrefixRecordCollectionError(err, self.root.clone()))
     }
 
     /// Processes prefix records (that you can get by using
@@ -110,12 +125,15 @@ impl Prefix {
     pub async fn find_designated_package(
         &self,
         package_name: &PackageName,
-    ) -> miette::Result<PrefixRecord> {
+    ) -> Result<PrefixRecord, PrefixError> {
         let prefix_records = self.find_installed_packages()?;
         prefix_records
             .into_iter()
             .find(|r| r.repodata_record.package_record.name == *package_name)
-            .ok_or_else(|| miette::miette!("could not find {} in prefix", package_name.as_source()))
+            .ok_or(PrefixError::DesignatedPackageNotFound(
+                package_name.as_normalized().to_string(),
+                self.root.clone(),
+            ))
     }
 }
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -18,6 +18,7 @@ use uv_configuration::RAYON_INITIALIZE;
 #[derive(Error, Debug, Diagnostic)]
 pub enum PrefixError {
     #[error("failed to collect prefix records from '{1}'")]
+    #[diagnostic(help("try `pixi clean` to reset the environment and run the command again"))]
     PrefixRecordCollectionError(#[source] std::io::Error, PathBuf),
 
     #[error("failed to find the designated package '{0}' in the prefix: '{1}'")]

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -26,7 +26,7 @@ pub enum PrefixError {
 
     #[error("executing prefix related task failed")]
     #[diagnostic(help("try running the command again, or `pixi clean` to reset the environment"))]
-    JoinError(#[from] tokio::task::JoinError),
+    JoinError,
 }
 
 /// Points to a directory that serves as a Conda prefix.


### PR DESCRIPTION
Instead of:
```
❯ pixi i
Error: 
  ╰─▶ EOF while parsing a value at line 1 column 0
```

You'll now get errors like:
```
❯ pixi i
Error: 
  × failed to collect prefix records from '/Users/rubenarts/dev/pixi/examples/conda_mapping/.pixi/envs/default'
  ╰─▶ EOF while parsing a value at line 1 column 0
  help: try `pixi clean` to reset the environment and run the command again
```

This doesn't solve the issue but might help the users who walk into similar issues. The actual issue is described in: https://github.com/conda/rattler/issues/1062
