### PR TITLE
fix: return err when `pixi list` doesn't find pkg

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use console::Color;
 use human_bytes::human_bytes;
 use itertools::Itertools;
-use miette::IntoDiagnostic;
+use miette::{miette, IntoDiagnostic};
 use uv_configuration::ConfigSettings;
 
 use crate::cli::cli_config::{PrefixUpdateConfig, WorkspaceConfig};
@@ -290,13 +290,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     if packages_to_output.is_empty() {
-        eprintln!(
+        return Err(miette!(
             "{}No packages found in '{}' environment for '{}' platform.",
             console::style(console::Emoji("✘ ", "")).red(),
             environment.name().fancy_display(),
             consts::ENVIRONMENT_STYLE.apply_to(platform),
-        );
-        return Ok(());
+        ));
     }
 
     // Print as table string or JSON


### PR DESCRIPTION
Fixes #3211 

I was a bad contributor and didn't add tests because the edit was so minor, and I had a hard time finding a good place for it. If you do want a test, feel free to bonk me and let me know where you think I should add it. 