### PR TITLE
fix: pixi global revert error message

### DIFF
--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -130,9 +130,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 };
             }
             Err(err) => {
-                revert_environment_after_error(env_name, &last_updated_project)
-                    .await
-                    .wrap_err("Couldn't install packages. Reverting also failed.")?;
+                if let Err(revert_err) =
+                    revert_environment_after_error(env_name, &last_updated_project).await
+                {
+                    tracing::warn!("Reverting of the operation failed");
+                    tracing::info!("Reversion error: {:?}", revert_err);
+                }
                 return Err(err);
             }
         }

--- a/src/cli/global/remove.rs
+++ b/src/cli/global/remove.rs
@@ -109,12 +109,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             state_changes.report();
         }
         Err(err) => {
-            revert_environment_after_error(env_name, &project_original)
-                .await
-                .wrap_err(format!(
-                    "Could not remove {:?}. Reverting also failed.",
-                    args.packages
-                ))?;
+            if let Err(revert_err) =
+                revert_environment_after_error(env_name, &project_original).await
+            {
+                tracing::warn!("Reverting of the operation failed");
+                tracing::info!("Reversion error: {:?}", revert_err);
+            }
             return Err(err);
         }
     }

--- a/src/cli/global/uninstall.rs
+++ b/src/cli/global/uninstall.rs
@@ -49,15 +49,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 state_changes.report();
             }
             Err(err) => {
-                revert_environment_after_error(env_name, &last_updated_project)
-                    .await
-                    .wrap_err_with(|| {
-                        format!(
-                            "Couldn't uninstall environment {}. Reverting also failed.",
-                            env_name.fancy_display()
-                        )
-                    })?;
-
+                if let Err(revert_err) =
+                    revert_environment_after_error(env_name, &last_updated_project).await
+                {
+                    tracing::warn!("Reverting of the operation failed");
+                    tracing::info!("Reversion error: {:?}", revert_err);
+                }
                 return Err(err);
             }
         }


### PR DESCRIPTION
There was no way to get the original error if reverting failed. Now we always print the original error and the reverting error when given verbose flags