### PR TITLE
refactor: remove manual conflicts check for `--frozen` & `--locked`

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -198,7 +198,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         pypi_deps,
         source_specs,
         prefix_update_config.no_install,
-        &lock_file_update_config.lock_file_usage()?,
+        &lock_file_update_config.lock_file_usage(),
         &dependency_config.feature,
         &dependency_config.platforms,
         args.editable,

--- a/src/cli/cli_config.rs
+++ b/src/cli/cli_config.rs
@@ -112,16 +112,12 @@ pub struct LockFileUpdateConfig {
 }
 
 impl LockFileUpdateConfig {
-    pub fn lock_file_usage(&self) -> miette::Result<LockFileUsage> {
-        let usage: LockFileUsage = self
-            .lock_file_usage
-            .clone()
-            .try_into()
-            .map_err(|e: crate::cli::LockFileUsageError| miette::miette!(e))?;
+    pub fn lock_file_usage(&self) -> LockFileUsage {
+        let usage: LockFileUsage = self.lock_file_usage.clone().into();
         if self.no_lockfile_update {
-            Ok(LockFileUsage::Frozen)
+            LockFileUsage::Frozen
         } else {
-            Ok(usage)
+            usage
         }
     }
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -89,7 +89,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environments,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_usage.try_into()?,
+            lock_file_usage: args.lock_file_usage.into(),
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         },

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -184,7 +184,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let lock_file = workspace
         .update_lock_file(UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+            lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         })

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -283,7 +283,6 @@ pub struct LockFileUsageConfig {
     pub locked: bool,
 }
 
-
 pub async fn execute() -> miette::Result<()> {
     let args = Args::parse();
 
@@ -563,8 +562,6 @@ fn print_installed_commands() {
 mod tests {
     use super::*;
     use temp_env;
-
-
 
     #[test]
     fn test_clap_boolean_env_var_behavior() {

--- a/src/cli/reinstall.rs
+++ b/src/cli/reinstall.rs
@@ -82,7 +82,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             &environment,
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
-                lock_file_usage: args.lock_file_usage.clone().try_into()?,
+                lock_file_usage: args.lock_file_usage.clone().into(),
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
             },

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -121,7 +121,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             &workspace.default_environment(),
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
-                lock_file_usage: lock_file_update_config.lock_file_usage()?,
+                lock_file_usage: lock_file_update_config.lock_file_usage(),
                 no_install: prefix_update_config.no_install,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
             },

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -127,7 +127,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Ensure that the lock-file is up-to-date.
     let lock_file = workspace
         .update_lock_file(UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+            lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
             ..UpdateLockFileOptions::default()
         })

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -280,7 +280,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environment,
         UpdateMode::QuickValidate,
         UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+            lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: args.prefix_update_config.no_install
                 && args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),

--- a/src/cli/shell_hook.rs
+++ b/src/cli/shell_hook.rs
@@ -162,7 +162,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environment,
         args.prefix_update_config.update_mode(),
         UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+            lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: args.prefix_update_config.no_install
                 && args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),

--- a/src/cli/tree.rs
+++ b/src/cli/tree.rs
@@ -81,7 +81,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let lock_file = workspace
         .update_lock_file(UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+            lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         })

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -93,7 +93,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             pypi_deps,
             IndexMap::default(),
             args.prefix_update_config.no_install,
-            &args.lock_file_update_config.lock_file_usage()?,
+            &args.lock_file_update_config.lock_file_usage(),
             &args.specs.feature,
             &[],
             false,

--- a/src/cli/workspace/export/conda_explicit_spec.rs
+++ b/src/cli/workspace/export/conda_explicit_spec.rs
@@ -168,7 +168,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let lockfile = workspace
         .update_lock_file(UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+            lock_file_usage: args.lock_file_update_config.lock_file_usage(),
             no_install: args.lock_file_update_config.no_lockfile_update,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         })

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -504,7 +504,7 @@ impl PixiControl {
         // Ensure the lock-file is up-to-date
         let lock_file = project
             .update_lock_file(UpdateLockFileOptions {
-                lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
+                lock_file_usage: args.lock_file_update_config.lock_file_usage(),
                 ..UpdateLockFileOptions::default()
             })
             .await?;

--- a/tests/integration_rust/upgrade_tests.rs
+++ b/tests/integration_rust/upgrade_tests.rs
@@ -45,7 +45,7 @@ async fn pypi_dependency_index_preserved_on_upgrade() {
             pypi_deps,
             IndexMap::default(),
             args.prefix_update_config.no_install,
-            &args.lock_file_update_config.lock_file_usage().unwrap(),
+            &args.lock_file_update_config.lock_file_usage(),
             &args.specs.feature,
             &[],
             true,


### PR DESCRIPTION
There was some very custom machinery to check `--frozen` and `--locked` conflicts. While just using clap will do, this removes all of that and adds clap conflict. Also removes related tests.

## Tested
Ran the commands manually with `--locked` etc. and through env variables and conflicts seem to work.