### PR TITLE
Use native tls roots with uv

### DIFF
--- a/src/install_pypi/mod.rs
+++ b/src/install_pypi/mod.rs
@@ -106,6 +106,7 @@ impl<'a> PyPIPrefixUpdaterBuilder<'a> {
             .keyring(uv_context.keyring_provider)
             .connectivity(Connectivity::Online)
             .extra_middleware(uv_context.extra_middleware.clone())
+            .native_tls(true)
             .index_locations(&index_locations);
 
         for p in &uv_context.proxies {

--- a/src/lock_file/resolve/pypi.rs
+++ b/src/lock_file/resolve/pypi.rs
@@ -338,6 +338,7 @@ pub async fn resolve_pypi(
         .markers(&marker_environment)
         .keyring(context.keyring_provider)
         .connectivity(Connectivity::Online)
+        .native_tls(true)
         .extra_middleware(context.extra_middleware.clone());
 
     for p in &context.proxies {


### PR DESCRIPTION
From https://docs.astral.sh/uv/reference/settings/#native-tls

> By default, uv loads certificates from the bundled webpki-roots crate. The webpki-roots are a reliable set of trust roots from Mozilla, and including them in uv improves portability and performance (especially on macOS).

> However, in some cases, you may want to use the platform's native certificate store, especially if you're relying on a corporate trust root (e.g., for a mandatory proxy) that's included in your system's certificate store.

Fixes #3359

Since pixi always uses native roots even when using rustls-tls, this should always be true as far as I understand it