### PR TITLE
test: run `test_no_change_should_be_fully_cached` again

### DIFF
--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -71,7 +71,6 @@ def test_build_conda_package_variants(
         assert package.exists()
 
 
-@pytest.mark.skip(reason="pixi-build-rattler-build seems to always rebuild at the moment")
 def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspace) -> None:
     simple_workspace.write_files()
     # Setting PIXI_CACHE_DIR shouldn't be necessary


### PR DESCRIPTION
With the latest backend release, this works again on my machine.

Let's see if CI agrees.