### PR TITLE
docs: remove main heading

### DIFF
--- a/docs/advanced/channel_logic.md
+++ b/docs/advanced/channel_logic.md
@@ -1,5 +1,3 @@
-# Channel Logic
-
 All logic regarding the decision which dependencies can be installed from which channel is done by the instruction we give the solver.
 
 The actual code regarding this is in the [`rattler_solve`](https://github.com/conda/rattler/blob/02e68c9539c6009cc1370fbf46dc69ca5361d12d/crates/rattler_solve/src/resolvo/mod.rs) crate.
@@ -31,7 +29,7 @@ flowchart TD
     D --> E
 ```
 
-# Channel Priority
+## Channel Priority
 
 Channel priority is dictated by the order in the `workspace.channels` array, where the first channel is the highest priority.
 For instance:
@@ -63,7 +61,7 @@ flowchart TD
 This method ensures the solver only adds a package to the candidates if it's found in the highest priority channel available.
 If you have 10 channels and the package is found in the 5th channel it will exclude the next 5 channels from the candidates if they also contain the package.
 
-# Use Case: pytorch and nvidia with conda-forge
+## Use Case: pytorch and nvidia with conda-forge
 A common use case is to use `pytorch` with `nvidia` drivers, while also needing the `conda-forge` channel for the main dependencies.
 ```toml
 [workspace]

--- a/docs/advanced/explain_info_command.md
+++ b/docs/advanced/explain_info_command.md
@@ -1,5 +1,3 @@
-# Info Command
-
 `pixi info` prints out useful information to debug a situation or to get an overview of your machine/workspace.
 This information can also be retrieved in `json` format using the `--json` flag, which can be useful for programmatically reading it.
 

--- a/docs/advanced/installation.md
+++ b/docs/advanced/installation.md
@@ -1,5 +1,3 @@
-# Installation
-
 To install `pixi` you can run the following command in your terminal:
 
 === "Linux & macOS"

--- a/docs/advanced/pixi_shell.md
+++ b/docs/advanced/pixi_shell.md
@@ -1,5 +1,3 @@
-# pixi shell
-
 The `pixi shell` command is similar to `conda activate` but works a little different under the hood.
 Instead of requiring a change to your `~/.bashrc` or other files, it will launch a fresh shell.
 That also means that, instead of `conda deactivate`, it's enough to just exit the current shell, e.g. by pressing `Ctrl+D`.
@@ -12,7 +10,7 @@ On Unix systems the shell command works by creating a "fake" PTY session that wi
 
 The temporary script that we generate ends with `echo "PIXI_ENV_ACTIVATED"` which is used to detect if the environment was activated successfully. If we do not receive this string after one second, we will issue a warning to the user.
 
-## Issues with pixi shell
+## Issues With Pixi Shell
 
 As explained, `pixi shell` only works well if we execute the activation script _after_ launching shell. Certain commands that are run in the `~/.bashrc` might swallow the activation command, and the environment won't be activated.
 
@@ -32,7 +30,7 @@ fi
 
 In order to fix this, we would advise you to follow the steps below to use `pixi shell-hook` instead.
 
-## Emulating `conda activate` with pixi
+## Emulating `conda activate` With Pixi
 
 To emulate `conda activate` - which activates a conda environment in the current shell - you can use the `pixi shell-hook` subcommand. The `shell-hook` is going to print a shell script to your `stdout` that can be used by your shell to activate the environment.
 

--- a/docs/advanced/shebang.md
+++ b/docs/advanced/shebang.md
@@ -1,6 +1,3 @@
-
-# Using `pixi exec` to Create Self-Contained Scripts
-
 !!!warning "Only on Unix-like systems"
     The following approach only works on Unix-like systems (i.e. Linux and macOS) since Windows does not support shebang lines.
 

--- a/docs/build/advanced_cpp.md
+++ b/docs/build/advanced_cpp.md
@@ -1,6 +1,3 @@
-# Tutorial: Building a C++ Package with rattler-build and recipe.yaml
-
-
 In this tutorial, we will show you how to build the same C++ package as from [Building a C++ Package](cpp.md) tutorial using [`rattler-build`](https://rattler.build).
 In this tutorial we assume that you've read the [Building a C++ Package](cpp.md) tutorial.
 If you haven't read it yet, we recommend you to do so before continuing.

--- a/docs/build/cpp.md
+++ b/docs/build/cpp.md
@@ -1,5 +1,3 @@
-# Tutorial: Building a C++ package
-
 This example shows how to build a C++ package with CMake and use it together with `pixi-build`.
 To read more about how building packages work with Pixi see the [Getting Started](./getting_started.md) guide.
 

--- a/docs/build/dependency_types.md
+++ b/docs/build/dependency_types.md
@@ -1,5 +1,3 @@
-# Run, Host and Build Dependencies
-
 If you add a package to the [dependency table](../reference/pixi_manifest.md#dependencies) of a feature that dependency will be available in all environments that include that feature.
 The dependencies of a package that is being built are a bit more granular.
 Here you can see the three types of dependencies for a simple C++ package.

--- a/docs/build/getting_started.md
+++ b/docs/build/getting_started.md
@@ -1,6 +1,4 @@
 
-## Introduction
-
 Next to managing workflows and environments, Pixi can also build packages.
 This is useful for the following reasons:
 

--- a/docs/build/python.md
+++ b/docs/build/python.md
@@ -1,5 +1,3 @@
-# Tutorial: Building a Python Package
-
 In this tutorial, we will show you how to create a simple Python package with pixi.
 
 !!! warning

--- a/docs/build/variants.md
+++ b/docs/build/variants.md
@@ -1,5 +1,3 @@
-# Tutorial: Adding Variants
-
 In this tutorial, we will show you how to use variants in order to build a Pixi package against different versions of a dependency.
 Some might call this functionality, build matrix, build configurations or parameterized builds, in the conda ecosystem this is referred to as a variant.
 

--- a/docs/build/workspace.md
+++ b/docs/build/workspace.md
@@ -1,5 +1,3 @@
-# Tutorial: Integrating Multiple Packages in a Workspace
-
 In this tutorial, we will show you how to integrate multiple Pixi packages into a single workspace.
 
 !!! warning

--- a/docs/deployment/authentication.md
+++ b/docs/deployment/authentication.md
@@ -1,5 +1,3 @@
-# Authentication
-
 You can authenticate Pixi with a server like prefix.dev, a private quetz instance or anaconda.org.
 Different servers use different authentication methods.
 In this documentation page, we detail how you can authenticate against the different servers and where the authentication information is stored.

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -1,5 +1,3 @@
-# Bringing Pixi to Production
-
 One way to bring a Pixi package into production is to containerize it using tools like Docker or Podman.
 
 <!-- Keep in sync with https://github.com/prefix-dev/pixi-docker/blob/main/README.md -->

--- a/docs/deployment/pixi_pack.md
+++ b/docs/deployment/pixi_pack.md
@@ -1,4 +1,3 @@
-# Pixi Pack
 <!-- Keep in sync with https://github.com/quantco/pixi-pack/blob/main/README.md -->
 
 [`pixi-pack`](https://github.com/quantco/pixi-pack) is a simple tool that takes a Pixi environment and packs it into a compressed archive that can be shipped to the target machine.

--- a/docs/deployment/s3.md
+++ b/docs/deployment/s3.md
@@ -1,5 +1,3 @@
-# Use S3 with Pixi
-
 If you want to use S3 object storage to fetch your packages, you can use the `s3://` protocol as a channel.
 
 ```toml title="pixi.toml"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,6 +1,3 @@
-# Getting Started
-
-
 Every Pixi workspace is described by a Pixi manifest.
 In this simple example we have a single task `start` which runs a Python file and two dependencies, `cowpy` and `python`.
 

--- a/docs/integration/editor/devcontainer.md
+++ b/docs/integration/editor/devcontainer.md
@@ -1,5 +1,3 @@
-# Use pixi inside of a devcontainer
-
 [VSCode Devcontainers](https://code.visualstudio.com/docs/devcontainers/containers) are a popular tool to develop on a workspace with a consistent environment.
 They are also used in [GitHub Codespaces](https://github.com/environments/codespaces) which makes it a great way to develop on a workspace without having to install anything on your local machine.
 

--- a/docs/integration/editor/jupyterlab.md
+++ b/docs/integration/editor/jupyterlab.md
@@ -1,4 +1,3 @@
-
 ## Basic usage
 
 Using JupyterLab with Pixi is very simple.

--- a/docs/integration/editor/r_studio.md
+++ b/docs/integration/editor/r_studio.md
@@ -1,5 +1,3 @@
-# Developing R scripts in RStudio
-
 You can use `pixi` to manage your R dependencies. The conda-forge channel contains a wide range of R packages that can be installed using `pixi`.
 
 ## Installing R packages

--- a/docs/integration/third_party/pixi_diff.md
+++ b/docs/integration/third_party/pixi_diff.md
@@ -1,5 +1,3 @@
-# Calculate Lockfile diffs
-
 ![pixi-diff demo](https://raw.githubusercontent.com/pavelzw/pixi-diff/refs/heads/main/.github/assets/demo/demo-light.gif#only-light)
 ![pixi-diff demo](https://raw.githubusercontent.com/pavelzw/pixi-diff/refs/heads/main/.github/assets/demo/demo-dark.gif#only-dark)
 

--- a/docs/integration/third_party/starship.md
+++ b/docs/integration/third_party/starship.md
@@ -1,6 +1,3 @@
-
-# Starship
-
 ![Starship with Pixi support](../../assets/starship-light.png#only-light)
 ![Starship with Pixi support](../../assets/starship-dark.png#only-dark)
 

--- a/docs/misc/Community.md
+++ b/docs/misc/Community.md
@@ -1,5 +1,3 @@
-# Community
-
 When you want to show your users and contributors that they can use Pixi in your repo, you can use the following badge:
 
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)

--- a/docs/misc/packaging.md
+++ b/docs/misc/packaging.md
@@ -1,5 +1,3 @@
-# Packaging Pixi
-
 This is a guide for distribution maintainers wanting to package Pixi for a different package manager.
 Users of Pixi can ignore this page.
 

--- a/docs/misc/vision.md
+++ b/docs/misc/vision.md
@@ -1,6 +1,3 @@
-
-# Vision
-
 We created `pixi` because we want to have a cargo/npm/yarn like package management experience for conda. We really love what the conda packaging ecosystem achieves, but we think that the user experience can be improved a lot.
 Modern package managers like `cargo` have shown us, how great a package manager can be. We want to bring that experience to the conda ecosystem.
 

--- a/docs/python/pyproject_toml.md
+++ b/docs/python/pyproject_toml.md
@@ -1,5 +1,3 @@
-# `pyproject.toml` in pixi
-
 We support the use of the `pyproject.toml` as our manifest file in pixi.
 This allows the user to keep one file with all configuration.
 The `pyproject.toml` file is a standard for Python projects.

--- a/docs/python/pytorch.md
+++ b/docs/python/pytorch.md
@@ -1,5 +1,3 @@
-# Pytorch Integration Guide
-
 ## Overview
 This guide explains how to integrate PyTorch with `pixi`, it supports multiple ways of installing PyTorch.
 

--- a/docs/python/tutorial.md
+++ b/docs/python/tutorial.md
@@ -1,5 +1,3 @@
-# Tutorial: Doing Python development with Pixi
-
 In this tutorial, we will show you how to create a simple Python project with pixi.
 We will show some of the features that Pixi provides, that are currently not a part of `pdm`, `poetry` etc.
 

--- a/docs/switching_from/conda.md
+++ b/docs/switching_from/conda.md
@@ -1,4 +1,3 @@
-# Transitioning from the `conda` or `mamba` to `pixi`
 Welcome to the guide designed to ease your transition from `conda` or `mamba` to `pixi`.
 This document compares key commands and concepts between these tools, highlighting `pixi`'s unique approach to managing environments and packages.
 With `pixi`, you'll experience a workspace-based workflow, enhancing your development process, and allowing for easy sharing of your work.

--- a/docs/switching_from/poetry.md
+++ b/docs/switching_from/poetry.md
@@ -1,4 +1,3 @@
-# Transitioning from `poetry` to `pixi`
 Welcome to the guide designed to ease your transition from `poetry` to `pixi`.
 This document compares key commands and concepts between these tools, highlighting `pixi`'s unique approach to managing environments and packages.
 With `pixi`, you'll experience a workspace-based workflow similar to `poetry` while including the `conda` ecosystem and allowing for easy sharing of your work.

--- a/docs/tutorials/multi_environment.md
+++ b/docs/tutorials/multi_environment.md
@@ -1,5 +1,3 @@
-# Tutorial: Using Multiple Environments
-
 In this tutorial we will show you how to use multiple environments in one Pixi workspace.
 
 ## Why Is This Useful?

--- a/docs/tutorials/ros2.md
+++ b/docs/tutorials/ros2.md
@@ -1,5 +1,3 @@
-# Tutorial: Develop a ROS 2 package with `pixi`
-
 In this tutorial, we will show you how to develop a ROS 2 package using `pixi`.
 The tutorial is written to be executed from top to bottom, missing steps might result in errors.
 

--- a/docs/tutorials/rust.md
+++ b/docs/tutorials/rust.md
@@ -1,5 +1,3 @@
-# Tutorial: Develop a Rust package using `pixi`
-
 In this tutorial, we will show you how to develop a Rust package using `pixi`.
 The tutorial is written to be executed from top to bottom, missing steps might result in errors.
 

--- a/docs/workspace/environment.md
+++ b/docs/workspace/environment.md
@@ -1,6 +1,3 @@
-
-# Environments
-
 Pixi is a tool to manage virtual environments.
 This document explains what an environment looks like and how to use it.
 

--- a/docs/workspace/lockfile.md
+++ b/docs/workspace/lockfile.md
@@ -1,5 +1,3 @@
-# The `pixi.lock` lock file
-
 > A lock file is the protector of the environments, and Pixi is the key to unlock it.
 
 ## What is a lock file?

--- a/docs/workspace/multi_environment.md
+++ b/docs/workspace/multi_environment.md
@@ -1,5 +1,3 @@
-# Multi Environment Support
-
 ### Motivating Example
 
 There are multiple scenarios where multiple environments are useful.

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -1,4 +1,3 @@
-
 [Pixi's vision](../misc/vision.md) includes being supported on all major platforms. Sometimes that needs some extra configuration to work well.
 On this page, you will learn what you can configure to align better with the platform you are making your application for.
 

--- a/docs/workspace/system_requirements.md
+++ b/docs/workspace/system_requirements.md
@@ -1,4 +1,3 @@
-# System Requirements in pixi
 **System requirements** tell Pixi the minimum system specifications needed to install and run your workspace’s environment.
 They ensure that the dependencies match the operating system and hardware of your machine.
 


### PR DESCRIPTION
The main heading defaults to the title `mkdocs.yml`. By removing the heading we don't have to keep them synchronized.