### PR TITLE
feat: improve type of outputs, add Eq, PartialEq, etc.

### DIFF
--- a/crates/pixi_build_types/src/procedures/conda_build.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+};
 
 use rattler_conda_types::GenericVirtualPackage;
 use serde::{Deserialize, Serialize};
@@ -32,7 +35,7 @@ pub struct CondaBuildParams {
     /// returned from a call to `conda/getMetadata`. Pass `None` to build all
     /// outputs.
     #[serde(default)]
-    pub outputs: Option<Vec<CondaOutputIdentifier>>,
+    pub outputs: Option<BTreeSet<CondaOutputIdentifier>>,
 
     /// The variants that we want to build
     pub variant_configuration: Option<HashMap<String, Vec<String>>>,
@@ -50,7 +53,7 @@ pub struct CondaBuildParams {
 }
 
 /// Identifier of an output.
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct CondaOutputIdentifier {
     pub name: Option<String>,
     pub version: Option<String>,


### PR DESCRIPTION
This makes it easier to compare CondaOutputIdentifier's in Rust.

I also changed the type of the selected outputs to use a `BTreeSet`. This is a bit more efficient to check whether an identifier is contained within the selected outputs and should serialize the same way as a `Vec`.