### PR TITLE
fix: rebuild if dependencies changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "miette 7.6.0",
+ "ordermap",
  "pin-project-lite",
  "pixi_build_discovery",
  "pixi_build_frontend",
@@ -4921,6 +4922,7 @@ dependencies = [
  "pixi_record",
  "pixi_spec",
  "pixi_spec_containers",
+ "pixi_stable_hash",
  "pixi_test_utils",
  "pixi_utils",
  "rand 0.9.2",
@@ -5381,6 +5383,7 @@ dependencies = [
  "ordermap",
  "rattler_conda_types",
  "rattler_digest",
+ "serde_json",
  "url",
  "xxhash-rust",
 ]

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -21,13 +21,12 @@
 use std::{convert::Infallible, fmt::Display, hash::Hash, path::PathBuf, str::FromStr};
 
 use ordermap::OrderMap;
+use pixi_stable_hash::{IsDefault, StableHashBuilder};
 use rattler_conda_types::{BuildNumberSpec, StringMatcher, Version, VersionSpec};
 use rattler_digest::{Md5, Md5Hash, Sha256, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, DisplayFromStr, SerializeDisplay, serde_as};
 use url::Url;
-
-use pixi_stable_hash::{IsDefault, StableHashBuilder};
 
 /// Enum containing all versions of the project model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -106,6 +105,14 @@ pub struct ProjectModelV1 {
     /// The target of the project, this may contain
     /// platform specific configurations.
     pub targets: Option<TargetsV1>,
+}
+
+impl IsDefault for ProjectModelV1 {
+    type Item = Self;
+
+    fn is_non_default(&self) -> Option<&Self::Item> {
+        Some(self)
+    }
 }
 
 impl From<ProjectModelV1> for VersionedProjectModel {

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -20,6 +20,7 @@ fs-err = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }
+ordermap = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true }
 reqwest-middleware = { workspace = true }
@@ -56,6 +57,7 @@ pixi_glob = { workspace = true }
 pixi_record = { workspace = true }
 pixi_spec = { workspace = true }
 pixi_spec_containers = { workspace = true }
+pixi_stable_hash = { workspace = true, features = ["serde_json"] }
 pixi_utils = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pixi_command_dispatcher/src/build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build/mod.rs
@@ -13,7 +13,8 @@ use std::hash::{Hash, Hasher};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 pub use build_cache::{
     BuildCache, BuildCacheEntry, BuildCacheError, BuildHostEnvironment, BuildHostPackage,
-    BuildInput, CachedBuild, CachedBuildSourceInfo,
+    BuildInput, CachedBuild, CachedBuildSourceInfo, PackageBuildInputHash,
+    PackageBuildInputHashBuilder,
 };
 pub use build_environment::BuildEnvironment;
 pub use dependencies::{

--- a/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
@@ -3,16 +3,19 @@ use std::path::PathBuf;
 use chrono::Utc;
 use itertools::chain;
 use miette::Diagnostic;
+use pixi_build_discovery::EnabledProtocols;
 use pixi_glob::GlobModificationTime;
 use pixi_record::PinnedSourceSpec;
-use rattler_conda_types::ChannelUrl;
+use rattler_conda_types::{ChannelConfig, ChannelUrl};
 use tokio::sync::Mutex;
 use tracing::instrument;
 
 use crate::{
     BuildEnvironment, CommandDispatcher, CommandDispatcherError, CommandDispatcherErrorResultExt,
     PackageIdentifier, SourceCheckoutError,
-    build::{BuildCacheEntry, BuildCacheError, BuildInput, CachedBuild},
+    build::{
+        BuildCacheEntry, BuildCacheError, BuildInput, CachedBuild, PackageBuildInputHashBuilder,
+    },
 };
 
 /// A list of globs that should be ignored when calculating any input hash.
@@ -44,6 +47,12 @@ pub struct SourceBuildCacheStatusSpec {
 
     /// The build environment used to build the package.
     pub build_environment: BuildEnvironment,
+
+    /// The channel configuration to use when building the package.
+    pub channel_config: ChannelConfig,
+
+    /// The protocols that are enabled when discovering the build backend.
+    pub enabled_protocols: EnabledProtocols,
 }
 
 pub enum CachedBuildStatus {
@@ -125,6 +134,18 @@ impl SourceBuildCacheStatusSpec {
             return Ok(CachedBuildStatus::UpToDate(cached_build));
         }
 
+        // Check if the project configuration has changed.
+        let cached_build = match self
+            .check_package_configuration_changed(command_dispatcher, cached_build, source)
+            .await?
+        {
+            CachedBuildStatus::UpToDate(cached_build) => cached_build,
+            CachedBuildStatus::Stale(cached_build) => {
+                return Ok(CachedBuildStatus::Stale(cached_build));
+            }
+            CachedBuildStatus::Missing => return Ok(CachedBuildStatus::Missing),
+        };
+
         // Determine if the package is out of date by checking the source
         let cached_build = match self
             .check_source_out_of_date(command_dispatcher, cached_build, source)
@@ -173,6 +194,8 @@ impl SourceBuildCacheStatusSpec {
                     source: source.clone(),
                     channels: self.channels.clone(),
                     build_environment: self.build_environment.clone(),
+                    channel_config: self.channel_config.clone(),
+                    enabled_protocols: self.enabled_protocols.clone(),
                 })
                 .await
                 .try_into_failed()?
@@ -214,6 +237,65 @@ impl SourceBuildCacheStatusSpec {
             }
         }
 
