### PR TITLE
feat: add run export information to search

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -21,8 +21,7 @@ use tracing::{debug, error};
 use url::Url;
 
 use super::cli_config::ChannelsConfig;
-use crate::workspace::WorkspaceLocatorError;
-use crate::{cli::cli_config::WorkspaceConfig, WorkspaceLocator};
+use crate::{cli::cli_config::WorkspaceConfig, workspace::WorkspaceLocatorError, WorkspaceLocator};
 
 /// Search a conda package
 ///
@@ -389,6 +388,26 @@ fn print_package_info<W: Write>(
     writeln!(out, "\nDependencies:")?;
     for dependency in package.package_record.depends {
         writeln!(out, " - {}", dependency)?;
+    }
+
+    if let Some(run_exports) = package.package_record.run_exports.as_ref() {
+        writeln!(out, "\nRun exports:")?;
+        let mut print_run_exports = |name: &str, run_exports: &[String]| {
+            if !run_exports.is_empty() {
+                writeln!(out, "  {name}:")?;
+                for run_export in run_exports {
+                    writeln!(out, "   - {}", run_export)?;
+                }
+            }
+            Ok::<(), std::io::Error>(())
+        };
+        print_run_exports("noarch", &run_exports.noarch)?;
+        print_run_exports("strong", &run_exports.strong)?;
+        print_run_exports("weak", &run_exports.weak)?;
+        print_run_exports("strong constrains", &run_exports.strong_constrains)?;
+        print_run_exports("weak constrains", &run_exports.weak_constrains)?;
+    } else {
+        writeln!(out, "\nRun exports: not available in repodata")?;
     }
 
     // Print summary of older versions for package

--- a/tests/integration_rust/snapshots/integration_rust__search_tests__search_multiple_versions.snap
+++ b/tests/integration_rust/snapshots/integration_rust__search_tests__search_multiple_versions.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_rust/search_tests.rs
-assertion_line: 137
 expression: output
 ---
 foo-0.2.0-h60d57d3_1 (+ 1 build)
@@ -17,6 +16,8 @@ MD5                 046ee97456e4c968d514dcb0b4632a8c
 SHA256              a19e6a97fb5def2f6bd7385348ba603c54859500a30d168455cb19d3b347c7e7
 
 Dependencies:
+
+Run exports: not available in repodata
 
 Other Versions (1):
 Version  Build      


### PR DESCRIPTION
Add `run_export` information to the output of `pixi search`. If the data is not available from the repodata the output will be:

```
Run exports: not available in repodata
```