### PR TITLE
feat: add channels to the build-v1 apis

### DIFF
--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -10,7 +10,7 @@ use std::{
     path::PathBuf,
 };
 
-use rattler_conda_types::{PackageName, Platform, VersionWithSource};
+use rattler_conda_types::{ChannelUrl, PackageName, Platform, VersionWithSource};
 use serde::{Deserialize, Serialize};
 
 pub const METHOD_NAME: &str = "conda/build_v1";
@@ -19,6 +19,13 @@ pub const METHOD_NAME: &str = "conda/build_v1";
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CondaBuildV1Params {
+    /// The canonical channel URLs that define where dependencies will be
+    /// fetched from. Although this information is not immediately useful for
+    /// the backend, the backend may choose to generate a different recipe based
+    /// on the channels.
+    #[serde(default)]
+    pub channels: Vec<ChannelUrl>,
+
     /// The path to the build prefix, or `None` if no build prefix is created.
     pub build_prefix: Option<CondaBuildV1Prefix>,
 

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use ordermap::OrderSet;
-use rattler_conda_types::{NoArchType, PackageName, Platform, VersionWithSource};
+use rattler_conda_types::{ChannelUrl, NoArchType, PackageName, Platform, VersionWithSource};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -27,6 +27,13 @@ pub const METHOD_NAME: &str = "conda/outputs";
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CondaOutputsParams {
+    /// The canonical channel URLs that define where dependencies will be
+    /// fetched from. Although this information is not immediately useful for
+    /// the backend, the backend may choose to generate a different recipe based
+    /// on the channels.
+    #[serde(default)]
+    pub channels: Vec<ChannelUrl>,
+
     /// The native platform for which the outputs should be computed.
     ///
     /// This is usually the same platform as the platform on which the backend

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -230,6 +230,7 @@ impl BuildBackendMetadataSpec {
         project_model_hash: Option<Vec<u8>>,
     ) -> Result<CachedCondaMetadata, CommandDispatcherError<BuildBackendMetadataError>> {
         let params = CondaOutputsParams {
+            channels: self.channels,
             host_platform: self.build_environment.host_platform,
             build_platform: self.build_environment.build_platform,
             variant_configuration: self.variants.map(|variants| variants.into_iter().collect()),

--- a/crates/pixi_command_dispatcher/src/source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build/mod.rs
@@ -306,7 +306,6 @@ impl SourceBuildSpec {
                 method: BackendSourceBuildMethod::BuildV0(BackendSourceBuildV0Method {
                     editable: self.editable(),
                     channel_config: self.channel_config,
-                    channels: self.channels,
                     build_environment: self.build_environment,
                     variants: self.variants,
                     output_directory: self.output_directory,
@@ -315,6 +314,7 @@ impl SourceBuildSpec {
                 package: self.package,
                 source: self.source,
                 work_directory,
+                channels: self.channels,
             })
             .await
             .map_err_with(SourceBuildError::from)?;
@@ -347,6 +347,7 @@ impl SourceBuildSpec {
                 build_platform,
                 variant_configuration: self.variants.clone(),
                 work_directory: work_directory.clone(),
+                channels: self.channels.clone(),
             })
             .await
             .map_err(BackendSourceBuildError::BuildError)
@@ -497,6 +498,7 @@ impl SourceBuildSpec {
                 package: self.package,
                 source: self.source,
                 work_directory,
+                channels: self.channels,
             })
             .await
             .map_err_with(SourceBuildError::from)?;


### PR DESCRIPTION
This adds the `channels` that are used to fetch a package's dependencies to the build v1 protocol. This allows backends to generate different recipes based on the channels that are available at solve and installation time.

This is a forward- & backward-compatible build API change.

@ruben-arts This should allow you to derive the ROS `distro` based on the channels!
