### PR TITLE
feat(init): optionally create `.envrc`

### DIFF
--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -329,6 +329,7 @@ impl PixiControl {
                 format: None,
                 pyproject_toml: false,
                 scm: Some(GitAttributes::Github),
+                direnv: false,
             },
         }
     }
@@ -347,6 +348,7 @@ impl PixiControl {
                 format: None,
                 pyproject_toml: false,
                 scm: Some(GitAttributes::Github),
+                direnv: false,
             },
         }
     }

--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -88,7 +88,7 @@ fn get_completion_script(shell: Shell) -> String {
 }
 
 /// Replace the parts of the bash completion script that need different functionality.
-fn replace_bash_completion(script: &str) -> Cow<str> {
+fn replace_bash_completion(script: &'_ str) -> Cow<'_, str> {
     // Adds tab completion to the pixi run command.
     // NOTE THIS IS FORMATTED BY HAND
     // Replace the '-' with '__' since that's what clap's generator does as well for Bash Shell completion.
@@ -117,7 +117,7 @@ fn replace_bash_completion(script: &str) -> Cow<str> {
 }
 
 /// Replace the parts of the zsh completion script that need different functionality.
-fn replace_zsh_completion(script: &str) -> Cow<str> {
+fn replace_zsh_completion(script: &'_ str) -> Cow<'_, str> {
     // Adds tab completion to the pixi run command.
     // NOTE THIS IS FORMATTED BY HAND
     let pattern = r"(?ms)(\(run\))(?:.*?)(_arguments.*?)(\*::task)";

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -11,6 +11,8 @@ pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";
 pub const DEFAULT_FEATURE_NAME: &str = DEFAULT_ENVIRONMENT_NAME;
 pub const PYPROJECT_PIXI_PREFIX: &str = "tool.pixi";
 
+pub const DIRENV_MANIFEST: &str = ".envrc";
+
 pub const WORKSPACE_MANIFEST: &str = "pixi.toml";
 pub const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 pub const CONFIG_FILE: &str = "config.toml";

--- a/docs/integration/third_party/direnv.md
+++ b/docs/integration/third_party/direnv.md
@@ -15,6 +15,8 @@ watch_file pixi.lock # (1)!
 eval "$(pixi shell-hook)" # (2)!
 ```
 
+`pixi init . --direnv` can do that for you.
+
 1. This ensures that every time your `pixi.lock` changes, `direnv` invokes the shell-hook again.
 2. This installs the environment if needed, and activates it. `direnv` ensures that the environment is deactivated when you leave the directory.
 

--- a/docs/reference/cli/pixi/init.md
+++ b/docs/reference/cli/pixi/init.md
@@ -31,6 +31,8 @@ pixi init [OPTIONS] [PATH]
 - <a id="arg---scm" href="#arg---scm">`--scm (-s) <SCM>`</a>
 :  Source Control Management used for this workspace
 <br>**options**: `github`, `gitlab`, `codeberg`
+- <a id="arg---direnv" href="#arg---direnv">`--direnv`</a>
+:  Create a `.envrc` file that auto-activates pixi when entering the project directory
 
 ## Description
 Creates a new workspace

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -358,6 +358,37 @@ def test_pixi_init_cwd(pixi: Path, tmp_pixi_workspace: Path) -> None:
         manifest_content = manifest_path.read_text()
         assert "[workspace]" in manifest_content
 
+        # Verify that the manifest file is created
+        direnv_path = tmp_pixi_workspace / ".envrc"
+        assert not direnv_path.exists()
+
+
+def test_pixi_init_cwd_with_direnv(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    # Change directory to workspace
+    with cwd(tmp_pixi_workspace):
+        # Create a new project
+        verify_cli_command([pixi, "init", ".", "--direnv"], ExitCode.SUCCESS)
+
+        # Verify that the manifest file is created
+        manifest_path = tmp_pixi_workspace / "pixi.toml"
+        assert manifest_path.exists()
+
+        # Verify that the manifest file contains expected content
+        manifest_content = manifest_path.read_text()
+        assert "[workspace]" in manifest_content
+
+        # Verify that the manifest file contains expected content
+        manifest_content = manifest_path.read_text()
+        assert "[workspace]" in manifest_content
+
+        # Verify that the manifest file is created
+        direnv_path = tmp_pixi_workspace / ".envrc"
+        assert direnv_path.exists()
+
+        # Verify that the manifest file contains expected content
+        direnv_content = direnv_path.read_text()
+        assert "watch_file pixi.lock" in direnv_content
+
 
 def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> None:
     # Specify project dir


### PR DESCRIPTION
I have direnv in use and would like to have that
activate pixi automatically.

Add an option `--direnv` into the `init` command
that adds a .envrc file with the contents proposed in https://pixi.sh/latest/integration/third_party/direnv/