### PR TITLE
perf: only call `pixi global` completion functions when necessary

### DIFF
--- a/src/cli/global/sync.rs
+++ b/src/cli/global/sync.rs
@@ -22,9 +22,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Prune environments that are not listed
     let state_change = project.prune_old_environments().await?;
 
-    // Prune broken completions
-    let completions_dir = crate::global::completions::CompletionsDir::from_env().await?;
-    completions_dir.prune_old_completions()?;
+    #[cfg(unix)]
+    {
+        // Prune broken completions
+        let completions_dir = crate::global::completions::CompletionsDir::from_env().await?;
+        completions_dir.prune_old_completions()?;
+    }
 
     if state_change.has_changed() {
         has_changed = true;

--- a/src/cli/global/sync.rs
+++ b/src/cli/global/sync.rs
@@ -23,7 +23,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let state_change = project.prune_old_environments().await?;
 
     // Prune broken completions
-    project.completions_dir.prune_old_completions()?;
+    let completions_dir = crate::global::completions::CompletionsDir::from_env().await?;
+    completions_dir.prune_old_completions()?;
 
     if state_change.has_changed() {
         has_changed = true;

--- a/src/cli/global/update.rs
+++ b/src/cli/global/update.rs
@@ -86,7 +86,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             // prune old environments and completions
             let state_changes = project_original.prune_old_environments().await?;
             state_changes.report();
-            project_original.completions_dir.prune_old_completions()?;
+            let completions_dir = global::completions::CompletionsDir::from_env().await?;
+            completions_dir.prune_old_completions()?;
             project_original.environments().keys().cloned().collect()
         }
     };

--- a/src/cli/global/update.rs
+++ b/src/cli/global/update.rs
@@ -86,8 +86,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             // prune old environments and completions
             let state_changes = project_original.prune_old_environments().await?;
             state_changes.report();
-            let completions_dir = global::completions::CompletionsDir::from_env().await?;
-            completions_dir.prune_old_completions()?;
+            #[cfg(unix)]
+            {
+                let completions_dir = global::completions::CompletionsDir::from_env().await?;
+                completions_dir.prune_old_completions()?;
+            }
             project_original.environments().keys().cloned().collect()
         }
     };

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -356,6 +356,7 @@ pub(crate) enum StateChange {
     UninstalledShortcut(String),
     #[allow(dead_code)] // This variant is not used on Windows
     AddedCompletion(String),
+    #[allow(dead_code)] // This variant is not used on Windows
     RemovedCompletion(String),
 }
 

