### PR TITLE
fix: let amend_pypi_purls() always use reqwest client with the mirror middle ware

### DIFF
--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -2052,7 +2052,7 @@ async fn spawn_solve_pypi_task<'p>(
     let locked_pypi_records = locked_pypi_packages.records.clone();
 
     pypi_mapping::amend_pypi_purls(
-        environment.workspace().client()?.clone().into(),
+        environment.workspace().authenticated_client()?.clone(),
         pypi_name_mapping_location,
         pixi_solve_records
             .iter_mut()


### PR DESCRIPTION
now 2 places to request conda-mapping, one for solving conda enviornemts with the `workspace::authenticated_client()`, another one for solving pypi environments with `workspace::client()`.

This pr let the latter case also use `authenticated_client()`.