### PR TITLE
ci: only run fast tests with `pixi run test-fast`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ repository.workspace = true
 version = "0.51.0"
 
 [features]
-default = ["online_tests", "rustls-tls"]
+default = ["rustls-tls"]
 native-tls = [
   "reqwest/native-tls",
   "reqwest/native-tls-alpn",

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -64,3 +64,7 @@ pixi_test_utils = { workspace = true }
 tempfile = { workspace = true }
 text_trees = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
+
+
+[features]
+slow_integration_tests = []

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -68,6 +68,7 @@ fn default_build_environment() -> BuildEnvironment {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 pub async fn simple_test() {
     let (reporter, events) = EventReporter::new();
     let (tool_platform, tool_virtual_packages) = tool_platform();
@@ -368,6 +369,7 @@ pub async fn test_stale_host_dependency_triggers_rebuild() {
 }
 
 #[tokio::test]
+#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 pub async fn instantiate_backend_with_from_source() {
     let root_dir = workspaces_dir().join("source-backends");
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,7 +38,7 @@ test-all-extra-slow = { depends-on = [
 test-all-fast = { depends-on = ["test-fast", "test-integration-fast"] }
 test-all-slow = { depends-on = ["test-slow", "test-integration-slow"] }
 test-fast = "cargo nextest run --workspace --all-targets"
-test-slow = """cargo nextest run --workspace --all-targets --features slow_integration_tests
+test-slow = """cargo nextest run --workspace --all-targets --features slow_integration_tests,online_tests
               --status-level skip --failure-output immediate-final --no-fail-fast --final-status-level slow"""
 
 [feature.pytest.dependencies]

--- a/tests/integration_python/test_edge_cases.py
+++ b/tests/integration_python/test_edge_cases.py
@@ -1,13 +1,14 @@
-from pathlib import Path
+import platform
 import shutil
 import subprocess
-import pytest
-import platform
 import sys
+from pathlib import Path
+
+import pytest
 import tomli
 import tomli_w
 
-from .common import CURRENT_PLATFORM, verify_cli_command, ExitCode, CONDA_FORGE_CHANNEL
+from .common import CONDA_FORGE_CHANNEL, CURRENT_PLATFORM, ExitCode, verify_cli_command
 
 
 @pytest.mark.extra_slow
@@ -340,6 +341,7 @@ def test_build_git_source_deps(
     )
 
 
+@pytest.mark.slow
 def test_installation_pypi_conda_mismatch(
     pixi: Path, tmp_pixi_workspace: Path, test_data: Path, pixi_tomls: Path
 ) -> None:
@@ -413,6 +415,7 @@ def test_installation_pypi_conda_mismatch(
     assert (site_packages / "foobar" / "b.py").exists(), "b.py does not exist"
 
 
+@pytest.mark.slow
 def test_pypi_url_fragment_in_project_deps(tmp_pixi_workspace: Path, pixi: Path) -> None:
     pyproject_content = f"""
 [project]

--- a/tests/integration_python/test_pypi_options.py
+++ b/tests/integration_python/test_pypi_options.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+
 import pytest
 import yaml
 
-from .common import verify_cli_command, ExitCode, CURRENT_PLATFORM, CONDA_FORGE_CHANNEL
+from .common import CONDA_FORGE_CHANNEL, CURRENT_PLATFORM, ExitCode, verify_cli_command
 
 
 @pytest.mark.extra_slow
@@ -24,6 +25,7 @@ def test_no_build_option(pixi: Path, tmp_pixi_workspace: Path, tmp_path: Path) -
     )
 
 
+@pytest.mark.slow
 def test_pypi_overrides(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """
     Tests the behavior of pixi install command with dependency overrides specified in pixi.toml.

--- a/tests/integration_rust/add_tests.rs
+++ b/tests/integration_rust/add_tests.rs
@@ -654,7 +654,6 @@ async fn add_dependency_pinning_strategy() {
 /// Test adding a git dependency with a specific branch
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_git_deps() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -708,7 +707,6 @@ preview = ['pixi-build']
 #[cfg(not(windows))]
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_git_deps_with_creds() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -762,7 +760,6 @@ preview = ['pixi-build']
 /// Test adding a git dependency with a specific commit
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 async fn add_git_with_specific_commit() {
     let pixi = PixiControl::from_manifest(
         r#"
@@ -813,8 +810,6 @@ preview = ['pixi-build']"#,
 /// Test adding a git dependency with a specific tag
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
-
 async fn add_git_with_tag() {
     let pixi = PixiControl::from_manifest(
         r#"

--- a/tests/integration_rust/solve_group_tests.rs
+++ b/tests/integration_rust/solve_group_tests.rs
@@ -277,8 +277,6 @@ async fn test_compressed_mapping_catch_not_pandoc_not_a_python_package() {
 
 #[tokio::test]
 #[cfg_attr(not(feature = "online_tests"), ignore)]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
-
 async fn test_dont_record_not_present_package_as_purl() {
     let pixi = PixiControl::new().unwrap();
     pixi.init().await.unwrap();


### PR DESCRIPTION
- only run `online_tests` when explicitly requested
- mark more tests as slow