### PR TITLE
feat: ability to ignore pypi packages during installation

### DIFF
--- a/crates/pixi_core/src/install_pypi/mod.rs
+++ b/crates/pixi_core/src/install_pypi/mod.rs
@@ -136,6 +136,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
 
     /// Configure package names that should never be treated as extraneous
     /// in the PyPI installation planning.
+    #[allow(dead_code)]
     pub fn with_ignored_extraneous<I>(mut self, names: I) -> Self
     where
         I: IntoIterator<Item = PackageName>,

--- a/crates/pixi_core/src/install_pypi/mod.rs
+++ b/crates/pixi_core/src/install_pypi/mod.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    sync::Arc,
+};
 
 use crate::environment::{ContinuePyPIPrefixUpdate, on_python_interpreter_change};
 use chrono::{DateTime, Utc};
@@ -39,6 +43,7 @@ use uv_distribution_types::{
 };
 use uv_install_wheel::LinkMode;
 use uv_installer::{Preparer, SitePackages, UninstallError};
+use uv_pep508::PackageName;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_resolver::{ExcludeNewer, FlatIndex};
 
@@ -101,6 +106,8 @@ pub struct PyPIEnvironmentUpdater<'a> {
     config: PyPIUpdateConfig<'a>,
     build_config: PyPIBuildConfig<'a>,
     context_config: PyPIContextConfig<'a>,
+    // Names that should never be marked as extraneous in PyPI planning
+    ignored_extraneous: HashSet<PackageName>,
 }
 
 type PyPIRecords = (PypiPackageData, PypiPackageEnvironmentData);
@@ -123,7 +130,18 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             config,
             build_config,
             context_config,
+            ignored_extraneous: Default::default(),
         }
+    }
+
+    /// Configure package names that should never be treated as extraneous
+    /// in the PyPI installation planning.
+    pub fn with_ignored_extraneous<I>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = PackageName>,
+    {
+        self.ignored_extraneous = names.into_iter().collect();
+        self
     }
 
     /// Update PyPI packages in the environment, handling all setup, planning, and execution
@@ -342,6 +360,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             self.context_config.uv_context.cache.clone(),
             self.config.lock_file_dir,
         )
+        .with_ignored_extraneous(self.ignored_extraneous.clone())
         .plan(
             &site_packages,
             CachedWheels::new(registry_index, built_wheel_index),

--- a/crates/pixi_core/src/install_pypi/plan/planner.rs
+++ b/crates/pixi_core/src/install_pypi/plan/planner.rs
@@ -13,6 +13,7 @@ use pixi_consts::consts;
 use std::collections::HashSet;
 use uv_cache::Cache;
 use uv_distribution_types::{InstalledDist, Name};
+use uv_pep508::PackageName;
 
 use crate::install_pypi::conversions::ConvertToUvDistError;
 
@@ -35,6 +36,8 @@ use super::{
 pub struct InstallPlanner {
     uv_cache: Cache,
     lock_file_dir: PathBuf,
+    // Packages that should never be marked as extraneous
+    ignored_extraneous: HashSet<PackageName>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -56,6 +59,7 @@ impl InstallPlanner {
         Self {
             uv_cache,
             lock_file_dir: lock_file_dir.as_ref().to_path_buf(),
+            ignored_extraneous: HashSet::new(),
         }
     }
 
@@ -65,7 +69,19 @@ impl InstallPlanner {
         Self {
             uv_cache: self.uv_cache.with_refresh(refresh),
             lock_file_dir: self.lock_file_dir.clone(),
+            ignored_extraneous: self.ignored_extraneous,
         }
+    }
+
+    /// Provide a list of packages that should never be marked as extraneous.
+    /// Any installed distribution with a name in this list will be ignored
+    /// during the extraneous/duplicate detection phase.
+    pub fn with_ignored_extraneous<I>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = PackageName>,
+    {
+        self.ignored_extraneous = names.into_iter().collect();
+        self
     }
 
     /// Figure out what we can link from the cache locally
@@ -189,6 +205,11 @@ impl InstallPlanner {
             let installer = dist
                 .installer()
                 .map_or(String::new(), |f| f.unwrap_or_default());
+
+            // If this package is in the ignore list, never consider it extraneous
+            if self.ignored_extraneous.contains(dist.name()) {
+                continue;
+            }
 
             match pkg {
                 // Apparently we need this package

--- a/crates/pixi_core/src/install_pypi/plan/test/mod.rs
+++ b/crates/pixi_core/src/install_pypi/plan/test/mod.rs
@@ -292,16 +292,8 @@ fn test_installed_one_none_required() {
 #[test]
 fn test_ignored_packages_not_extraneous() {
     let site_packages = MockedSitePackages::new()
-        .add_registry(
-            "aiofiles",
-            "0.6.0",
-            InstalledDistOptions::default(),
-        )
-        .add_registry(
-            "requests",
-            "2.31.0",
-            InstalledDistOptions::default(),
-        );
+        .add_registry("aiofiles", "0.6.0", InstalledDistOptions::default())
+        .add_registry("requests", "2.31.0", InstalledDistOptions::default());
     let required = RequiredPackages::new();
 
     // Build a planner that ignores `aiofiles` for extraneous detection; `requests`

--- a/crates/pixi_core/src/install_pypi/plan/test/mod.rs
+++ b/crates/pixi_core/src/install_pypi/plan/test/mod.rs
@@ -6,6 +6,7 @@ use harness::empty_wheel;
 use std::path::PathBuf;
 use std::str::FromStr;
 use url::Url;
+use uv_distribution_types::Name;
 
 mod harness;
 
@@ -284,6 +285,48 @@ fn test_installed_one_none_required() {
         )
         .expect("should install");
     assert_eq!(install_plan.extraneous.len(), 1);
+}
+
+/// Ignored packages should never be marked as extraneous; non-ignored are
+/// still removed when unneeded
+#[test]
+fn test_ignored_packages_not_extraneous() {
+    let site_packages = MockedSitePackages::new()
+        .add_registry(
+            "aiofiles",
+            "0.6.0",
+            InstalledDistOptions::default(),
+        )
+        .add_registry(
+            "requests",
+            "2.31.0",
+            InstalledDistOptions::default(),
+        );
+    let required = RequiredPackages::new();
+
+    // Build a planner that ignores `aiofiles` for extraneous detection; `requests`
+    // should be considered extraneous and be uninstalled
+    let plan = harness::install_planner()
+        .with_ignored_extraneous(vec![uv_pep508::PackageName::from_str("aiofiles").unwrap()]);
+
+    let required_dists = required.to_required_dists();
+    let install_plan = plan
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            &uv_configuration::BuildOptions::default(),
+        )
+        .expect("should plan");
+
+    // `aiofiles` should not be marked as extraneous; but `requests` should
+    let names: Vec<String> = install_plan
+        .extraneous
+        .iter()
+        .map(|d| d.name().to_string())
+        .collect();
+    assert_eq!(names.len(), 1, "unexpected extraneous: {:?}", names);
+    assert!(names.contains(&"requests".to_string()));
 }
 
 /// When a package was previously installed from a registry, but we now require it from a local source


### PR DESCRIPTION
This paves the way to doing subset installs for PyPI as well as conda and combined, the code for this relatively straightforward as we retain control over what we install as opposed to offloading that to uv. So it basically, when it would mark a package as `extraneous`, just not do so.