### PR TITLE
docs: update title pixi-diff-to-markdown

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,7 +156,7 @@ nav:
           - JupyterLab: integration/editor/jupyterlab.md
       - Continuous Integration:
           - GitHub Actions: integration/ci/github_actions.md
-          - Lockfile Updates: integration/ci/updates_github_actions.md
+          - Pixi Diff-to-markdown: integration/ci/updates_github_actions.md
       - Extensions:
           - Introduction: integration/extensions/introduction.md
           - Pixi Diff: integration/extensions/pixi_diff.md


### PR DESCRIPTION
Unfortunately there's a bug in mkdocs which doesn't allow another toc entry when the same file is used in different places. Let's use a common one we can live with