### PR TITLE
fix: discover closest package when running pixi build

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -86,6 +86,7 @@ impl CondaBuildReporter for ProgressReporter {
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
         .with_search_start(args.project_config.workspace_locator_start())
+        .with_closest_package(true)
         .locate()?
         .with_cli_config(args.config_cli);
 


### PR DESCRIPTION
## Overview

We hit a situation when using `pixi-build-backends` codebase structure, `workspace` from the root wasn't discovered.

The fix was to use `with_closest_package(true)` when creating a locator in `build.rs`


I also decided to change the API to different sane defaults. This means that by default, it will always try to discover it.

I decided it by looking at the all places where we are using the locator ( it is easier to forget to set it up, and we almost always use it ) 