### PR TITLE
fix: always pass index locations

### DIFF
--- a/src/install_pypi/mod.rs
+++ b/src/install_pypi/mod.rs
@@ -104,7 +104,8 @@ impl<'a> PyPIPrefixUpdaterBuilder<'a> {
             .allow_insecure_host(uv_context.allow_insecure_host.clone())
             .keyring(uv_context.keyring_provider)
             .connectivity(Connectivity::Online)
-            .extra_middleware(uv_context.extra_middleware.clone());
+            .extra_middleware(uv_context.extra_middleware.clone())
+            .index_locations(&index_locations);
 
         for p in &uv_context.proxies {
             uv_client_builder = uv_client_builder.proxy(p.clone())


### PR DESCRIPTION
fixes: https://github.com/prefix-dev/pixi/issues/3919
fixes: https://github.com/prefix-dev/pixi/issues/3937

## Overview of the problem
When installing PyPI packages that have build requirements, the build requirements solver wasn't configured to receive user-defined index locations


## How to verify it

you can use this pyproject.toml
```
[project]
name = "bug-demo"
requires-python = ">=3.10"
version = "0.1.0"

dependencies = ["pluggy"]

[build-system]
requires = [
  "boltons",
  "hatchling>=1.27.0",
]
build-backend = "hatchling.build"

[tool.hatch.build]
include = ["src"]
targets.wheel.strict-naming = false
targets.wheel.packages = ["src/bug_demo"]
targets.sdist.strict-naming = false
targets.sdist.packages = ["src/bug_demo"]


[tool.pixi.project]
channels = ["https://prefix.dev/conda-forge"]
platforms = ["linux-64", "osx-arm64"]

[tool.pixi.pypi-options]
index-url = "http://localhost:8080"

[tool.pixi.pypi-dependencies]
bug-demo = { path = ".", editable = true }
```

Download `only` hatchling package and put it in `./local-pypi-packages`
and use `pypi-server run -p 8080 ./local-pypi-packages --disable-fallback` .

running `pixi install` should fail ( without this fix it doesn't fail ) 


Note!
It is important to use pixi clean cache `--pypi` and always use `--disable-fallback`! Otherwise, pypi-server is falling back to pypi
And it's not possible to verify if the index location is used.
