### PR TITLE
docs: start using recursive source run dependencies

### DIFF
--- a/docs/build/workspace.md
+++ b/docs/build/workspace.md
@@ -37,10 +37,10 @@ The source directory structure now looks like this:
 ```
 
 Within a Pixi manifest, you can manage a workspace and/or describe a package.
-In the case of `python_rich` we choose to do both, so the only thing we have to add is the dependency on the `cpp_math`.
+In the case of `python_rich` we choose to do both, so the only thing we have to add `cpp_math` as a run dependency of `python_rich`.
 
 ```py title="pixi.toml"
---8<-- "docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.toml:workspace"
+--8<-- "docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.toml:run-dependencies"
 ```
 
 We only want to use the `workspace` table of the top-level manifest.

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.lock
@@ -775,11 +775,15 @@ packages:
   subdir: noarch
   depends:
   - rich 13.9.*
+  - cpp_math
   - python
   input:
-    hash: 4a5deb4813653adb9ff8f0e09aa107677ea5b96c19a39cc0bc3eac8a4e2f6a3f
+    hash: 5008932e0e6d18c40ded1127ee4523f72febd1388b532f87bdaccf21d300126b
     globs:
     - pixi.toml
+  sources:
+    cpp_math:
+      path: packages/cpp_math
 - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.toml
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.toml
@@ -1,4 +1,3 @@
-# --8<-- [start:workspace]
 [workspace]
 channels = [
   "https://prefix.dev/pixi-build-backends",
@@ -8,9 +7,7 @@ platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
 preview = ["pixi-build"]
 
 [dependencies]
-cpp_math = { path = "packages/cpp_math" }
 python_rich = { path = "." }
-# --8<-- [end:workspace]
 
 
 [tasks]
@@ -26,5 +23,8 @@ backend = { name = "pixi-build-python", version = "0.1.*" }
 [package.host-dependencies]
 hatchling = "==1.26.3"
 
+# --8<-- [start:run-dependencies]
 [package.run-dependencies]
+cpp_math = { path = "packages/cpp_math" }
 rich = "13.9.*"
+# --8<-- [end:run-dependencies]

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.lock
@@ -1192,11 +1192,15 @@ packages:
   subdir: noarch
   depends:
   - rich >=13.9.4,<14
+  - cpp_math
   - python
   input:
-    hash: f77143f26667bd070bf291d71e56fb9957f0df77305cff3a6e6ad02be34a4ce7
+    hash: 5a77b1b4bb054a8d0a228e613224f1e29c100c006d0ac90c8528219e872e2b84
     globs:
     - pixi.toml
+  sources:
+    cpp_math:
+      path: packages/cpp_math
 - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
   md5: 47d31b792659ce70f470b5c82fdfb7a4

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.toml
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.toml
@@ -8,7 +8,6 @@ preview = ["pixi-build"]
 
 # --8<-- [start:dependencies]
 [dependencies]
-cpp_math = { path = "packages/cpp_math" }
 python_rich = { path = "." }
 # --8<-- [end:dependencies]
 
@@ -45,4 +44,5 @@ backend = { name = "pixi-build-python", version = "0.1.*" }
 hatchling = "==1.26.3"
 
 [package.run-dependencies]
+cpp_math = { path = "packages/cpp_math" }
 rich = ">=13.9.4,<14"


### PR DESCRIPTION
The newest Pixi and pixi-backend versions support this. So let's start using it in our documentation.