### PR TITLE
feat: implement stable hash for ProjectModelV1 to improve cache consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ site/
 pytest-temp
 /vendor
 *.conda
+*.local.*

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -351,6 +351,8 @@ impl std::fmt::Debug for BinaryPackageSpecV1 {
 
 // Custom Hash implementations that skip default values for stability
 impl Hash for ProjectModelV1 {
+    /// Custom hash implementation that skips default/empty values to keep the hash
+    /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let ProjectModelV1 {
             name,
@@ -401,6 +403,8 @@ impl Hash for ProjectModelV1 {
 }
 
 impl Hash for TargetSelectorV1 {
+    /// Custom hash implementation that uses discriminant values to keep the hash
+    /// as stable as possible when adding new enum variants.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             TargetSelectorV1::Unix => 0u8.hash(state),
@@ -416,6 +420,8 @@ impl Hash for TargetSelectorV1 {
 }
 
 impl Hash for TargetsV1 {
+    /// Custom hash implementation that skips empty collections to keep the hash
+    /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let TargetsV1 {
             default_target,
@@ -434,6 +440,8 @@ impl Hash for TargetsV1 {
 }
 
 impl Hash for TargetV1 {
+    /// Custom hash implementation that skips empty collections to keep the hash
+    /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let TargetV1 {
             host_dependencies,
@@ -460,6 +468,8 @@ impl Hash for TargetV1 {
 }
 
 impl Hash for PackageSpecV1 {
+    /// Custom hash implementation that uses discriminant values to keep the hash
+    /// as stable as possible when adding new enum variants.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             PackageSpecV1::Binary(spec) => {
@@ -475,6 +485,8 @@ impl Hash for PackageSpecV1 {
 }
 
 impl Hash for SourcePackageSpecV1 {
+    /// Custom hash implementation that uses discriminant values to keep the hash
+    /// as stable as possible when adding new enum variants.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             SourcePackageSpecV1::Url(spec) => {
@@ -494,6 +506,8 @@ impl Hash for SourcePackageSpecV1 {
 }
 
 impl Hash for UrlSpecV1 {
+    /// Custom hash implementation that skips None values to keep the hash
+    /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let UrlSpecV1 { url, md5, sha256 } = self;
         
@@ -508,6 +522,8 @@ impl Hash for UrlSpecV1 {
 }
 
 impl Hash for GitSpecV1 {
+    /// Custom hash implementation that skips None values to keep the hash
+    /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let GitSpecV1 {
             git,
@@ -526,6 +542,7 @@ impl Hash for GitSpecV1 {
 }
 
 impl Hash for PathSpecV1 {
+    /// Custom hash implementation to keep the hash as stable as possible.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let PathSpecV1 { path } = self;
         
@@ -534,6 +551,8 @@ impl Hash for PathSpecV1 {
 }
 
 impl Hash for GitReferenceV1 {
+    /// Custom hash implementation that uses discriminant values to keep the hash
+    /// as stable as possible when adding new enum variants.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             GitReferenceV1::Branch(b) => {
@@ -556,6 +575,8 @@ impl Hash for GitReferenceV1 {
 }
 
 impl Hash for BinaryPackageSpecV1 {
+    /// Custom hash implementation that skips None values to keep the hash
+    /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let BinaryPackageSpecV1 {
             version,

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -619,8 +619,7 @@ impl Hash for BinaryPackageSpecV1 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
+    use std::hash::{DefaultHasher, Hash, Hasher};
 
     fn calculate_hash<T: Hash>(obj: &T) -> u64 {
         let mut hasher = DefaultHasher::new();
@@ -704,7 +703,7 @@ mod tests {
         let mut deps = OrderMap::new();
         deps.insert(
             "python".to_string(),
-            PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default())),
+            PackageSpecV1::Binary(Box::default()),
         );
 
         let target_with_deps = TargetV1 {
@@ -770,7 +769,7 @@ mod tests {
     #[test]
     fn test_enum_variant_hash_stability() {
         // Test PackageSpecV1 enum variants
-        let binary_spec = PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default()));
+        let binary_spec = PackageSpecV1::Binary(Box::default());
         let source_spec = PackageSpecV1::Source(SourcePackageSpecV1::Path(PathSpecV1 {
             path: "test".to_string(),
         }));
@@ -785,7 +784,7 @@ mod tests {
         );
 
         // Same variant with same content should have same hash
-        let binary_spec2 = PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default()));
+        let binary_spec2 = PackageSpecV1::Binary(Box::default());
         let hash3 = calculate_hash(&binary_spec2);
 
         assert_eq!(

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -367,7 +367,7 @@ impl Hash for ProjectModelV1 {
             documentation,
             targets,
         } = self;
-        
+
         name.hash(state);
         if let Some(version) = version {
             version.hash(state);
@@ -427,7 +427,7 @@ impl Hash for TargetsV1 {
             default_target,
             targets,
         } = self;
-        
+
         if let Some(default_target) = default_target {
             default_target.hash(state);
         }
@@ -448,7 +448,7 @@ impl Hash for TargetV1 {
             build_dependencies,
             run_dependencies,
         } = self;
-        
+
         if let Some(host_dependencies) = host_dependencies {
             if !host_dependencies.is_empty() {
                 host_dependencies.hash(state);
@@ -510,7 +510,7 @@ impl Hash for UrlSpecV1 {
     /// as stable as possible when adding new optional fields to the struct.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let UrlSpecV1 { url, md5, sha256 } = self;
-        
+
         url.hash(state);
         if let Some(md5) = md5 {
             md5.hash(state);
@@ -530,7 +530,7 @@ impl Hash for GitSpecV1 {
             rev,
             subdirectory,
         } = self;
-        
+
         git.hash(state);
         if let Some(rev) = rev {
             rev.hash(state);
@@ -545,7 +545,7 @@ impl Hash for PathSpecV1 {
     /// Custom hash implementation to keep the hash as stable as possible.
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let PathSpecV1 { path } = self;
-        
+
         path.hash(state);
     }
 }
@@ -588,7 +588,7 @@ impl Hash for BinaryPackageSpecV1 {
             md5,
             sha256,
         } = self;
-        
+
         if let Some(version) = version {
             version.hash(state);
         }

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -352,35 +352,49 @@ impl std::fmt::Debug for BinaryPackageSpecV1 {
 // Custom Hash implementations that skip default values for stability
 impl Hash for ProjectModelV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-        if let Some(ref version) = self.version {
+        let ProjectModelV1 {
+            name,
+            version,
+            description,
+            authors,
+            license,
+            license_file,
+            readme,
+            homepage,
+            repository,
+            documentation,
+            targets,
+        } = self;
+        
+        name.hash(state);
+        if let Some(version) = version {
             version.hash(state);
         }
-        if let Some(ref description) = self.description {
+        if let Some(description) = description {
             description.hash(state);
         }
-        if let Some(ref authors) = self.authors {
+        if let Some(authors) = authors {
             authors.hash(state);
         }
-        if let Some(ref license) = self.license {
+        if let Some(license) = license {
             license.hash(state);
         }
-        if let Some(ref license_file) = self.license_file {
+        if let Some(license_file) = license_file {
             license_file.hash(state);
         }
-        if let Some(ref readme) = self.readme {
+        if let Some(readme) = readme {
             readme.hash(state);
         }
-        if let Some(ref homepage) = self.homepage {
+        if let Some(homepage) = homepage {
             homepage.hash(state);
         }
-        if let Some(ref repository) = self.repository {
+        if let Some(repository) = repository {
             repository.hash(state);
         }
-        if let Some(ref documentation) = self.documentation {
+        if let Some(documentation) = documentation {
             documentation.hash(state);
         }
-        if let Some(ref targets) = self.targets {
+        if let Some(targets) = targets {
             targets.hash(state);
         }
     }
@@ -403,10 +417,15 @@ impl Hash for TargetSelectorV1 {
 
 impl Hash for TargetsV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        if let Some(ref default_target) = self.default_target {
+        let TargetsV1 {
+            default_target,
+            targets,
+        } = self;
+        
+        if let Some(default_target) = default_target {
             default_target.hash(state);
         }
-        if let Some(ref targets) = self.targets {
+        if let Some(targets) = targets {
             if !targets.is_empty() {
                 targets.hash(state);
             }
@@ -416,17 +435,23 @@ impl Hash for TargetsV1 {
 
 impl Hash for TargetV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        if let Some(ref host_dependencies) = self.host_dependencies {
+        let TargetV1 {
+            host_dependencies,
+            build_dependencies,
+            run_dependencies,
+        } = self;
+        
+        if let Some(host_dependencies) = host_dependencies {
             if !host_dependencies.is_empty() {
                 host_dependencies.hash(state);
             }
         }
-        if let Some(ref build_dependencies) = self.build_dependencies {
+        if let Some(build_dependencies) = build_dependencies {
             if !build_dependencies.is_empty() {
                 build_dependencies.hash(state);
             }
         }
-        if let Some(ref run_dependencies) = self.run_dependencies {
+        if let Some(run_dependencies) = run_dependencies {
             if !run_dependencies.is_empty() {
                 run_dependencies.hash(state);
             }
@@ -470,11 +495,13 @@ impl Hash for SourcePackageSpecV1 {
 
 impl Hash for UrlSpecV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.url.hash(state);
-        if let Some(ref md5) = self.md5 {
+        let UrlSpecV1 { url, md5, sha256 } = self;
+        
+        url.hash(state);
+        if let Some(md5) = md5 {
             md5.hash(state);
         }
-        if let Some(ref sha256) = self.sha256 {
+        if let Some(sha256) = sha256 {
             sha256.hash(state);
         }
     }
@@ -482,11 +509,17 @@ impl Hash for UrlSpecV1 {
 
 impl Hash for GitSpecV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.git.hash(state);
-        if let Some(ref rev) = self.rev {
+        let GitSpecV1 {
+            git,
+            rev,
+            subdirectory,
+        } = self;
+        
+        git.hash(state);
+        if let Some(rev) = rev {
             rev.hash(state);
         }
-        if let Some(ref subdirectory) = self.subdirectory {
+        if let Some(subdirectory) = subdirectory {
             subdirectory.hash(state);
         }
     }
@@ -494,7 +527,9 @@ impl Hash for GitSpecV1 {
 
 impl Hash for PathSpecV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.path.hash(state);
+        let PathSpecV1 { path } = self;
+        
+        path.hash(state);
     }
 }
 
@@ -522,28 +557,39 @@ impl Hash for GitReferenceV1 {
 
 impl Hash for BinaryPackageSpecV1 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        if let Some(ref version) = self.version {
+        let BinaryPackageSpecV1 {
+            version,
+            build,
+            build_number,
+            file_name,
+            channel,
+            subdir,
+            md5,
+            sha256,
+        } = self;
+        
+        if let Some(version) = version {
             version.hash(state);
         }
-        if let Some(ref build) = self.build {
+        if let Some(build) = build {
             build.hash(state);
         }
-        if let Some(ref build_number) = self.build_number {
+        if let Some(build_number) = build_number {
             build_number.hash(state);
         }
-        if let Some(ref file_name) = self.file_name {
+        if let Some(file_name) = file_name {
             file_name.hash(state);
         }
-        if let Some(ref channel) = self.channel {
+        if let Some(channel) = channel {
             channel.hash(state);
         }
-        if let Some(ref subdir) = self.subdir {
+        if let Some(subdir) = subdir {
             subdir.hash(state);
         }
-        if let Some(ref md5) = self.md5 {
+        if let Some(md5) = md5 {
             md5.hash(state);
         }
-        if let Some(ref sha256) = self.sha256 {
+        if let Some(sha256) = sha256 {
             sha256.hash(state);
         }
     }

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -577,16 +577,16 @@ mod tests {
             documentation: None,
             targets: None,
         };
-        
+
         let hash1 = calculate_hash(&project_model);
-        
+
         // Add empty targets field (should NOT change hash due to our custom implementation)
         project_model.targets = Some(TargetsV1 {
             default_target: None,
             targets: Some(OrderMap::new()),
         });
         let hash2 = calculate_hash(&project_model);
-        
+
         // Add a target with empty dependencies (should NOT change hash)
         let empty_target = TargetV1 {
             host_dependencies: Some(OrderMap::new()),
@@ -598,10 +598,16 @@ mod tests {
             targets: Some(OrderMap::new()),
         });
         let hash3 = calculate_hash(&project_model);
-        
+
         // Hash should remain the same when adding empty/default values
-        assert_eq!(hash1, hash2, "Hash should not change when adding empty targets");
-        assert_eq!(hash1, hash3, "Hash should not change when adding empty target with empty dependencies");
+        assert_eq!(
+            hash1, hash2,
+            "Hash should not change when adding empty targets"
+        );
+        assert_eq!(
+            hash1, hash3,
+            "Hash should not change when adding empty target with empty dependencies"
+        );
     }
 
     #[test]
@@ -620,17 +626,20 @@ mod tests {
             documentation: None,
             targets: None,
         };
-        
+
         let hash1 = calculate_hash(&project_model);
-        
+
         // Add a meaningful field (should change hash)
         project_model.description = Some("A test project".to_string());
         let hash2 = calculate_hash(&project_model);
-        
+
         // Add a real dependency (should change hash)
         let mut deps = OrderMap::new();
-        deps.insert("python".to_string(), PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default())));
-        
+        deps.insert(
+            "python".to_string(),
+            PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default())),
+        );
+
         let target_with_deps = TargetV1 {
             host_dependencies: Some(deps),
             build_dependencies: Some(OrderMap::new()),
@@ -641,18 +650,24 @@ mod tests {
             targets: Some(OrderMap::new()),
         });
         let hash3 = calculate_hash(&project_model);
-        
+
         // Hash should change when adding meaningful values
         assert_ne!(hash1, hash2, "Hash should change when adding description");
-        assert_ne!(hash1, hash3, "Hash should change when adding real dependency");
-        assert_ne!(hash2, hash3, "Hash should change when adding dependency to project with description");
+        assert_ne!(
+            hash1, hash3,
+            "Hash should change when adding real dependency"
+        );
+        assert_ne!(
+            hash2, hash3,
+            "Hash should change when adding dependency to project with description"
+        );
     }
 
     #[test]
     fn test_binary_package_spec_hash_stability() {
         let spec1 = BinaryPackageSpecV1::default();
         let hash1 = calculate_hash(&spec1);
-        
+
         // Create another default spec with explicit None values
         let spec2 = BinaryPackageSpecV1 {
             version: None,
@@ -665,18 +680,24 @@ mod tests {
             sha256: None,
         };
         let hash2 = calculate_hash(&spec2);
-        
+
         // Both should have the same hash since they're effectively the same
-        assert_eq!(hash1, hash2, "Default spec and explicit None spec should have same hash");
-        
+        assert_eq!(
+            hash1, hash2,
+            "Default spec and explicit None spec should have same hash"
+        );
+
         // Add a meaningful value
         let spec3 = BinaryPackageSpecV1 {
             file_name: Some("test.tar.bz2".to_string()),
             ..Default::default()
         };
         let hash3 = calculate_hash(&spec3);
-        
-        assert_ne!(hash1, hash3, "Hash should change when adding meaningful value");
+
+        assert_ne!(
+            hash1, hash3,
+            "Hash should change when adding meaningful value"
+        );
     }
 
     #[test]
@@ -686,18 +707,24 @@ mod tests {
         let source_spec = PackageSpecV1::Source(SourcePackageSpecV1::Path(PathSpecV1 {
             path: "test".to_string(),
         }));
-        
+
         let hash1 = calculate_hash(&binary_spec);
         let hash2 = calculate_hash(&source_spec);
-        
+
         // Different enum variants should have different hashes
-        assert_ne!(hash1, hash2, "Different enum variants should have different hashes");
-        
+        assert_ne!(
+            hash1, hash2,
+            "Different enum variants should have different hashes"
+        );
+
         // Same variant with same content should have same hash
         let binary_spec2 = PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default()));
         let hash3 = calculate_hash(&binary_spec2);
-        
-        assert_eq!(hash1, hash3, "Same enum variant with same content should have same hash");
+
+        assert_eq!(
+            hash1, hash3,
+            "Same enum variant with same content should have same hash"
+        );
     }
 
     fn create_sample_target_v1() -> TargetV1 {

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -701,10 +701,7 @@ mod tests {
 
         // Add a real dependency (should change hash)
         let mut deps = OrderMap::new();
-        deps.insert(
-            "python".to_string(),
-            PackageSpecV1::Binary(Box::default()),
-        );
+        deps.insert("python".to_string(), PackageSpecV1::Binary(Box::default()));
 
         let target_with_deps = TargetV1 {
             host_dependencies: Some(deps),

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -68,7 +68,7 @@ impl VersionedProjectModel {
 /// The source package name of a package. Not normalized per se.
 pub type SourcePackageName = String;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectModelV1 {
     /// The name of the project
@@ -114,7 +114,7 @@ impl From<ProjectModelV1> for VersionedProjectModel {
 
 /// Represents a target selector. Currently, we only support explicit platform
 /// selection.
-#[derive(Debug, Clone, DeserializeFromStr, SerializeDisplay, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, DeserializeFromStr, SerializeDisplay, Eq, PartialEq)]
 pub enum TargetSelectorV1 {
     // Platform specific configuration
     Unix,
@@ -151,7 +151,7 @@ impl FromStr for TargetSelectorV1 {
 }
 
 /// A collect of targets including a default target.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TargetsV1 {
     pub default_target: Option<TargetV1>,
@@ -161,7 +161,7 @@ pub struct TargetsV1 {
     pub targets: Option<OrderMap<TargetSelectorV1, TargetV1>>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TargetV1 {
     /// Host dependencies of the project
@@ -174,7 +174,7 @@ pub struct TargetV1 {
     pub run_dependencies: Option<OrderMap<SourcePackageName, PackageSpecV1>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum PackageSpecV1 {
     /// This is a binary dependency
@@ -183,7 +183,7 @@ pub enum PackageSpecV1 {
     Source(SourcePackageSpecV1),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum SourcePackageSpecV1 {
     /// The spec is represented as an archive that can be downloaded from the
     /// specified URL. The package should be retrieved from the URL and can
@@ -202,7 +202,7 @@ pub enum SourcePackageSpecV1 {
 }
 
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UrlSpecV1 {
     /// The URL of the package
@@ -233,7 +233,7 @@ impl std::fmt::Debug for UrlSpecV1 {
 }
 
 /// A specification of a package from a git repository.
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GitSpecV1 {
     /// The git url of the package which can contain git+ prefixes.
@@ -247,7 +247,7 @@ pub struct GitSpecV1 {
 }
 
 /// A specification of a package from a path
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PathSpecV1 {
     /// The path to the package
@@ -255,7 +255,7 @@ pub struct PathSpecV1 {
 }
 
 /// A reference to a specific commit in a git repository.
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum GitReferenceV1 {
     /// The HEAD commit of a branch.
@@ -273,7 +273,7 @@ pub enum GitReferenceV1 {
 
 /// Similar to a [`rattler_conda_types::NamelessMatchSpec`]
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize, Default, Hash, Eq, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Default, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BinaryPackageSpecV1 {
     /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
@@ -349,9 +349,356 @@ impl std::fmt::Debug for BinaryPackageSpecV1 {
     }
 }
 
+// Custom Hash implementations that skip default values for stability
+impl Hash for ProjectModelV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        if let Some(ref version) = self.version {
+            version.hash(state);
+        }
+        if let Some(ref description) = self.description {
+            description.hash(state);
+        }
+        if let Some(ref authors) = self.authors {
+            authors.hash(state);
+        }
+        if let Some(ref license) = self.license {
+            license.hash(state);
+        }
+        if let Some(ref license_file) = self.license_file {
+            license_file.hash(state);
+        }
+        if let Some(ref readme) = self.readme {
+            readme.hash(state);
+        }
+        if let Some(ref homepage) = self.homepage {
+            homepage.hash(state);
+        }
+        if let Some(ref repository) = self.repository {
+            repository.hash(state);
+        }
+        if let Some(ref documentation) = self.documentation {
+            documentation.hash(state);
+        }
+        if let Some(ref targets) = self.targets {
+            targets.hash(state);
+        }
+    }
+}
+
+impl Hash for TargetSelectorV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            TargetSelectorV1::Unix => 0u8.hash(state),
+            TargetSelectorV1::Linux => 1u8.hash(state),
+            TargetSelectorV1::Win => 2u8.hash(state),
+            TargetSelectorV1::MacOs => 3u8.hash(state),
+            TargetSelectorV1::Platform(p) => {
+                4u8.hash(state);
+                p.hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for TargetsV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if let Some(ref default_target) = self.default_target {
+            default_target.hash(state);
+        }
+        if let Some(ref targets) = self.targets {
+            if !targets.is_empty() {
+                targets.hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for TargetV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if let Some(ref host_dependencies) = self.host_dependencies {
+            if !host_dependencies.is_empty() {
+                host_dependencies.hash(state);
+            }
+        }
+        if let Some(ref build_dependencies) = self.build_dependencies {
+            if !build_dependencies.is_empty() {
+                build_dependencies.hash(state);
+            }
+        }
+        if let Some(ref run_dependencies) = self.run_dependencies {
+            if !run_dependencies.is_empty() {
+                run_dependencies.hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for PackageSpecV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            PackageSpecV1::Binary(spec) => {
+                0u8.hash(state);
+                spec.hash(state);
+            }
+            PackageSpecV1::Source(spec) => {
+                1u8.hash(state);
+                spec.hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for SourcePackageSpecV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            SourcePackageSpecV1::Url(spec) => {
+                0u8.hash(state);
+                spec.hash(state);
+            }
+            SourcePackageSpecV1::Git(spec) => {
+                1u8.hash(state);
+                spec.hash(state);
+            }
+            SourcePackageSpecV1::Path(spec) => {
+                2u8.hash(state);
+                spec.hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for UrlSpecV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.url.hash(state);
+        if let Some(ref md5) = self.md5 {
+            md5.hash(state);
+        }
+        if let Some(ref sha256) = self.sha256 {
+            sha256.hash(state);
+        }
+    }
+}
+
+impl Hash for GitSpecV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.git.hash(state);
+        if let Some(ref rev) = self.rev {
+            rev.hash(state);
+        }
+        if let Some(ref subdirectory) = self.subdirectory {
+            subdirectory.hash(state);
+        }
+    }
+}
+
+impl Hash for PathSpecV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.path.hash(state);
+    }
+}
+
+impl Hash for GitReferenceV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            GitReferenceV1::Branch(b) => {
+                0u8.hash(state);
+                b.hash(state);
+            }
+            GitReferenceV1::Tag(t) => {
+                1u8.hash(state);
+                t.hash(state);
+            }
+            GitReferenceV1::Rev(r) => {
+                2u8.hash(state);
+                r.hash(state);
+            }
+            GitReferenceV1::DefaultBranch => {
+                3u8.hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for BinaryPackageSpecV1 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if let Some(ref version) = self.version {
+            version.hash(state);
+        }
+        if let Some(ref build) = self.build {
+            build.hash(state);
+        }
+        if let Some(ref build_number) = self.build_number {
+            build_number.hash(state);
+        }
+        if let Some(ref file_name) = self.file_name {
+            file_name.hash(state);
+        }
+        if let Some(ref channel) = self.channel {
+            channel.hash(state);
+        }
+        if let Some(ref subdir) = self.subdir {
+            subdir.hash(state);
+        }
+        if let Some(ref md5) = self.md5 {
+            md5.hash(state);
+        }
+        if let Some(ref sha256) = self.sha256 {
+            sha256.hash(state);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    fn calculate_hash<T: Hash>(obj: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        obj.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn test_hash_stability_with_default_values() {
+        // Create a minimal ProjectModelV1 instance
+        let mut project_model = ProjectModelV1 {
+            name: "test-project".to_string(),
+            version: None,
+            description: None,
+            authors: None,
+            license: None,
+            license_file: None,
+            readme: None,
+            homepage: None,
+            repository: None,
+            documentation: None,
+            targets: None,
+        };
+        
+        let hash1 = calculate_hash(&project_model);
+        
+        // Add empty targets field (should NOT change hash due to our custom implementation)
+        project_model.targets = Some(TargetsV1 {
+            default_target: None,
+            targets: Some(OrderMap::new()),
+        });
+        let hash2 = calculate_hash(&project_model);
+        
+        // Add a target with empty dependencies (should NOT change hash)
+        let empty_target = TargetV1 {
+            host_dependencies: Some(OrderMap::new()),
+            build_dependencies: Some(OrderMap::new()),
+            run_dependencies: Some(OrderMap::new()),
+        };
+        project_model.targets = Some(TargetsV1 {
+            default_target: Some(empty_target),
+            targets: Some(OrderMap::new()),
+        });
+        let hash3 = calculate_hash(&project_model);
+        
+        // Hash should remain the same when adding empty/default values
+        assert_eq!(hash1, hash2, "Hash should not change when adding empty targets");
+        assert_eq!(hash1, hash3, "Hash should not change when adding empty target with empty dependencies");
+    }
+
+    #[test]
+    fn test_hash_changes_with_meaningful_values() {
+        // Create a minimal ProjectModelV1 instance
+        let mut project_model = ProjectModelV1 {
+            name: "test-project".to_string(),
+            version: None,
+            description: None,
+            authors: None,
+            license: None,
+            license_file: None,
+            readme: None,
+            homepage: None,
+            repository: None,
+            documentation: None,
+            targets: None,
+        };
+        
+        let hash1 = calculate_hash(&project_model);
+        
+        // Add a meaningful field (should change hash)
+        project_model.description = Some("A test project".to_string());
+        let hash2 = calculate_hash(&project_model);
+        
+        // Add a real dependency (should change hash)
+        let mut deps = OrderMap::new();
+        deps.insert("python".to_string(), PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default())));
+        
+        let target_with_deps = TargetV1 {
+            host_dependencies: Some(deps),
+            build_dependencies: Some(OrderMap::new()),
+            run_dependencies: Some(OrderMap::new()),
+        };
+        project_model.targets = Some(TargetsV1 {
+            default_target: Some(target_with_deps),
+            targets: Some(OrderMap::new()),
+        });
+        let hash3 = calculate_hash(&project_model);
+        
+        // Hash should change when adding meaningful values
+        assert_ne!(hash1, hash2, "Hash should change when adding description");
+        assert_ne!(hash1, hash3, "Hash should change when adding real dependency");
+        assert_ne!(hash2, hash3, "Hash should change when adding dependency to project with description");
+    }
+
+    #[test]
+    fn test_binary_package_spec_hash_stability() {
+        let spec1 = BinaryPackageSpecV1::default();
+        let hash1 = calculate_hash(&spec1);
+        
+        // Create another default spec with explicit None values
+        let spec2 = BinaryPackageSpecV1 {
+            version: None,
+            build: None,
+            build_number: None,
+            file_name: None,
+            channel: None,
+            subdir: None,
+            md5: None,
+            sha256: None,
+        };
+        let hash2 = calculate_hash(&spec2);
+        
+        // Both should have the same hash since they're effectively the same
+        assert_eq!(hash1, hash2, "Default spec and explicit None spec should have same hash");
+        
+        // Add a meaningful value
+        let spec3 = BinaryPackageSpecV1 {
+            file_name: Some("test.tar.bz2".to_string()),
+            ..Default::default()
+        };
+        let hash3 = calculate_hash(&spec3);
+        
+        assert_ne!(hash1, hash3, "Hash should change when adding meaningful value");
+    }
+
+    #[test]
+    fn test_enum_variant_hash_stability() {
+        // Test PackageSpecV1 enum variants
+        let binary_spec = PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default()));
+        let source_spec = PackageSpecV1::Source(SourcePackageSpecV1::Path(PathSpecV1 {
+            path: "test".to_string(),
+        }));
+        
+        let hash1 = calculate_hash(&binary_spec);
+        let hash2 = calculate_hash(&source_spec);
+        
+        // Different enum variants should have different hashes
+        assert_ne!(hash1, hash2, "Different enum variants should have different hashes");
+        
+        // Same variant with same content should have same hash
+        let binary_spec2 = PackageSpecV1::Binary(Box::new(BinaryPackageSpecV1::default()));
+        let hash3 = calculate_hash(&binary_spec2);
+        
+        assert_eq!(hash1, hash3, "Same enum variant with same content should have same hash");
+    }
 
     fn create_sample_target_v1() -> TargetV1 {
         TargetV1 {

--- a/crates/pixi_glob/src/snapshots/pixi_glob__glob_hash__test__glob_hash_case_1_satisfiability.snap
+++ b/crates/pixi_glob/src/snapshots/pixi_glob__glob_hash__test__glob_hash_case_1_satisfiability.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 Globs:
 - tests/data/satisfiability/source-dependency/**/*
-Hash: 2af8b3776309635d86d34ffe69185add140ef7de69f06de2adb4ebc96e8899d5
+Hash: 8151bbd1583b71eee793ac0415b624bbb16f83353528773073c22836739b1009
 Matched files:
 - tests/data/satisfiability/source-dependency/child-package/pixi.toml
 - tests/data/satisfiability/source-dependency/pixi.lock

--- a/src/lock_file/satisfiability/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@source-dependency-changed-project-model.snap
+++ b/src/lock_file/satisfiability/snapshots/pixi__lock_file__satisfiability__tests__failing_satisiability@source-dependency-changed-project-model.snap
@@ -4,4 +4,4 @@ expression: s
 ---
 environment 'default' does not satisfy the requirements of the project for platform 'linux-64'
     Diagnostic severity: error
-    Caused by: the input hash for 'child-package' (ad12699c055c41f25e89c25aa8d89c24cb87050356ca4df340d6b5d8b8d6e39d) does not match the hash in the lock-file (f367fc1db50bc77106ba19cc044ed55e397d5ae9880e4d631cde0d9a884573a8)
+    Caused by: the input hash for 'child-package' (739fe1749de1ec9d6d857d63fcea2e291b51a42d265e79c54688d3baf971f5d0) does not match the hash in the lock-file (78aeb8c1b1c88409ca82cd8dd726f94441fe5c9b8940301113491f08caed4b21)

--- a/tests/data/non-satisfiability/source-dependency-changed-project-model/pixi.lock
+++ b/tests/data/non-satisfiability/source-dependency-changed-project-model/pixi.lock
@@ -41,7 +41,7 @@ packages:
   - libstdcxx >=15
   - libgcc >=15
   input:
-    hash: f367fc1db50bc77106ba19cc044ed55e397d5ae9880e4d631cde0d9a884573a8
+    hash: 78aeb8c1b1c88409ca82cd8dd726f94441fe5c9b8940301113491f08caed4b21
     globs: []
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
   sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195

--- a/tests/data/satisfiability/source-dependency/pixi.lock
+++ b/tests/data/satisfiability/source-dependency/pixi.lock
@@ -41,7 +41,7 @@ packages:
   - libstdcxx >=15
   - libgcc >=15
   input:
-    hash: f367fc1db50bc77106ba19cc044ed55e397d5ae9880e4d631cde0d9a884573a8
+    hash: 78aeb8c1b1c88409ca82cd8dd726f94441fe5c9b8940301113491f08caed4b21
     globs: []
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
   sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195


### PR DESCRIPTION
## Summary

Implements custom Hash traits for ProjectModelV1 and all nested types that skip default/empty values in hash calculation for better stability. This allows adding new optional fields without breaking existing hashes, improving cache consistency and reducing unnecessary rebuilds.

## Technical Details

- Removed `#[derive(Hash)]` from all ProjectModelV1 types
- Implemented manual Hash traits that ignore:
  - `None` values in Option fields  
  - Empty OrderMap collections
  - Default struct values
- Used discriminant values for enum variants to ensure consistency
- Added .gitignore pattern for `*.local.*` files

## Before/After Behavior

**Before**: Adding any new field would change the hash, breaking cache invalidation
```rust
// Adding a new optional field would change hash even if None
pub struct ProjectModelV1 {
    pub name: String,
    pub new_field: Option<String>, // This would break existing hashes
    // ...
}
```

**After**: Adding new optional fields with default values doesn't affect hash
```rust  
// Hash remains stable when new fields are None or empty
impl Hash for ProjectModelV1 {
    fn hash<H: Hasher>(&self, state: &mut H) {
        self.name.hash(state);
        if let Some(ref new_field) = self.new_field {
            new_field.hash(state); // Only hashes if Some()
        }
    }
}
```

## Testing

Added 4 comprehensive tests covering:
- Hash stability with default values - ensures empty/None values don't change hash
- Hash changes with meaningful values - verifies real changes still affect hash  
- Binary package spec stability - tests default vs explicit None equality
- Enum variant consistency - validates same variants hash identically

## Benefits

- **Forward compatibility**: Adding new optional fields won't break existing hashes
- **Cache stability**: Reduces unnecessary cache invalidation and rebuilds
- **Development workflow**: Safer to extend ProjectModelV1 structure over time