### PR TITLE
test: enable windows doc tests

### DIFF
--- a/tests/integration_python/test_docs_examples.py
+++ b/tests/integration_python/test_docs_examples.py
@@ -1,17 +1,10 @@
-import pytest
-from pathlib import Path
 import shutil
+from pathlib import Path
+
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
-
-from .common import verify_cli_command, repo_root, current_platform, get_manifest
-import sys
-
-
-pytestmark = pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Enable again as soon as pixi build supports windows builds with multiple platforms",
-)
+from .common import current_platform, get_manifest, repo_root, verify_cli_command
 
 
 @pytest.mark.extra_slow


### PR DESCRIPTION
We disabled doc tests on Windows early on, since Windows support wasn't really there then.

We for sure want to test this now.