### PR TITLE
fix: use windows latest as arm build runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,8 +351,9 @@ jobs:
 
   build-binary-windows-aarch64:
     needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
-    runs-on: windows_arm64_2025_large
+    if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main'  || contains(github.event.pull_request.labels.*.name, 'test:extra_slow')}} # Only run on the main branch
+    # Using windows-latest as it's only run on main, thus speed is not that important
+    runs-on: windows-latest
     name: "build binary | windows aarch64"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I found that we're not using the run any more for the releases, so making it the paid runner makes little sense as we don't need main to be fast.

Edit the CI job this PR fixes: https://github.com/prefix-dev/pixi/actions/runs/13925247542/job/38967978468?pr=3378