### PR TITLE
fix: fixed a typo in init.rs

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -392,7 +392,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             // Early exit if 'pyproject.toml' already contains a '[tool.pixi.workspace]' table
             if pyproject.has_pixi_table() {
                 eprintln!(
-                    "{}Nothing to do here: 'pyproject.toml' already contains a '[tool.pixi.workspace3]' section.",
+                    "{}Nothing to do here: 'pyproject.toml' already contains a '[tool.pixi.workspace]' section.",
                     console::style(console::Emoji("🤔 ", "")).blue(),
                 );
                 return Ok(());


### PR DESCRIPTION
Fixed this line:
```
🤔 Nothing to do here: 'pyproject.toml' already contains a '[tool.pixi.workspace3]' section.
```
(removed the redundant 3)