### PR TITLE
ci: fix separate PR for rattler

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,7 @@
     },
     {
       "description": "We want a separate PR for rattler crates",
-      "matchPackageNames": "/(rattler|file_url)/",
+      "matchPackageNames": ["rattler*", "file_url"],
       "matchManagers": ["cargo"],
       "separateMajorMinor": false
     },


### PR DESCRIPTION
The original script didn't work as can be seen here: https://github.com/prefix-dev/pixi/pull/3648

Let's hope that this does the trick.