### PR TITLE
test: make pypi git test stable

### DIFF
--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -912,7 +912,7 @@ platforms = ["{platform}"]
     .unwrap();
 
     // Add python
-    pixi.add("python").await.unwrap();
+    pixi.add("python>=3.13.2,<3.14").await.unwrap();
 
     // Add a package
     pixi.add("boltons")


### PR DESCRIPTION
This test broke with Python 3.13.3 release.
By being specific about the version we avoid having to update snapshots all the time.

See also https://github.com/prefix-dev/pixi/pull/3562#issuecomment-2796187065