### PR TITLE
fix: Documentation link and error in `pixi init`

### DIFF
--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -274,11 +274,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let config = Config::load_global();
 
     if is_init_dir_equal_to_pixi_home_parent(&dir) {
+        let help_msg = format!(
+            "Please follow the getting started guide at https://pixi.sh/v{}/init_getting_started/ or run the following command to create a new workspace in a subdirectory:\n\n  {}\n",
+            consts::PIXI_VERSION,
+            console::style("pixi init my_workspace").bold(),
+        );
         miette::bail!(
-            "You cannot create a workspace in the parent of the pixi home directory.\n\
-            Please see https://pixi.sh/pixi/v{}/reference/environment_variables/ \
-            for more information about the pixi home directory.",
-            consts::PIXI_VERSION
+            help = help_msg,
+            "You cannot do a nameless initialization in the parent directory of your PIXI_HOME.",
         );
     }
 

--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -281,7 +281,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
         miette::bail!(
             help = help_msg,
-            "You cannot do a nameless initialization in the parent directory of your PIXI_HOME.",
+            "initialization without a name in the parent directory of your PIXI_HOME is not allowed.",
         );
     }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,7 +241,7 @@ plugins:
 
         # Redirects for links from code to make sure we don't break them.
         # Using descriptive names that never existed, to avoid conflicts.
-         # crates/pixi_cli/src/init.rs
+        # crates/pixi_cli/src/init.rs
         "init_getting_started.md": "first_project.md"
 
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,7 +241,8 @@ plugins:
 
         # Redirects for links from code to make sure we don't break them.
         # Using descriptive names that never existed, to avoid conflicts.
-        "init_getting_started.md": "first_project.md" # crates/pixi_cli/src/init.rs
+         # crates/pixi_cli/src/init.rs
+        "init_getting_started.md": "first_project.md"
 
   - search
   - social

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,10 @@ plugins:
         "integration/editor/pycharm.md": "integration/editor/jetbrains.md"
         "advanced/installation.md": "installation.md"
 
+        # Redirects for links from code to make sure we don't break them.
+        # Using descriptive names that never existed, to avoid conflicts.
+        "init_getting_started.md": "first_project.md" # crates/pixi_cli/src/init.rs
+
   - search
   - social
   - mike:

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -382,7 +382,8 @@ def test_pixi_init_pixi_home_parent(pixi: Path, tmp_pixi_workspace: Path) -> Non
     verify_cli_command(
         [pixi, "init", pixi_home.parent],
         ExitCode.FAILURE,
-        stderr_contains="pixi init ",  # Test that we print a helpful error message
+        # Test that we print a helpful error message
+        stderr_contains="pixi init",
         env={"PIXI_HOME": str(pixi_home)},
     )
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -382,7 +382,7 @@ def test_pixi_init_pixi_home_parent(pixi: Path, tmp_pixi_workspace: Path) -> Non
     verify_cli_command(
         [pixi, "init", pixi_home.parent],
         ExitCode.FAILURE,
-        stderr_contains="You cannot create a workspace in the parent of the pixi home directory",
+        stderr_contains="pixi init ",  # Test that we print a helpful error message
         env={"PIXI_HOME": str(pixi_home)},
     )
 


### PR DESCRIPTION
A before and after:
<img width="1274" height="301" alt="image" src="https://github.com/user-attachments/assets/c0e57b7b-cc10-4211-882b-bec8907966eb" />

The link was broken, and the user still didn't know what to do to avoid this warning without reading the documentation. 
