### PR TITLE
fix: add build profiles to not build in editable mode in `pixi build`

### DIFF
--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -76,6 +76,9 @@ pub struct BackendSourceBuildV0Method {
     /// The directory where to place the built package. This is used as a hint
     /// for the backend, it may still place the package elsewhere.
     pub output_directory: Option<PathBuf>,
+
+    /// Whether to build the package in editable mode.
+    pub editable: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -95,6 +98,9 @@ pub struct BackendSourceBuildV1Method {
     /// The directory where to place the built package. This is used as a hint
     /// for the backend, it may still place the package elsewhere.
     pub output_directory: Option<PathBuf>,
+
+    /// Whether to build the package in editable mode.
+    pub editable: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -142,7 +148,6 @@ impl BackendSourceBuildSpec {
                 Self::build_v1(
                     self.backend,
                     self.package,
-                    self.source,
                     params,
                     self.work_directory,
                     log_sink,
@@ -187,7 +192,7 @@ impl BackendSourceBuildSpec {
                             params.build_environment.host_virtual_packages.clone(),
                         ),
                     }),
-                    editable: source.is_mutable(),
+                    editable: params.editable,
                 },
                 move |line| {
                     let _err = futures::executor::block_on(log_sink.send(line));
@@ -255,7 +260,6 @@ impl BackendSourceBuildSpec {
     async fn build_v1(
         backend: Backend,
         record: PackageIdentifier,
-        source: PinnedSourceSpec,
         params: BackendSourceBuildV1Method,
         work_directory: PathBuf,
         mut log_sink: UnboundedSender<String>,
@@ -283,7 +287,7 @@ impl BackendSourceBuildSpec {
                     },
                     work_directory,
                     output_directory: params.output_directory,
-                    editable: Some(source.is_mutable()),
+                    editable: Some(params.editable),
                 },
                 move |line| {
                     let _err = futures::executor::block_on(log_sink.send(line));

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -22,8 +22,8 @@ use rattler_conda_types::{
 use thiserror::Error;
 
 use crate::{
-    BuildEnvironment, CommandDispatcher, CommandDispatcherError, CommandDispatcherErrorResultExt,
-    SourceBuildError, SourceBuildSpec, executor::ExecutorFutures,
+    BuildEnvironment, BuildProfile, CommandDispatcher, CommandDispatcherError,
+    CommandDispatcherErrorResultExt, SourceBuildError, SourceBuildSpec, executor::ExecutorFutures,
     install_pixi::reporter::WrappingInstallReporter,
 };
 
@@ -205,6 +205,8 @@ impl InstallPixiEnvironmentSpec {
                 output_directory: None,
                 work_directory: None,
                 clean: false,
+                // When we install a pixi environment we always build in development mode.
+                build_profile: BuildProfile::Development,
             })
             .await?;
 

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -76,6 +76,7 @@ pub use reporter::{
     CondaSolveReporter, GitCheckoutReporter, PixiInstallReporter, PixiSolveReporter, Reporter,
     ReporterContext,
 };
+use serde::Serialize;
 pub use solve_conda::SolveCondaEnvironmentSpec;
 pub use solve_pixi::{PixiEnvironmentSpec, SolvePixiEnvironmentError};
 pub use source_build::{SourceBuildError, SourceBuildResult, SourceBuildSpec};
@@ -89,4 +90,21 @@ pub use source_metadata::{Cycle, SourceMetadata, SourceMetadataError, SourceMeta
 /// A helper function to check if a value is the default value for its type.
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
     T::default() == *value
+}
+
+/// A build profile indicates the type of build that should happen. Dependencies
+/// should not change regarding of the build profile, but the way the build is
+/// executed can change. For example, a release build might use optimizations
+/// while a development build might not.
+///
+/// ### Note
+///
+/// This feature is still in very early stages and is not yet fully implemented.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize)]
+pub enum BuildProfile {
+    /// Build a version of the package that is suitable for development.
+    Development,
+
+    /// Build a version of the package that is suitable for release.
+    Release,
 }

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use indicatif::ProgressBar;
 use miette::{Context, IntoDiagnostic};
 use pixi_command_dispatcher::{
-    BuildBackendMetadataSpec, BuildEnvironment, CacheDirs, SourceBuildSpec,
+    BuildBackendMetadataSpec, BuildEnvironment, BuildProfile, CacheDirs, SourceBuildSpec,
 };
 use pixi_config::ConfigCli;
 use pixi_manifest::FeaturesExt;
@@ -146,6 +146,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 enabled_protocols: Default::default(),
                 work_directory: None,
                 clean: args.clean,
+                build_profile: BuildProfile::Release,
             })
             .await?;
 


### PR DESCRIPTION
This adds veeeeryyy preliminary build profiles to source builds. In development mode we build editable packages and in release mode we dont. Release mode is used during pixi build and development mode is used when installing a pixi environment.

This fixes a regression where `pixi build` would build an editable package.

There is also some more tracing code in here which allowed me to debug some issues.