### PR TITLE
docs: don't allow users to select the quotes

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -143,6 +143,9 @@ table code {
   overflow-x: auto;
   padding: 1rem 0;
   cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }
 
 .quote-scroll {


### PR DESCRIPTION
Avoids the quotes to be selected. 

This did look a little weird. Now you can grab and move the text without it getting selected.