### PR TITLE
feat(init): add default-platforms config support

### DIFF
--- a/crates/pixi_api/src/workspace/init/mod.rs
+++ b/crates/pixi_api/src/workspace/init/mod.rs
@@ -185,7 +185,7 @@ fn is_init_dir_equal_to_pixi_home_parent(init_dir: &Path) -> bool {
 }
 
 fn resolve_platforms(options: &InitOptions, config: &Config) -> Vec<String> {
-    if options.platforms.is_empty() {
+    let platforms = if options.platforms.is_empty() {
         let platforms = config.default_platforms();
         if platforms.is_empty() {
             vec![Platform::current().to_string()]
@@ -193,10 +193,11 @@ fn resolve_platforms(options: &InitOptions, config: &Config) -> Vec<String> {
             platforms
         }
     } else {
-        // Dedup so a repeated `--platform` (or one matching the current
-        // platform) doesn't write a manifest the parser then rejects.
-        options.platforms.iter().cloned().unique().collect()
-    }
+        options.platforms.clone()
+    };
+
+    // A repeated platform would produce a manifest that fails validation.
+    platforms.into_iter().unique().collect()
 }
 
 fn resolve_channels_from_options(options: &InitOptions, config: &Config) -> Vec<NamedChannelOrUrl> {
@@ -1250,9 +1251,12 @@ mod tests {
             ..Config::default()
         };
 
-        assert_eq!(resolve_platforms(&options, &config), config.default_platforms);
+        assert_eq!(
+            resolve_platforms(&options, &config),
+            config.default_platforms
+        );
 
-        options.platforms = vec!["osx-64".to_string()];
-        assert_eq!(resolve_platforms(&options, &config), options.platforms);
+        options.platforms = vec!["osx-64".to_string(), "osx-64".to_string()];
+        assert_eq!(resolve_platforms(&options, &config), vec!["osx-64"]);
     }
 }

--- a/crates/pixi_api/src/workspace/init/mod.rs
+++ b/crates/pixi_api/src/workspace/init/mod.rs
@@ -66,7 +66,7 @@ fn build_render_context(dir: &Path, options: &InitOptions, config: &Config) -> R
         default_name: get_name_from_dir(dir).unwrap_or_else(|_| String::from("new_workspace")),
         version: "0.1.0".to_string(),
         author: get_default_author(),
-        platforms: resolve_platforms(options),
+        platforms: resolve_platforms(options, config),
         channels: resolve_channels_from_options(options, config),
         index_url: config.pypi_config.index_url.clone(),
         extra_index_urls: config.pypi_config.extra_index_urls.clone(),
