### PR TITLE
fix: print build log if build fails

### DIFF
--- a/crates/pixi_command_dispatcher/src/reporter.rs
+++ b/crates/pixi_command_dispatcher/src/reporter.rs
@@ -209,7 +209,7 @@ pub trait BackendSourceBuildReporter {
     );
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: BackendSourceBuildId);
+    fn on_finished(&mut self, id: BackendSourceBuildId, failed: bool);
 }
 
 /// A trait that is used to report the progress of the

--- a/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
@@ -465,7 +465,7 @@ impl BackendSourceBuildReporter for EventReporter {
         });
     }
 
-    fn on_finished(&mut self, id: BackendSourceBuildId) {
+    fn on_finished(&mut self, id: BackendSourceBuildId, _failed: bool) {
         let event = Event::BackendSourceBuildFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.lock().unwrap().push(event);


### PR DESCRIPTION
Fixes #4074

At the moment `--verbose` has to be passed for Pixi to print build output. However, if the build fails we want the build output to be passed even if `--verbose` wasn't set. This PR fixes that.