### PR TITLE
fix: warn about no pinning strategy for unused features

### DIFF
--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -390,7 +390,7 @@ impl TomlManifest {
 
             warnings.push(Warning::from(
                 GenericError::new(format!(
-                    "The feature '{}' is defined but not used in any environment",
+                    "The feature '{}' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any set `pinning-strategy`",
                     feature_name
                 ))
                 .with_opt_span(span)

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_excluded_target_selector.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_excluded_target_selector.snap
@@ -16,7 +16,8 @@ expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"t
     ╰────
   help: Add one of 'osx-64', 'osx-arm64' to the supported platforms, using `pixi project platform add osx-64`
 
-  ⚠ The feature 'foo' is defined but not used in any environment
+  ⚠ The feature 'foo' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any
+  │ set `pinning-strategy`
    ╭─[pixi.toml:7:18]
  6 │
  7 │         [feature.foo]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_target_selector.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_target_selector.snap
@@ -16,7 +16,8 @@ expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"t
    ╰────
   help: Add osx-64 to the supported platforms, using `pixi project platform add osx-64`
 
-  ⚠ The feature 'foo' is defined but not used in any environment
+  ⚠ The feature 'foo' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any
+  │ set `pinning-strategy`
    ╭─[pixi.toml:7:18]
  6 │
  7 │         [feature.foo.target.osx-64.dependencies]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__unused_features.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__unused_features.snap
@@ -2,7 +2,8 @@
 source: crates/pixi_manifest/src/toml/manifest.rs
 expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"foo\"\n        channels = []\n        platforms = ['osx-64']\n\n        [feature.foobar.dependencies]\n\n        [feature.generic.target.osx.dependencies]\n        \"#,)"
 ---
-  ⚠ The feature 'foobar' is defined but not used in any environment
+  ⚠ The feature 'foobar' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any
+  │ set `pinning-strategy`
    ╭─[pixi.toml:7:18]
  6 │
  7 │         [feature.foobar.dependencies]
@@ -11,7 +12,8 @@ expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"f
    ╰────
   help: Remove the feature from the manifest or add it to an environment
 
-  ⚠ The feature 'generic' is defined but not used in any environment
+  ⚠ The feature 'generic' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding
+  │ any set `pinning-strategy`
     ╭─[pixi.toml:9:18]
   8 │
   9 │         [feature.generic.target.osx.dependencies]


### PR DESCRIPTION
This PR initially tried to fix https://github.com/prefix-dev/pixi/issues/3245 where users noticed that the dependency version pinning strategy is not applied in features that are not used by any environment. This is because right now the solver does not even run for the dependencies in an unused feature because there is no environment in which the solve could happen. One could run a sanity check solve for such an unused feature's dependencies but that would require quite some changes. For now I'd at least improve the warning that is shown when there is an unused feature and inform the user that those dependencies are not being resolved at all.