### PR TITLE
chore: make sure we only build one version of `version-ranges`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,23 @@ jobs:
       - name: Machete
         uses: bnjbvr/cargo-machete@main
 
+  # Checks for duplicate version of package
+  cargo-vendor:
+    name: Cargo Vendor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          cache: ${{ github.ref == 'refs/heads/main' }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target/pixi"
+          key: ${{ hashFiles('pixi.lock') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Test cargo vendor
+        run: cargo vendor --locked
+
   #
   # Run tests on important platforms.
   #

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 site/
 .cache
 pytest-temp
+/vendor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4166,7 +4166,7 @@ dependencies = [
  "serde",
  "unicode-width 0.2.0",
  "unscanny",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=57832d0588fbb7aab824813481104761dc1c7740)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -4188,7 +4188,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "url",
  "urlencoding",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=57832d0588fbb7aab824813481104761dc1c7740)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -4946,7 +4946,7 @@ dependencies = [
  "priority-queue",
  "rustc-hash",
  "thiserror 2.0.11",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -7532,7 +7532,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
  "walkdir",
  "zip 0.6.6",
 ]
@@ -7838,7 +7838,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -8069,7 +8069,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.1.14",
  "unscanny",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -8092,7 +8092,7 @@ dependencies = [
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -8463,14 +8463,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version-ranges"
-version = "0.1.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=57832d0588fbb7aab824813481104761dc1c7740#57832d0588fbb7aab824813481104761dc1c7740"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "version-ranges"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -375,7 +375,7 @@ tokio = { workspace = true, features = ["rt"] }
 
 [patch.crates-io]
 # This is a temporary patch to get `cargo vendor` to work with the `uv` and pep508_rs` crates.
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "57832d0588fbb7aab824813481104761dc1c7740" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "b70cf707aa43f21b32f3a61b8a0889b15032d5c4" }
 
 # Config for 'dist'
 [workspace.metadata.dist]


### PR DESCRIPTION
Fixes: https://github.com/prefix-dev/pixi/issues/2839

To make sure we don't build version-ranges twice