### PR TITLE
chore: bump to latest rattler release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,6 +847,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1233,19 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1627,7 +1655,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
- "console",
+ "console 0.15.11",
  "shell-words",
  "tempfile",
  "thiserror 1.0.69",
@@ -1862,7 +1890,7 @@ dependencies = [
 name = "fancy_display"
 version = "0.1.0"
 dependencies = [
- "console",
+ "console 0.15.11",
 ]
 
 [[package]]
@@ -1883,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e6bbcc80ea90b1924156b36e41b1ac75170580fff3b26fb6724c306538312b"
+checksum = "765662dc0b26e038099a5a1529f5d48443111eea45377c312be892997651710e"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2952,14 +2980,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.0",
  "portable-atomic",
  "unicode-width 0.2.1",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2975,7 +3003,7 @@ version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
- "console",
+ "console 0.15.11",
  "globset",
  "once_cell",
  "pest",
@@ -3821,12 +3849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4056,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
+name = "path_resolver"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933c29f43f5a73681fab36fc1620126e0ec380d70119f99b5dd9f57c9c594157"
+dependencies = [
+ "fs-err",
+ "indexmap 2.10.0",
+ "itertools 0.14.0",
+ "proptest",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,7 +4272,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_complete_nushell",
- "console",
+ "console 0.15.11",
  "console-subscriber",
  "crossbeam-channel",
  "csv",
@@ -4497,7 +4533,7 @@ name = "pixi_config"
 version = "0.1.0"
 dependencies = [
  "clap",
- "console",
+ "console 0.15.11",
  "dirs",
  "fs-err",
  "insta",
@@ -4523,7 +4559,7 @@ dependencies = [
 name = "pixi_consts"
 version = "0.1.0"
 dependencies = [
- "console",
+ "console 0.15.11",
  "rattler_cache",
  "rattler_conda_types",
  "url",
@@ -4589,7 +4625,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "chrono",
- "console",
+ "console 0.15.11",
  "dunce",
  "fancy_display",
  "fs-err",
@@ -4955,6 +4991,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.5",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,6 +5147,12 @@ dependencies = [
  "thiserror 2.0.12",
  "toml",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -5261,14 +5323,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rattler"
-version = "0.34.5"
+name = "rand_xorshift"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9465b31e72e448e972c1b7f79ea8f44b34c99d03c1275043691bf8d72c09440"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rattler"
+version = "0.34.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce6b787931a5f396b45dca4acf0431905a4eb7ff7cad453888dab6c42f1cc38"
 dependencies = [
  "anyhow",
  "clap",
- "console",
+ "console 0.15.11",
  "digest",
  "dirs",
  "fs-err",
@@ -5281,6 +5352,7 @@ dependencies = [
  "memmap2 0.9.5",
  "once_cell",
  "parking_lot",
+ "path_resolver",
  "rattler_cache",
  "rattler_conda_types",
  "rattler_digest",
@@ -5306,9 +5378,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.24"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d2edc091cf33829a824f090f1e351c9bcb8db000b9bc31fe202b4f1cdb7fad"
+checksum = "76598fec2758c8261cc57f023cf489c0e30e210b2fa732b61ad05aa8b8626ce2"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -5338,9 +5410,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.4"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb9289d58c0539ae1f9687b10a4b55b85035b055d3fe0d1f689e4c8df62f1e"
+checksum = "12f311bbbbc12c0547b82a3ea1c9a779f1ef6044e76935786d22667608ba4f62"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -5379,9 +5451,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cb77b51634b518f0a770a25243af1b1578041696dcdf48fcf5a1755aa1bee"
+checksum = "f40b746768824bc3306dcb597e549e836eda023dab8d7407d32b9f342c70cc5d"
 dependencies = [
  "blake2",
  "digest",
@@ -5397,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.9"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849272dd1725b658aa95f322f01901c6b05cd78d9dc7970f8e28ff781b6a785d"
+checksum = "7a35d250ab357908362255d409d7657bb01e305c3c127cfec203eb8efb1a4977"
 dependencies = [
  "chrono",
  "file_url",
@@ -5433,9 +5505,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979794ca4262c4c9bfb12eac9b5e83e3dce504e8671ad2b11977ab56745c6ddf"
+checksum = "61ae4908e4f2f2ab0a9e238d1fdedadffe719920228764b55c1b0413c66c73ca"
 dependencies = [
  "chrono",
  "configparser",
@@ -5463,9 +5535,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.4"
+version = "0.25.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e47dc4a2a439925a2cc0f8b8d9bebed27ef63e9adf12144c940a7e094a2ad5"
+checksum = "094baff5ae2e2ee3392dd1aef9dd132ea7e5aee3ade2d2edf3395cc181809787"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5491,9 +5563,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.43"
+version = "0.22.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082858b75d031cfc630daa0944fa5757d8e6b94d8201e0d4a3306a529e278be0"
+checksum = "710ef963205d3033e57244bcebda9e87db59788db62badf26a719c905397bc1a"
 dependencies = [
  "bzip2 0.6.0",
  "chrono",
@@ -5521,9 +5593,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c4a81089f4ab2f7c8d81eec3beb54a54928cca8e7545608183ba85ffea5521"
+checksum = "7220c1bd91ddf426a14802b5c525658ec28829e18d1a4316580c9b2196822f63"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -5543,9 +5615,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.5"
+version = "0.23.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93efa4f78ab6429071418a99dd1792641b77cca1f22dd0a722e14020dbef4d56"
+checksum = "d17a7f4355306a08850b2f58247bbb85589f9bfbb8652356ccae51c263743cf8"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5601,9 +5673,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.2"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc183de329999050a9cbfffee4edb05e6825865b04adff86e3def5272827cab6"
+checksum = "8bff4d6c731cbaafef1cf4b2b0dcebd2d95282b57381bba3b8942f72b951f4c7"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -5622,9 +5694,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.4"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc83b9cd70414cc7a9a2b4b99246fad5f1d1f6728f26128cc27c7f6f2cafe29f"
+checksum = "158365304e321111954d30881da244253c0eadefbb3930d2ece8f8e2f3c8830b"
 dependencies = [
  "chrono",
  "futures",
@@ -5640,9 +5712,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.17"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac89c5b00d88c8d7864cc4b2d12fdfd2fda41eb8185bafa72c6d056d98030d97"
+checksum = "21249a67a45d94d9be92084046e71d713392f49fc341f0bef2faba3812f8db0d"
 dependencies = [
  "archspec",
  "libloading",
@@ -6209,6 +6281,18 @@ name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -7528,6 +7612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7571,6 +7661,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -7875,7 +7971,7 @@ name = "uv-console"
 version = "0.0.1"
 source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
 dependencies = [
- "console",
+ "console 0.15.11",
 ]
 
 [[package]]
@@ -8413,7 +8509,7 @@ source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3
 dependencies = [
  "anyhow",
  "configparser",
- "console",
+ "console 0.15.11",
  "fs-err",
  "futures",
  "rustc-hash",
@@ -8731,6 +8827,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ http-cache-reqwest = "0.16.0"
 human_bytes = "0.4.3"
 humantime = "2.1.0"
 indexmap = "2.10.0"
-indicatif = "0.17.11"
+indicatif = "0.18.0"
 insta = "1.42.1"
 is_executable = "1.0.4"
 itertools = "0.14.0"
@@ -124,7 +124,7 @@ which = "8.0.0"
 file_url = "0.2.5"
 rattler = { version = "0.34.3", default-features = false }
 rattler_cache = { version = "0.3.22", default-features = false }
-rattler_conda_types = { version = "0.35.2", default-features = false, features = [
+rattler_conda_types = { version = "0.36.0", default-features = false, features = [
   "rayon",
 ] }
 rattler_digest = { version = "1.1.3", default-features = false }

--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
+++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
@@ -1,11 +1,9 @@
 ---
 source: crates/pixi_manifest/src/manifests/workspace.rs
-assertion_line: 298
 expression: "expect_parse_failure(&format!(\"{PROJECT_BOILERPLATE}\\n{}\", examples[0]))"
-snapshot_kind: text
 ---
-  × 'foobar' is not a known platform. Valid platforms are 'noarch', 'unknown', 'linux-32', 'linux-64', 'linux-aarch64', 'linux-armv6l', 'linux-armv7l', 'linux-ppc64le', 'linux-ppc64', 'linux-ppc',
-  │ 'linux-s390x', 'linux-riscv32', 'linux-riscv64', 'osx-64', 'osx-arm64', 'win-32', 'win-64', 'win-arm64', 'emscripten-wasm32', 'wasi-wasm32', 'zos-z'
+  × 'foobar' is not a known platform. Valid platforms are 'noarch', 'unknown', 'linux-32', 'linux-64', 'linux-aarch64', 'linux-armv6l', 'linux-armv7l', 'linux-loong64', 'linux-ppc64le', 'linux-
+  │ ppc64', 'linux-ppc', 'linux-s390x', 'linux-riscv32', 'linux-riscv64', 'osx-64', 'osx-arm64', 'win-32', 'win-64', 'win-arm64', 'emscripten-wasm32', 'wasi-wasm32', 'zos-z'
    ╭─[pixi.toml:8:9]
  7 │
  8 │ [target.foobar.dependencies]


### PR DESCRIPTION
Bumps rattler to the latest version, the most notable change is:

* https://github.com/conda/rattler/pull/1497

Fixes https://github.com/prefix-dev/pixi/issues/4157
Fixes https://github.com/prefix-dev/pixi/issues/1813
Fixes https://github.com/prefix-dev/pixi/issues/379