### PR TITLE
`init --import enviornment.yml --format pyproject` now runs without error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ pytest-temp
 /vendor
 *.conda
 *.local.*
+.history
+/__*


### PR DESCRIPTION
fixes #2523

Done at SciPy sprints 2025! @wolfv @ruben-arts 

Currently produces a valid pyproject.toml file, probably not yet complete. There's kind of a tangle of conditionals in `init.rs`, so we should probably have a conversation about intended behavior.

Might also have some overlap with #4096