### PR TITLE
feat(test): transform reporter events into tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,6 +4681,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "strsim",
+ "text_trees",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -7229,6 +7230,12 @@ dependencies = [
  "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "text_trees"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419ea7ab2f07ffc59c5e9424bcb73677933940f8bdadbe21649c1584dc06d0cf"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tabwriter = "1.4.1"
 tar = "0.4.44"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tempfile = "3.17.1"
+text_trees = "0.1.2"
 thiserror = "2.0.11"
 tokio = "1.43.0"
 tokio-stream = "0.1.17"

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -48,4 +48,5 @@ pixi_utils = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true, features = ["json"] }
 pixi_config = { workspace = true }
+text_trees = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/git.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/git.rs
@@ -29,10 +29,7 @@ impl CommandDispatcherProcessor {
                     .as_deref_mut()
                     .and_then(Reporter::as_git_reporter)
                     .map(|reporter| {
-                        reporter.on_checkout_queued(
-                            parent_context,
-                            &RepositoryReference::from(&task.spec),
-                        )
+                        reporter.on_queued(parent_context, &RepositoryReference::from(&task.spec))
                     });
 
                 entry.insert(PendingGitCheckout::Pending(reporter_id, vec![task.tx]));
@@ -44,7 +41,7 @@ impl CommandDispatcherProcessor {
                     .and_then(Reporter::as_git_reporter)
                     .zip(reporter_id)
                 {
-                    reporter.on_checkout_start(id)
+                    reporter.on_start(id)
                 }
 
                 let resolver = self.inner.git_resolver.clone();
@@ -78,7 +75,7 @@ impl CommandDispatcherProcessor {
             .and_then(Reporter::as_git_reporter)
             .zip(*reporter_id)
         {
-            reporter.on_checkout_finished(id)
+            reporter.on_finished(id)
         }
 
         match result {

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/install_pixi.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/install_pixi.rs
@@ -18,7 +18,7 @@ impl CommandDispatcherProcessor {
             .reporter
             .as_deref_mut()
             .and_then(Reporter::as_pixi_install_reporter)
-            .map(|reporter| reporter.on_install_queued(parent_context, &task.spec));
+            .map(|reporter| reporter.on_queued(parent_context, &task.spec));
 
         // Store information about the pending environment.
         let pending_env_id = self
@@ -35,7 +35,7 @@ impl CommandDispatcherProcessor {
             .and_then(Reporter::as_pixi_install_reporter)
             .zip(reporter_id)
         {
-            reporter.on_install_start(id)
+            reporter.on_start(id)
         }
 
         // Add the task to the list of pending futures.
@@ -72,7 +72,7 @@ impl CommandDispatcherProcessor {
             .and_then(Reporter::as_pixi_install_reporter)
             .zip(env.reporter_id)
         {
-            reporter.on_install_finished(id)
+            reporter.on_finished(id)
         }
 
         let Some(result) = result.into_ok_or_failed() else {

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_conda.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_conda.rs
@@ -19,7 +19,7 @@ impl CommandDispatcherProcessor {
             .reporter
             .as_deref_mut()
             .and_then(Reporter::as_conda_solve_reporter)
-            .map(|reporter| reporter.on_solve_queued(parent_context, &task.spec));
+            .map(|reporter| reporter.on_queued(parent_context, &task.spec));
 
         // Store information about the pending environment.
         let environment_id = self.conda_solves.insert(PendingSolveCondaEnvironment {
@@ -56,7 +56,7 @@ impl CommandDispatcherProcessor {
                 .and_then(Reporter::as_conda_solve_reporter)
                 .zip(reporter_id)
             {
-                reporter.on_solve_start(id)
+                reporter.on_start(id)
             }
 
             // Add the task to the list of pending futures.
@@ -90,7 +90,7 @@ impl CommandDispatcherProcessor {
             .and_then(Reporter::as_conda_solve_reporter)
             .zip(env.reporter_id)
         {
-            reporter.on_solve_finished(id)
+            reporter.on_finished(id)
         }
 
         // Notify the command dispatcher that the result is available.

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_pixi.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_pixi.rs
@@ -21,7 +21,7 @@ impl CommandDispatcherProcessor {
             .reporter
             .as_deref_mut()
             .and_then(Reporter::as_pixi_solve_reporter)
-            .map(|reporter| reporter.on_solve_queued(parent_context, &task.spec));
+            .map(|reporter| reporter.on_queued(parent_context, &task.spec));
 
         // Store information about the pending environment.
         let pending_env_id = self.solve_pixi_environments.insert(PendingPixiEnvironment {
@@ -36,7 +36,7 @@ impl CommandDispatcherProcessor {
             .and_then(Reporter::as_pixi_solve_reporter)
             .zip(reporter_id)
         {
-            reporter.on_solve_start(id)
+            reporter.on_start(id)
         }
 
         // Add the task to the list of pending futures.
@@ -73,7 +73,7 @@ impl CommandDispatcherProcessor {
             .and_then(Reporter::as_pixi_solve_reporter)
             .zip(env.reporter_id)
         {
-            reporter.on_solve_finished(id)
+            reporter.on_finished(id)
         }
 
         let Some(result) = result.into_ok_or_failed() else {

--- a/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
@@ -23,30 +23,35 @@ use xxhash_rust::xxh3::Xxh3;
 
 /// Specification for a tool environment. Tool environments are cached between
 /// runs.
-#[derive(Debug)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct InstantiateToolEnvironmentSpec {
     /// The main requirement of the tool environment.
     pub requirement: (rattler_conda_types::PackageName, PixiSpec),
 
     /// The requirements of the tool environment.
+    #[serde(skip_serializing_if = "DependencyMap::is_empty")]
     pub additional_requirements: DependencyMap<rattler_conda_types::PackageName, PixiSpec>,
 
     /// Additional constraints applied to the environment.
+    #[serde(skip_serializing_if = "DependencyMap::is_empty")]
     pub constraints: DependencyMap<rattler_conda_types::PackageName, NamelessMatchSpec>,
 
     /// The platform to instantiate the tool environment for.
     pub build_environment: BuildEnvironment,
 
     /// The channels to use for solving
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub channels: Vec<ChannelUrl>,
 
     /// Exclude any packages after the first cut-off date.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude_newer: Option<DateTime<Utc>>,
 
     /// The channel configuration to use for this environment.
     pub channel_config: ChannelConfig,
 
     /// The protocols that are enabled for source packages
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub enabled_protocols: EnabledProtocols,
 }
 

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -55,6 +55,7 @@ pub use command_dispatcher::{
 };
 pub use executor::Executor;
 pub use install_pixi::{InstallPixiEnvironmentError, InstallPixiEnvironmentSpec};
+pub use instantiate_tool_env::{InstantiateToolEnvironmentError, InstantiateToolEnvironmentSpec};
 pub use limits::Limits;
 pub use reporter::{
     CondaSolveReporter, GitCheckoutReporter, PixiInstallReporter, PixiSolveReporter, Reporter,

--- a/crates/pixi_command_dispatcher/src/reporter.rs
+++ b/crates/pixi_command_dispatcher/src/reporter.rs
@@ -18,17 +18,17 @@ pub trait PixiInstallReporter {
     /// This function should return an identifier which is used to identify this
     /// particular installation. Other functions in this trait will use this
     /// identifier to link the events to the particular solve.
-    fn on_install_queued(
+    fn on_queued(
         &mut self,
         reason: Option<ReporterContext>,
         env: &InstallPixiEnvironmentSpec,
     ) -> PixiInstallId;
 
     /// Called when solving of the specified environment has started.
-    fn on_install_start(&mut self, solve_id: PixiInstallId);
+    fn on_start(&mut self, solve_id: PixiInstallId);
 
     /// Called when solving of the specified environment has finished.
-    fn on_install_finished(&mut self, solve_id: PixiInstallId);
+    fn on_finished(&mut self, solve_id: PixiInstallId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -46,17 +46,17 @@ pub trait PixiSolveReporter {
     /// This function should return an identifier which is used to identify this
     /// particular solve. Other functions in this trait will use this identifier
     /// to link the events to the particular solve.
-    fn on_solve_queued(
+    fn on_queued(
         &mut self,
         reason: Option<ReporterContext>,
         env: &PixiEnvironmentSpec,
     ) -> PixiSolveId;
 
     /// Called when solving of the specified environment has started.
-    fn on_solve_start(&mut self, solve_id: PixiSolveId);
+    fn on_start(&mut self, solve_id: PixiSolveId);
 
     /// Called when solving of the specified environment has finished.
-    fn on_solve_finished(&mut self, solve_id: PixiSolveId);
+    fn on_finished(&mut self, solve_id: PixiSolveId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -74,17 +74,17 @@ pub trait CondaSolveReporter {
     /// This function should return an identifier which is used to identify this
     /// particular solve. Other functions in this trait will use this identifier
     /// to link the events to the particular solve.
-    fn on_solve_queued(
+    fn on_queued(
         &mut self,
         reason: Option<ReporterContext>,
         env: &SolveCondaEnvironmentSpec,
     ) -> CondaSolveId;
 
     /// Called when solving of the specified environment has started.
-    fn on_solve_start(&mut self, solve_id: CondaSolveId);
+    fn on_start(&mut self, solve_id: CondaSolveId);
 
     /// Called when solving of the specified environment has finished.
-    fn on_solve_finished(&mut self, solve_id: CondaSolveId);
+    fn on_finished(&mut self, solve_id: CondaSolveId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -93,17 +93,17 @@ pub struct GitCheckoutId(pub usize);
 
 pub trait GitCheckoutReporter {
     /// Called when a git checkout was queued on the [`crate::CommandDispatcher`].
-    fn on_checkout_queued(
+    fn on_queued(
         &mut self,
         reason: Option<ReporterContext>,
         env: &RepositoryReference,
     ) -> GitCheckoutId;
 
     /// Called when the git checkout has started.
-    fn on_checkout_start(&mut self, checkout_id: GitCheckoutId);
+    fn on_start(&mut self, checkout_id: GitCheckoutId);
 
     /// Called when the git checkout has finished.
-    fn on_checkout_finished(&mut self, checkout_id: GitCheckoutId);
+    fn on_finished(&mut self, checkout_id: GitCheckoutId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]

--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -16,7 +16,7 @@ use rattler_conda_types::{ChannelConfig, ChannelUrl, PackageRecord};
 use thiserror::Error;
 
 /// Represents a request for source metadata.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, serde::Serialize)]
 pub struct SourceMetadataSpec {
     /// The source specification
     pub source_spec: SourceSpec,
@@ -25,12 +25,14 @@ pub struct SourceMetadataSpec {
     pub channel_config: ChannelConfig,
 
     /// The channels to use for solving.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub channels: Vec<ChannelUrl>,
 
     /// Information about the build environment.
     pub build_environment: BuildEnvironment,
 
     /// The protocols that are enabled for this source
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub enabled_protocols: EnabledProtocols,
 }
 

--- a/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
@@ -129,7 +129,7 @@ impl EventReporter {
 }
 
 impl CondaSolveReporter for EventReporter {
-    fn on_solve_queued(
+    fn on_queued(
         &mut self,
         context: Option<ReporterContext>,
         env: &SolveCondaEnvironmentSpec,
@@ -147,13 +147,13 @@ impl CondaSolveReporter for EventReporter {
         next_id
     }
 
-    fn on_solve_start(&mut self, solve_id: CondaSolveId) {
+    fn on_start(&mut self, solve_id: CondaSolveId) {
         let event = Event::CondaSolveStarted { id: solve_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
     }
 
-    fn on_solve_finished(&mut self, solve_id: CondaSolveId) {
+    fn on_finished(&mut self, solve_id: CondaSolveId) {
         let event = Event::CondaSolveFinished { id: solve_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
@@ -161,7 +161,7 @@ impl CondaSolveReporter for EventReporter {
 }
 
 impl PixiSolveReporter for EventReporter {
-    fn on_solve_queued(
+    fn on_queued(
         &mut self,
         context: Option<ReporterContext>,
         env: &PixiEnvironmentSpec,
@@ -179,13 +179,13 @@ impl PixiSolveReporter for EventReporter {
         next_id
     }
 
-    fn on_solve_start(&mut self, solve_id: PixiSolveId) {
+    fn on_start(&mut self, solve_id: PixiSolveId) {
         let event = Event::PixiSolveStarted { id: solve_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
     }
 
-    fn on_solve_finished(&mut self, solve_id: PixiSolveId) {
+    fn on_finished(&mut self, solve_id: PixiSolveId) {
         let event = Event::PixiSolveFinished { id: solve_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
@@ -193,7 +193,7 @@ impl PixiSolveReporter for EventReporter {
 }
 
 impl PixiInstallReporter for EventReporter {
-    fn on_install_queued(
+    fn on_queued(
         &mut self,
         context: Option<ReporterContext>,
         env: &InstallPixiEnvironmentSpec,
@@ -211,13 +211,13 @@ impl PixiInstallReporter for EventReporter {
         next_id
     }
 
-    fn on_install_start(&mut self, solve_id: PixiInstallId) {
+    fn on_start(&mut self, solve_id: PixiInstallId) {
         let event = Event::PixiInstallStarted { id: solve_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
     }
 
-    fn on_install_finished(&mut self, solve_id: PixiInstallId) {
+    fn on_finished(&mut self, solve_id: PixiInstallId) {
         let event = Event::PixiInstallFinished { id: solve_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
@@ -225,7 +225,7 @@ impl PixiInstallReporter for EventReporter {
 }
 
 impl GitCheckoutReporter for EventReporter {
-    fn on_checkout_queued(
+    fn on_queued(
         &mut self,
         context: Option<ReporterContext>,
         env: &RepositoryReference,
@@ -243,13 +243,13 @@ impl GitCheckoutReporter for EventReporter {
         next_id
     }
 
-    fn on_checkout_start(&mut self, checkout_id: GitCheckoutId) {
+    fn on_start(&mut self, checkout_id: GitCheckoutId) {
         let event = Event::GitCheckoutStarted { id: checkout_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
     }
 
-    fn on_checkout_finished(&mut self, checkout_id: GitCheckoutId) {
+    fn on_finished(&mut self, checkout_id: GitCheckoutId) {
         let event = Event::GitCheckoutFinished { id: checkout_id };
         println!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);
@@ -337,13 +337,13 @@ impl Reporter for EventReporter {
         Some(self)
     }
 
-    fn as_source_metadata_reporter(&mut self) -> Option<&mut dyn SourceMetadataReporter> {
-        Some(self)
-    }
-
     fn as_instantiate_tool_environment_reporter(
         &mut self,
     ) -> Option<&mut dyn InstantiateToolEnvironmentReporter> {
+        Some(self)
+    }
+
+    fn as_source_metadata_reporter(&mut self) -> Option<&mut dyn SourceMetadataReporter> {
         Some(self)
     }
 }

--- a/crates/pixi_command_dispatcher/tests/integration/event_tree.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_tree.rs
@@ -1,0 +1,220 @@
+use std::{collections::HashMap, fmt::Display};
+
+use itertools::Itertools;
+use pixi_command_dispatcher::{
+    ReporterContext,
+    reporter::{
+        CondaSolveId, GitCheckoutId, InstantiateToolEnvId, PixiInstallId, PixiSolveId,
+        SourceMetadataId,
+    },
+};
+use rattler_conda_types::PackageName;
+use slotmap::SlotMap;
+use text_trees::{FormatCharacters, StringTreeNode, TreeFormatting};
+
+use crate::event_reporter::Event;
+
+slotmap::new_key_type! {
+    pub struct NodeId;
+}
+
+pub struct Node {
+    label: String,
+    children: Vec<NodeId>,
+}
+
+pub struct EventTree {
+    rootes: Vec<NodeId>,
+    nodes: slotmap::SlotMap<NodeId, Node>,
+}
+
+impl EventTree {
+    pub fn new<'i>(events: impl IntoIterator<Item = &'i Event>) -> Self {
+        let mut builder = EventTreeBuilder::new();
+
+        let mut checkout_name = HashMap::new();
+        let mut pixi_solve_name = HashMap::new();
+        let mut source_metadata_name = HashMap::new();
+        let mut instantiate_tool_env_name = HashMap::new();
+
+        for event in events {
+            match event {
+                Event::CondaSolveQueued { id, context, .. } => {
+                    builder.set_event_context((*id).into(), *context);
+                }
+                Event::CondaSolveStarted { id } => {
+                    let node = builder.alloc_node(format!("Conda solve #{}", id.0));
+                    builder.set_context_node((*id).into(), node);
+                }
+                Event::CondaSolveFinished { .. } => {}
+                Event::PixiSolveQueued { id, context, spec } => {
+                    pixi_solve_name.insert(
+                        *id,
+                        spec.dependencies
+                            .names()
+                            .map(PackageName::as_source)
+                            .format(", ")
+                            .to_string(),
+                    );
+                    builder.set_event_context((*id).into(), *context);
+                }
+                Event::PixiSolveStarted { id } => {
+                    let node = builder
+                        .alloc_node(format!("Pixi solve ({})", pixi_solve_name.get(id).unwrap()));
+                    builder.set_context_node((*id).into(), node);
+                }
+                Event::PixiSolveFinished { .. } => {}
+                Event::PixiInstallQueued { id, context, .. } => {
+                    builder.set_event_context((*id).into(), *context);
+                }
+                Event::PixiInstallStarted { id } => {
+                    let node = builder.alloc_node(format!("Pixi install #{}", id.0));
+                    builder.set_context_node((*id).into(), node);
+                }
+                Event::PixiInstallFinished { .. } => {}
+                Event::GitCheckoutQueued {
+                    id,
+                    context,
+                    reference,
+                } => {
+                    checkout_name.insert(
+                        *id,
+                        format!("{}@{}", reference.url.as_url(), reference.reference),
+                    );
+                    builder.set_event_context((*id).into(), *context);
+                }
+                Event::GitCheckoutStarted { id } => {
+                    let node = builder
+                        .alloc_node(format!("Git Checkout ({})", checkout_name.get(id).unwrap()));
+                    builder.set_context_node((*id).into(), node);
+                }
+                Event::GitCheckoutFinished { .. } => {}
+                Event::SourceMetadataQueued { id, context, spec } => {
+                    source_metadata_name.insert(*id, spec.source_spec.to_toml_value().to_string());
+                    builder.set_event_context((*id).into(), *context);
+                }
+                Event::SourceMetadataStarted { id } => {
+                    let node = builder.alloc_node(format!(
+                        "Source metadata ({})",
+                        source_metadata_name.get(id).unwrap()
+                    ));
+                    builder.set_context_node((*id).into(), node);
+                }
+                Event::SourceMetadataFinished { .. } => {}
+                Event::InstantiateToolEnvQueued { id, context, spec } => {
+                    instantiate_tool_env_name
+                        .insert(*id, spec.requirement.0.as_source().to_string());
+                    builder.set_event_context((*id).into(), *context);
+                }
+                Event::InstantiateToolEnvStarted { id } => {
+                    let node = builder.alloc_node(format!(
+                        "Instantiate tool environment ({})",
+                        instantiate_tool_env_name.get(id).unwrap()
+                    ));
+                    builder.set_context_node((*id).into(), node);
+                }
+                Event::InstantiateToolEnvFinished { .. } => {}
+            }
+        }
+
+        builder.finish()
+    }
+}
+
+impl Display for EventTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn make_node(nodes: &slotmap::SlotMap<NodeId, Node>, id: NodeId) -> StringTreeNode {
+            let node = &nodes[id];
+            let mut tree = StringTreeNode::new(node.label.clone());
+            for child in &node.children {
+                tree.push_node(make_node(nodes, *child))
+            }
+            tree
+        }
+
+        let format = TreeFormatting::dir_tree(FormatCharacters::box_chars());
+        for root in &self.rootes {
+            write!(
+                f,
+                "{}",
+                make_node(&self.nodes, *root)
+                    .to_string_with_format(&format)
+                    .unwrap()
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+struct EventTreeBuilder {
+    nodes: SlotMap<NodeId, Node>,
+    rootes: Vec<NodeId>,
+    event_parent_nodes: HashMap<EventId, NodeId>,
+    event_nodes: HashMap<EventId, NodeId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::From)]
+pub enum EventId {
+    CondaSolve(CondaSolveId),
+    PixiSolve(PixiSolveId),
+    PixiInstall(PixiInstallId),
+    GitCheckout(GitCheckoutId),
+    SourceMetadata(SourceMetadataId),
+    InstantiateToolEnv(InstantiateToolEnvId),
+}
+
+impl From<ReporterContext> for EventId {
+    fn from(context: ReporterContext) -> Self {
+        match context {
+            ReporterContext::SolvePixi(id) => Self::PixiSolve(id),
+            ReporterContext::SolveConda(id) => Self::CondaSolve(id),
+            ReporterContext::InstallPixi(id) => Self::PixiInstall(id),
+            ReporterContext::SourceMetadata(id) => Self::SourceMetadata(id),
+            ReporterContext::InstantiateToolEnv(id) => Self::InstantiateToolEnv(id),
+        }
+    }
+}
+
+impl EventTreeBuilder {
+    fn new() -> Self {
+        Self {
+            nodes: SlotMap::default(),
+            rootes: Vec::new(),
+            event_parent_nodes: HashMap::new(),
+            event_nodes: Default::default(),
+        }
+    }
+
+    fn alloc_node(&mut self, label: String) -> NodeId {
+        self.nodes.insert(Node {
+            label,
+            children: Vec::new(),
+        })
+    }
+
+    fn set_event_context(&mut self, id: EventId, context: Option<ReporterContext>) {
+        if let Some(context) = context
+            .and_then(|context| self.event_nodes.get(&context.into()))
+            .copied()
+        {
+            self.event_parent_nodes.insert(id, context);
+        }
+    }
+
+    fn set_context_node(&mut self, id: EventId, node: NodeId) {
+        self.event_nodes.insert(id, node);
+        if let Some(parent) = self.event_parent_nodes.get(&id) {
+            self.nodes[*parent].children.push(node);
+        } else {
+            self.rootes.push(node);
+        }
+    }
+
+    fn finish(self) -> EventTree {
+        EventTree {
+            rootes: self.rootes,
+            nodes: self.nodes,
+        }
+    }
+}

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -1,12 +1,15 @@
 mod event_reporter;
+mod event_tree;
 
-use event_reporter::{Event, EventReporter};
-use itertools::Itertools;
+use std::str::FromStr;
+
+use event_reporter::EventReporter;
 use pixi_command_dispatcher::{CacheDirs, CommandDispatcher, Executor, PixiEnvironmentSpec};
 use pixi_spec::{GitReference, GitSpec};
 use pixi_spec_containers::DependencyMap;
-use std::str::FromStr;
 use url::Url;
+
+use crate::event_tree::EventTree;
 
 /// Returns a default set of cache directories for the test.
 fn default_cache_dirs() -> CacheDirs {
@@ -47,12 +50,6 @@ pub async fn simple_test() {
         .await
         .unwrap();
 
-    let events = events
-        .lock()
-        .unwrap()
-        .iter()
-        .map(Event::event_type)
-        .collect_vec();
-
-    insta::assert_json_snapshot!(events);
+    let event_tree = EventTree::new(events.lock().unwrap().iter());
+    insta::assert_snapshot!(event_tree.to_string());
 }

--- a/crates/pixi_command_dispatcher/tests/integration/snapshots/integration__simple_test.snap
+++ b/crates/pixi_command_dispatcher/tests/integration/snapshots/integration__simple_test.snap
@@ -1,78 +1,12 @@
 ---
 source: crates/pixi_command_dispatcher/tests/integration/main.rs
-expression: events
+expression: event_tree.to_string()
 ---
-[
-  {
-    "type": "pixi-solve-queued",
-    "id": 0
-  },
-  {
-    "type": "pixi-solve-started",
-    "id": 0
-  },
-  {
-    "type": "git-checkout-queued",
-    "id": 0
-  },
-  {
-    "type": "git-checkout-started",
-    "id": 0
-  },
-  {
-    "type": "git-checkout-finished",
-    "id": 0
-  },
-  {
-    "type": "pixi-solve-queued",
-    "id": 1
-  },
-  {
-    "type": "pixi-solve-started",
-    "id": 1
-  },
-  {
-    "type": "conda-solve-queued",
-    "id": 0
-  },
-  {
-    "type": "conda-solve-started",
-    "id": 0
-  },
-  {
-    "type": "conda-solve-finished",
-    "id": 0
-  },
-  {
-    "type": "pixi-solve-finished",
-    "id": 1
-  },
-  {
-    "type": "pixi-install-queued",
-    "id": 0
-  },
-  {
-    "type": "pixi-install-started",
-    "id": 0
-  },
-  {
-    "type": "pixi-install-finished",
-    "id": 0
-  },
-  {
-    "type": "conda-solve-queued",
-    "id": 1
-  },
-  {
-    "type": "conda-solve-started",
-    "id": 1
-  },
-  {
-    "type": "conda-solve-finished",
-    "id": 1
-  },
-  {
-    "type": "pixi-solve-finished",
-    "id": 0
-  }
-]
+Pixi solve (boost-check)
+├── Source metadata ({ git = "https://github.com/wolfv/pixi-build-examples.git", rev = "a4c27e86a4a5395759486552abb3df8a47d50172", subdirectory = "boost-check" })
+│   ├── Git Checkout (https://github.com/wolfv/pixi-build-examples@a4c27e86a4a5395759486552abb3df8a47d50172)
+│   └── Instantiate tool environment (pixi-build-cmake)
+│       ├── Pixi solve (pixi-build-cmake)
+│       │   └── Conda solve #0
+│       └── Pixi install #0
+└── Conda solve #1

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -340,6 +340,12 @@ impl SourceSpec {
     pub fn is_git(&self) -> bool {
         matches!(self, Self::Git(_))
     }
+
+    /// Converts this instance into a [`toml_edit::Value`].
+    pub fn to_toml_value(&self) -> toml_edit::Value {
+        ::serde::Serialize::serialize(self, toml_edit::ser::ValueSerializer::new())
+            .expect("conversion to toml cannot fail")
+    }
 }
 
 impl From<SourceSpec> for PixiSpec {

--- a/src/reporters/git.rs
+++ b/src/reporters/git.rs
@@ -70,7 +70,7 @@ impl GitCheckoutProgress {
 
 impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
     /// Called when a git checkout was queued on the [`CommandQueue`].
-    fn on_checkout_queued(
+    fn on_queued(
         &mut self,
         _context: Option<ReporterContext>,
         env: &RepositoryReference,
@@ -80,7 +80,7 @@ impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
         checkout_id
     }
 
-    fn on_checkout_start(&mut self, checkout_id: GitCheckoutId) {
+    fn on_start(&mut self, checkout_id: GitCheckoutId) {
         let pb = self.multi_progress.insert_after(
             self.last_progress_bar().unwrap_or(&self.anchor),
             ProgressBar::hidden(),
@@ -114,7 +114,7 @@ impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
         self.bars.insert(checkout_id, pb);
     }
 
-    fn on_checkout_finished(&mut self, checkout_id: GitCheckoutId) {
+    fn on_finished(&mut self, checkout_id: GitCheckoutId) {
         let removed_pb = self
             .bars
             .shift_remove(&checkout_id)


### PR DESCRIPTION
This PR adds the functionality to go from reporter events to a hierarchy that shows how the command dispatcher performed its work internally:

As an example:

```
Pixi solve (boost-check)
├── Source metadata ({ git = "https://github.com/wolfv/pixi-build-examples.git", rev = "a4c27e86a4a5395759486552abb3df8a47d50172", subdirectory = "boost-check" })
│   ├── Git Checkout (https://github.com/wolfv/pixi-build-examples@a4c27e86a4a5395759486552abb3df8a47d50172)
│   └── Instantiate tool environment (pixi-build-cmake)
│       ├── Pixi solve (pixi-build-cmake)
│       │   └── Conda solve #0
│       └── Pixi install #0
└── Conda solve #1
```

I think this could be quite useful for testing. Nothing in pixi itself was changed for this PR (except for some renames).