### PR TITLE
refactor: reduce difference between default and named feature

### DIFF
--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -1,3 +1,9 @@
+use indexmap::{IndexMap, IndexSet};
+use itertools::Either;
+use pixi_spec::PixiSpec;
+use rattler_conda_types::{PackageName, Platform};
+use serde::{Deserialize, Serialize};
+use std::ops::Not;
 use std::{
     borrow::{Borrow, Cow},
     convert::Infallible,
@@ -5,12 +11,6 @@ use std::{
     hash::{Hash, Hasher},
     str::FromStr,
 };
-
-use indexmap::{IndexMap, IndexSet};
-use itertools::Either;
-use pixi_spec::PixiSpec;
-use rattler_conda_types::{PackageName, Platform};
-use serde::{de::Error, Deserialize, Serialize};
 
 use crate::{
     channel::PrioritizedChannel,
@@ -23,11 +23,13 @@ use crate::{
 
 /// The name of a feature. This is either a string or default for the default
 /// feature.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Default)]
-pub enum FeatureName {
-    #[default]
-    Default,
-    Named(String),
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct FeatureName(Cow<'static, str>);
+
+impl Default for FeatureName {
+    fn default() -> Self {
+        FeatureName::DEFAULT.clone()
+    }
 }
 
 impl Serialize for FeatureName {
@@ -47,40 +49,38 @@ impl<'de> Deserialize<'de> for FeatureName {
     where
         D: serde::Deserializer<'de>,
     {
-        match String::deserialize(deserializer)?.as_str() {
-            consts::DEFAULT_FEATURE_NAME => Err(D::Error::custom(
-                "The name 'default' is reserved for the default feature",
-            )),
-            name => Ok(FeatureName::Named(name.to_string())),
-        }
+        Ok(String::deserialize(deserializer)?.into())
     }
 }
 
 impl<'s> From<&'s str> for FeatureName {
     fn from(value: &'s str) -> Self {
-        match value {
-            consts::DEFAULT_FEATURE_NAME => FeatureName::Default,
-            name => FeatureName::Named(name.to_string()),
-        }
+        FeatureName(Cow::Owned(value.to_owned()))
     }
 }
-impl FeatureName {
-    /// Returns the name of the feature or `None` if this is the default
-    /// feature.
-    pub fn name(&self) -> Option<&str> {
-        match self {
-            FeatureName::Default => None,
-            FeatureName::Named(name) => Some(name),
-        }
-    }
 
+impl From<String> for FeatureName {
+    fn from(value: String) -> Self {
+        Self(Cow::Owned(value))
+    }
+}
+
+impl FeatureName {
+    pub const DEFAULT: Self = FeatureName(Cow::Borrowed(consts::DEFAULT_FEATURE_NAME));
+
+    /// Returns the string representation of the feature.
     pub fn as_str(&self) -> &str {
-        self.name().unwrap_or(consts::DEFAULT_FEATURE_NAME)
+        &self.0
     }
 
     /// Returns true if the feature is the default feature.
     pub fn is_default(&self) -> bool {
-        matches!(self, FeatureName::Default)
+        self == &Self::DEFAULT
+    }
+
+    /// Returns the name of the feature if it is not default.
+    pub fn non_default(&self) -> Option<&str> {
+        self.is_default().not().then(|| self.as_str())
     }
 }
 
@@ -100,26 +100,17 @@ impl FromStr for FeatureName {
 
 impl From<FeatureName> for String {
     fn from(name: FeatureName) -> Self {
-        match name {
-            FeatureName::Default => consts::DEFAULT_FEATURE_NAME.to_string(),
-            FeatureName::Named(name) => name,
-        }
+        name.0.into_owned()
     }
 }
 impl<'a> From<&'a FeatureName> for String {
     fn from(name: &'a FeatureName) -> Self {
-        match name {
-            FeatureName::Default => consts::DEFAULT_FEATURE_NAME.to_string(),
-            FeatureName::Named(name) => name.clone(),
-        }
+        name.as_str().to_owned()
     }
 }
 impl fmt::Display for FeatureName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FeatureName::Default => write!(f, "{}", consts::DEFAULT_FEATURE_NAME),
-            FeatureName::Named(name) => write!(f, "{}", name),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -176,7 +167,7 @@ impl Feature {
 
     /// Returns true if this feature is the default feature.
     pub fn is_default(&self) -> bool {
-        self.name == FeatureName::Default
+        self.name.is_default()
     }
 
     /// Returns a mutable reference to the platforms of the feature. Create them
@@ -444,10 +435,7 @@ mod tests {
             "combined dependencies should be owned"
         );
 
-        let bla_feature = manifest
-            .features
-            .get(&FeatureName::Named(String::from("bla")))
-            .unwrap();
+        let bla_feature = manifest.features.get(&FeatureName::from("bla")).unwrap();
         assert_matches!(
             bla_feature.dependencies(SpecType::Run, None).unwrap(),
             Cow::Borrowed(_),

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -206,10 +206,7 @@ impl ManifestDocument {
         // should be refactored to determine the priority of the table to use
         // The spec is described here:
         // https://github.com/prefix-dev/pixi/issues/2807#issuecomment-2577826553
-        let table = match feature_name {
-            FeatureName::Default => Some(self.detect_table_name()),
-            FeatureName::Named(_) => None,
-        };
+        let table = feature_name.is_default().then(|| self.detect_table_name());
 
         let table_name = TableName::new()
             .with_prefix(self.table_prefix())
@@ -568,7 +565,7 @@ impl ManifestDocument {
 
         let env_table = TableName::new()
             .with_prefix(self.table_prefix())
-            .with_feature_name(Some(&FeatureName::Default))
+            .with_feature_name(Some(&FeatureName::DEFAULT))
             .with_table(Some("environments"));
 
         // Insert into the environment table
@@ -584,7 +581,7 @@ impl ManifestDocument {
     pub fn remove_environment(&mut self, name: &str) -> Result<bool, TomlError> {
         let env_table = TableName::new()
             .with_prefix(self.table_prefix())
-            .with_feature_name(Some(&FeatureName::Default))
+            .with_feature_name(Some(&FeatureName::DEFAULT))
             .with_table(Some("environments"));
 
         Ok(self

--- a/crates/pixi_manifest/src/manifests/source.rs
+++ b/crates/pixi_manifest/src/manifests/source.rs
@@ -139,7 +139,7 @@ mod test {
     fn test_add_empty_system_requirement_environment(#[case] mut source: ManifestDocument) {
         let empty_requirements = SystemRequirements::default();
         source
-            .add_system_requirements(&empty_requirements, &FeatureName::Default)
+            .add_system_requirements(&empty_requirements, &FeatureName::DEFAULT)
             .unwrap();
 
         let manifests = Manifests::from_workspace_source(source.into_source_with_provenance())
@@ -164,7 +164,7 @@ mod test {
             ..SystemRequirements::default()
         };
         source
-            .add_system_requirements(&single_system_requirements, &FeatureName::Default)
+            .add_system_requirements(&single_system_requirements, &FeatureName::DEFAULT)
             .unwrap();
 
         let manifests = Manifests::from_workspace_source(source.into_source_with_provenance())
@@ -192,7 +192,7 @@ mod test {
             archspec: Some("x86_64".to_string()),
         };
         source
-            .add_system_requirements(&full_system_requirements, &FeatureName::Default)
+            .add_system_requirements(&full_system_requirements, &FeatureName::DEFAULT)
             .unwrap();
 
         let kind = source.kind();
@@ -233,7 +233,7 @@ mod test {
             ..SystemRequirements::default()
         };
         source
-            .add_system_requirements(&family_system_requirements, &FeatureName::Default)
+            .add_system_requirements(&family_system_requirements, &FeatureName::DEFAULT)
             .unwrap();
 
         let kind = source.kind();

--- a/crates/pixi_manifest/src/manifests/table_name.rs
+++ b/crates/pixi_manifest/src/manifests/table_name.rs
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(
             "dependencies".to_string(),
             TableName::new()
-                .with_feature_name(Some(&FeatureName::Default))
+                .with_feature_name(Some(&FeatureName::DEFAULT))
                 .with_table(Some("dependencies"))
                 .to_string()
         );
@@ -145,13 +145,13 @@ mod tests {
         assert_eq!(
             "target.linux-64.dependencies".to_string(),
             TableName::new()
-                .with_feature_name(Some(&FeatureName::Default))
+                .with_feature_name(Some(&FeatureName::DEFAULT))
                 .with_platform(Some(&Platform::Linux64))
                 .with_table(Some("dependencies"))
                 .to_string()
         );
 
-        let feature_name = FeatureName::Named("test".to_string());
+        let feature_name = FeatureName::from("test");
         assert_eq!(
             "feature.test.dependencies".to_string(),
             TableName::new()

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -322,8 +322,8 @@ impl PyProjectManifest {
             .iter()
             .map(|(name, _)| {
                 (
-                    FeatureName::Named(name.clone()),
-                    Feature::new(FeatureName::Named(name.clone())),
+                    FeatureName::from(name.clone()),
+                    Feature::new(FeatureName::from(name.clone())),
                 )
             })
             .collect();
@@ -398,7 +398,7 @@ impl PyProjectManifest {
             .clone()
             .and_then(|name| pep508_rs::PackageName::new(name).ok());
         for (group, reqs) in pypi_dependency_groups {
-            let feature_name = FeatureName::Named(group.to_string());
+            let feature_name = FeatureName::from(group.to_string());
             let target = workspace_manifest
                 .features
                 .entry(feature_name.clone())

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -176,7 +176,7 @@ impl TomlManifest {
 
         // Construct a default feature
         let default_feature = Feature {
-            name: FeatureName::Default,
+            name: FeatureName::default(),
 
             // The default feature does not overwrite the platforms or channels from the project
             // metadata.
@@ -204,13 +204,20 @@ impl TomlManifest {
         // Construct the features including the default feature
         let mut feature_name_to_span = IndexMap::new();
         let features: IndexMap<FeatureName, Feature> =
-            IndexMap::from_iter([(FeatureName::Default, default_feature)]);
+            IndexMap::from_iter([(FeatureName::default(), default_feature)]);
         let named_features = self
             .feature
             .map(PixiSpanned::into_inner)
             .unwrap_or_default()
             .into_iter()
             .map(|(name, feature)| {
+                if name.value.is_default() {
+                    return Err(TomlError::from(
+                        GenericError::new("The feature 'default' is reserved and cannot be redefined")
+                            .with_opt_span(name.span)
+                            .with_help("All tables at the root of the document are implicitly added to the 'default' feature, use those instead."),
+                    ));
+                }
                 let WithWarnings {
                     value: feature,
                     warnings: mut feature_warnings,
@@ -312,7 +319,7 @@ impl TomlManifest {
             if !no_default_feature {
                 used_features.push(
                     features
-                        .get(&FeatureName::Default)
+                        .get(&FeatureName::DEFAULT)
                         .expect("default feature must exist"),
                 );
             };
@@ -545,6 +552,25 @@ impl<'de> toml_span::Deserialize<'de> for TomlManifest {
             warnings,
         })
     }
+}
+
+/// Defines some of the properties that might be defined in other parts of the
+/// manifest but we do require to be set in the workspace section.
+///
+/// This can be used to inject these properties.
+#[derive(Debug, Clone, Default)]
+pub struct ExternalWorkspaceProperties {
+    pub name: Option<String>,
+    pub version: Option<Version>,
+    pub description: Option<String>,
+    pub authors: Option<Vec<String>>,
+    pub license: Option<String>,
+    pub license_file: Option<PathBuf>,
+    pub readme: Option<PathBuf>,
+    pub homepage: Option<Url>,
+    pub repository: Option<Url>,
+    pub documentation: Option<Url>,
+    pub features: IndexMap<FeatureName, Feature>,
 }
 
 #[cfg(test)]
@@ -902,23 +928,18 @@ mod test {
         "#,
         ));
     }
-}
 
-/// Defines some of the properties that might be defined in other parts of the
-/// manifest but we do require to be set in the workspace section.
-///
-/// This can be used to inject these properties.
-#[derive(Debug, Clone, Default)]
-pub struct ExternalWorkspaceProperties {
-    pub name: Option<String>,
-    pub version: Option<Version>,
-    pub description: Option<String>,
-    pub authors: Option<Vec<String>>,
-    pub license: Option<String>,
-    pub license_file: Option<PathBuf>,
-    pub readme: Option<PathBuf>,
-    pub homepage: Option<Url>,
-    pub repository: Option<Url>,
-    pub documentation: Option<Url>,
-    pub features: IndexMap<FeatureName, Feature>,
+    #[test]
+    fn test_redefine_default_feature() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = []
+
+        [feature.default.dependencies]
+        "#,
+        ));
+    }
 }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__redefine_default_feature.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__redefine_default_feature.snap
@@ -1,0 +1,12 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"foo\"\n        channels = []\n        platforms = []\n\n        [feature.default.dependencies]\n        \"#,)"
+---
+  × The feature 'default' is reserved and cannot be redefined
+   ╭─[pixi.toml:7:18]
+ 6 │
+ 7 │         [feature.default.dependencies]
+   ·                  ───────
+ 8 │
+   ╰────
+  help: All tables at the root of the document are implicitly added to the 'default' feature, use those instead.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -114,7 +114,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Add the platform if it is not already present
     workspace
         .manifest()
-        .add_platforms(dependency_config.platforms.iter(), &FeatureName::Default)?;
+        .add_platforms(dependency_config.platforms.iter(), &FeatureName::DEFAULT)?;
 
     let (match_specs, source_specs, pypi_deps) = match dependency_config.dependency_type() {
         DependencyType::CondaDependency(spec_type) => {

--- a/src/cli/cli_config.rs
+++ b/src/cli/cli_config.rs
@@ -321,7 +321,7 @@ impl DependencyConfig {
             )
         }
         // Print something if we've modified for features
-        if let FeatureName::Named(feature) = &self.feature {
+        if let Some(feature) = self.feature.non_default() {
             {
                 eprintln!(
                     "{operation} these only for feature: {}",

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -383,7 +383,7 @@ async fn alias_task(mut workspace: WorkspaceMut, args: AliasArgs) -> miette::Res
         name.clone(),
         task.clone(),
         args.platform,
-        &FeatureName::Default,
+        &FeatureName::DEFAULT,
     )?;
     workspace.save().await.into_diagnostic()?;
     eprintln!(
@@ -399,7 +399,7 @@ async fn remove_tasks(mut workspace: WorkspaceMut, args: RemoveArgs) -> miette::
     let mut to_remove = Vec::new();
     let feature = args
         .feature
-        .map_or(FeatureName::Default, FeatureName::Named);
+        .map_or_else(FeatureName::default, FeatureName::from);
     for name in args.names.iter() {
         if let Some(platform) = args.platform {
             if !workspace
@@ -463,7 +463,7 @@ async fn add_task(mut workspace: WorkspaceMut, args: AddArgs) -> miette::Result<
     let task: Task = args.clone().into();
     let feature = args
         .feature
-        .map_or(FeatureName::Default, FeatureName::Named);
+        .map_or_else(FeatureName::default, FeatureName::from);
     workspace
         .manifest()
         .add_task(name.clone(), task.clone(), args.platform, &feature)?;

--- a/src/cli/workspace/channel/mod.rs
+++ b/src/cli/workspace/channel/mod.rs
@@ -59,7 +59,7 @@ impl AddRemoveArgs {
     fn feature_name(&self) -> FeatureName {
         self.feature
             .clone()
-            .map_or(FeatureName::Default, FeatureName::Named)
+            .map_or_else(FeatureName::default, FeatureName::from)
     }
 
     fn report(self, operation: &str, channel_config: &ChannelConfig) -> miette::Result<()> {

--- a/src/cli/workspace/platform/remove.rs
+++ b/src/cli/workspace/platform/remove.rs
@@ -28,7 +28,7 @@ pub struct Args {
 pub async fn execute(workspace: Workspace, args: Args) -> miette::Result<()> {
     let feature_name = args
         .feature
-        .map_or(FeatureName::Default, FeatureName::Named);
+        .map_or_else(FeatureName::default, FeatureName::from);
 
     let mut workspace = workspace.modify()?;
 
@@ -55,10 +55,10 @@ pub async fn execute(workspace: Workspace, args: Args) -> miette::Result<()> {
         eprintln!(
             "{}Removed {}",
             console::style(console::Emoji("✔ ", "")).green(),
-            match &feature_name {
-                FeatureName::Default => platform.to_string(),
-                FeatureName::Named(name) => format!("{} from the feature {}", platform, name),
-            },
+            &feature_name.non_default().map_or_else(
+                || platform.to_string(),
+                |name| format!("{} from the feature {}", platform, name)
+            )
         );
     }
 

--- a/src/cli/workspace/system_requirements/add.rs
+++ b/src/cli/workspace/system_requirements/add.rs
@@ -62,8 +62,7 @@ pub async fn execute(workspace: Workspace, args: Args) -> miette::Result<()> {
 
     let feature_name = args
         .feature
-        .clone()
-        .map_or(FeatureName::Default, FeatureName::Named);
+        .map_or_else(FeatureName::default, FeatureName::from);
 
     // Add the platforms to the lock-file
     let mut workspace = workspace.modify()?;

--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -339,7 +339,7 @@ impl<'p> HasFeaturesIter<'p> for Environment<'p> {
         let environment_features = self.environment.features.iter().map(|feature_name| {
             manifest
                 .features
-                .get(&FeatureName::Named(feature_name.clone()))
+                .get(&FeatureName::from(feature_name.clone()))
                 .expect("feature usage should have been validated upfront")
         });
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1080,17 +1080,17 @@ mod tests {
         assert_debug_snapshot!(workspace
             .workspace
             .value
-            .tasks(Some(Platform::Osx64), &FeatureName::Default)
+            .tasks(Some(Platform::Osx64), &FeatureName::DEFAULT)
             .unwrap());
         assert_debug_snapshot!(workspace
             .workspace
             .value
-            .tasks(Some(Platform::Win64), &FeatureName::Default)
+            .tasks(Some(Platform::Win64), &FeatureName::DEFAULT)
             .unwrap());
         assert_debug_snapshot!(workspace
             .workspace
             .value
-            .tasks(Some(Platform::Linux64), &FeatureName::Default)
+            .tasks(Some(Platform::Linux64), &FeatureName::DEFAULT)
             .unwrap());
     }
 

--- a/tests/integration_rust/common/builders.rs
+++ b/tests/integration_rust/common/builders.rs
@@ -209,7 +209,7 @@ impl AddBuilder {
     }
 
     pub fn with_feature(mut self, feature: impl ToString) -> Self {
-        self.args.dependency_config.feature = FeatureName::Named(feature.to_string());
+        self.args.dependency_config.feature = FeatureName::from(feature.to_string());
         self
     }
 

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -612,7 +612,6 @@ impl TasksControl<'_> {
         platform: Option<Platform>,
         feature_name: FeatureName,
     ) -> TaskAddBuilder {
-        let feature = feature_name.name().map(|s| s.to_string());
         TaskAddBuilder {
             manifest_path: Some(self.pixi.manifest_path()),
             args: AddArgs {
@@ -620,7 +619,7 @@ impl TasksControl<'_> {
                 commands: vec![],
                 depends_on: None,
                 platform,
-                feature,
+                feature: feature_name.non_default().map(str::to_owned),
                 cwd: None,
                 env: Default::default(),
                 description: None,

--- a/tests/integration_rust/install_tests.rs
+++ b/tests/integration_rust/install_tests.rs
@@ -238,7 +238,7 @@ async fn install_locked_with_config() {
 
     // Verify that the folders are present in the target directory using a task.
     pixi.tasks()
-        .add("which_python".into(), None, FeatureName::Default)
+        .add("which_python".into(), None, FeatureName::default())
         .with_commands([which_command])
         .execute()
         .await

--- a/tests/integration_rust/task_tests.rs
+++ b/tests/integration_rust/task_tests.rs
@@ -16,7 +16,7 @@ pub async fn add_remove_task() {
 
     // Simple task
     pixi.tasks()
-        .add("test".into(), None, FeatureName::Default)
+        .add("test".into(), None, FeatureName::default())
         .with_commands(["echo hello"])
         .execute()
         .await
@@ -50,13 +50,13 @@ pub async fn add_command_types() {
 
     // Add a command with dependencies
     pixi.tasks()
-        .add("test".into(), None, FeatureName::Default)
+        .add("test".into(), None, FeatureName::default())
         .with_commands(["echo hello"])
         .execute()
         .await
         .unwrap();
     pixi.tasks()
-        .add("test2".into(), None, FeatureName::Default)
+        .add("test2".into(), None, FeatureName::default())
         .with_commands(["echo hello", "echo bonjour"])
         .with_depends_on(vec!["test".into()])
         .execute()
@@ -97,21 +97,21 @@ async fn test_alias() {
     pixi.init().without_channels().await.unwrap();
 
     pixi.tasks()
-        .add("hello".into(), None, FeatureName::Default)
+        .add("hello".into(), None, FeatureName::default())
         .with_commands(["echo hello"])
         .execute()
         .await
         .unwrap();
 
     pixi.tasks()
-        .add("world".into(), None, FeatureName::Default)
+        .add("world".into(), None, FeatureName::default())
         .with_commands(["echo world"])
         .execute()
         .await
         .unwrap();
 
     pixi.tasks()
-        .add("helloworld".into(), None, FeatureName::Default)
+        .add("helloworld".into(), None, FeatureName::default())
         .with_depends_on(vec!["hello".into(), "world".into()])
         .execute()
         .await
@@ -141,7 +141,7 @@ pub async fn add_remove_target_specific_task() {
 
     // Simple task
     pixi.tasks()
-        .add("test".into(), Some(Platform::Win64), FeatureName::Default)
+        .add("test".into(), Some(Platform::Win64), FeatureName::default())
         .with_commands(["echo only_on_windows"])
         .execute()
         .await
@@ -158,7 +158,7 @@ pub async fn add_remove_target_specific_task() {
 
     // Simple task
     pixi.tasks()
-        .add("test".into(), None, FeatureName::Default)
+        .add("test".into(), None, FeatureName::default())
         .with_commands(["echo hello"])
         .execute()
         .await
@@ -189,7 +189,7 @@ async fn test_cwd() {
     fs_err::create_dir(pixi.workspace_path().join("test")).unwrap();
 
     pixi.tasks()
-        .add("pwd-test".into(), None, FeatureName::Default)
+        .add("pwd-test".into(), None, FeatureName::default())
         .with_commands(["pwd"])
         .with_cwd(PathBuf::from("test"))
         .execute()
@@ -212,7 +212,7 @@ async fn test_cwd() {
 
     // Test that an unknown cwd gives an error
     pixi.tasks()
-        .add("unknown-cwd".into(), None, FeatureName::Default)
+        .add("unknown-cwd".into(), None, FeatureName::default())
         .with_commands(["pwd"])
         .with_cwd(PathBuf::from("tests"))
         .execute()
@@ -237,7 +237,7 @@ async fn test_task_with_env() {
     pixi.init().without_channels().await.unwrap();
 
     pixi.tasks()
-        .add("env-test".into(), None, FeatureName::Default)
+        .add("env-test".into(), None, FeatureName::default())
         .with_commands(["echo From a $HELLO_WORLD"])
         .with_env(vec![(
             String::from("HELLO_WORLD"),
@@ -269,7 +269,7 @@ async fn test_clean_env() {
 
     std::env::set_var("HELLO", "world from env");
     pixi.tasks()
-        .add("env-test".into(), None, FeatureName::Default)
+        .add("env-test".into(), None, FeatureName::default())
         .with_commands(["echo Hello is: $HELLO"])
         .execute()
         .await


### PR DESCRIPTION
This PR makes the deifference between the default and named features smaller in code. This fixes a number of issues where we implicitly try to find a named feature called "default" which would then break the code.

Previously a `FeatureName` was an enum with the distinction between the default feature name or another named feature. With this PR a `FeatureName` is always a string but we special case the string "default".

I also modified the parsing logic to emit an error if a user tries to redefine the default feature. This is also tested.