### PR TITLE
fix: path diff not calculated on Windows

### DIFF
--- a/src/global/install.rs
+++ b/src/global/install.rs
@@ -106,6 +106,7 @@ pub(crate) async fn create_executable_trampolines(
     let mut activation_variables = prefix.run_activation().await?;
     let path_after_activation = activation_variables
         .remove("PATH")
+        .or_else(|| activation_variables.remove("Path"))
         .unwrap_or_else(|| path_current.clone());
 
     let path_diff = path_diff(&path_current, &path_after_activation, prefix)?;


### PR DESCRIPTION
On Windows environment variables are case preserving, we should deal with that situation