### PR TITLE
chore: Add more verbose context for failed solves

### DIFF
--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -1838,7 +1838,7 @@ async fn spawn_solve_conda_environment_task(
         .await
         .with_context(|| {
             format!(
-                "failed to solve '{}' for {}",
+                "failed to solve requirements of environment '{}' for platform '{}'",
                 group.name().fancy_display(),
                 platform
             )
@@ -2140,7 +2140,7 @@ async fn spawn_solve_pypi_task<'p>(
         .await
         .with_context(|| {
             format!(
-                "failed to solve the pypi requirements of '{}' '{}'",
+                "failed to solve the pypi requirements of environment '{}' for platform '{}'",
                 environment_name.fancy_display(),
                 consts::PLATFORM_STYLE.apply_to(platform)
             )


### PR DESCRIPTION
Resolves https://github.com/prefix-dev/pixi/issues/3821

* Add clarifying text that distinguishes between the environment name and the platform for failed solves.