### PR TITLE
feat: produces a cache miss when a no-binary, no-build was found

### DIFF
--- a/crates/pixi_core/src/install_pypi/mod.rs
+++ b/crates/pixi_core/src/install_pypi/mod.rs
@@ -346,6 +346,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             &site_packages,
             CachedWheels::new(registry_index, built_wheel_index),
             &required_dists,
+            setup.build_options.clone(),
         )
         .into_diagnostic()
         .context("error while determining PyPI installation plan")?;

--- a/crates/pixi_core/src/install_pypi/plan/cache.rs
+++ b/crates/pixi_core/src/install_pypi/plan/cache.rs
@@ -9,11 +9,22 @@
 
 use uv_cache::{CacheBucket, WheelCache};
 use uv_cache_info::Timestamp;
+use uv_configuration::BuildOptions;
 use uv_distribution::{BuiltWheelIndex, RegistryWheelIndex};
 use uv_distribution::{HttpArchivePointer, LocalArchivePointer};
 use uv_distribution_types::BuiltDist;
 use uv_distribution_types::{CachedDirectUrlDist, CachedDist, Dist, Name, SourceDist};
 use uv_pypi_types::VerbatimParsedUrl;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DistCacheError {
+    #[error("URL dependency points to a wheel which conflicts with `--no-binary` option: {url}")]
+    NoBinaryConflictUrl { url: String },
+    #[error("Path dependency points to a wheel which conflicts with `--no-binary` option: {path}")]
+    NoBinaryConflictPath { path: String },
+    #[error(transparent)]
+    Distribution(#[from] uv_distribution::Error),
+}
 
 /// Provides cache lookup functionality for distributions.
 /// This trait can also be used to mock the cache for testing purposes.
@@ -24,7 +35,8 @@ pub trait DistCache<'a> {
         &mut self,
         dist: &'a Dist,
         uv_cache: &uv_cache::Cache,
-    ) -> Result<Option<CachedDist>, uv_distribution::Error>;
+        build_options: BuildOptions,
+    ) -> Result<Option<CachedDist>, DistCacheError>;
 }
 
 /// Provides both access to registry dists and locally built dists
@@ -44,11 +56,22 @@ impl<'a> DistCache<'a> for CachedWheels<'a> {
         &mut self,
         dist: &'a Dist,
         uv_cache: &uv_cache::Cache,
