### PR TITLE
chore: slightly cleanup cli output

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -1102,7 +1102,7 @@ impl Config {
         }
 
         config.loaded_from.push(path.to_path_buf());
-        tracing::info!("Loaded config from: {}", path.display());
+        tracing::debug!("Loaded config from: {}", path.display());
 
         config
             .validate()

--- a/src/cli/global/install.rs
+++ b/src/cli/global/install.rs
@@ -157,6 +157,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         Some(env_names),
         Some(&env_changes),
         None,
+        false,
     )
     .await?;
 

--- a/src/cli/global/list.rs
+++ b/src/cli/global/list.rs
@@ -63,7 +63,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 "The environments are not in sync with the manifest, to sync run\n\tpixi global sync"
             );
         }
-        list_all_global_environments(&project, None, None, args.regex).await?;
+        list_all_global_environments(&project, None, None, args.regex, true).await?;
     }
 
     Ok(())

--- a/src/global/list.rs
+++ b/src/global/list.rs
@@ -289,8 +289,6 @@ pub async fn list_all_global_environments(
         );
         if show_header {
             println!("{}", header);
-        } else {
-            tracing::info!("{}", header);
         }
         println!("{}", message);
     }

--- a/src/global/list.rs
+++ b/src/global/list.rs
@@ -167,6 +167,7 @@ pub async fn list_all_global_environments(
     envs: Option<Vec<EnvironmentName>>,
     envs_changes: Option<&EnvChanges>,
     regex: Option<String>,
+    show_header: bool,
 ) -> miette::Result<()> {
     let mut project_envs = project.environments().clone();
     project_envs.sort_by(|a, _, b, _| a.to_string().cmp(&b.to_string()));
@@ -282,11 +283,16 @@ pub async fn list_all_global_environments(
     if message.is_empty() {
         println!("No global environments found.");
     } else {
-        println!(
-            "Global environments as specified in '{}'\n{}",
-            console::style(project.manifest.path.display()).bold(),
-            message
+        let header = format!(
+            "Global environments as specified in '{}'",
+            project.manifest.path.display()
         );
+        if show_header {
+            println!("{}", header);
+        } else {
+            tracing::info!("{}", header);
+        }
+        println!("{}", message);
     }
 
     Ok(())


### PR DESCRIPTION
Go from:
![Screenshot 2025-05-13 at 11 17 02](https://github.com/user-attachments/assets/ab3a1bf6-f20f-4a53-93ae-1f07b93051a3)
To:
![Screenshot 2025-05-13 at 11 39 35](https://github.com/user-attachments/assets/7d184452-fba1-4abd-8165-bef21135442e)

This is a personal improvement, not sure if everyone agrees, but I don't think the path helps in this case as most users don't care about the manifest. 

`pixi global list` still contains the "header" as I think there it makes more sense, because it's a tool that requests more information.