### PR TITLE
chore: make none cached sharing tests extra slow

### DIFF
--- a/tests/integration_python/test_edge_cases.py
+++ b/tests/integration_python/test_edge_cases.py
@@ -42,7 +42,7 @@ def test_python_mismatch(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
 
-@pytest.mark.slow
+@pytest.mark.extra_slow
 def test_prefix_only_created_when_sdist(
     pixi: Path, tmp_pixi_workspace: Path, tmp_path: Path
 ) -> None:
@@ -476,7 +476,7 @@ def test_help_warning_when_platform_not_supported(pixi: Path, tmp_pixi_workspace
     )
 
 
-@pytest.mark.slow
+@pytest.mark.extra_slow
 def test_issue_4123_cache_prevents_editable_install(
     pixi: Path, tmp_pixi_workspace: Path, tmp_path: Path
 ) -> None:

--- a/tests/integration_python/test_reinstall.py
+++ b/tests/integration_python/test_reinstall.py
@@ -57,7 +57,7 @@ def test_pixi_reinstall_default_env(pixi: Path, reinstall_workspace: Path) -> No
     )
 
 
-@pytest.mark.slow
+@pytest.mark.extra_slow
 def test_pixi_reinstall_multi_env(pixi: Path, reinstall_workspace: Path) -> None:
     env = {
         "PIXI_CACHE_DIR": str(reinstall_workspace.joinpath("pixi_cache")),


### PR DESCRIPTION
These tests use a `PIXI_CACHE_DIR` making them slower than normal tests. So added the extra_slow tag to them to avoid red CI on them taking longer then 100 sec.