### PR TITLE
refactor: change section header from [project] to [workspace] in the docs source files

### DIFF
--- a/docs/source_files/pixi_tomls/activation.toml
+++ b/docs/source_files/pixi_tomls/activation.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 channels = []
 name = "activation"
 platforms = ["linux-64", "win-64"]

--- a/docs/source_files/pixi_tomls/lots_of_channels.toml
+++ b/docs/source_files/pixi_tomls/lots_of_channels.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "lots_of_channels"
 platforms = []
 #  --8<-- [start:project_channels_long]

--- a/docs/source_files/pixi_tomls/main_pixi.toml
+++ b/docs/source_files/pixi_tomls/main_pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 # --8<-- [start:project_name]
 name = "project-name"
 # --8<-- [end:project_name]

--- a/docs/source_files/pixi_tomls/multi-environment-py-envs.toml
+++ b/docs/source_files/pixi_tomls/multi-environment-py-envs.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pixi"
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]

--- a/docs/source_files/pixi_tomls/multi-environment-simple.toml
+++ b/docs/source_files/pixi_tomls/multi-environment-simple.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pixi"
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]

--- a/docs/source_files/pixi_tomls/pytorch-conda-forge-envs.toml
+++ b/docs/source_files/pixi_tomls/pytorch-conda-forge-envs.toml
@@ -1,5 +1,5 @@
 # --8<-- [start:use-envs]
-[project]
+[workspace]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pytorch-conda-forge"
 platforms = ["linux-64"]

--- a/docs/source_files/pixi_tomls/pytorch-conda-forge.toml
+++ b/docs/source_files/pixi_tomls/pytorch-conda-forge.toml
@@ -1,5 +1,5 @@
 # --8<-- [start:minimal]
-[project]
+[workspace]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pytorch-conda-forge"
 platforms = ["linux-64", "win-64"]

--- a/docs/source_files/pixi_tomls/pytorch-from-pytorch-channel.toml
+++ b/docs/source_files/pixi_tomls/pytorch-from-pytorch-channel.toml
@@ -1,5 +1,5 @@
 # --8<-- [start:minimal]
-[project]
+[workspace]
 name = "pytorch-from-pytorch-channel"
 # `main` is not free! It's a paid channel for organizations over 200 people.
 channels = ["main", "nvidia", "pytorch"]

--- a/docs/source_files/pixi_tomls/pytorch-pypi-envs.toml
+++ b/docs/source_files/pixi_tomls/pytorch-pypi-envs.toml
@@ -1,5 +1,5 @@
 # --8<-- [start:multi-env]
-[project]
+[workspace]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pytorch-pypi-envs"
 platforms = ["linux-64", "win-64"]

--- a/docs/source_files/pixi_tomls/pytorch-pypi.toml
+++ b/docs/source_files/pixi_tomls/pytorch-pypi.toml
@@ -1,5 +1,5 @@
 # --8<-- [start:minimal]
-[project]
+[workspace]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pytorch-pypi"
 platforms = ["osx-arm64", "linux-64", "win-64"]

--- a/docs/source_files/pixi_tomls/simple_pixi.toml
+++ b/docs/source_files/pixi_tomls/simple_pixi.toml
@@ -1,6 +1,6 @@
 
 # --8<-- [start:project]
-[project]
+[workspace]
 channels = ["conda-forge"]
 name = "project-name"
 platforms = ["linux-64"]


### PR DESCRIPTION
This PR changes the `[project]` headers in the toml files in `docs/source_files/pixi_tomls` to `[workspace]`.