### PR TITLE
feat: add install-as-debug task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -25,6 +25,9 @@ install = { cmd = "cargo install --path crates/pixi --locked", description = "In
 install-as = { cmd = "python scripts/install.py", depends-on = [
   "build-release",
 ] }
+install-as-debug = { cmd = "python scripts/install.py --debug", depends-on = [
+  "build-debug",
+] }
 pypi-proxy = "python scripts/pypi-proxy.py"
 release = "python scripts/release.py"
 run-all-examples = { cmd = "python tests/scripts/run-all-examples.py --pixi-exec $CARGO_TARGET_DIR/release/pixi", depends-on = [

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,7 +25,7 @@ install = { cmd = "cargo install --path crates/pixi --locked", description = "In
 install-as = { cmd = "python scripts/install.py", depends-on = [
   "build-release",
 ] }
-install-as-debug = { cmd = "python scripts/install.py --debug", depends-on = [
+install-debug-as = { cmd = "python scripts/install.py --debug", depends-on = [
   "build-debug",
 ] }
 pypi-proxy = "python scripts/pypi-proxy.py"

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -25,15 +25,23 @@ def main() -> None:
         default=DEFAULT_DESTINATION_DIR,
         help=f"Destination directory for the executable, default: {DEFAULT_DESTINATION_DIR}",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Use the debug dir instead of release"
+    )
 
+    print(os.environ["CARGO_TARGET_DIR"])
     args = parser.parse_args()
 
+    rel_or_deb = "release" if not args.debug else "debug"
+
     built_executable_path = Path(os.environ["CARGO_TARGET_DIR"]).joinpath(
-        "release", executable_extension("pixi")
+        rel_or_deb, executable_extension("pixi")
     )
     destination_path = args.dest.joinpath(executable_extension(args.name))
 
-    print(f"Copying the executable to {destination_path}")
+    print(f"Copying ({rel_or_deb}) the executable to {destination_path}")
     destination_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(built_executable_path, destination_path)
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -25,11 +25,7 @@ def main() -> None:
         default=DEFAULT_DESTINATION_DIR,
         help=f"Destination directory for the executable, default: {DEFAULT_DESTINATION_DIR}",
     )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Use the debug dir instead of release"
-    )
+    parser.add_argument("--debug", action="store_true", help="Use the debug dir instead of release")
 
     print(os.environ["CARGO_TARGET_DIR"])
     args = parser.parse_args()


### PR DESCRIPTION
I use this task all the time, especially with git worktrees as an alias to de target folder does not work. I would like to use the debug version a lot of the time though, because of the faster compilation times. Especially when iterating. I opted *not* to use task arguments cause this autocompletes more nicely.