### PR TITLE
fix: fix panic for `pixi task list` for platform specific tasks

### DIFF
--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -362,11 +362,10 @@ async fn list_tasks(workspace: Workspace, args: ListArgs) -> miette::Result<()> 
         .map(|(env, task_names)| {
             let task_map = task_names
                 .into_iter()
-                .map(|task_name| {
-                    let task = env
-                        .task(&task_name, Some(env.best_platform()))
-                        .expect("task should be available here");
-                    (task_name, task)
+                .flat_map(|task_name| {
+                    env.task(&task_name, Some(env.best_platform()))
+                        .ok()
+                        .map(|task| (task_name, task))
                 })
                 .collect();
             (env, task_map)

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -364,7 +364,7 @@ async fn list_tasks(workspace: Workspace, args: ListArgs) -> miette::Result<()> 
                 .into_iter()
                 .map(|task_name| {
                     let task = env
-                        .task(&task_name, None)
+                        .task(&task_name, Some(env.best_platform()))
                         .expect("task should be available here");
                     (task_name, task)
                 })

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1212,3 +1212,26 @@ def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:
         """
     manifest.write_text(toml)
     verify_cli_command([pixi, "info", "--manifest-path", manifest], stdout_contains="foo, bar")
+
+
+def test_pixi_task_list_platforms(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = """
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ["linux-64", "win-64", "osx-64"]
+
+        [tasks]
+        foo = "echo foo"
+
+        [target.unix.tasks]
+        bar = "echo bar"
+
+        [target.win.tasks]
+        bar = "echo bar"
+        """
+    manifest.write_text(toml)
+    verify_cli_command(
+        [pixi, "task", "list", "--manifest-path", manifest], stderr_contains=["foo", "bar"]
+    )

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1220,7 +1220,7 @@ def test_pixi_task_list_platforms(pixi: Path, tmp_pixi_workspace: Path) -> None:
         [workspace]
         name = "test"
         channels = []
-        platforms = ["linux-64", "win-64", "osx-64"]
+        platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
         [tasks]
         foo = "echo foo"


### PR DESCRIPTION
Addresses #3398 