### PR TITLE
docs: fixed Anaconda domain name 

### DIFF
--- a/docs/deployment/authentication.md
+++ b/docs/deployment/authentication.md
@@ -107,7 +107,7 @@ The JSON should follow the following format:
             "password": "your_password"
         }
     },
-    "conda.anaconda.org": {
+    "anaconda.org": {
         "CondaToken": "your_token"
     },
     "s3://my-bucket": {


### PR DESCRIPTION
I happened upon the `pixi` docs by accident when trying to use `rattler-build` to upload a `conda` package to `anaconda.org`. 