### PR TITLE
feat: pixi build `--build-platform`

### DIFF
--- a/docs/reference/cli/pixi/build.md
+++ b/docs/reference/cli/pixi/build.md
@@ -15,6 +15,9 @@ pixi build [OPTIONS]
 - <a id="arg---target-platform" href="#arg---target-platform">`--target-platform (-t) <TARGET_PLATFORM>`</a>
 :  The target platform to build for (defaults to the current platform)
 <br>**default**: `current_platform`
+- <a id="arg---build-platform" href="#arg---build-platform">`--build-platform <BUILD_PLATFORM>`</a>
+:  The build platform to use for building (defaults to the current platform)
+<br>**default**: `current_platform`
 - <a id="arg---output-dir" href="#arg---output-dir">`--output-dir (-o) <OUTPUT_DIR>`</a>
 :  The output directory to place the built artifacts
 <br>**default**: `.`

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -28,6 +28,10 @@ pub struct Args {
     #[clap(long, short, default_value_t = Platform::current())]
     pub target_platform: Platform,
 
+    /// The build platform to use for building (defaults to the current platform)
+    #[clap(long, default_value_t = Platform::current())]
+    pub build_platform: Platform,
+
     /// The output directory to place the built artifacts
     #[clap(long, short, default_value = ".")]
     pub output_dir: PathBuf,
@@ -70,7 +74,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Build platform virtual packages
     let build_virtual_packages: Vec<GenericVirtualPackage> = workspace
         .default_environment()
-        .virtual_packages(Platform::current())
+        .virtual_packages(args.build_platform)
         .into_iter()
         .map(GenericVirtualPackage::from)
         .collect();
@@ -85,7 +89,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let build_environment = BuildEnvironment {
         host_platform: args.target_platform,
-        build_platform: Platform::current(),
+        build_platform: args.build_platform,
         build_virtual_packages,
         host_virtual_packages,
     };


### PR DESCRIPTION
Adds the `--build-platform` flag to `pixi build` to allow specifying a different platform than the current one to package a pixi project. This is useful on Windows Arm64 if the `build-dependencies` are only available for `win-64`.