### PR TITLE
ci: extend ignore paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "schedule": ["on tuesday"],
   "enabledManagers": ["github-actions", "pixi", "cargo"],
   "commitMessagePrefix": "chore(ci):",
-  "ignorePaths": ["examples/**", "docs/**", "tests/**"],
+  "ignorePaths": ["**/examples/**", "**/docs/**", "**/tests/**"],
   "packageRules": [
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
For some reason without the globs it didn't work. Let's hope that this now suffices.