### PR TITLE
feat: add environment size and prefix to pixi info

### DIFF
--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -92,7 +92,6 @@ impl Display for EnvironmentInfo {
                 consts::SOLVE_GROUP_STYLE.apply_to(solve_group)
             )?;
         }
-        // TODO: add environment size when PR 674 is merged
         if let Some(size) = &self.environment_size {
             writeln!(f, "{:>WIDTH$}: {}", bold.apply_to("Environment size"), size)?;
         }
@@ -144,6 +143,13 @@ impl Display for EnvironmentInfo {
                 platform_list
             )?;
         }
+
+        writeln!(
+            f,
+            "{:>WIDTH$}: {}",
+            bold.apply_to("Prefix location"),
+            self.prefix.display()
+        )?;
 
         if !self.system_requirements.is_empty() {
             let serialized = to_string(&self.system_requirements)
@@ -415,13 +421,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                         .map(|t| t.into_keys().cloned().collect())
                         .unwrap_or_default();
 
+                    let environment_size =
+                        args.extended.then(|| dir_size(env.dir()).ok()).flatten();
+
                     EnvironmentInfo {
                         name: env.name().clone(),
                         features: env.features().map(|feature| feature.name.clone()).collect(),
                         solve_group: env
                             .solve_group()
                             .map(|solve_group| solve_group.name().to_string()),
-                        environment_size: None,
+                        environment_size,
                         dependencies: env
                             .combined_dependencies(Some(env.best_platform()))
                             .names()

--- a/tests/integration_python/__snapshots__/test_main_cli.ambr
+++ b/tests/integration_python/__snapshots__/test_main_cli.ambr
@@ -1,4 +1,83 @@
 # serializer version: 1
+# name: test_info_output_extended
+  dict({
+    'auth_dir': str,
+    'cache_dir': str,
+    'cache_size': str,
+    'config_locations': list,
+    'environments_info': list([
+      dict({
+        'channels': list([
+          'conda-forge',
+        ]),
+        'dependencies': list([
+        ]),
+        'environment_size': str,
+        'features': list([
+          'default',
+        ]),
+        'name': 'default',
+        'platforms': list,
+        'prefix': str,
+        'pypi_dependencies': list([
+        ]),
+        'solve_group': None,
+        'system_requirements': dict({
+          'archspec': None,
+          'cuda': None,
+          'libc': None,
+          'linux': None,
+          'macos': None,
+        }),
+        'tasks': list([
+        ]),
+      }),
+      dict({
+        'channels': list([
+          'conda-forge',
+        ]),
+        'dependencies': list([
+          'python',
+        ]),
+        'environment_size': str,
+        'features': list([
+          'py312',
+          'default',
+        ]),
+        'name': 'py312',
+        'platforms': list,
+        'prefix': str,
+        'pypi_dependencies': list([
+        ]),
+        'solve_group': None,
+        'system_requirements': dict({
+          'archspec': None,
+          'cuda': None,
+          'libc': None,
+          'linux': None,
+          'macos': None,
+        }),
+        'tasks': list([
+        ]),
+      }),
+    ]),
+    'global_info': dict({
+      'bin_dir': str,
+      'env_dir': str,
+      'manifest': str,
+    }),
+    'platform': str,
+    'project_info': dict({
+      'last_updated': str,
+      'manifest_path': str,
+      'name': 'test',
+      'pixi_folder_size': str,
+      'version': None,
+    }),
+    'version': str,
+    'virtual_packages': list,
+  })
+# ---
 # name: test_pixi_task_list_json
   list([
     dict({

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import shutil
 import platform
 from syrupy.assertion import SnapshotAssertion
+from syrupy.matchers import path_type
 
 from .common import (
     cwd,
@@ -1332,3 +1333,56 @@ def test_pixi_task_list_json(
     task_data = json.loads(result.stdout)
 
     assert task_data == snapshot
+
+
+def test_info_output_extended(
+    pixi: Path, tmp_pixi_workspace: Path, snapshot: SnapshotAssertion
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = """
+        [workspace]
+        name = "test"
+        channels = ["conda-forge"]
+        platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+        [feature.py312.dependencies]
+        python = "~=3.12.0"
+
+        [environments]
+        py312 = ["py312"]
+    """
+    manifest.write_text(toml)
+
+    verify_cli_command([pixi, "install", "--manifest-path", manifest, "--all"])
+
+    result = verify_cli_command(
+        [pixi, "info", "--manifest-path", manifest, "--extended", "--json"], ExitCode.SUCCESS
+    )
+    info_data = json.loads(result.stdout)
+
+    # Stub out path, size and other dynamic data from snapshot
+    path_matcher = path_type(
+        {
+            "auth_dir": (str,),
+            "cache_dir": (str,),
+            "cache_size": (str,),
+            "config_locations": (list,),
+            "environments_info.0.prefix": (str,),
+            "environments_info.0.environment_size": (str,),
+            "environments_info.0.platforms": (list,),
+            "environments_info.1.prefix": (str,),
+            "environments_info.1.environment_size": (str,),
+            "environments_info.1.platforms": (list,),
+            "global_info.bin_dir": (str,),
+            "global_info.env_dir": (str,),
+            "global_info.manifest": (str,),
+            "platform": (str,),
+            "project_info.manifest_path": (str,),
+            "project_info.pixi_folder_size": (str,),
+            "project_info.last_updated": (str,),
+            "version": (str,),
+            "virtual_packages": (list,),
+        }
+    )
+
+    assert info_data == snapshot(matcher=path_matcher)


### PR DESCRIPTION
Fixes https://github.com/prefix-dev/pixi/issues/3667 and also exposes size for each environment. Not sure if I should add any tests for this or not!