--- a/src/global/completions.rs
+++ b/src/global/completions.rs
@@ -84,10 +84,6 @@ impl Completion {
         }
     }
 
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
     /// Install the shell completion
     pub async fn install(&self) -> miette::Result<Option<StateChange>> {
         tracing::debug!("Requested to install completion {}.", self.source.display());

--- a/src/global/completions.rs
+++ b/src/global/completions.rs
@@ -34,6 +34,7 @@ impl CompletionsDir {
     }
 
     /// Prune old completions
+    #[cfg(unix)]
     pub fn prune_old_completions(&self) -> miette::Result<()> {
         for directory in [self.bash_path(), self.zsh_path(), self.fish_path()] {
             if !directory.is_dir() {
@@ -52,6 +53,12 @@ impl CompletionsDir {
             }
         }
 
+        Ok(())
+    }
+
+    /// Prune old completions
+    #[cfg(not(unix))]
+    pub fn prune_old_completions(&self) -> miette::Result<()> {
         Ok(())
     }
 
@@ -198,6 +205,7 @@ pub fn contained_completions(
 /// based on the provided `exposed_mappings` and `executable_names`. It compares the
 /// current state of the completion scripts in the `completions_dir` with the expected
 /// state derived from the `exposed_mappings`.
+#[cfg(unix)]
 pub(crate) async fn completions_sync_status(
     exposed_mappings: IndexSet<Mapping>,
     executable_names: Vec<String>,
@@ -240,4 +248,14 @@ pub(crate) async fn completions_sync_status(
     }
 
     Ok((completions_to_remove, completions_to_add))
+}
+
+#[cfg(not(unix))]
+pub(crate) async fn completions_sync_status(
+    exposed_mappings: IndexSet<Mapping>,
+    executable_names: Vec<String>,
+    prefix_root: &Path,
+    completions_dir: &CompletionsDir,
+) -> miette::Result<(Vec<Completion>, Vec<Completion>)> {
+    Ok((Vec::new(), Vec::new()))
 }

--- a/src/global/completions.rs
+++ b/src/global/completions.rs
@@ -34,7 +34,6 @@ impl CompletionsDir {
     }
 
     /// Prune old completions
-    #[cfg(unix)]
     pub fn prune_old_completions(&self) -> miette::Result<()> {
         for directory in [self.bash_path(), self.zsh_path(), self.fish_path()] {
             if !directory.is_dir() {
@@ -56,12 +55,6 @@ impl CompletionsDir {
         Ok(())
     }
 
-    /// Prune old completions
-    #[cfg(not(unix))]
-    pub fn prune_old_completions(&self) -> miette::Result<()> {
-        Ok(())
-    }
-
     pub fn bash_path(&self) -> PathBuf {
         self.path().join("bash")
     }
@@ -78,7 +71,6 @@ impl CompletionsDir {
 #[derive(Debug, Clone)]
 pub struct Completion {
     name: String,
-    #[allow(dead_code)] // This member variable is not used on Windows
     source: PathBuf,
     destination: PathBuf,
 }
@@ -97,7 +89,6 @@ impl Completion {
     }
 
     /// Install the shell completion
-    #[cfg(unix)]
     pub async fn install(&self) -> miette::Result<Option<StateChange>> {
         tracing::debug!("Requested to install completion {}.", self.source.display());
 
@@ -112,15 +103,6 @@ impl Completion {
             .into_diagnostic()?;
 
         Ok(Some(StateChange::AddedCompletion(self.name.clone())))
-    }
-
-    #[cfg(not(unix))]
-    pub async fn install(&self) -> miette::Result<Option<StateChange>> {
-        tracing::info!(
-            "Symlinks are only supported on unix-like platforms. Skipping completion installation for {}.",
-            self.name
-        );
-        Ok(None)
     }
 
     /// Remove the shell completion
@@ -248,14 +230,4 @@ pub(crate) async fn completions_sync_status(
     }
 
     Ok((completions_to_remove, completions_to_add))
-}
-
-#[cfg(not(unix))]
-pub(crate) async fn completions_sync_status(
-    exposed_mappings: IndexSet<Mapping>,
-    executable_names: Vec<String>,
-    prefix_root: &Path,
-    completions_dir: &CompletionsDir,
-) -> miette::Result<(Vec<Completion>, Vec<Completion>)> {
-    Ok((Vec::new(), Vec::new()))
 }

--- a/src/global/completions.rs
+++ b/src/global/completions.rs
@@ -183,7 +183,6 @@ pub fn contained_completions(
 /// based on the provided `exposed_mappings` and `executable_names`. It compares the
 /// current state of the completion scripts in the `completions_dir` with the expected
 /// state derived from the `exposed_mappings`.
-#[cfg(unix)]
 pub(crate) async fn completions_sync_status(
     exposed_mappings: IndexSet<Mapping>,
     executable_names: Vec<String>,

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod common;
+#[cfg(unix)]
 pub(crate) mod completions;
 pub(crate) mod install;
 pub(crate) mod list;

--- a/src/global/mod.rs
+++ b/src/global/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod common;
-#[cfg(unix)]
+#[cfg(unix)] // Completions are only supported on unix-like systems
 pub(crate) mod completions;
 pub(crate) mod install;
 pub(crate) mod list;

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -1252,6 +1252,7 @@ impl Project {
         Ok(state_changes)
     }
 
+    #[cfg(unix)]
     pub async fn sync_completions(
         &self,
         env_name: &EnvironmentName,
@@ -1291,6 +1292,15 @@ impl Project {
             state_changes.insert_change(env_name, state_change);
         }
 
+        Ok(state_changes)
+    }
+
+    #[cfg(not(unix))]
+    pub async fn sync_completions(
+        &self,
+        env_name: &EnvironmentName,
+    ) -> miette::Result<StateChanges> {
+        let mut state_changes = StateChanges::default();
         Ok(state_changes)
     }
 

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -647,7 +647,7 @@ impl Project {
             );
         }
 
-        #[cfg(unix)]
+        #[cfg(unix)] // Completions are only supported on unix-like systems
         {
             // Prune old completions
             let completions_dir = super::completions::CompletionsDir::from_env().await?;
@@ -1207,7 +1207,7 @@ impl Project {
         Ok(state_changes)
     }
 
-    #[cfg(unix)]
+    #[cfg(unix)] // Completions are only supported on unix like systems
     pub async fn sync_completions(
         &self,
         env_name: &EnvironmentName,


### PR DESCRIPTION
Fixes #3476

On Windows we never install completions, so let's also avoid the completion checks then

Also skip completions check for `environment_in_sync`.
This check is pretty expensive and unless users manually remove things in that directory, that check also isn't necessary.