### PR TITLE
ci: stop using dev drive for cargo test windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,22 +241,19 @@ jobs:
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
     runs-on: windows_x64_2025_large
     steps:
+      # We don't use the dev drive here since we run out of space otherwise
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        # We don't put Pixi on the dev drive since it runs out of space otherwise
-      - name: Create Dev Drive
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1 -OnlyCargo
       - uses: prefix-dev/setup-pixi@main
         with:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
-          cache-directories: ${{ env.DEV_DRIVE }}/target
+          workspaces: ". -> target/pixi"
           key: ${{ hashFiles('pixi.lock') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Test pixi
         run: pixi run test-slow --retries 2
         env:
-          CARGO_TARGET_DIR: ${{ env.DEV_DRIVE }}/target
           PIXI_TEST_R2_ACCESS_KEY_ID: ${{ secrets.PIXI_TEST_R2_ACCESS_KEY_ID }}
           PIXI_TEST_R2_SECRET_ACCESS_KEY: ${{ secrets.PIXI_TEST_R2_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -1,10 +1,6 @@
 # Configures a drive for testing in CI.
 # Credits to astral-sh/uv: https://github.com/astral-sh/uv/blob/d2b9ffdc9e3f336e46b0af18a8554de560bfbefc/.github/workflows/setup-dev-drive.ps1
 
-param(
-    [switch]$OnlyCargo
-)
-
 # When not using a GitHub Actions "larger runner", the `D:` drive is present and
 # has similar or better performance characteristics than a ReFS dev drive.
 # Sometimes using a larger runner is still more performant (e.g., when running
@@ -61,13 +57,7 @@ Write-Output `
     "TEMP=$($Tmp)" `
     "RUSTUP_HOME=$($Drive)/.rustup" `
     "CARGO_HOME=$($Drive)/.cargo" `
+	"RATTLER_CACHE_DIR=$($Drive)/rattler-cache" `
+    "PIXI_HOME=$($Drive)/.pixi" `
+    "PIXI_WORKSPACE=$($Drive)/pixi" `
     >> $env:GITHUB_ENV
-
-# If not cargo-only mode, set additional Pixi-related environment variables
-if (-not $OnlyCargo) {
-    Write-Output `
-        "RATTLER_CACHE_DIR=$($Drive)/rattler-cache" `
-        "PIXI_HOME=$($Drive)/.pixi" `
-        "PIXI_WORKSPACE=$($Drive)/pixi" `
-        >> $env:GITHUB_ENV
-}


### PR DESCRIPTION
We ran out of space, so we only used cargo there.
But that conflicts with us setting cargo target dir in the pixi.toml. At this point it's not worth it IMO.
Let's just not use the dev drive for this job