### PR TITLE
fix: hashing for same package-name

### DIFF
--- a/crates/pixi_pypi_spec/src/name.rs
+++ b/crates/pixi_pypi_spec/src/name.rs
@@ -2,10 +2,24 @@ use pep508_rs::{InvalidNameError, PackageName};
 use std::{borrow::Borrow, str::FromStr};
 
 /// A package name for Pypi that also stores the source version of the name.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone)]
 pub struct PypiPackageName {
     source: String,
     normalized: PackageName,
+}
+
+impl PartialEq for PypiPackageName {
+    fn eq(&self, other: &Self) -> bool {
+        self.normalized == other.normalized
+    }
+}
+
+impl Eq for PypiPackageName {}
+
+impl std::hash::Hash for PypiPackageName {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.normalized.hash(state);
+    }
 }
 
 impl Borrow<PackageName> for PypiPackageName {
@@ -39,5 +53,37 @@ impl PypiPackageName {
 
     pub fn as_source(&self) -> &str {
         &self.source
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        hash::{Hash, Hasher},
+        str::FromStr,
+    };
+
+    use crate::PypiPackageName;
+
+    #[test]
+    fn hash_equality() {
+        // Assert equality of two package names with different source strings
+        let name = PypiPackageName::from_str("foo-bar").unwrap();
+        let name2 = PypiPackageName::from_str("foo_bar").unwrap();
+        assert_eq!(name, name2);
+
+        // Assert that the hash values are equal
+        let mut hasher = std::hash::DefaultHasher::new();
+        name.hash(&mut hasher);
+        let hash = hasher.finish();
+
+        let mut hasher = std::hash::DefaultHasher::new();
+        name2.hash(&mut hasher);
+        let hash2 = hasher.finish();
+
+        assert_eq!(
+            hash, hash2,
+            "Normalized PyPI name and Non-Normalized name do not hash to the same value"
+        );
     }
 }


### PR DESCRIPTION
I think it is more correct to hash and compare on the normalized package name. Now this issue is not causing an error while it should: https://github.com/prefix-dev/pixi/issues/3736