### PR TITLE
feat(install): add `--to-prefix` option

### DIFF
--- a/crates/pixi_core/src/lib.rs
+++ b/crates/pixi_core/src/lib.rs
@@ -5,8 +5,11 @@ pub mod diff;
 pub mod environment;
 mod install_pypi;
 pub mod lock_file;
+mod prefix;
+pub mod prefix_override;
 pub mod prompt;
 pub mod repodata;
+
 pub mod workspace;
 
 pub mod signals;

--- a/crates/pixi_core/src/prefix.rs
+++ b/crates/pixi_core/src/prefix.rs
@@ -1,0 +1,1 @@
+// Empty module - placeholder for future prefix utilities

--- a/crates/pixi_core/src/prefix_override.rs
+++ b/crates/pixi_core/src/prefix_override.rs
@@ -1,0 +1,75 @@
+use rattler_conda_types::Platform;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+thread_local! {
+    static PREFIX_OVERRIDES: RefCell<HashMap<String, PathBuf>> = RefCell::new(HashMap::new());
+    static PLATFORM_OVERRIDES: RefCell<HashMap<String, Platform>> = RefCell::new(HashMap::new());
+}
+
+/// A RAII guard that manages thread-local prefix overrides
+pub struct PrefixOverrideGuard {
+    env_names: Vec<String>,
+}
+
+impl PrefixOverrideGuard {
+    /// Create a new prefix override guard for a single environment
+    pub fn new(env_name: String, custom_prefix: PathBuf) -> Self {
+        PREFIX_OVERRIDES.with(|overrides| {
+            overrides
+                .borrow_mut()
+                .insert(env_name.clone(), custom_prefix);
+        });
+
+        Self {
+            env_names: vec![env_name],
+        }
+    }
+
+    /// Create a new prefix override guard with platform override for a single environment
+    pub fn new_with_platform(env_name: String, custom_prefix: PathBuf, platform: Platform) -> Self {
+        PREFIX_OVERRIDES.with(|overrides| {
+            overrides
+                .borrow_mut()
+                .insert(env_name.clone(), custom_prefix);
+        });
+
+        PLATFORM_OVERRIDES.with(|overrides| {
+            overrides.borrow_mut().insert(env_name.clone(), platform);
+        });
+
+        Self {
+            env_names: vec![env_name],
+        }
+    }
+}
+
+impl Drop for PrefixOverrideGuard {
+    fn drop(&mut self) {
+        // Remove all overrides for the environments this guard was managing
+        PREFIX_OVERRIDES.with(|overrides| {
+            let mut map = overrides.borrow_mut();
+            for env_name in &self.env_names {
+                map.remove(env_name);
+            }
+        });
+
+        PLATFORM_OVERRIDES.with(|overrides| {
+            let mut map = overrides.borrow_mut();
+            for env_name in &self.env_names {
+                map.remove(env_name);
+            }
+        });
+    }
+}
+
+/// Get the prefix override for a specific environment, if any
+pub fn get_prefix_override(env_name: &str) -> Option<PathBuf> {
+    PREFIX_OVERRIDES.with(|overrides| overrides.borrow().get(env_name).cloned())
+}
+
+/// Get the platform override for a specific environment, if any
+pub fn get_platform_override(env_name: &str) -> Option<Platform> {
+    PLATFORM_OVERRIDES.with(|overrides| overrides.borrow().get(env_name).cloned())
+}

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -96,7 +96,18 @@ impl<'p> Environment<'p> {
     }
 
     /// Returns the directory where this environment is stored.
+    ///
+    /// This method first checks for any thread-local prefix overrides before
+    /// falling back to the default environment directory.
     pub fn dir(&self) -> std::path::PathBuf {
+        // Check for thread-local prefix override first
+        if let Some(override_path) =
+            crate::prefix_override::get_prefix_override(self.name().as_str())
+        {
+            return override_path;
+        }
+
+        // Fall back to default behavior
         self.workspace
             .environments_dir()
             .join(self.environment.name.as_str())
@@ -118,6 +129,13 @@ impl<'p> Environment<'p> {
 
     /// Returns the best platform for the current platform & environment.
     pub fn best_platform(&self) -> Platform {
+        // Check for thread-local platform override first
+        if let Some(override_platform) =
+            crate::prefix_override::get_platform_override(self.name().as_str())
+        {
+            return override_platform;
+        }
+
         let current = Platform::current();
 
         // If the current platform is supported, return it.

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -20,6 +20,10 @@ pixi install [OPTIONS]
 - <a id="arg---skip" href="#arg---skip">`--skip <SKIP>`</a>
 :  Skip installation of specific packages present in the lockfile. Requires --frozen. This can be useful for instance in a Dockerfile to skip local source dependencies when installing dependencies
 <br>May be provided more than once.
+- <a id="arg---to-prefix" href="#arg---to-prefix">`--to-prefix <PREFIX>`</a>
+:  Install to a custom prefix directory instead of the default environment location
+- <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
+:  The platform to install packages for (only used with --to-prefix)
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
@@ -65,6 +69,8 @@ If you want to install all environments, you can use the `--all` flag.
 Running `pixi install` is not required before running other commands like `pixi run` or `pixi shell`. These commands will automatically install the environment if it is not already installed.
 
 You can use `pixi reinstall` to reinstall all environments, one environment or just some packages of an environment.
+
+Use the `--to-prefix` flag to install packages to a custom directory instead of the default environment location.
 
 
 --8<-- "docs/reference/cli/pixi/install_extender:example"

--- a/tests/integration_rust/common/mod.rs
+++ b/tests/integration_rust/common/mod.rs
@@ -567,6 +567,8 @@ impl PixiControl {
                 config: Default::default(),
                 all: false,
                 skip: None,
+                to_prefix: None,
+                platform: None,
             },
         }
     }


### PR DESCRIPTION
# Add `--to-prefix` option for custom environment installation

## Summary

This PR introduces the `--to-prefix` option to the `pixi install` command, enabling installation of environments to custom directories instead of the default `.pixi/envs/<env-name>` location. This addresses a long-standing community need with an officially-supported solution that supersedes existing third-party tools.

## Motivation

The community has requested flexible environment installation locations for container deployments, CI/CD pipelines, system integration, and production scenarios. Previously, users relied on third-party tools like [`pixi-install-to-prefix`](https://github.com/pavelzw/pixi-install-to-prefix), which had critical limitations:

- **No PyPI package support**: Only conda packages could be installed
- **Maintenance overhead**: Required independent updates and version coordination  
- **Limited integration**: Could not leverage pixi's internal optimizations
- **Behavioral inconsistencies**: Different behavior from native pixi commands

## Implementation

### Core Features

**Custom Prefix Installation**
```bash
pixi install --to-prefix ./my-environment
```

**Platform Override Support**
```bash
pixi install --to-prefix ./env --platform linux-64
```

**Platform Validation**
- Pre-installation compatibility checks
- Clear error messages for unsupported platform combinations

### Technical Architecture

**PrefixOverrideGuard**: Thread-local RAII pattern for safe prefix management
```rust
pub struct PrefixOverrideGuard {
    env_names: Vec<String>,
}
```

**Environment Integration**: Modified `Environment::dir()` and `Environment::best_platform()` to check thread-local overrides before falling back to default behavior.
