### PR TITLE
docs: mention self-extracting binaries in pixi_pack

### DIFF
--- a/docs/deployment/pixi_pack.md
+++ b/docs/deployment/pixi_pack.md
@@ -64,29 +64,29 @@ pixi-pack pack --platform win-64
 You can create a self-extracting binary that contains the packed environment and a script that unpacks the environment.
 This can be useful if you want to distribute the environment to users that don't have `pixi-pack` installed.
 
-```bash
-# unix
-$ pixi-pack pack --create-executable
-$ ls
-environment.sh
-$ ./environment.sh
-$ ls
-env/
-activate.sh
-environment.sh
-```
+=== "Linux & macOS"
+    ```bash
+    $ pixi-pack pack --create-executable
+    $ ls
+    environment.sh
+    $ ./environment.sh
+    $ ls
+    env/
+    activate.sh
+    environment.sh
+    ```
 
-```powershell
-# windows
-PS > pixi-pack pack --create-executable
-PS > ls
-environment.ps1
-PS > .\environment.ps1
-PS > ls
-env/
-activate.sh
-environment.ps1
-```
+=== "Windows"
+    ```powershell
+    PS > pixi-pack pack --create-executable
+    PS > ls
+    environment.ps1
+    PS > .\environment.ps1
+    PS > ls
+    env/
+    activate.sh
+    environment.ps1
+    ```
 
 !!! note
 

--- a/docs/deployment/pixi_pack.md
+++ b/docs/deployment/pixi_pack.md
@@ -56,10 +56,10 @@ Since `pixi-pack` just downloads the `.conda` and `.tar.bz2` files from the cond
 pixi-pack pack --platform win-64
 ```
 
-!!!note ""
+!!! note
     You can only unpack a pack on a system that has the same platform as the pack was created for.
 
-### Self-extracting binaries
+### Self-Extracting Binaries
 
 You can create a self-extracting binary that contains the packed environment and a script that unpacks the environment.
 This can be useful if you want to distribute the environment to users that don't have `pixi-pack` installed.
@@ -88,8 +88,9 @@ activate.sh
 environment.ps1
 ```
 
-> [!TIP]
-> The produced executable is a simple shell script that contains both the `pixi-pack` binary as well as the packed environment.
+!!! note
+
+    The produced executable is a simple shell script that contains both the `pixi-pack` binary as well as the packed environment.
 
 ### Inject Additional Packages
 
@@ -132,10 +133,12 @@ micromamba create -p ./env --file environment.yml
 conda env create -p ./env --file environment.yml
 ```
 
-!!!note ""
+!!! note
+
     The `environment.yml` and `repodata.json` files are only for this use case, `pixi-pack unpack` does not use them.
 
-!!!note ""
+!!! note
+
     Both `conda` and `mamba` are always installing pip as a side effect when they install python, see [`conda`'s documentation](https://docs.conda.io/projects/conda/en/25.1.x/user-guide/configuration/settings.html#add-pip-as-python-dependency-add-pip-as-python-dependency).
     This is different from how `pixi` works and can lead to solver errors when using `pixi-pack`'s compatibility mode since `pixi-pack` doesn't include `pip` by default.
     You can fix this issue in two ways:

--- a/docs/deployment/pixi_pack.md
+++ b/docs/deployment/pixi_pack.md
@@ -59,6 +59,38 @@ pixi-pack pack --platform win-64
 !!!note ""
     You can only unpack a pack on a system that has the same platform as the pack was created for.
 
+### Self-extracting binaries
+
+You can create a self-extracting binary that contains the packed environment and a script that unpacks the environment.
+This can be useful if you want to distribute the environment to users that don't have `pixi-pack` installed.
+
+```bash
+# unix
+$ pixi-pack pack --create-executable
+$ ls
+environment.sh
+$ ./environment.sh
+$ ls
+env/
+activate.sh
+environment.sh
+```
+
+```powershell
+# windows
+PS > pixi-pack pack --create-executable
+PS > ls
+environment.ps1
+PS > .\environment.ps1
+PS > ls
+env/
+activate.sh
+environment.ps1
+```
+
+> [!TIP]
+> The produced executable is a simple shell script that contains both the `pixi-pack` binary as well as the packed environment.
+
 ### Inject Additional Packages
 
 You can inject additional packages into the environment that are not specified in `pixi.lock` by using the `--inject` flag:
@@ -88,7 +120,7 @@ Using a cache is particularly useful when:
 
 ### Unpacking Without pixi-pack
 
-If you don't have `pixi-pack` available on your target system, you can still install the environment if you have `conda` or `micromamba` available.
+If you don't have `pixi-pack` available on your target system, and do not want to use self-extracting binaries (see above), you can still install the environment if you have `conda` or `micromamba` available. 
 Just unarchive the `environment.tar`, then you have a local channel on your system where all necessary packages are available.
 Next to this local channel, you will find an `environment.yml` file that contains the environment specification.
 You can then install the environment using `conda` or `micromamba`:


### PR DESCRIPTION
added section about self-extracting binaries (copy-pasted from the pixi-pack README) and a reference to it in the "unpacking without pixi-pack" section