### PR TITLE
fix: pypi panic with path dependencies in lock file

### DIFF
--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -11,9 +11,7 @@ use uv_distribution_filename::DistExtension;
 use uv_normalize::{InvalidNameError, PackageName};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::VerbatimUrl;
-use uv_pypi_types::{
-    ParsedPathUrl, ParsedUrl, ParsedUrlError, RequirementSource, VerbatimParsedUrl,
-};
+use uv_pypi_types::{ParsedPathUrl, ParsedUrl, RequirementSource, VerbatimParsedUrl};
 
 use crate::{ConversionError, into_uv_git_reference, to_uv_marker_tree, to_uv_version_specifiers};
 
@@ -236,14 +234,13 @@ pub fn pep508_requirement_to_uv_requirement(
                 // it is actually a path
                 let url = match url_or_path {
                     UrlOrPath::Path(path) => {
-                        let ext = DistExtension::from_path(Path::new(path.as_str()))
-                            .map_err(|e| {
-                                ParsedUrlError::MissingExtensionPath(
+                        let ext =
+                            DistExtension::from_path(Path::new(path.as_str())).map_err(|e| {
+                                ConversionError::ExpectedArchiveButFoundPath(
                                     PathBuf::from_str(path.as_str()).expect("not a path"),
                                     e,
                                 )
-                            })
-                            .expect("cannot get extension");
+                            })?;
                         let parsed_url = ParsedUrl::Path(ParsedPathUrl::from_source(
                             path.as_str().into(),
                             ext,

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -3,7 +3,9 @@
 
 use std::error::Error;
 use std::fmt::{Debug, Display};
+use std::path::PathBuf;
 use thiserror::Error;
+use uv_distribution_filename::ExtensionError;
 use uv_pep440::VersionSpecifierBuildError;
 
 #[derive(Debug)]
@@ -139,4 +141,7 @@ pub enum ConversionError {
 
     #[error(transparent)]
     TrustedHostError(#[from] uv_configuration::TrustedHostError),
+
+    #[error("expected an archive but found path")]
+    ExpectedArchiveButFoundPath(PathBuf, #[source] ExtensionError),
 }

--- a/src/lock_file/package_identifier.rs
+++ b/src/lock_file/package_identifier.rs
@@ -175,6 +175,6 @@ pub enum ConversionError {
     Version(String),
     // #[error("'{0}' is not a valid python extra")]
     // Extra(String),
-    #[error("Failed to convert to pypi package name")]
+    #[error(transparent)]
     NameConversion(#[from] PixiConversionError),
 }

--- a/src/lock_file/satisfiability/mod.rs
+++ b/src/lock_file/satisfiability/mod.rs
@@ -378,7 +378,7 @@ pub enum PlatformUnsat {
         locked_path: String,
     },
 
-    #[error("failed to convert between pep508 and uv types {0}")]
+    #[error("failed to convert between pep508 and uv types: {0}")]
     UvTypesConversionError(#[from] ConversionError),
 
     #[error("'{name}' is locked as a conda package but only requested by pypi dependencies")]


### PR DESCRIPTION
Related issue: https://github.com/prefix-dev/pixi/issues/3687