### PR TITLE
fix: check for the environments not the environments dir

### DIFF
--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -349,7 +349,7 @@ impl Workspace {
             let detached_environments_path =
                 detached_environments_path.join(consts::ENVIRONMENTS_DIR);
             let _ = CUSTOM_TARGET_DIR_WARN.get_or_init(|| {
-                if default_envs_dir.exists() && !default_envs_dir.is_symlink() {
+                if !default_envs_dir.is_symlink() && self.environments().iter().any(|env| default_envs_dir.join(env.name().as_str()).exists()) {
                     tracing::warn!(
                         "Environments found in '{}', this will be ignored and the environment will be installed in the 'detached-environments' directory: '{}'. It's advised to remove the {} folder from the default directory to avoid confusion{}.",
                         default_envs_dir.display(),


### PR DESCRIPTION
Fixes #3030 

We incorrectly checked the environments' folder, so a warning was triggered every time on Windows. 

Also tested it on my windows machine.
