### PR TITLE
docs: fix broken project manifest link

### DIFF
--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -3,7 +3,6 @@ The `pixi.toml` is the workspace manifest, also known as the Pixi workspace conf
 
 A `toml` file is structured in different tables.
 This document will explain the usage of the different tables.
-For more technical documentation check Pixi on [docs.rs](https://docs.rs/pixi/latest/pixi/struct.Project.html).
 
 !!! tip
     We also support the `pyproject.toml` file. It has the same structure as the `pixi.toml` file. except that you need to prepend the tables with `tool.pixi` instead of just the table name.

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -3,7 +3,7 @@ The `pixi.toml` is the workspace manifest, also known as the Pixi workspace conf
 
 A `toml` file is structured in different tables.
 This document will explain the usage of the different tables.
-For more technical documentation check Pixi on [docs.rs](https://docs.rs/pixi/latest/pixi/workspace/manifest/struct.ProjectManifest.html).
+For more technical documentation check Pixi on [docs.rs](https://docs.rs/pixi/latest/pixi/struct.Project.html).
 
 !!! tip
     We also support the `pyproject.toml` file. It has the same structure as the `pixi.toml` file. except that you need to prepend the tables with `tool.pixi` instead of just the table name.


### PR DESCRIPTION
Not sure where exactly you wanna link here but the url is broken.

Old: https://docs.rs/pixi/latest/pixi/workspace/manifest/struct.ProjectManifest.html
New: https://docs.rs/pixi/latest/pixi/struct.Project.html