### PR TITLE
fix: support for riscv64 linux

### DIFF
--- a/.github/workflows/trampoline.yaml
+++ b/.github/workflows/trampoline.yaml
@@ -36,6 +36,10 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             os: ubuntu-latest
 
+          - name: "Linux-riscv64"
+            target: riscv64gc-unknown-linux-gnu
+            os: ubuntu-latest
+
           - name: "macOS-x86"
             target: x86_64-apple-darwin
             os: macos-13

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -187,6 +187,7 @@ fn get_arch_tags(platform: Platform) -> Result<uv_platform_tags::Arch, PyPITagEr
         Some(Arch::ArmV7l) => Ok(uv_platform_tags::Arch::Armv7L),
         Some(Arch::Ppc64le) => Ok(uv_platform_tags::Arch::Powerpc64Le),
         Some(Arch::Ppc64) => Ok(uv_platform_tags::Arch::Powerpc64),
+        Some(Arch::Riscv64) => Ok(uv_platform_tags::Arch::Riscv64),
         Some(Arch::S390X) => Ok(uv_platform_tags::Arch::S390X),
         Some(unsupported_arch) => Err(PyPITagError::FailedToDetermineArchTags(unsupported_arch)),
     }

--- a/src/global/trampoline.rs
+++ b/src/global/trampoline.rs
@@ -64,6 +64,11 @@ const TRAMPOLINE_BIN: &[u8] =
 const TRAMPOLINE_BIN: &[u8] =
     include_bytes!("../../trampoline/binaries/pixi-trampoline-powerpc64le-unknown-linux-gnu.zst");
 
+#[cfg(target_arch = "riscv64")]
+#[cfg(target_os = "linux")]
+const TRAMPOLINE_BIN: &[u8] =
+    include_bytes!("../../trampoline/binaries/pixi-trampoline-riscv64gc-unknown-linux-gnu.zst");
+
 #[cfg(target_arch = "x86_64")]
 #[cfg(target_os = "linux")]
 const TRAMPOLINE_BIN: &[u8] =


### PR DESCRIPTION
Add trampline for riscv64 and fix a missing case for riscv64

Should fix build errors for riscv64 like https://archriscv.felixc.at/.status/log.htm?url=logs/pixi/pixi-0.45.0-1.log

CI passes in my fork: https://github.com/kxxt/pixi/actions/runs/14470130653/job/40581673032