### PR TITLE
feat: default to "workspace" with `pixi init`

### DIFF
--- a/crates/pixi_build_frontend/tests/diagnostics.rs
+++ b/crates/pixi_build_frontend/tests/diagnostics.rs
@@ -59,7 +59,7 @@ async fn test_invalid_manifest() {
     let source_dir = tempfile::TempDir::new().unwrap();
     let manifest = source_dir
         .path()
-        .join(pixi_consts::consts::PROJECT_MANIFEST);
+        .join(pixi_consts::consts::WORKSPACE_MANIFEST);
     tokio::fs::write(&manifest, "[workspace]").await.unwrap();
     let err = BuildFrontend::default()
         .setup_protocol(SetupRequest {
@@ -92,7 +92,7 @@ async fn test_not_a_package() {
     let source_dir = tempfile::TempDir::new().unwrap();
     let manifest = source_dir
         .path()
-        .join(pixi_consts::consts::PROJECT_MANIFEST);
+        .join(pixi_consts::consts::WORKSPACE_MANIFEST);
     tokio::fs::write(
         &manifest,
         r#"
@@ -126,7 +126,7 @@ async fn test_invalid_backend() {
     let source_dir = tempfile::TempDir::new().unwrap();
     let manifest = source_dir
         .path()
-        .join(pixi_consts::consts::PROJECT_MANIFEST);
+        .join(pixi_consts::consts::WORKSPACE_MANIFEST);
 
     let toml = r#"
     [workspace]

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";
 pub const DEFAULT_FEATURE_NAME: &str = DEFAULT_ENVIRONMENT_NAME;
 pub const PYPROJECT_PIXI_PREFIX: &str = "tool.pixi";
 
-pub const PROJECT_MANIFEST: &str = "pixi.toml";
+pub const WORKSPACE_MANIFEST: &str = "pixi.toml";
 pub const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const PIXI_VERSION: &str = match option_env!("PIXI_VERSION") {

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -491,7 +491,7 @@ impl WorkspaceDiscoverer {
 
     /// Discover the workspace manifest in a directory.
     fn provenance_from_dir(dir: &Path) -> Option<ManifestProvenance> {
-        let pixi_toml_path = dir.join(consts::PROJECT_MANIFEST);
+        let pixi_toml_path = dir.join(consts::WORKSPACE_MANIFEST);
         let pyproject_toml_path = dir.join(consts::PYPROJECT_MANIFEST);
         if pixi_toml_path.is_file() {
             Some(ManifestProvenance::new(pixi_toml_path, ManifestKind::Pixi))

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -178,6 +178,17 @@ impl ManifestDocument {
     /// Detect the table name to use when querying elements of the manifest.
     fn detect_table_name(&self) -> &'static str {
         if self.manifest().as_table().contains_key("workspace") {
+            // pixi.toml
+            "workspace"
+        } else if self
+            .manifest()
+            .as_table()
+            .get("tool")
+            .and_then(|t| t.get("pixi"))
+            .and_then(|t| t.get("workspace"))
+            .is_some()
+        {
+            // pyproject.toml
             "workspace"
         } else {
             "project"
@@ -677,16 +688,31 @@ impl ManifestDocument {
 
     /// Sets the name of the project
     pub fn set_name(&mut self, name: &str) {
-        self.as_table_mut()["project"]["name"] = value(name);
+        let table = self.as_table_mut();
+        if table.contains_key("project") {
+            table["project"]["name"] = value(name);
+        } else {
+            table["workspace"]["name"] = value(name);
+        }
     }
 
     /// Sets the description of the project
     pub fn set_description(&mut self, description: &str) {
-        self.as_table_mut()["project"]["description"] = value(description);
+        let table = self.as_table_mut();
+        if table.contains_key("project") {
+            table["project"]["description"] = value(description);
+        } else {
+            table["workspace"]["description"] = value(description);
+        }
     }
 
     /// Sets the version of the project
     pub fn set_version(&mut self, version: &str) {
-        self.as_table_mut()["project"]["version"] = value(version);
+        let table = self.as_table_mut();
+        if table.contains_key("project") {
+            table["project"]["version"] = value(version);
+        } else {
+            table["workspace"]["version"] = value(version);
+        }
     }
 }

--- a/crates/pixi_manifest/src/manifests/provenance.rs
+++ b/crates/pixi_manifest/src/manifests/provenance.rs
@@ -81,7 +81,7 @@ impl ManifestKind {
     /// Try to determine the type of manifest from a path
     pub fn try_from_path(path: &Path) -> Option<Self> {
         match path.file_name().and_then(OsStr::to_str)? {
-            consts::PROJECT_MANIFEST => Some(Self::Pixi),
+            consts::WORKSPACE_MANIFEST => Some(Self::Pixi),
             consts::PYPROJECT_MANIFEST => Some(Self::Pyproject),
             _ => None,
         }
@@ -90,7 +90,7 @@ impl ManifestKind {
     /// Returns the default file name for a manifest of a certain kind.
     pub fn file_name(self) -> &'static str {
         match self {
-            ManifestKind::Pixi => consts::PROJECT_MANIFEST,
+            ManifestKind::Pixi => consts::WORKSPACE_MANIFEST,
             ManifestKind::Pyproject => consts::PYPROJECT_MANIFEST,
         }
     }

--- a/src/install_pypi/mod.rs
+++ b/src/install_pypi/mod.rs
@@ -64,7 +64,7 @@ pub async fn update_python_distributions(
     let python_record = pixi_records
         .iter()
         .find(|r| is_python_record(r))
-        .ok_or_else(|| miette::miette!("could not resolve pypi dependencies because no python interpreter is added to the dependencies of the project.\nMake sure to add a python interpreter to the [dependencies] section of the {manifest}, or run:\n\n\tpixi add python", manifest=consts::PROJECT_MANIFEST))?;
+        .ok_or_else(|| miette::miette!("could not resolve pypi dependencies because no python interpreter is added to the dependencies of the project.\nMake sure to add a python interpreter to the [dependencies] section of the {manifest}, or run:\n\n\tpixi add python", manifest=consts::WORKSPACE_MANIFEST))?;
     let tags = get_pypi_tags(
         platform,
         system_requirements,

--- a/src/lock_file/resolve/pypi.rs
+++ b/src/lock_file/resolve/pypi.rs
@@ -237,7 +237,7 @@ pub async fn resolve_pypi(
         .collect::<Result<Vec<_>, _>>()
         .into_diagnostic()?;
 
-    use pixi_consts::consts::PROJECT_MANIFEST;
+    use pixi_consts::consts::WORKSPACE_MANIFEST;
     // Determine the python interpreter that is installed as part of the conda
     // packages.
     let python_record = locked_pixi_records
@@ -246,7 +246,7 @@ pub async fn resolve_pypi(
             PixiRecord::Binary(r) => is_python_record(r),
             _ => false,
         })
-        .ok_or_else(|| miette::miette!("could not resolve pypi dependencies because no python interpreter is added to the dependencies of the project.\nMake sure to add a python interpreter to the [dependencies] section of the {PROJECT_MANIFEST}, or run:\n\n\tpixi add python"))?;
+        .ok_or_else(|| miette::miette!("could not resolve pypi dependencies because no python interpreter is added to the dependencies of the project.\nMake sure to add a python interpreter to the [dependencies] section of the {WORKSPACE_MANIFEST}, or run:\n\n\tpixi add python"))?;
 
     // Construct the marker environment for the target platform
     let marker_environment = determine_marker_environment(platform, python_record.as_ref())?;

--- a/src/workspace/discovery.rs
+++ b/src/workspace/discovery.rs
@@ -60,7 +60,7 @@ pub enum WorkspaceLocatorError {
     /// The workspace could not be located.
     #[error(
         "could not find {project_manifest} or {pyproject_manifest} at directory {0}",
-        project_manifest = consts::PROJECT_MANIFEST,
+        project_manifest = consts::WORKSPACE_MANIFEST,
         pyproject_manifest = consts::PYPROJECT_MANIFEST
     )]
     WorkspaceNotFound(PathBuf),

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -348,7 +348,7 @@ def test_pixi_init_cwd(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
         # Verify that the manifest file contains expected content
         manifest_content = manifest_path.read_text()
-        assert "[project]" in manifest_content
+        assert "[workspace]" in manifest_content
 
 
 def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> None:
@@ -364,7 +364,7 @@ def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> Non
 
     # Verify that the manifest file contains expected content
     manifest_content = manifest_path.read_text()
-    assert "[project]" in manifest_content
+    assert "[workspace]" in manifest_content
 
 
 @pytest.mark.slow

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -274,10 +274,10 @@ impl PixiControl {
         // Either pixi.toml or pyproject.toml
         if self
             .workspace_path()
-            .join(consts::PROJECT_MANIFEST)
+            .join(consts::WORKSPACE_MANIFEST)
             .exists()
         {
-            self.workspace_path().join(consts::PROJECT_MANIFEST)
+            self.workspace_path().join(consts::WORKSPACE_MANIFEST)
         } else if self
             .workspace_path()
             .join(consts::PYPROJECT_MANIFEST)
@@ -285,7 +285,7 @@ impl PixiControl {
         {
             self.workspace_path().join(consts::PYPROJECT_MANIFEST)
         } else {
-            self.workspace_path().join(consts::PROJECT_MANIFEST)
+            self.workspace_path().join(consts::WORKSPACE_MANIFEST)
         }
     }
 


### PR DESCRIPTION
`[workspace]` should be preferred over `[project]`.
At the moment they are simple aliases, but we should warn on `project` in the future.