### PR TITLE
ci: revert machete update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
       interval: weekly
     commit-message:
       prefix: chore(ci)
+    ignore:
+      - dependency-name: bnjbvr/cargo-machete
     groups:
       dependencies:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Machete
-        uses: bnjbvr/cargo-machete@v0.8.0
+        uses: bnjbvr/cargo-machete@v0.7.1
 
   # Checks for duplicate version of package
   cargo-vendor:


### PR DESCRIPTION
I've expected that the latest GitHub actions update now does the right thing automatically, but it doesn't