+        Ok(CachedBuildStatus::UpToDate(cached_build))
+    }
+
+    /// Checks if the package configuration has changed by computing a hash and
+    /// comparing that against the stored hash.
+    ///
+    /// TODO: Optimize the crap out of this, currently we have to checkout the
+    /// source, discover the backend, and compute hashes. We can probably
+    /// already early out if some of this information is cached more granularly.
+    /// E.g. if the pixi.toml file didnt change (compare using timestamp) then
+    /// we can probably skip a bunch of these things.
+    async fn check_package_configuration_changed(
+        &self,
+        command_dispatcher: &CommandDispatcher,
+        cached_build: CachedBuild,
+        source: &PinnedSourceSpec,
+    ) -> Result<CachedBuildStatus, CommandDispatcherError<SourceBuildCacheStatusError>> {
+        let Some(source_info) = &cached_build.source else {
+            return Ok(CachedBuildStatus::UpToDate(cached_build));
+        };
+
+        let Some(current_hash) = source_info.package_build_input_hash else {
+            tracing::debug!(
+                "package is stale because the package build input hash is missing or stale",
+            );
+            return Ok(CachedBuildStatus::Stale(cached_build));
+        };
+
+        // Checkout the source for the package.
+        let source_checkout = command_dispatcher
+            .checkout_pinned_source(source.clone())
+            .await
+            .map_err_with(SourceBuildCacheStatusError::SourceCheckout)?;
+
+        // Determine the backend parameters for the package.
+        let backend = command_dispatcher
+            .discover_backend(
+                &source_checkout.path,
+                self.channel_config.clone(),
+                self.enabled_protocols.clone(),
+            )
+            .await
+            .map_err_with(SourceBuildCacheStatusError::Discovery)?;
+
+        // Compute a hash of the package configuration.
+        let package_build_input_hash = PackageBuildInputHashBuilder {
+            project_model: backend.init_params.project_model.as_ref(),
+            configuration: backend.init_params.configuration.as_ref(),
+            target_configuration: backend.init_params.target_configuration.as_ref(),
+        }
+        .finish();
+
+        // Compare the hashes
+        if current_hash != package_build_input_hash {
+            tracing::debug!("package is stale because the package build input hash has changed");
+            return Ok(CachedBuildStatus::Stale(cached_build));
+        }
+
+        // Compute the input hash of the build.
         Ok(CachedBuildStatus::UpToDate(cached_build))
     }
 
@@ -295,6 +377,10 @@ pub enum SourceBuildCacheStatusError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     SourceCheckout(SourceCheckoutError),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Discovery(pixi_build_discovery::DiscoveryError),
 
     #[error("a cycle was detected in the build/host dependencies of the package")]
     Cycle,

