### PR TITLE
fix: update template variable for extra index URLs in init file

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -88,7 +88,7 @@ name = "{{ name }}"
 platforms = {{ platforms }}
 version = "{{ version }}"
 
-{%- if index_url or extra_indexes %}
+{%- if index_url or extra_index_urls %}
 
 [pypi-options]
 {% if index_url %}index-url = "{{ index_url }}"{% endif %}
@@ -192,7 +192,7 @@ channels = {{ channels }}
 platforms = {{ platforms }}
 
 
-{%- if index_url or extra_indexes %}
+{%- if index_url or extra_index_urls %}
 
 [tool.pixi.pypi-options]
 {% if index_url %}index-url = "{{ index_url }}"{% endif %}


### PR DESCRIPTION
fixes #4000 

FYI @nichmor 

I didn't add tests  - not sure where/how to add them. Feel free to add them...

--
Here is what I did locally to test this (`pixid` is the compiled version of my local repo):
```
❯ cat $PIXI_HOME/config.toml
[pypi-config]
extra-index-urls = ["http://localhost:9999/simple/"]

 # create projects:
❯ pixi init test-before
✔ Created $HOME/test-before/pixi.toml
❯ pixid init test-after
✔ Created $HOME/test-after/pixi.toml
```
```
# examine pixi.toml files:
# before:
❯ cat test-before/pixi.toml
```
```toml
[workspace]
channels = ["conda-forge"]
name = "test-before"
platforms = ["linux-64"]
version = "0.1.0"

[tasks]

[dependencies]
```
```
# after:
❯ cat test-after/pixi.toml
```
```toml
[workspace]
channels = ["conda-forge"]
name = "test-after"
platforms = ["linux-64"]
version = "0.1.0"

[pypi-options]

extra-index-urls = ["http://localhost:9999/simple/"]

[tasks]

[dependencies]
```