### PR TITLE
feat: enhance pixi task add CLI command to support issue #3828

### DIFF
--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -645,6 +645,8 @@ impl TasksControl<'_> {
                 description: None,
                 clean_env: false,
                 args: None,
+                inputs: None,
+                outputs: None,
             },
         }
     }


### PR DESCRIPTION
## Summary
This PR enhances the `pixi task add` CLI command to address all requirements from issue #3828.

## Changes Made

### 🔧 Enhanced CLI Features
- **Enhanced dependency parsing**: Support for `task:env` and `task::arg1,arg2` formats
- **Task arguments with defaults**: `--arg name` and `--arg name=default`
- **Inputs/outputs support**: `--inputs "*.rs"` and `--outputs "target/*"`
- **Alias creation**: Create aliases using `--depends-on` without commands
- **Validation**: Ensures either commands or dependencies are provided

### 🔄 Backward Compatibility
- All existing functionality preserved
- Existing task definitions continue to work unchanged
- No breaking changes to the API

### ✅ Testing
- Comprehensive manual testing of all new features
- All existing tests pass
- Fixed integration test compilation
- Clippy and formatting checks pass

## Example Usage

```bash
# Enhanced dependency with environment
pixi task add deploy --depends-on build:production

# Task with arguments and defaults
pixi task add compile echo "Mode: $MODE" --arg mode=debug

# Alias creation (no commands, just dependencies)
pixi task add test-all --depends-on test-unit test-integration

# With inputs and outputs
pixi task add build cargo build --inputs "src/**/*.rs" --outputs "target/debug/*"
```

Fixes #3828