### PR TITLE
feat(error): Improve error handling for reserved names in exposed binaries

### DIFF
--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -448,8 +448,8 @@ pub struct ParseExposedKeyError(String);
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
     use super::*;
+    use insta::assert_snapshot;
 
     #[test]
     fn test_invalid_key() {

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -361,7 +361,7 @@ impl FancyDisplay for ExposedName {
 }
 
 /// Error that occurs when trying to use a reserved name as an exposed binary name.
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, Diagnostic, PartialEq)]
 pub(crate) enum ExposedNameError {
     /// Error when attempting to use the package manager's name as an exposed binary name
     #[error("The name '{0}' is reserved and cannot be used as an exposed name")]
@@ -449,8 +449,7 @@ pub struct ParseExposedKeyError(String);
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
-
-    use super::ParsedManifest;
+    use super::*;
 
     #[test]
     fn test_invalid_key() {

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -561,12 +561,12 @@ mod tests {
     fn test_invalid_name_format() {
         let long_string = "a".repeat(256);
         let test_cases = vec![
-            "",               // Empty string
-            "-invalid",       // Starts with hyphen
-            "_invalid",       // Starts with underscore
-            "invalid@name",   // Contains invalid character
-            "invalid name",   // Contains space
-            &long_string,     // Too long
+            "",             // Empty string
+            "-invalid",     // Starts with hyphen
+            "_invalid",     // Starts with underscore
+            "invalid@name", // Contains invalid character
+            "invalid name", // Contains space
+            &long_string,   // Too long
         ];
 
         for name in test_cases {
@@ -587,7 +587,7 @@ mod tests {
             "valid_name",
             "validName",
             "valid-name_123",
-            "a",              // Single character
+            "a",                // Single character
             &max_length_string, // Maximum length
         ];
 

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -411,7 +411,7 @@ fn is_valid_exposed_name(name: &str) -> bool {
     }
 
     // Check if the first character is alphanumeric
-    if !name.chars().next().map_or(false, |c| c.is_alphanumeric()) {
+    if !name.chars().next().is_some_and(|c| c.is_alphanumeric()) {
         return false;
     }
 

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -559,13 +559,14 @@ mod tests {
 
     #[test]
     fn test_invalid_name_format() {
+        let long_string = "a".repeat(256);
         let test_cases = vec![
             "",               // Empty string
             "-invalid",       // Starts with hyphen
             "_invalid",       // Starts with underscore
             "invalid@name",   // Contains invalid character
             "invalid name",   // Contains space
-            &"a".repeat(256), // Too long
+            &long_string,     // Too long
         ];
 
         for name in test_cases {
@@ -580,13 +581,14 @@ mod tests {
 
     #[test]
     fn test_valid_name_format() {
+        let max_length_string = "a".repeat(255);
         let test_cases = vec![
             "valid-name",
             "valid_name",
             "validName",
             "valid-name_123",
             "a",              // Single character
-            &"a".repeat(255), // Maximum length
+            &max_length_string, // Maximum length
         ];
 
         for name in test_cases {

--- a/src/global/project/parsed_manifest.rs
+++ b/src/global/project/parsed_manifest.rs
@@ -399,7 +399,7 @@ impl FromStr for ExposedName {
 }
 
 /// Validates if a name is suitable for use as an exposed binary name.
-/// 
+///
 /// Rules:
 /// - Must not be empty
 /// - Must start with an alphanumeric character
@@ -416,7 +416,8 @@ fn is_valid_exposed_name(name: &str) -> bool {
     }
 
     // Check if all characters are valid
-    name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    name.chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
 }
 
 impl<'de> toml_span::Deserialize<'de> for ExposedName {
@@ -560,12 +561,12 @@ mod tests {
     #[test]
     fn test_invalid_name_format() {
         let test_cases = vec![
-            "",                     // Empty string
-            "-invalid",            // Starts with hyphen
-            "_invalid",            // Starts with underscore
-            "invalid@name",        // Contains invalid character
-            "invalid name",        // Contains space
-            &"a".repeat(256),      // Too long
+            "",               // Empty string
+            "-invalid",       // Starts with hyphen
+            "_invalid",       // Starts with underscore
+            "invalid@name",   // Contains invalid character
+            "invalid name",   // Contains space
+            &"a".repeat(256), // Too long
         ];
 
         for name in test_cases {
@@ -585,8 +586,8 @@ mod tests {
             "valid_name",
             "validName",
             "valid-name_123",
-            "a",                    // Single character
-            &"a".repeat(255),       // Maximum length
+            "a",              // Single character
+            &"a".repeat(255), // Maximum length
         ];
 
         for name in test_cases {
@@ -599,7 +600,11 @@ mod tests {
     fn test_case_sensitivity() {
         let name = "PIXI";
         let result = ExposedName::from_str(name);
-        assert!(result.is_err(), "Expected error for uppercase name: {}", name);
+        assert!(
+            result.is_err(),
+            "Expected error for uppercase name: {}",
+            name
+        );
         match result.unwrap_err() {
             ExposedNameError::PixiBinParseError(_) => (),
             _ => panic!("Expected PixiBinParseError for name: {}", name),


### PR DESCRIPTION
## Description

This PR improves error handling for reserved names in exposed binaries by:

1. Adding a new `InvalidFormatError` variant to handle invalid name formats
2. Implementing comprehensive name validation with clear rules
3. Adding detailed documentation for error types
4. Expanding test coverage with various test cases

## Changes

- Added validation for exposed binary names (length, characters, format)
- Improved error messages with specific diagnostic information
- Added comprehensive test cases for various scenarios
- Enhanced documentation for error types and validation rules

## Testing

All tests pass, including the new test cases for:
- Invalid name formats
- Valid name formats
- Case sensitivity