### PR TITLE
fix: use `help_heading` instead of `next_help_heading`

### DIFF
--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -26,6 +26,8 @@ pixi add [OPTIONS] <SPEC>...
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The feature for which the dependency should be modified
 <br>**default**: `default`
+- <a id="arg---editable" href="#arg---editable">`--editable`</a>
+:  Whether the pypi requirement should be editable
 
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
@@ -65,8 +67,6 @@ pixi add [OPTIONS] <SPEC>...
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---editable" href="#arg---editable">`--editable`</a>
-:  Whether the pypi requirement should be editable
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -11,6 +11,13 @@ Install an environment, both updating the lockfile and installing the environmen
 pixi install [OPTIONS]
 ```
 
+## Options
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to install
+<br>May be provided more than once.
+- <a id="arg---all" href="#arg---all">`--all (-a)`</a>
+:  Install all environments
+
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
@@ -31,11 +38,6 @@ pixi install [OPTIONS]
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
-:  The environment to install
-<br>May be provided more than once.
-- <a id="arg---all" href="#arg---all">`--all (-a)`</a>
-:  Install all environments
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -28,6 +28,8 @@ pixi list [OPTIONS] [REGEX]
 <br>**options**: `size`, `name`, `kind`
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  The environment to list packages for. Defaults to the default environment
+- <a id="arg---explicit" href="#arg---explicit">`--explicit (-x)`</a>
+:  Only list packages that are explicitly defined in the workspace
 
 ## Update Options
 - <a id="arg---no-lockfile-update" href="#arg---no-lockfile-update">`--no-lockfile-update`</a>
@@ -38,8 +40,6 @@ pixi list [OPTIONS] [REGEX]
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---explicit" href="#arg---explicit">`--explicit (-x)`</a>
-:  Only list packages that are explicitly defined in the workspace
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/reinstall.md
+++ b/docs/reference/cli/pixi/reinstall.md
@@ -16,6 +16,13 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 :  Specifies the package that should be reinstalled. If no package is given, the whole environment will be reinstalled
 <br>May be provided more than once.
 
+## Options
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to install
+<br>May be provided more than once.
+- <a id="arg---all" href="#arg---all">`--all (-a)`</a>
+:  Install all environments
+
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
@@ -36,11 +43,6 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
-:  The environment to install
-<br>May be provided more than once.
-- <a id="arg---all" href="#arg---all">`--all (-a)`</a>
-:  Install all environments
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -16,6 +16,18 @@ pixi run [OPTIONS] [TASK]...
 :  The pixi task or a task shell command you want to run in the workspace's environment, which can be an executable in the environment's PATH
 <br>May be provided more than once.
 
+## Options
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to run the task in
+- <a id="arg---clean-env" href="#arg---clean-env">`--clean-env`</a>
+:  Use a clean environment to run the task
+- <a id="arg---skip-deps" href="#arg---skip-deps">`--skip-deps`</a>
+:  Don't run the dependencies of the task ('depends-on' field in the task definition)
+- <a id="arg---dry-run" href="#arg---dry-run">`--dry-run (-n)`</a>
+:  Run the task in dry-run mode (only print the command that would run)
+- <a id="arg---help" href="#arg---help">`--help`</a>
+:
+
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
@@ -46,16 +58,6 @@ pixi run [OPTIONS] [TASK]...
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
-:  The environment to run the task in
-- <a id="arg---clean-env" href="#arg---clean-env">`--clean-env`</a>
-:  Use a clean environment to run the task
-- <a id="arg---skip-deps" href="#arg---skip-deps">`--skip-deps`</a>
-:  Don't run the dependencies of the task ('depends-on' field in the task definition)
-- <a id="arg---dry-run" href="#arg---dry-run">`--dry-run (-n)`</a>
-:  Run the task in dry-run mode (only print the command that would run)
-- <a id="arg---help" href="#arg---help">`--help`</a>
-:
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -14,6 +14,11 @@ pixi shell-hook [OPTIONS]
 ## Options
 - <a id="arg---shell" href="#arg---shell">`--shell (-s) <SHELL>`</a>
 :  Sets the shell, options: [`bash`,  `zsh`,  `xonsh`,  `cmd`, `powershell`,  `fish`,  `nushell`]
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to activate in the script
+- <a id="arg---json" href="#arg---json">`--json`</a>
+:  Emit the environment variables set by running the activation as JSON
+<br>**default**: `false`
 
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
@@ -48,11 +53,6 @@ pixi shell-hook [OPTIONS]
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
-:  The environment to activate in the script
-- <a id="arg---json" href="#arg---json">`--json`</a>
-:  Emit the environment variables set by running the activation as JSON
-<br>**default**: `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/shell.md
+++ b/docs/reference/cli/pixi/shell.md
@@ -11,6 +11,10 @@ Start a shell in a pixi environment, run `exit` to leave the shell
 pixi shell [OPTIONS]
 ```
 
+## Options
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to activate in the shell
+
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
@@ -44,8 +48,6 @@ pixi shell [OPTIONS]
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
-:  The environment to activate in the shell
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/tree.md
+++ b/docs/reference/cli/pixi/tree.md
@@ -20,6 +20,8 @@ pixi tree [OPTIONS] [REGEX]
 :  The platform to list packages for. Defaults to the current platform
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  The environment to list packages for. Defaults to the default environment
+- <a id="arg---invert" href="#arg---invert">`--invert (-i)`</a>
+:  Invert tree and show what depends on given package in the regex argument
 
 ## Update Options
 - <a id="arg---no-lockfile-update" href="#arg---no-lockfile-update">`--no-lockfile-update`</a>
@@ -30,8 +32,6 @@ pixi tree [OPTIONS] [REGEX]
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---invert" href="#arg---invert">`--invert (-i)`</a>
-:  Invert tree and show what depends on given package in the regex argument
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -16,6 +16,18 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 :  The packages to upgrade
 <br>May be provided more than once.
 
+## Options
+- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
+:  The feature to update
+<br>**default**: `default`
+- <a id="arg---exclude" href="#arg---exclude">`--exclude <EXCLUDE>`</a>
+:  The packages which should be excluded
+<br>May be provided more than once.
+- <a id="arg---json" href="#arg---json">`--json`</a>
+:  Output the changes in JSON format
+- <a id="arg---dry-run" href="#arg---dry-run">`--dry-run (-n)`</a>
+:  Only show the changes that would be made, without actually updating the manifest, lock file, or environment
+
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
@@ -42,16 +54,6 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
-:  The feature to update
-<br>**default**: `default`
-- <a id="arg---exclude" href="#arg---exclude">`--exclude <EXCLUDE>`</a>
-:  The packages which should be excluded
-<br>May be provided more than once.
-- <a id="arg---json" href="#arg---json">`--json`</a>
-:  Output the changes in JSON format
-- <a id="arg---dry-run" href="#arg---dry-run">`--dry-run (-n)`</a>
-:  Only show the changes that would be made, without actually updating the manifest, lock file, or environment
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/workspace/channel/add.md
+++ b/docs/reference/cli/pixi/workspace/channel/add.md
@@ -22,6 +22,8 @@ pixi workspace channel add [OPTIONS] <CHANNEL>...
 :  Specify the channel priority
 - <a id="arg---prepend" href="#arg---prepend">`--prepend`</a>
 :  Add the channel(s) to the beginning of the channels list, making them the highest priority
+- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
+:  The name of the feature to modify
 
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
@@ -49,8 +51,6 @@ pixi workspace channel add [OPTIONS] <CHANNEL>...
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
-:  The name of the feature to modify
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/workspace/channel/remove.md
+++ b/docs/reference/cli/pixi/workspace/channel/remove.md
@@ -22,6 +22,8 @@ pixi workspace channel remove [OPTIONS] <CHANNEL>...
 :  Specify the channel priority
 - <a id="arg---prepend" href="#arg---prepend">`--prepend`</a>
 :  Add the channel(s) to the beginning of the channels list, making them the highest priority
+- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
+:  The name of the feature to modify
 
 ## Config Options
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
@@ -49,8 +51,6 @@ pixi workspace channel remove [OPTIONS] <CHANNEL>...
 - <a id="arg---locked" href="#arg---locked">`--locked`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
-- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
-:  The name of the feature to modify
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/src/cli/cli_config.rs
+++ b/src/cli/cli_config.rs
@@ -101,10 +101,9 @@ impl ChannelsConfig {
 }
 
 #[derive(Parser, Debug, Default, Clone)]
-#[clap(next_help_heading = consts::CLAP_UPDATE_OPTIONS)]
 pub struct LockFileUpdateConfig {
     /// Don't update lockfile, implies the no-install as well.
-    #[clap(long)]
+    #[clap(long, help_heading = consts::CLAP_UPDATE_OPTIONS)]
     pub no_lockfile_update: bool,
 
     /// Lock file usage from the CLI
@@ -126,14 +125,13 @@ impl LockFileUpdateConfig {
 
 /// Configuration for how to update the prefix
 #[derive(Parser, Debug, Default, Clone)]
-#[clap(next_help_heading = consts::CLAP_UPDATE_OPTIONS)]
 pub struct PrefixUpdateConfig {
     /// Don't modify the environment, only modify the lock-file.
-    #[arg(long)]
+    #[arg(long, help_heading = consts::CLAP_UPDATE_OPTIONS)]
     pub no_install: bool,
 
     /// Run the complete environment validation. This will reinstall a broken environment.
-    #[arg(long)]
+    #[arg(long, help_heading = consts::CLAP_UPDATE_OPTIONS)]
     pub revalidate: bool,
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -76,26 +76,25 @@ pub struct Args {
 }
 
 #[derive(Debug, Parser)]
-#[clap(next_help_heading = consts::CLAP_GLOBAL_OPTIONS)]
 pub struct GlobalOptions {
     /// Display help information
-    #[clap(long, short, global = true, action = clap::ArgAction::Help)]
+    #[clap(long, short, global = true, action = clap::ArgAction::Help, help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     help: Option<bool>,
 
     /// Increase logging verbosity (-v for warnings, -vv for info, -vvv for debug, -vvvv for trace)
-    #[clap(short, long, action = clap::ArgAction::Count, global = true)]
+    #[clap(short, long, action = clap::ArgAction::Count, global = true, help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     verbose: u8,
 
     /// Decrease logging verbosity (quiet mode)
-    #[clap(short, long, action = clap::ArgAction::Count, global = true)]
+    #[clap(short, long, action = clap::ArgAction::Count, global = true, help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     quiet: u8,
 
     /// Whether the log needs to be colored.
-    #[clap(long, default_value = "auto", global = true, env = "PIXI_COLOR")]
+    #[clap(long, default_value = "auto", global = true, env = "PIXI_COLOR", help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     color: ColorOutput,
 
     /// Hide all progress bars, always turned on if stderr is not a terminal.
-    #[clap(long, default_value = "false", global = true, env = "PIXI_NO_PROGRESS")]
+    #[clap(long, default_value = "false", global = true, env = "PIXI_NO_PROGRESS", help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     no_progress: bool,
 }
 
@@ -179,16 +178,15 @@ pub enum Command {
 
 #[derive(Parser, Debug, Default, Copy, Clone)]
 #[group(multiple = false)]
-#[clap(next_help_heading = consts::CLAP_UPDATE_OPTIONS)]
 /// Lock file usage from the CLI
 pub struct LockFileUsageConfig {
     /// Install the environment as defined in the lockfile, doesn't update
     /// lockfile if it isn't up-to-date with the manifest file.
-    #[clap(long, conflicts_with = "locked", env = "PIXI_FROZEN")]
+    #[clap(long, conflicts_with = "locked", env = "PIXI_FROZEN", help_heading = consts::CLAP_UPDATE_OPTIONS)]
     pub frozen: bool,
     /// Check if lockfile is up-to-date before installing the environment,
     /// aborts when lockfile isn't up-to-date with the manifest file.
-    #[clap(long, conflicts_with = "frozen", env = "PIXI_LOCKED")]
+    #[clap(long, conflicts_with = "frozen", env = "PIXI_LOCKED", help_heading = consts::CLAP_UPDATE_OPTIONS)]
     pub locked: bool,
 }
 


### PR DESCRIPTION
We were using `#[clap(next_help_heading = "..")]` in a few places, but then any argument that followed also got that help heading, even if it was not included on the struct that defined the clap attribute.

Instead I used an explicit `help_heading` everywhere and updated the reference docs.