### PR TITLE
chore: deprecation of configuration

### DIFF
--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// A build section in the pixi manifest.
 /// that defines what backend is used to build the project.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PackageBuild {
     /// Information about the build backend
     pub backend: BuildBackend,
@@ -48,7 +48,7 @@ impl PackageBuild {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BuildBackend {
     /// The name of the build backend to install
     pub name: rattler_conda_types::PackageName,

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -77,14 +77,12 @@ impl TomlPackageBuild {
             None
         };
 
-        // Convert target-specific build configurations
+        // Convert target-specific build config
         let target_config = self
             .target
             .into_iter()
             .flat_map(|(selector, target)| {
-                target
-                    .configuration
-                    .map(|config| (selector.into_inner(), config))
+                target.config.map(|config| (selector.into_inner(), config))
             })
             .collect::<IndexMap<_, _>>();
 

--- a/crates/pixi_manifest/src/toml/build_target.rs
+++ b/crates/pixi_manifest/src/toml/build_target.rs
@@ -1,21 +1,29 @@
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
 
 use crate::toml::build_backend::convert_toml_to_serde;
+use crate::warning::Deprecation;
 
 #[derive(Debug)]
 pub struct TomlPackageBuildTarget {
-    pub configuration: Option<serde_value::Value>,
+    pub config: Option<serde_value::Value>,
+    pub warnings: Vec<crate::Warning>,
 }
 
 impl<'de> toml_span::Deserialize<'de> for TomlPackageBuildTarget {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = TableHelper::new(value)?;
-        let configuration = th
-            .take("configuration")
-            .map(|(_, mut value)| convert_toml_to_serde(&mut value))
-            .transpose()?;
+        let mut warnings = Vec::new();
+
+        let config = if let Some((_, mut value)) = th.take("config") {
+            Some(convert_toml_to_serde(&mut value)?)
+        } else if let Some((key, mut value)) = th.table.remove_entry("configuration") {
+            warnings.push(Deprecation::renamed_field("configuration", "config", key.span).into());
+            Some(convert_toml_to_serde(&mut value)?)
+        } else {
+            None
+        };
 
         th.finalize(None)?;
-        Ok(TomlPackageBuildTarget { configuration })
+        Ok(TomlPackageBuildTarget { config, warnings })
     }
 }

--- a/crates/pixi_manifest/src/toml/package.rs
+++ b/crates/pixi_manifest/src/toml/package.rs
@@ -907,4 +907,61 @@ mod test {
             .unwrap_err();
         assert_snapshot!(format_parse_error(input, parse_error));
     }
+
+    #[test]
+    fn test_target_specific_build_config() {
+        let input = r#"
+        name = "package-name"
+        version = "1.0.0"
+        
+        [build.config]
+        test = "test_normal"
+        
+        [build.target.unix.config]
+        test = "test_unix"
+        
+        [build]
+        backend = { name = "bla", version = "1.0" }
+        "#;
+        let package = TomlPackage::from_toml_str(input).unwrap();
+        let workspace = WorkspacePackageProperties::default();
+
+        let parsed = package
+            .into_manifest(
+                workspace,
+                PackageDefaults::default(),
+                &Preview::default(),
+                None,
+            )
+            .unwrap();
+
+        // Now check if we can also parse the deprecated `configuration` key
+        let input = r#"
+        name = "package-name"
+        version = "1.0.0"
+        
+        [build.configuration]
+        test = "test_normal"
+        
+        [build.target.unix.configuration]
+        test = "test_unix"
+        
+        [build]
+        backend = { name = "bla", version = "1.0" }
+        "#;
+        let package = TomlPackage::from_toml_str(input).unwrap();
+        let workspace = WorkspacePackageProperties::default();
+
+        let parsed_deprecated = package
+            .into_manifest(
+                workspace,
+                PackageDefaults::default(),
+                &Preview::default(),
+                None,
+            )
+            .unwrap();
+
+        assert!(!parsed_deprecated.warnings.is_empty());
+        assert_eq!(parsed.value.build, parsed_deprecated.value.build);
+    }
 }


### PR DESCRIPTION
This PR already did the initial work but I missed this field in that work: https://github.com/prefix-dev/pixi/pull/4380

This fixes:
```toml
[package.build.target.unix.config]
xxx = "xxx"
```