### PR TITLE
style: Alphabetise command list in cli help

### DIFF
--- a/docs/reference/cli/pixi.md
+++ b/docs/reference/cli/pixi.md
@@ -11,32 +11,32 @@ pixi [OPTIONS] <COMMAND>
 ## Subcommands
 | Command | Description |
 |---------|-------------|
-| [`init`](pixi/init.md) | Creates a new workspace |
 | [`add`](pixi/add.md) | Adds dependencies to the workspace |
-| [`remove`](pixi/remove.md) | Removes dependencies from the workspace |
-| [`install`](pixi/install.md) | Install an environment, both updating the lockfile and installing the environment |
-| [`reinstall`](pixi/reinstall.md) | Re-install an environment, both updating the lockfile and re-installing the environment |
-| [`update`](pixi/update.md) | The `update` command checks if there are newer versions of the dependencies and updates the `pixi.lock` file and environments accordingly |
-| [`upgrade`](pixi/upgrade.md) | Checks if there are newer versions of the dependencies and upgrades them in the lockfile and manifest file |
-| [`lock`](pixi/lock.md) | Solve environment and update the lock file without installing the environments |
-| [`run`](pixi/run.md) | Runs task in the pixi environment |
-| [`exec`](pixi/exec.md) | Run a command and install it in a temporary environment |
-| [`shell`](pixi/shell.md) | Start a shell in a pixi environment, run `exit` to leave the shell |
-| [`shell-hook`](pixi/shell-hook.md) | Print the pixi environment activation script |
-| [`workspace`](pixi/workspace.md) | Modify the workspace configuration file through the command line |
-| [`task`](pixi/task.md) | Interact with tasks in the workspace |
-| [`list`](pixi/list.md) | List workspace's packages |
-| [`tree`](pixi/tree.md) | Show a tree of workspace dependencies |
-| [`global`](pixi/global.md) | Subcommand for global package management actions |
 | [`auth`](pixi/auth.md) | Login to prefix.dev or anaconda.org servers to access private channels |
-| [`config`](pixi/config.md) | Configuration management |
-| [`info`](pixi/info.md) | Information about the system, workspace and environments for the current machine |
-| [`upload`](pixi/upload.md) | Upload a conda package |
-| [`search`](pixi/search.md) | Search a conda package |
-| [`self-update`](pixi/self-update.md) | Update pixi to the latest version or a specific version |
+| [`build`](pixi/build.md) | Workspace configuration |
 | [`clean`](pixi/clean.md) | Cleanup the environments |
 | [`completion`](pixi/completion.md) | Generates a completion script for a shell |
