### PR TITLE
fix: `BUILD_EDITABLE_PYTHON` env flag

### DIFF
--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -3,7 +3,7 @@ import shutil
 import json
 import pytest
 
-from ..common import verify_cli_command
+from ..common import ExitCode, verify_cli_command
 
 
 @pytest.mark.slow
@@ -171,6 +171,7 @@ def test_non_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace
     env = {
         "BUILD_EDITABLE_PYTHON": "false",
         "PIXI_CACHE_DIR": str(tmp_pixi_workspace.joinpath("pixi_cache")),
+        "PIXI_BUILD_BACKEND_OVERRIDE": "pixi-build-python=/var/home/julian/Projekte/github.com/prefix-dev/pixi-build-backends/target/release/pixi-build-python",
     }
 
     verify_cli_command(
@@ -192,6 +193,7 @@ def test_non_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace
             manifest_path,
             "check-editable",
         ],
+        ExitCode.FAILURE,
         env=env,
         stdout_contains="The package is not installed as editable.",
     )

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -171,7 +171,6 @@ def test_non_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace
     env = {
         "BUILD_EDITABLE_PYTHON": "false",
         "PIXI_CACHE_DIR": str(tmp_pixi_workspace.joinpath("pixi_cache")),
-        "PIXI_BUILD_BACKEND_OVERRIDE": "pixi-build-python=/var/home/julian/Projekte/github.com/prefix-dev/pixi-build-backends/target/release/pixi-build-python",
     }
 
     verify_cli_command(

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -121,6 +121,10 @@ def test_source_change_trigger_rebuild(
 
 @pytest.mark.slow
 def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
+    """
+    This one tries to run the Python based rich example project,
+    installed as a normal package by overriding with an environment variable.
+    """
     project = "editable-pyproject"
     test_data = build_data.joinpath(project)
 
@@ -147,4 +151,47 @@ def test_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Pa
             "check-editable",
         ],
         stdout_contains="The package is installed as editable.",
+    )
+
+
+@pytest.mark.slow
+def test_non_editable_pyproject(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
+    """
+    This one tries to run the Python based rich example project,
+    installed as a normal package by overriding with an environment variable.
+    """
+    project = "editable-pyproject"
+    test_data = build_data.joinpath(project)
+
+    target_dir = tmp_pixi_workspace.joinpath(project)
+    shutil.copytree(test_data, target_dir)
+    manifest_path = target_dir.joinpath("pyproject.toml")
+
+    # TODO: Setting the cache dir shouldn't be necessary!
+    env = {
+        "BUILD_EDITABLE_PYTHON": "false",
+        "PIXI_CACHE_DIR": str(tmp_pixi_workspace.joinpath("pixi_cache")),
+    }
+
+    verify_cli_command(
+        [
+            pixi,
+            "install",
+            "--manifest-path",
+            manifest_path,
+        ],
+        env=env,
+    )
+
+    # Verify that package is installed as editable
+    verify_cli_command(
+        [
+            pixi,
+            "run",
+            "--manifest-path",
+            manifest_path,
+            "check-editable",
+        ],
+        env=env,
+        stdout_contains="The package is not installed as editable.",
     )


### PR DESCRIPTION
Fixes #3120

Depends on https://github.com/prefix-dev/pixi-build-backends/pull/75