### PR TITLE
fix(init): obscure error when importing `environment.yml` with empty `pip:`

### DIFF
--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -1,11 +1,10 @@
 import os
 import platform
 import subprocess
-from contextlib import contextmanager
+import sys
+from collections.abc import Sequence
 from enum import IntEnum
 from pathlib import Path
-import sys
-from collections.abc import Generator, Sequence
 from typing import override
 
 from rattler import Platform
@@ -160,16 +159,6 @@ def get_manifest(directory: Path) -> Path:
         return pyproject_toml
     else:
         raise ValueError("Neither pixi.toml nor pyproject.toml found")
-
-
-@contextmanager
-def cwd(path: str | Path) -> Generator[None, None, None]:
-    oldpwd = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(oldpwd)
 
 
 def run_and_get_env(pixi: Path, *args: str, env_var: str) -> tuple[str | None, Output]:

--- a/tests/integration_python/test_edge_cases.py
+++ b/tests/integration_python/test_edge_cases.py
@@ -462,7 +462,7 @@ allow-direct-references = true
 
 def test_help_warning_when_platform_not_supported(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """Test that the help command warns about unsupported platforms"""
-    verify_cli_command([pixi, "init", tmp_pixi_workspace], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", tmp_pixi_workspace])
 
     # Remove all platforms
     manifest_path = tmp_pixi_workspace / "pixi.toml"

--- a/tests/integration_python/test_init.py
+++ b/tests/integration_python/test_init.py
@@ -10,7 +10,7 @@ from .common import ExitCode, verify_cli_command
 
 def test_pixi_init_cwd(pixi: Path, tmp_pixi_workspace: Path) -> None:
     # Create a new project
-    verify_cli_command([pixi, "init", "."], ExitCode.SUCCESS, cwd=tmp_pixi_workspace)
+    verify_cli_command([pixi, "init", "."], cwd=tmp_pixi_workspace)
 
     # Verify that the manifest file is created
     manifest_path = tmp_pixi_workspace / "pixi.toml"
@@ -26,7 +26,7 @@ def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> Non
     project_dir = tmp_pixi_workspace / "project_dir"
 
     # Create a new project
-    verify_cli_command([pixi, "init", project_dir], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", project_dir])
 
     # Verify that the manifest file is created
     manifest_path = project_dir / "pixi.toml"
@@ -65,7 +65,6 @@ dependencies:
 
     verify_cli_command(
         [pixi, "init", "--import", "environment.yml"],
-        ExitCode.SUCCESS,
         cwd=tmp_pixi_workspace,
     )
 
@@ -86,8 +85,6 @@ dependencies:
 def test_pixi_init_pyproject(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest_path = tmp_pixi_workspace / "pyproject.toml"
     # Create a new project
-    verify_cli_command(
-        [pixi, "init", tmp_pixi_workspace, "--format", "pyproject"], ExitCode.SUCCESS
-    )
+    verify_cli_command([pixi, "init", tmp_pixi_workspace, "--format", "pyproject"])
     # Verify that install works
-    verify_cli_command([pixi, "install", "--manifest-path", manifest_path], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "install", "--manifest-path", manifest_path])

--- a/tests/integration_python/test_init.py
+++ b/tests/integration_python/test_init.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from .common import ExitCode, verify_cli_command
+
+
+def test_pixi_init_cwd(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    # Create a new project
+    verify_cli_command([pixi, "init", "."], ExitCode.SUCCESS, cwd=tmp_pixi_workspace)
+
+    # Verify that the manifest file is created
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    assert manifest_path.exists()
+
+    # Verify that the manifest file contains expected content
+    manifest_content = manifest_path.read_text()
+    assert "[workspace]" in manifest_content
+
+
+def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    # Specify project dir
+    project_dir = tmp_pixi_workspace / "project_dir"
+
+    # Create a new project
+    verify_cli_command([pixi, "init", project_dir], ExitCode.SUCCESS)
+
+    # Verify that the manifest file is created
+    manifest_path = project_dir / "pixi.toml"
+    assert manifest_path.exists()
+
+    # Verify that the manifest file contains expected content
+    manifest_content = manifest_path.read_text()
+    assert "[workspace]" in manifest_content
+
+
+def test_pixi_init_pixi_home_parent(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    pixi_home = tmp_pixi_workspace / ".pixi"
+    pixi_home.mkdir(exist_ok=True)
+
+    verify_cli_command(
+        [pixi, "init", pixi_home.parent],
+        ExitCode.FAILURE,
+        # Test that we print a helpful error message
+        stderr_contains="pixi init",
+        env={"PIXI_HOME": str(pixi_home)},
+    )
+
+
+@pytest.mark.slow
+def test_pixi_init_pyproject(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest_path = tmp_pixi_workspace / "pyproject.toml"
+    # Create a new project
+    verify_cli_command(
+        [pixi, "init", tmp_pixi_workspace, "--format", "pyproject"], ExitCode.SUCCESS
+    )
+    # Verify that install works
+    verify_cli_command([pixi, "install", "--manifest-path", manifest_path], ExitCode.SUCCESS)

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -32,7 +32,7 @@ def test_pixi(pixi: Path) -> None:
 def test_project_commands(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest_path = tmp_pixi_workspace / "pixi.toml"
     # Create a new project
-    verify_cli_command([pixi, "init", tmp_pixi_workspace], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", tmp_pixi_workspace])
 
     # Channel commands
     verify_cli_command(
@@ -252,7 +252,7 @@ def test_simple_project_setup(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest_path = tmp_pixi_workspace / "pixi.toml"
     conda_forge = "https://prefix.dev/conda-forge"
     # Create a new project
-    verify_cli_command([pixi, "init", "-c", conda_forge, tmp_pixi_workspace], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", "-c", conda_forge, tmp_pixi_workspace])
 
     # Add package
     verify_cli_command(
@@ -822,7 +822,7 @@ def test_pixi_manifest_path(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest_path = tmp_pixi_workspace / "pixi.toml"
 
     # Create a new project
-    verify_cli_command([pixi, "init", tmp_pixi_workspace], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", tmp_pixi_workspace])
 
     # Modify project without manifest path
     verify_cli_command(
@@ -1373,9 +1373,7 @@ def test_pixi_task_list_json(pixi: Path, tmp_pixi_workspace: Path) -> None:
         """
     manifest.write_text(toml)
 
-    result = verify_cli_command(
-        [pixi, "task", "list", "--json", "--manifest-path", manifest], ExitCode.SUCCESS
-    )
+    result = verify_cli_command([pixi, "task", "list", "--json", "--manifest-path", manifest])
 
     task_data = json.loads(result.stdout)
 
@@ -1426,9 +1424,7 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
     verify_cli_command([pixi, "install", "--manifest-path", manifest, "--all"])
 
-    result = verify_cli_command(
-        [pixi, "info", "--manifest-path", manifest, "--extended", "--json"], ExitCode.SUCCESS
-    )
+    result = verify_cli_command([pixi, "info", "--manifest-path", manifest, "--extended", "--json"])
     info_data = json.loads(result.stdout)
 
     # Stub out path, size and other dynamic data from snapshot()
@@ -1562,7 +1558,7 @@ def test_frozen_no_install_invariant(pixi: Path, tmp_pixi_workspace: Path) -> No
     ]
 
     # Create a new project with bzip2 (lightweight package)
-    verify_cli_command([pixi, "init", tmp_pixi_workspace], ExitCode.SUCCESS)
+    verify_cli_command([pixi, "init", tmp_pixi_workspace])
     # Add bzip2 package to keep installation time low
     verify_cli_command([pixi, "add", "--manifest-path", manifest_path, "bzip2"])
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -16,7 +16,6 @@ from .common import (
     EMPTY_BOILERPLATE_PROJECT,
     PIXI_VERSION,
     ExitCode,
-    cwd,
     find_commands_supporting_frozen_and_no_install,
     verify_cli_command,
 )
@@ -342,61 +341,6 @@ def test_simple_project_setup(pixi: Path, tmp_pixi_workspace: Path) -> None:
         ],
         stderr_contains=["osx-arm64", "test", "Removed"],
     )
-
-
-def test_pixi_init_cwd(pixi: Path, tmp_pixi_workspace: Path) -> None:
-    # Change directory to workspace
-    with cwd(tmp_pixi_workspace):
-        # Create a new project
-        verify_cli_command([pixi, "init", "."], ExitCode.SUCCESS)
-
-        # Verify that the manifest file is created
-        manifest_path = tmp_pixi_workspace / "pixi.toml"
-        assert manifest_path.exists()
-
-        # Verify that the manifest file contains expected content
-        manifest_content = manifest_path.read_text()
-        assert "[workspace]" in manifest_content
-
-
-def test_pixi_init_non_existing_dir(pixi: Path, tmp_pixi_workspace: Path) -> None:
-    # Specify project dir
-    project_dir = tmp_pixi_workspace / "project_dir"
-
-    # Create a new project
-    verify_cli_command([pixi, "init", project_dir], ExitCode.SUCCESS)
-
-    # Verify that the manifest file is created
-    manifest_path = project_dir / "pixi.toml"
-    assert manifest_path.exists()
-
-    # Verify that the manifest file contains expected content
-    manifest_content = manifest_path.read_text()
-    assert "[workspace]" in manifest_content
-
-
-def test_pixi_init_pixi_home_parent(pixi: Path, tmp_pixi_workspace: Path) -> None:
-    pixi_home = tmp_pixi_workspace / ".pixi"
-    pixi_home.mkdir(exist_ok=True)
-
-    verify_cli_command(
-        [pixi, "init", pixi_home.parent],
-        ExitCode.FAILURE,
-        # Test that we print a helpful error message
-        stderr_contains="pixi init",
-        env={"PIXI_HOME": str(pixi_home)},
-    )
-
-
-@pytest.mark.slow
-def test_pixi_init_pyproject(pixi: Path, tmp_pixi_workspace: Path) -> None:
-    manifest_path = tmp_pixi_workspace / "pyproject.toml"
-    # Create a new project
-    verify_cli_command(
-        [pixi, "init", tmp_pixi_workspace, "--format", "pyproject"], ExitCode.SUCCESS
-    )
-    # Verify that install works
-    verify_cli_command([pixi, "install", "--manifest-path", manifest_path], ExitCode.SUCCESS)
 
 
 def test_upgrade_package_does_not_exist(

--- a/tests/integration_python/test_shell.py
+++ b/tests/integration_python/test_shell.py
@@ -2,16 +2,14 @@ from pathlib import Path
 import json
 import platform
 
-from .common import ALL_PLATFORMS, ExitCode, verify_cli_command
+from .common import ALL_PLATFORMS, verify_cli_command
 
 
 def test_shell_hook_completions(
     pixi: Path, tmp_pixi_workspace: Path, completions_channel_1: str
 ) -> None:
     # Create a new workspace
-    verify_cli_command(
-        [pixi, "init", "--channel", completions_channel_1, tmp_pixi_workspace], ExitCode.SUCCESS
-    )
+    verify_cli_command([pixi, "init", "--channel", completions_channel_1, tmp_pixi_workspace])
 
     verify_cli_command(
         [pixi, "add", "--manifest-path", tmp_pixi_workspace, "ripgrep-completions"],
@@ -122,7 +120,6 @@ def test_shell_activation_order(pixi: Path, tmp_pixi_workspace: Path) -> None:
     # Ask pixi to compute the environment for shell activation via shell-hook --json
     out = verify_cli_command(
         [pixi, "shell-hook", "--manifest-path", manifest, "--json"],
-        expected_exit_code=ExitCode.SUCCESS,
     )
 
     data = json.loads(out.stdout)


### PR DESCRIPTION
Fixes #4574