### PR TITLE
test: `pixi global` stop checking for `quicklaunch` on Windows

### DIFF
--- a/tests/integration_python/pixi_global/test_shortcuts.py
+++ b/tests/integration_python/pixi_global/test_shortcuts.py
@@ -57,7 +57,7 @@ class MacOSConfig(PlatformConfig):
 
 class WindowsConfig(PlatformConfig):
     def _shortcut_paths(self, data_home: Path, name: str) -> List[Path]:
-        return [data_home / "Desktop" / f"{name}.lnk", data_home / "Quick Launch" / f"{name}.lnk"]
+        return [data_home / "Desktop" / f"{name}.lnk"]
 
     def shortcut_exists(self, data_home: Path, name: str) -> bool:
         for path in self._shortcut_paths(data_home, name):


### PR DESCRIPTION
`quicklaunch` has been deprecated for menuinst: https://github.com/conda/rattler/pull/1196