### PR TITLE
feat: migrate to `uv_distribution_types` for package requirements and update uv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d14b66eac142247efb8561051ff0fb3d3f58a09801a541b89f46dcc4cc67b84"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
 dependencies = [
  "cfg-if",
  "home",
@@ -4243,7 +4243,7 @@ dependencies = [
  "serde",
  "unicode-width 0.2.0",
  "unscanny",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
 ]
 
 [[package]]
@@ -4265,7 +4265,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "url",
  "urlencoding",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
 ]
 
 [[package]]
@@ -4327,6 +4327,18 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.9.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.2",
+ "indexmap 2.9.0",
+ "serde",
 ]
 
 [[package]]
@@ -5169,15 +5181,15 @@ dependencies = [
 
 [[package]]
 name = "pubgrub"
-version = "0.3.0-alpha.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4#b70cf707aa43f21b32f3a61b8a0889b15032d5c4"
+version = "0.3.0"
+source = "git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db#06ec5a5f59ffaeb6cf5079c6cb184467da06c9db"
 dependencies = [
  "indexmap 2.9.0",
  "log",
  "priority-queue",
  "rustc-hash",
  "thiserror 2.0.12",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
 ]
 
 [[package]]
@@ -6070,7 +6082,7 @@ dependencies = [
  "futures",
  "indexmap 2.9.0",
  "itertools 0.14.0",
- "petgraph",
+ "petgraph 0.7.1",
  "tracing",
 ]
 
@@ -7794,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7820,13 +7832,14 @@ dependencies = [
 [[package]]
 name = "uv-build-backend"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "csv",
  "flate2",
  "fs-err",
  "globset",
  "itertools 0.14.0",
+ "schemars",
  "serde",
  "sha2",
  "spdx",
@@ -7837,14 +7850,16 @@ dependencies = [
  "uv-distribution-filename",
  "uv-fs",
  "uv-globfilter",
+ "uv-macros",
  "uv-normalize",
+ "uv-options-metadata",
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
  "walkdir",
  "zip",
 ]
@@ -7852,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anstream",
  "fs-err",
@@ -7886,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "nanoid",
@@ -7900,7 +7915,6 @@ dependencies = [
  "uv-cache-info",
  "uv-cache-key",
  "uv-dirs",
- "uv-distribution-filename",
  "uv-distribution-types",
  "uv-fs",
  "uv-normalize",
@@ -7912,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -7926,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "hex",
  "memchr",
@@ -7938,7 +7952,7 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7957,6 +7971,7 @@ dependencies = [
  "reqwest-retry",
  "rkyv",
  "rmp-serde",
+ "rustc-hash",
  "serde",
  "serde_json",
  "sys-info",
@@ -7979,6 +7994,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
+ "uv-redacted",
  "uv-small-str",
  "uv-static",
  "uv-torch",
@@ -7989,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "either",
  "fs-err",
@@ -8006,19 +8022,19 @@ dependencies = [
  "uv-cache",
  "uv-cache-info",
  "uv-cache-key",
+ "uv-distribution-types",
+ "uv-git",
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
- "uv-pypi-types",
  "uv-static",
- "which",
 ]
 
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "console",
 ]
@@ -8026,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -8037,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "futures",
@@ -8069,7 +8085,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "either",
@@ -8115,7 +8131,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "memchr",
  "rkyv",
@@ -8133,16 +8149,17 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "arcstr",
  "bitflags 2.9.0",
  "fs-err",
+ "http 1.3.1",
  "itertools 0.14.0",
  "jiff",
  "owo-colors",
  "percent-encoding",
- "petgraph",
+ "petgraph 0.8.1",
  "rkyv",
  "rustc-hash",
  "serde",
@@ -8162,17 +8179,18 @@ dependencies = [
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-small-str",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
 ]
 
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
  "async_zip",
+ "blake2",
  "fs-err",
  "futures",
  "md-5",
@@ -8194,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "backon",
  "dunce",
@@ -8205,7 +8223,7 @@ dependencies = [
  "junction",
  "path-slash",
  "percent-encoding",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "same-file",
  "schemars",
  "serde",
@@ -8218,7 +8236,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -8234,6 +8252,7 @@ dependencies = [
  "uv-cache-key",
  "uv-fs",
  "uv-git-types",
+ "uv-redacted",
  "uv-static",
  "uv-version",
  "which",
@@ -8242,20 +8261,22 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tracing",
  "url",
+ "uv-redacted",
 ]
 
 [[package]]
 name = "uv-globfilter"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "globset",
+ "owo-colors",
  "regex",
  "regex-automata 0.4.9",
  "thiserror 2.0.12",
@@ -8266,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "configparser",
  "csv",
@@ -8300,7 +8321,7 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8338,7 +8359,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8349,7 +8370,7 @@ dependencies = [
 [[package]]
 name = "uv-metadata"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "async_zip",
  "fs-err",
@@ -8357,6 +8378,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
+ "tracing",
  "uv-distribution-filename",
  "uv-normalize",
  "uv-pypi-types",
@@ -8366,9 +8388,10 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "rkyv",
+ "schemars",
  "serde",
  "uv-small-str",
 ]
@@ -8376,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "dashmap",
  "futures",
@@ -8386,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "serde",
 ]
@@ -8394,20 +8417,20 @@ dependencies = [
 [[package]]
 name = "uv-pep440"
 version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "rkyv",
  "serde",
  "tracing",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
  "unscanny",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
 ]
 
 [[package]]
 name = "uv-pep508"
 version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "arcstr",
  "boxcar",
@@ -8419,18 +8442,18 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 2.0.12",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
  "url",
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
- "version-ranges",
+ "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
 ]
 
 [[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "memchr",
  "rkyv",
@@ -8443,26 +8466,25 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "hashbrown 0.15.2",
  "indexmap 2.9.0",
  "itertools 0.14.0",
  "jiff",
  "mailparse",
- "petgraph",
+ "petgraph 0.8.1",
  "regex",
  "rkyv",
  "rustc-hash",
+ "schemars",
  "serde",
  "serde-untagged",
  "thiserror 2.0.12",
- "toml",
  "toml_edit",
  "tracing",
  "url",
  "uv-distribution-filename",
- "uv-fs",
  "uv-git-types",
  "uv-normalize",
  "uv-pep440",
@@ -8473,7 +8495,7 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "configparser",
@@ -8481,6 +8503,7 @@ dependencies = [
  "futures",
  "goblin",
  "itertools 0.14.0",
+ "once_cell",
  "owo-colors",
  "procfs",
  "regex",
@@ -8488,6 +8511,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "rmp-serde",
+ "rustc-hash",
  "same-file",
  "serde",
  "serde_json",
@@ -8523,9 +8547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-redacted"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
+dependencies = [
+ "url",
+]
+
+[[package]]
 name = "uv-requirements"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "configparser",
@@ -8560,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "memchr",
@@ -8583,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "arcstr",
  "clap",
@@ -8595,7 +8627,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "owo-colors",
- "petgraph",
+ "petgraph 0.8.1",
  "pubgrub",
  "rkyv",
  "rustc-hash",
@@ -8630,6 +8662,7 @@ dependencies = [
  "uv-requirements-txt",
  "uv-small-str",
  "uv-static",
+ "uv-torch",
  "uv-types",
  "uv-warnings",
  "uv-workspace",
@@ -8638,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "home",
@@ -8654,17 +8687,18 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "arcstr",
  "rkyv",
+ "schemars",
  "serde",
 ]
 
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -8674,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "uv-macros",
 ]
@@ -8682,13 +8716,14 @@ dependencies = [
 [[package]]
 name = "uv-torch"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "either",
  "fs-err",
  "serde",
  "thiserror 2.0.12",
  "tracing",
+ "url",
  "uv-distribution-types",
  "uv-normalize",
  "uv-pep440",
@@ -8699,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "thiserror 2.0.12",
@@ -8710,7 +8745,7 @@ dependencies = [
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anyhow",
  "rustc-hash",
@@ -8732,13 +8767,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.6.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+version = "0.7.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 
 [[package]]
 name = "uv-virtualenv"
 version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "itertools 0.14.0",
@@ -8756,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -8766,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.6.9#3d946027841ac949b9ecfd5ceaeec721836ee555"
+source = "git+https://github.com/astral-sh/uv?tag=0.7.8#0ddcc190556d9d20686bd81f17a364cf907e8f68"
 dependencies = [
  "fs-err",
  "glob",
@@ -8780,6 +8815,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "url",
+ "uv-build-backend",
  "uv-cache-key",
  "uv-distribution-types",
  "uv-fs",
@@ -8817,6 +8853,14 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.1"
+source = "git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db#06ec5a5f59ffaeb6cf5079c6cb184467da06c9db"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version-ranges"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,7 +4243,7 @@ dependencies = [
  "serde",
  "unicode-width 0.2.0",
  "unscanny",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -4265,7 +4265,7 @@ dependencies = [
  "unicode-width 0.2.0",
  "url",
  "urlencoding",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -5189,7 +5189,7 @@ dependencies = [
  "priority-queue",
  "rustc-hash",
  "thiserror 2.0.12",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -7859,7 +7859,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
+ "version-ranges",
  "walkdir",
  "zip",
 ]
@@ -8179,7 +8179,7 @@ dependencies = [
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-small-str",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -8424,7 +8424,7 @@ dependencies = [
  "tracing",
  "unicode-width 0.2.0",
  "unscanny",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -8447,7 +8447,7 @@ dependencies = [
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
- "version-ranges 0.1.1 (git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db)",
+ "version-ranges",
 ]
 
 [[package]]
@@ -8858,14 +8858,6 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 name = "version-ranges"
 version = "0.1.1"
 source = "git+https://github.com/astral-sh/pubgrub?rev=06ec5a5f59ffaeb6cf5079c6cb184467da06c9db#06ec5a5f59ffaeb6cf5079c6cb184467da06c9db"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "version-ranges"
-version = "0.1.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=b70cf707aa43f21b32f3a61b8a0889b15032d5c4#b70cf707aa43f21b32f3a61b8a0889b15032d5c4"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,15 +103,15 @@ toml_edit = "0.22.24"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 typed-path = "0.10.0"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
 
 wax = "0.6.0"
 which = "7.0.2"
@@ -137,22 +137,22 @@ rattler_virtual_packages = { version = "2.0.9", default-features = false }
 
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.6.9" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.7.8" }
 winapi = { version = "0.3.9", default-features = false }
 xxhash-rust = "0.8.15"
 zip = { version = "2.4.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,7 +390,7 @@ tokio = { workspace = true, features = ["rt"] }
 
 [patch.crates-io]
 # This is a temporary patch to get `cargo vendor` to work with the `uv` and pep508_rs` crates.
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "b70cf707aa43f21b32f3a61b8a0889b15032d5c4" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f59ffaeb6cf5079c6cb184467da06c9db" }
 
 # Config for 'dist'
 [workspace.metadata.dist]

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -302,7 +302,9 @@ pub fn to_parsed_git_url(
             Some(into_uv_git_sha(git_source.commit)),
         )
         .into_diagnostic()?,
-        git_source.subdirectory.map(|s| PathBuf::from(s.as_str())),
+        git_source
+            .subdirectory
+            .map(|s| PathBuf::from(s.as_str()).into_boxed_path()),
     );
 
     Ok(parsed_git_url)
@@ -317,12 +319,10 @@ pub fn to_uv_specifiers(
 }
 
 pub fn to_requirements<'req>(
-    requirements: impl Iterator<Item = &'req uv_pypi_types::Requirement>,
+    requirements: impl Iterator<Item = &'req uv_distribution_types::Requirement>,
 ) -> Result<Vec<pep508_rs::Requirement>, crate::ConversionError> {
     let requirements: Result<Vec<pep508_rs::Requirement>, _> = requirements
         .map(|requirement| {
-            let requirement: uv_pep508::Requirement<uv_pypi_types::VerbatimParsedUrl> =
-                uv_pep508::Requirement::from(requirement.clone());
             pep508_rs::Requirement::from_str(&requirement.to_string())
                 .map_err(crate::Pep508Error::Pep508Error)
         })

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -8,10 +8,11 @@ use std::{
 use thiserror::Error;
 use url::Url;
 use uv_distribution_filename::DistExtension;
+use uv_distribution_types::RequirementSource;
 use uv_normalize::{InvalidNameError, PackageName};
 use uv_pep440::VersionSpecifiers;
 use uv_pep508::VerbatimUrl;
-use uv_pypi_types::{ParsedPathUrl, ParsedUrl, RequirementSource, VerbatimParsedUrl};
+use uv_pypi_types::{ParsedPathUrl, ParsedUrl, VerbatimParsedUrl};
 
 use crate::{ConversionError, into_uv_git_reference, to_uv_marker_tree, to_uv_version_specifiers};
 
@@ -83,20 +84,24 @@ pub enum AsPep508Error {
     GitUrlParseError(#[from] uv_git_types::GitUrlParseError),
 }
 
-/// Convert into a [`uv_pypi_types::Requirement`], which is an uv extended
+/// Convert into a [`uv_distribution_types::Requirement`], which is an uv extended
 /// requirement type
 pub fn as_uv_req(
     req: &PixiPypiSpec,
     name: &str,
     project_root: &Path,
-) -> Result<uv_pypi_types::Requirement, AsPep508Error> {
+) -> Result<uv_distribution_types::Requirement, AsPep508Error> {
     let name = PackageName::from_str(name)?;
     let source = match req {
         PixiPypiSpec::Version { version, index, .. } => {
             // TODO: implement index later
             RequirementSource::Registry {
                 specifier: manifest_version_to_version_specifiers(version)?,
-                index: index.clone(),
+                index: index.clone().map(|url| {
+                    uv_distribution_types::IndexMetadata::from(
+                        uv_distribution_types::IndexUrl::from(VerbatimUrl::from_url(url)),
+                    )
+                }),
                 conflict: None,
             }
         }
@@ -136,7 +141,9 @@ pub fn as_uv_req(
                     .transpose()
                     .expect("could not parse sha"),
             )?,
-            subdirectory: subdirectory.as_ref().and_then(|s| s.parse().ok()),
+            subdirectory: subdirectory
+                .as_ref()
+                .map(|s| PathBuf::from(s).into_boxed_path()),
             // The full url used to clone, comparable to the git+ url in pip. e.g:
             // - 'git+SCHEMA://HOST/PATH@REF#subdirectory=SUBDIRECTORY'
             // - 'git+ssh://github.com/user/repo@d099af3b1028b00c232d8eda28a997984ae5848b'
@@ -168,7 +175,7 @@ pub fn as_uv_req(
 
             if canonicalized.is_dir() {
                 RequirementSource::Directory {
-                    install_path: canonicalized,
+                    install_path: canonicalized.into_boxed_path(),
                     editable: editable.unwrap_or_default(),
                     url: verbatim,
                     // TODO: we could see if we ever need this
@@ -183,7 +190,7 @@ pub fn as_uv_req(
                 }
             } else {
                 RequirementSource::Path {
-                    install_path: canonicalized,
+                    install_path: canonicalized.into_boxed_path(),
                     url: verbatim,
                     ext: DistExtension::from_path(path)?,
                 }
@@ -199,7 +206,9 @@ pub fn as_uv_req(
             let verbatim_url = VerbatimUrl::from_url(url.clone());
 
             RequirementSource::Url {
-                subdirectory: subdirectory.as_ref().map(|sub| PathBuf::from(sub.as_str())),
+                subdirectory: subdirectory
+                    .as_ref()
+                    .map(|sub| PathBuf::from(sub.as_str()).into_boxed_path()),
                 location: location_url,
                 url: verbatim_url,
                 ext: DistExtension::from_path(url.path())?,
@@ -212,7 +221,7 @@ pub fn as_uv_req(
         },
     };
 
-    Ok(uv_pypi_types::Requirement {
+    Ok(uv_distribution_types::Requirement {
         name: name.clone(),
         extras: req
             .extras()
@@ -226,10 +235,10 @@ pub fn as_uv_req(
     })
 }
 
-/// Convert a [`pep508_rs::Requirement`] into a [`uv_pypi_types::Requirement`]
+/// Convert a [`pep508_rs::Requirement`] into a [`uv_distribution_types::Requirement`]
 pub fn pep508_requirement_to_uv_requirement(
     requirement: pep508_rs::Requirement,
-) -> Result<uv_pypi_types::Requirement, ConversionError> {
+) -> Result<uv_distribution_types::Requirement, ConversionError> {
     let parsed_url = if let Some(version_or_url) = requirement.version_or_url {
         match version_or_url {
             pep508_rs::VersionOrUrl::VersionSpecifier(version) => Some(
@@ -250,7 +259,7 @@ pub fn pep508_requirement_to_uv_requirement(
                                 )
                             })?;
                         let parsed_url = ParsedUrl::Path(ParsedPathUrl::from_source(
-                            path.as_str().into(),
+                            PathBuf::from(path.as_str()).into_boxed_path(),
                             ext,
                             verbatim_url.to_url(),
                         ));

--- a/src/install_pypi/plan/test/harness.rs
+++ b/src/install_pypi/plan/test/harness.rs
@@ -28,7 +28,7 @@ impl InstalledDistBuilder {
         let registry = InstalledRegistryDist {
             name,
             version,
-            path,
+            path: path.into(),
             cache_info: None,
         };
         InstalledDist::Registry(registry)
@@ -52,6 +52,7 @@ impl InstalledDistBuilder {
             dir_info: uv_pypi_types::DirInfo {
                 editable: Some(editable),
             },
+            subdirectory: None,
         };
 
         let installed_direct_url = InstalledDirectUrlDist {
@@ -60,7 +61,7 @@ impl InstalledDistBuilder {
             direct_url: Box::new(direct_url.clone()),
             url: directory_url,
             editable,
-            path: install_path,
+            path: install_path.into(),
             cache_info: None,
         };
         (InstalledDist::Url(installed_direct_url), direct_url)
@@ -92,7 +93,7 @@ impl InstalledDistBuilder {
             direct_url: Box::new(direct_url.clone()),
             url,
             editable: false,
-            path: install_path,
+            path: install_path.into(),
             cache_info: None,
         };
         (InstalledDist::Url(installed_direct_url), direct_url)
@@ -131,7 +132,7 @@ impl InstalledDistBuilder {
             version,
             direct_url: Box::new(direct_url.clone()),
             url,
-            path: install_path,
+            path: install_path.into(),
             editable: false,
             cache_info: None,
         };
@@ -413,7 +414,7 @@ impl<'a> CachedDistProvider<'a> for AllCached {
                 .unwrap();
         let dist = uv_distribution_types::CachedRegistryDist {
             filename: wheel_filename,
-            path: Default::default(),
+            path: PathBuf::new().into(),
             hashes: vec![].into(),
             cache_info: Default::default(),
         };

--- a/src/install_pypi/plan/validation.rs
+++ b/src/install_pypi/plan/validation.rs
@@ -74,7 +74,11 @@ pub(crate) fn need_reinstall(
             };
 
             match direct_url_json {
-                uv_pypi_types::DirectUrl::LocalDirectory { url, dir_info } => {
+                uv_pypi_types::DirectUrl::LocalDirectory {
+                    url,
+                    dir_info,
+                    subdirectory: _,
+                } => {
                     // Recreate file url
                     let result = Url::parse(&url);
                     match result {

--- a/src/lock_file/package_identifier.rs
+++ b/src/lock_file/package_identifier.rs
@@ -135,7 +135,7 @@ impl PypiPackageIdentifier {
     /// in this package identifier.
     pub(crate) fn satisfies(
         &self,
-        requirement: &uv_pypi_types::Requirement,
+        requirement: &uv_distribution_types::Requirement,
     ) -> Result<bool, ConversionError> {
         // Verify the name of the package
         let uv_normalized = to_uv_normalize(self.name.as_normalized())?;
@@ -145,21 +145,21 @@ impl PypiPackageIdentifier {
 
         // Check the version of the requirement
         match &requirement.source {
-            uv_pypi_types::RequirementSource::Registry { specifier, .. } => {
+            uv_distribution_types::RequirementSource::Registry { specifier, .. } => {
                 let uv_version = to_uv_version(&self.version)?;
                 Ok(specifier.contains(&uv_version))
             }
             // a pypi -> conda requirement on these versions are not supported
-            uv_pypi_types::RequirementSource::Url { .. } => {
+            uv_distribution_types::RequirementSource::Url { .. } => {
                 unreachable!("direct url requirement on conda package is not supported")
             }
-            uv_pypi_types::RequirementSource::Git { .. } => {
+            uv_distribution_types::RequirementSource::Git { .. } => {
                 unreachable!("git requirement on conda package is not supported")
             }
-            uv_pypi_types::RequirementSource::Path { .. } => {
+            uv_distribution_types::RequirementSource::Path { .. } => {
                 unreachable!("path requirement on conda package is not supported")
             }
-            uv_pypi_types::RequirementSource::Directory { .. } => {
+            uv_distribution_types::RequirementSource::Directory { .. } => {
                 unreachable!("directory requirement on conda package is not supported")
             }
         }

--- a/src/lock_file/resolve/build_dispatch.rs
+++ b/src/lock_file/resolve/build_dispatch.rs
@@ -39,11 +39,11 @@ use uv_configuration::{
 };
 use uv_dispatch::{BuildDispatch, BuildDispatchError, SharedState};
 use uv_distribution_filename::DistFilename;
+use uv_distribution_types::Requirement;
 use uv_distribution_types::{
     CachedDist, DependencyMetadata, IndexLocations, IsBuildBackendError, Resolution, SourceDist,
 };
 use uv_install_wheel::LinkMode;
-use uv_pypi_types::Requirement;
 use uv_python::{Interpreter, InterpreterError, PythonEnvironment};
 use uv_resolver::{ExcludeNewer, FlatIndex};
 use uv_types::{BuildContext, BuildStack, HashStrategy};

--- a/src/lock_file/resolve/pypi.rs
+++ b/src/lock_file/resolve/pypi.rs
@@ -36,11 +36,12 @@ use url::Url;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_configuration::{ConfigSettings, Constraints, Overrides};
 use uv_distribution::DistributionDatabase;
+use uv_distribution_types::RequirementSource;
 use uv_distribution_types::{
     BuiltDist, DependencyMetadata, Diagnostic, Dist, FileLocation, HashPolicy, IndexCapabilities,
     IndexUrl, Name, Resolution, ResolvedDist, SourceDist, ToUrlError,
 };
-use uv_pypi_types::{Conflicts, HashAlgorithm, HashDigests, RequirementSource};
+use uv_pypi_types::{Conflicts, HashAlgorithm, HashDigests};
 use uv_requirements::LookaheadResolver;
 use uv_resolver::{
     AllowedYanks, DefaultResolverProvider, FlatIndex, InMemoryIndex, Manifest, Options, Preference,
@@ -81,7 +82,7 @@ fn parse_hashes_from_hash_vec(hashes: &HashDigests) -> Result<Option<PackageHash
             HashAlgorithm::Md5 => {
                 md5 = Some(hash.digest.to_string());
             }
-            HashAlgorithm::Sha384 | HashAlgorithm::Sha512 => {
+            HashAlgorithm::Sha384 | HashAlgorithm::Sha512 | HashAlgorithm::Blake2b => {
                 // We do not support these algorithms
             }
         }
@@ -314,7 +315,7 @@ pub async fn resolve_pypi(
     let index_strategy = to_index_strategy(pypi_options.index_strategy.as_ref());
     let mut uv_client_builder = RegistryClientBuilder::new(context.cache.clone())
         .allow_insecure_host(context.allow_insecure_host.clone())
-        .index_urls(index_locations.index_urls())
+        .index_locations(&index_locations)
         .index_strategy(index_strategy)
         .markers(&marker_environment)
         .keyring(context.keyring_provider)
@@ -332,19 +333,26 @@ pub async fn resolve_pypi(
             .into_diagnostic()?;
 
     // Resolve the flat indexes from `--find-links`.
-    let flat_index = {
-        let client = FlatIndexClient::new(&registry_client, &context.cache);
-        let entries = client
-            .fetch(
-                index_locations
-                    .flat_indexes()
-                    .map(uv_distribution_types::Index::url),
-            )
-            .await
-            .into_diagnostic()
-            .wrap_err("failed to query find-links locations")?;
-        FlatIndex::from_entries(entries, Some(&tags), &context.hash_strategy, &build_options)
-    };
+    // In UV 0.7.8, we need to fetch flat index entries from the index locations
+    let flat_index_client = FlatIndexClient::new(
+        registry_client.cached_client(),
+        Connectivity::Online,
+        &context.cache,
+    );
+    let flat_index_urls: Vec<&IndexUrl> = index_locations
+        .flat_indexes()
+        .map(|index| index.url())
+        .collect();
+    let flat_index_entries = flat_index_client
+        .fetch_all(flat_index_urls.into_iter())
+        .await
+        .into_diagnostic()?;
+    let flat_index = FlatIndex::from_entries(
+        flat_index_entries,
+        Some(&tags),
+        &context.hash_strategy,
+        &build_options,
+    );
 
     // Hi maintainers! For anyone coming here, if you expose any additional `uv` options, similar to `index_strategy`, make sure to
     // include them in this struct as well instead of relying on the default.
@@ -410,9 +418,9 @@ pub async fn resolve_pypi(
                 conflict: None,
             };
 
-            Ok::<_, ConversionError>(uv_pypi_types::Requirement {
+            Ok::<_, ConversionError>(uv_distribution_types::Requirement {
                 name: to_uv_normalize(p.name.as_normalized())?,
-                extras: vec![],
+                extras: vec![].into(),
                 marker: Default::default(),
                 source,
                 groups: Default::default(),
@@ -438,7 +446,7 @@ pub async fn resolve_pypi(
             let (package_data, _) = record;
             let requirement = uv_pep508::Requirement {
                 name: to_uv_normalize(&package_data.name)?,
-                extras: Vec::new(),
+                extras: Vec::new().into(),
                 version_or_url: Some(uv_pep508::VersionOrUrl::VersionSpecifier(
                     uv_pep440::VersionSpecifiers::from(
                         uv_pep440::VersionSpecifier::equals_version(to_uv_version(

--- a/src/lock_file/resolve/resolver_provider.rs
+++ b/src/lock_file/resolve/resolver_provider.rs
@@ -37,7 +37,7 @@ impl<Context: BuildContext> ResolverProvider for CondaResolverProvider<'_, Conte
     fn get_package_versions<'io>(
         &'io self,
         package_name: &'io uv_normalize::PackageName,
-        index: Option<&'io IndexUrl>,
+        index: Option<&'io uv_distribution_types::IndexMetadata>,
     ) -> impl Future<Output = uv_resolver::PackageVersionsResult> + 'io {
         if let Some((repodata_record, identifier)) = self.conda_python_identifiers.get(package_name)
         {
@@ -142,7 +142,7 @@ impl<Context: BuildContext> ResolverProvider for CondaResolverProvider<'_, Conte
                     metadata: Metadata {
                         name,
                         version,
-                        requires_dist: vec![],
+                        requires_dist: vec![].into(),
                         requires_python: None,
                         provides_extras: iden.extras.iter().cloned().collect(),
                         dependency_groups: Default::default(),

--- a/src/lock_file/satisfiability/mod.rs
+++ b/src/lock_file/satisfiability/mod.rs
@@ -32,8 +32,9 @@ use thiserror::Error;
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
 use uv_distribution_filename::{DistExtension, ExtensionError, SourceDistExtension};
+use uv_distribution_types::RequirementSource;
 use uv_git_types::GitReference;
-use uv_pypi_types::{ParsedUrlError, RequirementSource};
+use uv_pypi_types::ParsedUrlError;
 use uv_resolver::RequiresPython;
 
 use super::{
@@ -232,10 +233,10 @@ pub enum PlatformUnsat {
     FailedToConvertRequirement(pep508_rs::PackageName, #[source] Box<ParsedUrlError>),
 
     #[error("the requirement '{0}' could not be satisfied (required by '{1}')")]
-    UnsatisfiableRequirement(Box<uv_pypi_types::Requirement>, String),
+    UnsatisfiableRequirement(Box<uv_distribution_types::Requirement>, String),
 
     #[error("the conda package does not satisfy the pypi requirement '{0}' (required by '{1}')")]
-    CondaUnsatisfiableRequirement(Box<uv_pypi_types::Requirement>, String),
+    CondaUnsatisfiableRequirement(Box<uv_distribution_types::Requirement>, String),
 
     #[error("there was a duplicate entry for '{0}'")]
     DuplicateEntry(String),
@@ -279,7 +280,7 @@ pub enum PlatformUnsat {
     #[error("editable pypi dependency on conda resolved package '{0}' is not supported")]
     EditableDependencyOnCondaInstalledPackage(
         uv_normalize::PackageName,
-        Box<uv_pypi_types::RequirementSource>,
+        Box<uv_distribution_types::RequirementSource>,
     ),
 
     #[error("direct pypi url dependency to a conda installed package '{0}' is not supported")]
@@ -736,14 +737,14 @@ enum Dependency {
         SourceSpec,
         Cow<'static, str>,
     ),
-    PyPi(uv_pypi_types::Requirement, Cow<'static, str>),
+    PyPi(uv_distribution_types::Requirement, Cow<'static, str>),
 }
 
 /// Check satatisfiability of a pypi requirement against a locked pypi package
 /// This also does an additional check for git urls when using direct url
 /// references
 pub(crate) fn pypi_satifisfies_editable(
-    spec: &uv_pypi_types::Requirement,
+    spec: &uv_distribution_types::Requirement,
     locked_data: &PypiPackageData,
     project_root: &Path,
 ) -> Result<(), Box<PlatformUnsat>> {
@@ -782,11 +783,11 @@ pub(crate) fn pypi_satifisfies_editable(
                     ))
                 })?;
 
-                if &canocalized_path != install_path {
+                if &canocalized_path != install_path.as_ref() {
                     return Err(Box::new(PlatformUnsat::EditablePackagePathMismatch(
                         spec.name.clone(),
                         absolute_path.into_owned(),
-                        install_path.clone(),
+                        install_path.to_path_buf(),
                     )));
                 }
                 Ok(())
@@ -799,7 +800,7 @@ pub(crate) fn pypi_satifisfies_editable(
 /// This also does an additional check for git urls when using direct url
 /// references
 pub(crate) fn pypi_satifisfies_requirement(
-    spec: &uv_pypi_types::Requirement,
+    spec: &uv_distribution_types::Requirement,
     locked_data: &PypiPackageData,
     project_root: &Path,
 ) -> Result<(), Box<PlatformUnsat>> {
@@ -1222,7 +1223,7 @@ pub(crate) async fn verify_package_platform_satisfiability(
                                 // editable and vice versa.
                                 expected_editable_pypi_packages.insert(requirement.name.clone());
 
-                                FoundPackage::PyPi(PypiPackageIdx(idx), requirement.extras)
+                                FoundPackage::PyPi(PypiPackageIdx(idx), requirement.extras.to_vec())
                             } else {
                                 if let Err(err) = pypi_satifisfies_requirement(
                                     &requirement,
@@ -1232,7 +1233,7 @@ pub(crate) async fn verify_package_platform_satisfiability(
                                     delayed_pypi_error.get_or_insert(err);
                                 }
 
-                                FoundPackage::PyPi(PypiPackageIdx(idx), requirement.extras)
+                                FoundPackage::PyPi(PypiPackageIdx(idx), requirement.extras.to_vec())
                             }
                         }
                         Ok(None) => {


### PR DESCRIPTION
i had to adjust our index populating to fit our existing tests with the breaking changes from uv's side, there are also few name and function changes they made.