@@ -184,9 +184,14 @@ fn is_init_dir_equal_to_pixi_home_parent(init_dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn resolve_platforms(options: &InitOptions) -> Vec<String> {
+fn resolve_platforms(options: &InitOptions, config: &Config) -> Vec<String> {
     if options.platforms.is_empty() {
-        vec![Platform::current().to_string()]
+        let platforms = config.default_platforms();
+        if platforms.is_empty() {
+            vec![Platform::current().to_string()]
+        } else {
+            platforms
+        }
     } else {
         // Dedup so a repeated `--platform` (or one matching the current
         // platform) doesn't write a manifest the parser then rejects.
@@ -1227,5 +1232,27 @@ mod tests {
         assert!(!outcome.pyproject_exists);
         assert_eq!(outcome.mojo_exists, pre_existing_mojo);
         assert!(outcome.pixi_exists);
+    }
+
+    #[test]
+    fn resolve_platforms_uses_config_defaults_unless_explicit() {
+        let mut options = InitOptions {
+            path: PathBuf::new(),
+            channels: None,
+            platforms: Vec::new(),
+            env_file: None,
+            format: None,
+            scm: None,
+            conda_pypi_mapping: None,
+        };
+        let config = Config {
+            default_platforms: vec!["win-64".to_string(), "linux-64".to_string()],
+            ..Config::default()
+        };
+
+        assert_eq!(resolve_platforms(&options, &config), config.default_platforms);
+
+        options.platforms = vec!["osx-64".to_string()];
+        assert_eq!(resolve_platforms(&options, &config), options.platforms);
     }
 }

--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -312,6 +312,19 @@ fn alter_config(
                     }
                     config.default_channels = new_channels;
                 }
+                // Like `default-channels`, `default-platforms` replaces lower
+                // layers, so append and prepend operate on the effective list.
+                "default-platforms" => {
+                    let input = value.expect("value must be provided");
+                    let mut platforms =
+                        load_config(common_args, &GlobalConfigSource::Search)?.default_platforms;
+                    if is_prepend {
+                        platforms.insert(0, input);
+                    } else {
+                        platforms.push(input);
+                    }
+                    config.default_platforms = platforms;
+                }
                 // `extra-index-urls` is concatenated across layers, so only
                 // this file's own share of the list is edited; copying the
                 // lower layers in would list them twice. A prepend therefore
@@ -328,7 +341,11 @@ fn alter_config(
                     config.pypi_config.extra_index_urls = new_urls;
                 }
                 _ => {
-                    let list_keys = ["default-channels", "pypi-config.extra-index-urls"];
+                    let list_keys = [
+                        "default-channels",
+                        "default-platforms",
+                        "pypi-config.extra-index-urls",
+                    ];
                     let msg_cmd = if is_prepend { "prepend" } else { "append" };
                     return Err(miette::miette!(
                         "{} is only supported for list keys: {}",
@@ -352,6 +369,7 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
 
     match key {
         "default-channels" => new.default_channels = config.default_channels.clone(),
+        "default-platforms" => new.default_platforms = config.default_platforms.clone(),
         "shell" => new.shell = config.shell.clone(),
         "tls-no-verify" => new.tls_no_verify = config.tls_no_verify,
         "offline" => new.offline = config.offline,
@@ -369,6 +387,7 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
         _ => {
             let keys = [
                 "default-channels",
+                "default-platforms",
                 "tls-no-verify",
                 "offline",
                 "authentication-override-file",

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -1968,6 +1968,7 @@ impl Config {
             "concurrency.downloads",
             "concurrency.solves",
             "default-channels",
+            "default-platforms",
             "detached-environments",
             "experimental",
             "experimental.use-environment-activation-cache",
@@ -2251,6 +2252,13 @@ impl Config {
         match key {
             "default-channels" => {
                 self.default_channels = value
+                    .map(|v| serde_json::de::from_str(&v))
+                    .transpose()
+                    .into_diagnostic()?
+                    .unwrap_or_default();
+            }
+            "default-platforms" => {
+                self.default_platforms = value
                     .map(|v| serde_json::de::from_str(&v))
                     .transpose()
                     .into_diagnostic()?
@@ -3186,6 +3194,7 @@ UNUSED = "unused"
         let mut config = Config::default();
         let other = Config {
             default_channels: vec![NamedChannelOrUrl::from_str("conda-forge").unwrap()],
+            default_platforms: vec!["linux-64".to_string()],
             channel_config: ChannelConfig::default_with_root_dir(PathBuf::from("/root/dir")),
             tls_no_verify: Some(true),
             tls_root_certs: Some(TlsRootCerts::System),
@@ -3597,6 +3606,7 @@ UNUSED = "unused"
         // See if the toml parses in kebab-case
         let toml = r#"
             default-channels = ["conda-forge"]
+            default-platforms = ["linux-64", "osx-64"]
             change-ps1 = true
             tls-no-verify = false
             authentication-override-file = "/path/to/your/override.json"
@@ -3626,6 +3636,13 @@ UNUSED = "unused"
             config.default_channels,
             vec![NamedChannelOrUrl::from_str("conda-forge").unwrap()]
         );
+        config
+            .set(
+                "default-platforms",
+                Some(r#"["linux-64", "osx-64"]"#.to_string()),
+            )
+            .unwrap();
+        assert_eq!(config.default_platforms, vec!["linux-64", "osx-64"]);
 
         config
             .set("tls-no-verify", Some("true".to_string()))

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -1141,7 +1141,6 @@ pub struct Config {
     pub default_channels: Vec<NamedChannelOrUrl>,
 
     #[serde(default)]
-    #[serde(alias = "default_platforms")] // BREAK: remove to stop supporting snake_case alias
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub default_platforms: Vec<String>,
 

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -1140,6 +1140,11 @@ pub struct Config {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub default_channels: Vec<NamedChannelOrUrl>,
 
+    #[serde(default)]
+    #[serde(alias = "default_platforms")] // BREAK: remove to stop supporting snake_case alias
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub default_platforms: Vec<String>,
+
     /// Path to the file containing the authentication token.
     #[serde(default)]
     #[serde(alias = "authentication_override_file")] // BREAK: remove to stop supporting snake_case alias
@@ -1297,6 +1302,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             default_channels: Vec::new(),
+            default_platforms: Vec::new(),
             authentication_override_file: None,
             tls_no_verify: None,
             tls_root_certs: None,
@@ -2022,6 +2028,11 @@ impl Config {
             } else {
                 other.default_channels
             },
+            default_platforms: if other.default_platforms.is_empty() {
+                self.default_platforms
+            } else {
+                other.default_platforms
+            },
             tls_no_verify: other.tls_no_verify.or(self.tls_no_verify),
             tls_root_certs: other.tls_root_certs.or(self.tls_root_certs),
             offline: other.offline.or(self.offline),
@@ -2091,6 +2102,11 @@ impl Config {
         } else {
             self.default_channels.clone()
         }
+    }
+
+    /// Retrieve the value for the default_platforms field (defaults to empty).
+    pub fn default_platforms(&self) -> Vec<String> {
+        self.default_platforms.clone()
     }
 
     /// Retrieve the value for the tls_no_verify field (defaults to false).
@@ -4490,5 +4506,18 @@ UNUSED = "unused"
         };
         let err = config.validate().unwrap_err();
         assert!(format!("{err}").contains("cache.conda-packages"));
+    }
+
+    #[test]
+    fn config_parses_and_merges_default_platforms() {
+        let (base, _) = Config::from_toml(r#"default-platforms = ["linux-64"]"#, None).unwrap();
+        let (override_config, _) =
+            Config::from_toml(r#"default-platforms = ["win-64", "osx-64"]"#, None).unwrap();
+
+        assert_eq!(base.default_platforms(), vec!["linux-64"]);
+        assert_eq!(
+            base.merge_config(override_config).default_platforms(),
+            vec!["win-64", "osx-64"]
+        );
     }
 }

--- a/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
+++ b/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
@@ -14,6 +14,7 @@ Config {
             "defaults",
         ),
     ],
+    default_platforms: [],
     authentication_override_file: None,
     tls_no_verify: Some(
         false,

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -85,6 +85,7 @@ For backwards compatibility, the following configuration options can still be wr
 in `snake_case`:
 
     - `default_channels`
+    - `default_platforms`
     - `change_ps1`
     - `tls_no_verify`
     - `authentication_override_file`
@@ -109,6 +110,18 @@ workspace is discovered. This defaults to only `conda-forge`.
     For example, `pixi search` uses the effective channels of the workspace's default environment when it discovers a
     workspace. Workspace-independent commands such as `pixi exec` still use `default-channels` when invoked from a
     workspace directory.
+
+### `default-platforms`
+
+The default platforms to select when running `pixi init`.
+This defaults to the current platform if not specified.
+
+```toml title="config.toml"
+default-platforms = ["win-64", "linux-64", "osx-64"]
+```
+
+!!! note
+The `default-platforms` are only used when initializing a new project. You can override this by explicitly providing platforms with the `--platform` flag.
 
 ### `shell`
 

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -85,7 +85,6 @@ For backwards compatibility, the following configuration options can still be wr
 in `snake_case`:
 
     - `default_channels`
-    - `default_platforms`
     - `change_ps1`
     - `tls_no_verify`
     - `authentication_override_file`
@@ -117,11 +116,11 @@ The default platforms to select when running `pixi init`.
 This defaults to the current platform if not specified.
 
 ```toml title="config.toml"
-default-platforms = ["win-64", "linux-64", "osx-64"]
+--8<-- "docs/source_files/pixi_config_tomls/main_config.toml:default-platforms"
 ```
 
 !!! note
-The `default-platforms` are only used when initializing a new project. You can override this by explicitly providing platforms with the `--platform` flag.
+    The `default-platforms` are only used when initializing a new project. You can override this by explicitly providing platforms with the `--platform` flag.
 
 ### `shell`
 

--- a/docs/source_files/pixi_config_tomls/main_config.toml
+++ b/docs/source_files/pixi_config_tomls/main_config.toml
@@ -2,6 +2,10 @@
 default-channels = ["conda-forge"]
 # --8<-- [end:default-channels]
 
+# --8<-- [start:default-platforms]
+default-platforms = ["linux-64", "osx-64", "win-64"]
+# --8<-- [end:default-platforms]
+
 # --8<-- [start:tls-no-verify]
 tls-no-verify = false
 # --8<-- [end:tls-no-verify]


### PR DESCRIPTION
Pixi currently has no way to configure default platforms for new workspaces. This adds `default-platforms` alongside `default-channels`, allowing `pixi init` to create multi-platform workspaces by default.

Explicit `--platform` arguments override the configured defaults.

Fixes #4572