### PR TITLE
docs: clarify which pyproject_toml is used

### DIFF
--- a/docs/python/pyproject_toml.md
+++ b/docs/python/pyproject_toml.md
@@ -285,7 +285,7 @@ Given a source tree:
     └── pyproject.toml
 ```
 
-Concretly what this looks like in the `pyproject.toml`:
+Concretly what this looks like in the `pyproject.toml` for `main_project`:
 
 ```toml
 [tool.pixi.pypi-dependencies]


### PR DESCRIPTION
Clarify the `pyproject.toml` for the `main_project` to ease reading in the last section.