### PR TITLE
feat: improve error messages when a python interpreter is needed

### DIFF
--- a/src/lock_file/resolve/build_dispatch.rs
+++ b/src/lock_file/resolve/build_dispatch.rs
@@ -212,7 +212,7 @@ enum LazyBuildDispatchError {
         "installation of conda environment is required to solve PyPI source dependencies but `--no-install` flag has been set"
     )]
     InstallationRequiredButDisallowed,
-    #[error("failed to initialize build dispatch: '{0}'")]
+    #[error("failed to initialize python build process: {0}")]
     InitializationError(String),
     #[error(transparent)]
     Uv(#[from] BuildDispatchError),
@@ -269,12 +269,10 @@ impl<'a> LazyBuildDispatch<'a> {
                 self.prefix_updater.name().as_str()
             );
 
-            let repodata_records = self.repodata_records.as_ref().map_err(|err| {
-                LazyBuildDispatchError::InitializationError(format!(
-                    "failed to get repodata of the building conda prefix: {}",
-                    err
-                ))
-            })?;
+            let repodata_records = self
+                .repodata_records
+                .as_ref()
+                .map_err(|err| LazyBuildDispatchError::InitializationError(format!("{}", err)))?;
 
             let prefix = self
                 .prefix_updater


### PR DESCRIPTION
I found that the error for the new behavior introduced here: https://github.com/prefix-dev/pixi/pull/4009 can be impoved.

This was before:
```
Error:   × failed to solve the pypi requirements of 'default' 'linux-64'
  ├─▶ Failed to build `rag @ file:///private/tmp/hang`
  ╰─▶ failed to initialize build dispatch: 'failed to get repodata of the building conda prefix: Unable to solve pypi dependencies for the default solve group — no compatible Python interpreter for 'osx-arm64''
```

This is after:
```
Error:   × failed to solve the pypi requirements of 'default' 'linux-64'
  ├─▶ Failed to build `rag @ file:///private/tmp/hang`
  ╰─▶ failed to initialize python build process: there is no compatible Python interpreter for 'osx-arm64'
```