### PR TITLE
docs(direnv): Pass shell info to shell-hook

### DIFF
--- a/docs/integration/third_party/direnv.md
+++ b/docs/integration/third_party/direnv.md
@@ -14,7 +14,7 @@ Enter the following into your `.envrc` file:
 
 ```shell title=".envrc"
 watch_file pixi.lock # (1)!
-eval "$(pixi shell-hook)" # (2)!
+eval "$(pixi shell-hook -s $(basename "$SHELL"))" # (2)!
 ```
 
 1. This ensures that every time your `pixi.lock` changes, `direnv` invokes the shell-hook again.


### PR DESCRIPTION
### Before

```
❯ direnv allow
direnv: loading ~/Desktop/pixi-bench-demo/.envrc
/home/gavin/Desktop/pixi-bench-demo/.pixi/envs/default/share/bash-completion/completions/git:466: compgen: command not found 
/home/gavin/Desktop/pixi-bench-demo/.pixi/envs/default/share/bash-completion/completions/git:3952: complete: command not found 
/home/gavin/Desktop/pixi-bench-demo/.pixi/envs/default/share/bash-completion/completions/git:3952: complete: command not found
```

### After

```
❯ direnv allow
direnv: loading ~/Desktop/pixi-bench-demo/.envrc
~/Desktop/pixi-bench-demo ❯
```