### PR TITLE
fix: propagate error diagnostics from backends

### DIFF
--- a/crates/pixi_build_frontend/src/protocols/builders/rattler_build.rs
+++ b/crates/pixi_build_frontend/src/protocols/builders/rattler_build.rs
@@ -37,6 +37,7 @@ pub enum FinishError {
 #[derive(thiserror::Error, Debug, Diagnostic)]
 pub enum ProtocolBuildError {
     #[error(transparent)]
+    #[diagnostic(transparent)]
     FailedToBuildPixi(#[from] PixiProtocolBuildError),
 }
 

--- a/crates/pixi_manifest/src/features_ext.rs
+++ b/crates/pixi_manifest/src/features_ext.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use indexmap::IndexSet;
+use miette::Diagnostic;
 use rattler_conda_types::{
     ChannelConfig, ChannelUrl, NamedChannelOrUrl, ParseChannelError, Platform,
 };
@@ -13,7 +14,7 @@ use crate::{
 
 /// ChannelPriorityCombination error, thrown when multiple channel priorities
 /// are set
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Diagnostic)]
 #[error("Multiple channel priorities are not allowed in a single environment")]
 pub struct ChannelPriorityCombinationError;
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,11 +1,20 @@
 mod cache;
 mod reporters;
 
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    hash::{Hash, Hasher},
+    ops::Not,
+    path::{Component, Path, PathBuf},
+    str::FromStr,
+    sync::{Arc, LazyLock},
+};
+
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use chrono::Utc;
 use itertools::Itertools;
-use miette::Diagnostic;
-use miette::IntoDiagnostic;
+use miette::{Diagnostic, IntoDiagnostic};
 use pixi_build_frontend::{BackendOverride, JsonRPCBuildProtocol, SetupRequest, ToolContext};
 use pixi_build_types::{
     procedures::{
@@ -16,8 +25,9 @@ use pixi_build_types::{
 };
 use pixi_config::get_cache_dir;
 use pixi_consts::consts::CACHED_GIT_DIR;
-use pixi_git::GitError;
-use pixi_git::{git::GitReference, resolver::GitResolver, source::Fetch, GitUrl, Reporter};
+use pixi_git::{
+    git::GitReference, resolver::GitResolver, source::Fetch, GitError, GitUrl, Reporter,
+};
 pub use pixi_glob::{GlobHashCache, GlobHashError};
 use pixi_glob::{GlobHashKey, GlobModificationTime, GlobModificationTimeError};
 use pixi_manifest::Targets;
@@ -31,16 +41,6 @@ use rattler_conda_types::{
 use rattler_digest::Sha256;
 use reporters::SourceReporter;
 pub use reporters::{BuildMetadataReporter, BuildReporter, SourceCheckoutReporter};
-use std::sync::LazyLock;
-use std::{
-    collections::HashMap,
-    ffi::OsStr,
-    hash::{Hash, Hasher},
-    ops::Not,
-    path::{Component, Path, PathBuf},
-    str::FromStr,
-    sync::Arc,
-};
 use thiserror::Error;
 use tracing::instrument;
 use typed_path::{Utf8TypedPath, Utf8TypedPathBuf};
@@ -48,11 +48,13 @@ use url::Url;
 use uv_configuration::RAYON_INITIALIZE;
 use xxhash_rust::xxh3::Xxh3;
 
-use crate::build::cache::{
-    BuildCache, BuildInput, CachedBuild, CachedCondaMetadata, SourceInfo, SourceMetadataCache,
-    SourceMetadataInput,
+use crate::{
+    build::cache::{
+        BuildCache, BuildInput, CachedBuild, CachedCondaMetadata, SourceInfo, SourceMetadataCache,
+        SourceMetadataInput,
+    },
+    Workspace,
 };
-use crate::Workspace;
 
 /// A list of globs that should be ignored when calculating any input hash.
 /// These are typically used for build artifacts that should not be included in
@@ -86,10 +88,12 @@ pub enum BuildError {
     #[error("error calculating sha for {}", &.0.display())]
     CalculateSha(PathBuf, #[source] std::io::Error),
 
-    #[error("failed to initialize a build backend for {}", &.0.pinned)]
+    #[error("the initialization of the build backend for '{}' failed", &.0.pinned)]
     BuildFrontendSetup(
         Box<SourceCheckout>,
-        #[diagnostic_source] pixi_build_frontend::BuildFrontendError,
+        #[source]
+        #[diagnostic_source]
+        pixi_build_frontend::BuildFrontendError,
     ),
 
     #[error(transparent)]
@@ -720,7 +724,8 @@ impl BuildContext {
         source: &SourceCheckout,
         build_id: usize,
     ) -> Result<JsonRPCBuildProtocol, BuildError> {
-        // The RAYON_INITIALIZE is required to ensure that rayon is explicitly initialized.
+        // The RAYON_INITIALIZE is required to ensure that rayon is explicitly
+        // initialized.
         LazyLock::force(&RAYON_INITIALIZE);
 
         // Instantiate a protocol for the source directory.


### PR DESCRIPTION
Fixes #3158

This PR ensures that diagnostics from backend errors are now properly propagated.

`main`:

```
Error:   × failed to extract metadata for 'subproject'
  ╰─▶ failed to initialize a build backend for subproject
```

This PR:

```
Error:   × failed to extract metadata for package 'subproject'
  ├─▶   × the initialization of the build backend for 'subproject' failed
  │
  ╰─▶   × missing field 'build' in table
         ╭─[F:\projects\issues\issue-3158\subproject\pixi.toml:7:1]
       6 │
       7 │ ╭─▶ [package.run-dependencies]
       8 │ ╰─▶ python = "*"
         ╰────
```