### PR TITLE
feat: conda `--exclude-newer`

### DIFF
--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -87,6 +87,7 @@ pub const CLAP_CONFIG_OPTIONS: &str = "Config Options";
 pub const CLAP_GIT_OPTIONS: &str = "Git Options";
 pub const CLAP_GLOBAL_OPTIONS: &str = "Global Options";
 pub const CLAP_UPDATE_OPTIONS: &str = "Update Options";
+pub const CLAP_SOLVER_OPTIONS: &str = "Solver Options";
 
 pub static TASK_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().blue());
 pub static PLATFORM_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().yellow());

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -7,6 +7,7 @@ use pixi_spec::{GitSpec, SourceSpec};
 use rattler_conda_types::{MatchSpec, PackageName};
 
 use super::{cli_config::LockFileUpdateConfig, has_specs::HasSpecs};
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     cli::cli_config::{DependencyConfig, PrefixUpdateConfig, WorkspaceConfig},
     environment::sanity_check_project,
@@ -87,6 +88,9 @@ pub struct Args {
     pub lock_file_update_config: LockFileUpdateConfig,
 
     #[clap(flatten)]
+    pub solver_config: SolverConfig,
+
+    #[clap(flatten)]
     pub config: ConfigCli,
 
     /// Whether the pypi requirement should be editable
@@ -95,10 +99,17 @@ pub struct Args {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let (dependency_config, prefix_update_config, lock_file_update_config, workspace_config) = (
+    let (
+        dependency_config,
+        prefix_update_config,
+        lock_file_update_config,
+        solver_config,
+        workspace_config,
+    ) = (
         args.dependency_config,
         args.prefix_update_config,
         args.lock_file_update_config,
+        args.solver_config,
         args.workspace_config,
     );
 
@@ -176,6 +187,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         source_specs,
         &prefix_update_config,
         &lock_file_update_config,
+        &solver_config,
         &dependency_config.feature,
         &dependency_config.platforms,
         args.editable,

--- a/src/cli/cli_config.rs
+++ b/src/cli/cli_config.rs
@@ -4,6 +4,7 @@ use crate::lock_file::UpdateMode;
 use crate::workspace::DiscoveryStart;
 use crate::DependencyType;
 use crate::Workspace;
+use chrono::{DateTime, Utc};
 use clap::Parser;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
@@ -110,6 +111,18 @@ pub struct LockFileUpdateConfig {
     /// Lock file usage from the CLI
     #[clap(flatten)]
     pub lock_file_usage: super::LockFileUsageConfig,
+}
+
+#[derive(Parser, Debug, Default, Clone)]
+#[clap(next_help_heading = consts::CLAP_SOLVER_OPTIONS)]
+pub struct SolverConfig {
+    /// Exclude any packages that have been created after the given date.
+    #[clap(
+        long = "exclude-newer",
+        env = "PIXI_EXCLUDE_NEWER",
+        value_name = "DATE"
+    )]
+    pub exclude_newer: Option<DateTime<Utc>>,
 }
 
 impl LockFileUpdateConfig {

--- a/src/cli/exec.rs
+++ b/src/cli/exec.rs
@@ -1,5 +1,3 @@
-use std::{path::Path, str::FromStr, sync::LazyLock};
-
 use clap::{Parser, ValueHint};
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
@@ -14,9 +12,10 @@ use rattler_conda_types::{GenericVirtualPackage, MatchSpec, PackageName, Platfor
 use rattler_solve::{resolvo::Solver, SolverImpl, SolverTask};
 use rattler_virtual_packages::{VirtualPackage, VirtualPackageOverrides};
 use reqwest_middleware::ClientWithMiddleware;
+use std::{path::Path, str::FromStr, sync::LazyLock};
 use uv_configuration::RAYON_INITIALIZE;
 
-use super::cli_config::ChannelsConfig;
+use super::cli_config::{ChannelsConfig, SolverConfig};
 use crate::{
     environment::list::{print_package_table, PackageToOutput},
     prefix::Prefix,
@@ -56,6 +55,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub config: ConfigCli,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 }
 
 /// CLI entry point for `pixi exec`
@@ -194,6 +196,7 @@ pub async fn create_exec_prefix(
         Solver.solve(SolverTask {
             specs: specs_clone,
             virtual_packages,
+            exclude_newer: args.solver_config.exclude_newer,
             ..SolverTask::from_iter(&repodata)
         })
     })

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,4 +1,4 @@
-use crate::cli::cli_config::WorkspaceConfig;
+use crate::cli::cli_config::{SolverConfig, WorkspaceConfig};
 use crate::environment::get_update_lock_file_and_prefix;
 use crate::lock_file::{ReinstallPackages, UpdateMode};
 use crate::{UpdateLockFileOptions, WorkspaceLocator};
@@ -28,6 +28,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_usage: super::LockFileUsageConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// The environment to install
     #[arg(long, short)]
@@ -76,6 +79,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 lock_file_usage: args.lock_file_usage.into(),
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                exclude_newer: args.solver_config.exclude_newer,
             },
             ReinstallPackages::default(),
         )

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use miette::{miette, IntoDiagnostic};
 use uv_configuration::ConfigSettings;
 
