### PR TITLE
chore: put `AGENTS.md` into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Thumbs.db
 .env.local
 .env.*.local
 
+# Agents
+AGENTS.md
+
 # Documentation and build artifacts
 site/
 .build


### PR DESCRIPTION
Codex doesn't support `AGENTS.local.md` and we don't want to encourage AI-generated (external) contributions at the moment