### PR TITLE
Mark `add_tests::add_pypi_git` as an online test

### DIFF
--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -895,6 +895,7 @@ preview = ['pixi-build']"#,
 
 /// Test adding a git dependency using ssh url
 #[tokio::test]
+#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn add_pypi_git() {
     let pixi = PixiControl::from_manifest(
         format!(


### PR DESCRIPTION
Mark `add_tests::add_pypi_git` as requiring Internet, as in isolated environment it fails with:

```
thread 'add_tests::add_pypi_git' panicked at tests/integration_rust/add_tests.rs:915:30:
called `Result::unwrap()` on an `Err` value:   × Request failed after 3 retries
  ├─▶ error sending request for url (https://prefix.dev/conda-forge/noarch/
  │   repodata_shards.msgpack.zst)
  ├─▶ client error (Connect)
  ├─▶ dns error: failed to lookup address information: Name or service not
  │   known
  ╰─▶ failed to lookup address information: Name or service not known
```