### PR TITLE
fix: skip unneeded url parse and only add git+ when needed

### DIFF
--- a/crates/pixi_git/src/url.rs
+++ b/crates/pixi_git/src/url.rs
@@ -31,7 +31,12 @@ impl CanonicalUrl {
 
         // Strip credentials.
         let _ = url.set_password(None);
-        let _ = url.set_username("");
+
+        // Only stripping the username if the scheme is not `ssh`. This is because `ssh` URLs should
+        // have the `git` username.
+        if !url.scheme().contains("ssh") {
+            let _ = url.set_username("");
+        }
 
         // Strip a trailing slash.
         if url.path().ends_with('/') {

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -73,7 +73,7 @@ pub enum AsPep508Error {
     #[error("using an editable flag for a path that is not a directory: {path}")]
     EditableIsNotDir { path: PathBuf },
     #[error("error while canonicalization {0}")]
-    VerabatimUrlError(#[from] uv_pep508::VerbatimUrlError),
+    VerbatimUrlError(#[from] uv_pep508::VerbatimUrlError),
     #[error("error in extension parsing")]
     ExtensionError(#[from] uv_distribution_filename::ExtensionError),
     #[error("error in parsing version specifiers")]

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -431,8 +431,8 @@ impl<'p> LockFileDerivedData<'p> {
         .await
         .with_context(|| {
             format!(
-                "{}: error installing/updating PyPI dependencies",
-                environment.name()
+                "Failed to update PyPI packages for environment '{}'",
+                environment.name().fancy_display()
             )
         })?;
 

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -2065,12 +2065,12 @@ async fn spawn_solve_pypi_task<'p>(
             .collect::<Result<_, ConversionError>>()
             .into_diagnostic()?;
 
-        let index_map = IndexMap::from_iter(dependencies);
+        let requirements = IndexMap::from_iter(dependencies);
 
         let (records, prefix_task_result) = lock_file::resolve_pypi(
             resolution_context,
             &pypi_options,
-            index_map,
+            requirements,
             system_requirements,
             &pixi_solve_records,
             &locked_pypi_records,

--- a/src/uv_reporter.rs
+++ b/src/uv_reporter.rs
@@ -145,7 +145,12 @@ impl uv_installer::PrepareReporter for UvReporter {
     }
 
     fn on_build_start(&self, dist: &BuildableSource) -> usize {
-        self.start(format!("building {}", dist))
+        let name: String = if let Some(name) = dist.name() {
+            name.to_string()
+        } else {
+            dist.to_string()
+        };
+        self.start(format!("building {}", name))
     }
 
     fn on_build_complete(&self, _dist: &BuildableSource, id: usize) {
@@ -161,13 +166,15 @@ impl uv_installer::PrepareReporter for UvReporter {
     }
 
     // TODO: figure out how to display this nicely
-    fn on_download_start(&self, _name: &PackageName, _size: Option<u64>) -> usize {
-        0
+    fn on_download_start(&self, name: &PackageName, _size: Option<u64>) -> usize {
+        self.start(format!("downloading {}", name))
     }
 
     fn on_download_progress(&self, _index: usize, _bytes: u64) {}
 
-    fn on_download_complete(&self, _name: &PackageName, _index: usize) {}
+    fn on_download_complete(&self, _name: &PackageName, id: usize) {
+        self.finish(id);
+    }
 }
 
 impl uv_installer::InstallReporter for UvReporter {
@@ -210,13 +217,15 @@ impl uv_resolver::ResolverReporter for UvReporter {
     }
 
     // TODO: figure out how to display this nicely
-    fn on_download_start(&self, _name: &PackageName, _size: Option<u64>) -> usize {
-        0
+    fn on_download_start(&self, name: &PackageName, _size: Option<u64>) -> usize {
+        self.start(format!("downloading {}", name))
     }
 
     fn on_download_progress(&self, _id: usize, _bytes: u64) {}
 
-    fn on_download_complete(&self, _name: &PackageName, _id: usize) {}
+    fn on_download_complete(&self, _name: &PackageName, id: usize) {
+        self.finish(id);
+    }
 }
 
 impl uv_distribution::Reporter for UvReporter {
@@ -237,11 +246,13 @@ impl uv_distribution::Reporter for UvReporter {
     }
 
     // TODO: figure out how to display this nicely
-    fn on_download_start(&self, _name: &PackageName, _size: Option<u64>) -> usize {
-        0
+    fn on_download_start(&self, name: &PackageName, _size: Option<u64>) -> usize {
+        self.start(format!("downloading {}", name))
     }
 
     fn on_download_progress(&self, _id: usize, _bytes: u64) {}
 
-    fn on_download_complete(&self, _name: &PackageName, _id: usize) {}
+    fn on_download_complete(&self, _name: &PackageName, id: usize) {
+        self.finish(id);
+    }
 }

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -239,7 +239,7 @@ async fn add_functionality_os() {
 
 /// Test the `pixi add --pypi` functionality
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+// #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_pypi_functionality() {
     let pixi = PixiControl::new().unwrap();
 

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -239,7 +239,7 @@ async fn add_functionality_os() {
 
 /// Test the `pixi add --pypi` functionality
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-// #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_pypi_functionality() {
     let pixi = PixiControl::new().unwrap();
 


### PR DESCRIPTION
The second time parsing the git URL would remove the `git@` from `ssh://git@github..` which is not right in this case.

TODO:
- [x] Add/validate tests