### PR TITLE
feat: make install.sh posix compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Some notable features we envision for upcoming releases are:
 To install Pixi on macOS and Linux, open a terminal and run the following command:
 
 ```bash
-curl -fsSL https://pixi.sh/install.sh | bash
+curl -fsSL https://pixi.sh/install.sh | sh
 # or with brew
 brew install pixi
 ```

--- a/docs/advanced/installation.md
+++ b/docs/advanced/installation.md
@@ -4,7 +4,7 @@ To install `pixi` you can run the following command in your terminal:
 
 === "Linux & macOS"
     ```bash
-    curl -fsSL https://pixi.sh/install.sh | bash
+    curl -fsSL https://pixi.sh/install.sh | sh
     ```
 
     The above invocation will automatically download the latest version of `pixi`, extract it, and move the `pixi` binary to `~/.pixi/bin`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ To install `pixi` you can run the following command in your terminal:
 
 === "Linux & macOS"
     ```bash
-    curl -fsSL https://pixi.sh/install.sh | bash
+    curl -fsSL https://pixi.sh/install.sh | sh
     ```
 
     The above invocation will automatically download the latest version of `pixi`, extract it, and move the `pixi` binary to `~/.pixi/bin`.


### PR DESCRIPTION
make install.sh posix compliant, then we can install without bash on Unix-like os.