### PR TITLE
feat: attempt to fix --frozen and --locked story

### DIFF
--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -120,7 +120,7 @@ impl LockFileUpdateConfig {
             ));
         }
 
-        let usage: LockFileUsage = self.lock_file_usage.to_usage().into_diagnostic()?;
+        let usage: LockFileUsage = self.lock_file_usage.to_usage()?;
         Ok(usage)
     }
 }

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -120,12 +120,11 @@ impl LockFileUpdateConfig {
             ));
         }
 
-        let usage: LockFileUsage = self.lock_file_usage.clone().into();
-        if self.no_lockfile_update {
-            Ok(LockFileUsage::Frozen)
-        } else {
-            Ok(usage)
-        }
+        let usage: LockFileUsage = self
+            .lock_file_usage
+            .to_usage()
+            .map_err(|e| miette::miette!(e.to_string()))?;
+        Ok(usage)
     }
 }
 

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -120,10 +120,7 @@ impl LockFileUpdateConfig {
             ));
         }
 
-        let usage: LockFileUsage = self
-            .lock_file_usage
-            .to_usage()
-            .map_err(|e| miette::miette!(e.to_string()))?;
+        let usage: LockFileUsage = self.lock_file_usage.to_usage().into_diagnostic()?;
         Ok(usage)
     }
 }

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -120,8 +120,7 @@ impl LockFileUpdateConfig {
             ));
         }
 
-        let usage: LockFileUsage = self.lock_file_usage.to_usage()?;
-        Ok(usage)
+        Ok(self.lock_file_usage.to_usage())
     }
 }
 
@@ -155,7 +154,7 @@ pub struct LockAndInstallConfig {
     pub lock_file_update_config: LockFileUpdateConfig,
 
     /// Shorthand for the combination of --no-install and --frozen.
-    #[arg(long, help_heading = consts::CLAP_UPDATE_OPTIONS, conflicts_with_all = ["locked"])]
+    #[arg(long, help_heading = consts::CLAP_UPDATE_OPTIONS)]
     pub as_is: bool,
 }
 

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -104,7 +104,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environments,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_usage.to_usage()?,
+            lock_file_usage: args.lock_file_usage.to_usage(),
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         },

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
+use miette::IntoDiagnostic;
 use pixi_config::ConfigCli;
 use pixi_core::{
     UpdateLockFileOptions, WorkspaceLocator,
@@ -104,10 +105,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environments,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
-            lock_file_usage: args
-                .lock_file_usage
-                .to_usage()
-                .map_err(|e| miette::miette!(e.to_string()))?,
+            lock_file_usage: args.lock_file_usage.to_usage().into_diagnostic()?,
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         },

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -105,7 +105,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environments,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_usage.to_usage().into_diagnostic()?,
+            lock_file_usage: args.lock_file_usage.to_usage()?,
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         },

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
-use miette::IntoDiagnostic;
 use pixi_config::ConfigCli;
 use pixi_core::{
     UpdateLockFileOptions, WorkspaceLocator,

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -104,7 +104,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         &environments,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_usage.into(),
+            lock_file_usage: args
+                .lock_file_usage
+                .to_usage()
+                .map_err(|e| miette::miette!(e.to_string()))?,
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         },

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -11,8 +11,9 @@
 use clap::builder::styling::{AnsiColor, Color, Style};
 use clap::{CommandFactory, Parser};
 use indicatif::ProgressDrawTarget;
-use miette::{Diagnostic, IntoDiagnostic};
+use miette::IntoDiagnostic;
 use pixi_consts::consts;
+use pixi_core::environment::LockFileUsage;
 use pixi_progress::global_multi_progress;
 
 use std::{env, io::IsTerminal};
@@ -192,94 +193,10 @@ pub enum Command {
     External(Vec<String>),
 }
 
