### PR TITLE
fix: environment never recovering after subset install

### DIFF
--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -204,6 +204,13 @@ impl LockedEnvironmentHash {
     }
 }
 
+impl LockedEnvironmentHash {
+    /// Create an invalid hash for revalidation purposes
+    pub(crate) fn invalid() -> Self {
+        LockedEnvironmentHash("invalid-hash".to_string())
+    }
+}
+
 /// Information about the environment that was used to create the environment.
 #[derive(Serialize, Deserialize)]
 pub(crate) struct EnvironmentFile {
@@ -500,6 +507,13 @@ impl InstallFilter {
     pub fn target_packages(mut self, packages: impl Into<Vec<String>>) -> Self {
         self.target_packages = packages.into();
         self
+    }
+
+    /// Is the filter currently active
+    pub fn filter_active(&self) -> bool {
+        !self.skip_direct.is_empty()
+            || !self.skip_with_deps.is_empty()
+            || !self.target_packages.is_empty()
     }
 }
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -361,6 +361,14 @@ impl<'p> LockFileDerivedData<'p> {
             .update_prefix(environment, reinstall_packages, filter)
             .await?;
 
+        // We write an invalid hash when filtering, as we will need to do a full
+        // revalidation of the environment anyways
+        let hash = if filter.filter_active() {
+            LockedEnvironmentHash::invalid()
+        } else {
+            hash
+        };
+
         // Save an environment file to the environment directory after the update.
         // Avoiding writing the cache away before the update is done.
         write_environment_file(

--- a/tests/integration_rust/install_filter_tests.rs
+++ b/tests/integration_rust/install_filter_tests.rs
@@ -199,6 +199,13 @@ async fn install_subset_e2e_skip_with_deps() {
         .await
         .unwrap();
     let prefix = pixi.default_env_path().unwrap();
+    // When filtering is active, the environment file should contain an invalid hash
+    let env_file = prefix.join("conda-meta").join("pixi");
+    let env_file_contents = fs_err::read_to_string(&env_file).expect("read environment file");
+    assert!(
+        env_file_contents.contains("invalid-hash"),
+        "environment file should contain the invalid hash when filtering is active"
+    );
     assert!(!is_conda_package_installed(&prefix, "dummy-g").await);
     assert!(!is_conda_package_installed(&prefix, "dummy-b").await);
     assert!(is_conda_package_installed(&prefix, "dummy-a").await);


### PR DESCRIPTION
There was a problem when doing a subset install like:

```bash
pixi init
pixi add python
pixi add --pypi flask
pixi install --only flask --skip-with-deps click
pixi r python -c "import click" # <--- This would error
```

Would not work. Now we invalidate the QuickValidation by writing out an **invalid environment hash**. The end-to-end test has also been updated accordingly.

