### PR TITLE
test: skip multi-output test

### DIFF
--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -71,7 +71,8 @@ fn default_build_environment() -> BuildEnvironment {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+#[ignore = "broken: multi-output recipes don't work with latest pixi-build-rattler-build"]
+//#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
 pub async fn simple_test() {
     let (reporter, events) = EventReporter::new();
     let (tool_platform, tool_virtual_packages) = tool_platform();


### PR DESCRIPTION
With the latest `pixi-build-rattler-build` release multi-output recipes don't seem to work anymore. Let's disable the test for now and open an issue to track this