### PR TITLE
feat: pixi search `--version` `--max-displayed-versions` flags

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -820,12 +820,18 @@ Search a package, output will list the latest version of the package.
 - `--channel <CHANNEL> (-c)`: specify a channel that the project uses. Defaults to `conda-forge`. (Allowed to be used more than once)
 - `--limit <LIMIT> (-l)`: optionally limit the number of search results
 - `--platform <PLATFORM> (-p)`: specify a platform that you want to search for. (default: current platform)
+- `--version <VERSION>`: specify a version constraint for the search. If the version is not specified, the latest version will be searched. Conflicts with `--max-displayed-versions`.
+- `--max-displayed-versions <MAX_DISPLAYED_VERSIONS>`: specify the maximum number of versions to display for each package. Conflicts with `--version`.  (default: 4)
 
 ```zsh
 pixi search pixi
 pixi search --limit 30 "py*"
 # search in a different channel and for a specific platform
 pixi search -c robostack --platform linux-64 "plotjuggler*"
+# Show data for pixi==0.40.3
+pixi search pixi --version 0.40.3
+# Show data for last 10 versions
+pixi search pixi --max-displayed-versions 10
 ```
 
 ## `self-update`

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -371,6 +371,8 @@ impl PixiControl {
                 platform: Platform::current(),
                 limit: None,
                 channels: ChannelsConfig::default(),
+                version: None,
+                max_displayed_versions: 4,
             },
         }
     }


### PR DESCRIPTION
solves #3173 

I added 2 flags for `pixi search`
1. `--version` - the user may search a specific version in order to examine information of a specific package version
2. `--max-displayed-versions` - currently, pixi displays only 4 versions. With this flag the user can decide to examine more version numbers

Notes:
* this 2 flags are mutually exclusive, as `--version` outputs a specific version (so it wouldn't make sense to user them together).
* Originally I suggested that the version query could be done as `pkg==version` - I didn't really know how to do that, and was afraid that it will collid with the wildcard search feature - if someone wants to take it further, go ahaed.

