### PR TITLE
fix: `pixi global` make sure that `prefix_path_entries` are always in `path_diff`

### DIFF
--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -14,7 +14,8 @@ use pixi_utils::{executable_from_path, is_binary_folder};
 use rattler_conda_types::{
     MatchSpec, Matches, PackageName, ParseStrictness, Platform, RepoDataRecord,
 };
-use std::{env, ops::Not, path::PathBuf, str::FromStr};
+use rattler_shell::activation::prefix_path_entries;
+use std::{env, path::PathBuf, str::FromStr};
 
 use fs_err::tokio as tokio_fs;
 
@@ -107,7 +108,7 @@ pub(crate) async fn create_executable_trampolines(
         .remove("PATH")
         .unwrap_or_else(|| path_current.clone());
 
-    let path_diff = path_diff(&path_current, &path_after_activation)?;
+    let path_diff = path_diff(&path_current, &path_after_activation, prefix)?;
 
     for ScriptExecMapping {
         global_script_path,
@@ -196,15 +197,17 @@ pub(crate) async fn create_executable_trampolines(
 }
 
 /// Compute the difference between two PATH variables (the entries split by `;` or `:`)
-fn path_diff(path_before: &str, path_after: &str) -> miette::Result<String> {
+fn path_diff(path_before: &str, path_after: &str, prefix: &Prefix) -> miette::Result<String> {
     // Split paths into vectors using platform-specific delimiter
     let paths_before: Vec<PathBuf> = std::env::split_paths(&path_before).collect();
     let paths_after: Vec<PathBuf> = std::env::split_paths(path_after).collect();
 
+    let prefix_path_entries = prefix_path_entries(prefix.root(), &Platform::current());
+
     // Calculate the PATH diff
     let path_diff = paths_after
         .iter()
-        .filter(|p| paths_before.contains(p).not());
+        .filter(|p| !paths_before.contains(p) || prefix_path_entries.contains(p));
 
     env::join_paths(path_diff)
         .map(|p| p.to_string_lossy().to_string())


### PR DESCRIPTION
`path_diff` might cache too little if the entries are already in the PATH. This change should avoid this problem as far as possible