### PR TITLE
docs: Add keyring auth support doc and bump setup-pixi action version

### DIFF
--- a/docs/integration/ci/github_actions.md
+++ b/docs/integration/ci/github_actions.md
@@ -8,7 +8,7 @@ We created [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) to 
 ## Usage
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     pixi-version: v0.51.0
     cache: true
@@ -19,7 +19,7 @@ We created [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) to 
 
 !!!warning "Pin your action versions"
     Since pixi is not yet stable, the API of this action may change between minor versions.
-    Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.8.14`) to avoid breaking changes.
+    Please pin the versions of this action to a specific version (i.e., `prefix-dev/setup-pixi@v0.9.0`) to avoid breaking changes.
     You can automatically update the version of this action by using [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
 
     Put the following in your `.github/dependabot.yml` file to enable Dependabot for your GitHub Actions:
@@ -61,7 +61,7 @@ You can specify the behavior by setting the `cache` input argument.
     This can be done by setting the `cache-write` argument.
 
     ```yaml
-    - uses: prefix-dev/setup-pixi@v0.8.14
+    - uses: prefix-dev/setup-pixi@v0.9.0
       with:
         cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
@@ -106,7 +106,7 @@ test:
       environment: [py311, py312]
   steps:
   - uses: actions/checkout@v4
-  - uses: prefix-dev/setup-pixi@v0.8.14
+  - uses: prefix-dev/setup-pixi@v0.9.0
     with:
       environments: ${{ matrix.environment }}
 ```
@@ -116,7 +116,7 @@ test:
 The following example will install both the `py311` and the `py312` environment on the runner.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     environments: >- # (1)!
       py311
@@ -157,7 +157,7 @@ Specify the token using the `auth-token` input argument.
 This form of authentication (bearer token in the request headers) is mainly used at [prefix.dev](https://prefix.dev).
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}
@@ -169,7 +169,7 @@ Specify the username and password using the `auth-username` and `auth-password` 
 This form of authentication (HTTP Basic Auth) is used in some enterprise environments with [artifactory](https://jfrog.com/artifactory) for example.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     auth-host: custom-artifactory.com
     auth-username: ${{ secrets.PIXI_USERNAME }}
@@ -182,7 +182,7 @@ Specify the conda-token using the `conda-token` input argument.
 This form of authentication (token is encoded in URL: `https://my-quetz-instance.com/t/<token>/get/custom-channel`) is used at [anaconda.org](https://anaconda.org) or with [quetz instances](https://github.com/mamba-org/quetz).
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     auth-host: anaconda.org # (1)!
     auth-conda-token: ${{ secrets.CONDA_TOKEN }}
@@ -196,7 +196,7 @@ Specify the S3 key pair using the `auth-access-key-id` and `auth-secret-access-k
 You can also specify the session token using the `auth-session-token` input argument.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     auth-host: s3://my-s3-bucket
     auth-s3-access-key-id: ${{ secrets.ACCESS_KEY_ID }}
@@ -207,6 +207,16 @@ You can also specify the session token using the `auth-session-token` input argu
 1. only needed if your key uses a session token
 
 See the [S3 section](../../deployment/s3.md) for more information about S3 authentication.
+
+#### PyPI keyring provider
+
+You can specify whether to use keyring to look up credentials for PyPI.
+
+```yml
+- uses: prefix-dev/setup-pixi@v0.9.0
+  with:
+    pypi-keyring-provider: subprocess # one of 'subprocess', 'disabled'
+```
 
 ### Custom shell wrapper
 
@@ -279,7 +289,7 @@ To this end, `setup-pixi` adds all environment variables set when executing `pix
 As a result, all installed binaries can be accessed without having to call `pixi run`.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     activate-environment: true
 ```
@@ -287,7 +297,7 @@ As a result, all installed binaries can be accessed without having to call `pixi
 If you are installing multiple environments, you will need to specify the name of the environment that you want to be activated.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     environments: >-
       py311
@@ -304,7 +314,7 @@ You can specify whether `setup-pixi` should run `pixi install --frozen` or `pixi
 See the [official documentation](https://prefix.dev/docs/pixi/cli#install) for more information about the `--frozen` and `--locked` flags.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     locked: true
     # or
@@ -334,7 +344,7 @@ The second type is the debug logging of the pixi executable.
 This can be specified by setting the `log-level` input.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     log-level: vvv # (1)!
 ```
@@ -361,7 +371,7 @@ If nothing is specified, `post-cleanup` will default to `true`.
 On self-hosted runners, you also might want to alter the default pixi install location to a temporary location. You can use `pixi-bin-path: ${{ runner.temp }}/bin/pixi` to do this.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     post-cleanup: true
     pixi-bin-path: ${{ runner.temp }}/bin/pixi # (1)!
@@ -377,7 +387,7 @@ You can also use a preinstalled local version of pixi on the runner by not setti
 This can be overwritten by setting the `manifest-path` input argument.
 
 ```yaml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     manifest-path: pyproject.toml
 ```
@@ -387,7 +397,7 @@ This can be overwritten by setting the `manifest-path` input argument.
 If you only want to install pixi and not install the current workspace, you can use the `run-install` option.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     run-install: false
 ```
@@ -398,7 +408,7 @@ You can also download pixi from a custom URL by setting the `pixi-url` input arg
 Optionally, you can combine this with the `pixi-url-headers` input argument to supply additional headers for the download request, such as a bearer token.
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     pixi-url: https://pixi-mirror.example.com/releases/download/v0.48.0/pixi-x86_64-unknown-linux-musl
     pixi-url-headers: '{"Authorization": "Bearer ${{ secrets.PIXI_MIRROR_BEARER_TOKEN }}"}'
@@ -414,7 +424,7 @@ It will be rendered with the following variables:
 By default, `pixi-url` is equivalent to the following template:
 
 ```yml
-- uses: prefix-dev/setup-pixi@v0.8.14
+- uses: prefix-dev/setup-pixi@v0.9.0
   with:
     pixi-url: |
       {{#if latest~}}


### PR DESCRIPTION
Companion to https://github.com/prefix-dev/setup-pixi/pull/220