### PR TITLE
test: run test_build_git_source_deps_from_tag again for Windows

### DIFF
--- a/tests/integration_python/pixi_build/test_git.py
+++ b/tests/integration_python/pixi_build/test_git.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import platform
 import shutil
 import pytest
 
@@ -180,7 +179,6 @@ def test_build_git_source_deps_from_rev(
     )
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Not reliable on Windows")
 @pytest.mark.slow
 def test_build_git_source_deps_from_tag(
     pixi: Path, tmp_pixi_workspace: Path, build_data: Path


### PR DESCRIPTION
The actual cause was the git update: https://github.com/prefix-dev/pixi/pull/3272