### PR TITLE
fix: improve source metadata error

### DIFF
--- a/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
@@ -208,7 +208,7 @@ impl SourceMetadataCollector {
 
         // Make sure that a package with the name defined in spec is available from the
         // backend.
-        if !source_metadata.skipped_packages.is_empty() {
+        if source_metadata.records.is_empty() {
             return Err(CommandDispatcherError::Failed(
                 CollectSourceMetadataError::PackageMetadataNotFound {
                     help: Self::create_metadata_not_found_help(


### PR DESCRIPTION
Before:
```
Error:   × failed to solve requirements of environment 'default' for platform 'osx-arm64'
  ╰─▶   × the package 'ros-jazzy-my-python-ros-apkg' is not provided by the project located at 'src/my_python_ros_pkg'
        help: No packages are provided by the build-backend
```

After:
```
Error:   × failed to solve requirements of environment 'default' for platform 'osx-arm64'
  ╰─▶   × the package 'ros-jazzy-my-python-ros-apkg' is not provided by the project located at 'src/my_python_ros_pkg'
        help: The build backend does provide other packages, did you mean 'ros-jazzy-my-python-ros-pkg'?
```