### PR TITLE
fix: don't keep reinstalling local pypi archives

### DIFF
--- a/src/install_pypi/plan/test/mod.rs
+++ b/src/install_pypi/plan/test/mod.rs
@@ -635,11 +635,13 @@ fn test_archive_is_path() {
         Url::from_file_path(&wheel_path).unwrap(),
         InstalledDistOptions::default(),
     );
-    // Create relative path
 
     // Requires following package
-    let required =
-        RequiredPackages::new().add_local_wheel("foobar", "0.1.0", PathBuf::from("./some-dir/../foobar.whl"));
+    let required = RequiredPackages::new().add_local_wheel(
+        "foobar",
+        "0.1.0",
+        PathBuf::from("./some-dir/../foobar.whl"),
+    );
     let plan = harness::install_planner_with_lock_dir(tmp.path().to_path_buf());
     let installs = plan
         .plan_install(&site_packages, AllCached, &required.to_borrowed())

--- a/src/install_pypi/plan/test/mod.rs
+++ b/src/install_pypi/plan/test/mod.rs
@@ -639,7 +639,7 @@ fn test_archive_is_path() {
 
     // Requires following package
     let required =
-        RequiredPackages::new().add_local_wheel("foobar", "0.1.0", PathBuf::from("./foobar.whl"));
+        RequiredPackages::new().add_local_wheel("foobar", "0.1.0", PathBuf::from("./some-dir/../foobar.whl"));
     let plan = harness::install_planner_with_lock_dir(tmp.path().to_path_buf());
     let installs = plan
         .plan_install(&site_packages, AllCached, &required.to_borrowed())

--- a/src/install_pypi/plan/test/mod.rs
+++ b/src/install_pypi/plan/test/mod.rs
@@ -5,7 +5,6 @@ use assert_matches::assert_matches;
 use harness::fake_wheel;
 use std::path::PathBuf;
 use std::str::FromStr;
-use typed_path::Path;
 use url::Url;
 
 mod harness;

--- a/src/install_pypi/plan/validation.rs
+++ b/src/install_pypi/plan/validation.rs
@@ -18,13 +18,13 @@ pub enum NeedsReinstallError {
     #[error(transparent)]
     UvConversion(#[from] ConversionError),
     #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error(transparent)]
     Conversion(#[from] url::ParseError),
     #[error(transparent)]
     ParsedUrl(#[from] ParsedUrlError),
-    #[error("Error converting to parsed git url {0}")]
+    #[error("error converting to parsed git url {0}")]
     PixiGitUrl(String),
+    #[error("while checking freshness {0}")]
+    FreshnessError(std::io::Error),
 }
 
 /// Check if a package needs to be reinstalled
@@ -111,7 +111,9 @@ pub(crate) fn need_reinstall(
                             if url == locked_url {
                                 // Okay so these are the same, but we need to check if the cache is newer
                                 // than the source directory
-                                if !check_url_freshness(&url, installed)? {
+                                if !check_url_freshness(&url, installed)
+                                    .map_err(NeedsReinstallError::FreshnessError)?
+                                {
                                     return Ok(ValidateCurrentInstall::Reinstall(
                                         NeedReinstall::SourceDirectoryNewerThanCache,
                                     ));
@@ -148,14 +150,31 @@ pub(crate) fn need_reinstall(
                     // Subdirectory is either in the url or not supported
                     subdirectory: _,
                 } => {
+                    let lock_file_dir = typed_path::Utf8TypedPathBuf::from(
+                        lock_file_dir.to_string_lossy().as_ref(),
+                    );
                     let locked_url = match &locked.location {
                         // Remove `direct+` scheme if it is there so we can compare the required to
                         // the installed url
-                        UrlOrPath::Url(url) => strip_direct_scheme(url),
-                        UrlOrPath::Path(_path) => {
-                            return Ok(ValidateCurrentInstall::Reinstall(
-                                NeedReinstall::GitArchiveIsPath,
-                            ))
+                        UrlOrPath::Url(url) => strip_direct_scheme(url).into_owned(),
+                        UrlOrPath::Path(path) => {
+                            let path = if path.is_absolute() {
+                                path.clone()
+                            } else {
+                                // Relative paths will be relative to the lock file directory
+                                lock_file_dir.join(path).normalize()
+                            };
+                            let url = Url::from_file_path(PathBuf::from(path.as_str()));
+                            match url {
+                                Ok(url) => url,
+                                Err(_) => {
+                                    return Ok(ValidateCurrentInstall::Reinstall(
+                                        NeedReinstall::UnableToParseFileUrl {
+                                            url: path.to_string(),
+                                        },
+                                    ))
+                                }
+                            }
                         }
                     };
 
@@ -171,9 +190,11 @@ pub(crate) fn need_reinstall(
                         ));
                     };
 
-                    if locked_url.as_ref() == &installed_url {
+                    if locked_url == installed_url {
                         // Check cache freshness
-                        if !check_url_freshness(&locked_url, installed)? {
+                        if !check_url_freshness(&locked_url, installed)
+                            .map_err(NeedsReinstallError::FreshnessError)?
+                        {
                             return Ok(ValidateCurrentInstall::Reinstall(
                                 NeedReinstall::ArchiveDistNewerThanCache,
                             ));

--- a/src/install_pypi/utils.rs
+++ b/src/install_pypi/utils.rs
@@ -87,7 +87,6 @@ fn uv_old_up_to_date_with(source: &Path, target: &InstalledDist) -> Result<bool,
         // target is not up-to-date.
         return Ok(false);
     };
-    dbg!(target.install_path());
     let created_at = Timestamp::from_path(target.install_path().join("METADATA"))?;
     Ok(modified_at <= created_at)
 }

--- a/src/install_pypi/utils.rs
+++ b/src/install_pypi/utils.rs
@@ -87,6 +87,7 @@ fn uv_old_up_to_date_with(source: &Path, target: &InstalledDist) -> Result<bool,
         // target is not up-to-date.
         return Ok(false);
     };
+    dbg!(target.install_path());
     let created_at = Timestamp::from_path(target.install_path().join("METADATA"))?;
     Ok(modified_at <= created_at)
 }


### PR DESCRIPTION
When using a pypi local archive things keep reinstalling.

```toml
[workspace]
authors = ["Tim de Jager <tim@prefix.dev>"]
channels = ["https://prefix.dev/conda-forge"]
name = "installation-order"
platforms = ["osx-arm64"]
version = "0.1.0"

[tasks]

[dependencies]
python = "3.13.*"

[pypi-dependencies]
minimal = { path = "./minimal-0.1.0-py2.py3-none-any.whl" }
```

```
...
 INFO pixi::install_pypi: 4 of 5 required packages are considered are installed and up-to-date
 INFO pixi::install_pypi: *re-installing* following packages: minimal
 INFO pixi::install_pypi: re-installing 'minimal' because: 'Git archive is a path'
 INFO pixi::install_pypi: Prepared 1 package in 0ms
 INFO pixi::install_pypi: Installed 1 package in 1ms
✔ The default environment has been installed.
```

The above kept happening. This PR fixes that behavior.

This pull request includes several changes to the `src/install_pypi/plan/test/harness.rs`, `src/install_pypi/plan/test/mod.rs`, and `src/install_pypi/plan/validation.rs` files to improve the handling of PyPI package installations and their validation. 

The most important changes are summarized below:

### Improvements to PyPI package data handling:

* Renamed the `directory` function to `path` in `impl PyPIPackageDataBuilder` to better reflect its purpose.
* Added a new method `add_local_wheel` to `RequiredPackages` for adding local wheel files.

### Enhancements to test harness:

* Introduced `install_planner_with_lock_dir` function to create an `InstallPlanner` with a specified lock directory. This will help for relative path testing.
* Added `fake_wheel` function to create a fake wheel file for testing purposes.

### Validation improvements:

* Updated error handling in `NeedsReinstallError` to include a new variant `FreshnessError` for errors encountered while checking freshness.
* (The fix) Enhanced the `need_reinstall` function to handle relative paths and check the freshness of URLs more robustly. [[1]](diffhunk://#diff-c39a6646c1097760df071d2d2fedbe38a38a58a0bb78f1424fe8180614ce17a7R153-R178) [[2]](diffhunk://#diff-c39a6646c1097760df071d2d2fedbe38a38a58a0bb78f1424fe8180614ce17a7L174-R197)