-use crate::cli::cli_config::WorkspaceConfig;
+use crate::cli::cli_config::{SolverConfig, WorkspaceConfig};
 use crate::lock_file::{UpdateLockFileOptions, UvResolutionContext};
 use crate::WorkspaceLocator;
 use fancy_display::FancyDisplay;
@@ -69,6 +69,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// Only list packages that are explicitly defined in the workspace.
     #[arg(short = 'x', long)]
@@ -183,6 +186,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         })
         .await?;
 

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use miette::{Context, IntoDiagnostic};
 
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     cli::cli_config::WorkspaceConfig,
     diff::{LockFileDiff, LockFileJsonDiff},
@@ -15,6 +16,9 @@ use crate::{
 pub struct Args {
     #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// Output the changes in JSON format.
     #[clap(long)]
@@ -33,6 +37,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: LockFileUsage::Update,
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         })
         .await?;
 

--- a/src/cli/reinstall.rs
+++ b/src/cli/reinstall.rs
@@ -1,4 +1,4 @@
-use crate::cli::cli_config::WorkspaceConfig;
+use crate::cli::cli_config::{SolverConfig, WorkspaceConfig};
 use crate::environment::get_update_lock_file_and_prefix;
 use crate::lock_file::{ReinstallPackages, UpdateMode};
 use crate::{UpdateLockFileOptions, WorkspaceLocator};
@@ -30,6 +30,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_usage: super::LockFileUsageConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// The environment to install.
     #[arg(long, short)]
@@ -84,6 +87,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 lock_file_usage: args.lock_file_usage.into(),
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                exclude_newer: args.solver_config.exclude_newer,
             },
             reinstall_packages.clone(),
         )

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -1,4 +1,5 @@
 use super::{cli_config::LockFileUpdateConfig, has_specs::HasSpecs};
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     cli::cli_config::{DependencyConfig, PrefixUpdateConfig, WorkspaceConfig},
     environment::get_update_lock_file_and_prefix,
@@ -34,6 +35,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     #[clap(flatten)]
     pub config: ConfigCli,
@@ -123,6 +127,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 lock_file_usage: lock_file_update_config.lock_file_usage(),
                 no_install: prefix_update_config.no_install,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                exclude_newer: args.solver_config.exclude_newer,
             },
             ReinstallPackages::default(),
         )

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -30,7 +30,7 @@ use crate::{
     Workspace, WorkspaceLocator,
 };
 
-use super::cli_config::LockFileUpdateConfig;
+use super::cli_config::{LockFileUpdateConfig, SolverConfig};
 
 /// Runs task in the pixi environment.
 ///
@@ -54,6 +54,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     #[clap(flatten)]
     pub config: ConfigCli,
@@ -128,6 +131,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .update_lock_file(UpdateLockFileOptions {
             lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
             ..UpdateLockFileOptions::default()
         })
         .await?;

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -25,7 +25,7 @@ use pixi_pty::unix::PtySession;
 #[cfg(target_family = "unix")]
 use crate::prefix::Prefix;
 
-use super::cli_config::LockFileUpdateConfig;
+use super::cli_config::{LockFileUpdateConfig, SolverConfig};
 
 /// Start a shell in a pixi environment, run `exit` to leave the shell.
 #[derive(Parser, Debug)]
@@ -38,6 +38,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    solver_config: SolverConfig,
 
     #[clap(flatten)]
     config: ConfigCli,
