### PR TITLE
ci: bump timeout extra slow tests

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -59,10 +59,10 @@ test-common-wheels = { cmd = "pytest -s --numprocesses=auto tests/wheel_tests/",
 ] }
 test-common-wheels-ci = { cmd = "pytest --numprocesses=auto --verbose tests/wheel_tests/" }
 test-integration-ci = "pytest --numprocesses=auto --durations=0 --timeout=100 --verbose -m 'not extra_slow' tests/integration_python"
-test-integration-extra-slow = { cmd = "pytest --numprocesses=auto --durations=0 --timeout=300 tests/integration_python", depends-on = [
+test-integration-extra-slow = { cmd = "pytest --numprocesses=auto --durations=0 --timeout=600 tests/integration_python", depends-on = [
   "build-release",
 ] }
-test-integration-extra-slow-ci = "pytest --numprocesses=auto --durations=0 --timeout=300 tests/integration_python"
+test-integration-extra-slow-ci = "pytest --numprocesses=auto --durations=0 --timeout=600 tests/integration_python"
 test-integration-fast = { cmd = "pytest --pixi-build=debug --numprocesses=auto --durations=0 --timeout=100 -m 'not slow and not extra_slow' tests/integration_python", depends-on = [
   "build-debug",
 ] }


### PR DESCRIPTION
The pytorch examples are often timing out.
Let's hope that this solves that.