-#[derive(Debug, Error, Diagnostic)]
+#[derive(Debug, Error)]
 pub enum LockFileUsageError {
     #[error("the argument '--locked' cannot be used together with '--frozen'")]
     FrozenAndLocked,
-}
-
-#[derive(Debug, Default, Copy, Clone)]
-/// Lock file usage from the CLI with automatic validation
-pub struct LockFileUsageArgs {
-    inner: LockFileUsageArgsRaw,
-}
-
-#[derive(Parser, Debug, Default, Copy, Clone)]
-#[group(multiple = false)]
-/// Raw lock file usage arguments (use LockFileUsageArgs instead)
-struct LockFileUsageArgsRaw {
-    /// Install the environment as defined in the lockfile, doesn't update
-    /// lockfile if it isn't up-to-date with the manifest file.
-    #[clap(long, env = "PIXI_FROZEN", help_heading = consts::CLAP_UPDATE_OPTIONS, conflicts_with = "locked")]
-    frozen: bool,
-    /// Check if lockfile is up-to-date before installing the environment,
-    /// aborts when lockfile isn't up-to-date with the manifest file.
-    #[clap(long, env = "PIXI_LOCKED", help_heading = consts::CLAP_UPDATE_OPTIONS, conflicts_with = "frozen")]
-    locked: bool,
-}
-
-impl LockFileUsageArgs {
-    pub fn frozen(&self) -> bool {
-        self.inner.frozen
-    }
-
-    pub fn locked(&self) -> bool {
-        self.inner.locked
-    }
-}
-
-// Automatic conversion from raw args (conflicts handled by clap)
-impl From<LockFileUsageArgsRaw> for LockFileUsageArgs {
-    fn from(raw: LockFileUsageArgsRaw) -> Self {
-        LockFileUsageArgs { inner: raw }
-    }
-}
-
-// For clap flattening - this provides automatic validation
-impl clap::FromArgMatches for LockFileUsageArgs {
-    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
-        let raw = LockFileUsageArgsRaw::from_arg_matches(matches)?;
-        Ok(raw.into())
-    }
-
-    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
-        *self = Self::from_arg_matches(matches)?;
-        Ok(())
-    }
-}
-
-impl clap::Args for LockFileUsageArgs {
-    fn augment_args(cmd: clap::Command) -> clap::Command {
-        LockFileUsageArgsRaw::augment_args(cmd)
-    }
-
-    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
-        LockFileUsageArgsRaw::augment_args_for_update(cmd)
-    }
-}
-
-impl From<LockFileUsageArgs> for pixi_core::environment::LockFileUsage {
-    fn from(value: LockFileUsageArgs) -> Self {
-        if value.frozen() {
-            Self::Frozen
-        } else if value.locked() {
-            Self::Locked
-        } else {
-            Self::Update
-        }
-    }
-}
-
-impl From<LockFileUsageConfig> for pixi_core::environment::LockFileUsage {
-    fn from(value: LockFileUsageConfig) -> Self {
-        if value.frozen {
-            Self::Frozen
-        } else if value.locked {
-            Self::Locked
-        } else {
-            Self::Update
-        }
-    }
 }
 
 /// Configuration for lock file usage, used by LockFileUpdateConfig
@@ -287,12 +204,45 @@ impl From<LockFileUsageConfig> for pixi_core::environment::LockFileUsage {
 pub struct LockFileUsageConfig {
     /// Install the environment as defined in the lockfile, doesn't update
     /// lockfile if it isn't up-to-date with the manifest file.
-    #[clap(long, env = "PIXI_FROZEN", help_heading = consts::CLAP_UPDATE_OPTIONS, conflicts_with = "locked")]
+    #[clap(
+        long,
+        env = "PIXI_FROZEN",
+        action = clap::ArgAction::Set,
+        default_value_t = false,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        require_equals = true,
+        help_heading = consts::CLAP_UPDATE_OPTIONS
+    )]
     pub frozen: bool,
     /// Check if lockfile is up-to-date before installing the environment,
     /// aborts when lockfile isn't up-to-date with the manifest file.
