### PR TITLE
test: build aarch musl with musl gcc instead of gnu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -457,6 +457,8 @@ x86_64-unknown-linux-musl = "8core_ubuntu_latest_runner"
 [workspace.metadata.dist.dependencies.apt]
 gcc-aarch64-linux-gnu = { version = '*', targets = [
   "aarch64-unknown-linux-gnu",
+] }
+gcc-aarch64-unknown-linux-musl = { version = '*', targets = [
   "aarch64-unknown-linux-musl",
 ] }
 


### PR DESCRIPTION
Testing building using musl, as that suddenly broke in the release.