### PR TITLE
chore: fix winget releaser job

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: prefix-dev.pixi
-          installers-regex: '\.msi' # Only .msi files
+          installers-regex: '\.msi$' # Only .msi files
           token: ${{ secrets.WINGET_TOKEN }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}


### PR DESCRIPTION
I've updated the token but we didn't update the releaser after the cargo-dist upgrade.