-    #[clap(long, env = "PIXI_LOCKED", help_heading = consts::CLAP_UPDATE_OPTIONS, conflicts_with = "frozen")]
+    #[clap(
+        long,
+        env = "PIXI_LOCKED",
+        action = clap::ArgAction::Set,
+        default_value_t = false,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        require_equals = true,
+        help_heading = consts::CLAP_UPDATE_OPTIONS
+    )]
     pub locked: bool,
+}
+
+impl LockFileUsageConfig {
+    pub fn to_usage(&self) -> Result<LockFileUsage, LockFileUsageError> {
+        if self.frozen && self.locked {
+            return Err(LockFileUsageError::FrozenAndLocked);
+        }
+        Ok(if self.frozen {
+            LockFileUsage::Frozen
+        } else if self.locked {
+            LockFileUsage::Locked
+        } else {
+            LockFileUsage::Update
+        })
+    }
 }
 
 pub async fn execute() -> miette::Result<()> {
@@ -585,6 +535,11 @@ mod tests {
                 parsed.frozen,
                 "Expected PIXI_FROZEN=true to set frozen=true"
             );
+            let usage = parsed.to_usage().unwrap();
+            assert!(matches!(
+                usage,
+                pixi_core::environment::LockFileUsage::Frozen
+            ));
         });
 
         // Test PIXI_FROZEN=false
@@ -596,6 +551,11 @@ mod tests {
                 !parsed.frozen,
                 "Expected PIXI_FROZEN=false to set frozen=false"
             );
+            let usage = parsed.to_usage().unwrap();
+            assert!(matches!(
+                usage,
+                pixi_core::environment::LockFileUsage::Update
+            ));
         });
 
         // Test unset
@@ -603,10 +563,7 @@ mod tests {
             let result = LockFileUsageConfig::try_parse_from(["test"]);
             assert!(result.is_ok());
             let parsed = result.unwrap();
-            assert!(
-                !parsed.frozen,
-                "Expected unset PIXI_FROZEN to set frozen=false"
-            );
+            assert!(!parsed.frozen, "Expected unset PIXI_FROZEN to be false");
         });
     }
 
@@ -617,10 +574,59 @@ mod tests {
             let result = LockFileUsageConfig::try_parse_from(["test", "--frozen"]);
             assert!(result.is_ok());
             let parsed = result.unwrap();
-            assert!(
-                parsed.frozen,
-                "Expected CLI argument --frozen to override PIXI_FROZEN=false"
-            );
+            let usage = parsed.to_usage().unwrap();
+            assert!(matches!(
+                usage,
+                pixi_core::environment::LockFileUsage::Frozen
+            ));
         });
+    }
+
+    #[test]
+    fn test_locked_env_and_conflicts() {
+        // PIXI_FROZEN=true and PIXI_LOCKED=false should work
+        temp_env::with_vars(
+            vec![
+                ("PIXI_FROZEN", Some("true")),
+                ("PIXI_LOCKED", Some("false")),
+            ],
+            || {
+                let parsed = LockFileUsageConfig::try_parse_from(["test"]).unwrap();
+                let usage = parsed.to_usage().expect("should validate");
+                assert!(matches!(
+                    usage,
+                    pixi_core::environment::LockFileUsage::Frozen
+                ));
+            },
+        );
+
+        // PIXI_FROZEN=true and PIXI_LOCKED=true should conflict
+        temp_env::with_vars(
+            vec![("PIXI_FROZEN", Some("true")), ("PIXI_LOCKED", Some("true"))],
+            || {
+                let parsed = LockFileUsageConfig::try_parse_from(["test"]).unwrap();
+                let err = parsed.to_usage();
+                assert!(err.is_err(), "Expected conflict when both are true");
+            },
+        );
+    }
+
+    #[test]
+    fn test_require_equals_for_boolean_flags() {
+        // Disallow space-separated value for --locked
+        let err = LockFileUsageConfig::try_parse_from(["test", "--locked", "true"]);
+        assert!(
+            err.is_err(),
+            "--locked true should not be accepted (require_equals)"
+        );
+
+        // Allow equals form
+        let ok = LockFileUsageConfig::try_parse_from(["test", "--locked=true"])
+            .expect("--locked=true should parse");
+        assert!(ok.locked);
+
+        // Bare flag still sets true
+        let ok2 = LockFileUsageConfig::try_parse_from(["test", "--locked"]).unwrap();
+        assert!(ok2.locked);
     }
 }

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -11,7 +11,7 @@
 use clap::builder::styling::{AnsiColor, Color, Style};
 use clap::{CommandFactory, Parser};
 use indicatif::ProgressDrawTarget;
