### PR TITLE
fix: examples in self-update_extender

### DIFF
--- a/docs/reference/cli/pixi/self-update_extender
+++ b/docs/reference/cli/pixi/self-update_extender
@@ -3,8 +3,8 @@
 ## Examples
 
 ```shell
-pixi global uninstall my-env
-pixi global uninstall pixi-pack rattler-build
+pixi self-update
+pixi self-update --version 0.46.0
 ```
 
 


### PR DESCRIPTION
Looks like the wrong example commands made their way into the docs for `self-update`.