### PR TITLE
refactor: PyPI merge logic so that its more easy to extend

### DIFF
--- a/crates/pixi_manifest/src/pypi/merge.rs
+++ b/crates/pixi_manifest/src/pypi/merge.rs
@@ -1,0 +1,77 @@
+use indexmap::IndexMap;
+use std::hash::Hash;
+
+/// A trait for types that support a union-style merge policy.
+pub trait MergeUnion {
+    fn union(&self, other: &Self) -> Self;
+}
+
+/// Merge two optional single-assignment values.
+/// - If both are `Some`, return a conflict error via the provided closure.
+/// - Otherwise prefer `a` when set, else `b`.
+pub fn merge_single_option<T: Clone, E>(
+    a: &Option<T>,
+    b: &Option<T>,
+    conflict: impl FnOnce(&T, &T) -> E,
+) -> Result<Option<T>, E> {
+    match (a, b) {
+        (Some(a), Some(b)) => Err(conflict(a, b)),
+        (Some(a), None) => Ok(Some(a.clone())),
+        (None, Some(b)) => Ok(Some(b.clone())),
+        (None, None) => Ok(None),
+    }
+}
+
+/// Merge two optional lists by concatenating and de-duplicating, preserving order.
+pub fn merge_list_dedup<T: Clone + Eq + Hash>(
+    a: &Option<Vec<T>>,
+    b: &Option<Vec<T>>,
+) -> Option<Vec<T>> {
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let set = a
+                .iter()
+                .cloned()
+                .chain(b.iter().cloned())
+                .collect::<indexmap::IndexSet<_>>();
+            Some(set.into_iter().collect())
+        }
+        (Some(a), None) => Some(a.clone()),
+        (None, Some(b)) => Some(b.clone()),
+        (None, None) => None,
+    }
+}
+
+/// Merge two optional maps where left (`a`) overrides right (`b`) on key conflicts.
+pub fn merge_map_override_left<K, V>(
+    a: &Option<IndexMap<K, V>>,
+    b: &Option<IndexMap<K, V>>,
+) -> Option<IndexMap<K, V>>
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+{
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            let mut merged = b.clone();
+            merged.extend(a.iter().map(|(k, v)| (k.clone(), v.clone())));
+            Some(merged)
+        }
+        (Some(a), None) => Some(a.clone()),
+        (None, Some(b)) => Some(b.clone()),
+        (None, None) => None,
+    }
+}
+
+/// Implement `MergeUnion` for `Option<T>` where `T` itself supports `MergeUnion`.
+impl<T: MergeUnion + Clone> MergeUnion for Option<T> {
+    fn union(&self, other: &Self) -> Self {
+        // This contains the different matches for different cases
+        match (self, other) {
+            (Some(a), Some(b)) => Some(a.union(b)),
+            (Some(a), None) => Some(a.clone()),
+            (None, Some(b)) => Some(b.clone()),
+            (None, None) => None,
+        }
+    }
+}

--- a/crates/pixi_manifest/src/pypi/mod.rs
+++ b/crates/pixi_manifest/src/pypi/mod.rs
@@ -1,1 +1,2 @@
+pub mod merge;
 pub mod pypi_options;

--- a/crates/pixi_manifest/src/pypi/pypi_options.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_options.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, path::PathBuf};
+use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use indexmap::IndexSet;
@@ -141,18 +141,9 @@ pub struct PypiOptions {
     pub no_binary: Option<NoBinary>,
 }
 
