### PR TITLE
fix: use new windows runners with the dev drive feature

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -2,6 +2,8 @@ self-hosted-runner:
   labels:
     - 8core_ubuntu_latest_runner
     - 16core_windows_latest_runner
+    - windows_arm64_2025_large
+    - windows_x64_2025_large
 
 paths:
   .github/workflows/release.yml:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
     runs-on: windows_x64_2025_large
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
+      - name: Create Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
       - uses: prefix-dev/setup-pixi@v0.8.3
         with:
@@ -327,7 +327,7 @@ jobs:
     name: "build binary | windows x86_64"
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
+      - name: Create Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
       - name: Copy Git Repo to Dev Drive
         run: |
@@ -356,7 +356,7 @@ jobs:
     name: "build binary | windows aarch64"
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
+      - name: Create Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
       - name: Copy Git Repo to Dev Drive
         run: |
@@ -394,7 +394,7 @@ jobs:
       TARGET_RELEASE: "target/pixi/release"
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
+      - name: Create Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
       - name: Copy Git Repo to Dev Drive
         run: |
@@ -471,7 +471,7 @@ jobs:
       TARGET_RELEASE: "target/pixi/release"
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
+      - name: Create Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
       - name: Copy Git Repo to Dev Drive
         run: |
@@ -575,7 +575,7 @@ jobs:
       TARGET_RELEASE: "target/pixi/release"
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
+      - name: Create Dev Drive
         run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
       - name: Copy Git Repo to Dev Drive
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,11 +222,11 @@ jobs:
           PIXI_TEST_R2_SECRET_ACCESS_KEY: ${{ secrets.PIXI_TEST_R2_SECRET_ACCESS_KEY }}
 
   cargo-test-windows:
-    name: "cargo test | windows"
+    name: "cargo test | windows x64"
     timeout-minutes: 15
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 16core_windows_latest_runner
+    runs-on: windows_x64_2025_large
     steps:
       - uses: actions/checkout@v4
       - name: Create Dev Drive using ReFS
@@ -323,7 +323,7 @@ jobs:
   build-binary-windows-x86_64:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: 16core_windows_latest_runner
+    runs-on: windows_x64_2025_large
     name: "build binary | windows x86_64"
     steps:
       - uses: actions/checkout@v4
@@ -352,7 +352,7 @@ jobs:
   build-binary-windows-aarch64:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
-    runs-on: 16core_windows_latest_runner
+    runs-on: windows_arm64_2025_large
     name: "build binary | windows aarch64"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -1,19 +1,56 @@
-# This creates a 20GB dev drive, and exports all required environment
-# variables so that rustup, pixi and others all use the dev drive as much
-# as possible.
-$Volume = New-VHD -Path C:/pixi_dev_drive.vhdx -SizeBytes 20GB |
-        Mount-VHD -Passthru |
-        Initialize-Disk -Passthru |
-        New-Partition -AssignDriveLetter -UseMaximumSize |
-        Format-Volume -FileSystem NTFS -Confirm:$false -Force
+# Configures a drive for testing in CI.
+# Credits to astral-sh/uv: https://github.com/astral-sh/uv/blob/d2b9ffdc9e3f336e46b0af18a8554de560bfbefc/.github/workflows/setup-dev-drive.ps1
 
-Write-Output $Volume
+# When not using a GitHub Actions "larger runner", the `D:` drive is present and
+# has similar or better performance characteristics than a ReFS dev drive.
+# Sometimes using a larger runner is still more performant (e.g., when running
+# the test suite) and we need to create a dev drive. This script automatically
+# configures the appropriate drive.
 
-$Drive = "$($Volume.DriveLetter):"
+# Note we use `Get-PSDrive` is not sufficient because the drive letter is assigned.
+if (Test-Path "D:\") {
+    Write-Output "Using existing drive at D:"
+    $Drive = "D:"
+} else {
+	# The size (20 GB) is chosen empirically to be large enough for our
+	# workflows; larger drives can take longer to set up.
+	$Volume = New-VHD -Path C:/pixi_dev_drive.vhdx -SizeBytes 20GB |
+						Mount-VHD -Passthru |
+						Initialize-Disk -Passthru |
+						New-Partition -AssignDriveLetter -UseMaximumSize |
+						Format-Volume -DevDrive -Confirm:$false -Force
+
+	$Drive = "$($Volume.DriveLetter):"
+
+	# Set the drive as trusted
+	# See https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-designate-a-dev-drive-as-trusted
+	fsutil devdrv trust $Drive
+
+	# Disable antivirus filtering on dev drives
+	# See https://learn.microsoft.com/en-us/windows/dev-drive/#how-do-i-configure-additional-filters-on-dev-drive
+	fsutil devdrv enable /disallowAv
+
+	# Remount so the changes take effect
+	Dismount-VHD -Path C:/pixi_dev_drive.vhdx
+	Mount-VHD -Path C:/pixi_dev_drive.vhdx
+
+	# Show some debug information
+	Write-Output $Volume
+	fsutil devdrv query $Drive
+
+    Write-Output "Using Dev Drive at $Volume"
+}
+
 $Tmp = "$($Drive)/pixi-tmp"
 
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
+
+# Move Cargo to the dev drive
+New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
+if (Test-Path "C:/Users/runneradmin/.cargo") {
+    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+}
 
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -6,8 +6,6 @@
 # Sometimes using a larger runner is still more performant (e.g., when running
 # the test suite) and we need to create a dev drive. This script automatically
 # configures the appropriate drive.
-
-# Note we use `Get-PSDrive` is not sufficient because the drive letter is assigned.
 if (Test-Path "D:\") {
     Write-Output "Using existing drive at D:"
     $Drive = "D:"

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -5,7 +5,7 @@ $Volume = New-VHD -Path C:/pixi_dev_drive.vhdx -SizeBytes 20GB |
         Mount-VHD -Passthru |
         Initialize-Disk -Passthru |
         New-Partition -AssignDriveLetter -UseMaximumSize |
-        Format-Volume -FileSystem ReFS -Confirm:$false -Force
+        Format-Volume -FileSystem NTFS -Confirm:$false -Force
 
 Write-Output $Volume
 


### PR DESCRIPTION
Updated the windows runners to the latest Windows 2025 preview version of Windows Server.

Changed the script to match with how `uv` setups up their runners. 