### PR TITLE
fix: clear progress bar after install

### DIFF
--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -20,7 +20,7 @@ pub use satisfiability::{
     EnvironmentUnsat, PlatformUnsat, verify_environment_satisfiability,
     verify_platform_satisfiability,
 };
-pub use update::{LockFileDerivedData, ReinstallPackages, UpdateContext};
+pub use update::{LockFileDerivedData, PackageFilterNames, ReinstallPackages, UpdateContext};
 pub use update::{UpdateLockFileOptions, UpdateMode};
 pub use utils::filter_lock_file;
 


### PR DESCRIPTION
Fixes #4294 

When using `get_update_lock_file_and_prefixes` `LockFileDerivedData` is returned. This struct contains the `CommandDispatcher` that was used to do computations for the update. However, this struct holds a reference to the progress bar which keeps it alive. 

The fix was to destructure the `LockFileDerivedData` and only take the parts that are actually needed. This in turn destroys the `CommandDispatcher` and cleans up the progress bar.