### PR TITLE
chore(build): improve logging for tool env instantiation

### DIFF
--- a/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
@@ -231,17 +231,17 @@ impl InstantiateToolEnvironmentSpec {
             .map_err_with(Box::new)
             .map_err_with(InstantiateToolEnvironmentError::SolveEnvironment)?;
 
-    if tracing::event_enabled!(tracing::Level::INFO) {
-        let packages_str = solved_environment
-            .iter()
-            .map(|p| {
-                let record = p.package_record();
-                format!("{}={}", record.name.as_normalized(), record.version)
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        tracing::info!("Packages in tool environment: {}", packages_str);
-}
+        if tracing::event_enabled!(tracing::Level::INFO) {
+            let packages_str = solved_environment
+                .iter()
+                .map(|p| {
+                    let record = p.package_record();
+                    format!("{}={}", record.name.as_normalized(), record.version)
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            tracing::info!("Packages in tool environment: {}", packages_str);
+        }
 
         // Ensure that solution contains matching api version package
         if !solved_environment


### PR DESCRIPTION
closes gh-4006

sample:

```console
 INFO solve{name="pixi-build-rattler-build" platform=osx-64}: pixi_command_dispatcher::solve_pixi: fetched 264 records in 728.639875ms
 INFO pixi_command_dispatcher::instantiate_tool_env: Packages in tool environment: pixi-build-rattler-build=0.1.15=h0dc7051_0, pixi-build-api-version=0=h4616a5c_0, liblzma=5.8.1=hd471939_2, libzlib=1.3.1=hd23fc13_2, openssl=3.5.0=hc426f3f_1, ca-certificates=2025.6.15=hbd8a1cb_0

 ╭─ Running build for recipe: meson-1.8.99-pyh4616a5c_0
```