### PR TITLE
chore: add pre-commit-minimal back

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,4 +99,4 @@ repos:
         types: [file, rust]
         entry: pixi run --environment=lint cargo-clippy
         pass_filenames: false
-        stages: [pre-commit, manual]
+        stages: [pre-push, manual]

--- a/docs/deployment/pixi_pack.md
+++ b/docs/deployment/pixi_pack.md
@@ -121,7 +121,7 @@ Using a cache is particularly useful when:
 
 ### Unpacking Without pixi-pack
 
-If you don't have `pixi-pack` available on your target system, and do not want to use self-extracting binaries (see above), you can still install the environment if you have `conda` or `micromamba` available. 
+If you don't have `pixi-pack` available on your target system, and do not want to use self-extracting binaries (see above), you can still install the environment if you have `conda` or `micromamba` available.
 Just unarchive the `environment.tar`, then you have a local channel on your system where all necessary packages are available.
 Next to this local channel, you will find an `environment.yml` file that contains the environment specification.
 You can then install the environment using `conda` or `micromamba`:

--- a/pixi.toml
+++ b/pixi.toml
@@ -106,7 +106,8 @@ lint-pixi_docs = { depends-on = [
   "cargo-fmt-pixi_docs",
   "cargo-clippy-pixi_docs",
 ] }
-pre-commit-install = "pre-commit install --install-hooks"
+pre-commit-install = "pre-commit install --install-hooks -t=pre-commit -t=pre-push"
+pre-commit-install-minimal = "pre-commit install -t=pre-commit"
 pre-commit-run = "pre-commit run --all-files"
 prettier-fmt = { cmd = "prettier --write" }
 ruff-format = "ruff format --force-exclude"


### PR DESCRIPTION
I tried "cargo-clippy" in my pre-commit now for a while, but the overhead is just to much.
I want my minimal version back again :)