### PR TITLE
fix: global progress

### DIFF
--- a/crates/pixi_manifest/src/pypi/pypi_options.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_options.rs
@@ -464,7 +464,7 @@ mod tests {
             ]),
             index_strategy: None,
             no_build: None,
-            dependency_overrides:Some(IndexMap::from_iter([
+            dependency_overrides: Some(IndexMap::from_iter([
                 (
                     "pkg1".parse().unwrap(),
                     PixiPypiSpec::RawVersion("==1.0.0".parse().unwrap()),

--- a/crates/pixi_progress/src/lib.rs
+++ b/crates/pixi_progress/src/lib.rs
@@ -31,13 +31,13 @@ macro_rules! println {
             let _err = mp.println("");
         }
     };
-    ($fmt_str:literal, $( $arg:expr ),*) => {
+    ($($arg:tt)*) => {
         let mp = $crate::global_multi_progress();
         if mp.is_hidden() {
-            eprintln!($fmt_str, $( $arg ),*);
+            eprintln!($($arg)*);
         } else {
             // Ignore any error
-            let _err = mp.println(format!($fmt_str, $( $arg ),*));
+            let _err = mp.println(format!($($arg)*));
         }
     }
 }

--- a/src/global/common.rs
+++ b/src/global/common.rs
@@ -468,20 +468,20 @@ impl StateChanges {
                         exposed_names.sort();
 
                         if exposed_names.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Exposed executable {} from environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 exposed_names[0].fancy_display(),
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Exposed executables from environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for exposed_name in exposed_names {
-                                eprintln!("   - {}", exposed_name.fancy_display());
+                                pixi_progress::println!("   - {}", exposed_name.fancy_display());
                             }
                         }
                     }
@@ -496,20 +496,20 @@ impl StateChanges {
                         );
                         exposed_names.sort();
                         if exposed_names.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Removed exposed executable {} from environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 exposed_names[0].fancy_display(),
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Removed exposed executables from environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for exposed_name in exposed_names {
-                                eprintln!("   - {}", exposed_name.fancy_display());
+                                pixi_progress::println!("   - {}", exposed_name.fancy_display());
                             }
                         }
                     }
@@ -524,20 +524,20 @@ impl StateChanges {
                         );
                         exposed_names.sort();
                         if exposed_names.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Updated executable {} of environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 exposed_names[0].fancy_display(),
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Updated executables of environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for exposed_name in exposed_names {
-                                eprintln!("   - {}", exposed_name.fancy_display());
+                                pixi_progress::println!("   - {}", exposed_name.fancy_display());
                             }
                         }
                     }
@@ -554,7 +554,7 @@ impl StateChanges {
                         added_pkgs.sort_by(|pkg1, pkg2| pkg1.name.cmp(&pkg2.name));
 
                         if added_pkgs.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Added package {}={} to environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 console::style(pkg.name.as_normalized()).green(),
@@ -562,13 +562,13 @@ impl StateChanges {
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Added packages of environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for pkg in added_pkgs {
-                                eprintln!(
+                                pixi_progress::println!(
                                     "   - {}={}",
                                     console::style(pkg.name.as_normalized()).green(),
                                     console::style(&pkg.version).blue(),
@@ -577,14 +577,14 @@ impl StateChanges {
                         }
                     }
                     StateChange::AddedEnvironment => {
-                        eprintln!(
+                        pixi_progress::println!(
                             "{}Added environment {}.",
                             console::style(console::Emoji("✔ ", "")).green(),
                             env_name.fancy_display()
                         );
                     }
                     StateChange::RemovedEnvironment => {
-                        eprintln!(
+                        pixi_progress::println!(
                             "{}Removed environment {}.",
                             console::style(console::Emoji("✔ ", "")).green(),
                             env_name.fancy_display()
@@ -606,20 +606,20 @@ impl StateChanges {
                         installed_items.sort();
 
                         if installed_items.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Installed shortcut {} of environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 installed_items[0],
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Installed shortcuts of environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for installed_item in installed_items {
-                                eprintln!("   - {}", installed_item);
+                                pixi_progress::println!("   - {}", installed_item);
                             }
                         }
                     }
@@ -636,20 +636,20 @@ impl StateChanges {
                         uninstalled_items.sort();
 
                         if uninstalled_items.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Uninstalled shortcut {} of environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 uninstalled_items[0],
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Uninstalled shortcuts of environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for uninstalled_item in uninstalled_items {
-                                eprintln!("   - {}", uninstalled_item);
+                                pixi_progress::println!("   - {}", uninstalled_item);
                             }
                         }
                     }
@@ -666,20 +666,20 @@ impl StateChanges {
                         installed_items.sort();
 
                         if installed_items.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Exposed completion {} of environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 installed_items[0],
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Exposed completions of environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for installed_item in installed_items {
-                                eprintln!("   - {}", installed_item);
+                                pixi_progress::println!("   - {}", installed_item);
                             }
                         }
                     }
@@ -696,20 +696,20 @@ impl StateChanges {
                         uninstalled_items.sort();
 
                         if uninstalled_items.len() == 1 {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Removed completion {} of environment {}.",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 uninstalled_items[0],
                                 env_name.fancy_display()
                             );
                         } else {
-                            eprintln!(
+                            pixi_progress::println!(
                                 "{}Removed completions of environment {}:",
                                 console::style(console::Emoji("✔ ", "")).green(),
                                 env_name.fancy_display()
                             );
                             for uninstalled_item in uninstalled_items {
-                                eprintln!("   - {}", uninstalled_item);
+                                pixi_progress::println!("   - {}", uninstalled_item);
                             }
                         }
                     }
@@ -724,7 +724,7 @@ impl StateChanges {
     ) {
         // Check if there are any changes
         if environment_update.is_empty() {
-            eprintln!(
+            pixi_progress::println!(
                 "{}Environment {} was already up-to-date.",
                 console::style(console::Emoji("✔ ", "")).green(),
                 env_name.fancy_display(),
@@ -759,9 +759,9 @@ impl StateChanges {
 
         // Output messages based on the type of changes
         if top_level_changes.is_empty() && !transitive_changes.is_empty() {
-            eprintln!("{check_mark}Updated environment {env_fancy}.",);
+            pixi_progress::println!("{check_mark}Updated environment {env_fancy}.",);
         } else if top_level_changes.is_empty() && transitive_changes.is_empty() {
-            eprintln!("{check_mark}Environment {env_fancy} was already up-to-date.");
+            pixi_progress::println!("{check_mark}Environment {env_fancy} was already up-to-date.");
         } else if top_level_changes.len() == 1 {
             let changes = console::style(top_level_changes[0].0.as_normalized()).green();
             let version_string = top_level_changes[0]
@@ -770,11 +770,11 @@ impl StateChanges {
                 .map(|version| format!("={version}"))
                 .unwrap_or_default();
 
-            eprintln!(
+            pixi_progress::println!(
                 "{check_mark}{message} package {changes}{version_string} in environment {env_fancy}."
             );
         } else if top_level_changes.len() > 1 {
-            eprintln!(
+            pixi_progress::println!(
                 "{}{} packages in environment {}.",
                 console::style(console::Emoji("✔ ", "")).green(),
                 message,
@@ -786,7 +786,7 @@ impl StateChanges {
                     .version_fancy_display()
                     .map(|version| format!(" {version}"))
                     .unwrap_or_default();
-                eprintln!("    - {package_fancy}{change_fancy}");
+                pixi_progress::println!("    - {package_fancy}{change_fancy}");
             }
         }
     }

--- a/src/global/project/mod.rs
+++ b/src/global/project/mod.rs
@@ -589,6 +589,8 @@ impl Project {
             })
             .await?;
 
+        command_dispatcher.clear_reporter().await;
+
         let install_changes = get_install_changes(result.transaction);
         Ok(EnvironmentUpdate::new(install_changes, dependencies_names))
     }


### PR DESCRIPTION
This should fix the global progress bars from cluttering while doing something like an update.

I also seemed like the added macro did not accept a trailing comma, so I capture the entire token-tree instead, and forward that which according to the LLM should be fine.

Its now back to:

<img width="627" height="625" alt="image" src="https://github.com/user-attachments/assets/4f9cba25-e1fd-4057-857b-a40d3d2dd998" />
