### PR TITLE
feat: upgrade to 0.8.20 and get rid of non-async build dispatch calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.17"
-source = "git+https://github.com/charliermarsh/rs-async-zip?rev=c909fda63fcafe4af496a07bfda28a5aae97e58d#c909fda63fcafe4af496a07bfda28a5aae97e58d"
+source = "git+https://github.com/astral-sh/rs-async-zip?rev=c909fda63fcafe4af496a07bfda28a5aae97e58d#c909fda63fcafe4af496a07bfda28a5aae97e58d"
 dependencies = [
  "async-compression",
  "crc32fast",
@@ -4762,7 +4762,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml-span",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "tracing-subscriber",
  "typed-path",
@@ -4955,7 +4955,7 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "thiserror 2.0.12",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "url",
 ]
@@ -5066,7 +5066,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "toml-span",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "url",
 ]
@@ -5105,7 +5105,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "toml-span",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "url",
 ]
@@ -5178,7 +5178,7 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.12",
  "toml-span",
- "toml_edit",
+ "toml_edit 0.22.27",
  "tracing",
  "typed-path",
  "url",
@@ -5405,7 +5405,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -5595,7 +5595,7 @@ dependencies = [
  "pep508_rs",
  "serde",
  "thiserror 2.0.12",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -7043,6 +7043,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7860,9 +7869,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "foldhash",
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -7885,6 +7910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7892,9 +7926,33 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d3b47e6b7a040216ae5302712c94d1cf88c95b47efa80e2c59ce96c878267e"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow",
 ]
 
@@ -7903,6 +7961,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
@@ -8228,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8255,7 +8319,7 @@ dependencies = [
 [[package]]
 name = "uv-build-backend"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "csv",
  "flate2",
@@ -8269,7 +8333,7 @@ dependencies = [
  "spdx",
  "tar",
  "thiserror 2.0.12",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "uv-distribution-filename",
  "uv-fs",
@@ -8291,7 +8355,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anstream",
  "fs-err",
@@ -8305,7 +8369,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
- "toml_edit",
+ "toml_edit 0.23.3",
  "tracing",
  "uv-cache-key",
  "uv-configuration",
@@ -8326,7 +8390,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "fs-err",
  "nanoid",
@@ -8351,13 +8415,13 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "fs-err",
  "globwalk",
  "serde",
  "thiserror 2.0.12",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "walkdir",
 ]
@@ -8365,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "hex",
  "memchr",
@@ -8378,7 +8442,7 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8431,8 +8495,9 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
+ "bitflags",
  "either",
  "fs-err",
  "rayon",
@@ -8455,20 +8520,21 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-static",
+ "uv-warnings",
 ]
 
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
- "console 0.15.11",
+ "console 0.16.0",
 ]
 
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -8479,7 +8545,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "futures",
@@ -8511,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "either",
@@ -8528,7 +8594,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "url",
  "uv-cache",
@@ -8558,7 +8624,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "memchr",
  "rkyv",
@@ -8575,7 +8641,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "arcstr",
  "bitflags",
@@ -8613,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -8640,7 +8706,7 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "backon",
  "dunce",
