### PR TITLE
test: invalidate lock-file if a pypi dependency is requested

### DIFF
--- a/src/lock_file/outdated.rs
+++ b/src/lock_file/outdated.rs
@@ -10,7 +10,7 @@ use rattler_lock::{LockFile, LockedPackageRef};
 use super::{verify_environment_satisfiability, verify_platform_satisfiability};
 use crate::{
     build::GlobHashCache,
-    lock_file::satisfiability::EnvironmentUnsat,
+    lock_file::satisfiability::{verify_solve_group_satisfiability, EnvironmentUnsat},
     workspace::{Environment, SolveGroup},
     Workspace,
 };
@@ -143,6 +143,7 @@ async fn find_unsatisfiable_targets<'p>(
     lock_file: &LockFile,
     glob_hash_cache: GlobHashCache,
 ) -> UnsatisfiableTargets<'p> {
+    let mut verified_environments = HashMap::new();
     let mut unsatisfiable_targets = UnsatisfiableTargets::default();
     for environment in project.environments() {
         let platforms = environment.platforms();
@@ -178,7 +179,8 @@ async fn find_unsatisfiable_targets<'p>(
 
             match unsat {
                 EnvironmentUnsat::AdditionalPlatformsInLockFile(platforms) => {
-                    // If the there are additional platforms in the lock file, then we have to remove them
+                    // If the there are additional platforms in the lock file, then we have to
+                    // remove them
                     for platform in platforms {
                         unsatisfiable_targets
                             .outdated_conda
@@ -230,7 +232,9 @@ async fn find_unsatisfiable_targets<'p>(
             )
             .await
             {
-                Ok(_) => {}
+                Ok(verified_env) => {
+                    verified_environments.insert((environment.clone(), platform), verified_env);
+                }
                 Err(unsat) if unsat.is_pypi_only() => {
                     tracing::info!(
                         "the pypi dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
@@ -258,6 +262,57 @@ async fn find_unsatisfiable_targets<'p>(
             }
         }
     }
+
+    // Verify grouped environments
+    for solve_group in project.solve_groups() {
+        'platform: for platform in solve_group.platforms() {
+            let mut envs = Vec::with_capacity(solve_group.environments().len());
+            for env in solve_group.environments() {
+                if let Some(verified_env) = verified_environments.remove(&(env, platform)) {
+                    envs.push(verified_env);
+                } else {
+                    // If the environment is not verified, the solve group will already be outdated.
+                    continue 'platform;
+                }
+            }
+
+            let Err(unsat) = verify_solve_group_satisfiability(envs) else {
+                continue;
+            };
+
+            tracing::info!(
+                "the dependencies of solve group '{0}' for platform {platform} are out of date because {unsat}",
+                solve_group.name(),
+            );
+
+            for env in solve_group.environments() {
+                unsatisfiable_targets
+                    .outdated_conda
+                    .entry(env.clone())
+                    .or_default()
+                    .insert(platform);
+            }
+        }
+    }
+
+    // Verify individual environments as if they are solve-groups
+    for ((individual_env, platform), verified_env) in verified_environments {
+        let Err(unsat) = verify_solve_group_satisfiability([verified_env]) else {
+            continue;
+        };
+
+        tracing::info!(
+                "the dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
+                individual_env.name().fancy_display(),
+            );
+
+        unsatisfiable_targets
+            .outdated_conda
+            .entry(individual_env.clone())
+            .or_default()
+            .insert(platform);
+    }
+
     unsatisfiable_targets
 }
 

--- a/src/lock_file/outdated.rs
+++ b/src/lock_file/outdated.rs
@@ -179,7 +179,7 @@ async fn find_unsatisfiable_targets<'p>(
 
             match unsat {
                 EnvironmentUnsat::AdditionalPlatformsInLockFile(platforms) => {
-                    // If the there are additional platforms in the lock file, then we have to
+                    // If there are additional platforms in the lock file, then we have to
                     // remove them
                     for platform in platforms {
                         unsatisfiable_targets

--- a/src/lock_file/satisfiability.rs
+++ b/src/lock_file/satisfiability.rs
@@ -1672,7 +1672,7 @@ mod tests {
         Environment(String, #[source] EnvironmentUnsat),
 
         #[error(
-            "environment '{0}' does not satisfy the requirements of the project for platform '{1}"
+            "environment '{0}' does not satisfy the requirements of the project for platform '{1}'"
         )]
         PlatformUnsat(String, Platform, #[source] PlatformUnsat),
 

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@binary-spec-source-record.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@binary-spec-source-record.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: package 'source' is locked as source, but is only required as binary

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@expected-editable-multiple.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@expected-editable-multiple.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: expected bar and foo to be editable but in the lock-file but they are not, whereas baz is NOT expected to be editable which in the lock-file it is

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@expected-editable.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@expected-editable.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: expected foo to be editable but in the lock-file it is not

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@explicit-pypi-dependency.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@explicit-pypi-dependency.snap
@@ -1,0 +1,7 @@
+---
+source: src/lock_file/satisfiability.rs
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project for platform 'win-64
+    Diagnostic severity: error
+    Caused by: 'boltons' is locked as a conda package but only requested by pypi dependencies

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@explicit-pypi-dependency.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@explicit-pypi-dependency.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: 'boltons' is locked as a conda package but only requested by pypi dependencies

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@mismatched-spec.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@mismatched-spec.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: the requirement 'pixi <0.15.2' could not be satisfied (required by '<environment>')

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@missing-dependency.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@missing-dependency.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: the requirement 'vc14_runtime >=14.29.30139' could not be satisfied (required by 'pixi-0.15.2-h7ea99a0_0.conda')

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@missing-pypi-extra.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@missing-pypi-extra.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: the requirement 'ipython>=7.8.0 ; extra == 'jupyter'' could not be satisfied (required by 'black')

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@solve-groups-pypi.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@solve-groups-pypi.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: the requirement 'packaging>=20.0' could not be satisfied (required by 'matplotlib')

--- a/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@source-dependency.snap
+++ b/src/lock_file/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@source-dependency.snap
@@ -2,6 +2,6 @@
 source: src/lock_file/satisfiability.rs
 expression: s
 ---
-environment 'default' does not satisfy the requirements of the project for platform 'win-64
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
     Diagnostic severity: error
     Caused by: the input hash for 'child-package' (f72524d6ca020fe2a30ceeb88e1d4931d8b7d8a07ba02c86e9450d12726070ce) does not match the hash in the lock-file (b67010bf5bc5608db89c0399e726852b07a7ef4fb26b3aa18171f1d0f6a19c89)

--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -75,7 +75,7 @@ impl<'p> Environment<'p> {
     }
 
     /// Returns the name of this environment.
-    pub fn name(&self) -> &EnvironmentName {
+    pub fn name(&self) -> &'p EnvironmentName {
         &self.environment.name
     }
 

--- a/tests/data/non-satisfiability/explicit-pypi-dependency/pixi.lock
+++ b/tests/data/non-satisfiability/explicit-pypi-dependency/pixi.lock
@@ -1,0 +1,31 @@
+#
+# This lock-file should not satisfy the accompanying pixi.toml file.
+#
+# boltons is requested as a pypi package. The pypi dependency can also be
+# satisfied by the conda package that is in the lock-file, but since none of the
+# conda packages reference the boltons conda package, it should be dropped in
+# favor of the pypi package.
+
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.2-h261c0b1_101_cp313.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
+  sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
+  md5: d88c38e66d85ecc9c7e2c4110676bbf4
+  depends:
+  - python >=3.9
+  purls:
+  - pkg:pypi/boltons?source=hash-mapping
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.2-h261c0b1_101_cp313.conda
+  build_number: 101
+  sha256: b6e7a6f314343926b5a236592272e5014edcda150e14d18d0fb9440d8a185c3f
+  md5: 5116c74f5e3e77b915b7b72eea0ec946
+  # Faked to be empty to reduce the size of the example
+  depends: []

--- a/tests/data/non-satisfiability/explicit-pypi-dependency/pixi.toml
+++ b/tests/data/non-satisfiability/explicit-pypi-dependency/pixi.toml
@@ -1,0 +1,10 @@
+[workspace]
+channels = ["conda-forge"]
+platforms = ["win-64"]
+version = "0.1.0"
+
+[dependencies]
+python = ">=3.13.2,<3.14"
+
+[pypi-dependencies]
+boltons = "*"


### PR DESCRIPTION
Fixes #2238

This PR adds support to detect if a package that is locked as a conda package is only referenced by pypi dependencies in which case the lock-file is invalidated. 