@@ -286,6 +289,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             no_install: args.prefix_update_config.no_install
                 && args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         },
         ReinstallPackages::default(),
     )

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -21,7 +21,7 @@ use crate::{
     UpdateLockFileOptions, Workspace, WorkspaceLocator,
 };
 
-use super::cli_config::LockFileUpdateConfig;
+use super::cli_config::{LockFileUpdateConfig, SolverConfig};
 
 /// Print the pixi environment activation script.
 ///
@@ -42,6 +42,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    solver_config: SolverConfig,
 
     #[clap(flatten)]
     config: ConfigCli,
@@ -163,6 +166,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             no_install: args.prefix_update_config.no_install
                 && args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         },
         ReinstallPackages::default(),
     )

--- a/src/cli/tree.rs
+++ b/src/cli/tree.rs
@@ -19,7 +19,7 @@ use crate::{
     WorkspaceLocator,
 };
 
-use super::cli_config::LockFileUpdateConfig;
+use super::cli_config::{LockFileUpdateConfig, SolverConfig};
 
 /// Show a tree of workspace dependencies
 #[derive(Debug, Parser)]
@@ -54,6 +54,9 @@ pub struct Args {
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
 
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
+
     /// Invert tree and show what depends on given package in the regex argument
     #[arg(short, long, requires = "regex")]
     pub invert: bool,
@@ -87,6 +90,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         })
         .await
         .wrap_err("Failed to update lock file")?;

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Ordering, collections::HashSet};
 
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     cli::cli_config::WorkspaceConfig,
     diff::{LockFileDiff, LockFileJsonDiff},
@@ -29,6 +30,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub project_config: WorkspaceConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// Don't install the (solve) environments needed for pypi-dependencies
     /// solving.
@@ -161,6 +165,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Update the packages in the lock-file.
     let updated_lock_file = UpdateContext::builder(&workspace)
+        .with_opt_exclude_newer(args.solver_config.exclude_newer)
         .with_lock_file(relaxed_lock_file.clone())
         .with_no_install(args.no_install)
         .finish()

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -11,7 +11,7 @@ use pixi_manifest::{FeatureName, PyPiRequirement, SpecType};
 use pixi_spec::PixiSpec;
 use rattler_conda_types::{MatchSpec, StringMatcher};
 
-use super::cli_config::{LockFileUpdateConfig, PrefixUpdateConfig};
+use super::cli_config::{LockFileUpdateConfig, PrefixUpdateConfig, SolverConfig};
 use crate::{
     cli::cli_config::WorkspaceConfig,
     diff::LockFileJsonDiff,
@@ -32,6 +32,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     #[clap(flatten)]
     config: ConfigCli,
@@ -93,6 +96,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             IndexMap::default(),
             &args.prefix_update_config,
             &args.lock_file_update_config,
+            &args.solver_config,
             &args.specs.feature,
             &[],
             false,

--- a/src/cli/workspace/channel/add.rs
+++ b/src/cli/workspace/channel/add.rs
@@ -30,6 +30,7 @@ pub async fn execute(args: AddRemoveArgs) -> miette::Result<()> {
             no_install: args.prefix_update_config.no_install
                 && args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         },
         ReinstallPackages::default(),
     )

--- a/src/cli/workspace/channel/mod.rs
+++ b/src/cli/workspace/channel/mod.rs
@@ -2,7 +2,9 @@ pub mod add;
 pub mod list;
 pub mod remove;
 
-use crate::cli::cli_config::{LockFileUpdateConfig, PrefixUpdateConfig, WorkspaceConfig};
+use crate::cli::cli_config::{
+    LockFileUpdateConfig, PrefixUpdateConfig, SolverConfig, WorkspaceConfig,
+};
 use clap::Parser;
 use miette::IntoDiagnostic;
 use pixi_config::ConfigCli;
@@ -39,6 +41,9 @@ pub struct AddRemoveArgs {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     #[clap(flatten)]
     pub config: ConfigCli,

--- a/src/cli/workspace/channel/remove.rs
+++ b/src/cli/workspace/channel/remove.rs
@@ -28,6 +28,7 @@ pub async fn execute(args: AddRemoveArgs) -> miette::Result<()> {
             no_install: args.prefix_update_config.no_install
                 && args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         },
         ReinstallPackages::default(),
     )

