### PR TITLE
fix: `pixi lock` reporting

### DIFF
--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -50,15 +50,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let json_diff = LockFileJsonDiff::new(Some(&workspace), diff);
         let json = serde_json::to_string_pretty(&json_diff).expect("failed to convert to json");
         println!("{}", json);
-    } else if diff.is_empty() {
+    } else if new_lock_file.was_outdated {
+        eprintln!(
+            "{}Updated lock-file",
+            console::style(console::Emoji("✔ ", "")).green()
+        );
+        diff.print()
+            .into_diagnostic()
+            .context("failed to print lock-file diff")?;
+    } else {
         eprintln!(
             "{}Lock-file was already up-to-date",
             console::style(console::Emoji("✔ ", "")).green()
         );
-    } else {
-        diff.print()
-            .into_diagnostic()
-            .context("failed to print lock-file diff")?;
     }
 
     // Return with a non-zero exit code if `--check` has been passed and the lock file has been updated

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -117,6 +117,7 @@ impl Workspace {
                 io_concurrency_limit: IoConcurrencyLimit::default(),
                 build_context: BuildContext::from_workspace(self, command_dispatcher)?,
                 glob_hash_cache,
+                was_outdated: false,
             });
         }
 
@@ -141,6 +142,7 @@ impl Workspace {
                 io_concurrency_limit: IoConcurrencyLimit::default(),
                 build_context: BuildContext::from_workspace(self, command_dispatcher)?,
                 glob_hash_cache,
+                was_outdated: false,
             });
         }
 
@@ -261,6 +263,9 @@ pub struct LockFileDerivedData<'p> {
 
     /// An object that caches input hashes
     pub glob_hash_cache: GlobHashCache,
+
+    /// Whether the lock file was outdated
+    pub was_outdated: bool,
 }
 
 /// The mode to use when updating a prefix.
@@ -1646,6 +1651,7 @@ impl<'p> UpdateContext<'p> {
             io_concurrency_limit: self.io_concurrency_limit,
             build_context: self.build_context,
             glob_hash_cache: self.glob_hash_cache,
+            was_outdated: true,
         })
     }
 }

--- a/src/workspace/workspace_mut.rs
+++ b/src/workspace/workspace_mut.rs
@@ -357,6 +357,7 @@ impl WorkspaceMut {
             build_context,
             glob_hash_cache,
             io_concurrency_limit,
+            was_outdated: _,
         } = UpdateContext::builder(self.workspace())
             .with_lock_file(unlocked_lock_file)
             .with_no_install(
@@ -409,6 +410,7 @@ impl WorkspaceMut {
             io_concurrency_limit,
             build_context,
             glob_hash_cache,
+            was_outdated: true,
         };
         if !lock_file_update_config.no_lockfile_update && !dry_run {
             updated_lock_file.write_to_disk()?;


### PR DESCRIPTION
We currently rely on the lock file diff to determine whether things have changed or not. However, not all changes are tracked there and we probably don't even certain changes to be reported.

This PR changes this check to directly record whether the lock file has been adapted