### PR TITLE
feat: make sharded repodata enabled by default

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -243,8 +243,7 @@ impl From<RepodataChannelConfig> for SourceConfig {
             jlap_enabled: !value.disable_jlap.unwrap_or(false),
             zstd_enabled: !value.disable_zstd.unwrap_or(false),
             bz2_enabled: !value.disable_bzip2.unwrap_or(false),
-            // TODO: Change sharded repodata default to true, when enough testing has been done.
-            sharded_enabled: !value.disable_sharded.unwrap_or(true),
+            sharded_enabled: !value.disable_sharded.unwrap_or(false),
             cache_action: Default::default(),
         }
     }


### PR DESCRIPTION
Improves: #3271

Since we've been testing it for a long time already I think we can confidently make this the default.

The second question is, are we going to make `https://prefix.dev/conda-forge` the default channel as well to give users the best possible experience? 🤔 