--- a/src/cli/workspace/export/conda_explicit_spec.rs
+++ b/src/cli/workspace/export/conda_explicit_spec.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     cli::cli_config::{LockFileUpdateConfig, WorkspaceConfig},
     lock_file::UpdateLockFileOptions,
@@ -44,6 +45,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub lock_file_update_config: LockFileUpdateConfig,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     #[clap(flatten)]
     config: ConfigCli,
@@ -173,6 +177,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         })
         .await?
         .lock_file;

--- a/src/cli/workspace/platform/add.rs
+++ b/src/cli/workspace/platform/add.rs
@@ -5,6 +5,7 @@ use miette::IntoDiagnostic;
 use pixi_manifest::FeatureName;
 use rattler_conda_types::Platform;
 
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     environment::{get_update_lock_file_and_prefix, LockFileUsage},
     lock_file::{ReinstallPackages, UpdateMode},
@@ -16,6 +17,9 @@ pub struct Args {
     /// The platform name(s) to add.
     #[clap(required = true, num_args=1..)]
     pub platform: Vec<String>,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// Don't update the environment, only add changed packages to the
     /// lock-file.
@@ -55,6 +59,7 @@ pub async fn execute(workspace: Workspace, args: Args) -> miette::Result<()> {
             lock_file_usage: LockFileUsage::Update,
             no_install: args.no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         },
         ReinstallPackages::default(),
     )

--- a/src/cli/workspace/platform/remove.rs
+++ b/src/cli/workspace/platform/remove.rs
@@ -3,6 +3,7 @@ use miette::IntoDiagnostic;
 use pixi_manifest::FeatureName;
 use rattler_conda_types::Platform;
 
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     environment::{get_update_lock_file_and_prefix, LockFileUsage},
     lock_file::{ReinstallPackages, UpdateMode},
@@ -14,6 +15,9 @@ pub struct Args {
     /// The platform name to remove.
     #[clap(required = true, num_args=1.., value_name = "PLATFORM")]
     pub platforms: Vec<Platform>,
+
+    #[clap(flatten)]
+    pub solver_config: SolverConfig,
 
     /// Don't update the environment, only remove the platform(s) from the
     /// lock-file.
@@ -44,6 +48,7 @@ pub async fn execute(workspace: Workspace, args: Args) -> miette::Result<()> {
             lock_file_usage: LockFileUsage::Update,
             no_install: args.no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            exclude_newer: args.solver_config.exclude_newer,
         },
         ReinstallPackages::default(),
     )

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -12,6 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+pub use conda_prefix::{CondaPrefixUpdated, CondaPrefixUpdater, CondaPrefixUpdaterBuilder};
 use dialoguer::theme::ColorfulTheme;
 use miette::{Context, IntoDiagnostic};
 use pixi_consts::consts;
@@ -19,6 +20,8 @@ use pixi_git::credentials::store_credentials_from_url;
 use pixi_manifest::{FeaturesExt, PyPiRequirement};
 use pixi_progress::await_in_progress;
 use pixi_spec::{GitSpec, PixiSpec};
+pub use pypi_prefix::update_prefix_pypi;
+pub use python_status::PythonStatus;
 use rattler_conda_types::Platform;
 use rattler_lock::LockedPackageRef;
 use serde::{Deserialize, Serialize};
@@ -31,10 +34,6 @@ use crate::{
     workspace::{grouped_environment::GroupedEnvironment, Environment, HasWorkspaceRef},
     Workspace,
 };
-
-pub use conda_prefix::{CondaPrefixUpdated, CondaPrefixUpdater, CondaPrefixUpdaterBuilder};
-pub use pypi_prefix::update_prefix_pypi;
-pub use python_status::PythonStatus;
 
 /// Verify the location of the prefix folder is not changed so the applied
 /// prefix path is still valid. Errors when there is a file system error or the
@@ -414,9 +413,8 @@ pub async fn get_update_lock_file_and_prefix<'env>(
     // Ensure that the lock-file is up-to-date
     let mut lock_file = project
         .update_lock_file(UpdateLockFileOptions {
-            lock_file_usage: update_lock_file_options.lock_file_usage,
             no_install,
-            max_concurrent_solves: update_lock_file_options.max_concurrent_solves,
+            ..update_lock_file_options
         })
         .await?;
 

