### PR TITLE
feat: prevent pixi init to be executed in parent of pixi home directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,6 +4309,7 @@ dependencies = [
  "reqwest-middleware",
  "rlimit",
  "rstest",
+ "same-file",
  "self-replace",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ reqwest-middleware = "0.4"
 reqwest-retry = "0.7.0"
 rlimit = "0.10.2"
 rstest = "0.25.0"
+same-file = "1.0.6"
 self-replace = "1.5.0"
 serde = "1.0.218"
 serde-untagged = "0.1.6"
@@ -327,6 +328,7 @@ reqwest = { workspace = true, features = [
 ] }
 reqwest-middleware = { workspace = true }
 rlimit = { workspace = true }
+same-file = { workspace = true }
 self-replace = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -10,7 +10,7 @@ use std::{
 use clap::{Parser, ValueEnum};
 use miette::{Context, IntoDiagnostic};
 use minijinja::{Environment, context};
-use pixi_config::{get_default_author, pixi_home, Config};
+use pixi_config::{Config, get_default_author, pixi_home};
 use pixi_consts::consts;
 use pixi_manifest::{
     DependencyOverwriteBehavior, FeatureName, SpecType, pyproject::PyProjectManifest,
@@ -276,9 +276,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = Config::load_global();
 
     if is_init_dir_equal_to_pixi_home_parent(&dir) {
-        miette::bail!(
-            "You cannot create a workspace in the parent of the pixi home directory."
-        );
+        miette::bail!("You cannot create a workspace in the parent of the pixi home directory.");
     }
 
     // Deprecation warning for the `pyproject` option

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -276,7 +276,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = Config::load_global();
 
     if is_init_dir_equal_to_pixi_home_parent(&dir) {
-        miette::bail!("You cannot create a workspace in the parent of the pixi home directory.");
+        miette::bail!(
+            "You cannot create a workspace in the parent of the pixi home directory.\n\
+            Please see https://pixi.sh/pixi/v{}/reference/environment_variables/ \
+            for more information about the pixi home directory.",
+            consts::PIXI_VERSION
+        );
     }
 
     // Deprecation warning for the `pyproject` option

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -18,6 +18,7 @@ use pixi_manifest::{
 use pixi_spec::PixiSpec;
 use pixi_utils::conda_environment_file::CondaEnvFile;
 use rattler_conda_types::{NamedChannelOrUrl, Platform};
+use same_file::is_same_file;
 use tokio::fs::OpenOptions;
 use url::Url;
 use uv_normalize::PackageName;
@@ -259,7 +260,7 @@ fn is_init_dir_equal_to_pixi_home_parent(init_dir: &Path) -> bool {
     pixi_home()
         .as_ref()
         .and_then(|home_dir| home_dir.parent())
-        .map(|parent| parent == init_dir)
+        .and_then(|parent| is_same_file(parent, init_dir).ok())
         .unwrap_or(false)
 }
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -404,6 +404,18 @@ def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> Non
     assert "[workspace]" in manifest_content
 
 
+def test_pixi_init_pixi_home_parent(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    pixi_home = tmp_pixi_workspace / ".pixi"
+    pixi_home.mkdir(exist_ok=True)
+
+    verify_cli_command(
+        [pixi, "init", pixi_home.parent],
+        ExitCode.FAILURE,
+        stderr_contains="You cannot create a workspace in the parent of the pixi home directory",
+        env={"PIXI_HOME": str(pixi_home)},
+    )
+
+
 @pytest.mark.slow
 def test_pixi_init_pyproject(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest_path = tmp_pixi_workspace / "pyproject.toml"


### PR DESCRIPTION
Closes #4166.

@lucascolley I implemented the feature. Can you guide me on how your testing strategy imposes tests for this change? 