### PR TITLE
feat(pixi_api): Implement task support for WorkspaceContext

### DIFF
--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -44,6 +44,24 @@ impl<I: Interface> WorkspaceContext<I> {
             .await
     }
 
+    pub async fn add_task(
+        &self,
+        name: TaskName,
+        task: Task,
+        feature: FeatureName,
+        platform: Option<Platform>,
+    ) -> miette::Result<()> {
+        crate::workspace::task::add_task(
+            &self.interface,
+            self.workspace.clone(),
+            name,
+            task,
+            feature,
+            platform,
+        )
+        .await
+    }
+
     pub async fn remove_task(
         &self,
         names: Vec<TaskName>,

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -62,6 +62,22 @@ impl<I: Interface> WorkspaceContext<I> {
         .await
     }
 
+    pub async fn alias_task(
+        &self,
+        name: TaskName,
+        task: Task,
+        platform: Option<Platform>,
+    ) -> miette::Result<()> {
+        crate::workspace::task::alias_task(
+            &self.interface,
+            self.workspace.clone(),
+            name,
+            task,
+            platform,
+        )
+        .await
+    }
+
     pub async fn remove_task(
         &self,
         names: Vec<TaskName>,

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -20,6 +20,10 @@ impl<I: Interface> WorkspaceContext<I> {
         }
     }
 
+    pub fn workspace(&self) -> Workspace {
+        self.workspace.clone()
+    }
+
     pub async fn init(interface: I, options: InitOptions) -> miette::Result<Workspace> {
         crate::workspace::init::init(&interface, options).await
     }

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -29,19 +29,18 @@ impl<I: Interface> WorkspaceContext<I> {
     }
 
     pub async fn name(&self) -> String {
-        crate::workspace::workspace::name::get(self.workspace.clone()).await
+        crate::workspace::workspace::name::get(&self.workspace).await
     }
 
     pub async fn set_name(&self, name: &str) -> miette::Result<()> {
-        crate::workspace::workspace::name::set(&self.interface, self.workspace.clone(), name).await
+        crate::workspace::workspace::name::set(&self.interface, &self.workspace, name).await
     }
 
     pub async fn list_tasks(
         &self,
         environment: Option<EnvironmentName>,
     ) -> miette::Result<HashMap<EnvironmentName, HashMap<TaskName, Task>>> {
-        crate::workspace::task::list_tasks(&self.interface, self.workspace.clone(), environment)
-            .await
+        crate::workspace::task::list_tasks(&self.interface, &self.workspace, environment).await
     }
 
     pub async fn add_task(
@@ -53,7 +52,7 @@ impl<I: Interface> WorkspaceContext<I> {
     ) -> miette::Result<()> {
         crate::workspace::task::add_task(
             &self.interface,
-            self.workspace.clone(),
+            &self.workspace,
             name,
             task,
             feature,
@@ -68,14 +67,8 @@ impl<I: Interface> WorkspaceContext<I> {
         task: Task,
         platform: Option<Platform>,
     ) -> miette::Result<()> {
-        crate::workspace::task::alias_task(
-            &self.interface,
-            self.workspace.clone(),
-            name,
-            task,
-            platform,
-        )
-        .await
+        crate::workspace::task::alias_task(&self.interface, &self.workspace, name, task, platform)
+            .await
     }
 
     pub async fn remove_task(
@@ -86,7 +79,7 @@ impl<I: Interface> WorkspaceContext<I> {
     ) -> miette::Result<()> {
         crate::workspace::task::remove_tasks(
             &self.interface,
-            self.workspace.clone(),
+            &self.workspace,
             names,
             platform,
             feature,
@@ -101,8 +94,8 @@ impl<I: Interface> WorkspaceContext<I> {
     ) -> miette::Result<()> {
         crate::workspace::reinstall::reinstall(
             &self.interface,
+            &self.workspace,
             options,
-            self.workspace.clone(),
             lock_file_usage,
         )
         .await

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -1,7 +1,10 @@
+use std::collections::HashMap;
+
 use pixi_core::{Workspace, environment::LockFileUsage};
+use pixi_manifest::{EnvironmentName, Task, TaskName};
 
 use crate::interface::Interface;
-use crate::workspace::{init::InitOptions, reinstall::ReinstallOptions};
+use crate::workspace::{InitOptions, ReinstallOptions};
 
 pub struct WorkspaceContext<I: Interface> {
     interface: I,
@@ -28,6 +31,13 @@ impl<I: Interface> WorkspaceContext<I> {
         crate::workspace::workspace::name::set(&self.interface, self.workspace.clone(), name).await
     }
 
+    pub async fn list_tasks(
+        &self,
+        environment: Option<EnvironmentName>,
+    ) -> miette::Result<HashMap<EnvironmentName, HashMap<TaskName, Task>>> {
+        crate::workspace::task::list_tasks(&self.interface, self.workspace.clone(), environment)
+            .await
+    }
     pub async fn reinstall(
         &self,
         options: ReinstallOptions,

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -20,8 +20,8 @@ impl<I: Interface> WorkspaceContext<I> {
         }
     }
 
-    pub fn workspace(&self) -> Workspace {
-        self.workspace.clone()
+    pub fn workspace(&self) -> &Workspace {
+        &self.workspace
     }
 
     pub async fn init(interface: I, options: InitOptions) -> miette::Result<Workspace> {

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use pixi_core::{Workspace, environment::LockFileUsage};
-use pixi_manifest::{EnvironmentName, Task, TaskName};
+use pixi_manifest::{EnvironmentName, FeatureName, Task, TaskName};
+use rattler_conda_types::Platform;
 
 use crate::interface::Interface;
 use crate::workspace::{InitOptions, ReinstallOptions};
@@ -38,6 +39,23 @@ impl<I: Interface> WorkspaceContext<I> {
         crate::workspace::task::list_tasks(&self.interface, self.workspace.clone(), environment)
             .await
     }
+
+    pub async fn remove_task(
+        &self,
+        names: Vec<TaskName>,
+        platform: Option<Platform>,
+        feature: FeatureName,
+    ) -> miette::Result<()> {
+        crate::workspace::task::remove_tasks(
+            &self.interface,
+            self.workspace.clone(),
+            names,
+            platform,
+            feature,
+        )
+        .await
+    }
+
     pub async fn reinstall(
         &self,
         options: ReinstallOptions,

--- a/crates/pixi_api/src/lib.rs
+++ b/crates/pixi_api/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod workspace;
 
-pub mod context;
-pub mod interface;
+mod context;
+pub use context::WorkspaceContext;
+
+mod interface;
+pub use interface::Interface;
 
 // Reexport for pixi_api consumers
 pub use pixi_core as core;

--- a/crates/pixi_api/src/lib.rs
+++ b/crates/pixi_api/src/lib.rs
@@ -8,3 +8,5 @@ pub use interface::Interface;
 
 // Reexport for pixi_api consumers
 pub use pixi_core as core;
+pub use pixi_manifest as manifest;
+pub use rattler_conda_types;

--- a/crates/pixi_api/src/workspace/init/mod.rs
+++ b/crates/pixi_api/src/workspace/init/mod.rs
@@ -26,10 +26,7 @@ mod template;
 
 pub use options::{GitAttributes, InitOptions, ManifestFormat};
 
-pub(crate) async fn init<I: Interface>(
-    interface: &I,
-    options: InitOptions,
-) -> miette::Result<Workspace> {
+pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::Result<Workspace> {
     let env = Environment::new();
     // Fail silently if the directory already exists or cannot be created.
     fs_err::create_dir_all(&options.path).into_diagnostic()?;

--- a/crates/pixi_api/src/workspace/mod.rs
+++ b/crates/pixi_api/src/workspace/mod.rs
@@ -1,4 +1,10 @@
-pub mod init;
-pub mod reinstall;
+pub(crate) mod init;
+pub use init::{GitAttributes, InitOptions, ManifestFormat};
+
+pub(crate) mod reinstall;
+pub use reinstall::ReinstallOptions;
+
+pub(crate) mod task;
+
 #[allow(clippy::module_inception)]
-pub mod workspace;
+pub(crate) mod workspace;

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -14,8 +14,8 @@ pub use options::ReinstallOptions;
 
 pub async fn reinstall<I: Interface>(
     interface: &I,
+    workspace: &Workspace,
     options: ReinstallOptions,
-    workspace: Workspace,
     lock_file_usage: LockFileUsage,
 ) -> miette::Result<()> {
     // Install either:

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -12,7 +12,7 @@ mod options;
 
 pub use options::ReinstallOptions;
 
-pub(crate) async fn reinstall<I: Interface>(
+pub async fn reinstall<I: Interface>(
     interface: &I,
     options: ReinstallOptions,
     workspace: Workspace,

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -90,6 +90,31 @@ pub async fn add_task<I: Interface>(
     Ok(())
 }
 
+pub async fn alias_task<I: Interface>(
+    interface: &I,
+    workspace: Workspace,
+    name: TaskName,
+    task: Task,
+    platform: Option<Platform>,
+) -> miette::Result<()> {
+    let mut workspace = workspace.modify()?;
+
+    workspace
+        .manifest()
+        .add_task(name.clone(), task.clone(), platform, &FeatureName::DEFAULT)?;
+    workspace.save().await.into_diagnostic()?;
+
+    interface
+        .success(&format!(
+            "Added alias `{}`: {}",
+            name.fancy_display().bold(),
+            task,
+        ))
+        .await;
+
+    Ok(())
+}
+
 pub async fn remove_tasks<I: Interface>(
     interface: &I,
     workspace: Workspace,

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -4,7 +4,9 @@ use fancy_display::FancyDisplay;
 use miette::IntoDiagnostic;
 use pixi_core::{
     Workspace,
-    workspace::{Environment, virtual_packages::verify_current_platform_can_run_environment},
+    workspace::{
+        Environment, WorkspaceMut, virtual_packages::verify_current_platform_can_run_environment,
+    },
 };
 use pixi_manifest::{EnvironmentName, FeatureName, Task, TaskName};
 use rattler_conda_types::Platform;
@@ -66,14 +68,12 @@ pub async fn list_tasks<I: Interface>(
 
 pub async fn add_task<I: Interface>(
     interface: &I,
-    workspace: &Workspace,
+    mut workspace: WorkspaceMut,
     name: TaskName,
     task: Task,
     feature: FeatureName,
     platform: Option<Platform>,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.clone().modify()?;
-
     workspace
         .manifest()
         .add_task(name.clone(), task.clone(), platform, &feature)?;
@@ -92,13 +92,11 @@ pub async fn add_task<I: Interface>(
 
 pub async fn alias_task<I: Interface>(
     interface: &I,
-    workspace: &Workspace,
+    mut workspace: WorkspaceMut,
     name: TaskName,
     task: Task,
     platform: Option<Platform>,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.clone().modify()?;
-
     workspace
         .manifest()
         .add_task(name.clone(), task.clone(), platform, &FeatureName::DEFAULT)?;
@@ -117,12 +115,11 @@ pub async fn alias_task<I: Interface>(
 
 pub async fn remove_tasks<I: Interface>(
     interface: &I,
-    workspace: &Workspace,
+    mut workspace: WorkspaceMut,
     names: Vec<TaskName>,
     platform: Option<Platform>,
     feature: FeatureName,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.clone().modify()?;
     let mut to_remove = Vec::new();
 
     for name in names.iter() {

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -64,6 +64,32 @@ pub async fn list_tasks<I: Interface>(
         .collect())
 }
 
+pub async fn add_task<I: Interface>(
+    interface: &I,
+    workspace: Workspace,
+    name: TaskName,
+    task: Task,
+    feature: FeatureName,
+    platform: Option<Platform>,
+) -> miette::Result<()> {
+    let mut workspace = workspace.modify()?;
+
+    workspace
+        .manifest()
+        .add_task(name.clone(), task.clone(), platform, &feature)?;
+    workspace.save().await.into_diagnostic()?;
+
+    interface
+        .success(&format!(
+            "Added task `{}`: {}",
+            name.fancy_display().bold(),
+            task,
+        ))
+        .await;
+
+    Ok(())
+}
+
 pub async fn remove_tasks<I: Interface>(
     interface: &I,
     workspace: Workspace,

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -175,11 +175,9 @@ pub async fn remove_tasks<I: Interface>(
     workspace.save().await.into_diagnostic()?;
 
     for name in removed {
-        eprintln!(
-            "{}Removed task `{}` ",
-            console::style(console::Emoji("✔ ", "+")).green(),
-            name.fancy_display().bold(),
-        );
+        interface
+            .success(&format!("Removed task `{}` ", name.fancy_display().bold()))
+            .await;
     }
 
     Ok(())

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -8,7 +8,7 @@ use pixi_manifest::{EnvironmentName, Task, TaskName};
 
 use crate::interface::Interface;
 
-pub(crate) async fn list_tasks<I: Interface>(
+pub async fn list_tasks<I: Interface>(
     _interface: &I,
     workspace: Workspace,
     environment: Option<EnvironmentName>,

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -13,7 +13,7 @@ use crate::interface::Interface;
 
 pub async fn list_tasks<I: Interface>(
     _interface: &I,
-    workspace: Workspace,
+    workspace: &Workspace,
     environment: Option<EnvironmentName>,
 ) -> miette::Result<HashMap<EnvironmentName, HashMap<TaskName, Task>>> {
     let explicit_environment = environment
@@ -66,13 +66,13 @@ pub async fn list_tasks<I: Interface>(
 
 pub async fn add_task<I: Interface>(
     interface: &I,
-    workspace: Workspace,
+    workspace: &Workspace,
     name: TaskName,
     task: Task,
     feature: FeatureName,
     platform: Option<Platform>,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.modify()?;
+    let mut workspace = workspace.clone().modify()?;
 
     workspace
         .manifest()
@@ -92,12 +92,12 @@ pub async fn add_task<I: Interface>(
 
 pub async fn alias_task<I: Interface>(
     interface: &I,
-    workspace: Workspace,
+    workspace: &Workspace,
     name: TaskName,
     task: Task,
     platform: Option<Platform>,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.modify()?;
+    let mut workspace = workspace.clone().modify()?;
 
     workspace
         .manifest()
@@ -117,12 +117,12 @@ pub async fn alias_task<I: Interface>(
 
 pub async fn remove_tasks<I: Interface>(
     interface: &I,
-    workspace: Workspace,
+    workspace: &Workspace,
     names: Vec<TaskName>,
     platform: Option<Platform>,
     feature: FeatureName,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.modify()?;
+    let mut workspace = workspace.clone().modify()?;
     let mut to_remove = Vec::new();
 
     for name in names.iter() {

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -1,0 +1,62 @@
+use std::collections::{HashMap, HashSet};
+
+use pixi_core::{
+    Workspace,
+    workspace::{Environment, virtual_packages::verify_current_platform_can_run_environment},
+};
+use pixi_manifest::{EnvironmentName, Task, TaskName};
+
+use crate::interface::Interface;
+
+pub(crate) async fn list_tasks<I: Interface>(
+    _interface: &I,
+    workspace: Workspace,
+    environment: Option<EnvironmentName>,
+) -> miette::Result<HashMap<EnvironmentName, HashMap<TaskName, Task>>> {
+    let explicit_environment = environment
+        .map(|n| {
+            workspace
+                .environment(&n)
+                .ok_or_else(|| miette::miette!("unknown environment '{n}'"))
+        })
+        .transpose()?;
+
+    let lockfile = workspace.load_lock_file().await.ok();
+
+    let env_task_map: HashMap<Environment, HashSet<TaskName>> =
+        if let Some(explicit_environment) = explicit_environment {
+            HashMap::from([(
+                explicit_environment.clone(),
+                explicit_environment.get_filtered_tasks(),
+            )])
+        } else {
+            workspace
+                .environments()
+                .iter()
+                .filter_map(|env| {
+                    if verify_current_platform_can_run_environment(env, lockfile.as_ref()).is_ok() {
+                        Some((env.clone(), env.get_filtered_tasks()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+    Ok(env_task_map
+        .into_iter()
+        .map(|(env, task_names)| {
+            let env_name = env.name().clone();
+            let best_platform = env.best_platform();
+            let task_map = task_names
+                .into_iter()
+                .flat_map(|task_name| {
+                    env.task(&task_name, Some(best_platform))
+                        .ok()
+                        .map(|task| (task_name, task.clone()))
+                })
+                .collect();
+            (env_name, task_map)
+        })
+        .collect())
+}

--- a/crates/pixi_api/src/workspace/workspace/name.rs
+++ b/crates/pixi_api/src/workspace/workspace/name.rs
@@ -3,11 +3,11 @@ use pixi_core::Workspace;
 
 use crate::interface::Interface;
 
-pub(crate) async fn get(workspace: Workspace) -> String {
+pub async fn get(workspace: Workspace) -> String {
     workspace.display_name().to_string()
 }
 
-pub(crate) async fn set<I: Interface>(
+pub async fn set<I: Interface>(
     interface: &I,
     workspace: Workspace,
     name: &str,

--- a/crates/pixi_api/src/workspace/workspace/name.rs
+++ b/crates/pixi_api/src/workspace/workspace/name.rs
@@ -3,16 +3,16 @@ use pixi_core::Workspace;
 
 use crate::interface::Interface;
 
-pub async fn get(workspace: Workspace) -> String {
+pub async fn get(workspace: &Workspace) -> String {
     workspace.display_name().to_string()
 }
 
 pub async fn set<I: Interface>(
     interface: &I,
-    workspace: Workspace,
+    workspace: &Workspace,
     name: &str,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.modify()?;
+    let mut workspace = workspace.clone().modify()?;
 
     // Set the new workspace name
     workspace.manifest().set_name(name)?;

--- a/crates/pixi_api/src/workspace/workspace/name.rs
+++ b/crates/pixi_api/src/workspace/workspace/name.rs
@@ -1,5 +1,5 @@
 use miette::IntoDiagnostic;
-use pixi_core::Workspace;
+use pixi_core::{Workspace, workspace::WorkspaceMut};
 
 use crate::interface::Interface;
 
@@ -9,11 +9,9 @@ pub async fn get(workspace: &Workspace) -> String {
 
 pub async fn set<I: Interface>(
     interface: &I,
-    workspace: &Workspace,
+    mut workspace: WorkspaceMut,
     name: &str,
 ) -> miette::Result<()> {
-    let mut workspace = workspace.clone().modify()?;
-
     // Set the new workspace name
     workspace.manifest().set_name(name)?;
 

--- a/crates/pixi_cli/src/cli_interface.rs
+++ b/crates/pixi_cli/src/cli_interface.rs
@@ -1,5 +1,5 @@
 use miette::IntoDiagnostic;
-use pixi_api::interface::Interface;
+use pixi_api::Interface;
 
 #[derive(Default)]
 pub struct CliInterface {}

--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -1,7 +1,7 @@
 use std::{cmp::PartialEq, path::PathBuf};
 
 use clap::{Parser, ValueEnum};
-use pixi_api::{Interface, WorkspaceContext, workspace::InitOptions};
+use pixi_api::{WorkspaceContext, workspace::InitOptions};
 use rattler_conda_types::NamedChannelOrUrl;
 
 use crate::cli_interface::CliInterface;
@@ -96,11 +96,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Deprecation warning for the `pyproject` option
     if uses_deprecated_pyproject_flag {
-        CliInterface::default().warning(&format!(
-            "The '{}' option is deprecated and will be removed in the future.\nUse '{}' instead.",
+        eprintln!(
+            "{}The '{}' option is deprecated and will be removed in the future.\nUse '{}' instead.",
+            console::style(console::Emoji("⚠️ ", "")).yellow(),
             console::style("--pyproject").bold().red(),
             console::style("--format pyproject").bold().green(),
-        )).await;
+        );
         options.format = Some(pixi_api::workspace::ManifestFormat::Pyproject);
     }
 

--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -1,7 +1,7 @@
 use std::{cmp::PartialEq, path::PathBuf};
 
 use clap::{Parser, ValueEnum};
-use pixi_api::{context::WorkspaceContext, interface::Interface, workspace::init::InitOptions};
+use pixi_api::{Interface, WorkspaceContext, workspace::InitOptions};
 use rattler_conda_types::NamedChannelOrUrl;
 
 use crate::cli_interface::CliInterface;
@@ -68,15 +68,15 @@ pub enum GitAttributes {
 impl From<Args> for InitOptions {
     fn from(args: Args) -> Self {
         let format = args.format.map(|f| match f {
-            ManifestFormat::Pixi => pixi_api::workspace::init::ManifestFormat::Pixi,
-            ManifestFormat::Pyproject => pixi_api::workspace::init::ManifestFormat::Pyproject,
-            ManifestFormat::Mojoproject => pixi_api::workspace::init::ManifestFormat::Mojoproject,
+            ManifestFormat::Pixi => pixi_api::workspace::ManifestFormat::Pixi,
+            ManifestFormat::Pyproject => pixi_api::workspace::ManifestFormat::Pyproject,
+            ManifestFormat::Mojoproject => pixi_api::workspace::ManifestFormat::Mojoproject,
         });
 
         let scm = args.scm.map(|s| match s {
-            GitAttributes::Github => pixi_api::workspace::init::GitAttributes::Github,
-            GitAttributes::Gitlab => pixi_api::workspace::init::GitAttributes::Gitlab,
-            GitAttributes::Codeberg => pixi_api::workspace::init::GitAttributes::Codeberg,
+            GitAttributes::Github => pixi_api::workspace::GitAttributes::Github,
+            GitAttributes::Gitlab => pixi_api::workspace::GitAttributes::Gitlab,
+            GitAttributes::Codeberg => pixi_api::workspace::GitAttributes::Codeberg,
         });
 
         InitOptions {
@@ -101,7 +101,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             console::style("--pyproject").bold().red(),
             console::style("--format pyproject").bold().green(),
         )).await;
-        options.format = Some(pixi_api::workspace::init::ManifestFormat::Pyproject);
+        options.format = Some(pixi_api::workspace::ManifestFormat::Pyproject);
     }
 
     WorkspaceContext::init(CliInterface {}, options).await?;

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -76,8 +76,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_cli_config(args.config.clone());
 
     let lock_file_usage = args.lock_file_usage.to_usage();
-    let workspace_context = WorkspaceContext::new(CliInterface {}, workspace);
-    workspace_context
+    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    workspace_ctx
         .reinstall(args.into(), lock_file_usage)
         .await?;
 

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use pixi_api::context::WorkspaceContext;
-use pixi_api::workspace::reinstall::ReinstallOptions;
+use pixi_api::WorkspaceContext;
+use pixi_api::workspace::ReinstallOptions;
 use pixi_config::ConfigCli;
 use pixi_core::WorkspaceLocator;
 use pixi_core::lock_file::{ReinstallEnvironment, ReinstallPackages};

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -322,7 +322,7 @@ async fn list_tasks(
     args: ListArgs,
 ) -> miette::Result<()> {
     if args.json {
-        print_tasks_json(&workspace_ctx.workspace());
+        print_tasks_json(workspace_ctx.workspace());
         return Ok(());
     }
 

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -364,7 +364,7 @@ async fn add_task(
 
     workspace_ctx
         .add_task(
-            args.clone().name,
+            args.name.clone(),
             args.clone().into(),
             feature,
             args.platform,

--- a/crates/pixi_cli/src/workspace/name.rs
+++ b/crates/pixi_cli/src/workspace/name.rs
@@ -38,11 +38,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let workspace_context = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
 
     match args.command {
-        Command::Get => print!("{}", workspace_context.name().await),
-        Command::Set(args) => workspace_context.set_name(&args.name).await?,
+        Command::Get => print!("{}", workspace_ctx.name().await),
+        Command::Set(args) => workspace_ctx.set_name(&args.name).await?,
     }
 
     Ok(())

--- a/crates/pixi_cli/src/workspace/name.rs
+++ b/crates/pixi_cli/src/workspace/name.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pixi_api::context::WorkspaceContext;
+use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
 
 use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -153,7 +153,7 @@ impl TypedDependency {
 }
 
 /// Represents different types of scripts
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum Task {
     Plain(TemplateString),
     Execute(Box<Execute>),
@@ -324,7 +324,7 @@ impl Deref for GlobPatterns {
 }
 
 /// A command script executes a single command from the environment
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Execute {
     /// A list of arguments, the first argument denotes the command to run. When
     /// deserializing both an array of strings and a single string are
@@ -409,7 +409,7 @@ impl std::str::FromStr for TaskArg {
 }
 
 /// A custom command script executes a single command in the environment
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Custom {
     /// A list of arguments, the first argument denotes the command to run. When
     /// deserializing both an array of strings and a single string are
@@ -571,7 +571,7 @@ impl TemplateStringError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum CmdArgs {
     Single(TemplateString),
     Multiple(Vec<TemplateString>),
@@ -640,7 +640,7 @@ impl CmdArgs {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Alias {
     /// A list of commands that should be run before this one
     pub depends_on: Vec<Dependency>,


### PR DESCRIPTION
Implements the required logic for `pixi task ...` in `pixi_api`, including
- `pixi task list`
- `pixi task add`
- `pixi task alias`
- `pixi task remove`

In addition to that, some minor refactors inside `pixi_api`. 