### PR TITLE
fix: execute link scripts

### DIFF
--- a/src/environment/conda_prefix.rs
+++ b/src/environment/conda_prefix.rs
@@ -339,7 +339,7 @@ pub async fn update_prefix_conda(
             Installer::new()
                 .with_download_client(authenticated_client)
                 .with_io_concurrency_semaphore(io_concurrency_limit)
-                .with_execute_link_scripts(false)
+                .with_execute_link_scripts(true)
                 .with_installed_packages(installed_packages)
                 .with_target_platform(host_platform)
                 .with_package_cache(package_cache)


### PR DESCRIPTION
I think we should finally do this to make sure we're compatible with the entire conda ecosystem.