### PR TITLE
feat: add the option for multiple `--only` flags.

### DIFF
--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -57,9 +57,9 @@ pub struct Args {
     #[arg(long)]
     pub skip_with_deps: Option<Vec<String>>,
 
-    /// Install and build only this package and its dependencies
+    /// Install and build only these package(s) and their dependencies. Can be passed multiple times.
     #[arg(long)]
-    pub only: Option<String>,
+    pub only: Option<Vec<String>>,
 }
 
 const SKIP_CUTOFF: usize = 5;
@@ -97,7 +97,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let filter = InstallFilter::new()
         .skip_direct(args.skip.clone().unwrap_or_default())
         .skip_with_deps(args.skip_with_deps.clone().unwrap_or_default())
-        .target_package(args.only.clone());
+        .target_packages(args.only.clone().unwrap_or_default());
 
     // Update the prefixes by installing all packages
     let (lock_file, _) = get_update_lock_file_and_prefixes(
@@ -121,7 +121,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Message what's installed
     let mut message = console::style(console::Emoji("✔ ", "")).green().to_string();
 
-    let skip_opts = args.skip.is_some() || args.skip_with_deps.is_some() || args.only.is_some();
+    let skip_opts = args.skip.is_some()
+        || args.skip_with_deps.is_some()
+        || args.only.as_ref().map_or(false, |v| !v.is_empty());
 
     if installed_envs.len() == 1 {
         write!(
@@ -142,7 +144,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             let num_retained = names.retained.len();
 
             // When only is set, also print the number of packages that will be installed
-            if args.only.is_some() {
+            if args.only.as_ref().map_or(false, |v| !v.is_empty()) {
                 write!(&mut message, ", including {} packages", num_retained).unwrap();
             }
 

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -123,7 +123,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let skip_opts = args.skip.is_some()
         || args.skip_with_deps.is_some()
-        || args.only.as_ref().map_or(false, |v| !v.is_empty());
+        || args.only.as_ref().is_some_and(|v| !v.is_empty());
 
     if installed_envs.len() == 1 {
         write!(
@@ -144,7 +144,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             let num_retained = names.retained.len();
 
             // When only is set, also print the number of packages that will be installed
-            if args.only.as_ref().map_or(false, |v| !v.is_empty()) {
+            if args.only.as_ref().is_some_and(|v| !v.is_empty()) {
                 write!(&mut message, ", including {} packages", num_retained).unwrap();
             }
 

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -478,8 +478,8 @@ pub struct InstallFilter {
     pub skip_direct: Vec<String>,
     /// Packages to skip together with their dependencies (hard stop)
     pub skip_with_deps: Vec<String>,
-    /// Target a single package (and its deps) to install
-    pub target_package: Option<String>,
+    /// Target one or more packages (and their deps) to install; empty means no targeting
+    pub target_packages: Vec<String>,
 }
 
 impl InstallFilter {
@@ -497,8 +497,8 @@ impl InstallFilter {
         self
     }
 
-    pub fn target_package(mut self, package: Option<String>) -> Self {
-        self.target_package = package;
+    pub fn target_packages(mut self, packages: impl Into<Vec<String>>) -> Self {
+        self.target_packages = packages.into();
         self
     }
 }

--- a/crates/pixi_core/src/lock_file/install_subset.rs
+++ b/crates/pixi_core/src/lock_file/install_subset.rs
@@ -583,9 +583,9 @@ mod tests {
         ];
         let dc = PackageReachability::new(nodes);
         let required = dc.collect_targets_dependencies(
-            &vec!["A".to_string(), "C".to_string()],
+            &["A".to_string(), "C".to_string()],
             &[],
-            &vec!["B".to_string()],
+            &["B".to_string()],
         );
         assert!(required.contains("A"));
         assert!(required.contains("C"));
@@ -605,8 +605,8 @@ mod tests {
         ];
         let dc = PackageReachability::new(nodes);
         let required = dc.collect_targets_dependencies(
-            &vec!["A".to_string(), "C".to_string()],
-            &vec!["B".to_string()],
+            &["A".to_string(), "C".to_string()],
+            &["B".to_string()],
             &[],
         );
         assert!(required.contains("A"));

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -459,7 +459,7 @@ impl<'p> LockFileDerivedData<'p> {
                     &filter.skip_direct,
                     &filter.target_packages,
                 );
-                let result = subset.filter(locked_env.packages(platform));
+                let result = subset.filter(locked_env.packages(platform))?;
                 let packages = result.install;
                 let ignored = result.ignore;
 
@@ -692,7 +692,7 @@ impl<'p> LockFileDerivedData<'p> {
             &filter.skip_direct,
             &filter.target_packages,
         );
-        let filtered = subset.filter(locked_env.packages(platform));
+        let filtered = subset.filter(locked_env.packages(platform))?;
 
         // Map to names, dedupe and sort for stable output.
         let retained = filtered

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -457,7 +457,7 @@ impl<'p> LockFileDerivedData<'p> {
                 let subset = InstallSubset::new(
                     &filter.skip_with_deps,
                     &filter.skip_direct,
-                    filter.target_package.as_deref(),
+                    &filter.target_packages,
                 );
                 let result = subset.filter(locked_env.packages(platform));
                 let packages = result.install;
@@ -690,7 +690,7 @@ impl<'p> LockFileDerivedData<'p> {
         let subset = InstallSubset::new(
             &filter.skip_with_deps,
             &filter.skip_direct,
-            filter.target_package.as_deref(),
+            &filter.target_packages,
         );
         let filtered = subset.filter(locked_env.packages(platform));
 

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -24,7 +24,8 @@ pixi install [OPTIONS]
 :  Skip a package and its entire dependency subtree. This performs a hard exclusion: the package and its dependencies are not installed unless reachable from another non-skipped root
 <br>May be provided more than once.
 - <a id="arg---only" href="#arg---only">`--only <ONLY>`</a>
-:  Install and build only this package and its dependencies
+:  Install and build only these package(s) and their dependencies. Can be passed multiple times
+<br>May be provided more than once.
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>

--- a/tests/integration_rust/common/builders.rs
+++ b/tests/integration_rust/common/builders.rs
@@ -469,8 +469,8 @@ impl InstallBuilder {
         self.args.skip_with_deps = Some(names);
         self
     }
-    pub fn with_only_package(mut self, pkg: impl Into<String>) -> Self {
-        self.args.only = Some(pkg.into());
+    pub fn with_only_package(mut self, pkg: Vec<String>) -> Self {
+        self.args.only = Some(pkg);
         self
     }
 }

--- a/tests/integration_rust/install_filter_tests.rs
+++ b/tests/integration_rust/install_filter_tests.rs
@@ -132,7 +132,7 @@ async fn install_filter_target_package_zoom_in() {
         .update_lock_file(UpdateLockFileOptions::default())
         .await
         .unwrap();
-    let filter = InstallFilter::new().target_package(Some("a".to_string()));
+    let filter = InstallFilter::new().target_packages(vec!["a".to_string()]);
     let skipped = derived
         .get_filtered_package_names(&env, &filter)
         .unwrap()
@@ -154,7 +154,7 @@ async fn install_filter_target_with_skip_with_deps_stop() {
         .await
         .unwrap();
     let filter = InstallFilter::new()
-        .target_package(Some("a".to_string()))
+        .target_packages(vec!["a".to_string()])
         .skip_with_deps(vec!["c".to_string()]);
     let skipped = derived
         .get_filtered_package_names(&env, &filter)


### PR DESCRIPTION
This augments the abilities introduced in #4404, with the ability to do multiple `--only`, before only one `--only` flag was accepted. In the end the technical change for this was pretty easy, we just add multiple starting points to the reachability analysis instead of one single root. These will then all be iterated through at some point. 

An additional thing that was added is a test to verify that `pixi install --only a --skip-with-deps a` skips the package. Something I felt was missing from the original test-suite.

## Tested

1. Added extra unit tests.
2. User tested:

```bash
╰─ pixi-dev i --only click                                                                                                                                                                                                                         ─╯
✔ The default environment has been installed, including 17 packages excluding 6 other packages.
╰─ pixi-dev i --only flask --only click                                                                                                                                                                                                            ─╯
✔ The default environment has been installed, including 23 packages no packages were skipped (check if cli args were correct).
╰─ pixi-dev i --only click --only python                                                                                                                                                                                                           ─╯
✔ The default environment has been installed, including 17 packages excluding 6 other packages.
╰─ pixi-dev i --only click --skip python                                                                                                                                                                                                           ─╯
✔ The default environment has been installed, including 16 packages excluding 'python' and 7 other packages.
╰─ pixi-dev i --only click --skip-with-deps click                                                                                                                                                                                                  ─╯
✔ The default environment has been installed, including 0 packages excluding 'click' and 23 other packages.
╰─ pixi-dev i --only click --skip click                                                                                                                                                                                                            ─╯
✔ The default environment has been installed, including 16 packages excluding 'click' and 7 other packages.
```

For `pixi.toml`:

```toml
[workspace]
authors = ["Tim de Jager <tdejager89@gmail.com>"]
channels = ["https://prefix.dev/conda-forge"]
name = "test-py"
platforms = ["osx-arm64"]
version = "0.1.0"

[tasks]

[dependencies]
python = ">=3.13.5,<3.14"
click = ">=8.2.1,<9"

[pypi-dependencies]
flask = ">=3.1.2, <4"

```