### PR TITLE
feat: Workspace name field optional

### DIFF
--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -36,14 +36,6 @@ The minimally required information in the `project` table is:
 --8<-- "docs/source_files/pixi_tomls/simple_pixi.toml:project"
 ```
 
-### `name`
-
-The name of the project.
-
-```toml
---8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_name"
-```
-
 ### `channels`
 
 This is a list that defines the channels used to fetch the packages from.
@@ -81,6 +73,14 @@ The available platforms are listed here: [link](https://docs.rs/rattler_conda_ty
     To support both, include both in your platforms list.
     Fallback: If `osx-arm64` can't resolve, use `osx-64`.
     Running `osx-64` on Apple Silicon uses [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) for Intel binaries.
+
+### `name` (optional)
+
+The name of the project. If not defined, the root directory name will be assumed as the project name.
+
+```toml
+--8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_name"
+```
 
 ### `version` (optional)
 

--- a/docs/source_files/pixi_tomls/simple_pixi.toml
+++ b/docs/source_files/pixi_tomls/simple_pixi.toml
@@ -2,6 +2,5 @@
 # --8<-- [start:project]
 [workspace]
 channels = ["conda-forge"]
-name = "project-name"
 platforms = ["linux-64"]
 # --8<-- [end:project]


### PR DESCRIPTION
# Problem
Pixi requires users to write `workspace.name` field in `pixi.toml`
Despite the fact, not doing this could be consider a bad practice, some users seems to like a little bit of freedom on this aspect as user in issue #3431 is proposing.

# Solution
Add root directory name as a fallback in case of field name not being defined in `pixi.toml` file.
If for some reason the root_directory is None, it returns the MissingField error.