### PR TITLE
docs: replace "project" with "workspace"

### DIFF
--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1,5 +1,5 @@
 
-The `pixi.toml` is the project manifest, also known as the Pixi project configuration file.
+The `pixi.toml` is the workspace manifest, also known as the Pixi workspace configuration file.
 
 A `toml` file is structured in different tables.
 This document will explain the usage of the different tables.
@@ -59,7 +59,7 @@ To access private or public channels on [prefix.dev](https://prefix.dev/channels
 
 ### `platforms`
 
-Defines the list of platforms that the project supports.
+Defines the list of platforms that the workspace supports.
 Pixi solves the dependencies for all these platforms and puts them in the lock file (`pixi.lock`).
 
 ```toml
@@ -76,8 +76,8 @@ The available platforms are listed here: [link](https://docs.rs/rattler_conda_ty
 
 ### `name` (optional)
 
-The name of the project.
-If the name is not specified, the name of the directory that contains the project is used.
+The name of the workspace.
+If the name is not specified, the name of the directory that contains the workspace is used.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_name"
@@ -85,7 +85,7 @@ If the name is not specified, the name of the directory that contains the projec
 
 ### `version` (optional)
 
-The version of the project.
+The version of the workspace.
 This should be a valid version based on the conda Version Spec.
 See the [version documentation](https://docs.rs/rattler_conda_types/latest/rattler_conda_types/struct.Version.html), for an explanation of what is allowed in a Version Spec.
 
@@ -95,7 +95,7 @@ See the [version documentation](https://docs.rs/rattler_conda_types/latest/rattl
 
 ### `authors` (optional)
 
-This is a list of authors of the project.
+This is a list of authors of the workspace.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_authors"
@@ -103,7 +103,7 @@ This is a list of authors of the project.
 
 ### `description` (optional)
 
-This should contain a short description of the project.
+This should contain a short description of the workspace.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_description"
@@ -135,7 +135,7 @@ readme = "README.md"
 
 ### `homepage` (optional)
 
-URL of the project homepage.
+URL of the workspace homepage.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_homepage"
@@ -143,7 +143,7 @@ URL of the project homepage.
 
 ### `repository` (optional)
 
-URL of the project source repository.
+URL of the workspace source repository.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_repository"
@@ -151,7 +151,7 @@ URL of the project source repository.
 
 ### `documentation` (optional)
 
-URL of the project documentation.
+URL of the workspace documentation.
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/main_pixi.toml:project_documentation"
@@ -214,9 +214,9 @@ channel-priority = "disabled"
 
 ### `requires-pixi` (optional)
 
-The required version spec for `pixi` itself to resolve and build the project. If unset (**Default**),
+The required version spec for `pixi` itself to resolve and build the workspace. If unset (**Default**),
 any version is ok. If set, it must be a string to a valid conda version spec, and the version of
-a running `pixi` must match the required spec before resolving or building the project, or exit with
+a running `pixi` must match the required spec before resolving or building the workspace, or exit with
 an error when not match.
 
 For example, with the following manifest, `pixi shell` will fail on `pixi 0.39.0`, but success after
@@ -235,14 +235,14 @@ requires-pixi = ">=0.40,<1.0"
 ```
 
 !!! note
-    This option should be used to improve the reproducibility of building the project. A complicated
+    This option should be used to improve the reproducibility of building the workspace. A complicated
     requirement spec may be an obstacle to setup the building environment.
 
 ## The `tasks` table
 
-Tasks are a way to automate certain custom commands in your project.
+Tasks are a way to automate certain custom commands in your workspace.
 For example, a `lint` or `format` step.
-Tasks in a Pixi project are essentially cross-platform shell commands, with a unified syntax across platforms.
+Tasks in a Pixi workspace are essentially cross-platform shell commands, with a unified syntax across platforms.
 For more in-depth information, check the [Advanced tasks documentation](../workspace/advanced_tasks.md).
 Pixi's tasks are run in a Pixi environment using `pixi run` and are executed using the [`deno_task_shell`](../workspace/advanced_tasks.md#our-task-runner-deno_task_shell).
 
@@ -276,7 +276,7 @@ For example, we can define a unix system with a specific minimal libc version.
 [system-requirements]
 libc = "2.28"
 ```
-or make the project depend on a specific version of `cuda`:
+or make the workspace depend on a specific version of `cuda`:
 ```toml
 [system-requirements]
 cuda = "12"
@@ -315,7 +315,7 @@ These options are explained in the sections below. Most of these options are tak
     Unlike pip, because we make use of uv, we have a strict index priority. This means that the first index is used where a package can be found.
     The order is determined by the order in the toml file. Where the `extra-index-urls` are preferred over the `index-url`. Read more about this on the [uv docs](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes)
 
-Often you might want to use an alternative or extra index for your project. This can be done by adding the `pypi-options` table to your `pixi.toml` file, the following options are available:
+Often you might want to use an alternative or extra index for your workspace. This can be done by adding the `pypi-options` table to your `pixi.toml` file, the following options are available:
 
 - `index-url`: replaces the main index url. If this is not set the default index used is `https://pypi.org/simple`.
    **Only one** `index-url` can be defined per environment.
@@ -400,7 +400,7 @@ By default, `uv` and thus `pixi`, will stop at the first index on which a given 
 ??? info "Details regarding the dependencies"
     For more detail regarding the dependency types, make sure to check the [Run, Host, Build](../build/dependency_types.md) dependency documentation.
 
-This section defines what dependencies you would like to use for your project.
+This section defines what dependencies you would like to use for your workspace.
 
 There are multiple dependencies tables.
 The default is `[dependencies]`, which are dependencies that are shared across platforms.
@@ -459,11 +459,11 @@ python = "~=3.10.3"
 Typical examples of host dependencies are:
 
 - Base interpreters: a Python package would list `python` here and an R package would list `mro-base` or `r-base`.
-- Libraries your project links against during compilation like `openssl`, `rapidjson`, or `xtensor`.
+- Libraries your workspace links against during compilation like `openssl`, `rapidjson`, or `xtensor`.
 
 ### `build-dependencies`
 
-This table contains dependencies that are needed to build the project.
+This table contains dependencies that are needed to build the workspace.
 Different from `dependencies` and `host-dependencies` these packages are installed for the architecture of the _build_ machine.
 This enables cross-compiling from one machine architecture to another.
 
@@ -527,7 +527,7 @@ boltons = { git = "https://github.com/mahmoud/boltons.git", tag = "25.0.0" }
 # With https, specific tag and some subdirectory
 boltons = { git = "https://github.com/mahmoud/boltons.git", tag = "25.0.0", subdirectory = "some-subdir" }
 
-# You can also directly add a source dependency from a path, tip keep this relative to the root of the project.
+# You can also directly add a source dependency from a path, tip keep this relative to the root of the workspace.
 minimal-project = { path = "./minimal-project", editable = true}
 
 # You can also use a direct url, to either a `.tar.gz` or `.zip`, or a `.whl` file
@@ -598,7 +598,7 @@ py-rattler = { git = "ssh://git@github.com/conda/rattler.git", subdirectory = "p
 ##### `path`
 
 A local path to install from. e.g. `path = "./path/to/package"`
-We would advise to keep your path projects in the project, and to use a relative path.
+We would advise to keep your path projects in the workspace, and to use a relative path.
 
 Set `editable` to `true` to install in editable mode, this is highly recommended as it is hard to reinstall if you're not using editable mode. e.g. `editable = true`
 
@@ -849,9 +849,9 @@ The global configuration options are documented in the [global configuration](..
 
 
 ## Preview features
-Pixi sometimes introduces new features that are not yet stable, but that we would like for users to test out. These features are called preview features. Preview features are disabled by default and can be enabled by setting the `preview` field in the project manifest. The preview field is an array of strings that specify the preview features to enable, or the boolean value `true` to enable all preview features.
+Pixi sometimes introduces new features that are not yet stable, but that we would like for users to test out. These features are called preview features. Preview features are disabled by default and can be enabled by setting the `preview` field in the workspace manifest. The preview field is an array of strings that specify the preview features to enable, or the boolean value `true` to enable all preview features.
 
-An example of a preview feature in the project manifest:
+An example of a preview feature in the manifest:
 
 ```toml
 --8<-- "docs/source_files/pixi_tomls/simple_pixi_build.toml:preview"


### PR DESCRIPTION
## Summary
I replaced the word "project" with "workspace" for consistency in terminology.