### PR TITLE
feat: change the way paths are handled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4417,6 +4417,7 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot 0.12.3",
+ "pathdiff",
  "pep440_rs",
  "pep508_rs",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,7 @@ miette = { workspace = true, features = ["fancy-no-backtrace"] }
 minijinja = { workspace = true, features = ["builtins"] }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
+pathdiff = { workspace = true }
 priority-queue = ">=2.1.2,<2.2.1" # need by uv, avoid update edition to 2024
 rstest = { workspace = true }
 uv-build-frontend = { workspace = true }

--- a/pixi_docs/Cargo.lock
+++ b/pixi_docs/Cargo.lock
@@ -4269,6 +4269,7 @@ dependencies = [
  "nix",
  "once_cell",
  "parking_lot 0.12.3",
+ "pathdiff",
  "pep440_rs",
  "pep508_rs",
  "percent-encoding",


### PR DESCRIPTION
This PR makes use of the `install_path` to create a relative path to lock instead of the url handling that was done before. The previous code existed before the time of uv workspaces, and this code should hopefully make this handling more correct. I ran into this while working on: https://github.com/prefix-dev/pixi/pull/3636

## Testing

I've added some specific tests for the handling of paths, including one windows specific case. We are using path dependencies in CI so I assume this should tackle some of the cases.

I've also checked if the `examples/pypi-source-deps` lock stays the same.