### PR TITLE
ci: renovate add pixi constraints

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,7 @@ name = "pixi"
 # Using faster repodata fetching from our experimental fast channel, which implements https://github.com/conda/ceps/pull/75
 channels = ["https://prefix.dev/conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]
+requires-pixi = ">=0.45"
 
 [dependencies]
 git = "==2.47.1"

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   "enabledManagers": ["github-actions", "pixi", "cargo"],
   "commitMessagePrefix": "chore(ci):",
   "ignorePaths": ["examples/**", "docs/**", "tests/**"],
+  "constraints": {
+    "pixi": ">=0.40"
+  },
   "packageRules": [
     {
       "groupName": "GitHub Actions",

--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,6 @@
   "enabledManagers": ["github-actions", "pixi", "cargo"],
   "commitMessagePrefix": "chore(ci):",
   "ignorePaths": ["examples/**", "docs/**", "tests/**"],
-  "constraints": {
-    "pixi": ">=0.40"
-  },
   "packageRules": [
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
This should help with renovate not being able to deal with newer pixi syntax: https://github.com/prefix-dev/pixi/pull/3604#issuecomment-2805008407