### PR TITLE
feat: make workspace name optional

### DIFF
--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -565,7 +565,13 @@ mod test {
                         &mut snapshot,
                         "Discovered workspace at: {}\n- Name: {}",
                         rel_path.display().to_string().replace("\\", "/"),
-                        &discovered.workspace.value.workspace.name
+                        &discovered
+                            .workspace
+                            .value
+                            .workspace
+                            .name
+                            .as_deref()
+                            .unwrap_or("??")
                     )
                     .unwrap();
 
@@ -620,7 +626,13 @@ mod test {
                     &mut snapshot,
                     "Discovered workspace at: {}\n- Name: {}",
                     rel_path.display().to_string().replace("\\", "/"),
-                    &discovered.workspace.value.workspace.name
+                    &discovered
+                        .workspace
+                        .value
+                        .workspace
+                        .name
+                        .as_deref()
+                        .unwrap_or("??")
                 )
                 .unwrap();
 

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -656,7 +656,7 @@ impl WorkspaceManifestMut<'_> {
     /// This function modifies both the workspace and the TOML document. Use
     /// `ManifestProvenance::save` to persist the changes to disk.
     pub fn set_name(&mut self, name: &str) -> miette::Result<()> {
-        self.workspace.workspace.name = name.to_string();
+        self.workspace.workspace.name = Some(name.to_string());
         self.document.set_name(name);
         Ok(())
     }

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -392,8 +392,11 @@ impl PyProjectManifest {
 
         // For each group of optional dependency or dependency group, add pypi
         // dependencies, filtering out self-references in optional dependencies
-        let project_name =
-            pep508_rs::PackageName::new(workspace_manifest.workspace.name.clone()).ok();
+        let project_name = workspace_manifest
+            .workspace
+            .name
+            .clone()
+            .and_then(|name| pep508_rs::PackageName::new(name).ok());
         for (group, reqs) in pypi_dependency_groups {
             let feature_name = FeatureName::Named(group.to_string());
             let target = workspace_manifest

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -427,7 +427,7 @@ impl TomlManifest {
                 warnings: mut package_warnings,
             } = package.into_manifest(
                 ExternalPackageProperties {
-                    name: Some(workspace.name.clone()),
+                    name: workspace.name.clone(),
                     version: workspace.version.clone(),
                     description: workspace.description.clone(),
                     authors: workspace.authors.clone(),
@@ -606,19 +606,7 @@ mod test {
     }
 
     #[test]
-    fn test_workspace_name_required() {
-        assert_snapshot!(expect_parse_failure(
-            r#"
-        [workspace]
-        channels = []
-        platforms = []
-        preview = ["pixi-build"]
-        "#,
-        ));
-    }
-
-    #[test]
-    fn test_workspace_name_from_workspace() {
+    fn test_workspace_name_from_package() {
         let workspace_manifest = WorkspaceManifest::from_toml_str(
             r#"
         [workspace]
@@ -636,7 +624,7 @@ mod test {
         )
         .unwrap();
 
-        assert_eq!(workspace_manifest.workspace.name, "foo");
+        assert_eq!(workspace_manifest.workspace.name.as_deref(), Some("foo"));
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -606,6 +606,33 @@ mod test {
     }
 
     #[test]
+    fn test_missing_package_name() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        channels = []
+        platforms = []
+        preview = ["pixi-build"]
+
+        [package]
+        # Since workspace doesnt define a name we expect an error here.
+
+        [package.build]
+        backend = { name = "foobar", version = "*" }
+        "#,
+        ), @r###"
+         × missing field 'name' in table
+          ╭─[pixi.toml:7:9]
+        6 │
+        7 │         [package]
+          ·         ──────────
+        8 │         # Since workspace doesnt define a name we expect an error here.
+        9 │
+          ╰────
+        "###);
+    }
+
+    #[test]
     fn test_workspace_name_from_package() {
         let workspace_manifest = WorkspaceManifest::from_toml_str(
             r#"

--- a/crates/pixi_manifest/src/toml/workspace.rs
+++ b/crates/pixi_manifest/src/toml/workspace.rs
@@ -16,7 +16,7 @@ use indexmap::{IndexMap, IndexSet};
 use pixi_spec::TomlVersionSpecStr;
 use pixi_toml::{TomlFromStr, TomlHashMap, TomlIndexMap, TomlIndexSet, TomlWith};
 use rattler_conda_types::{NamedChannelOrUrl, Platform, Version, VersionSpec};
-use toml_span::{de_helpers::TableHelper, DeserError, Error, ErrorKind, Span, Spanned, Value};
+use toml_span::{de_helpers::TableHelper, DeserError, Span, Spanned, Value};
 use url::Url;
 
 #[derive(Debug, Clone)]
@@ -109,11 +109,7 @@ impl TomlWorkspace {
         let warnings = preview_warnings;
 
         Ok(WithWarnings::from(Workspace {
-            name: self.name.or(external.name).ok_or(Error {
-                kind: ErrorKind::MissingField("name"),
-                span: self.span,
-                line_info: None,
-            })?,
+            name: self.name.or(external.name),
             version: self.version.or(external.version),
             description: self.description.or(external.description),
             authors: self.authors.or(external.authors),
@@ -246,9 +242,8 @@ mod test {
 
     use insta::assert_snapshot;
 
-    use crate::toml::manifest::ExternalWorkspaceProperties;
     use crate::{
-        toml::{FromTomlStr, TomlWorkspace},
+        toml::{manifest::ExternalWorkspaceProperties, FromTomlStr, TomlWorkspace},
         utils::test_utils::{expect_parse_failure, format_parse_error},
     };
 

--- a/crates/pixi_manifest/src/workspace.rs
+++ b/crates/pixi_manifest/src/workspace.rs
@@ -11,10 +11,10 @@ use super::pypi::pypi_options::PypiOptions;
 use crate::{preview::Preview, PrioritizedChannel, S3Options, Targets};
 
 /// Describes the contents of the `[workspace]` section of the project manifest.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct Workspace {
     /// The name of the project
-    pub name: String,
+    pub name: Option<String>,
 
     /// The version of the project
     pub version: Option<Version>,

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -36,14 +36,6 @@ The minimally required information in the `project` table is:
 --8<-- "docs/source_files/pixi_tomls/simple_pixi.toml:project"
 ```
 
-### `name`
-
-The name of the project.
-
-```toml
---8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_name"
-```
-
 ### `channels`
 
 This is a list that defines the channels used to fetch the packages from.
@@ -81,6 +73,15 @@ The available platforms are listed here: [link](https://docs.rs/rattler_conda_ty
     To support both, include both in your platforms list.
     Fallback: If `osx-arm64` can't resolve, use `osx-64`.
     Running `osx-64` on Apple Silicon uses [Rosetta](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment) for Intel binaries.
+
+### `name` (optional)
+
+The name of the project.
+If the name is not specified, the name of the directory that contains the workspace is used.
+
+```toml
+--8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_name"
+```
 
 ### `version` (optional)
 

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -77,7 +77,7 @@ The available platforms are listed here: [link](https://docs.rs/rattler_conda_ty
 ### `name` (optional)
 
 The name of the project.
-If the name is not specified, the name of the directory that contains the workspace is used.
+If the name is not specified, the name of the directory that contains the project is used.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_name"

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -48,7 +48,10 @@ impl Workspace {
                 format!("{PROJECT_PREFIX}ROOT"),
                 self.root().to_string_lossy().into_owned(),
             ),
-            (format!("{PROJECT_PREFIX}NAME"), self.name().to_string()),
+            (
+                format!("{PROJECT_PREFIX}NAME"),
+                self.display_name().to_string(),
+            ),
             (
                 format!("{PROJECT_PREFIX}MANIFEST"),
                 self.workspace
@@ -89,9 +92,9 @@ impl Environment<'_> {
     pub(crate) fn get_metadata_env(&self) -> IndexMap<String, String> {
         let prompt = match self.name() {
             EnvironmentName::Named(name) => {
-                format!("{}:{}", self.workspace().name(), name)
+                format!("{}:{}", self.workspace().display_name(), name)
             }
-            EnvironmentName::Default => self.workspace().name().to_string(),
+            EnvironmentName::Default => self.workspace().display_name().to_string(),
         };
         let mut map = IndexMap::from_iter([
             (format!("{ENV_PREFIX}NAME"), self.name().to_string()),
@@ -364,8 +367,10 @@ pub(crate) fn get_static_environment_variables<'p>(
 
     // Add the conda default env variable so that the existing tools know about the env.
     let env_name = match environment.name() {
-        EnvironmentName::Named(name) => format!("{}:{}", environment.workspace().name(), name),
-        EnvironmentName::Default => environment.workspace().name().to_string(),
+        EnvironmentName::Named(name) => {
+            format!("{}:{}", environment.workspace().display_name(), name)
+        }
+        EnvironmentName::Default => environment.workspace().display_name().to_string(),
     };
     let mut shell_env = HashMap::new();
     shell_env.insert("CONDA_DEFAULT_ENV".to_string(), env_name);
@@ -517,7 +522,10 @@ mod tests {
         let project = Workspace::from_str(Path::new("pixi.toml"), project).unwrap();
         let env = project.get_metadata_env();
 
-        assert_eq!(env.get("PIXI_PROJECT_NAME").unwrap(), project.name());
+        assert_eq!(
+            env.get("PIXI_PROJECT_NAME").unwrap(),
+            project.display_name()
+        );
         assert_eq!(
             env.get("PIXI_PROJECT_ROOT").unwrap(),
             project.root().to_str().unwrap()

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -178,7 +178,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         (Some(tmp), work_dir)
     };
 
-    let progress = ProgressReporter::new(workspace.name());
+    let progress = ProgressReporter::new(workspace.display_name());
 
     // Build platform virtual packages
     let build_platform_virtual_packages: Vec<GenericVirtualPackage> = workspace

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -391,7 +391,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     let project_info = workspace.clone().map(|p| WorkspaceInfo {
-        name: p.name().to_string(),
+        name: p.display_name().to_string(),
         manifest_path: p.workspace.provenance.path.clone(),
         last_updated: last_updated(p.lock_file_path()).ok(),
         pixi_folder_size,

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -312,7 +312,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     tracing::info!("Starting shell: {:?}", interactive_shell);
 
     let prompt_hook = if workspace.config().change_ps1() {
-        let prompt_name = prompt::prompt_name(workspace.name(), environment.name());
+        let prompt_name = prompt::prompt_name(workspace.display_name(), environment.name());
         [
             prompt::shell_prompt(&interactive_shell, prompt_name.as_str()),
             prompt::shell_hook(&interactive_shell)

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -109,7 +109,7 @@ async fn generate_activation_script(
     let hook = prompt::shell_hook(&shell).unwrap_or_default().to_owned();
 
     if project.config().change_ps1() {
-        let prompt_name = prompt::prompt_name(project.name(), environment.name());
+        let prompt_name = prompt::prompt_name(project.display_name(), environment.name());
         let shell_prompt = prompt::shell_prompt(&shell, prompt_name.as_str());
         Ok([script, hook, shell_prompt].join("\n"))
     } else {

--- a/src/cli/workspace/name/get.rs
+++ b/src/cli/workspace/name/get.rs
@@ -1,6 +1,6 @@
 use crate::Workspace;
 
 pub async fn execute(workspace: Workspace) -> miette::Result<()> {
-    println!("{}", workspace.name());
+    println!("{}", workspace.display_name());
     Ok(())
 }

--- a/src/cli/workspace/name/set.rs
+++ b/src/cli/workspace/name/set.rs
@@ -22,7 +22,12 @@ pub async fn execute(workspace: Workspace, args: Args) -> miette::Result<()> {
     eprintln!(
         "{}Updated workspace name to '{}'.",
         console::style(console::Emoji("✔ ", "")).green(),
-        workspace.workspace.value.workspace.name
+        workspace
+            .workspace
+            .value
+            .workspace
+            .name
+            .expect("workspace name must have been set")
     );
 
     Ok(())

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -1293,7 +1293,7 @@ impl Repodata for Project {
 mod tests {
     use std::{collections::HashMap, io::Write};
 
-    use fake::{faker::filesystem::zh_tw::FilePath, Fake};
+    use fake::{faker::filesystem::en::FilePath, Fake};
     use itertools::Itertools;
     use rattler_conda_types::{
         NamedChannelOrUrl, PackageRecord, Platform, RepoDataRecord, VersionWithSource,

--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -45,7 +45,7 @@ pub struct Environment<'p> {
 impl Debug for Environment<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Environment")
-            .field("project", &self.workspace.name())
+            .field("project", &self.workspace.display_name())
             .field("environment", &self.environment.name)
             .finish()
     }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -278,14 +278,15 @@ impl Workspace {
         WorkspaceMut::new(self)
     }
 
-    /// Returns the name of the workspace.
+    /// Returns the display name of the workspace. This name should be used to
+    /// provide context to a user.
     ///
     /// This is the name of the workspace as defined in the manifest, or if no
     /// name is specified the name of the root directory of the workspace.
     ///
     /// If the name of the root directory could not be determined, "workspace"
     /// is used as a fallback.
-    pub fn name(&self) -> &str {
+    pub fn display_name(&self) -> &str {
         self.workspace
             .value
             .workspace
@@ -311,7 +312,7 @@ impl Workspace {
         if let Ok(Some(detached_environments_path)) = self.config().detached_environments().path() {
             Some(detached_environments_path.join(format!(
                 "{}-{}",
-                self.name(),
+                self.display_name(),
                 xxh3_64(self.root.to_string_lossy().as_bytes())
             )))
         } else {
@@ -869,7 +870,7 @@ mod tests {
             WORKSPACE_STR,
         )
         .unwrap();
-        assert_eq!(workspace.name(), "foo");
+        assert_eq!(workspace.display_name(), "foo");
     }
 
     #[test]
@@ -888,7 +889,7 @@ mod tests {
             WORKSPACE_STR,
         )
         .unwrap();
-        assert_eq!(workspace.name(), "foobar");
+        assert_eq!(workspace.display_name(), "foobar");
     }
 
     #[test]
@@ -903,7 +904,7 @@ mod tests {
             WORKSPACE_STR,
         )
         .unwrap();
-        assert_eq!(workspace.name(), "workspace");
+        assert_eq!(workspace.display_name(), "workspace");
     }
 
     fn format_dependencies(deps: pixi_manifest::CondaDependencies) -> String {

--- a/tests/integration_rust/init_tests.rs
+++ b/tests/integration_rust/init_tests.rs
@@ -16,9 +16,9 @@ async fn init_creates_project_manifest() {
     let workspace = pixi.workspace().unwrap();
 
     // Default configuration should be present in the file
-    assert!(!workspace.name().is_empty());
+    assert!(!workspace.display_name().is_empty());
     assert_eq!(
-        workspace.name(),
+        workspace.display_name(),
         &pixi.workspace_path().file_stem().unwrap().to_string_lossy(),
         "project name should match the directory name"
     );


### PR DESCRIPTION
This PR makes the workspace name optional and instead allows deriving the name from the location of were the workspace is stored. E.g. if the workspace is stored under `/foo/bar/pixi.toml` the name of the workspace will default to `bar`. If the workspace is stored under `/pixi.toml` the workspace will have the fallback name "workspace". 

The workspace name is used only to provide context to the user so I think this behavior is appropriate. This is different from the package name, which is also stored in the lock-file. 

### Tests

I added 3 tests to verify the behavior.

Fixes https://github.com/prefix-dev/pixi/issues/3431
Closes #3514 