### PR TITLE
fix: reinstall if required is source and installed is from registry.

### DIFF
--- a/src/install_pypi/mod.rs
+++ b/src/install_pypi/mod.rs
@@ -277,7 +277,11 @@ pub async fn update_python_distributions(
         for (dist, reason) in &reinstalls {
             // Only log the re-install reason if it is not an installer mismatch
             if !matches!(reason, NeedReinstall::InstallerMismatch { .. }) {
-                tracing::debug!("re-installing {} because: {}", dist.name(), reason);
+                tracing::info!(
+                    "re-installing '{}' because: '{}'",
+                    console::style(dist.name()).blue(),
+                    reason
+                );
             }
         }
     }


### PR DESCRIPTION
When you switch from a registry package to a local source package, pixi should re-install it. This was previously not checked in the installation planner. This PR adds that check. **But** it doesn't fix the complete problem as we still get it from the cache afterward, so this PR is the first in a series to fix the problem of reinstallation completely. 

Reproducer:
First `pixi install` this:
```toml
[project]
channels = ["conda-forge"]
name = "pixi_test"
platforms = ["osx-arm64"]

[tasks]
check = "python -c 'import yaml; print(yaml.__file__)'"

[dependencies]
python = ">=3.9,<3.14"

[pypi-dependencies]
pyyaml = "==6.0.2,<7"
```
Then clone the `pyyaml` package: `git clone --branch 6.0.2 git@github.com:yaml/pyyaml.git`
And modify the pixi.toml to:
```toml
[project]
channels = ["conda-forge"]
name = "pixi_test"
platforms = ["osx-arm64"]

[tasks]
check = "python -c 'import yaml; print(yaml.__file__)'"

[dependencies]
python = ">=3.9,<3.14"

[pypi-dependencies]
pyyaml = { path = "pyyaml", editable=false }
```
This will now throw the reinstall plan with: 
```
 INFO pixi::install_pypi: re-installing 'pyyaml' because: 'Installed from registry from 'registry' but locked to a non-registry location from 'pyyaml''
```

This will then not correctly install it as it is using the wrong cache, but that will be fixed later 🤞 
