### PR TITLE
fix: use --locked to run the generation of cli docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           # Check if there are any changes
           if ! git diff --quiet; then
             echo "Error: Generated CLI documentation differs from committed version"
+            echo "Please run 'pixi run generate-cli-docs' to regenerate the documentation and commit the changes."
             git diff
             exit 1
           fi

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ python = "3.12.*"
 build-debug = "cargo build"
 build-release = "cargo build --release"
 bump = "tbump --only-patch $RELEASE_VERSION"
-generate-cli-docs = "cargo run --manifest-path pixi_docs/Cargo.toml"
+generate-cli-docs = "cargo run --locked --manifest-path pixi_docs/Cargo.toml"
 install = "cargo install --path . --locked"
 install-as = { cmd = "python scripts/install.py", depends-on = [
   "build-release",


### PR DESCRIPTION
Fixes the issue where the cli docs generation update the lockfile, creating a diff