### PR TITLE
fix: docs hash mismatch

### DIFF
--- a/docs/source_files/pixi_workspaces/pixi_build/advanced_cpp/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/advanced_cpp/pixi.lock
@@ -178,7 +178,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 5b55be93b3b82bea6d11d541c5c39f14ee9182919dd1198d9458d4144a4443a7
+    hash: 1ded8248b4c2fcc0265109ac1490b3f09ee5435517d0f1e70c69abe2eb47830a
     globs:
     - recipe.yaml
 - conda: .
@@ -190,7 +190,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 5b55be93b3b82bea6d11d541c5c39f14ee9182919dd1198d9458d4144a4443a7
+    hash: 1ded8248b4c2fcc0265109ac1490b3f09ee5435517d0f1e70c69abe2eb47830a
     globs:
     - recipe.yaml
 - conda: .
@@ -203,7 +203,7 @@ packages:
   - vc14_runtime >=14.16.27033
   - python_abi 3.12.* *_cp312
   input:
-    hash: 5b55be93b3b82bea6d11d541c5c39f14ee9182919dd1198d9458d4144a4443a7
+    hash: 1ded8248b4c2fcc0265109ac1490b3f09ee5435517d0f1e70c69abe2eb47830a
     globs:
     - recipe.yaml
 - conda: .
@@ -216,7 +216,7 @@ packages:
   - libgcc >=15
   - python_abi 3.12.* *_cp312
   input:
-    hash: 5b55be93b3b82bea6d11d541c5c39f14ee9182919dd1198d9458d4144a4443a7
+    hash: 1ded8248b4c2fcc0265109ac1490b3f09ee5435517d0f1e70c69abe2eb47830a
     globs:
     - recipe.yaml
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda

--- a/docs/source_files/pixi_workspaces/pixi_build/cpp/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/cpp/pixi.lock
@@ -179,7 +179,7 @@ packages:
   - libgcc >=15
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: .
   name: cpp_math
@@ -190,7 +190,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: .
   name: cpp_math
@@ -201,7 +201,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: .
   name: cpp_math
@@ -214,7 +214,7 @@ packages:
   - ucrt >=10.0.20348.0
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe

--- a/docs/source_files/pixi_workspaces/pixi_build/getting_started/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/getting_started/pixi.lock
@@ -729,7 +729,7 @@ packages:
   - rich 13.9.*
   - python
   input:
-    hash: 59c64633228bda74cb147f1415c99d4827e2edb7883520555569262724396c3a
+    hash: caed070f36e08e1cd2cd126bdd8b0f46c080e248f6d8b2ee62ae97cb218066bc
     globs: []
 - conda: ./recipe_by_file/recipe.yaml
   name: python_rich_by_file

--- a/docs/source_files/pixi_workspaces/pixi_build/python/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/python/pixi.lock
@@ -711,7 +711,7 @@ packages:
   - rich 13.9.*
   - python
   input:
-    hash: 59c64633228bda74cb147f1415c99d4827e2edb7883520555569262724396c3a
+    hash: caed070f36e08e1cd2cd126bdd8b0f46c080e248f6d8b2ee62ae97cb218066bc
     globs: []
 - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.lock
@@ -204,7 +204,7 @@ packages:
   - libgcc >=15
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -215,7 +215,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -226,7 +226,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -239,7 +239,7 @@ packages:
   - ucrt >=10.0.20348.0
   - python_abi 3.12.* *_cp312
   input:
-    hash: 36b915bcd3b835a2415c78c91d086f45b1426a686b8ffe190ac5e0a2c61024e9
+    hash: e208e555c3381ceb4b706043a5353589b65f79e9051158181a6d97894835a77a
     globs: []
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
@@ -772,7 +772,7 @@ packages:
   - rich 13.9.*
   - python
   input:
-    hash: 406279907173f5f938569e80d200869af47888ecb831b8d1ac7c753f53354570
+    hash: 3a583987145baa9b41d19a5bdc9c323a4cf20883b9c4b7f8ff3a87078546fc22
     globs: []
   sources:
     cpp_math:

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.lock
@@ -438,7 +438,7 @@ packages:
   - libgcc >=15
   - python_abi 3.11.* *_cp311
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -449,7 +449,7 @@ packages:
   - libcxx >=20
   - python_abi 3.11.* *_cp311
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -460,7 +460,7 @@ packages:
   - libcxx >=20
   - python_abi 3.11.* *_cp311
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -473,7 +473,7 @@ packages:
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -485,7 +485,7 @@ packages:
   - libgcc >=15
   - python_abi 3.12.* *_cp312
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -496,7 +496,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -507,7 +507,7 @@ packages:
   - libcxx >=20
   - python_abi 3.12.* *_cp312
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: packages/cpp_math
   name: cpp_math
@@ -520,7 +520,7 @@ packages:
   - ucrt >=10.0.20348.0
   - python_abi 3.12.* *_cp312
   input:
-    hash: 7e70cb22029453824857bc6f17a3e3b4fac8a6e1a070133ed207bc5dbee904e0
+    hash: 4fbee37587da7082f043da95d7ff73402ffe968386b69f5bb6879bc0c7703cd2
     globs: []
 - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_2.conda
   sha256: 7c91cea91b13f4314d125d1bedb9d03a29ebbd5080ccdea70260363424646dbe
@@ -1186,7 +1186,7 @@ packages:
   - rich >=13.9.4,<14
   - python
   input:
-    hash: 192af99f337859c9745cb4586ef1441f85b40aa81f2d1e5f743704a5c7ebde4c
+    hash: a8cfb006938cd10f70d3617f813084adcf8525b92dcc18830b1fb355ad4d672d
     globs: []
   sources:
     cpp_math:


### PR DESCRIPTION
Fixes the docs testing issue on `main` that was introduced by [#4153](https://github.com/prefix-dev/pixi/pull/4153)