-/// Clones and deduplicates two iterators of values
-fn clone_and_deduplicate<'a, I: Iterator<Item = &'a T>, T: Clone + Eq + Hash + 'a>(
-    values: I,
-    other: I,
-) -> Vec<T> {
-    values
-        .cloned()
-        .chain(other.cloned())
-        .collect::<IndexSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>()
-}
+use crate::pypi::merge::{
+    MergeUnion, merge_list_dedup, merge_map_override_left, merge_single_option,
+};
 
 impl PypiOptions {
     #[allow(clippy::too_many_arguments)]
@@ -206,101 +197,34 @@ impl PypiOptions {
     /// - Flat indexes are merged and deduplicated, in the order they are
     ///   provided
     pub fn union(&self, other: &PypiOptions) -> Result<PypiOptions, PypiOptionsMergeError> {
-        let index = if let Some(other_index) = other.index_url.clone() {
-            // Allow only one index
-            if let Some(own_index) = self.index_url.clone() {
-                return Err(PypiOptionsMergeError::MultiplePrimaryIndexes {
-                    first: own_index.to_string(),
-                    second: other_index.to_string(),
-                });
-            } else {
-                // Use the other index, because we don't have one
-                Some(other_index)
+        // Single-assignment fields with conflict detection
+        let index = merge_single_option(&self.index_url, &other.index_url, |a, b| {
+            PypiOptionsMergeError::MultiplePrimaryIndexes {
+                first: a.to_string(),
+                second: b.to_string(),
             }
-        } else {
-            // Use our index, because the other doesn't have one
-            self.index_url.clone()
-        };
+        })?;
 
-        // Allow only one index strategy
-        let index_strategy = if let Some(other_index_strategy) = other.index_strategy.clone() {
-            if let Some(own_index_strategy) = &self.index_strategy {
-                return Err(PypiOptionsMergeError::MultipleIndexStrategies {
-                    first: own_index_strategy.to_string(),
-                    second: other_index_strategy.to_string(),
-                });
-            } else {
-                Some(other_index_strategy)
-            }
-        } else {
-            self.index_strategy.clone()
-        };
+        let index_strategy =
+            merge_single_option(&self.index_strategy, &other.index_strategy, |a, b| {
+                PypiOptionsMergeError::MultipleIndexStrategies {
+                    first: a.to_string(),
+                    second: b.to_string(),
+                }
+            })?;
 
-        // Chain together and deduplicate the extra indexes
-        let extra_indexes = self
-            .extra_index_urls
-            .as_ref()
-            // Map for value
-            .map(|extra_indexes| {
-                clone_and_deduplicate(
-                    extra_indexes.iter(),
-                    other.extra_index_urls.clone().unwrap_or_default().iter(),
-                )
-            })
-            .or_else(|| other.extra_index_urls.clone());
+        // Ordered lists, deduplicated
+        let extra_indexes = merge_list_dedup(&self.extra_index_urls, &other.extra_index_urls);
+        let flat_indexes = merge_list_dedup(&self.find_links, &other.find_links);
 
-        // Chain together and deduplicate the flat indexes
-        let flat_indexes = self
-            .find_links
-            .as_ref()
-            .map(|flat_indexes| {
-                clone_and_deduplicate(
-                    flat_indexes.iter(),
-                    other.find_links.clone().unwrap_or_default().iter(),
-                )
-            })
-            .or_else(|| other.find_links.clone());
+        // Union-like fields
+        let no_build_isolation = self.no_build_isolation.union(&other.no_build_isolation);
+        let no_build = self.no_build.union(&other.no_build);
+        let no_binary = self.no_binary.union(&other.no_binary);
 
-        // Merge all the no build isolation packages. We take the union.
-        let no_build_isolation = match (&self.no_build_isolation, &other.no_build_isolation) {
-            (NoBuildIsolation::All, _) | (_, NoBuildIsolation::All) => NoBuildIsolation::All,
-            (NoBuildIsolation::Packages(a), NoBuildIsolation::Packages(b)) => {
-                let mut packages = a.clone();
-                packages.extend(b.iter().cloned());
-                NoBuildIsolation::Packages(packages)
-            }
-        };
-
-        // Set the no-build option
-        let no_build = match (self.no_build.as_ref(), other.no_build.as_ref()) {
-            (Some(a), Some(b)) => Some(a.union(b)),
-            (Some(a), None) => Some(a.clone()),
-            (None, Some(b)) => Some(b.clone()),
-            (None, None) => None,
-        };
-        // Set the dependency overrides
-        // notice that default feature comes last in the feature_ext
-        // so we want self overwriting the other
-        // i.e. if same key exists in both, we want the value from `self` to be used
-        // so we extend b with a (a overrides b)
-        let dependency_overrides = match (&self.dependency_overrides, &other.dependency_overrides) {
-            (Some(a), Some(b)) => {
-                let mut overrides = b.clone();
-                overrides.extend(a.into_iter().map(|(k, v)| (k.clone(), v.clone())));
-                Some(overrides)
-            }
-            (Some(a), None) => Some(a.clone()),
-            (None, Some(b)) => Some(b.clone()),
-            (None, None) => None,
-        };
-
-        // Set the no-binary option
-        let no_binary = match (self.no_binary.as_ref(), other.no_binary.as_ref()) {
-            (Some(a), Some(b)) => Some(a.union(b)),
-            (Some(a), None) => Some(a.clone()),
-            (None, Some(b)) => Some(b.clone()),
-            (None, None) => None,
-        };
+        // Maps with left (self) overriding right (other)
+        let dependency_overrides =
+            merge_map_override_left(&self.dependency_overrides, &other.dependency_overrides);
 
         Ok(PypiOptions {
             index_url: index,
@@ -312,6 +236,26 @@ impl PypiOptions {
             dependency_overrides,
             no_binary,
         })
+    }
+}
+
+// Implement the generic `MergeUnion` trait for our union-able types so they can be
+// composed uniformly (including for Option<T> via its MergeUnion impl).
+impl MergeUnion for NoBuild {
+    fn union(&self, other: &Self) -> Self {
+        NoBuild::union(self, other)
+    }
+}
+
+impl MergeUnion for NoBinary {
+    fn union(&self, other: &Self) -> Self {
+        NoBinary::union(self, other)
+    }
+}
+
+impl MergeUnion for NoBuildIsolation {
+    fn union(&self, other: &Self) -> Self {
+        NoBuildIsolation::union(self, other)
     }
 }
 

--- a/crates/pixi_manifest/src/utils/mod.rs
+++ b/crates/pixi_manifest/src/utils/mod.rs
@@ -4,6 +4,5 @@ mod spanned;
 #[cfg(test)]
 pub(crate) mod test_utils;
 mod with_source_code;
-
 pub use spanned::PixiSpanned;
 pub use with_source_code::WithSourceCode;


### PR DESCRIPTION
I had this refactor in my mind for a long time, but now got around with it with codex. Basically it makes the complex merging of PyPIOptions easier to read, by defining a few standard methods for use with merging. Basically making it more of a declarative read.

Better to read the diff side-by-side to see the benefit.