### PR TITLE
fix: feature activation environment variable priority

### DIFF
--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -623,6 +623,55 @@ mod tests {
         );
     }
 
+     #[test]
+    fn test_activation_env_priority() {
+        let manifest = Workspace::from_str(
+            Path::new("pixi.toml"),
+            r#"
+            [project]
+            name = "foobar"
+            channels = []
+            platforms = ["linux-64", "osx-64"]
+
+            [activation.env]
+            FOO_VAR = "default"
+
+            [feature.foo.activation.env]
+            FOO_VAR = "foo"
+
+            [feature.cuda.activation.env]
+            FOO_VAR = "cuda"
+
+            [environments]
+            foo = ["foo"]
+            cuda = ["cuda"] 
+            "#,
+        )
+        .unwrap();
+
+        let default_env = manifest.default_environment();
+        let foo_env = manifest.environment("foo").unwrap();
+        let cuda_env = manifest.environment("cuda").unwrap();
+          assert_eq!(
+            default_env.activation_env(None),
+            indexmap! {
+                "FOO_VAR".to_string() => "default",
+            }
+        );
+        assert_eq!(
+            foo_env.activation_env(None),
+            indexmap! {
+                "FOO_VAR".to_string() => "foo",
+            }
+        );
+        assert_eq!(
+            cuda_env.activation_env(None),
+            indexmap! {
+                "FOO_VAR".to_string() => "cuda",
+            }
+        );
+    }
+
     #[test]
     fn test_channel_feature_priority() {
         let manifest = Workspace::from_str(

--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -639,12 +639,15 @@ mod tests {
             [feature.foo.activation.env]
             FOO_VAR = "foo"
 
-            [feature.cuda.activation.env]
-            FOO_VAR = "cuda"
+            [feature.cuda1.activation.env]
+            FOO_VAR = "cuda1"
+
+            [feature.cuda2.activation.env]
+            FOO_VAR = "cuda2"
 
             [environments]
             foo = ["foo"]
-            cuda = ["cuda"] 
+            cuda = ["cuda1", "cuda2"] 
             "#,
         )
         .unwrap();
@@ -667,7 +670,7 @@ mod tests {
         assert_eq!(
             cuda_env.activation_env(None),
             indexmap! {
-                "FOO_VAR".to_string() => "cuda",
+                "FOO_VAR".to_string() => "cuda1",
             }
         );
     }

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -1554,7 +1554,8 @@ def test_run_with_environment_variable_priority(
         stdout_excludes="outside_env",
         env={"MY_ENV": "outside_env"},
     )
-    
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Signal handling is different on Windows",


### PR DESCRIPTION
This PR is to fix: https://github.com/prefix-dev/pixi/issues/4116

What I changed
As self.features() would put "default" envs in the last item, but the "default" env priority should be the lowest.Here, we use rfold (reverse fold) to ensure later features override earlier features for environment variables. Processing features in reverse order means that features appearing later in the list will have higher precedence.
Example: If features: [override_feature, user_feature, default]
rfold processes as: [default, user_feature, override_feature]
Result: override_feature env vars take precedence over all others.