### PR TITLE
fix: #3814 Validate `depends-on` must be a list

### DIFF
--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_manifest/src/toml/task.rs
+expression: "expect_parse_failure(r#\"\n            cmd = \"test\"\n            depends = [\"a\", \"b\"]\n        \"#)"
+---
+  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'description', 'clean-env', 'args'
+   ╭─[pixi.toml:3:13]
+ 2 │             cmd = "test"
+ 3 │             depends = ["a", "b"]
+   ·             ───┬───
+   ·                ╰── 'depends' was not expected here
+ 4 │
+   ╰────
+  help: Did you mean 'depends-on'?

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__depends_on_is_list.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__depends_on_is_list.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pixi_manifest/src/toml/task.rs
+expression: "expect_parse_failure(r#\"\n            cmd = \"test\"\n            depends-on = { task = \"z\" }\n        \"#)"
+---
+  × expected string or array, found table
+   ╭─[pixi.toml:3:26]
+ 2 │             cmd = "test"
+ 3 │             depends-on = { task = "z" }
+   ·                          ──────────────
+ 4 │
+   ╰────

--- a/crates/pixi_manifest/src/toml/task.rs
+++ b/crates/pixi_manifest/src/toml/task.rs
@@ -182,7 +182,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
         let task = if let Some(cmd) = cmd {
             let inputs = th.optional("inputs");
             let outputs = th.optional("outputs");
-            let depends_on = depends_on(&mut th).unwrap_or_default();
+            let depends_on = depends_on(&mut th)?;
             let cwd = th
                 .optional::<TomlFromStr<_>>("cwd")
                 .map(TomlFromStr::into_inner);
@@ -222,7 +222,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 args,
             }))
         } else {
-            let depends_on = depends_on(&mut th).unwrap_or_default();
+            let depends_on = depends_on(&mut th)?;
             let description = th.optional("description");
             let args = th.optional::<Vec<TaskArg>>("args");
             th.finalize(None)?;
@@ -268,6 +268,13 @@ mod test {
     use crate::toml::FromTomlStr;
     use pixi_test_utils::format_parse_error;
 
+    fn expect_parse_failure(pixi_toml: &str) -> String {
+        let parse_error = <TomlTask as crate::toml::FromTomlStr>::from_toml_str(pixi_toml)
+            .expect_err("parsing should fail");
+
+        format_parse_error(pixi_toml, parse_error)
+    }
+
     #[test]
     fn test_depends_on_deprecation() {
         let input = r#"
@@ -278,5 +285,25 @@ mod test {
         let mut parsed = TomlTask::from_toml_str(input).unwrap();
         assert_eq!(parsed.warnings.len(), 1);
         insta::assert_snapshot!(format_parse_error(input, parsed.warnings.remove(0)));
+    }
+
+    #[test]
+    fn test_additional_task_keys() {
+        insta::assert_snapshot!(expect_parse_failure(
+            r#"
+            cmd = "test"
+            depends = ["a", "b"]
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_depends_on_is_list() {
+        insta::assert_snapshot!(expect_parse_failure(
+            r#"
+            cmd = "test"
+            depends-on = { task = "z" }
+        "#
+        ));
     }
 }


### PR DESCRIPTION
Fixes #3814 

Added tests:
- `test_depends_on_is_list`
- `test_additional_task_keys`