### PR TITLE
feat: prototype additional hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
 
   build-binary-windows-aarch64:
     needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
     runs-on: 16core_windows_latest_runner
     name: "build binary | windows aarch64"
     steps:

--- a/crates/pixi_build_frontend/src/protocols/builders/conda_build/protocol.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/conda_build/protocol.rs
@@ -107,6 +107,7 @@ impl Protocol {
                 })
                 .collect::<miette::Result<_>>()?,
             input_globs: None,
+            additional_hash: None,
         };
 
         Ok(metadata)

--- a/crates/pixi_build_types/src/procedures/conda_metadata.rs
+++ b/crates/pixi_build_types/src/procedures/conda_metadata.rs
@@ -52,4 +52,10 @@ pub struct CondaMetadataResult {
     /// If this field is not present, the input manifest will be used.
     #[serde(default)]
     pub input_globs: Option<Vec<String>>,
+
+    /// Additional information that will be added to the hash of the lock-file.
+    /// This can be extra information (like a JSON string), or an arbitrary hash
+    /// that the backend produces in order to break the cache when needed.
+    #[serde(default)]
+    pub additional_hash: Option<String>,
 }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -34,6 +34,8 @@ pub struct InputHash {
     )]
     pub hash: Sha256Hash,
     pub globs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_data: Option<String>
 }
 
 impl From<SourceRecord> for CondaPackageData {
@@ -59,6 +61,8 @@ impl TryFrom<CondaSourceData> for SourceRecord {
             input_hash: value.input.map(|hash| InputHash {
                 hash: hash.hash,
                 globs: hash.globs,
+                // TODO?
+                extra_data: None,
             }),
         })
     }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -687,9 +687,20 @@ impl BuildContext {
                     globs: input_globs.clone(),
                 })
                 .await?;
+
+            // Add in extra data to the glob hash
+            if let Some(extra_data) = &metadata.additional_hash {
+                // let mut hasher = Xxh3::with_seed(0);
+                // input_hash.hash(&mut hasher);
+                // extra_data.hash(&mut hasher);
+                print!("extra_data: {}", extra_data);
+                // input_hash = hasher.finish();
+            };
+
             Some(InputHash {
                 hash: input_hash.hash,
                 globs: input_globs,
+                extra_data: metadata.additional_hash,
             })
         };
 


### PR DESCRIPTION
The idea here is the following:

Instead of adding additional files to the glob, it might be useful if the backends could add some metadata to break caches when they know it's needed. 

For example, we had the situation that changing the `cmake` version (or any build-time dependency for that matter) did not trigger a rebuild. We solved this (as far as I understand) by globbing the entire input file as part of the hash. This is a little broader than what we would like because now adding empty lines and so on would also break the cache.

Ideally, the backend would tell us: these are the files that are concerned, and these are some extra data that should influence the hash. This extra data could be build time dependencies and other things, and it would just be injected into the hash.

However, then the problem becomes that pixi cannot itself determine whether it needs to call CondaGetMetadata.

So I think we should ideally have two sets of globs:

- first set contains source files + metadata files (like recipe)
- second set contains source files without metadata files (but instead, the additional_hash data returned from getMetadata call)

Maybe someone can elaborate a bit why we have `input_globs` in the `CondaMetadataResult`, but it's currently `None` in all backends?

Maybe this is also a bit premature optimization and what we have now works well enough. 