@@ -8665,7 +8731,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -8690,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -8702,7 +8768,7 @@ dependencies = [
 [[package]]
 name = "uv-globfilter"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "globset",
  "owo-colors",
@@ -8716,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "configparser",
  "csv",
@@ -8750,12 +8816,13 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "async-channel",
  "fs-err",
  "futures",
+ "owo-colors",
  "rayon",
  "rustc-hash",
  "same-file",
@@ -8769,6 +8836,7 @@ dependencies = [
  "uv-cache-key",
  "uv-configuration",
  "uv-distribution",
+ "uv-distribution-filename",
  "uv-distribution-types",
  "uv-fs",
  "uv-git-types",
@@ -8789,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8800,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "uv-metadata"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "async_zip",
  "fs-err",
@@ -8818,7 +8886,7 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "rkyv",
  "schemars 1.0.4",
@@ -8829,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "dashmap",
  "futures",
@@ -8839,7 +8907,7 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "serde",
 ]
@@ -8847,20 +8915,21 @@ dependencies = [
 [[package]]
 name = "uv-pep440"
 version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "rkyv",
  "serde",
  "tracing",
  "unicode-width 0.2.1",
  "unscanny",
+ "uv-cache-key",
  "version-ranges",
 ]
 
 [[package]]
 name = "uv-pep508"
 version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "arcstr",
  "boxcar",
@@ -8874,6 +8943,7 @@ dependencies = [
  "thiserror 2.0.12",
  "unicode-width 0.2.1",
  "url",
+ "uv-cache-key",
  "uv-fs",
  "uv-normalize",
  "uv-pep440",
@@ -8882,9 +8952,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-platform"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
+dependencies = [
+ "fs-err",
+ "goblin",
+ "procfs",
+ "regex",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "tracing",
+ "uv-fs",
+ "uv-platform-tags",
+ "uv-static",
+]
+
+[[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "memchr",
  "rkyv",
@@ -8897,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "hashbrown 0.15.4",
  "indexmap 2.10.0",
@@ -8912,9 +8999,10 @@ dependencies = [
  "serde",
  "serde-untagged",
  "thiserror 2.0.12",
- "toml_edit",
+ "toml_edit 0.23.3",
  "tracing",
  "url",
+ "uv-cache-key",
  "uv-distribution-filename",
  "uv-git-types",
  "uv-normalize",
@@ -8927,19 +9015,17 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "configparser",
  "dunce",
  "fs-err",
  "futures",
- "goblin",
  "indexmap 2.10.0",
  "itertools 0.14.0",
  "once_cell",
  "owo-colors",
- "procfs",
  "ref-cast",
  "regex",
  "reqwest",
@@ -8970,6 +9056,7 @@ dependencies = [
  "uv-install-wheel",
  "uv-pep440",
  "uv-pep508",
+ "uv-platform",
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-redacted",
@@ -8986,7 +9073,7 @@ dependencies = [
 [[package]]
 name = "uv-redacted"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "ref-cast",
  "serde",
@@ -8996,17 +9083,17 @@ dependencies = [
 [[package]]
 name = "uv-requirements"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "configparser",
- "console 0.15.11",
+ "console 0.16.0",
  "fs-err",
  "futures",
  "rustc-hash",
  "serde",
  "thiserror 2.0.12",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "url",
  "uv-cache-key",
@@ -9032,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "fs-err",
  "memchr",
@@ -9056,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "arcstr",
  "clap",
@@ -9079,8 +9166,8 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "toml",
- "toml_edit",
+ "toml 0.9.5",
+ "toml_edit 0.23.3",
  "tracing",
  "url",
  "uv-cache-key",
@@ -9113,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "home",
@@ -9129,7 +9216,7 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -9140,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -9150,7 +9237,7 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "uv-macros",
 ]
@@ -9158,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "uv-torch"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "either",
  "fs-err",
@@ -9176,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "fs-err",
  "thiserror 2.0.12",
@@ -9187,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -9210,32 +9297,36 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.7.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+version = "0.8.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 
 [[package]]
 name = "uv-virtualenv"
 version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
+ "console 0.16.0",
  "fs-err",
  "itertools 0.14.0",
+ "owo-colors",
  "pathdiff",
  "self-replace",
  "thiserror 2.0.12",
  "tracing",
  "uv-configuration",
+ "uv-console",
  "uv-fs",
  "uv-pypi-types",
  "uv-python",
  "uv-shell",
  "uv-version",
+ "uv-warnings",
 ]
 
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -9245,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.7.20#2514203964449fcd3a5cac3320963aa57383e6b6"
+source = "git+https://github.com/astral-sh/uv?tag=0.8.5#ce37286814dbb802c422f0926487cfab7aefd2b7"
 dependencies = [
  "fs-err",
  "glob",
@@ -9255,8 +9346,8 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tokio",
- "toml",
- "toml_edit",
+ "toml 0.9.5",
+ "toml_edit 0.23.3",
  "tracing",
  "uv-build-backend",
  "uv-cache-key",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,15 +108,15 @@ toml_edit = "0.22.24"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 typed-path = "0.11.0"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
 
 wax = "0.6.0"
 which = "8.0.0"
@@ -144,23 +144,23 @@ simple_spawn_blocking = { version = "1.1.0", default-features = false }
 
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.7.20" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.8.5" }
 winapi = { version = "0.3.9", default-features = false }
 xxhash-rust = "0.8.15"
 zip = { version = "2.4.2", default-features = false }

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -470,6 +470,8 @@ pub fn to_uv_trusted_host(
 }
 
 /// Converts a date to a `uv_resolver::ExcludeNewer`
+/// since 0.8.2 uv also allows this per package,
+/// but we only support the global one for now
 pub fn to_exclude_newer(exclude_newer: chrono::DateTime<chrono::Utc>) -> uv_resolver::ExcludeNewer {
     let seconds_since_epoch = exclude_newer.timestamp();
     let nanoseconds = exclude_newer.timestamp_subsec_nanos();
@@ -480,5 +482,7 @@ pub fn to_exclude_newer(exclude_newer: chrono::DateTime<chrono::Utc>) -> uv_reso
             jiff::Timestamp::MAX
         },
     );
-    uv_resolver::ExcludeNewer::from(timestamp)
+    // Will convert into a global ExcludeNewer
+    // ..into is needed to convert into the uv timestamp type
+    uv_resolver::ExcludeNewer::global(timestamp.into())
 }

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -178,11 +178,11 @@ pub fn as_uv_req(
             if canonicalized.is_dir() {
                 RequirementSource::Directory {
                     install_path: canonicalized.into_boxed_path(),
-                    editable: editable.unwrap_or_default(),
+                    editable: Some(editable.unwrap_or_default()),
                     url: verbatim,
                     // TODO: we could see if we ever need this
                     // AFAICS it would be useful for constrainging dependencies
-                    r#virtual: false,
+                    r#virtual: Some(false),
                 }
             } else if *editable == Some(true) {
                 {

--- a/src/install_pypi/conversions.rs
+++ b/src/install_pypi/conversions.rs
@@ -206,7 +206,13 @@ pub fn convert_to_dist(
             let pkg_name =
                 uv_normalize::PackageName::from_str(pkg.name.as_ref()).expect("should be correct");
             if abs_path.is_dir() {
-                Dist::from_directory_url(pkg_name, absolute_url, &abs_path, pkg.editable, false)?
+                Dist::from_directory_url(
+                    pkg_name,
+                    absolute_url,
+                    &abs_path,
+                    Some(pkg.editable),
+                    Some(false),
+                )?
             } else {
                 Dist::from_file_url(
                     pkg_name,

--- a/src/install_pypi/mod.rs
+++ b/src/install_pypi/mod.rs
@@ -645,7 +645,8 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
     where
         'a: 'setup,
     {
-        static EMPTY_CONSTRAINTS: std::sync::LazyLock<Constraints> = std::sync::LazyLock::new(|| Constraints::default());
+        static EMPTY_CONSTRAINTS: std::sync::LazyLock<Constraints> =
+            std::sync::LazyLock::new(|| Constraints::default());
         BuildDispatch::new(
             &setup.registry_client,
             &self.context_config.uv_context.cache,

--- a/src/lock_file/resolve/build_dispatch.rs
+++ b/src/lock_file/resolve/build_dispatch.rs
@@ -30,19 +30,19 @@ use pixi_manifest::EnvironmentName;
 use pixi_manifest::pypi::pypi_options::NoBuildIsolation;
 use pixi_record::PixiRecord;
 use pixi_uv_conversions::BuildIsolation;
-use tokio::runtime::Handle;
 use uv_build_frontend::SourceBuild;
 use uv_cache::Cache;
 use uv_client::RegistryClient;
 use uv_configuration::{
     BuildKind, BuildOptions, BuildOutput, Concurrency, ConfigSettings, Constraints, IndexStrategy,
-    PreviewMode, SourceStrategy,
+    PackageConfigSettings, SourceStrategy,
 };
 use uv_dispatch::{BuildDispatch, BuildDispatchError, SharedState};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::Requirement;
 use uv_distribution_types::{
-    CachedDist, DependencyMetadata, IndexLocations, IsBuildBackendError, Resolution, SourceDist,
+    CachedDist, DependencyMetadata, ExtraBuildRequires, IndexLocations, IsBuildBackendError,
+    Resolution, SourceDist,
 };
 use uv_install_wheel::LinkMode;
 use uv_python::{Interpreter, InterpreterError, PythonEnvironment};
@@ -58,7 +58,9 @@ pub struct UvBuildDispatchParams<'a> {
     flat_index: &'a FlatIndex,
     dependency_metadata: &'a DependencyMetadata,
     config_settings: &'a ConfigSettings,
+    package_config_settings: PackageConfigSettings,
     build_options: &'a BuildOptions,
+    extra_build_requires: ExtraBuildRequires,
     hasher: &'a HashStrategy,
     index_strategy: IndexStrategy,
     constraints: Constraints,
@@ -67,7 +69,8 @@ pub struct UvBuildDispatchParams<'a> {
     exclude_newer: Option<ExcludeNewer>,
     sources: SourceStrategy,
     concurrency: Concurrency,
-    preview_mode: PreviewMode,
+    preview: uv_configuration::Preview,
+    workspace_cache: WorkspaceCache,
 }
 
 impl<'a> UvBuildDispatchParams<'a> {
@@ -89,7 +92,9 @@ impl<'a> UvBuildDispatchParams<'a> {
             flat_index,
             dependency_metadata,
             config_settings,
+            package_config_settings: PackageConfigSettings::default(),
             build_options,
+            extra_build_requires: ExtraBuildRequires::default(),
             hasher,
             index_strategy: IndexStrategy::default(),
             shared_state: SharedState::default(),
@@ -98,7 +103,8 @@ impl<'a> UvBuildDispatchParams<'a> {
             exclude_newer: None,
             sources: SourceStrategy::default(),
             concurrency: Concurrency::default(),
-            preview_mode: PreviewMode::default(),
+            preview: uv_configuration::Preview::default(),
+            workspace_cache: WorkspaceCache::default(),
         }
     }
 
@@ -148,8 +154,29 @@ impl<'a> UvBuildDispatchParams<'a> {
     }
 
     #[allow(dead_code)]
-    pub fn with_preview_mode(mut self, preview_mode: PreviewMode) -> Self {
-        self.preview_mode = preview_mode;
+    pub fn with_preview_mode(mut self, preview: uv_configuration::Preview) -> Self {
+        self.preview = preview;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_workspace_cache(mut self, workspace_cache: WorkspaceCache) -> Self {
+        self.workspace_cache = workspace_cache;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_package_config_settings(
+        mut self,
+        package_config_settings: PackageConfigSettings,
+    ) -> Self {
+        self.package_config_settings = package_config_settings;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn with_extra_build_requires(mut self, extra_build_requires: ExtraBuildRequires) -> Self {
+        self.extra_build_requires = extra_build_requires;
         self
     }
 }
@@ -205,6 +232,12 @@ pub struct LazyBuildDispatchDependencies {
     non_isolated_packages: OnceCell<BuildIsolation>,
     /// The python environment
     python_env: OnceCell<PythonEnvironment>,
+    /// The constraints for dependency resolution
+    constraints: OnceCell<Constraints>,
+    /// Extra build requirements
+    extra_build_requires: OnceCell<ExtraBuildRequires>,
+    /// Package-specific configuration settings
+    package_config_settings: OnceCell<PackageConfigSettings>,
 }
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
@@ -238,7 +271,6 @@ impl IsBuildBackendError for LazyBuildDispatchError {
 
 impl<'a> LazyBuildDispatch<'a> {
     /// Create a new `PixiBuildDispatch` instance.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         params: UvBuildDispatchParams<'a>,
         prefix_updater: CondaPrefixUpdater,
@@ -266,7 +298,7 @@ impl<'a> LazyBuildDispatch<'a> {
 
     /// Lazy initialization of the `BuildDispatch`. This also implies
     /// initializing the conda prefix.
-    async fn get_or_try_init(&self) -> Result<&BuildDispatch, LazyBuildDispatchError> {
+    async fn get_or_try_init(&self) -> Result<&BuildDispatch<'a>, LazyBuildDispatchError> {
         Box::pin(self.build_dispatch.get_or_try_init(async {
             // Disallow installing if the flag is set.
             if self.disallow_install_conda_prefix {
@@ -327,10 +359,25 @@ impl<'a> LazyBuildDispatch<'a> {
                     .get_or_init(|| PythonEnvironment::from_interpreter(interpreter.clone()))
             });
 
+            let constraints = self
+                .lazy_deps
+                .constraints
+                .get_or_init(|| self.params.constraints.clone());
+
+            let extra_build_requires = self
+                .lazy_deps
+                .extra_build_requires
+                .get_or_init(|| self.params.extra_build_requires.clone());
+
+            let package_config_settings = self
+                .lazy_deps
+                .package_config_settings
+                .get_or_init(|| self.params.package_config_settings.clone());
+
             let build_dispatch = BuildDispatch::new(
                 self.params.client,
                 self.params.cache,
-                self.params.constraints.clone(),
+                constraints,
                 interpreter,
                 self.params.index_locations,
                 self.params.flat_index,
@@ -338,15 +385,20 @@ impl<'a> LazyBuildDispatch<'a> {
                 self.params.shared_state.clone(),
                 self.params.index_strategy,
                 self.params.config_settings,
+                package_config_settings,
                 build_isolation,
+                extra_build_requires,
                 self.params.link_mode,
                 self.params.build_options,
                 self.params.hasher,
-                self.params.exclude_newer,
+                self.params
+                    .exclude_newer
+                    .clone()
+                    .unwrap_or(uv_resolver::ExcludeNewer::default()),
                 self.params.sources,
-                WorkspaceCache::default(),
+                self.params.workspace_cache.clone(),
                 self.params.concurrency,
-                self.params.preview_mode,
+                self.params.preview,
             )
             .with_build_extra_env_vars(env_vars);
 
@@ -356,54 +408,21 @@ impl<'a> LazyBuildDispatch<'a> {
     }
 }
 
-impl LazyBuildDispatch<'_> {
-    /// Helper method to ensure the build dispatch is initialized from a sync context.
-    /// This handles the async-to-sync conversion needed when the build dispatch is not yet initialized.
-    fn ensure_build_dispatch_initialized(&self) {
-        // Only initialize if not already done to avoid unnecessary work
-        if self.build_dispatch.get().is_none() {
-            // This will usually be called from the multi-threaded runtime, but there might
-            // be tests that calls this in the current thread runtime.
-            // In the current thread runtime we cannot use `block_in_place` as it will panic
-            let handle = Handle::current();
-            match handle.runtime_flavor() {
-                tokio::runtime::RuntimeFlavor::CurrentThread => {
-                    let runtime = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .expect("failed to initialize the runtime");
-                    runtime
-                        .block_on(self.get_or_try_init())
-                        .expect("failed to initialize the build dispatch");
-                }
-                // Others are multi-threaded runtimes
-                _ => {
-                    tokio::task::block_in_place(move || {
-                        handle
-                            .block_on(self.get_or_try_init())
-                            .expect("failed to initialize build dispatch");
-                    });
-                }
-            }
-        }
-    }
-}
-
 impl BuildContext for LazyBuildDispatch<'_> {
     type SourceDistBuilder = SourceBuild;
 
-    fn interpreter(&self) -> &uv_python::Interpreter {
+    async fn interpreter(&self) -> &uv_python::Interpreter {
         // In most cases the interpreter should be initialized, because one of the other
         // trait methods will have been called
         // But in case it is not, we will initialize it here
         //
         // Even though initialize does not initialize twice, we check it beforehand
         // because the initialization takes time
-        self.ensure_build_dispatch_initialized();
-        self.lazy_deps
-            .interpreter
-            .get()
-            .expect("python interpreter not initialized, this is a programming error")
+        self.get_or_try_init()
+            .await
+            .expect("could not initialize build dispatch correctly")
+            .interpreter()
+            .await
     }
 
     fn cache(&self) -> &uv_cache::Cache {
@@ -513,13 +532,24 @@ impl BuildContext for LazyBuildDispatch<'_> {
     }
 
     fn build_arena(&self) -> &BuildArena<Self::SourceDistBuilder> {
-        // Ensure the build dispatch is initialized
-        self.ensure_build_dispatch_initialized();
-
         // Get the inner build dispatch and delegate to its build_arena method
         self.build_dispatch
             .get()
             .expect("build dispatch not initialized, this is a programming error")
             .build_arena()
+    }
+
+    fn config_settings_package(&self) -> &uv_configuration::PackageConfigSettings {
+        self.lazy_deps
+            .package_config_settings
+            .get()
+            .expect("package config settings not initialized, this is a programming error")
+    }
+
+    fn extra_build_requires(&self) -> &uv_distribution_types::ExtraBuildRequires {
+        self.lazy_deps
+            .extra_build_requires
+            .get()
+            .expect("extra build requires not initialized, this is a programming error")
     }
 }

--- a/src/lock_file/resolve/build_dispatch.rs
+++ b/src/lock_file/resolve/build_dispatch.rs
@@ -147,9 +147,8 @@ impl<'a> UvBuildDispatchParams<'a> {
     }
 
     /// Set the exclude newer options for the build dispatch
-    #[allow(dead_code)]
-    pub fn with_exclude_newer(mut self, exclude_newer: Option<ExcludeNewer>) -> Self {
-        self.exclude_newer = exclude_newer;
+    pub fn with_exclude_newer(mut self, exclude_newer: ExcludeNewer) -> Self {
+        self.exclude_newer = Some(exclude_newer);
         self
     }
 

--- a/src/lock_file/resolve/pypi.rs
+++ b/src/lock_file/resolve/pypi.rs
@@ -454,7 +454,7 @@ pub async fn resolve_pypi(
     let options = Options {
         index_strategy,
         build_options: build_options.clone(),
-        exclude_newer: exclude_newer.map(to_exclude_newer),
+        exclude_newer: exclude_newer.map(to_exclude_newer).unwrap_or(uv_resolver::ExcludeNewer::default()),
         ..Options::default()
     };
 
@@ -610,7 +610,7 @@ pub async fn resolve_pypi(
         &requires_python,
         AllowedYanks::from_manifest(&manifest, &resolver_env, options.dependency_mode),
         &context.hash_strategy,
-        options.exclude_newer,
+        options.exclude_newer.clone(),
         &build_options,
         &context.capabilities,
     );
@@ -973,7 +973,7 @@ async fn lock_pypi_packages(
                             // instead of from the source path to copy the path that was passed in
                             // from the requirement.
                             let url_or_path = UrlOrPath::Path(install_path);
-                            (url_or_path, hash, dir.editable)
+                            (url_or_path, hash, dir.editable.unwrap_or(false))
                         }
                     };
 

--- a/src/lock_file/resolve/pypi.rs
+++ b/src/lock_file/resolve/pypi.rs
@@ -473,6 +473,7 @@ pub async fn resolve_pypi(
         &context.hash_strategy,
     )
     .with_index_strategy(index_strategy)
+    .with_exclude_newer(options.exclude_newer.clone())
     // Create a forked shared state that condains the in-memory index.
     // We need two in-memory indexes, one for the build dispatch and one for the
     // resolver. because we manually override requests for the resolver,

--- a/src/lock_file/resolve/pypi.rs
+++ b/src/lock_file/resolve/pypi.rs
@@ -454,7 +454,9 @@ pub async fn resolve_pypi(
     let options = Options {
         index_strategy,
         build_options: build_options.clone(),
-        exclude_newer: exclude_newer.map(to_exclude_newer).unwrap_or(uv_resolver::ExcludeNewer::default()),
+        exclude_newer: exclude_newer
+            .map(to_exclude_newer)
+            .unwrap_or(uv_resolver::ExcludeNewer::default()),
         ..Options::default()
     };
 

--- a/src/lock_file/resolve/uv_resolution_context.rs
+++ b/src/lock_file/resolve/uv_resolution_context.rs
@@ -1,9 +1,9 @@
 use miette::{Context, IntoDiagnostic};
 use uv_cache::Cache;
 use uv_client::ExtraMiddleware;
-use uv_configuration::{Concurrency, SourceStrategy, TrustedHost};
+use uv_configuration::{Concurrency, PackageConfigSettings, Preview, SourceStrategy, TrustedHost};
 use uv_dispatch::SharedState;
-use uv_distribution_types::IndexCapabilities;
+use uv_distribution_types::{ExtraBuildRequires, IndexCapabilities};
 use uv_types::{HashStrategy, InFlight};
 
 use crate::Workspace;
@@ -26,6 +26,9 @@ pub struct UvResolutionContext {
     pub shared_state: SharedState,
     pub extra_middleware: ExtraMiddleware,
     pub proxies: Vec<reqwest::Proxy>,
+    pub package_config_settings: PackageConfigSettings,
+    pub extra_build_requires: ExtraBuildRequires,
+    pub preview: Preview,
 }
 
 impl UvResolutionContext {
@@ -77,6 +80,9 @@ impl UvResolutionContext {
             shared_state: SharedState::default(),
             extra_middleware: ExtraMiddleware(uv_middlewares(project.config())),
             proxies: project.config().get_proxies().into_diagnostic()?,
+            package_config_settings: PackageConfigSettings::default(),
+            extra_build_requires: ExtraBuildRequires::default(),
+            preview: Preview::default(),
         })
     }
 

--- a/src/lock_file/resolve/uv_resolution_context.rs
+++ b/src/lock_file/resolve/uv_resolution_context.rs
@@ -5,6 +5,7 @@ use uv_configuration::{Concurrency, PackageConfigSettings, Preview, SourceStrate
 use uv_dispatch::SharedState;
 use uv_distribution_types::{ExtraBuildRequires, IndexCapabilities};
 use uv_types::{HashStrategy, InFlight};
+use uv_workspace::WorkspaceCache;
 
 use crate::Workspace;
 use pixi_config::{self, get_cache_dir};
@@ -29,6 +30,7 @@ pub struct UvResolutionContext {
     pub package_config_settings: PackageConfigSettings,
     pub extra_build_requires: ExtraBuildRequires,
     pub preview: Preview,
+    pub workspace_cache: WorkspaceCache,
 }
 
 impl UvResolutionContext {
@@ -83,6 +85,7 @@ impl UvResolutionContext {
             package_config_settings: PackageConfigSettings::default(),
             extra_build_requires: ExtraBuildRequires::default(),
             preview: Preview::default(),
+            workspace_cache: WorkspaceCache::default(),
         })
     }
 

--- a/src/lock_file/update.rs
+++ b/src/lock_file/update.rs
@@ -522,6 +522,8 @@ impl<'p> LockFileDerivedData<'p> {
                 // Update the prefix with Pypi records
                 {
                     let pypi_indexes = self.locked_env(environment)?.pypi_indexes().cloned();
+                    let index_strategy = environment.pypi_options().index_strategy.clone();
+                    let exclude_newer = environment.exclude_newer();
 
                     let config = PyPIUpdateConfig {
                         environment_name: environment.name(),
@@ -535,6 +537,8 @@ impl<'p> LockFileDerivedData<'p> {
                         no_build_isolation: &non_isolated_packages,
                         no_build: &no_build,
                         no_binary: &no_binary,
+                        index_strategy: index_strategy.as_ref(),
+                        exclude_newer: exclude_newer.as_ref(),
                     };
 
                     let context_config = PyPIContextConfig {

--- a/src/workspace/environment.rs
+++ b/src/workspace/environment.rs
@@ -661,7 +661,7 @@ mod tests {
         );
     }
 
-     #[test]
+    #[test]
     fn test_activation_env_priority() {
         let manifest = Workspace::from_str(
             Path::new("pixi.toml"),
@@ -693,7 +693,7 @@ mod tests {
         let default_env = manifest.default_environment();
         let foo_env = manifest.environment("foo").unwrap();
         let cuda_env = manifest.environment("cuda").unwrap();
-          assert_eq!(
+        assert_eq!(
             default_env.activation_env(None),
             indexmap! {
                 "FOO_VAR".to_string() => "default",


### PR DESCRIPTION
This PR does three things:

1. Upgrades to uv 0.8.20, and makes sure the code is compatible
2. Get rid of the weird block_on call that was sometimes making tokio hang
3. Start using and sharing some structs that we were re-creating like the workspace cache, as well as be more consistent what we pass through. For example exclude_newer was being used in resolution but not in installation, which seems just wrong.

Still in draft cause I need to fix clippy lints.