### PR TITLE
fix: Quick Demo example shell quoting

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Project setup is a breeze with Pixi.
 pixi init hello-world
 cd hello-world
 pixi add python
-pixi run python -c "print('Hello World!')"
+pixi run python -c 'print("Hello World!")'
 ```
 
 ![Pixi Demo](assets/vhs-tapes/pixi_project_demo_light.gif#only-light)


### PR DESCRIPTION
Text has the quoting backwards which caused an error:

<img width="599" height="184" alt="Screenshot 2025-08-06 at 15 04 30" src="https://github.com/user-attachments/assets/0ddfe48c-4307-4b36-a00a-f6d3c948bcb8" />

Pre-recorded demo has it correct:
<img width="780" height="461" alt="Screenshot 2025-08-06 at 15 05 21" src="https://github.com/user-attachments/assets/d7f5caa6-014a-402f-bb05-4c2b442665c4" />
