### PR TITLE
feat: use ordermap instead of indexmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4095,6 +4095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordermap"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d31b8b7a99f71bdff4235faf9ce9eada0ad3562c8fbeb7d607d9f41a6ec569d"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4640,9 +4650,9 @@ dependencies = [
 name = "pixi_build_type_conversions"
 version = "0.1.0"
 dependencies = [
- "indexmap 2.9.0",
  "insta",
  "itertools 0.14.0",
+ "ordermap",
  "pixi_build_types",
  "pixi_manifest",
  "pixi_spec",
@@ -4654,7 +4664,7 @@ dependencies = [
 name = "pixi_build_types"
 version = "0.1.0"
 dependencies = [
- "indexmap 2.9.0",
+ "ordermap",
  "rattler_conda_types",
  "rattler_digest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ miette = { version = "7.5.0" }
 minijinja = "2.7.0"
 nix = { version = "0.29.0", default-features = false }
 once_cell = "1.20.3"
+ordermap = "0.5.7"
 parking_lot = "0.12.3"
 pathdiff = "0.2.3"
 pep440_rs = "0.7.3"

--- a/crates/pixi_build_type_conversions/Cargo.toml
+++ b/crates/pixi_build_type_conversions/Cargo.toml
@@ -10,8 +10,8 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
-indexmap = { workspace = true }
 itertools = { workspace = true }
+ordermap = { workspace = true, features = ["serde"] }
 pixi_build_types = { workspace = true }
 pixi_manifest = { workspace = true }
 pixi_spec = { workspace = true }

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -64,8 +64,8 @@ fn to_pixi_spec_v1(
                 file_name: nameless.file_name,
                 channel: nameless.channel.map(|c| c.base_url.url().clone().into()),
                 subdir: nameless.subdir,
-                md5: nameless.md5.map(Into::into),
-                sha256: nameless.sha256.map(Into::into),
+                md5: nameless.md5,
+                sha256: nameless.sha256,
             }))
         }
     };

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -6,11 +6,10 @@
 //! This will mostly be boilerplate conversions but some of these are a bit more
 //! interesting
 
+use ordermap::OrderMap;
 use std::collections::HashMap;
-
 // Namespace to pbt, *please use* exclusively so we do not get confused between the two
 // different types
-use indexmap::IndexMap;
 use pixi_build_types as pbt;
 use pixi_manifest::{PackageManifest, PackageTarget, TargetSelector, Targets};
 use pixi_spec::{GitReference, PixiSpec, SpecConversionError};
@@ -78,12 +77,12 @@ fn to_pixi_spec_v1(
 fn to_pbt_dependencies<'a>(
     iter: impl Iterator<Item = (&'a PackageName, &'a PixiSpec)>,
     channel_config: &ChannelConfig,
-) -> Result<IndexMap<pbt::SourcePackageName, pbt::PackageSpecV1>, SpecConversionError> {
+) -> Result<OrderMap<pbt::SourcePackageName, pbt::PackageSpecV1>, SpecConversionError> {
     iter.map(|(name, spec)| {
         let converted = to_pixi_spec_v1(spec, channel_config)?;
         Ok((name.as_normalized().to_string(), converted))
     })
-    .collect::<Result<IndexMap<_, _>, _>>()
+    .collect::<Result<OrderMap<_, _>, _>>()
 }
 
 /// Converts a [`PackageTarget`] to a [`pbt::TargetV1`].

--- a/crates/pixi_build_types/Cargo.toml
+++ b/crates/pixi_build_types/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
-indexmap = { workspace = true }
+ordermap = { workspace = true, features = ["serde"] }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -15,7 +15,7 @@
 //!
 //! Only the whole ProjectModel is versioned explicitly in an enum.
 //! When making a change to one of the types, be sure to add another enum declaration if it is breaking.
-use indexmap::IndexMap;
+use ordermap::OrderMap;
 use rattler_conda_types::{BuildNumberSpec, StringMatcher, Version, VersionSpec};
 use rattler_digest::{Md5, Md5Hash, Sha256, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Serialize};
