### PR TITLE
initial commit for autoreload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,6 +2041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3021,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.8.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3385,6 +3414,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy-regex"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,6 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -3803,6 +3853,31 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.8.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "ntapi"
@@ -4346,6 +4421,7 @@ dependencies = [
  "miette 7.5.0",
  "minijinja",
  "nix",
+ "notify",
  "once_cell",
  "parking_lot 0.12.3",
  "pep440_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,6 +278,7 @@ uv-pypi-types = { workspace = true }
 
 ctrlc = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
+notify = "8.0.0"
 pixi_allocator = { workspace = true, optional = true }
 pixi_build_frontend = { workspace = true }
 pixi_build_types = { workspace = true }

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -185,6 +185,14 @@ impl Task {
             _ => None,
         }
     }
+
+    /// Returns the watched files of the task.
+    pub fn watched_files(&self) -> Option<&[String]> {
+        match self {
+            Task::Execute(exe) => exe.watched_files.as_deref(),
+            _ => None,
+        }
+    }
 }
 
 /// A command script executes a single command from the environment
@@ -218,6 +226,9 @@ pub struct Execute {
 
     /// Isolate the task from the running machine
     pub clean_env: bool,
+
+    /// Automatically reload the task when the inputs change
+    pub watched_files: Option<Vec<String>>,
 }
 
 impl From<Execute> for Task {

--- a/crates/pixi_manifest/src/toml/task.rs
+++ b/crates/pixi_manifest/src/toml/task.rs
@@ -58,6 +58,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 .map(TomlIndexMap::into_inner);
             let description = th.optional("description");
             let clean_env = th.optional("clean-env").unwrap_or(false);
+            let watched_files = th.optional("watched-files");
 
             th.finalize(None)?;
 
@@ -70,6 +71,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 env,
                 description,
                 clean_env,
+                watched_files,
             })
         } else {
             let depends_on = depends_on(&mut th).unwrap_or_default();

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -4,7 +4,7 @@ use std::{
     string::String,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, OnceLock,
     },
 };
 
