### PR TITLE
ci: update renovate rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,12 +17,6 @@
       "enabled": false
     },
     {
-      "description": "Rust >=1.85 is needed to update the cargo-machete action",
-      "matchPackageNames": "bnjbvr/cargo-machete",
-      "matchManagers": ["github-actions"],
-      "enabled": false
-    },
-    {
       "groupName": "Pixi",
       "matchManagers": ["pixi"]
     },
@@ -51,12 +45,6 @@
       "matchPackageNames": ["rattler*", "file_url"],
       "matchManagers": ["cargo"],
       "separateMajorMinor": false
-    },
-    {
-      "description": "Rust >=1.85 is needed to update deno_task_shell",
-      "matchPackageNames": "deno_task_shell",
-      "matchManagers": ["cargo"],
-      "enabled": false
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,7 +18,9 @@
     },
     {
       "groupName": "Pixi",
-      "matchManagers": ["pixi"]
+      "matchManagers": ["pixi"],
+      // We want to update Rust manually and keep it in sync with rust-toolchain
+      "excludePackagePatterns": ["rust"]
     },
     {
       "groupName": "Pixi-Lock",
@@ -26,25 +28,15 @@
       "matchUpdateTypes": ["lockFileMaintenance"]
     },
     {
-      "description": "We want to update Rust manually and keep it in sync with rust-toolchain",
-      "matchPackageNames": "rust",
-      "matchManagers": ["pixi"],
-      "enabled": false
-    },
-    {
       "groupName": "Cargo",
-      "matchManagers": ["cargo"]
+      "matchManagers": ["cargo"],
+      // We want to update rattler manually
+      "excludePackagePatterns": ["rattler*", "file_url"]
     },
     {
       "groupName": "Cargo-Lock",
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["lockFileMaintenance"]
-    },
-    {
-      "description": "We want a separate PR for rattler crates",
-      "matchPackageNames": ["rattler*", "file_url"],
-      "matchManagers": ["cargo"],
-      "separateMajorMinor": false
     }
   ]
 }


### PR DESCRIPTION
We are on Rust 1.86.0, so we don't need those rules anymore