### PR TITLE
fix: set pixi cache dir when building cmake extensions

### DIFF
--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -980,12 +980,10 @@ async fn test_setuptools_override_failure() {
     temp_env::async_with_vars(
         [("PIXI_CACHE_DIR", Some(tmp_dir_path.to_str().unwrap()))],
         async {
-            pixi.install().await.unwrap();
+            pixi.install().await.expect("cannot install project");
         },
     )
     .await;
-
-    pixi.install().await.expect("cannot install project");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
closes: 
https://github.com/prefix-dev/pixi/issues/4154