### PR TITLE
fix: dont prematurely shutdown runtime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,7 @@ pub fn main() -> miette::Result<()> {
             .expect("Failed building the Runtime");
 
         // Box the large main future to avoid stack overflows.
-        let result = runtime.block_on(Box::pin(pixi::cli::execute()));
-
-        // Avoid waiting for pending tasks to complete.
-        runtime.shutdown_background();
-
-        result
+        runtime.block_on(Box::pin(pixi::cli::execute()))
     };
 
     std::thread::Builder::new()


### PR DESCRIPTION
Fixes #3283 

We were calling [Runtime::shutdown_background](https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.shutdown_background) which immediately shuts down the runtime without waiting for spawned work to complete. 

There is a caveat:

> Note however, that because we do not wait for any blocking tasks to complete, this may result in a resource leak (in that any blocking tasks are still running until they return.

When solving, we are spawning several tasks which are also driving the progress bars. Since these tasks are not properly shut down the progress bars are also not cleaned up properly.

This PR simply removes the call because I also dont think it bring us much.