@@ -16,6 +16,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use pixi_config::ConfigCliActivation;
 use pixi_manifest::TaskName;
 use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing::Level;
 
 use crate::{
@@ -24,7 +25,7 @@ use crate::{
     lock_file::UpdateLockFileOptions,
     task::{
         get_task_env, AmbiguousTask, CanSkip, ExecutableTask, FailedToParseShellScript,
-        InvalidWorkingDirectory, SearchEnvironments, TaskAndEnvironment, TaskGraph,
+        FileWatcher, InvalidWorkingDirectory, SearchEnvironments, TaskAndEnvironment, TaskGraph,
     },
     workspace::{errors::UnsupportedPlatformError, Environment},
     Workspace, WorkspaceLocator,
@@ -253,16 +254,31 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         ctrlc_should_exit_process.store(false, Ordering::Relaxed);
 
-        // Execute the task itself within the command environment. If one of the tasks
-        // failed with a non-zero exit code, we exit this parent process with
+        // Check if this task has watched files
+        let has_watched_files = executable_task
+            .task()
+            .as_execute()
+            .and_then(|e| e.watched_files.as_ref())
+            .is_some_and(|files| !files.is_empty());
+
+        // Execute the task itself within the command environment
+        let result = if has_watched_files {
+            // For tasks with watched files, use execute_task_with_watched_files
+            execute_task_with_watched_files(&executable_task, task_env).await
+        } else {
+            // For regular tasks, use execute_task
+            execute_task(&executable_task, task_env).await
+        };
+
+        // If one of the tasks failed with a non-zero exit code, we exit this parent process with
         // the same code.
-        match execute_task(&executable_task, task_env).await {
+        match result {
             Ok(_) => {
                 task_idx += 1;
             }
             Err(TaskExecutionError::NonZeroExitCode(code)) => {
                 if code == 127 {
-                    command_not_found(&workspace, explicit_environment);
+                    command_not_found(&workspace, explicit_environment.clone());
                 }
                 std::process::exit(code);
             }
@@ -349,6 +365,181 @@ async fn execute_task(
     }
 
     Ok(())
+}
+
+async fn execute_task_with_watched_files(
+    task: &ExecutableTask<'_>,
+    command_env: &HashMap<String, String>,
+) -> Result<(), TaskExecutionError> {
+    // Run the task initially
+    execute_task(task, command_env).await?;
+
+    // Set up signal handler
+    let signal_handler = setup_signal_handler().await;
+
+    // Handle file events directly without spawning
+    let mut watcher = FileWatcher::new(
+        &task
+            .task()
+            .as_execute()
+            .and_then(|e| e.watched_files.clone())
+            .unwrap_or_default(),
+    )
+    .map_err(|e| {
+        let err_msg = format!("Failed to create file watcher: {}", e);
+        tracing::error!("{}", err_msg);
+        TaskExecutionError::InvalidWorkingDirectory(InvalidWorkingDirectory { path: err_msg })
+    })?;
+
+    // Print minimal information about watching
+    let watched_files = task
+        .task()
+        .as_execute()
+        .and_then(|e| e.watched_files.clone())
+        .unwrap_or_default();
+    eprintln!(
+        "Watching {} file(s) for changes. Press Ctrl+C to stop.",
+        watched_files.len()
+    );
+
+    // Main event loop for file watching
+    let mut last_exec_time = std::time::Instant::now();
+    let debounce_time = std::time::Duration::from_millis(300);
+
+    // Handle file events loop
+    let mut result = Ok(());
+    let watcher_result = async {
+        while let Some(event) = watcher.next_event().await {
+            match event {
+                Ok(event) => {
+                    // Only respond to actual modifications
+                    match event.kind {
+                        notify::event::EventKind::Create(_)
+                        | notify::event::EventKind::Modify(_)
+                        | notify::event::EventKind::Remove(_) => {
+                            // Debounce handling
+                            let now = std::time::Instant::now();
+                            if now.duration_since(last_exec_time) < debounce_time {
+                                continue;
+                            }
+
+                            last_exec_time = now;
+
+                            // Execute the task directly without additional output
+                            let _ = execute_task(task, command_env).await;
+                        }
+                        _ => continue, // Ignore other event types
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Error watching files: {}", e);
+                    result = Err(e);
+                    break;
+                }
+            }
+
+            // Check if cancellation was requested
+            if is_cancellation_requested(&signal_handler).await {
+                break;
+            }
+        }
+
+        result
+    };
+
+    // Wait for either the watcher to complete or cancellation to be requested
+    tokio::select! {
+        result = watcher_result => {
+            // The file watcher task completed, cleanup signal handler
+            cleanup_signal_handler(&signal_handler).await;
+
+            // Return the result
+            match result {
+                Ok(()) => Ok(()),
+                Err(e) => Err(TaskExecutionError::InvalidWorkingDirectory(InvalidWorkingDirectory {
+                    path: format!("File watching error: {}", e),
+                })),
+            }
+        }
+        _ = wait_for_cancellation(&signal_handler) => {
+            // Cleanup signal handler
+            cleanup_signal_handler(&signal_handler).await;
+
+            // Return success as we're cancelling gracefully
+            Ok(())
+        }
+    }
+}
+
+static SIGNAL_HANDLER: OnceLock<Arc<Mutex<SignalState>>> = OnceLock::new();
+
+// Signal state
+struct SignalState {
+    cancellation_requested: bool,
+    active_watchers: usize,
+}
+
+// Setup the signal handler (initialize if needed)
+async fn setup_signal_handler() -> Arc<Mutex<SignalState>> {
+    // Check if handler is already initialized
+    if let Some(handler) = SIGNAL_HANDLER.get() {
+        // Increment active watchers count
+        let mut state = handler.lock().await;
+        state.active_watchers += 1;
+        return handler.clone();
+    }
+
+    // Create new handler
+    let handler = Arc::new(Mutex::new(SignalState {
+        cancellation_requested: false,
+        active_watchers: 1, // Start with 1 since we're creating it
+    }));
+
+    // Set up signal handling
+    let handler_clone = handler.clone();
+    tokio::spawn(async move {
+        let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+            .expect("Failed to create signal handler");
+
+        sigint.recv().await;
+
+        // Set cancellation flag
+        let mut state = handler_clone.lock().await;
+        state.cancellation_requested = true;
+
+        // If there are multiple watchers, print a message
+        if state.active_watchers > 1 {
+            eprintln!("\nCancelling {} file watchers...", state.active_watchers);
+        }
+    });
+
+    // Initialize the global handler
+    SIGNAL_HANDLER.set(handler.clone()).ok();
+
+    handler
+}
+
+// Check if cancellation has been requested
+async fn is_cancellation_requested(signal_handler: &Arc<Mutex<SignalState>>) -> bool {
+    let state = signal_handler.lock().await;
+    state.cancellation_requested
+}
+
+// Wait for cancellation to be requested
+async fn wait_for_cancellation(signal_handler: &Arc<Mutex<SignalState>>) {
+    // Poll the cancellation flag periodically
+    loop {
+        if is_cancellation_requested(signal_handler).await {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+}
+
+// Cleanup signal handler when a watcher is done
+async fn cleanup_signal_handler(signal_handler: &Arc<Mutex<SignalState>>) {
+    let mut state = signal_handler.lock().await;
+    state.active_watchers -= 1;
 }
 
 /// Called to disambiguate between environments to run a task in.

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -99,6 +99,10 @@ pub struct AddArgs {
     /// environment to run the task
     #[arg(long)]
     pub clean_env: bool,
+
+    /// Automatically reload the task when the watched files change
+    #[arg(long)]
+    pub watched_files: Option<Vec<String>>,
 }
 
 /// Parse a single key-value pair
@@ -201,6 +205,8 @@ impl From<AddArgs> for Task {
                 Some(env)
             };
 
+            let watched_files = value.watched_files;
+
             Self::Execute(Execute {
                 cmd: CmdArgs::Single(cmd_args),
                 depends_on,
@@ -210,6 +216,7 @@ impl From<AddArgs> for Task {
                 env,
                 description,
                 clean_env,
+                watched_files,
             })
         }
     }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,12 +1,16 @@
 mod error;
 mod executable_task;
 mod file_hashes;
+mod reload;
 mod task_environment;
 mod task_graph;
 mod task_hash;
 
 pub use file_hashes::{FileHashes, FileHashesError};
 pub use pixi_manifest::{Task, TaskName};
+pub use reload::{
+    get_watched_files, has_watched_files, AutoReloadConfig, FileWatchError, FileWatcher,
+};
 pub use task_hash::{ComputationHash, EnvironmentHash, InputHashes, TaskHash};
 
 pub use executable_task::{

--- a/src/task/reload.rs
+++ b/src/task/reload.rs
@@ -1,0 +1,287 @@
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+use thiserror::Error;
+use tokio::sync::mpsc::{self, Receiver};
+use tracing::{info, warn};
+
+use crate::task::ExecutableTask;
+
+/// Errors that can occur when watching files.
+#[derive(Debug, Error)]
+pub enum FileWatchError {
+    /// An error occurred while watching files.
+    #[error("Error watching files: {0}")]
+    WatchError(#[from] notify::Error),
+
+    /// An I/O error occurred.
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    /// Task execution error.
+    #[error("Task execution error: {0}")]
+    TaskExecutionError(String),
+}
+
+/// Config for the auto-reload feature.
+pub struct AutoReloadConfig {
+    /// Duration to debounce file change events.
+    pub debounce: Duration,
+}
+
+impl Default for AutoReloadConfig {
+    fn default() -> Self {
+        Self {
+            debounce: Duration::from_millis(500),
+        }
+    }
+}
+
+/// Checks if a task has watched files defined
+pub fn has_watched_files(task: &ExecutableTask<'_>) -> bool {
+    task.task()
+        .as_execute()
+        .and_then(|e| e.watched_files.as_ref())
+        .is_some()
+}
+
+/// Get the watched files from a task
+pub fn get_watched_files(task: &ExecutableTask<'_>) -> Option<Vec<String>> {
+    task.task()
+        .as_execute()
+        .and_then(|e| e.watched_files.clone())
+}
+
+/// Watches files for changes and triggers task execution when they change.
+pub struct FileWatcher {
+    _watcher: RecommendedWatcher,
+    rx: Receiver<Result<notify::Event, notify::Error>>,
+    watched_paths: Vec<PathBuf>,
+}
+
+impl FileWatcher {
+    /// Creates a new file watcher that watches the specified paths.
+    pub fn new(paths: &[impl AsRef<Path>]) -> Result<Self, FileWatchError> {
+        // Create a channel to receive events
+        let (tx, rx) = mpsc::channel(100);
+
+        // Create a watcher
+        let mut watcher = RecommendedWatcher::new(
+            move |res| {
+                let _ = tx.blocking_send(res);
+            },
+            Config::default(),
+        )?;
+
+        let mut watched_paths = Vec::new();
+
+        // Watch each path
+        for path in paths {
+            let path = path.as_ref().to_path_buf();
+            if path.exists() {
+                let mode = if path.is_dir() {
+                    RecursiveMode::Recursive
+                } else {
+                    RecursiveMode::NonRecursive
+                };
+                watcher.watch(&path, mode)?;
+                watched_paths.push(path);
+            } else {
+                info!("Path does not exist, skipping: {}", path.display());
+                // Try to watch the parent directory if it exists
+                if let Some(parent) = path.parent() {
+                    if parent.exists() {
+                        info!("Watching parent directory instead: {}", parent.display());
+                        watcher.watch(parent, RecursiveMode::Recursive)?;
+                        watched_paths.push(parent.to_path_buf());
+                    }
+                }
+            }
+        }
+
+        if watched_paths.is_empty() {
+            warn!("No paths are being watched! Auto-reload will not work.");
+        } else {
+            info!("Watching paths: {:?}", watched_paths);
+        }
+
+        Ok(Self {
+            _watcher: watcher,
+            rx,
+            watched_paths,
+        })
+    }
+
+    /// Creates a file watcher from a task with watched_files.
+    pub fn from_task(task: &ExecutableTask<'_>) -> Result<Option<Self>, FileWatchError> {
+        let watched_files = match get_watched_files(task) {
+            Some(files) if !files.is_empty() => files,
+            _ => return Ok(None),
+        };
+
+        // Convert the glob patterns to absolute paths
+        let root_path = task.project().root();
+        let paths: Vec<_> = watched_files
+            .iter()
+            .map(|pattern| root_path.join(pattern))
+            .collect();
+
+        Ok(Some(Self::new(&paths)?))
+    }
+
+    /// Returns the paths being watched.
+    pub fn watched_paths(&self) -> &[PathBuf] {
+        &self.watched_paths
+    }
+
+    /// Returns the next file change event.
+    pub async fn next_event(&mut self) -> Option<Result<notify::Event, FileWatchError>> {
+        self.rx.recv().await.map(|res| res.map_err(|e| e.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::tempdir;
+    use tokio::time::sleep;
+
+    /// Helper function to create a test file in a directory
+    async fn create_test_file(dir: &std::path::Path, filename: &str, content: &str) -> PathBuf {
+        let file_path = dir.join(filename);
+        tokio::fs::write(&file_path, content).await.unwrap();
+        file_path
+    }
+
+    #[tokio::test]
+    async fn test_file_watcher_detects_changes() {
+        // Create a temporary directory
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.txt");
+
+        tokio::fs::write(&file_path, "initial content")
+            .await
+            .unwrap();
+
+        let mut watcher = FileWatcher::new(&[file_path.clone()]).unwrap();
+
+        // Spawn a task to modify the file after a short delay
+        let file_path_clone = file_path.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            tokio::fs::write(&file_path_clone, "updated content")
+                .await
+                .unwrap();
+        });
+
+        let event = watcher.next_event().await;
+
+        assert!(event.is_some());
+
+        // Verify the event is a modification
+        if let Some(Ok(event)) = event {
+            match event.kind {
+                notify::event::EventKind::Modify(_) | notify::event::EventKind::Create(_) => {
+                    // On some systems/filesystems, writing to a file can be reported as creating a new file
+                }
+                other => panic!("Expected Modify or Create event, got {:?}", other),
+            }
+        } else {
+            panic!("Expected Ok event");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_watcher_detects_creation() {
+        // Create a temporary directory
+        let dir = tempdir().unwrap();
+        let parent_dir = dir.path();
+
+        // Create a watcher for the directory
+        let mut watcher = FileWatcher::new(&[parent_dir]).unwrap();
+
+        let file_path = parent_dir.join("new_file.txt");
+        let file_path_clone = file_path.clone();
+
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            tokio::fs::write(&file_path_clone, "new file content")
+                .await
+                .unwrap();
+        });
+
+        // Wait for an event
+        let mut create_event_received = false;
+        for _ in 0..3 {
+            if let Some(Ok(event)) = watcher.next_event().await {
+                if let notify::event::EventKind::Create(_) = event.kind {
+                    create_event_received = true;
+                    break;
+                }
+            }
+        }
+
+        assert!(create_event_received, "Should have received a Create event");
+    }
+
+    #[tokio::test]
+    async fn test_file_watcher_detects_deletion() {
+        // Create a temporary directory
+        let dir = tempdir().unwrap();
+        let file_path = create_test_file(dir.path(), "to_delete.txt", "delete me").await;
+
+        // Create a watcher
+        let mut watcher = FileWatcher::new(&[file_path.clone()]).unwrap();
+
+        let file_path_clone = file_path.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            tokio::fs::remove_file(&file_path_clone).await.unwrap();
+        });
+
+        // Wait for events
+        let mut delete_event_received = false;
+        for _ in 0..3 {
+            if let Some(Ok(event)) = watcher.next_event().await {
+                if let notify::event::EventKind::Remove(_) = event.kind {
+                    delete_event_received = true;
+                    break;
+                }
+            }
+        }
+
+        assert!(delete_event_received, "Should have received a Remove event");
+    }
+
+    #[tokio::test]
+    async fn test_file_watcher_non_existent_path() {
+        let dir = tempdir().unwrap();
+        let non_existent_path = dir.path().join("does_not_exist.txt");
+
+        // Create a watcher for non-existent file (should watch parent)
+        let watcher = FileWatcher::new(&[non_existent_path.clone()]).unwrap();
+
+        // Should be watching the parent directory
+        assert_eq!(watcher.watched_paths().len(), 1);
+        assert_eq!(watcher.watched_paths()[0], dir.path());
+    }
+
+    #[tokio::test]
+    async fn test_file_watcher_multiple_paths() {
+        let dir = tempdir().unwrap();
+        let file1 = create_test_file(dir.path(), "file1.txt", "file1").await;
+        let file2 = create_test_file(dir.path(), "file2.txt", "file2").await;
+
+        // Create a watcher for multiple files
+        let watcher = FileWatcher::new(&[file1.clone(), file2.clone()]).unwrap();
+
+        // Should be watching both files
+        assert_eq!(watcher.watched_paths().len(), 2);
+        assert!(watcher.watched_paths().contains(&file1));
+        assert!(watcher.watched_paths().contains(&file2));
+    }
+}

--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -331,6 +331,25 @@ impl<'p> TaskGraph<'p> {
             order.push(id);
         }
     }
+
+    /// Returns an iterator over all task IDs in the graph.
+    pub fn task_ids(&self) -> impl Iterator<Item = TaskId> + '_ {
+        (0..self.nodes.len()).map(TaskId)
+    }
+
+    /// Returns an iterator over the root tasks in the graph.
+    /// Root tasks are tasks that are not dependencies of any other task.
+    pub fn root_tasks(&self) -> Vec<TaskId> {
+        let all_deps: HashSet<TaskId> = self
+            .nodes
+            .iter()
+            .flat_map(|node| node.dependencies.iter().copied())
+            .collect();
+
+        self.task_ids()
+            .filter(|id| !all_deps.contains(id))
+            .collect()
+    }
 }
 
 #[derive(Debug, Error, Diagnostic)]

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -55,6 +55,7 @@ def verify_cli_command(
     env: dict[str, str] | None = None,
     cwd: str | Path | None = None,
     reset_env: bool = False,
+    ctrl_c: bool = False,
 ) -> Output:
     base_env = {} if reset_env else dict(os.environ)
     complete_env = base_env if env is None else base_env | env

--- a/tests/integration_python/test_auto_reload.py
+++ b/tests/integration_python/test_auto_reload.py
@@ -1,0 +1,252 @@
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+from .common import EMPTY_BOILERPLATE_PROJECT
+
+
+def test_file_watching_and_rerunning(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    {EMPTY_BOILERPLATE_PROJECT}
+    [tasks]
+    watch-test = {{ cmd = "echo Running with content: $(cat input.txt)", watched-files = ["input.txt"] }}
+    """
+    manifest.write_text(toml)
+
+    input_file = tmp_pixi_workspace.joinpath("input.txt")
+    input_file.write_text("initial content")
+
+    cmd = [pixi, "run", "--manifest-path", str(manifest), "watch-test"]
+    process = subprocess.Popen(
+        [str(c) for c in cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(tmp_pixi_workspace),
+    )
+
+    try:
+        initial_output_found = False
+        # Check if stdout is None before trying to read from it
+        for _ in range(10):
+            if process.stdout is None:
+                time.sleep(0.3)
+                continue
+                
+            line = process.stdout.readline().strip()
+            if line and "initial content" in line:
+                initial_output_found = True
+                break
+            time.sleep(0.3)
+
+        assert initial_output_found, "Task didn't show initial content"
+
+        time.sleep(1)  # Wait for watcher to set up
+
+        input_file.write_text("updated content")
+
+        rerun_output_found = False
+        for _ in range(10):
+            if process.stdout is None:
+                time.sleep(0.3)
+                continue
+                
+            line = process.stdout.readline().strip()
+            if line and "updated content" in line:
+                rerun_output_found = True
+                break
+            time.sleep(0.3)
+
+        assert rerun_output_found, "Task didn't rerun after file was modified"
+    finally:
+        process.send_signal(signal.SIGINT)
+        time.sleep(0.5)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=1)
+
+
+def test_multiple_files_watching(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    {EMPTY_BOILERPLATE_PROJECT}
+    [tasks]
+    watch-multiple = {{ cmd = "echo FILES: f1=$(cat file1.txt) f2=$(cat file2.txt)", watched-files = ["file1.txt", "file2.txt"] }}
+    """
+    manifest.write_text(toml)
+
+    file1 = tmp_pixi_workspace.joinpath("file1.txt")
+    file1.write_text("one")
+
+    file2 = tmp_pixi_workspace.joinpath("file2.txt")
+    file2.write_text("two")
+    cmd = [str(pixi), "run", "--manifest-path", str(manifest), "watch-multiple"]
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(tmp_pixi_workspace),
+    )
+
+    try:
+        # Wait for initial output
+        initial_output_found = False
+        for _ in range(10):
+            if process.stdout is None:
+                time.sleep(0.3)
+                continue
+                
+            line = process.stdout.readline().strip()
+            if line and "f1=one" in line and "f2=two" in line:
+                initial_output_found = True
+                break
+            time.sleep(0.3)
+        assert initial_output_found, "Task didn't show initial content from both files"
+
+        time.sleep(1)  # Wait for watcher to set up
+
+        # Modify first file and verify rerun
+        file1.write_text("one-updated")
+
+        rerun1_found = False
+        for _ in range(10):
+            if process.stdout is None:
+                time.sleep(0.3)
+                continue
+                
+            line = process.stdout.readline().strip()
+            if line and "f1=one-updated" in line and "f2=two" in line:
+                rerun1_found = True
+                break
+            time.sleep(0.3)
+
+        assert rerun1_found, "Task didn't rerun after file1 was modified"
+    finally:
+        process.send_signal(signal.SIGINT)
+        time.sleep(0.5)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=1)
+
+
+def test_glob_pattern_watching(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    {EMPTY_BOILERPLATE_PROJECT}
+    [tasks]
+    watch-glob = {{ cmd = "echo LOG_CONTENT=$(cat test.log)", watched-files = ["*.log"] }}
+    """
+    manifest.write_text(toml)
+
+    log_file = tmp_pixi_workspace.joinpath("test.log")
+    log_file.write_text("initial_data")
+
+    cmd = [str(pixi), "run", "--manifest-path", str(manifest), "watch-glob"]
+    process = None
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=str(tmp_pixi_workspace),
+        )
+
+        time.sleep(1)  # Wait for process to start
+
+        log_file.write_text("modified_data")
+
+        time.sleep(1)  # Wait for change to be detected
+
+        process.send_signal(signal.SIGINT)
+        time.sleep(0.5)
+
+        stdout, stderr = process.communicate(timeout=2)
+        assert (
+            "initial_data" in stdout or "modified_data" in stdout
+        ), "Expected output not found"
+    finally:
+        if process and process.poll() is None:
+            process.kill()
+            process.wait(timeout=1)
+
+
+def test_empty_watched_files(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """Test behavior with empty watched-files list (should run once and exit)."""
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    {EMPTY_BOILERPLATE_PROJECT}
+    [tasks]
+    watch-empty = {{ cmd = "echo Empty watched files", watched-files = [] }}
+    """
+    manifest.write_text(toml)
+
+    cmd = [str(pixi), "run", "--manifest-path", str(manifest), "watch-empty"]
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(tmp_pixi_workspace),
+    )
+
+    try:
+        stdout, stderr = process.communicate(timeout=3)
+        assert "Empty watched files" in stdout, "Task didn't execute"
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=1)
+
+
+def test_nonexistent_watched_file(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    {EMPTY_BOILERPLATE_PROJECT}
+    [tasks]
+    watch-nonexistent = {{ cmd = "echo File created", watched-files = ["does_not_exist_yet.txt"] }}
+    """
+    manifest.write_text(toml)
+
+    cmd = [str(pixi), "run", "--manifest-path", str(manifest), "watch-nonexistent"]
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=str(tmp_pixi_workspace),
+    )
+
+    try:
+        # Wait for initial run
+        initial_run = False
+        for _ in range(5):
+            if process.stdout is None:
+                time.sleep(0.3)
+                continue
+                
+            line = process.stdout.readline().strip()
+            if line and "File created" in line:
+                initial_run = True
+                break
+            time.sleep(0.3)
+
+        assert initial_run, "Task didn't run initially"
+
+        time.sleep(1)  # Wait for watcher to set up
+
+        nonexistent_file = tmp_pixi_workspace.joinpath("does_not_exist_yet.txt")
+        nonexistent_file.write_text("now I exist")
+
+        # Allow time for detection
+        time.sleep(1)
+    finally:
+        process.send_signal(signal.SIGINT)
+        time.sleep(0.5)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=1)

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -612,6 +612,7 @@ impl TasksControl<'_> {
                 env: Default::default(),
                 description: None,
                 clean_env: false,
+                watched_files: None,
             },
         }
     }


### PR DESCRIPTION
This implements support for adding a set of watched files to each task in Pixi. 
The tasks can be defined as below and will run in async watching for changes. The watches can be cancelled by pressing ctrl c.
```toml
watch-task = {{ cmd = "cat watched_file.txt", watched-files = ["watched_file.txt"] }}
```