### PR TITLE
ci: use utf-8 encoding for python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ env:
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
   XDG_CACHE_HOME: ${{ github.workspace }}/.cache
   PYTEST_ADDOPTS: "--color=yes"
+  PYTHONIOENCODING: utf-8 # necessary to make unicode symbols print correctly on Windows
 
   #
   # Select a profile that is used for building the binary. The profile optimizes for certain use-cases.


### PR DESCRIPTION
Otherwise unicode symbols are not displayed correctly for our Python tests on Windows