@@ -161,20 +161,20 @@ pub struct TargetsV1 {
     pub targets: Option<HashMap<TargetSelectorV1, TargetV1>>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TargetV1 {
     /// Host dependencies of the project
-    pub host_dependencies: Option<IndexMap<SourcePackageName, PackageSpecV1>>,
+    pub host_dependencies: Option<OrderMap<SourcePackageName, PackageSpecV1>>,
 
     /// Build dependencies of the project
-    pub build_dependencies: Option<IndexMap<SourcePackageName, PackageSpecV1>>,
+    pub build_dependencies: Option<OrderMap<SourcePackageName, PackageSpecV1>>,
 
     /// Run dependencies of the project
-    pub run_dependencies: Option<IndexMap<SourcePackageName, PackageSpecV1>>,
+    pub run_dependencies: Option<OrderMap<SourcePackageName, PackageSpecV1>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum PackageSpecV1 {
     /// This is a binary dependency
@@ -183,7 +183,7 @@ pub enum PackageSpecV1 {
     Source(SourcePackageSpecV1),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub enum SourcePackageSpecV1 {
     /// The spec is represented as an archive that can be downloaded from the
     /// specified URL. The package should be retrieved from the URL and can
@@ -202,7 +202,7 @@ pub enum SourcePackageSpecV1 {
 }
 
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UrlSpecV1 {
     /// The URL of the package
@@ -233,7 +233,7 @@ impl std::fmt::Debug for UrlSpecV1 {
 }
 
 /// A specification of a package from a git repository.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GitSpecV1 {
     /// The git url of the package which can contain git+ prefixes.
@@ -247,7 +247,7 @@ pub struct GitSpecV1 {
 }
 
 /// A specification of a package from a path
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PathSpecV1 {
     /// The path to the package
@@ -255,7 +255,7 @@ pub struct PathSpecV1 {
 }
 
 /// A reference to a specific commit in a git repository.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum GitReferenceV1 {
     /// The HEAD commit of a branch.
@@ -273,7 +273,7 @@ pub enum GitReferenceV1 {
 
 /// Similar to a [`rattler_conda_types::NamelessMatchSpec`]
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default, Hash, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BinaryPackageSpecV1 {
     /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
@@ -291,9 +291,11 @@ pub struct BinaryPackageSpecV1 {
     /// The subdir of the channel
     pub subdir: Option<String>,
     /// The md5 hash of the package
-    pub md5: Option<SerializableHash<Md5>>,
+    #[serde_as(as = "Option<SerializableHash<Md5>>")]
+    pub md5: Option<Md5Hash>,
     /// The sha256 hash of the package
-    pub sha256: Option<SerializableHash<Sha256>>,
+    #[serde_as(as = "Option<SerializableHash<Sha256>>")]
+    pub sha256: Option<Sha256Hash>,
 }
 
 impl From<VersionSpec> for BinaryPackageSpecV1 {
@@ -337,10 +339,10 @@ impl std::fmt::Debug for BinaryPackageSpecV1 {
             debug_struct.field("subdir", subdir);
         }
         if let Some(md5) = &self.md5 {
-            debug_struct.field("md5", &format!("{:x}", md5.0));
+            debug_struct.field("md5", &format!("{:x}", md5));
         }
         if let Some(sha256) = &self.sha256 {
-            debug_struct.field("sha256", &format!("{:x}", sha256.0));
+            debug_struct.field("sha256", &format!("{:x}", sha256));
         }
 
         debug_struct.finish()
@@ -353,15 +355,15 @@ mod tests {
 
     fn create_sample_target_v1() -> TargetV1 {
         TargetV1 {
-            host_dependencies: Some(IndexMap::from([(
+            host_dependencies: Some(OrderMap::from([(
                 "host_dep1".to_string(),
                 PackageSpecV1::Binary(Box::default()),
             )])),
-            build_dependencies: Some(IndexMap::from([(
+            build_dependencies: Some(OrderMap::from([(
                 "build_dep1".to_string(),
                 PackageSpecV1::Binary(Box::default()),
             )])),
-            run_dependencies: Some(IndexMap::from([(
+            run_dependencies: Some(OrderMap::from([(
                 "run_dep1".to_string(),
                 PackageSpecV1::Binary(Box::default()),
             )])),

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -156,8 +156,6 @@ impl FromStr for TargetSelectorV1 {
 pub struct TargetsV1 {
     pub default_target: Option<TargetV1>,
 
-    /// We use an [`IndexMap`] to preserve the order in which the items where
-    /// defined in the manifest.
     pub targets: Option<HashMap<TargetSelectorV1, TargetV1>>,
 }
 


### PR DESCRIPTION
Use `ordermap` instead of `indexmap` so we can `Hash` structs. This change does not affect the API at all.

@Hofer-Julian We both need this change so I pulled it into a seperate PR.