--- a/src/lock_file/resolve/conda.rs
+++ b/src/lock_file/resolve/conda.rs
@@ -1,4 +1,5 @@
 use ahash::HashMap;
+use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_manifest::ChannelPriority;
@@ -23,6 +24,7 @@ pub async fn resolve_conda(
     available_repodata: Vec<RepoData>,
     available_source_packages: Vec<SourceMetadata>,
     channel_priority: ChannelPriority,
+    exclude_newer: Option<DateTime<Utc>>,
 ) -> miette::Result<LockedCondaPackages> {
     tokio::task::spawn_blocking(move || {
         // Combine the repodata from the source packages and from registry channels.
@@ -62,6 +64,7 @@ pub async fn resolve_conda(
             locked_packages,
             virtual_packages,
             channel_priority: channel_priority.into(),
+            exclude_newer,
             ..rattler_solve::SolverTask::from_iter(solvable_records)
         };
 

--- a/src/workspace/workspace_mut.rs
+++ b/src/workspace/workspace_mut.rs
@@ -1,10 +1,3 @@
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    str::FromStr,
-    sync::Arc,
-};
-
 use indexmap::IndexMap;
 use itertools::Itertools;
 use miette::{IntoDiagnostic, NamedSource};
@@ -19,8 +12,15 @@ use pixi_manifest::{
 use pixi_spec::PixiSpec;
 use rattler_conda_types::{NamelessMatchSpec, PackageName, Platform, Version};
 use rattler_lock::LockFile;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+};
 use toml_edit::DocumentMut;
 
+use crate::cli::cli_config::SolverConfig;
 use crate::{
     cli::cli_config::{LockFileUpdateConfig, PrefixUpdateConfig},
     diff::LockFileDiff,
@@ -234,6 +234,7 @@ impl WorkspaceMut {
         source_specs: SourceSpecs,
         prefix_update_config: &PrefixUpdateConfig,
         lock_file_update_config: &LockFileUpdateConfig,
+        solver_config: &SolverConfig,
         feature_name: &FeatureName,
         platforms: &[Platform],
         editable: bool,
@@ -358,6 +359,7 @@ impl WorkspaceMut {
             io_concurrency_limit,
         } = UpdateContext::builder(self.workspace())
             .with_lock_file(unlocked_lock_file)
+            .with_opt_exclude_newer(solver_config.exclude_newer)
             .with_no_install(
                 (prefix_update_config.no_install && lock_file_update_config.no_lockfile_update)
                     || dry_run,

--- a/tests/integration_rust/common/package_database.rs
+++ b/tests/integration_rust/common/package_database.rs
@@ -4,6 +4,7 @@
 // There are a bunch of functions that remain unused in tests but might be useful in the future.
 #![allow(dead_code)]
 
+use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use rattler_conda_types::{
@@ -142,6 +143,7 @@ pub struct PackageBuilder {
     depends: Vec<String>,
     subdir: Option<Platform>,
     archive_type: ArchiveType,
+    timestamp: Option<DateTime<Utc>>,
 }
 
 impl Package {
@@ -155,6 +157,7 @@ impl Package {
             depends: vec![],
             subdir: None,
             archive_type: ArchiveType::Conda,
+            timestamp: None,
         }
     }
 
@@ -201,6 +204,11 @@ impl PackageBuilder {
         self
     }
 
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
     /// Finish construction of the package
     pub fn finish(self) -> Package {
         let subdir = self.subdir.unwrap_or(Platform::NoArch);
@@ -234,7 +242,7 @@ impl PackageBuilder {
                 sha256: Some(sha256),
                 size: None,
                 subdir: subdir.to_string(),
-                timestamp: None,
+                timestamp: self.timestamp,
                 track_features: vec![],
                 version: self.version,
                 purls: None,


### PR DESCRIPTION
Adds the `--exclude-newer` CLI flag. Using this allows filtering package candidates that are older than a specific cutoff date. This is useful to pin the resolution to a particular date. 

This PR adds support for verifying the sastisfiability of a lock-file, and passing the information to the solver. A log message is emitted if locked records from the lock-file are removed due to them not satisfying the `exclude-newer` date.

Note that repodata patching can change the `timestamp` of repodata records so this method is not foolproof but will in practice be very accurate. 

A followup PR will add support for adding the configuration to the `pixi.toml` file and support for pypi as well.