-| [`build`](pixi/build.md) | Workspace configuration |
+| [`config`](pixi/config.md) | Configuration management |
+| [`exec`](pixi/exec.md) | Run a command and install it in a temporary environment |
+| [`global`](pixi/global.md) | Subcommand for global package management actions |
+| [`info`](pixi/info.md) | Information about the system, workspace and environments for the current machine |
+| [`init`](pixi/init.md) | Creates a new workspace |
+| [`install`](pixi/install.md) | Install an environment, both updating the lockfile and installing the environment |
+| [`list`](pixi/list.md) | List workspace's packages |
+| [`lock`](pixi/lock.md) | Solve environment and update the lock file without installing the environments |
+| [`reinstall`](pixi/reinstall.md) | Re-install an environment, both updating the lockfile and re-installing the environment |
+| [`remove`](pixi/remove.md) | Removes dependencies from the workspace |
+| [`run`](pixi/run.md) | Runs task in the pixi environment |
+| [`search`](pixi/search.md) | Search a conda package |
+| [`self-update`](pixi/self-update.md) | Update pixi to the latest version or a specific version |
+| [`shell`](pixi/shell.md) | Start a shell in a pixi environment, run `exit` to leave the shell |
+| [`shell-hook`](pixi/shell-hook.md) | Print the pixi environment activation script |
+| [`task`](pixi/task.md) | Interact with tasks in the workspace |
+| [`tree`](pixi/tree.md) | Show a tree of workspace dependencies |
+| [`update`](pixi/update.md) | The `update` command checks if there are newer versions of the dependencies and updates the `pixi.lock` file and environments accordingly |
+| [`upgrade`](pixi/upgrade.md) | Checks if there are newer versions of the dependencies and upgrades them in the lockfile and manifest file |
+| [`upload`](pixi/upload.md) | Upload a conda package |
+| [`workspace`](pixi/workspace.md) | Modify the workspace configuration file through the command line |
 
 
 ## Global Options

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -125,55 +125,45 @@ impl Args {
 
 #[derive(Parser, Debug)]
 pub enum Command {
-    Init(init::Args),
-
-    // Installation commands
     #[clap(visible_alias = "a")]
     Add(add::Args),
-    #[clap(visible_alias = "rm")]
-    Remove(remove::Args),
-    #[clap(visible_alias = "i")]
-    Install(install::Args),
-    Reinstall(reinstall::Args),
-    Update(update::Args),
-    Upgrade(upgrade::Args),
-    Lock(lock::Args),
-
-    #[clap(visible_alias = "r")]
-    Run(run::Args),
+    Auth(rattler::cli::auth::Args),
+    Build(build::Args),
+    Clean(clean::Args),
+    Completion(completion::Args),
+    Config(config::Args),
     #[clap(visible_alias = "x")]
     Exec(exec::Args),
-    #[clap(visible_alias = "s")]
-    Shell(shell::Args),
-    ShellHook(shell_hook::Args),
-
-    // Workspace Manifest modification commands
-    #[clap(alias = "project")]
-    Workspace(workspace::Args),
-    Task(task::Args),
-
-    // Environment inspection
-    #[clap(visible_alias = "ls")]
-    List(list::Args),
-    #[clap(visible_alias = "t")]
-    Tree(tree::Args),
-
-    // Global level commands
     #[clap(visible_alias = "g")]
     Global(global::Args),
-    Auth(rattler::cli::auth::Args),
-    Config(config::Args),
     Info(info::Args),
-    Upload(upload::Args),
+    Init(init::Args),
+    #[clap(visible_alias = "i")]
+    Install(install::Args),
+    #[clap(visible_alias = "ls")]
+    List(list::Args),
+    Lock(lock::Args),
+    Reinstall(reinstall::Args),
+    #[clap(visible_alias = "rm")]
+    Remove(remove::Args),
+    #[clap(visible_alias = "r")]
+    Run(run::Args),
     Search(search::Args),
     #[cfg_attr(not(feature = "self_update"), clap(hide = true))]
     #[cfg_attr(feature = "self_update", clap(hide = false))]
     SelfUpdate(self_update::Args),
-    Clean(clean::Args),
-    Completion(completion::Args),
-
-    // Build
-    Build(build::Args),
+    #[clap(visible_alias = "s")]
+    Shell(shell::Args),
+    ShellHook(shell_hook::Args),
+    Task(task::Args),
+    #[clap(visible_alias = "t")]
+    Tree(tree::Args),
+    Update(update::Args),
+    Upgrade(upgrade::Args),
+    Upload(upload::Args),
+    #[clap(alias = "project")]
+    Workspace(workspace::Args),
+}
 }
 
 #[derive(Parser, Debug, Default, Copy, Clone)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -125,6 +125,7 @@ impl Args {
 
 #[derive(Parser, Debug)]
 pub enum Command {
+    // Commands in alphabetical order
     #[clap(visible_alias = "a")]
     Add(add::Args),
     Auth(rattler::cli::auth::Args),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -164,7 +164,6 @@ pub enum Command {
     #[clap(alias = "project")]
     Workspace(workspace::Args),
 }
-}
 
 #[derive(Parser, Debug, Default, Copy, Clone)]
 #[group(multiple = false)]


### PR DESCRIPTION
There are enough commands to make an unordered list awkward to parse:

![image](https://github.com/user-attachments/assets/5769d4a4-9201-4516-b2de-373b39372411)
