### PR TITLE
fix: source globs and make them unique

### DIFF
--- a/crates/pixi_build_types/src/procedures/conda_build.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build.rs
@@ -75,7 +75,7 @@ pub struct CondaBuiltPackage {
 
     /// The globs that were used as input to the build. Use these for
     /// re-verifying the build.
-    pub input_globs: Vec<String>,
+    pub input_globs: BTreeSet<String>,
 
     /// The name of the package.
     pub name: String,

--- a/crates/pixi_build_types/src/procedures/conda_metadata.rs
+++ b/crates/pixi_build_types/src/procedures/conda_metadata.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+};
 use url::Url;
 
 use crate::{ChannelConfiguration, CondaPackageMetadata, PlatformAndVirtualPackages};
@@ -51,5 +54,5 @@ pub struct CondaMetadataResult {
     ///
     /// If this field is not present, the input manifest will be used.
     #[serde(default)]
-    pub input_globs: Option<Vec<String>>,
+    pub input_globs: Option<BTreeSet<String>>,
 }

--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -126,19 +126,10 @@ impl SourceMetadataSpec {
         let input_hash = if source.pinned.is_immutable() {
             None
         } else {
-            let input_globs = metadata
-                .input_globs
-                .clone()
-                .into_iter()
-                .flat_map(|glob| glob.into_iter())
-                .collect::<Vec<_>>();
-
+            let input_globs = metadata.input_globs.clone().unwrap_or_default();
             let input_hash = command_queue
                 .glob_hash_cache()
-                .compute_hash(GlobHashKey {
-                    root: source.path.clone(),
-                    globs: input_globs.clone(),
-                })
+                .compute_hash(GlobHashKey::new(&source.path, input_globs.clone()))
                 .await
                 .map_err(SourceMetadataError::GlobHash)?;
 

--- a/crates/pixi_glob/src/glob_mtime.rs
+++ b/crates/pixi_glob/src/glob_mtime.rs
@@ -37,8 +37,9 @@ impl GlobModificationTime {
         globs: impl IntoIterator<Item = &'a str>,
     ) -> Result<Self, GlobModificationTimeError> {
         // If the root is not a directory or does not exist, return NoMatches.
-        if !root_dir.is_dir() {
-            return Ok(Self::NoMatches);
+        let mut root = root_dir.to_owned();
+        if !root.is_dir() {
+            root.pop();
         }
 
         let glob_set = GlobSet::create(globs)?;

--- a/src/build/cache/build_cache.rs
+++ b/src/build/cache/build_cache.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     hash::{Hash, Hasher},
     io::SeekFrom,
     path::PathBuf,
@@ -189,7 +190,7 @@ pub struct CachedBuild {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SourceInfo {
-    pub globs: Vec<String>,
+    pub globs: BTreeSet<String>,
 }
 
 /// A cache entry returned by [`BuildCache::entry`] which enables

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -376,7 +376,7 @@ impl BuildContext {
                             .manifests()
                             .into_iter()
                             .chain(build_result.input_globs)
-                            .collect_vec(),
+                            .collect(),
                     }),
                 record: record.clone(),
             })
@@ -419,10 +419,10 @@ impl BuildContext {
             if let Some(input_globs) = &metadata.input_hash {
                 let new_hash = self
                     .glob_hash_cache
-                    .compute_hash(GlobHashKey {
-                        root: source.path.clone(),
-                        globs: input_globs.globs.clone(),
-                    })
+                    .compute_hash(GlobHashKey::new(
+                        source.path.clone(),
+                        input_globs.globs.clone(),
+                    ))
                     .await?;
                 if new_hash.hash == input_globs.hash {
                     tracing::debug!("found up-to-date cached metadata.");
@@ -493,14 +493,11 @@ impl BuildContext {
                         .into_iter()
                         .flat_map(|glob| glob.into_iter()),
                 )
-                .collect_vec();
+                .collect::<BTreeSet<_>>();
 
             let input_hash = self
                 .glob_hash_cache
-                .compute_hash(GlobHashKey {
-                    root: source.path.clone(),
-                    globs: input_globs.clone(),
-                })
+                .compute_hash(GlobHashKey::new(&source.path, input_globs.clone()))
                 .await?;
             Some(InputHash {
                 hash: input_hash.hash,

--- a/src/lock_file/satisfiability/mod.rs
+++ b/src/lock_file/satisfiability/mod.rs
@@ -1469,10 +1469,10 @@ pub(crate) async fn verify_package_platform_satisfiability(
         })?;
 
         let input_hash = input_hash_cache
-            .compute_hash(GlobHashKey {
-                root: source_dir,
-                globs: locked_input_hash.globs.clone(),
-            })
+            .compute_hash(GlobHashKey::new(
+                source_dir,
+                locked_input_hash.globs.clone(),
+            ))
             .await
             .map_err(PlatformUnsat::FailedToComputeInputHash)
             .map_err(Box::new)?;


### PR DESCRIPTION
There are two changes:

- if the source is a file, we use the parent directory as globbing "base". This fixes the issue where `foobar = { path = "./recipe/recipe.yaml" }` always produced a `0000...` hash. I think this is not surprising behavior.
- We also got an input glob of `recipe.yaml` twice in the glob section in the `pixi.lock`. Making globs a `BTreeSet` fixes this. I don't think duplicate globs would ever make sense.