### PR TITLE
fix: support for loong64 linux

### DIFF
--- a/.github/workflows/trampoline.yaml
+++ b/.github/workflows/trampoline.yaml
@@ -38,6 +38,10 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             os: ubuntu-latest
 
+          - name: "Linux-loong64"
+            target: loongarch64-unknown-linux-gnu
+            os: ubuntu-latest
+
           - name: "macOS-x86"
             target: x86_64-apple-darwin
             os: macos-13

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -189,6 +189,7 @@ fn get_arch_tags(platform: Platform) -> Result<uv_platform_tags::Arch, PyPITagEr
         Some(Arch::Ppc64) => Ok(uv_platform_tags::Arch::Powerpc64),
         Some(Arch::Riscv64) => Ok(uv_platform_tags::Arch::Riscv64),
         Some(Arch::S390X) => Ok(uv_platform_tags::Arch::S390X),
+        Some(Arch::Loong64) => Ok(uv_platform_tags::Arch::LoongArch64),
         Some(unsupported_arch) => Err(PyPITagError::FailedToDetermineArchTags(unsupported_arch)),
     }
 }

--- a/src/global/trampoline.rs
+++ b/src/global/trampoline.rs
@@ -74,6 +74,11 @@ const TRAMPOLINE_BIN: &[u8] =
 const TRAMPOLINE_BIN: &[u8] =
     include_bytes!("../../trampoline/binaries/pixi-trampoline-x86_64-unknown-linux-musl.zst");
 
+#[cfg(target_arch = "loongarch64")]
+#[cfg(target_os = "linux")]
+const TRAMPOLINE_BIN: &[u8] =
+    include_bytes!("../../trampoline/binaries/pixi-trampoline-loongarch64-unknown-linux-gnu.zst");
+
 // trampoline configuration folder name
 pub const TRAMPOLINE_CONFIGURATION: &str = "trampoline_configuration";
 // original trampoline binary name


### PR DESCRIPTION
[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

I've added support of loong64 upstream in https://github.com/conda/rattler/pull/1534 so we may take it forward now.