### PR TITLE
fix: shell-hook, avoid run unexpected commands

### DIFF
--- a/src/shell_snippets/pixi-bash.sh
+++ b/src/shell_snippets/pixi-bash.sh
@@ -1,14 +1,15 @@
 # shellcheck shell=bash
 pixi() {
-    local first_arg="$1"
-    local cmd="$PIXI_EXE $*"
+    local first_arg="${1-}"
 
-    eval "$cmd"
+    "${PIXI_EXE-}" "$@" || return $?
 
-    case "$first_arg" in
+    case "${first_arg-}" in
         add|a|remove|rm|install|i)
-            eval "$($PIXI_EXE shell-hook --change-ps1 false)"
+            eval "$("$PIXI_EXE" shell-hook --change-ps1 false)"
             hash -r
             ;;
-    esac
+    esac || :
+
+    return 0
 }

--- a/src/shell_snippets/pixi-zsh.sh
+++ b/src/shell_snippets/pixi-zsh.sh
@@ -1,14 +1,15 @@
 # shellcheck disable=all
 pixi() {
-    local first_arg="$1"
-    local cmd="$PIXI_EXE $*"
+    local first_arg="${1-}"
 
-    eval "$cmd"
+    "${PIXI_EXE-}" "$@" || return $?
 
-    case "$first_arg" in
+    case "${first_arg-}" in
         add|a|remove|rm|install|i)
-            eval "$($PIXI_EXE shell-hook --change-ps1 false)"
-            rehash # Clear the command hash table in zsh
+            eval "$("$PIXI_EXE" shell-hook --change-ps1 false)"
+            hash -r
             ;;
-    esac
+    esac || :
+
+    return 0
 }

--- a/src/shell_snippets/pixi-zsh.sh
+++ b/src/shell_snippets/pixi-zsh.sh
@@ -7,7 +7,7 @@ pixi() {
     case "${first_arg-}" in
         add|a|remove|rm|install|i)
             eval "$("$PIXI_EXE" shell-hook --change-ps1 false)"
-            hash -r
+            rehash # Clear the command hash table in zsh
             ;;
     esac || :
 


### PR DESCRIPTION
close #3490 
close #3308 

1. use `$PIXI_EXE "$@"` to run the main command.
2. respect the exit code of the main commmand