-use miette::IntoDiagnostic;
+use miette::{Diagnostic, IntoDiagnostic};
 use pixi_consts::consts;
 use pixi_core::environment::LockFileUsage;
 use pixi_progress::global_multi_progress;
@@ -193,7 +193,7 @@ pub enum Command {
     External(Vec<String>),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Diagnostic)]
 pub enum LockFileUsageError {
     #[error("the argument '--locked' cannot be used together with '--frozen'")]
     FrozenAndLocked,

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
+use miette::IntoDiagnostic;
 use pixi_config::ConfigCli;
 use pixi_core::environment::{InstallFilter, get_update_lock_file_and_prefix};
 use pixi_core::lock_file::{ReinstallPackages, UpdateMode};
@@ -82,11 +83,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             &environment,
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
-                lock_file_usage: args
-                    .lock_file_usage
-                    .clone()
-                    .to_usage()
-                    .map_err(|e| miette::miette!(e.to_string()))?,
+                lock_file_usage: args.lock_file_usage.clone().to_usage().into_diagnostic()?,
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
             },

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -82,7 +82,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             &environment,
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
-                lock_file_usage: args.lock_file_usage.clone().into(),
+                lock_file_usage: args
+                    .lock_file_usage
+                    .clone()
+                    .to_usage()
+                    .map_err(|e| miette::miette!(e.to_string()))?,
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
             },

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
-use miette::IntoDiagnostic;
 use pixi_config::ConfigCli;
 use pixi_core::environment::{InstallFilter, get_update_lock_file_and_prefix};
 use pixi_core::lock_file::{ReinstallPackages, UpdateMode};
@@ -83,7 +82,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             &environment,
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
-                lock_file_usage: args.lock_file_usage.clone().to_usage().into_diagnostic()?,
+                lock_file_usage: args.lock_file_usage.to_usage(),
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
             },

--- a/crates/pixi_docs/src/main.rs
+++ b/crates/pixi_docs/src/main.rs
@@ -299,16 +299,21 @@ fn arguments(options: &[&clap::Arg], parents: &[String]) -> String {
             if let Some(short) = opt.get_short() {
                 format!(" (-{})", short)
             } else {
-                "".to_string()
+                String::new()
             },
             if opt.get_action().takes_values() && !opt.is_positional() {
                 if let Some(value_names) = opt.get_value_names() {
-                    format!(" <{}>", value_names.join(" "))
+                    let sep = if opt.is_require_equals_set() {
+                        "="
+                    } else {
+                        " "
+                    };
+                    format!("{}<{}>", sep, value_names.join(" "))
                 } else {
-                    "".to_string()
+                    String::new()
                 }
             } else {
-                "".to_string()
+                String::new()
             }
         )
         .unwrap();

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -64,12 +64,16 @@ pixi add [OPTIONS] <SPEC>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -64,12 +64,12 @@ pixi add [OPTIONS] <SPEC>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/exec.md
+++ b/docs/reference/cli/pixi/exec.md
@@ -31,7 +31,7 @@ pixi exec [OPTIONS] [COMMAND]...
 <br>**default**: `current_platform`
 - <a id="arg---force-reinstall" href="#arg---force-reinstall">`--force-reinstall`</a>
 :  If specified a new environment is always created even if one already exists
