### PR TITLE
docs: Updating windows installation.md to correspond to installation.ps1

### DIFF
--- a/docs/advanced/installation.md
+++ b/docs/advanced/installation.md
@@ -14,8 +14,8 @@ To install `pixi` you can run the following command in your terminal:
     powershell -ExecutionPolicy ByPass -c "irm -useb https://pixi.sh/install.ps1 | iex"
     ```
 
-    The above invocation will automatically download the latest version of `pixi`, extract it, and move the `pixi` binary to `LocalAppData/pixi/bin`.
-    The command will also add `LocalAppData/pixi/bin` to your `PATH` environment variable, allowing you to invoke `pixi` from anywhere.
+    The above invocation will automatically download the latest version of `pixi`, extract it, and move the `pixi` binary to `%UserProfile%\.pixi\bin`.
+    The command will also add `%UserProfile%\.pixi\bin` to your `PATH` environment variable, allowing you to invoke `pixi` from anywhere.
 
 !!! tip
 


### PR DESCRIPTION
The windows installation script `pixi/install/install.ps1` is currently installing pixi at `%UserProfile%\.pixi\bin`, while the documentation `pixi/docs/advanced/installation.md` says that pixi gets installed in `LocalAppData/pixi/bin`. 
This fix is to change the documentation.