### PR TITLE
ci: trigger CI on lock file update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - update-pixi
   workflow_dispatch:
   pull_request:
     types:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - update-pixi
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"


### PR DESCRIPTION
Because of a Github actions limitation, PRs don't trigger any CI on our lockfile update job. We can workaround this by explicitly naming the branch.