### PR TITLE
feat: Update rattler dependencies to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1940,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75ca0511313d95b0ca15b916b4532975b31b92ed882ddeaa23cbfca4955f32a"
+checksum = "46ca1565923e8d9bcf962889abeeb2f15d4b73356689ce26ae7dd1f54b928498"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2047,14 +2047,14 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "fs-err",
- "rustix 0.38.44",
+ "rustix 1.0.3",
  "tokio",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2867,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
 
 [[package]]
 name = "icu_normalizer"
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
@@ -2912,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
@@ -3466,7 +3466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5201,9 +5201,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.33.3"
+version = "0.33.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2f6a77d473028c29adf77cbc29d651d6566ca551bad3434e2314d992c6c1f9"
+checksum = "38b4452e4b38244fa650ac773176483ffdd438396419ff651ff391f11cfd6f92"
 dependencies = [
  "anyhow",
  "clap",
@@ -5245,9 +5245,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f84f8ac550603c11d8c681e83c441c0565a29907c40583114b78fc3e31f72bb"
+checksum = "ba3a51a8e6c6947265800178ad45575dc41a452ff2fdba7b75871decfdf2841c"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5277,11 +5277,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea41e41b171d7185f57c4fa0e19ef145c96604ba151479ec070f928325dbe1a"
+checksum = "1707fa705c9bf60032a12ccd04647ef2ff38b171e383a1f47c035b3f2ee2d646"
 dependencies = [
  "chrono",
+ "core-foundation 0.10.0",
  "dirs 6.0.0",
  "file_url",
  "fs-err",
@@ -5316,9 +5317,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81b39557a833c5820f4c373f2b36147672e0c02f44a63387186d1f6f1f240f3"
+checksum = "5b25a80b1e35f1dd1a85b199a3f5096eb02768ac9bff512db209851e75af3514"
 dependencies = [
  "blake2",
  "digest",
@@ -5333,9 +5334,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.48"
+version = "0.22.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53b8a7a04cefca5f0ed5463c72bdcb232d7ae3eb27f979569bc6e90eb391763"
+checksum = "652bf0fe5cc5c4fdbb56be2050e728d053facdaf232de4198eeb5549705dbcc0"
 dependencies = [
  "chrono",
  "file_url",
@@ -5358,9 +5359,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52efa676b94d13ff3888074a8eb662e0a603ddddd5697cedc58b21de5f478cfb"
+checksum = "7c9b25725cedeef8dee22c41dee138daf76ebd70da50fe210aa5e50288036816"
 dependencies = [
  "quote",
  "syn",
@@ -5368,9 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d126c14a5f5a50027c9f05992e7caf2122acb7ce528b9009ee92d475dd329"
+checksum = "6369d7e9db87084701129a829cdb7d5db4c9969f5cac46e095e2e7ead4a5e5e3"
 dependencies = [
  "chrono",
  "configparser",
@@ -5398,9 +5399,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.10"
+version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb7aa16bcfa0f53ddbf580c58e43bd8ad7fd8a643c767c365ebf033734d4cd1"
+checksum = "5d27b2c0d358ccdc69c124a47b82d1f4c64770ba84fce4b0a71da8d96a3c5fe5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5409,7 +5410,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",
  "fs-err",
- "getrandom 0.3.2",
+ "getrandom 0.2.15",
  "google-cloud-auth",
  "google-cloud-token",
  "http 1.3.1",
@@ -5429,9 +5430,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.34"
+version = "0.22.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55a377f9b969915695c7aa994740ca157221f6a63d03812404e8d393d81e517"
+checksum = "c0a91c0e740da9eb193edb4cca9f85f426ca924cc3e5115c9d779953c6505f5b"
 dependencies = [
  "bzip2",
  "chrono",
@@ -5459,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb481bc7af5d6564f120307bc4481efb4e55c8502424acec3409a4e5d61ef12"
+checksum = "be52f893619691d2f4a621c05db51aaecb7e4173980543b2f1ce68d269ab0726"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -5470,9 +5471,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba15cb481b9d065194160fddff2fd21d15cac723622a1acddc8fae6b65ce0c7c"
+checksum = "40b1cf84f4f2fee3d9598905e1811b10f944e7650ee73ba2e66a3e6b7d9007d2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5527,9 +5528,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25e56d8c1b003bae96de82c498d550ddea9677825ad52a4d1ececf3ef33613"
+checksum = "4a608482d3a775190cc022690465bb28f877f806542ff38e5d39de2c4d764f95"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -5546,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc403ea44cf8a4c8f382992ce172fb184b1bd99703bf981c46a4acd6ea010dae"
+checksum = "3d56b9a5ce33b79d7cc159d57f001bb3309ea2baf674b1ffae7ea4a9d8c7dbcc"
 dependencies = [
  "chrono",
  "futures",
@@ -5566,9 +5567,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef443a173c98db5ed56c8de62caad2f2f9569a2945cb520c2e73ab800b029708"
+checksum = "548a207f80c292f4ea1e6ad2d7477c9ff6181f11851d4c265f6a44883ba22264"
 dependencies = [
  "archspec",
  "libloading",
@@ -8822,7 +8823,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9720,18 +9721,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap 2.8.0",
  "memchr",
- "thiserror 2.0.12",
  "time",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,22 +113,22 @@ wax = "0.6.0"
 which = "7.0.2"
 
 # Rattler crates
-file_url = "0.2.3"
-rattler = { version = "0.33.3", default-features = false }
-rattler_cache = { version = "0.3.14", default-features = false }
-rattler_conda_types = { version = "0.31.4", default-features = false, features = [
+file_url = "0.2.4"
+rattler = { version = "0.33.4", default-features = false }
+rattler_cache = { version = "0.3.16", default-features = false }
+rattler_conda_types = { version = "0.31.6", default-features = false, features = [
   "rayon",
 ] }
-rattler_digest = { version = "1.0.8", default-features = false }
-rattler_lock = { version = "0.22.48", default-features = false }
-rattler_menuinst = { version = "0.2.5", default-features = false }
-rattler_networking = { version = "0.22.10", default-features = false, features = [
+rattler_digest = { version = "1.1.0", default-features = false }
+rattler_lock = { version = "0.22.49", default-features = false }
+rattler_menuinst = { version = "0.2.6", default-features = false }
+rattler_networking = { version = "0.22.11", default-features = false, features = [
   "google-cloud-auth",
 ] }
-rattler_repodata_gateway = { version = "0.22.3", default-features = false }
-rattler_shell = { version = "0.22.24", default-features = false }
-rattler_solve = { version = "1.4.2", default-features = false }
-rattler_virtual_packages = { version = "2.0.8", default-features = false }
+rattler_repodata_gateway = { version = "0.22.4", default-features = false }
+rattler_shell = { version = "0.22.25", default-features = false }
+rattler_solve = { version = "1.4.3", default-features = false }
+rattler_virtual_packages = { version = "2.0.9", default-features = false }
 
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"

--- a/pixi_docs/Cargo.lock
+++ b/pixi_docs/Cargo.lock
@@ -1189,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.32"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75ca0511313d95b0ca15b916b4532975b31b92ed882ddeaa23cbfca4955f32a"
+checksum = "46ca1565923e8d9bcf962889abeeb2f15d4b73356689ce26ae7dd1f54b928498"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2016,14 +2016,14 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "fs-err",
- "rustix 0.38.44",
+ "rustix 1.0.3",
  "tokio",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5031,9 +5031,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.33.3"
+version = "0.33.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2f6a77d473028c29adf77cbc29d651d6566ca551bad3434e2314d992c6c1f9"
+checksum = "38b4452e4b38244fa650ac773176483ffdd438396419ff651ff391f11cfd6f92"
 dependencies = [
  "anyhow",
  "clap",
@@ -5075,9 +5075,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f84f8ac550603c11d8c681e83c441c0565a29907c40583114b78fc3e31f72bb"
+checksum = "ba3a51a8e6c6947265800178ad45575dc41a452ff2fdba7b75871decfdf2841c"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5107,11 +5107,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea41e41b171d7185f57c4fa0e19ef145c96604ba151479ec070f928325dbe1a"
+checksum = "1707fa705c9bf60032a12ccd04647ef2ff38b171e383a1f47c035b3f2ee2d646"
 dependencies = [
  "chrono",
+ "core-foundation 0.10.0",
  "dirs 6.0.0",
  "file_url",
  "fs-err",
@@ -5146,9 +5147,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81b39557a833c5820f4c373f2b36147672e0c02f44a63387186d1f6f1f240f3"
+checksum = "5b25a80b1e35f1dd1a85b199a3f5096eb02768ac9bff512db209851e75af3514"
 dependencies = [
  "blake2",
  "digest",
@@ -5163,9 +5164,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.48"
+version = "0.22.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53b8a7a04cefca5f0ed5463c72bdcb232d7ae3eb27f979569bc6e90eb391763"
+checksum = "652bf0fe5cc5c4fdbb56be2050e728d053facdaf232de4198eeb5549705dbcc0"
 dependencies = [
  "chrono",
  "file_url",
@@ -5188,9 +5189,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52efa676b94d13ff3888074a8eb662e0a603ddddd5697cedc58b21de5f478cfb"
+checksum = "7c9b25725cedeef8dee22c41dee138daf76ebd70da50fe210aa5e50288036816"
 dependencies = [
  "quote",
  "syn",
@@ -5198,9 +5199,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d126c14a5f5a50027c9f05992e7caf2122acb7ce528b9009ee92d475dd329"
+checksum = "6369d7e9db87084701129a829cdb7d5db4c9969f5cac46e095e2e7ead4a5e5e3"
 dependencies = [
  "chrono",
  "configparser",
@@ -5228,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.10"
+version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb7aa16bcfa0f53ddbf580c58e43bd8ad7fd8a643c767c365ebf033734d4cd1"
+checksum = "5d27b2c0d358ccdc69c124a47b82d1f4c64770ba84fce4b0a71da8d96a3c5fe5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5239,7 +5240,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",
  "fs-err",
- "getrandom 0.3.2",
+ "getrandom 0.2.15",
  "google-cloud-auth",
  "google-cloud-token",
  "http 1.3.1",
@@ -5259,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.34"
+version = "0.22.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55a377f9b969915695c7aa994740ca157221f6a63d03812404e8d393d81e517"
+checksum = "c0a91c0e740da9eb193edb4cca9f85f426ca924cc3e5115c9d779953c6505f5b"
 dependencies = [
  "bzip2",
  "chrono",
@@ -5289,9 +5290,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb481bc7af5d6564f120307bc4481efb4e55c8502424acec3409a4e5d61ef12"
+checksum = "be52f893619691d2f4a621c05db51aaecb7e4173980543b2f1ce68d269ab0726"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -5300,9 +5301,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba15cb481b9d065194160fddff2fd21d15cac723622a1acddc8fae6b65ce0c7c"
+checksum = "40b1cf84f4f2fee3d9598905e1811b10f944e7650ee73ba2e66a3e6b7d9007d2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5357,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25e56d8c1b003bae96de82c498d550ddea9677825ad52a4d1ececf3ef33613"
+checksum = "4a608482d3a775190cc022690465bb28f877f806542ff38e5d39de2c4d764f95"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -5376,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc403ea44cf8a4c8f382992ce172fb184b1bd99703bf981c46a4acd6ea010dae"
+checksum = "3d56b9a5ce33b79d7cc159d57f001bb3309ea2baf674b1ffae7ea4a9d8c7dbcc"
 dependencies = [
  "chrono",
  "futures",
@@ -5396,9 +5397,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef443a173c98db5ed56c8de62caad2f2f9569a2945cb520c2e73ab800b029708"
+checksum = "548a207f80c292f4ea1e6ad2d7477c9ff6181f11851d4c265f6a44883ba22264"
 dependencies = [
  "archspec",
  "libloading",
@@ -9514,18 +9515,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap 2.8.0",
  "memchr",
- "thiserror 2.0.12",
  "time",
  "zopfli",
 ]

--- a/tests/integration_rust/common/package_database.rs
+++ b/tests/integration_rust/common/package_database.rs
@@ -63,7 +63,7 @@ impl PackageDatabase {
 
             let repodata = RepoData {
                 info: Some(ChannelInfo {
-                    subdir: platform.to_string(),
+                    subdir: Some(platform.to_string()),
                     base_url: None,
                 }),
                 packages: self


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi/issues/3438 by updating the rattler dependency to include https://github.com/conda/rattler/pull/1195

* Ran 'pixi run update-rattler' to update rattler packages in the project.
* Needed to update a string in tests/integration_rust/common/package_database.rs to optional string for tests to pass.