### PR TITLE
test: mark more tests as "slow"

### DIFF
--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -1644,6 +1644,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_example_satisfiability(#[files("examples/*/p*.toml")] manifest_path: PathBuf) {
         // If a pyproject.toml is present check for `tool.pixi` in the file to avoid
         // testing of non-pixi files

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -656,6 +656,7 @@ async fn add_dependency_pinning_strategy() {
 /// Test adding a git dependency with a specific branch
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_git_deps() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -708,6 +709,7 @@ preview = ['pixi-build']
 #[cfg(not(windows))]
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_git_deps_with_creds() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -760,6 +762,7 @@ preview = ['pixi-build']
 /// Test adding a git dependency with a specific commit
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_git_with_specific_commit() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -809,6 +812,8 @@ preview = ['pixi-build']"#,
 /// Test adding a git dependency with a specific tag
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+
 async fn add_git_with_tag() {
     let pixi = PixiControl::from_manifest(
         r#"

--- a/tests/integration_rust/install_tests.rs
+++ b/tests/integration_rust/install_tests.rs
@@ -818,6 +818,7 @@ async fn pypi_prefix_is_not_created_when_whl() {
 /// and osxarm64.
 /// This should result in the PyPI package being overridden on linux and not on osxarm64.
 #[tokio::test]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn conda_pypi_override_correct_per_platform() {
     let pixi = PixiControl::new().unwrap();
     pixi.init_with_platforms(vec![
@@ -871,6 +872,8 @@ async fn conda_pypi_override_correct_per_platform() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+
 async fn test_multiple_prefix_update() {
     let current_platform = Platform::current();
 

--- a/tests/integration_rust/solve_group_tests.rs
+++ b/tests/integration_rust/solve_group_tests.rs
@@ -294,6 +294,8 @@ async fn test_compressed_mapping_catch_not_pandoc_not_a_python_package() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+
 async fn test_dont_record_not_present_package_as_purl() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();


### PR DESCRIPTION
I've marked every test that takes >1s as slow