-- <a id="arg---list" href="#arg---list">`--list <LIST>`</a>
+- <a id="arg---list" href="#arg---list">`--list=<LIST>`</a>
 :  Before executing the command, list packages in the environment Specify `--list=some_regex` to filter the shown packages
 - <a id="arg---no-modify-ps1" href="#arg---no-modify-ps1">`--no-modify-ps1`</a>
 :  Disable modification of the PS1 prompt to indicate the temporary environment

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -48,12 +48,16 @@ pixi install [OPTIONS]
 :  Use environment activation cache (experimental)
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -48,12 +48,12 @@ pixi install [OPTIONS]
 :  Use environment activation cache (experimental)
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -32,12 +32,16 @@ pixi list [OPTIONS] [REGEX]
 :  Only list packages that are explicitly defined in the workspace
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
 

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -32,12 +32,12 @@ pixi list [OPTIONS] [REGEX]
 :  Only list packages that are explicitly defined in the workspace
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/reinstall.md
+++ b/docs/reference/cli/pixi/reinstall.md
@@ -44,12 +44,12 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 :  Use environment activation cache (experimental)
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/reinstall.md
+++ b/docs/reference/cli/pixi/reinstall.md
@@ -44,12 +44,16 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 :  Use environment activation cache (experimental)
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -62,12 +62,16 @@ pixi remove [OPTIONS] <SPEC>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -62,12 +62,12 @@ pixi remove [OPTIONS] <SPEC>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -55,12 +55,12 @@ pixi run [OPTIONS] [TASK]...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -55,12 +55,16 @@ pixi run [OPTIONS] [TASK]...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 - <a id="arg---as-is" href="#arg---as-is">`--as-is`</a>
 :  Shorthand for the combination of --no-install and --frozen
 

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -50,12 +50,16 @@ pixi shell-hook [OPTIONS]
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 - <a id="arg---as-is" href="#arg---as-is">`--as-is`</a>
 :  Shorthand for the combination of --no-install and --frozen
 

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -50,12 +50,12 @@ pixi shell-hook [OPTIONS]
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/shell.md
+++ b/docs/reference/cli/pixi/shell.md
@@ -45,12 +45,12 @@ pixi shell [OPTIONS]
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/shell.md
+++ b/docs/reference/cli/pixi/shell.md
@@ -45,12 +45,16 @@ pixi shell [OPTIONS]
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 - <a id="arg---as-is" href="#arg---as-is">`--as-is`</a>
 :  Shorthand for the combination of --no-install and --frozen
 

--- a/docs/reference/cli/pixi/tree.md
+++ b/docs/reference/cli/pixi/tree.md
@@ -24,12 +24,12 @@ pixi tree [OPTIONS] [REGEX]
 :  Invert tree and show what depends on given package in the regex argument
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/tree.md
+++ b/docs/reference/cli/pixi/tree.md
@@ -24,12 +24,16 @@ pixi tree [OPTIONS] [REGEX]
 :  Invert tree and show what depends on given package in the regex argument
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
 

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -51,12 +51,12 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -51,12 +51,16 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/workspace/channel/add.md
+++ b/docs/reference/cli/pixi/workspace/channel/add.md
@@ -48,12 +48,16 @@ pixi workspace channel add [OPTIONS] <CHANNEL>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/workspace/channel/add.md
+++ b/docs/reference/cli/pixi/workspace/channel/add.md
@@ -48,12 +48,12 @@ pixi workspace channel add [OPTIONS] <CHANNEL>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/workspace/channel/remove.md
+++ b/docs/reference/cli/pixi/workspace/channel/remove.md
@@ -48,12 +48,16 @@ pixi workspace channel remove [OPTIONS] <CHANNEL>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/workspace/channel/remove.md
+++ b/docs/reference/cli/pixi/workspace/channel/remove.md
@@ -48,12 +48,12 @@ pixi workspace channel remove [OPTIONS] <CHANNEL>...
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
@@ -51,12 +51,12 @@ pixi workspace export conda-explicit-spec [OPTIONS] <OUTPUT_DIR>
 :  Use environment activation cache (experimental)
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen=<FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
 <br>**default**: `false`
 <br>**options**: `true`, `false`
-- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
+- <a id="arg---locked" href="#arg---locked">`--locked=<LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
 <br>**default**: `false`

--- a/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
@@ -51,12 +51,16 @@ pixi workspace export conda-explicit-spec [OPTIONS] <OUTPUT_DIR>
 :  Use environment activation cache (experimental)
 
 ## Update Options
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
+- <a id="arg---frozen" href="#arg---frozen">`--frozen <FROZEN>`</a>
 :  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
 <br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
+<br>**default**: `false`
+<br>**options**: `true`, `false`
+- <a id="arg---locked" href="#arg---locked">`--locked <LOCKED>`</a>
 :  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
 <br>**env**: `PIXI_LOCKED`
+<br>**default**: `false`
+<br>**options**: `true`, `false`
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock-file
 


### PR DESCRIPTION
This attempts to fix: https://github.com/prefix-dev/pixi/issues/4466. the issue that I re-introduced inadvertently.

I tried to do most of it through clap, this will change the CLI a bit that `--frozen=true` and `--locked=true` are allowed, and `false` for that matter. The `requires_equal` means you *cannot* use `--locked true`. But the big upside is that we are using mainly clap machinery to parse, which from my point of view is a big advantage. It also uses less code to boot. 

From my tests it seems that the env vars and how they are interpreted work as you would expect, i.e., the CLI options take precedence. But could be that I'm missing something.

I've tested the following:

```bash
PIXI_FROZEN=true PIXI_LOCKED=false pixi-dev i --frozen                                                                                                                                             ─╯
✔ The default environment has been installed.

PIXI_FROZEN=true PIXI_LOCKED=true pixi-dev i --frozen                                                                                                                                              ─╯
Error:   × the argument '--locked' cannot be used together with '--frozen'

╰─ PIXI_FROZEN=true PIXI_LOCKED=fakse pixi-dev i --frozen --locked                                                                                                                                    ─╯
Error:   × the argument '--locked' cannot be used together with '--frozen'

╰─ PIXI_FROZEN=true PIXI_LOCKED=false pixi-dev i --frozen --locked                                                                                                                                    ─╯
Error:   × the argument '--locked' cannot be used together with '--frozen'

╰─ PIXI_FROZEN=true PIXI_LOCKED=false pixi-dev i --frozen --locked=false                                                                                                                              ─╯
✔ The default environment has been installed.

╰─ PIXI_FROZEN=true PIXI_LOCKED=true pixi-dev i --frozen --locked=false                                                                                                                               ─╯
✔ The default environment has been installed.

╰─ PIXI_FROZEN=true PIXI_LOCKED=true pixi-dev i --frozen                                                                                                                                              ─╯
Error:   × the argument '--locked' cannot be used together with '--frozen'

╰─ PIXI_FROZEN=true PIXI_LOCKED=true pixi-dev i                                                                                                                                                       ─╯
Error:   × the argument '--locked' cannot be used together with '--frozen'

╰─ PIXI_FROZEN=asf PIXI_LOCKED=asf pixi-dev i --locked                                                                                                                                                ─╯
error: invalid value 'asf' for '--frozen[=<FROZEN>]'
  [possible values: true, false]

For more information, try '--help'.

╰─ PIXI_FROZEN=asf PIXI_LOCKED=asf pixi-dev i --locked --frozen=false                                                                                                                                 ─╯
✔ The default environment has been installed.

╰─ pixi-dev i --locked true                                                                                                                                                                           ─╯
error: unexpected argument 'true' found

Usage: pixi-dev install [OPTIONS]

For more information, try '--help'.
```