### PR TITLE
feat: expose module global when using pixi as dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod activation;
 pub mod cli;
 pub mod diff;
 pub mod environment;
-mod global;
+pub mod global;
 mod install_pypi;
 pub mod lock_file;
 mod prefix;


### PR DESCRIPTION
Unblocks: https://github.com/pavelzw/pixi-diff/pull/24

I used the simplest solution to expose the struct Project. This PR is meant for discussion. Another option would be to expose only Project for now.