### PR TITLE
fix: ignore package we can't match with in the virtual packages.

### DIFF
--- a/src/lock_file/virtual_packages.rs
+++ b/src/lock_file/virtual_packages.rs
@@ -15,6 +15,10 @@ use std::str::FromStr;
 use thiserror::Error;
 use uv_distribution_filename::WheelFilename;
 
+/// Define accepted virtual packages as a constant set
+/// These packages will be checked against the system virtual packages
+const ACCEPTED_VIRTUAL_PACKAGES: &[&str] = &["__glibc", "__cuda", "__osx", "__win", "__linux"];
+
 #[derive(Debug, Error, Diagnostic)]
 #[error("{msg}")]
 pub struct VirtualPackageNotFoundError {
@@ -207,15 +211,12 @@ pub(crate) fn validate_system_meets_environment_requirements(
 
     // Check if all the required virtual conda packages match the system virtual packages
     for required in required_virtual_packages {
-        // Define accepted virtual packages as a constant set
-        const ACCEPTED_PACKAGES: &[&str] = &["__glibc", "__cuda", "__osx", "__win", "__linux"];
-
-        // Check if the package name (normalized) is in our accepted list
+        // Check if the package name is in our accepted list
         let is_accepted = required
             .name
             .as_ref()
             .iter()
-            .any(|name| ACCEPTED_PACKAGES.contains(&name.as_normalized()));
+            .any(|name| ACCEPTED_VIRTUAL_PACKAGES.contains(&name.as_normalized()));
 
         // Skip if not in accepted packages
         if !is_accepted {

--- a/src/lock_file/virtual_packages.rs
+++ b/src/lock_file/virtual_packages.rs
@@ -207,6 +207,25 @@ pub(crate) fn validate_system_meets_environment_requirements(
 
     // Check if all the required virtual conda packages match the system virtual packages
     for required in required_virtual_packages {
+        // Define accepted virtual packages as a constant set
+        const ACCEPTED_PACKAGES: &[&str] = &["__glibc", "__cuda", "__osx", "__win", "__linux"];
+
+        // Check if the package name (normalized) is in our accepted list
+        let is_accepted = required
+            .name
+            .as_ref()
+            .iter()
+            .any(|name| ACCEPTED_PACKAGES.contains(&name.as_normalized()));
+
+        // Skip if not in accepted packages
+        if !is_accepted {
+            tracing::debug!(
+                "Skipping virtual package: {} as it's not in the accepted packages",
+                required
+            );
+            continue;
+        }
+
         let name = if let Some(name) = required.name.as_ref() {
             name
         } else {
@@ -446,5 +465,50 @@ mod test {
             );
             assert!(error.help.unwrap().contains(msg));
         }
+    }
+
+    #[test]
+    fn test_archspec_skip() {
+        let root_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let lockfile_path = root_dir.join("tests/data/lockfiles/archspec.lock");
+        let lockfile = LockFile::from_path(&lockfile_path).unwrap();
+        let platform = Platform::Linux64;
+
+        let overrides = VirtualPackageOverrides {
+            libc: Some(Override::String("2.17".to_string())),
+            ..VirtualPackageOverrides::default()
+        };
+
+        // validate that the archspec is skipped
+        validate_system_meets_environment_requirements(
+            &lockfile,
+            platform,
+            &EnvironmentName::default(),
+            Some(overrides),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_ignored_virtual_packages() {
+        let root_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let lockfile_path = root_dir.join("tests/data/lockfiles/ignored_virtual_packages.lock");
+        let lockfile = LockFile::from_path(&lockfile_path).unwrap();
+        let platform = Platform::Linux64;
+
+        let overrides = VirtualPackageOverrides {
+            libc: Some(Override::String("2.17".to_string())),
+            cuda: Some(Override::String("11.0".to_string())),
+            ..VirtualPackageOverrides::default()
+        };
+
+        // validate that the ignored virtual packages are skipped
+        validate_system_meets_environment_requirements(
+            &lockfile,
+            platform,
+            &EnvironmentName::default(),
+            Some(overrides),
+        )
+        .unwrap();
     }
 }

--- a/tests/data/lockfiles/archspec.lock
+++ b/tests/data/lockfiles/archspec.lock
@@ -1,0 +1,76 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://prefix.dev/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
+packages:
+- conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://prefix.dev/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+  build_number: 2
+  sha256: 7623b2b804165b458f520371c40f5a607847336a882a55d3cfbdfb6407082794
+  md5: 989cfef32fc3e5fb397e87479bec3809
+  depends:
+  - __archspec 1 x86_64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7773
+  timestamp: 1717599240447
+- conda: https://prefix.dev/conda-forge/linux-64/libblasfeo-0.1.4.2-h544d10a_100.conda
+  sha256: 4f64c244b1bda8f23deddf3c11f2b3402755a0433da716244a845a31403f329b
+  md5: 4a1612c7202bf04f5ea7a18110739a14
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _x86_64-microarch-level >=1
+  - libgcc >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 917774
+  timestamp: 1740067825220
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-14.2.0-h767d61c_2.conda
+  sha256: 3a572d031cb86deb541d15c1875aaa097baefc0c580b54dc61f5edab99215792
+  md5: ef504d1acbd74b7cc6849ef8af47dd03
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h767d61c_2
+  - libgcc-ng ==14.2.0=*_2
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 847885
+  timestamp: 1740240653082
+- conda: https://prefix.dev/conda-forge/linux-64/libgomp-14.2.0-h767d61c_2.conda
+  sha256: 1a3130e0b9267e781b89399580f3163632d59fe5b0142900d63052ab1a53490e
+  md5: 06d02030237f4d5b3d9a7e7d348fe3c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 459862
+  timestamp: 1740240588123

--- a/tests/data/lockfiles/ignored_virtual_packages.lock
+++ b/tests/data/lockfiles/ignored_virtual_packages.lock
@@ -1,0 +1,20 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+packages:
+- conda: https://prefix.dev/conda-forge/noarch/_x86_64-microarch-level-1-2_x86_64.conda
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - __cuda >=11.0,<12.0
+  - __glibc >=2.17,<3.0.a0
+  - __archspec 1 x86_64
+  - __non_existing_vpkg >=1.2.3
+  license: None
+  size: 10
+  timestamp: 12341234


### PR DESCRIPTION
Fixes #3280 

As we've introduced virtual package validation, but we don't match archspecs yet, we should ignore them. And for that same reason any virtual packages we don't understand. 

