### PR TITLE
fix: print all tasks for the current platform in `pixi info`

### DIFF
--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -412,7 +412,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 .iter()
                 .map(|env| {
                     let tasks = env
-                        .tasks(None)
+                        .tasks(Some(env.best_platform()))
                         .ok()
                         .map(|t| t.into_keys().cloned().collect())
                         .unwrap_or_default();

--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -182,7 +182,7 @@ impl<'p> Environment<'p> {
     pub fn tasks(
         &self,
         platform: Option<Platform>,
-    ) -> Result<HashMap<&'p TaskName, &'p Task>, UnsupportedPlatformError> {
+    ) -> Result<IndexMap<&'p TaskName, &'p Task>, UnsupportedPlatformError> {
         self.validate_platform_support(platform)?;
         let result = self
             .features()

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1157,3 +1157,24 @@ def test_dont_error_on_missing_platform(pixi: Path, tmp_pixi_workspace: Path) ->
         [pixi, "install", "--manifest-path", manifest],
         stderr_contains=["pixi project platform add zos-z"],
     )
+
+
+def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = """
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ["linux-64", "win-64", "osx-64"]
+
+        [tasks]
+        foo = "echo foo"
+
+        [target.unix.tasks]
+        bar = "echo bar"
+
+        [target.win.tasks]
+        bar = "echo bar"
+        """
+    manifest.write_text(toml)
+    verify_cli_command([pixi, "info", "--manifest-path", manifest], stdout_contains="foo, bar")


### PR DESCRIPTION
Fixes #3279