### PR TITLE
fix: default to outputting build  logs

### DIFF
--- a/crates/pixi_reporters/src/sync_reporter.rs
+++ b/crates/pixi_reporters/src/sync_reporter.rs
@@ -92,7 +92,7 @@ impl BackendSourceBuildReporter for SyncReporter {
         mut backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     ) {
         // Enable streaming of the logs from the backend
-        let print_backend_output = tracing::event_enabled!(tracing::Level::INFO);
+        let print_backend_output = tracing::event_enabled!(tracing::Level::WARN);
         // Stream the progress of the output to the screen.
         let progress_bar = self.multi_progress.clone();
 


### PR DESCRIPTION
Instead of always running with `pixi build/install -v` now the build output will always be shown, unless you run with `-q` to silence the output. 

We should still work on an improved experience because it's a bit to much for big builds with multiple packages, but it's better than nothing for now. 

fixes: https://github.com/prefix-dev/pixi/issues/4391
