### PR TITLE
docs: Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+We take security bugs in our projects seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/prefix-dev/pixi/security/advisories/new) tab.
+
+We will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.


### PR DESCRIPTION
Closes #3813

@baszalmstra @wolfv you need to enable security advisories (ideally for all repos) in https://github.com/organizations/prefix-dev/settings/security_products for https://github.com/prefix-dev/pixi/security/advisories/new to work