### PR TITLE
fix: respect exit code in shell shim

### DIFF
--- a/src/shell_snippets/pixi-bash.sh
+++ b/src/shell_snippets/pixi-bash.sh
@@ -4,6 +4,11 @@ pixi() {
     local cmd="$PIXI_EXE $*"
 
     eval "$cmd"
+    local exit_code=$?
+
+    if [ $exit_code -ne 0 ]; then
+        return $exit_code
+    fi
 
     case "$first_arg" in
         add|a|remove|rm|install|i)

--- a/src/shell_snippets/pixi-zsh.sh
+++ b/src/shell_snippets/pixi-zsh.sh
@@ -4,6 +4,11 @@ pixi() {
     local cmd="$PIXI_EXE $*"
 
     eval "$cmd"
+    local exit_code=$?
+
+    if [ $exit_code -ne 0 ]; then
+        return $exit_code
+    fi
 
     case "$first_arg" in
         add|a|remove|rm|install|i)


### PR DESCRIPTION
In `pixi shell` the exit code was eaten up by the shell shim (that serves the purpose of rehashing newly installed executables).

Fixes #3308 