### PR TITLE
perf: initialize the reqwest client lazily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,8 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 [[package]]
 name = "coalesced_map"
 version = "0.1.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2166,7 +2167,8 @@ dependencies = [
 [[package]]
 name = "file_url"
 version = "0.2.6"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765662dc0b26e038099a5a1529f5d48443111eea45377c312be892997651710e"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4436,8 +4438,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "path_resolver"
-version = "0.2.0"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67957e099f5b76f4cad98e0d41dd53746ab3a2debc1da12ee5b1cccb1d7b8dc8"
 dependencies = [
  "fs-err",
  "fxhash",
@@ -6048,8 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.37.4"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a19d1252198a856a647fe8434692995ddae72c6bba863082909653bebac8c"
 dependencies = [
  "anyhow",
  "clap",
@@ -6092,8 +6096,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.34"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5a97bf7728b72cd8c3e70d63d0da11789959182743d9552439ece81f74fcad"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6124,8 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.39.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11048d6facd778e987418c62fe9263d8ad15daf5fe9ced37f598027d13010920"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -6166,7 +6172,8 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.1.5"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40b746768824bc3306dcb597e549e836eda023dab8d7407d32b9f342c70cc5d"
 dependencies = [
  "blake2",
  "digest",
@@ -6182,8 +6189,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.24.1"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9412db1c14bccdade131375849e41176ece899ed596d8f227d30e00295cf7c2b"
 dependencies = [
  "chrono",
  "file_url",
@@ -6208,7 +6216,8 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.11"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "988d5d7ace4fb1d7549008236cf08de95e8ea2f1f80754109324a08c31e6dc6a"
 dependencies = [
  "quote",
  "syn",
@@ -6216,8 +6225,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.27"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77f1dc963b791246e2c8f89296117e89aa711cf6f1bd18a7c8f9a168576339b"
 dependencies = [
  "chrono",
  "configparser",
@@ -6245,8 +6255,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.13"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.25.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d59b505998f3f5af0ef5fae0e8466e03895a097787e51a17e56ec2c712442db"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -6275,8 +6286,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.23.4"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba85366951a5ec70f7d355d6f7d7fe9c2391134824031ebf11d75a05a344ca22"
 dependencies = [
  "bzip2 0.6.0",
  "chrono",
@@ -6305,7 +6317,8 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.6"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a7edbf8f23a099ccb32cc4f024886e35a873c462ca83f86c286556c275bf06"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -6315,7 +6328,8 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.12"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa5057629aeb20861919e9ae56875985d58028f3c6f433a20b5ded086e1cec5"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -6324,8 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.24.4"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28fa692522331b806e4a533ff1893aa8a0a359797b8acbfed0aadbfba82849e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6383,8 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.25.0"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e823fb6cec3bd53cf22d1a02fd9bb2bdf1c6ef7e55bb9354f9ada704d3dea056"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -6403,8 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "3.0.3"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9651a8c014cc2d900d7a8544b75444421aebbb964aaec4173245566b1f99ffe2"
 dependencies = [
  "chrono",
  "futures",
@@ -6420,8 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.1.5"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d246dc5defe7846ff6527c25cf9eaf6514cc7b7e6b94679146d638be96a14c"
 dependencies = [
  "archspec",
  "libloading",
@@ -7509,7 +7527,8 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,16 +1359,6 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 [[package]]
 name = "coalesced_map"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
-dependencies = [
- "dashmap",
- "tokio",
-]
-
-[[package]]
-name = "coalesced_map"
-version = "0.1.2"
 source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "dashmap",
@@ -4866,7 +4856,7 @@ dependencies = [
  "async-fd-lock",
  "base64 0.22.1",
  "chrono",
- "coalesced_map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coalesced_map",
  "derive_more",
  "dirs",
  "dunce",
@@ -4902,7 +4892,6 @@ dependencies = [
  "rattler_shell",
  "rattler_solve",
  "rattler_virtual_packages",
- "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_with",
@@ -5021,7 +5010,6 @@ dependencies = [
  "rattler_solve",
  "rattler_virtual_packages",
  "reqwest",
- "reqwest-middleware",
  "rlimit",
  "rstest",
  "serde",
@@ -5159,8 +5147,6 @@ dependencies = [
  "rattler_shell",
  "rattler_virtual_packages",
  "regex",
- "reqwest",
- "reqwest-middleware",
  "rstest",
  "serde",
  "serde_json",
@@ -5328,7 +5314,6 @@ name = "pixi_python_status"
 version = "0.1.0"
 dependencies = [
  "rattler",
- "rattler_conda_types",
 ]
 
 [[package]]
@@ -6351,7 +6336,7 @@ dependencies = [
  "cache_control",
  "cfg-if",
  "chrono",
- "coalesced_map 0.1.2 (git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client)",
+ "coalesced_map",
  "dashmap",
  "dirs",
  "file_url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coalesced_map"
+version = "0.1.2"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
+dependencies = [
+ "dashmap",
+ "tokio",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,8 +2176,7 @@ dependencies = [
 [[package]]
 name = "file_url"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765662dc0b26e038099a5a1529f5d48443111eea45377c312be892997651710e"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -3088,7 +3096,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3701,7 +3709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4439,8 +4447,7 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493dd224adc6163e40a1e58cefbeec27dabb69696017677406417b3516c800fa"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "fs-err",
  "fxhash",
@@ -4859,7 +4866,7 @@ dependencies = [
  "async-fd-lock",
  "base64 0.22.1",
  "chrono",
- "coalesced_map",
+ "coalesced_map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more",
  "dirs",
  "dunce",
@@ -4889,6 +4896,7 @@ dependencies = [
  "rattler",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_networking",
  "rattler_package_streaming",
  "rattler_repodata_gateway",
  "rattler_shell",
@@ -5077,6 +5085,7 @@ dependencies = [
  "dunce",
  "fs-err",
  "pixi_utils",
+ "rattler_networking",
  "reqwest",
  "reqwest-middleware",
  "serde",
@@ -5145,6 +5154,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_lock",
  "rattler_menuinst",
+ "rattler_networking",
  "rattler_repodata_gateway",
  "rattler_shell",
  "rattler_virtual_packages",
@@ -5749,7 +5759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5826,6 +5836,7 @@ dependencies = [
  "pixi_consts",
  "rattler_conda_types",
  "rattler_digest",
+ "rattler_networking",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -6053,8 +6064,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.37.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b76878f37ebe3061fefc83bb9c2b65a7df53318110ce8f7249635cb1615ab"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "anyhow",
  "clap",
@@ -6098,8 +6108,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a90d8113aad3c8bff55c59f37dc292ebed419fdd09242036c4d5be30fdccc9b"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6131,8 +6140,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f16f93c23cb051636dbe215be32da964969c4d8d416d6b5d4a50574f70ceb3b"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -6145,6 +6153,7 @@ dependencies = [
  "indexmap 2.11.1",
  "itertools 0.14.0",
  "lazy-regex",
+ "memmap2 0.9.8",
  "nom 8.0.0",
  "nom-language",
  "purl",
@@ -6172,8 +6181,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40b746768824bc3306dcb597e549e836eda023dab8d7407d32b9f342c70cc5d"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "blake2",
  "digest",
@@ -6190,8 +6198,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b480fb1b37b095f8541ae86e3d18aa27aff8d4229bb3f3dcd9b90304e917199"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "chrono",
  "file_url",
@@ -6216,8 +6223,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988d5d7ace4fb1d7549008236cf08de95e8ea2f1f80754109324a08c31e6dc6a"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "quote",
  "syn",
@@ -6226,8 +6232,7 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bce831eb3bf85a44face3998746e22c924d32ac5eab950f24a3a39b7b6bd99"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "chrono",
  "configparser",
@@ -6256,8 +6261,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.25.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5e48e1ecc33f1b73f9a6fc1a7755a298340fcaf5250034e5ee86388479d3ce"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -6287,8 +6291,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a1867b2b10cc5a204e479dee7a02f29794db31a05e2cdff40bfd9652cbd54c"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "bzip2 0.6.0",
  "chrono",
@@ -6317,8 +6320,7 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a7edbf8f23a099ccb32cc4f024886e35a873c462ca83f86c286556c275bf06"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -6328,8 +6330,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa5057629aeb20861919e9ae56875985d58028f3c6f433a20b5ded086e1cec5"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -6339,8 +6340,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05b845113ad91bc24d7023b201ff1f1b6600bc68ad723dc4495e2dd766c3c36"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6351,7 +6351,7 @@ dependencies = [
  "cache_control",
  "cfg-if",
  "chrono",
- "coalesced_map",
+ "coalesced_map 0.1.2 (git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client)",
  "dashmap",
  "dirs",
  "file_url",
@@ -6399,8 +6399,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3719c5f7eae3f4abd56ec6be280eecd50bdfd81670fde2fb3685911882e5e1f"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -6420,8 +6419,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c63a7fb3e15b1885b6969fe36ec6d41989c007a69944b38f8da3af2cda37bf"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "chrono",
  "futures",
@@ -6438,8 +6436,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431de037688708d9c65b5442e7b994ce63d63c9daf96bc78bb5ae43f908fe05b"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "archspec",
  "libloading",
@@ -7527,8 +7524,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+source = "git+https://github.com/baszalmstra/rattler?branch=perf%2Flazy-client#8f66658f1243768f7e1e38717ce89764d860ef2e"
 dependencies = [
  "tokio",
 ]
@@ -7795,7 +7791,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.59.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -9891,7 +9887,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,6 +240,7 @@ reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev =
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f59ffaeb6cf5079c6cb184467da06c9db" }
 
 # pixi-rattler-patches - START
+coalesced_map = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
 file_url = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
 rattler = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
 rattler_cache = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ which = "8.0.0"
 # Rattler crates
 coalesced_map = "0.1.1"
 file_url = "0.2.6"
-rattler = { version = "0.37.3", default-features = false }
+rattler = { version = "0.37.5", default-features = false }
 rattler_cache = { version = "0.3.34", default-features = false }
 rattler_conda_types = { version = "0.39.2", default-features = false, features = [
   "rayon",
@@ -238,21 +238,3 @@ strip = "none"               # or "debuginfo" to separate
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f59ffaeb6cf5079c6cb184467da06c9db" }
-
-# pixi-rattler-patches - START
-coalesced_map = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-file_url = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_cache = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_menuinst = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_package_streaming = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-simple_spawn_blocking = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
-# pixi-rattler-patches - END

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,3 +238,20 @@ strip = "none"               # or "debuginfo" to separate
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f59ffaeb6cf5079c6cb184467da06c9db" }
+
+# pixi-rattler-patches - START
+file_url = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_cache = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_menuinst = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_package_streaming = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+simple_spawn_blocking = { git = "https://github.com/baszalmstra/rattler", branch = "perf/lazy-client" }
+# pixi-rattler-patches - END

--- a/crates/pixi/tests/integration_rust/solve_group_tests.rs
+++ b/crates/pixi/tests/integration_rust/solve_group_tests.rs
@@ -748,7 +748,7 @@ async fn test_disabled_mapping() {
 
     let blocking_middleware = OfflineMiddleware;
 
-    let blocked_client = ClientBuilder::from_client(client.clone())
+    let blocked_client = ClientBuilder::from_client(client.client().clone())
         .with(blocking_middleware)
         .build();
 
@@ -763,7 +763,7 @@ async fn test_disabled_mapping() {
 
     let mut packages = vec![boltons_repo_data_record];
 
-    let mapping_client = pypi_mapping::MappingClient::builder(blocked_client).finish();
+    let mapping_client = pypi_mapping::MappingClient::builder(blocked_client.into()).finish();
     mapping_client
         .amend_purls(
             project.pypi_name_mapping_source().unwrap(),

--- a/crates/pixi_cli/src/search.rs
+++ b/crates/pixi_cli/src/search.rs
@@ -13,7 +13,7 @@ use miette::{IntoDiagnostic, Report};
 use pixi_config::{Config, default_channel_config};
 use pixi_core::{WorkspaceLocator, workspace::WorkspaceLocatorError};
 use pixi_progress::await_in_progress;
-use pixi_utils::reqwest::build_reqwest_clients;
+use pixi_utils::reqwest::build_lazy_reqwest_clients;
 use rattler_conda_types::{MatchSpec, PackageName, ParseStrictness, Platform, RepoDataRecord};
 use rattler_lock::Matches;
 use rattler_repodata_gateway::{GatewayError, RepoData};
@@ -22,8 +22,7 @@ use strsim::jaro;
 use tracing::{debug, error};
 use url::Url;
 
-use crate::cli_config::ChannelsConfig;
-use crate::cli_config::WorkspaceConfig;
+use crate::cli_config::{ChannelsConfig, WorkspaceConfig};
 
 /// Search a conda package
 ///
@@ -143,7 +142,7 @@ pub async fn execute_impl<W: Write>(
     let client = if let Some(project) = project {
         project.authenticated_client()?.clone()
     } else {
-        build_reqwest_clients(None, None)?.1
+        build_lazy_reqwest_clients(None, None)?.1
     };
 
     let config = Config::load_global();

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -23,7 +23,6 @@ miette = { workspace = true }
 ordermap = { workspace = true }
 pin-project-lite = { workspace = true }
 rand = { workspace = true }
-reqwest-middleware = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -40,6 +40,7 @@ xxhash-rust = { workspace = true, features = ["xxh3"] }
 rattler = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true }
+rattler_networking = { workspace = true }
 rattler_package_streaming = { workspace = true }
 rattler_repodata_gateway = { workspace = true }
 rattler_shell = { workspace = true }

--- a/crates/pixi_command_dispatcher/src/command_dispatcher/builder.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/builder.rs
@@ -5,9 +5,9 @@ use pixi_git::resolver::GitResolver;
 use pixi_glob::GlobHashCache;
 use rattler::package_cache::PackageCache;
 use rattler_conda_types::{GenericVirtualPackage, Platform};
+use rattler_networking::LazyClient;
 use rattler_repodata_gateway::{Gateway, MaxConcurrency};
 use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
-use reqwest_middleware::ClientWithMiddleware;
 
 use crate::build::source_metadata_cache::SourceMetadataCache;
 use crate::discover_backend_cache::DiscoveryCache;
@@ -25,7 +25,7 @@ pub struct CommandDispatcherBuilder {
     root_dir: Option<PathBuf>,
     reporter: Option<Box<dyn Reporter>>,
     git_resolver: Option<GitResolver>,
-    download_client: Option<ClientWithMiddleware>,
+    download_client: Option<LazyClient>,
     cache_dirs: Option<CacheDirs>,
     build_backend_overrides: BackendOverride,
     max_download_concurrency: MaxConcurrency,
@@ -61,7 +61,7 @@ impl CommandDispatcherBuilder {
     }
 
     /// Sets the reqwest client to use for network fetches.
-    pub fn with_download_client(self, client: ClientWithMiddleware) -> Self {
+    pub fn with_download_client(self, client: LazyClient) -> Self {
         Self {
             download_client: Some(client),
             ..self

--- a/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
@@ -23,8 +23,8 @@ use pixi_record::{PinnedPathSpec, PinnedSourceSpec, PixiRecord};
 use pixi_spec::{SourceLocationSpec, SourceSpec};
 use rattler::package_cache::PackageCache;
 use rattler_conda_types::{ChannelConfig, GenericVirtualPackage, Platform};
+use rattler_networking::LazyClient;
 use rattler_repodata_gateway::Gateway;
-use reqwest_middleware::ClientWithMiddleware;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use typed_path::Utf8TypedPath;
@@ -118,7 +118,7 @@ pub(crate) struct CommandDispatcherData {
     pub cache_dirs: CacheDirs,
 
     /// The reqwest client to use for network requests.
-    pub download_client: ClientWithMiddleware,
+    pub download_client: LazyClient,
 
     /// Backend overrides for build environments.
     pub build_backend_overrides: BackendOverride,
@@ -379,7 +379,7 @@ impl CommandDispatcher {
     }
 
     /// Returns the download client used by the command dispatcher.
-    pub fn download_client(&self) -> &ClientWithMiddleware {
+    pub fn download_client(&self) -> &LazyClient {
         &self.data.download_client
     }
 

--- a/crates/pixi_core/Cargo.toml
+++ b/crates/pixi_core/Cargo.toml
@@ -66,7 +66,6 @@ rattler_shell = { workspace = true }
 rattler_solve = { workspace = true }
 rattler_virtual_packages = { workspace = true }
 reqwest = { workspace = true }
-reqwest-middleware = { workspace = true }
 rlimit = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true }

--- a/crates/pixi_git/Cargo.toml
+++ b/crates/pixi_git/Cargo.toml
@@ -14,6 +14,7 @@ dashmap = { workspace = true }
 dunce = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 pixi_utils = { workspace = true, features = ["rustls-tls"] }
+rattler_networking = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
 reqwest-middleware = { workspace = true }
 serde = { workspace = true }

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use dashmap::DashMap;
 use dashmap::mapref::one::Ref;
-use reqwest_middleware::ClientWithMiddleware;
+use rattler_networking::LazyClient;
 use serde::Serialize;
 
 #[derive(Debug, thiserror::Error)]
@@ -50,7 +50,7 @@ impl GitResolver {
     pub async fn fetch(
         &self,
         url: GitUrl,
-        client: ClientWithMiddleware,
+        client: LazyClient,
         cache: PathBuf,
         reporter: Option<Arc<dyn Reporter>>,
     ) -> Result<Fetch, GitError> {

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -1,3 +1,4 @@
+use rattler_networking::LazyClient;
 /// Derived from `uv-git` implementation
 /// Source: https://github.com/astral-sh/uv/blob/4b8cc3e29e4c2a6417479135beaa9783b05195d3/crates/uv-git/src/source.rs
 /// This module expose `GitSource` type that represents a remote Git source that
@@ -8,8 +9,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-
-use reqwest_middleware::ClientWithMiddleware;
 use tracing::instrument;
 
 use crate::{
@@ -26,7 +25,7 @@ pub struct GitSource {
     /// The Git reference from the manifest file.
     git: GitUrl,
     /// The HTTP client to use for fetching.
-    client: ClientWithMiddleware,
+    client: LazyClient,
     /// The path to the Git source database.
     cache: PathBuf,
     /// The reporter to use for this source.
@@ -35,14 +34,10 @@ pub struct GitSource {
 
 impl GitSource {
     /// Initialize a new Git source.
-    pub fn new(
-        git: GitUrl,
-        client: impl Into<ClientWithMiddleware>,
-        cache: impl Into<PathBuf>,
-    ) -> Self {
+    pub fn new(git: GitUrl, client: LazyClient, cache: impl Into<PathBuf>) -> Self {
         Self {
             git,
-            client: client.into(),
+            client,
             cache: cache.into(),
             reporter: None,
         }

--- a/crates/pixi_global/Cargo.toml
+++ b/crates/pixi_global/Cargo.toml
@@ -39,6 +39,7 @@ rattler = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_lock = { workspace = true }
 rattler_menuinst = { workspace = true }
+rattler_networking = { workspace = true }
 rattler_repodata_gateway = { workspace = true }
 rattler_shell = { workspace = true }
 rattler_virtual_packages = { workspace = true }

--- a/crates/pixi_global/Cargo.toml
+++ b/crates/pixi_global/Cargo.toml
@@ -44,8 +44,6 @@ rattler_repodata_gateway = { workspace = true }
 rattler_shell = { workspace = true }
 rattler_virtual_packages = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true }
-reqwest-middleware = { workspace = true }
 rstest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/pixi_global/src/common.rs
+++ b/crates/pixi_global/src/common.rs
@@ -1,5 +1,12 @@
-use super::trampoline::{GlobalExecutable, Trampoline};
-use super::{EnvironmentName, ExposedName, Mapping};
+use std::{
+    collections::HashMap,
+    ffi::OsStr,
+    io::Read,
+    iter::Peekable,
+    ops::Not,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use ahash::HashSet;
 use console::StyledObject;
@@ -12,23 +19,18 @@ use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use pixi_config::pixi_home;
 use pixi_manifest::PrioritizedChannel;
-use pixi_utils::executable_from_path;
-use pixi_utils::prefix::Executable;
+use pixi_utils::{executable_from_path, prefix::Executable};
 use rattler::install::{Transaction, TransactionOperation};
 use rattler_conda_types::{
-    Channel, ChannelConfig, NamedChannelOrUrl, PackageName, PackageRecord, PrefixRecord,
-    RepoDataRecord, Version,
-};
-use std::collections::HashMap;
-use std::ffi::OsStr;
-use std::iter::Peekable;
-use std::ops::Not;
-use std::str::FromStr;
-use std::{
-    io::Read,
-    path::{Path, PathBuf},
+    Channel, ChannelConfig, HasArtifactIdentificationRefs, NamedChannelOrUrl, PackageName,
+    PackageRecord, PrefixRecord, Version,
 };
 use url::Url;
+
+use super::{
+    EnvironmentName, ExposedName, Mapping,
+    trampoline::{GlobalExecutable, Trampoline},
+};
 
 /// Global binaries directory, default to `$HOME/.pixi/bin`
 #[derive(Debug, Clone)]
@@ -56,9 +58,10 @@ impl BinDir {
 
     /// Asynchronously retrieves all files in the binary executable directory.
     ///
-    /// This function reads the directory specified by `self.0` and try to collect all
-    /// file paths into a vector. It returns a `miette::Result` containing the
-    /// vector of `GlobalExecutable`or an error if the directory can't be read.
+    /// This function reads the directory specified by `self.0` and try to
+    /// collect all file paths into a vector. It returns a `miette::Result`
+    /// containing the vector of `GlobalExecutable`or an error if the
+    /// directory can't be read.
     pub(crate) async fn executables(&self) -> miette::Result<Vec<GlobalExecutable>> {
         let mut files = Vec::new();
         let mut entries = tokio_fs::read_dir(&self.0).await.into_diagnostic()?;
@@ -83,13 +86,14 @@ impl BinDir {
 
     /// Returns the path to the executable script for the given exposed name.
     ///
-    /// This function constructs the path to the executable script by joining the
-    /// `bin_dir` with the provided `exposed_name`. If the target platform is
-    /// Windows, it sets the file extension to `.exe`.
+    /// This function constructs the path to the executable script by joining
+    /// the `bin_dir` with the provided `exposed_name`. If the target
+    /// platform is Windows, it sets the file extension to `.exe`.
     pub(crate) fn executable_trampoline_path(&self, exposed_name: &ExposedName) -> PathBuf {
         // Add .bat to the windows executable
         let exposed_name = if cfg!(windows) {
-            // Not using `.set_extension()` because it will break the `.` in the name for cases like `python3.9.1`
+            // Not using `.set_extension()` because it will break the `.` in the name for
+            // cases like `python3.9.1`
             format!("{}.exe", exposed_name)
         } else {
             exposed_name.to_string()
@@ -151,7 +155,8 @@ impl EnvDir {
         Self { path }
     }
 
-    /// Create a global environment directory based on passed global environment root
+    /// Create a global environment directory based on passed global environment
+    /// root
     pub(crate) async fn from_env_root(
         env_root: EnvRoot,
         environment_name: &EnvironmentName,
@@ -169,7 +174,8 @@ impl EnvDir {
     }
 }
 
-/// Checks if a file is binary by reading the first 1024 bytes and checking for null bytes.
+/// Checks if a file is binary by reading the first 1024 bytes and checking for
+/// null bytes.
 pub(crate) fn is_binary(file_path: impl AsRef<Path>) -> miette::Result<bool> {
     let mut file = fs::File::open(file_path.as_ref()).into_diagnostic()?;
     let mut buffer = [0; 1024];
@@ -350,7 +356,8 @@ impl EnvironmentUpdate {
     }
 
     /// Get only the package changes that were explicitly requested by the user.
-    /// This filters out transitive dependency changes to focus on user-installed packages.
+    /// This filters out transitive dependency changes to focus on
+    /// user-installed packages.
     pub fn user_requested_changes(
         &self,
         requested_packages: &[PackageName],
@@ -388,7 +395,8 @@ pub struct StateChanges {
 }
 
 impl StateChanges {
-    /// Creates a new `StateChanges` instance with a single environment name and an empty vector as its value.
+    /// Creates a new `StateChanges` instance with a single environment name and
+    /// an empty vector as its value.
     pub fn new_with_env(env_name: EnvironmentName) -> Self {
         Self {
             changes: HashMap::from([(env_name, Vec::new())]),
@@ -425,7 +433,8 @@ impl StateChanges {
         user_requested_changes: HashMap<PackageName, InstallChange>,
         project: &super::Project,
     ) -> miette::Result<()> {
-        // Convert to StateChange::AddedPackage for packages that were installed or upgraded
+        // Convert to StateChange::AddedPackage for packages that were installed or
+        // upgraded
         for (package_name, install_change) in user_requested_changes {
             if matches!(
                 install_change,
@@ -849,7 +858,8 @@ pub(crate) fn channel_url_to_prioritized_channel(
     channel: &str,
     channel_config: &ChannelConfig,
 ) -> miette::Result<PrioritizedChannel> {
-    // If channel url contains channel config alias as a substring, don't use it as a URL
+    // If channel url contains channel config alias as a substring, don't use it as
+    // a URL
     if channel.contains(channel_config.channel_alias.as_str()) {
         // Create channel from URL for parsing
         let channel = Channel::from_url(Url::from_str(channel).expect("channel should be url"));
@@ -865,12 +875,13 @@ pub(crate) fn channel_url_to_prioritized_channel(
         .into())
 }
 
-/// Determines which shortcuts need to be installed or removed by comparing the requested shortcuts
-/// with the installed package records.
+/// Determines which shortcuts need to be installed or removed by comparing the
+/// requested shortcuts with the installed package records.
 ///
-/// This function filters the provided `prefix_records` to find those that contain menuinst JSON files.
-/// It then compares these records with the requested `shortcuts` to
-/// determine which records need to be installed and which need to be uninstalled.
+/// This function filters the provided `prefix_records` to find those that
+/// contain menuinst JSON files. It then compares these records with the
+/// requested `shortcuts` to determine which records need to be installed and
+/// which need to be uninstalled.
 pub(crate) fn shortcuts_sync_status(
     shortcuts: IndexSet<PackageName>,
     prefix_records: Vec<PrefixRecord>,
@@ -947,13 +958,15 @@ pub fn contains_menuinst_document(prefix_record: &PrefixRecord, prefix_root: &Pa
 
 /// Figures out what the status is of the exposed binaries of the environment.
 ///
-/// Returns a tuple of the exposed binaries to remove and the exposed binaries to add.
+/// Returns a tuple of the exposed binaries to remove and the exposed binaries
+/// to add.
 pub(crate) async fn expose_scripts_sync_status(
     bin_dir: &BinDir,
     env_dir: &EnvDir,
     mappings: &IndexSet<Mapping>,
 ) -> miette::Result<(Vec<GlobalExecutable>, IndexSet<ExposedName>)> {
-    // Get all paths to the binaries from trampolines or scripts in the bin directory.
+    // Get all paths to the binaries from trampolines or scripts in the bin
+    // directory.
     let locally_exposed = bin_dir.executables().await?;
     let executable_paths = futures::future::join_all(locally_exposed.iter().map(|global_bin| {
         let global_bin = global_bin.clone();
@@ -1016,7 +1029,8 @@ pub(crate) async fn expose_scripts_sync_status(
     Ok((to_remove, to_add))
 }
 
-/// Check if all binaries were exposed, or if the user selected a subset of them.
+/// Check if all binaries were exposed, or if the user selected a subset of
+/// them.
 pub fn check_all_exposed(
     env_binaries: &IndexMap<PackageName, Vec<Executable>>,
     exposed_mapping_binaries: &IndexSet<Mapping>,
@@ -1037,26 +1051,29 @@ pub fn check_all_exposed(
     auto_exposed
 }
 
-pub(crate) fn get_install_changes(
-    install_transaction: Transaction<PrefixRecord, RepoDataRecord>,
+pub(crate) fn get_install_changes<
+    Old: HasArtifactIdentificationRefs,
+    New: HasArtifactIdentificationRefs,
+>(
+    install_transaction: Transaction<Old, New>,
 ) -> HashMap<PackageName, InstallChange> {
     install_transaction
         .operations
         .into_iter()
         .map(|transaction| match transaction {
             TransactionOperation::Install(package) => {
-                let pkg_name = package.package_record.name;
+                let pkg_name = package.name();
 
                 (
-                    pkg_name,
-                    InstallChange::Installed(package.package_record.version.version().clone()),
+                    pkg_name.clone(),
+                    InstallChange::Installed(package.version().version().clone()),
                 )
             }
             TransactionOperation::Change { old, new } => {
-                let old_pkg_version = old.repodata_record.package_record.version;
-                let new_pkg_version = new.package_record.version;
+                let old_pkg_version = old.version();
+                let new_pkg_version = new.version();
 
-                let pkg_name = new.package_record.name;
+                let pkg_name = new.name();
 
                 let same_base_version = old_pkg_version == new_pkg_version;
 
@@ -1072,21 +1089,21 @@ pub(crate) fn get_install_changes(
                     )
                 };
 
-                (pkg_name, change)
+                (pkg_name.clone(), change)
             }
             TransactionOperation::Reinstall { old, new } => {
-                let pkg_name = new.package_record.name;
+                let pkg_name = new.name();
                 (
-                    pkg_name,
+                    pkg_name.clone(),
                     InstallChange::Reinstalled(
-                        old.repodata_record.package_record.version.version().clone(),
-                        new.package_record.version.version().clone(),
+                        old.version().version().clone(),
+                        new.version().version().clone(),
                     ),
                 )
             }
             TransactionOperation::Remove(package) => {
-                let pkg_name = package.repodata_record.package_record.name;
-                (pkg_name, InstallChange::Removed)
+                let pkg_name = package.name();
+                (pkg_name.clone(), InstallChange::Removed)
             }
         })
         .collect()
@@ -1094,12 +1111,13 @@ pub(crate) fn get_install_changes(
 
 #[cfg(test)]
 mod tests {
-    use crate::trampoline::Configuration;
+    use std::str::FromStr;
+
+    use rstest::rstest;
+    use tempfile::tempdir;
 
     use super::*;
-    use rstest::rstest;
-    use std::str::FromStr;
-    use tempfile::tempdir;
+    use crate::trampoline::Configuration;
 
     #[tokio::test]
     async fn test_create() {
@@ -1286,7 +1304,8 @@ mod tests {
             }
         };
 
-        // Test to_remove and to_add to see if the legacy scripts are removed and trampolines are added
+        // Test to_remove and to_add to see if the legacy scripts are removed and
+        // trampolines are added
         let (to_remove, to_add) = expose_scripts_sync_status(&bin_dir, &env_dir, &exposed)
             .await
             .unwrap();

--- a/crates/pixi_python_status/Cargo.toml
+++ b/crates/pixi_python_status/Cargo.toml
@@ -10,4 +10,3 @@ version = "0.1.0"
 
 [dependencies]
 rattler = { workspace = true }
-rattler_conda_types = { workspace = true }

--- a/crates/pixi_python_status/src/lib.rs
+++ b/crates/pixi_python_status/src/lib.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use rattler::install::{PythonInfo, Transaction};
-use rattler_conda_types::{PrefixRecord, RepoDataRecord};
 
 /// Describes how the Python interpreter in a prefix changed between two
 /// transactions. This is used to determine whether site-packages need to be
@@ -26,7 +25,7 @@ pub enum PythonStatus {
 
 impl PythonStatus {
     /// Determine the [`PythonStatus`] from a [`Transaction`].
-    pub fn from_transaction(transaction: &Transaction<PrefixRecord, RepoDataRecord>) -> Self {
+    pub fn from_transaction<Old, New>(transaction: &Transaction<Old, New>) -> Self {
         match (
             transaction.current_python_info.as_ref(),
             transaction.python_info.as_ref(),

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -1,21 +1,25 @@
-use std::{any::Any, path::PathBuf, sync::Arc, sync::LazyLock, time::Duration};
+use std::{
+    any::Any,
+    borrow::Cow,
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
 use miette::IntoDiagnostic;
+use pixi_config::Config;
 use pixi_consts::consts;
 use rattler_networking::{
-    AuthenticationMiddleware, AuthenticationStorage, GCSMiddleware, MirrorMiddleware,
+    AuthenticationMiddleware, AuthenticationStorage, GCSMiddleware, LazyClient, MirrorMiddleware,
     OciMiddleware, S3Middleware,
     authentication_storage::{self, AuthenticationStorageError},
     mirror_middleware::Mirror,
     retry_policies::ExponentialBackoff,
 };
-
 use reqwest::Client;
-use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware};
+use reqwest_middleware::{ClientWithMiddleware, Middleware};
 use reqwest_retry::RetryTransientMiddleware;
-use std::collections::HashMap;
-
-use pixi_config::Config;
 
 /// The default retry policy employed by pixi.
 /// TODO: At some point we might want to make this configurable.
@@ -124,37 +128,18 @@ pub fn reqwest_client_builder(config: Option<&Config>) -> miette::Result<reqwest
     Ok(builder)
 }
 
-pub fn build_reqwest_clients(
-    config: Option<&Config>,
+pub fn build_reqwest_middleware_stack(
+    config: &Config,
     s3_config_project: Option<HashMap<String, rattler_networking::s3_middleware::S3Config>>,
-) -> miette::Result<(Client, ClientWithMiddleware)> {
-    // If we do not have a config, we will just load the global default.
-    let config = if let Some(config) = config {
-        config.clone()
-    } else {
-        Config::load_global()
-    };
-
-    if config.tls_no_verify() {
-        tracing::warn!(
-            "TLS verification is disabled. This is insecure and should only be used for testing or internal networks."
-        );
-    }
-
-    let client = reqwest_client_builder(Some(&config))?
-        .danger_accept_invalid_certs(config.tls_no_verify())
-        .build()
-        .expect("failed to create reqwest Client");
-
-    let mut client_builder = ClientBuilder::new(client.clone());
+) -> miette::Result<Box<[Arc<dyn Middleware>]>> {
+    let mut result: Vec<Arc<dyn Middleware>> = Vec::new();
 
     if !config.mirror_map().is_empty() {
-        client_builder = client_builder
-            .with(mirror_middleware(&config))
-            .with(oci_middleware());
+        result.push(Arc::new(mirror_middleware(config)));
+        result.push(Arc::new(oci_middleware()));
     }
 
-    client_builder = client_builder.with(GCSMiddleware);
+    result.push(Arc::new(GCSMiddleware));
 
     let s3_config_global = config.compute_s3_config();
     let s3_config_project = s3_config_project.unwrap_or_default();
@@ -162,21 +147,94 @@ pub fn build_reqwest_clients(
     s3_config.extend(s3_config_global);
     s3_config.extend(s3_config_project);
 
-    let store = auth_store(&config).into_diagnostic()?;
-    let s3_middleware = S3Middleware::new(s3_config, store);
-    client_builder = client_builder.with(s3_middleware);
+    let store = auth_store(config).into_diagnostic()?;
+    result.push(Arc::new(S3Middleware::new(s3_config, store)));
 
-    client_builder = client_builder.with_arc(Arc::new(
-        auth_middleware(&config).expect("could not create auth middleware"),
+    result.push(Arc::new(
+        auth_middleware(config).expect("could not create auth middleware"),
     ));
 
-    client_builder = client_builder.with(RetryTransientMiddleware::new_with_policy(
+    result.push(Arc::new(RetryTransientMiddleware::new_with_policy(
         default_retry_policy(),
-    ));
+    )));
 
-    let authenticated_client = client_builder.build();
+    Ok(result.into_boxed_slice())
+}
+
+pub fn build_reqwest_clients(
+    config: Option<&Config>,
+    s3_config_project: Option<HashMap<String, rattler_networking::s3_middleware::S3Config>>,
+) -> miette::Result<(Client, ClientWithMiddleware)> {
+    // If we do not have a config, we will just load the global default.
+    let config = if let Some(config) = config {
+        Cow::Borrowed(config)
+    } else {
+        Cow::Owned(Config::load_global())
+    };
+
+    let client = LazyReqwestClient::new(&config)?.into_client();
+    let middleware = build_reqwest_middleware_stack(&config, s3_config_project)?;
+    let authenticated_client = ClientWithMiddleware::new(client.clone(), middleware);
 
     Ok((client, authenticated_client))
+}
+
+pub fn build_lazy_reqwest_clients(
+    config: Option<&Config>,
+    s3_config_project: Option<HashMap<String, rattler_networking::s3_middleware::S3Config>>,
+) -> miette::Result<(LazyReqwestClient, LazyClient)> {
+    // If we do not have a config, we will just load the global default.
+    let config = if let Some(config) = config {
+        Cow::Borrowed(config)
+    } else {
+        Cow::Owned(Config::load_global())
+    };
+
+    let client = LazyReqwestClient::new(&config)?;
+    let middleware_stack = build_reqwest_middleware_stack(&config, s3_config_project)?;
+
+    let client_for_middleware = client.clone();
+    let client_with_middleware = rattler_networking::LazyClient::new(move || {
+        let client = client_for_middleware.into_client();
+        ClientWithMiddleware::new(client, middleware_stack)
+    });
+
+    Ok((client, client_with_middleware))
+}
+
+/// This is a wrapper around reqwest::Client that initializes the client lazily.
+///
+/// This is useful because the initialization of the client can be expensive.
+#[derive(Clone)]
+pub struct LazyReqwestClient {
+    pub client: Arc<LazyLock<reqwest::Client, Box<dyn FnOnce() -> reqwest::Client + Send + Sync>>>,
+}
+
+impl LazyReqwestClient {
+    pub fn new(config: &Config) -> miette::Result<Self> {
+        let tls_no_verify = config.tls_no_verify();
+        if tls_no_verify {
+            tracing::warn!(
+                "TLS verification is disabled. This is insecure and should only be used for testing or internal networks."
+            );
+        }
+
+        let builder =
+            reqwest_client_builder(Some(config))?.danger_accept_invalid_certs(tls_no_verify);
+
+        Ok(Self {
+            client: Arc::new(LazyLock::new(Box::new(move || {
+                builder
+                    .danger_accept_invalid_certs(tls_no_verify)
+                    .build()
+                    .expect("failed to create reqwest Client")
+            }))),
+        })
+    }
+
+    pub fn into_client(self) -> reqwest::Client {
+        (*self.client).clone()
+    }
 }
 
 pub fn uv_middlewares(config: &Config) -> Vec<Arc<dyn Middleware>> {
@@ -190,7 +248,8 @@ pub fn uv_middlewares(config: &Config) -> Vec<Arc<dyn Middleware>> {
     };
 
     // Add authentication middleware after mirror rewriting so it can authenticate
-    // against the rewritten URLs (important for mirrors that require different credentials)
+    // against the rewritten URLs (important for mirrors that require different
+    // credentials)
     if let Ok(auth_middleware) = auth_middleware(config) {
         middlewares.push(Arc::new(auth_middleware));
     }
@@ -199,9 +258,10 @@ pub fn uv_middlewares(config: &Config) -> Vec<Arc<dyn Middleware>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use pixi_config::Config;
     use url::Url;
+
+    use super::*;
 
     #[test]
     fn test_uv_middlewares_includes_auth_with_mirrors() {

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -4,7 +4,7 @@ use std::{
     collections::HashMap,
     path::PathBuf,
     sync::{Arc, LazyLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use miette::IntoDiagnostic;
@@ -224,10 +224,13 @@ impl LazyReqwestClient {
 
         Ok(Self {
             client: Arc::new(LazyLock::new(Box::new(move || {
-                builder
+                let start = Instant::now();
+                let client = builder
                     .danger_accept_invalid_certs(tls_no_verify)
                     .build()
-                    .expect("failed to create reqwest Client")
+                    .expect("failed to create reqwest Client");
+                tracing::debug!("instantiating reqwest Client took {:?}", start.elapsed());
+                client
             }))),
         })
     }

--- a/crates/pypi_mapping/Cargo.toml
+++ b/crates/pypi_mapping/Cargo.toml
@@ -23,6 +23,7 @@ pixi_config = { workspace = true }
 pixi_consts = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true }
+rattler_networking = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }

--- a/crates/pypi_mapping/src/custom_mapping.rs
+++ b/crates/pypi_mapping/src/custom_mapping.rs
@@ -1,7 +1,7 @@
 use async_once_cell::OnceCell as AsyncCell;
 use miette::{IntoDiagnostic, WrapErr};
 use rattler_conda_types::{PackageUrl, RepoDataRecord};
-use reqwest_middleware::ClientWithMiddleware;
+use rattler_networking::LazyClient;
 use std::path::Path;
 use url::Url;
 
@@ -32,7 +32,7 @@ impl CustomMapping {
     /// Fetch the custom mapping from the server or load from the local
     pub async fn fetch_custom_mapping(
         &self,
-        client: &ClientWithMiddleware,
+        client: &LazyClient,
     ) -> miette::Result<MappingByChannel> {
         self.mapping_value
             .get_or_try_init(async {
@@ -74,10 +74,11 @@ impl CustomMapping {
 }
 
 async fn fetch_mapping_from_url(
-    client: &ClientWithMiddleware,
+    client: &LazyClient,
     url: &Url,
 ) -> miette::Result<CompressedMapping> {
     let response = client
+        .client()
         .get(url.clone())
         .send()
         .await

--- a/crates/pypi_mapping/src/prefix/compressed_mapping_client.rs
+++ b/crates/pypi_mapping/src/prefix/compressed_mapping_client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_once_cell::OnceCell;
 use rattler_conda_types::{PackageUrl, RepoDataRecord};
-use reqwest_middleware::ClientWithMiddleware;
+use rattler_networking::LazyClient;
 use tokio::sync::Semaphore;
 use url::Url;
 
@@ -27,12 +27,12 @@ pub struct CompressedMappingClient {
 }
 
 pub struct CompressedMappingClientBuilder {
-    client: ClientWithMiddleware,
+    client: LazyClient,
     limit: Option<Arc<Semaphore>>,
 }
 
 struct CompressedMappingClientInner {
-    client: ClientWithMiddleware,
+    client: LazyClient,
     mapping: OnceCell<CompressedMapping>,
     limit: Option<Arc<Semaphore>>,
 }
@@ -69,7 +69,7 @@ impl CompressedMappingClientBuilder {
 impl CompressedMappingClient {
     /// Constructs a new `HashMappingClient` with the provided
     /// `ClientWithMiddleware`.
-    pub fn builder(client: ClientWithMiddleware) -> CompressedMappingClientBuilder {
+    pub fn builder(client: LazyClient) -> CompressedMappingClientBuilder {
         CompressedMappingClientBuilder {
             client,
             limit: None,
@@ -100,6 +100,7 @@ impl CompressedMappingClient {
                 };
                 let response = inner
                     .client
+                    .client()
                     .get(compressed_mapping_url)
                     .send()
                     .await?


### PR DESCRIPTION
This PR updates the code to use the latest rattler release and introduces the use of `LazyClient` to ensure we only initialize a reqwest client when we actually need to. This should then speed things up when this is not the case.

Closes https://github.com/prefix-dev/pixi/pull/4656