### PR TITLE
perf: early out on installer file not containing the pixi uv installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5049,6 +5049,7 @@ dependencies = [
  "rattler_shell",
  "rattler_solve",
  "rattler_virtual_packages",
+ "rayon",
  "reqwest",
  "reqwest-middleware",
  "rlimit",

--- a/crates/pixi_core/Cargo.toml
+++ b/crates/pixi_core/Cargo.toml
@@ -65,6 +65,7 @@ rattler_repodata_gateway = { workspace = true }
 rattler_shell = { workspace = true }
 rattler_solve = { workspace = true }
 rattler_virtual_packages = { workspace = true }
+rayon = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 rlimit = { workspace = true }


### PR DESCRIPTION
We've parallelized the check if a PyPI distribution was installed using the pixi uv installer or not. When the distribution is not installed by `pixi-uv` (e.g. a conda package) we can early out.

We also optimized reading the INSTALLER file by first checking the length of the file. If the length is not the same as the length of the "uv-pixi" string we can early out. This drastically reduces the IO required to perform the check.

For a large environment with roughly 367 conda installed python packages this provides a very large speedup:

**Before `109ms`:**
<img width="1720" height="669" alt="image" src="https://github.com/user-attachments/assets/28802557-c5b3-49ab-a8b9-5e66e82fa4ff" />

**After `3.9ms`:**
<img width="1714" height="670" alt="image" src="https://github.com/user-attachments/assets/84e29f32-24c8-46c0-bc2e-6cd05b31e6de" />