--- a/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
@@ -243,7 +243,7 @@ impl SourceBuildCacheStatusSpec {
     /// Checks if the package configuration has changed by computing a hash and
     /// comparing that against the stored hash.
     ///
-    /// TODO: Optimize the crap out of this, currently we have to checkout the
+    /// TODO: We should optimize this because currently we have to checkout the
     /// source, discover the backend, and compute hashes. We can probably
     /// already early out if some of this information is cached more granularly.
     /// E.g. if the pixi.toml file didnt change (compare using timestamp) then

--- a/crates/pixi_stable_hash/Cargo.toml
+++ b/crates/pixi_stable_hash/Cargo.toml
@@ -15,6 +15,7 @@ ordermap = { workspace = true }
 # Optional integrations
 rattler_conda_types = { workspace = true, optional = true }
 rattler_digest = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/pixi_stable_hash/src/json.rs
+++ b/crates/pixi_stable_hash/src/json.rs
@@ -1,0 +1,198 @@
+//! Stable hashing utilities for `serde_json::Value`.
+//!
+//! This module provides `StableJson`, a lightweight wrapper around a
+//! `serde_json::Value` that implements `Hash` with configurable behavior.
+//!
+//! - Uses variant discriminants to avoid collisions across JSON types
+//! - Recurses through arrays/objects, including lengths and keys
+//! - Optionally sorts object keys to make object hashing order-insensitive
+
+use std::hash::{Hash, Hasher};
+
+use serde_json::{Number, Value};
+
+use crate::{FieldDiscriminant, IsDefault};
+
+/// A reference-based hasher for `serde_json::Value` with configuration.
+#[derive(Clone, Copy, Debug)]
+pub struct StableJson<'a> {
+    value: &'a Value,
+    sort_keys: bool,
+}
+
+impl<'a> StableJson<'a> {
+    /// Create a new stable JSON hasher with default config (sort keys).
+    pub fn new(value: &'a Value) -> Self {
+        Self {
+            value,
+            sort_keys: true,
+        }
+    }
+
+    /// Configure whether to sort object keys before hashing.
+    pub fn with_sort_keys(mut self, sort_keys: bool) -> Self {
+        self.sort_keys = sort_keys;
+        self
+    }
+}
+
+impl Hash for StableJson<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        hash_value(self.value, self.sort_keys, state);
+    }
+}
+
+fn hash_value<H: Hasher>(v: &Value, sort_keys: bool, state: &mut H) {
+    match v {
+        Value::Null => {
+            FieldDiscriminant::new("json:null").hash(state);
+        }
+        Value::Bool(b) => {
+            FieldDiscriminant::new("json:bool").hash(state);
+            b.hash(state);
+        }
+        Value::Number(n) => {
+            FieldDiscriminant::new("json:number").hash(state);
+            hash_number(n, state);
+        }
+        Value::String(s) => {
+            FieldDiscriminant::new("json:string").hash(state);
+            s.hash(state);
+        }
+        Value::Array(arr) => {
+            FieldDiscriminant::new("json:array").hash(state);
+            arr.len().hash(state);
+            for item in arr {
+                FieldDiscriminant::new("json:array:elt").hash(state);
+                hash_value(item, sort_keys, state);
+            }
+        }
+        Value::Object(map) => {
+            FieldDiscriminant::new("json:object").hash(state);
+            if sort_keys {
+                let mut entries: Vec<(&str, &Value)> =
+                    map.iter().map(|(k, v)| (k.as_str(), v)).collect();
+                entries.sort_by(|a, b| a.0.cmp(b.0));
+                entries.len().hash(state);
+                for (k, v) in entries {
+                    FieldDiscriminant::new("json:object:key").hash(state);
+                    k.hash(state);
+                    FieldDiscriminant::new("json:object:val").hash(state);
+                    hash_value(v, sort_keys, state);
+                }
+            } else {
+                map.len().hash(state);
+                for (k, v) in map {
+                    FieldDiscriminant::new("json:object:key").hash(state);
+                    k.hash(state);
+                    FieldDiscriminant::new("json:object:val").hash(state);
+                    hash_value(v, sort_keys, state);
+                }
+            }
+        }
+    }
+}
+
+fn hash_number<H: Hasher>(n: &Number, state: &mut H) {
+    if let Some(i) = n.as_i64() {
+        FieldDiscriminant::new("json:number:i64").hash(state);
+        i.hash(state);
+    } else if let Some(u) = n.as_u64() {
+        FieldDiscriminant::new("json:number:u64").hash(state);
+        u.hash(state);
+    } else if let Some(f) = n.as_f64() {
+        FieldDiscriminant::new("json:number:f64").hash(state);
+        // Normalize -0.0 to +0.0 for a canonical zero representation
+        let f = if f == 0.0 { 0.0 } else { f };
+        f.to_bits().hash(state);
+    } else {
+        // Fallback: shouldn't happen for valid JSON numbers
+        FieldDiscriminant::new("json:number:other").hash(state);
+        n.to_string().hash(state);
+    }
+}
+
+impl IsDefault for StableJson<'_> {
+    type Item = Self;
+
+    fn is_non_default(&self) -> Option<&Self::Item> {
+        if !self.value.is_null() {
+            Some(self)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::Hasher;
+
+    use xxhash_rust::xxh3::Xxh3;
+
+    use super::*;
+
+    #[test]
+    fn object_key_order_ignored_when_sorting() {
+        let v1 = serde_json::json!({ "b": 2, "a": 1, "c": [1, 2]});
+        let v2 = serde_json::json!({ "c": [1, 2], "a": 1, "b": 2});
+
+        let mut h1 = Xxh3::default();
+        StableJson::new(&v1).with_sort_keys(true).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableJson::new(&v2).with_sort_keys(true).hash(&mut h2);
+        let r2 = h2.finish();
+
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn object_key_order_ignored_by_default() {
+        let v1 = serde_json::json!({ "y": 2, "x": 1 });
+        let v2 = serde_json::json!({ "x": 1, "y": 2 });
+
+        let mut h1 = Xxh3::default();
+        StableJson::new(&v1).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableJson::new(&v2).hash(&mut h2);
+        let r2 = h2.finish();
+
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn array_order_affects_hash() {
+        let v1 = serde_json::json!([1, 2, 3]);
+        let v2 = serde_json::json!([3, 2, 1]);
+
+        let mut h1 = Xxh3::default();
+        StableJson::new(&v1).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableJson::new(&v2).hash(&mut h2);
+        let r2 = h2.finish();
+
+        assert_ne!(r1, r2);
+    }
+
+    #[test]
+    fn different_types_do_not_collide() {
+        let s = serde_json::json!("1");
+        let n = serde_json::json!(1);
+
+        let mut h1 = Xxh3::default();
+        StableJson::new(&s).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableJson::new(&n).hash(&mut h2);
+        let r2 = h2.finish();
+
+        assert_ne!(r1, r2);
+    }
+}

--- a/crates/pixi_stable_hash/src/map.rs
+++ b/crates/pixi_stable_hash/src/map.rs
@@ -1,0 +1,155 @@
+//! Stable hashing wrapper for map-like iterables.
+//!
+//! `StableMap` hashes any iterator over entries `(&K, &V)` that implements
+//! `ExactSizeIterator`. It stores the iterator by value and clones it during
+//! hashing to avoid consuming the original.
+//!
+//! Notes:
+//! - Key order matters (no sorting performed).
+//! - The hash includes a type discriminant, entry count, then for each entry a
+//!   discriminant for the key and value followed by their hashes.
+//! - Keys and values must implement `Hash`.
+
+use std::hash::{Hash, Hasher};
+
+use crate::{FieldDiscriminant, IsDefault};
+
+/// Stable hasher that stores an iterator of entries by value.
+pub struct StableMap<I> {
+    iter: I,
+}
+
+impl<I> StableMap<I> {
+    /// Create a new `StableMap` from an iterator over `(&K, &V)`.
+    pub fn new(iter: I) -> Self {
+        Self { iter }
+    }
+}
+
+impl<K, V, I> Hash for StableMap<I>
+where
+    I: Clone + ExactSizeIterator<Item = (K, V)>,
+    K: Hash,
+    V: IsDefault,
+    <V as IsDefault>::Item: Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        FieldDiscriminant::new("map").hash(state);
+        let iter = self.iter.clone();
+        iter.len().hash(state);
+        for (k, v) in iter {
+            if let Some(value) = v.is_non_default() {
+                FieldDiscriminant::new("map:key").hash(state);
+                k.hash(state);
+                FieldDiscriminant::new("map:val").hash(state);
+                value.hash(state);
+            }
+        }
+    }
+}
+
+impl<I> IsDefault for StableMap<I>
+where
+    I: Clone + ExactSizeIterator,
+{
+    type Item = Self;
+
+    fn is_non_default(&self) -> Option<&Self::Item> {
+        if self.iter.len() == 0 {
+            None
+        } else {
+            Some(self)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, hash::Hasher};
+
+    use ordermap::OrderMap;
+    use xxhash_rust::xxh3::Xxh3;
+
+    use super::*;
+    use crate::StableHashBuilder;
+
+    #[test]
+    fn btreemap_same_contents_same_hash() {
+        let mut m1: BTreeMap<&str, i32> = BTreeMap::new();
+        m1.insert("a", 1);
+        m1.insert("b", 2);
+
+        let mut m2: BTreeMap<&str, i32> = BTreeMap::new();
+        m2.insert("b", 2);
+        m2.insert("a", 1);
+
+        let mut h1 = Xxh3::default();
+        StableMap::new(m1.iter()).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableMap::new(m2.iter()).hash(&mut h2);
+        let r2 = h2.finish();
+
+        // BTreeMap iteration is ordered by key; both maps yield same order
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn ordermap_order_affects_hash() {
+        let mut m1: OrderMap<&str, i32> = OrderMap::new();
+        m1.insert("a", 1);
+        m1.insert("b", 2);
+
+        let mut m2: OrderMap<&str, i32> = OrderMap::new();
+        m2.insert("b", 2);
+        m2.insert("a", 1);
+
+        let mut h1 = Xxh3::default();
+        StableMap::new(m1.iter()).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableMap::new(m2.iter()).hash(&mut h2);
+        let r2 = h2.finish();
+
+        // OrderMap preserves insertion order; hashes should differ
+        assert_ne!(r1, r2);
+    }
+
+    #[test]
+    fn length_is_part_of_hash() {
+        let mut m1: BTreeMap<&str, i32> = BTreeMap::new();
+        m1.insert("a", 1);
+
+        let mut m2: BTreeMap<&str, i32> = BTreeMap::new();
+        m2.insert("a", 1);
+        m2.insert("b", 2);
+
+        let mut h1 = Xxh3::default();
+        StableMap::new(m1.iter()).hash(&mut h1);
+        let r1 = h1.finish();
+
+        let mut h2 = Xxh3::default();
+        StableMap::new(m2.iter()).hash(&mut h2);
+        let r2 = h2.finish();
+
+        assert_ne!(r1, r2);
+    }
+
+    #[test]
+    fn empty_map_is_default_skipped_by_builder() {
+        let m1: BTreeMap<&str, i32> = BTreeMap::new();
+        let mut h_empty = Xxh3::default();
+        StableHashBuilder::<'_, _>::new()
+            .field("m", &StableMap::new(m1.iter()))
+            .finish(&mut h_empty);
+        let r_empty = h_empty.finish();
+
+        let mut h_baseline = Xxh3::default();
+        StableHashBuilder::<'_, _>::new().finish(&mut h_baseline);
+        let r_baseline = h_baseline.finish();
+
+        assert_eq!(r_empty, r_baseline);
+    }
+}


### PR DESCRIPTION
Fixes #4403

Currently, the build cache does not include any information about the project model or the configuration. This caused pixi to relock a package but not rebuild a package if one of the dependencies is changed. This PR adds a hash to the cache that describes the content of the packages project model and backend configuration. 

I left a TODO in place, which could be implemented to improve the performance of checking this hash. This could speed up checking if something changed at all. 

This PR also extends the stable hash crate with the ability to hash json values and generic maps.  