### PR TITLE
docs: Set sso_region in s3 config example

### DIFF
--- a/docs/advanced/s3.md
+++ b/docs/advanced/s3.md
@@ -42,6 +42,7 @@ You can also specify `AWS_CONFIG_FILE` and `AWS_PROFILE` to use a custom AWS con
 sso_account_id = 123456789012
 sso_role_name = PowerUserAccess
 sso_start_url = https://my-company.awsapps.com/start
+sso_region = eu-central-1
 region = eu-central-1
 output = json
 ```


### PR DESCRIPTION
otherwise you will get the following error:

```
❯ pixi list
Error:
  × dispatch failure
  ├─▶ other
  ├─▶ the credentials provider was not properly configured
  ╰─▶ ProfileFile provider could not be built: profile `conda` was not defined: `sso_region` was missing
```