### PR TITLE
fix: fish completion script

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -498,20 +498,20 @@ impl PyPIConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, Copy, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum PinningStrategy {
-    /// Default semver strategy e.g. "1.2.3" becomes ">=1.2.3, <2" but "0.1.0"
-    /// becomes ">=0.1.0, <0.2"
+    /// Default semver strategy e.g. `1.2.3` becomes `>=1.2.3, <2` but `0.1.0`
+    /// becomes `>=0.1.0, <0.2`
     #[default]
     Semver,
-    /// Pin the latest minor e.g. "1.2.3" becomes ">=1.2.3, <1.3"
+    /// Pin the latest minor e.g. `1.2.3` becomes `>=1.2.3, <1.3`
     Minor,
-    /// Pin the latest major e.g. "1.2.3" becomes ">=1.2.3, <2"
+    /// Pin the latest major e.g. `1.2.3` becomes `>=1.2.3, <2`
     Major,
-    /// Pin to the latest version or higher. e.g. "1.2.3" becomes ">=1.2.3"
+    /// Pin to the latest version or higher. e.g. `1.2.3` becomes `>=1.2.3`
     LatestUp,
-    /// Pin the version chosen by the solver. e.g. "1.2.3" becomes "==1.2.3"
+    /// Pin the version chosen by the solver. e.g. `1.2.3` becomes `==1.2.3`
     // Adding "Version" to the name for future extendability.
     ExactVersion,
-    /// No pinning, keep the requirement empty. e.g. "1.2.3" becomes "*"
+    /// No pinning, keep the requirement empty. e.g. `1.2.3` becomes `*`
     // Calling it no-pin to make it simple to type, as other option was pin-unconstrained.
     NoPin,
 }

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1571,7 +1571,7 @@ platforms = ["{CURRENT_PLATFORM}"]
     fish_completion_file = tmp_pixi_workspace / "pixi.fish"
     fish_completion_file.write_text(out)
 
-    # Check that the file was created
+    # Check that the file can be parsed by fish
     verify_cli_command(
         [
             pixi,

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -16,7 +16,8 @@ from .common import (
     PIXI_VERSION,
     ExitCode,
     cwd,
-    verify_cli_command, CONDA_FORGE_CHANNEL,
+    verify_cli_command,
+    CONDA_FORGE_CHANNEL,
 )
 
 
@@ -1545,6 +1546,7 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
         }
     )
 
+
 @pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="Fish shell is not supported on Windows",
@@ -1562,15 +1564,21 @@ platforms = ["{CURRENT_PLATFORM}"]
     verify_cli_command([pixi, "add", "fish", "--manifest-path", tmp_pixi_workspace])
 
     # Verify that the shell hook generates the correct completions
-    output = verify_cli_command(
-        [pixi, "completion", "--shell", "fish"]
-    )
+    output = verify_cli_command([pixi, "completion", "--shell", "fish"])
     out = output.stdout
     # write output to file
     fish_completion_file = tmp_pixi_workspace / "pixi.fish"
     fish_completion_file.write_text(out)
 
     # Check that the file was created
-    verify_cli_command([pixi, "run", "--manifest-path", tmp_pixi_workspace, "fish", "-c", f"source {fish_completion_file}"],)
-
-
+    verify_cli_command(
+        [
+            pixi,
+            "run",
+            "--manifest-path",
+            tmp_pixi_workspace,
+            "fish",
+            "-c",
+            f"source {fish_completion_file}",
+        ],
+    )

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1551,6 +1551,7 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
     sys.platform.startswith("win"),
     reason="Fish shell is not supported on Windows",
 )
+@pytest.mark.slow
 def test_fish_completions(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     toml = f"""


### PR DESCRIPTION
Apparently, we are not allowed to use `"*"` or `">"` in fish completions. This fixes that and adds a test so it doesn't come back.

Fixes #4308 