-    ) -> Result<Option<CachedDist>, uv_distribution::Error> {
+        build_options: BuildOptions,
+    ) -> Result<Option<CachedDist>, DistCacheError> {
+        // Check if installation of a binary version of the package should be allowed.
+        let no_binary = build_options.no_binary_package(dist.name());
+        let no_build = build_options.no_build_package(dist.name());
+
         match dist {
             Dist::Built(BuiltDist::Registry(wheel)) => {
                 let cached = self.registry.get(wheel.name()).find_map(|entry| {
                     if entry.index.url() != &wheel.best_wheel().index {
+                        return None;
+                    }
+                    if entry.built && no_build {
+                        return None;
+                    }
+                    if !entry.built && no_binary {
                         return None;
                     }
                     if entry.dist.filename == wheel.best_wheel().filename {
@@ -65,6 +88,12 @@ impl<'a> DistCache<'a> for CachedWheels<'a> {
                 }
             }
             Dist::Built(BuiltDist::DirectUrl(wheel)) => {
+                if no_binary {
+                    return Err(DistCacheError::NoBinaryConflictUrl {
+                        url: wheel.url.to_string(),
+                    });
+                }
+
                 // Find the exact wheel from the cache, since we know the filename in advance.
                 let cache_entry = uv_cache
                     .shard(
@@ -101,6 +130,12 @@ impl<'a> DistCache<'a> for CachedWheels<'a> {
                 }
             }
             Dist::Built(BuiltDist::Path(wheel)) => {
+                if no_binary {
+                    return Err(DistCacheError::NoBinaryConflictPath {
+                        path: wheel.url.to_string(),
+                    });
+                }
+
                 // Validate that the path exists.
                 if !wheel.install_path.exists() {
                     return Ok(None);
@@ -173,6 +208,12 @@ impl<'a> DistCache<'a> for CachedWheels<'a> {
                                 return None;
                             }
                             if entry.dist.filename.name != *sdist.name() {
+                                return None;
+                            }
+                            if entry.built && no_build {
+                                return None;
+                            }
+                            if !entry.built && no_binary {
                                 return None;
                             }
                             if entry.dist.filename.version == sdist.version {

--- a/crates/pixi_core/src/install_pypi/plan/installation_source.rs
+++ b/crates/pixi_core/src/install_pypi/plan/installation_source.rs
@@ -80,7 +80,8 @@ pub fn decide_installation_source<'a>(
     dist: &'a Dist,
     dist_cache: &mut impl DistCache<'a>,
     operation: Operation,
-) -> Result<InstallationSources, uv_distribution::Error> {
+    build_options: uv_configuration::BuildOptions,
+) -> Result<InstallationSources, super::DistCacheError> {
     let mut installation_sources = InstallationSources::new();
     // First, check if we need to revalidate the package
     // then we should get it from the remote
@@ -94,7 +95,7 @@ pub fn decide_installation_source<'a>(
     }
 
     // Check if the distribution is cached
-    match dist_cache.is_cached(dist, uv_cache)? {
+    match dist_cache.is_cached(dist, uv_cache, build_options)? {
         Some(cached_dist) => {
             installation_sources.add_cached(&cached_dist, operation.cached());
         }

--- a/crates/pixi_core/src/install_pypi/plan/mod.rs
+++ b/crates/pixi_core/src/install_pypi/plan/mod.rs
@@ -43,7 +43,7 @@ mod reasons;
 mod required_dists;
 mod validation;
 
-pub use cache::CachedWheels;
+pub use cache::{CachedWheels, DistCacheError};
 pub(crate) use models::NeedReinstall;
 pub use models::PyPIInstallationPlan;
 pub use planner::InstallPlanner;

--- a/crates/pixi_core/src/install_pypi/plan/planner.rs
+++ b/crates/pixi_core/src/install_pypi/plan/planner.rs
@@ -6,6 +6,7 @@ use std::{
 use super::{
     installation_source::{self, Operation},
     validation::NeedsReinstallError,
+    cache::DistCacheError,
 };
 use itertools::{Either, Itertools};
 use pixi_consts::consts;
@@ -46,6 +47,8 @@ pub enum InstallPlannerError {
     UvConversion(#[from] pixi_uv_conversions::ConversionError),
     #[error(transparent)]
     RetrieveDistFromCache(#[from] uv_distribution::Error),
+    #[error(transparent)]
+    DistCache(#[from] DistCacheError),
 }
 
 impl InstallPlanner {
@@ -75,6 +78,7 @@ impl InstallPlanner {
         site_packages: &'a Installed,
         mut dist_cache: Cached,
         required_dists: &'a RequiredDists,
+        build_options: uv_configuration::BuildOptions,
     ) -> Result<PyPIInstallationPlan, InstallPlannerError> {
         // Convert RequiredDists to the reference map for internal processing
         let required_dists_map = required_dists.as_ref_map();
@@ -140,6 +144,7 @@ impl InstallPlanner {
                     required_dist,
                     &mut dist_cache,
                     Operation::Reinstall,
+                    build_options.clone(),
                 )
                 .map_err(InstallPlannerError::from)?;
 
@@ -162,6 +167,7 @@ impl InstallPlanner {
                 dist,
                 &mut dist_cache,
                 Operation::Install,
+                build_options.clone(),
             )
             .map_err(InstallPlannerError::from)?;
 

--- a/crates/pixi_core/src/install_pypi/plan/planner.rs
+++ b/crates/pixi_core/src/install_pypi/plan/planner.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use super::{
+    cache::DistCacheError,
     installation_source::{self, Operation},
     validation::NeedsReinstallError,
-    cache::DistCacheError,
 };
 use itertools::{Either, Itertools};
 use pixi_consts::consts;

--- a/crates/pixi_core/src/install_pypi/plan/test/harness.rs
+++ b/crates/pixi_core/src/install_pypi/plan/test/harness.rs
@@ -406,7 +406,8 @@ impl<'a> DistCache<'a> for NoCache {
         &mut self,
         _dist: &'a uv_distribution_types::Dist,
         _uv_cache: &uv_cache::Cache,
-    ) -> Result<Option<uv_distribution_types::CachedDist>, uv_distribution::Error> {
+        _build_options: uv_configuration::BuildOptions,
+    ) -> Result<Option<uv_distribution_types::CachedDist>, super::super::DistCacheError> {
         Ok(None)
     }
 }
@@ -418,7 +419,8 @@ impl<'a> DistCache<'a> for AllCached {
         &mut self,
         dist: &'a uv_distribution_types::Dist,
         _uv_cache: &uv_cache::Cache,
-    ) -> Result<Option<uv_distribution_types::CachedDist>, uv_distribution::Error> {
+        _build_options: uv_configuration::BuildOptions,
+    ) -> Result<Option<uv_distribution_types::CachedDist>, super::super::DistCacheError> {
         match dist {
             uv_distribution_types::Dist::Built(BuiltDist::Registry(wheel)) => {
                 let dist = CachedRegistryDist {

--- a/crates/pixi_core/src/install_pypi/plan/test/mod.rs
+++ b/crates/pixi_core/src/install_pypi/plan/test/mod.rs
@@ -21,7 +21,7 @@ fn test_no_installed_require_one() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // We should install a single package
@@ -40,7 +40,7 @@ fn test_no_installed_require_one_cached() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists)
+        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // We should install a single package
@@ -65,7 +65,7 @@ fn test_install_required_equivalent() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // Should not install package
@@ -94,7 +94,7 @@ fn test_install_required_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // We should install a single package
@@ -125,7 +125,7 @@ fn test_install_required_mismatch_cached() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists)
+        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // We should install a single package
@@ -155,7 +155,7 @@ fn test_install_required_installer_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(
@@ -182,7 +182,7 @@ fn test_installed_one_other_installer() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // We should not do anything
@@ -206,7 +206,7 @@ fn test_install_required_python_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(
@@ -236,7 +236,7 @@ fn test_installed_one_none_required() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let install_plan = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
     assert_eq!(install_plan.extraneous.len(), 1);
 }
@@ -261,7 +261,7 @@ fn test_installed_registry_required_local_source() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(
@@ -288,7 +288,7 @@ fn test_installed_local_required_registry() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(
@@ -323,7 +323,7 @@ fn test_installed_local_required_local() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_eq!(
@@ -374,7 +374,7 @@ fn test_local_source_newer_than_local_metadata() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
     assert_matches!(
         installs.reinstalls[0].1,
@@ -417,7 +417,7 @@ fn test_local_source_older_than_local_metadata() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
     assert_eq!(installs.reinstalls.len(), 0);
     assert_eq!(installs.cached.len(), 0);
@@ -448,7 +448,7 @@ fn test_installed_editable_required_non_editable() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(
@@ -478,7 +478,7 @@ fn test_installed_archive_require_registry() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(installs.reinstalls[0].1, NeedReinstall::UrlMismatch { .. });
@@ -487,7 +487,7 @@ fn test_installed_archive_require_registry() {
     let required = RequiredPackages::new().add_archive("aiofiles", "0.6.0", remote_url.clone());
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
     assert!(installs.cached.is_empty());
     assert!(installs.remote.is_empty());
@@ -514,7 +514,7 @@ fn test_installed_git_require_registry() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(installs.reinstalls[0].1, NeedReinstall::UrlMismatch { .. });
@@ -527,7 +527,7 @@ fn test_installed_git_require_registry() {
     let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_git_url.clone());
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert!(
@@ -560,7 +560,7 @@ fn test_installed_git_require_git_commit_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert_matches!(
@@ -596,7 +596,7 @@ fn test_installed_git_the_same() {
     let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_git_url.clone());
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert!(
@@ -624,7 +624,7 @@ fn test_uv_refresh() {
     ));
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists)
+        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     // Should not install package
@@ -664,7 +664,7 @@ fn test_archive_is_path() {
     let plan = harness::install_planner_with_lock_dir(tmp.path().to_path_buf());
     let required_dists = required.to_required_dists_with_lock_dir(tmp.path());
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists)
+        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
     // Should not install package
     assert!(installs.reinstalls.is_empty());
@@ -690,7 +690,7 @@ fn duplicates_are_not_extraneous() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists)
+        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
         .expect("should install");
 
     assert!(installs.extraneous.is_empty());

--- a/crates/pixi_core/src/install_pypi/plan/test/mod.rs
+++ b/crates/pixi_core/src/install_pypi/plan/test/mod.rs
@@ -21,7 +21,12 @@ fn test_no_installed_require_one() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // We should install a single package
@@ -40,7 +45,12 @@ fn test_no_installed_require_one_cached() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            AllCached,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // We should install a single package
@@ -65,7 +75,12 @@ fn test_install_required_equivalent() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // Should not install package
@@ -94,7 +109,12 @@ fn test_install_required_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // We should install a single package
@@ -125,7 +145,12 @@ fn test_install_required_mismatch_cached() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            AllCached,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // We should install a single package
@@ -155,7 +180,12 @@ fn test_install_required_installer_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(
@@ -182,7 +212,12 @@ fn test_installed_one_other_installer() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // We should not do anything
@@ -206,7 +241,12 @@ fn test_install_required_python_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(
@@ -236,7 +276,12 @@ fn test_installed_one_none_required() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let install_plan = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
     assert_eq!(install_plan.extraneous.len(), 1);
 }
@@ -261,7 +306,12 @@ fn test_installed_registry_required_local_source() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(
@@ -288,7 +338,12 @@ fn test_installed_local_required_registry() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(
@@ -323,7 +378,12 @@ fn test_installed_local_required_local() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_eq!(
@@ -374,7 +434,12 @@ fn test_local_source_newer_than_local_metadata() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
     assert_matches!(
         installs.reinstalls[0].1,
@@ -417,7 +482,12 @@ fn test_local_source_older_than_local_metadata() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
     assert_eq!(installs.reinstalls.len(), 0);
     assert_eq!(installs.cached.len(), 0);
@@ -448,7 +518,12 @@ fn test_installed_editable_required_non_editable() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(
@@ -478,7 +553,12 @@ fn test_installed_archive_require_registry() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(installs.reinstalls[0].1, NeedReinstall::UrlMismatch { .. });
@@ -487,7 +567,12 @@ fn test_installed_archive_require_registry() {
     let required = RequiredPackages::new().add_archive("aiofiles", "0.6.0", remote_url.clone());
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
     assert!(installs.cached.is_empty());
     assert!(installs.remote.is_empty());
@@ -514,7 +599,12 @@ fn test_installed_git_require_registry() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(installs.reinstalls[0].1, NeedReinstall::UrlMismatch { .. });
@@ -527,7 +617,12 @@ fn test_installed_git_require_registry() {
     let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_git_url.clone());
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert!(
@@ -560,7 +655,12 @@ fn test_installed_git_require_git_commit_mismatch() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert_matches!(
@@ -596,7 +696,12 @@ fn test_installed_git_the_same() {
     let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_git_url.clone());
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert!(
@@ -624,7 +729,12 @@ fn test_uv_refresh() {
     ));
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            AllCached,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     // Should not install package
@@ -664,7 +774,12 @@ fn test_archive_is_path() {
     let plan = harness::install_planner_with_lock_dir(tmp.path().to_path_buf());
     let required_dists = required.to_required_dists_with_lock_dir(tmp.path());
     let installs = plan
-        .plan(&site_packages, AllCached, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            AllCached,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
     // Should not install package
     assert!(installs.reinstalls.is_empty());
@@ -690,7 +805,12 @@ fn duplicates_are_not_extraneous() {
     let plan = harness::install_planner();
     let required_dists = required.to_required_dists();
     let installs = plan
-        .plan(&site_packages, NoCache, &required_dists, uv_configuration::BuildOptions::default())
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            uv_configuration::BuildOptions::default(),
+        )
         .expect("should install");
 
     assert!(installs.extraneous.is_empty());


### PR DESCRIPTION
This PR adds the case where we are using a built or non-built version from cache and we have no specified we want a source or dont want a binary package.

This is kind of a corner case, but uv covers it so its nice to have :)