### PR TITLE
fix: pixi init config loading

### DIFF
--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -271,8 +271,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let mojoproject_manifest_path = dir.join(consts::MOJOPROJECT_MANIFEST);
     let gitignore_path = dir.join(".gitignore");
     let gitattributes_path = dir.join(".gitattributes");
-    let config = Config::load_global();
-
+    let config = Config::load(&dir);
     if is_init_dir_equal_to_pixi_home_parent(&dir) {
         let help_msg = format!(
             "Please follow the getting started guide at https://pixi.sh/v{}/init_getting_started/ or run the following command to create a new workspace in a subdirectory:\n\n  {}\n",

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -1326,8 +1326,8 @@ impl Config {
         ]
     }
 
-    /// Merge the given config into the current one.
-    /// The given config will have higher priority
+    /// Merge the `other` config into `self`.
+    /// The `other` config will have higher priority
     #[must_use]
     pub fn merge_config(mut self, mut other: Config) -> Self {
         self.mirrors.extend(other.mirrors);

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1664,11 +1664,13 @@ If you get here you know all commands that *are* supported correctly listen to -
         )
 
 
+@pytest.mark.slow
 def test_add_url_no_channel(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """
     Check that a helpful error message is raised when attempting to
     add a `url::pkg` where `url` is not a channel of the workspace.
     """
+
     verify_cli_command([pixi, "init", tmp_pixi_workspace])
 
     # helpful error for missing channel
@@ -1712,7 +1714,7 @@ def test_add_url_no_channel(pixi: Path, tmp_pixi_workspace: Path) -> None:
         [
             pixi,
             "add",
-            "https://prefix.dev/conda-forge::xz",
+            "https://conda.anaconda.org/conda-forge::xz",
             "--feature=prefix",
             "--manifest-path",
             tmp_pixi_workspace,
@@ -1740,20 +1742,20 @@ def test_add_url_no_channel(pixi: Path, tmp_pixi_workspace: Path) -> None:
             tmp_pixi_workspace,
         ],
         expected_exit_code=ExitCode.FAILURE,
-        stderr_contains="unavailable channel 'https://prefix.dev/conda-forge/'",
+        stderr_contains="unavailable channel 'https://conda.anaconda.org/conda-forge/'",
     )
     # and helpful message now feature is used:
     verify_cli_command(
         [
             pixi,
             "add",
-            "https://prefix.dev/conda-forge::libzlib",
+            "https://conda.anaconda.org/conda-forge::libzlib",
             "--feature=prefix",
             "--manifest-path",
             tmp_pixi_workspace,
         ],
         expected_exit_code=ExitCode.FAILURE,
-        stderr_contains="pixi workspace channel add https://prefix.dev/conda-forge",
+        stderr_contains="pixi workspace channel add https://conda.anaconda.org/conda-forge",
     )
 
     verify_cli_command(
@@ -1763,7 +1765,7 @@ def test_add_url_no_channel(pixi: Path, tmp_pixi_workspace: Path) -> None:
             "channel",
             "add",
             "--feature=prefix",
-            "https://prefix.dev/conda-forge",
+            "https://conda.anaconda.org/conda-forge",
             "--manifest-path",
             tmp_pixi_workspace,
         ],


### PR DESCRIPTION
`pixi init` originally only considered the global config. That meant that there was no good way to set the config for our test infrastructure, which is especially important for the default channel config

I also had to fix a test that relied on that kinda broken behaviour