### PR TITLE
fix: improve `pixi list` output for conda source packages

### DIFF
--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -89,6 +89,8 @@ pub static ENVIRONMENT_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().ma
 pub static EXPOSED_NAME_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().yellow());
 pub static FEATURE_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().cyan());
 pub static SOLVE_GROUP_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().cyan());
+pub static CONDA_PACKAGE_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().green());
+pub static PYPI_PACKAGE_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().blue());
 pub static DEFAULT_PYPI_INDEX_URL: LazyLock<Url> =
     LazyLock::new(|| Url::parse("https://pypi.org/simple").unwrap());
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -83,6 +83,16 @@ enum KindPackage {
     Conda,
     Pypi,
 }
+
+impl From<&PackageExt> for KindPackage {
+    fn from(package: &PackageExt) -> Self {
+        match package {
+            PackageExt::Conda(_) => KindPackage::Conda,
+            PackageExt::PyPI(_, _) => KindPackage::Pypi,
+        }
+    }
+}
+
 impl FancyDisplay for KindPackage {
     fn fancy_display(&self) -> console::StyledObject<&str> {
         match self {
@@ -389,11 +399,8 @@ fn create_package_to_output<'a, 'b>(
 ) -> miette::Result<PackageToOutput> {
     let name = package.name().to_string();
     let version = package.version().into_owned();
+    let kind = KindPackage::from(package);
 
-    let kind = match package {
-        PackageExt::Conda(_) => KindPackage::Conda,
-        PackageExt::PyPI(_, _) => KindPackage::Pypi,
-    };
     let build = match package {
         PackageExt::Conda(pkg) => Some(pkg.record().build.clone()),
         PackageExt::PyPI(_, _) => None,

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -83,17 +83,11 @@ enum KindPackage {
     Conda,
     Pypi,
 }
-impl KindPackage {
-    fn color(&self) -> Color {
-        match self {
-            KindPackage::Conda => Color::Green,
-            KindPackage::Pypi => Color::Blue,
-        }
-    }
+impl FancyDisplay for KindPackage {
     fn fancy_display(&self) -> console::StyledObject<&str> {
         match self {
-            KindPackage::Conda => console::style("conda").fg(self.color()).bold(),
-            KindPackage::Pypi => console::style("pypi").fg(self.color()).bold(),
+            KindPackage::Conda => consts::CONDA_PACKAGE_STYLE.apply_to("conda"),
+            KindPackage::Pypi => consts::PYPI_PACKAGE_STYLE.apply_to("pypi"),
         }
     }
 }
@@ -331,9 +325,11 @@ fn print_packages_as_table(packages: &Vec<PackageToOutput>) -> io::Result<()> {
             write!(
                 writer,
                 "{}",
-                console::style(&package.name)
-                    .fg(package.kind.color())
-                    .bold()
+                match package.kind {
+                    KindPackage::Conda =>
+                        consts::CONDA_PACKAGE_STYLE.apply_to(&package.name).bold(),
+                    KindPackage::Pypi => consts::PYPI_PACKAGE_STYLE.apply_to(&package.name).bold(),
+                }
             )?
         } else {
             write!(writer, "{}", &package.name)?;


### PR DESCRIPTION
Now it also prints the source and uses the colors to print the kind.

### Before:

![image](https://github.com/user-attachments/assets/30c2ef99-5702-4de2-8612-ff5c00e51298)

### After:


![image](https://github.com/user-attachments/assets/4751e0cf-a662-4c44-95fe-b602af0c373e)