### PR TITLE
ci: renovate don't update macOS runner

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,12 @@
       "matchManagers": ["github-actions"]
     },
     {
+      "description": "We run multiple macOS runner versions on purpose since 13 runs on x86_64",
+      "matchPackageNames": "macos",
+      "matchManagers": ["github-actions"],
+      "enabled": false
+    },
+    {
       "description": "Rust >=1.85 is needed to update the cargo-machete action",
       "matchPackageNames": "bnjbvr/cargo-machete",
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
We run multiple macOS runner versions on purpose since 13 runs on x86_64 See https://github.com/prefix-dev/pixi/pull/3605