### PR TITLE
test: run slow tests in release mode

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -38,7 +38,7 @@ test-all-extra-slow = { depends-on = [
 test-all-fast = { depends-on = ["test-fast", "test-integration-fast"] }
 test-all-slow = { depends-on = ["test-slow", "test-integration-slow"] }
 test-fast = "cargo nextest run --workspace --all-targets"
-test-slow = """cargo nextest run --workspace --all-targets --retries 2 --features slow_integration_tests
+test-slow = """cargo nextest run --release --workspace --all-targets --retries 2 --features slow_integration_tests
               --status-level skip --failure-output immediate-final --no-fail-fast --final-status-level slow"""
 
 


### PR DESCRIPTION
It seems like we didn't run the slow tests in release mode. Since we do run the slow Python tests in release mode, it makes sense to use release mode as well