### PR TITLE
fix: json prints of the tasks

### DIFF
--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -154,6 +154,14 @@ impl Task {
         }
     }
 
+    pub fn as_single_command_no_render(&self) -> Result<Option<Cow<str>>, TaskStringError> {
+        match self {
+            Task::Plain(str) => Ok(Some(Cow::Owned(str.source().to_string()))),
+            Task::Custom(custom) => custom.cmd.as_single_no_render(),
+            Task::Execute(exe) => exe.cmd.as_single_no_render(),
+            Task::Alias(_) => Ok(None),
+        }
+    }
     /// Returns the environment variables for the task to run in.
     pub fn env(&self) -> Option<&IndexMap<String, String>> {
         match self {
@@ -218,9 +226,9 @@ impl Task {
     }
 
     /// Returns the arguments of the task.
-    pub fn get_args(&self) -> Option<&Vec<TaskArg>> {
+    pub fn args(&self) -> Option<&[TaskArg]> {
         match self {
-            Task::Execute(exe) => exe.args.as_ref(),
+            Task::Execute(exe) => exe.args.as_deref(),
             _ => None,
         }
     }
@@ -469,6 +477,15 @@ impl CmdArgs {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Some(rendered_args.join(" ")))
             }
+        }
+    }
+
+    pub fn as_single_no_render(&self) -> Result<Option<Cow<str>>, TaskStringError> {
+        match self {
+            CmdArgs::Single(cmd) => Ok(Some(Cow::Owned(cmd.source().to_string()))),
+            CmdArgs::Multiple(args) => Ok(Some(Cow::Owned(
+                args.iter().map(|arg| arg.source().to_string()).join(" "),
+            ))),
         }
     }
 }

--- a/src/cli/task.rs
+++ b/src/cli/task.rs
@@ -550,6 +550,7 @@ pub struct TaskInfo {
     cmd: Option<String>,
     description: Option<String>,
     depends_on: Vec<Dependency>,
+    args: Option<Vec<TaskArg>>,
     cwd: Option<PathBuf>,
     env: Option<IndexMap<String, String>>,
     clean_env: bool,
@@ -561,11 +562,12 @@ impl From<&Task> for TaskInfo {
     fn from(task: &Task) -> Self {
         TaskInfo {
             cmd: task
-                .as_single_command(None)
+                .as_single_command_no_render()
                 .ok()
                 .and_then(|cmd| cmd.map(|c| c.to_string())),
             description: task.description().map(|desc| desc.to_string()),
             depends_on: task.depends_on().to_vec(),
+            args: task.args().map(|args| args.to_vec()),
             cwd: task.working_directory().map(PathBuf::from),
             env: task.env().cloned(),
             clean_env: task.clean_env(),

--- a/src/task/task_graph.rs
+++ b/src/task/task_graph.rs
@@ -202,7 +202,7 @@ impl<'p> TaskGraph<'p> {
 
                     let task_name = args.remove(0);
 
-                    let arg_values = if let Some(task_arguments) = task.get_args() {
+                    let arg_values = if let Some(task_arguments) = task.args() {
                         // Check if we don't have more arguments than the task expects
                         if args.len() > task_arguments.len() {
                             return Err(TaskGraphError::TooManyArguments(task_name.to_string()));
@@ -210,7 +210,7 @@ impl<'p> TaskGraph<'p> {
 
                         Some(Self::merge_args(
                             &TaskName::from(task_name.clone()),
-                            Some(task_arguments),
+                            Some(&task_arguments.to_vec()),
                             Some(&args),
                         )?)
                     } else {
@@ -371,7 +371,7 @@ impl<'p> TaskGraph<'p> {
                     run_environment: task_env,
                     args: Some(Self::merge_args(
                         &dependency.task_name,
-                        task_dependency.get_args(),
+                        task_dependency.args().map(|args| args.to_vec()).as_ref(),
                         dependency.args.as_ref(),
                     )?),
                     dependencies: Vec::new(),

--- a/tests/integration_python/__snapshots__/test_main_cli.ambr
+++ b/tests/integration_python/__snapshots__/test_main_cli.ambr
@@ -1,0 +1,33 @@
+# serializer version: 1
+# name: test_pixi_task_list_json
+  list([
+    dict({
+      'environment': 'default',
+      'features': list([
+        dict({
+          'name': 'default',
+          'tasks': list([
+            dict({
+              'args': list([
+                dict({
+                  'default': 'World',
+                  'name': 'name',
+                }),
+              ]),
+              'clean_env': False,
+              'cmd': "echo 'Hello {{name | title}}'",
+              'cwd': None,
+              'depends_on': list([
+              ]),
+              'description': None,
+              'env': None,
+              'inputs': None,
+              'name': 'test-task',
+              'outputs': None,
+            }),
+          ]),
+        }),
+      ]),
+    }),
+  ])
+# ---

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import shutil
+from syrupy.assertion import SnapshotAssertion
 
 from .common import (
     cwd,
@@ -1280,3 +1281,27 @@ def test_pixi_add_alias(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
     assert "dummy-a" in manifest_content["tasks"]
     assert manifest_content["tasks"]["dummy-a"] == [{"task": "dummy-b"}, {"task": "dummy-c"}]
+
+
+def test_pixi_task_list_json(
+    pixi: Path, tmp_pixi_workspace: Path, snapshot: SnapshotAssertion
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = """
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+        [tasks]
+        test-task = { cmd = "echo 'Hello {{name | title}}'", args = [{arg = "name", default = "World"}] }
+        """
+    manifest.write_text(toml)
+
+    result = verify_cli_command(
+        [pixi, "task", "list", "--json", "--manifest-path", manifest], ExitCode.SUCCESS
+    )
+
+    task_data = json.loads(result.stdout)
+
+    assert task_data == snapshot


### PR DESCRIPTION
The tasks with commands including arguments were not printing properly. 
The previous behaviour: 
![image](https://github.com/user-attachments/assets/8ff3160b-1e7d-4f6f-bf8c-998c0ca2168b)
After the changes:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/fb87c009-268d-46bc-8163-849715bb2529" />
