### PR TITLE
fix: clear filesystem caches in between pixi run steps

### DIFF
--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -266,6 +266,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 // Clear the current progress reports.
                 lock_file.command_dispatcher.clear_reporter().await;
 
+                // Clear caches based on the filesystem. The tasks might change files on disk.
+                lock_file.command_dispatcher.clear_filesystem_caches().await;
+
                 let command_env = get_task_env(
                     &executable_task.run_environment,
                     args.clean_env || executable_task.task().clean_env(),

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
@@ -391,8 +391,8 @@ impl CommandDispatcherProcessor {
                 self.on_source_build_cache_status(task)
             }
             ForegroundMessage::ClearReporter(sender) => self.clear_reporter(sender),
-            ForegroundMessage::ClearSourceBuildCacheStatusCache(sender) => {
-                self.clear_source_build_cache_status_cache(sender)
+            ForegroundMessage::ClearFilesystemCaches(sender) => {
+                self.clear_filesystem_caches(sender)
             }
             ForegroundMessage::SourceMetadata(task) => self.on_source_metadata(task),
             ForegroundMessage::BackendSourceBuild(task) => self.on_backend_source_build(task),
@@ -559,11 +559,14 @@ impl CommandDispatcherProcessor {
         let _ = sender.send(());
     }
 
-    /// Clears cached results for source_build_cache_status, preserving in-flight tasks.
-    fn clear_source_build_cache_status_cache(&mut self, sender: oneshot::Sender<()>) {
+    /// Clears cached results based on the filesystem, preserving in-flight tasks.
+    fn clear_filesystem_caches(&mut self, sender: oneshot::Sender<()>) {
+        self.inner.glob_hash_cache.clear();
+
+        // Clear source build cache status, preserving in-flight tasks.
         self.source_build_cache_status
             .retain(|_, v| matches!(v, PendingDeduplicatingTask::Pending(_, _)));
-        // Keep ids map so subsequent identical specs reuse their id; this is harmless.
+
         let _ = sender.send(());
     }
 

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
@@ -391,6 +391,9 @@ impl CommandDispatcherProcessor {
                 self.on_source_build_cache_status(task)
             }
             ForegroundMessage::ClearReporter(sender) => self.clear_reporter(sender),
+            ForegroundMessage::ClearSourceBuildCacheStatusCache(sender) => {
+                self.clear_source_build_cache_status_cache(sender)
+            }
             ForegroundMessage::SourceMetadata(task) => self.on_source_metadata(task),
             ForegroundMessage::BackendSourceBuild(task) => self.on_backend_source_build(task),
         }
@@ -553,6 +556,14 @@ impl CommandDispatcherProcessor {
         if let Some(reporter) = self.reporter.as_mut() {
             reporter.on_clear()
         }
+        let _ = sender.send(());
+    }
+
+    /// Clears cached results for source_build_cache_status, preserving in-flight tasks.
+    fn clear_source_build_cache_status_cache(&mut self, sender: oneshot::Sender<()>) {
+        self.source_build_cache_status
+            .retain(|_, v| matches!(v, PendingDeduplicatingTask::Pending(_, _)));
+        // Keep ids map so subsequent identical specs reuse their id; this is harmless.
         let _ = sender.send(());
     }
 

--- a/crates/pixi_command_dispatcher/src/discover_backend_cache.rs
+++ b/crates/pixi_command_dispatcher/src/discover_backend_cache.rs
@@ -78,9 +78,4 @@ impl DiscoveryCache {
             }
         }
     }
-
-    // Note: we intentionally do not implement a clear() here because the
-    // underlying coalesced map does not expose a general clear operation.
-    // Callers that need to invalidate discovery results should bump their
-    // cache key inputs or recreate the cache instance at construction time.
 }

--- a/crates/pixi_command_dispatcher/src/discover_backend_cache.rs
+++ b/crates/pixi_command_dispatcher/src/discover_backend_cache.rs
@@ -78,4 +78,9 @@ impl DiscoveryCache {
             }
         }
     }
+
+    // Note: we intentionally do not implement a clear() here because the
+    // underlying coalesced map does not expose a general clear operation.
+    // Callers that need to invalidate discovery results should bump their
+    // cache key inputs or recreate the cache instance at construction time.
 }

--- a/crates/pixi_glob/src/glob_hash_cache.rs
+++ b/crates/pixi_glob/src/glob_hash_cache.rs
@@ -129,4 +129,9 @@ impl GlobHashCache {
             }
         }
     }
+
+    /// Clears all memoized glob hashes. In-flight computations are unaffected.
+    pub fn clear(&self) {
+        self.cache.clear();
+    }
 }


### PR DESCRIPTION
Clears filesystem caches after installing an environment for a step in `pixi run`.