### PR TITLE
refactor: Move diff into a separate pixi_diff crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4796,6 +4796,7 @@ dependencies = [
  "pixi_config",
  "pixi_consts",
  "pixi_core",
+ "pixi_diff",
  "pixi_git",
  "pixi_global",
  "pixi_manifest",
@@ -4953,7 +4954,6 @@ dependencies = [
 name = "pixi_core"
 version = "0.1.0"
 dependencies = [
- "ahash",
  "async-once-cell",
  "async-trait",
  "barrier_cell",
@@ -4987,6 +4987,7 @@ dependencies = [
  "pixi_config",
  "pixi_consts",
  "pixi_default_versions",
+ "pixi_diff",
  "pixi_git",
  "pixi_glob",
  "pixi_install_pypi",
@@ -5055,6 +5056,23 @@ name = "pixi_default_versions"
 version = "0.1.0"
 dependencies = [
  "rattler_conda_types",
+]
+
+[[package]]
+name = "pixi_diff"
+version = "0.1.0"
+dependencies = [
+ "ahash",
+ "console 0.15.11",
+ "indexmap 2.11.1",
+ "itertools 0.14.0",
+ "pixi_consts",
+ "pixi_manifest",
+ "rattler_conda_types",
+ "rattler_lock",
+ "serde",
+ "serde_json",
+ "tabwriter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ pixi_config = { path = "crates/pixi_config" }
 pixi_consts = { path = "crates/pixi_consts" }
 pixi_core = { path = "crates/pixi_core" }
 pixi_default_versions = { path = "crates/pixi_default_versions" }
+pixi_diff = { path = "crates/pixi_diff" }
 pixi_git = { path = "crates/pixi_git" }
 pixi_glob = { path = "crates/pixi_glob" }
 pixi_global = { path = "crates/pixi_global" }

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -68,6 +68,7 @@ pixi_command_dispatcher = { workspace = true }
 pixi_config = { workspace = true }
 pixi_consts = { workspace = true }
 pixi_core = { workspace = true }
+pixi_diff = { workspace = true }
 pixi_git = { workspace = true }
 pixi_global = { workspace = true }
 pixi_manifest = { workspace = true, features = ["rattler_lock"] }

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -2,13 +2,12 @@ use clap::Parser;
 use miette::{Context, IntoDiagnostic};
 use pixi_core::{
     WorkspaceLocator,
-    diff::{LockFileDiff, LockFileJsonDiff},
     environment::LockFileUsage,
     lock_file::{LockFileDerivedData, UpdateLockFileOptions},
 };
+use pixi_diff::{LockFileDiff, LockFileJsonDiff};
 
 use crate::cli_config::NoInstallConfig;
-
 use crate::cli_config::WorkspaceConfig;
 
 /// Solve environment and update the lock file without installing the
@@ -54,7 +53,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Format as json?
     if args.json {
         let diff = LockFileDiff::from_lock_files(&original_lock_file, &lock_file);
-        let json_diff = LockFileJsonDiff::new(Some(&workspace), diff);
+        let json_diff = LockFileJsonDiff::new(Some(workspace.named_environments()), diff);
         let json = serde_json::to_string_pretty(&json_diff).expect("failed to convert to json");
         println!("{}", json);
     } else if lock_updated {

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -6,14 +6,12 @@ use itertools::Itertools;
 use miette::{Context, IntoDiagnostic, MietteDiagnostic};
 use pixi_config::ConfigCli;
 use pixi_consts::consts;
+use pixi_core::WorkspaceLocator;
 use pixi_core::{
     Workspace,
     lock_file::{UpdateContext, filter_lock_file},
 };
-use pixi_core::{
-    WorkspaceLocator,
-    diff::{LockFileDiff, LockFileJsonDiff},
-};
+use pixi_diff::{LockFileDiff, LockFileJsonDiff};
 use pixi_manifest::EnvironmentName;
 use rattler_conda_types::Platform;
 use rattler_lock::{LockFile, LockedPackageRef};
@@ -182,7 +180,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Format as json?
     if args.json {
         let diff = LockFileDiff::from_lock_files(loaded_lock_file, &lock_file);
-        let json_diff = LockFileJsonDiff::new(Some(&workspace), diff);
+        let json_diff = LockFileJsonDiff::new(Some(workspace.named_environments()), diff);
         let json = serde_json::to_string_pretty(&json_diff).expect("failed to convert to json");
         println!("{}", json);
     } else if diff.is_empty() {

--- a/crates/pixi_core/Cargo.toml
+++ b/crates/pixi_core/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.0"
 slow_integration_tests = []
 
 [dependencies]
-ahash = { workspace = true }
 async-once-cell = { workspace = true }
 barrier_cell = { workspace = true }
 chrono = { workspace = true }
@@ -41,6 +40,7 @@ pixi_command_dispatcher = { workspace = true }
 pixi_config = { workspace = true }
 pixi_consts = { workspace = true }
 pixi_default_versions = { workspace = true }
+pixi_diff = { workspace = true }
 pixi_git = { workspace = true }
 pixi_glob = { workspace = true }
 pixi_install_pypi = { workspace = true }

--- a/crates/pixi_core/src/lib.rs
+++ b/crates/pixi_core/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(clippy::dbg_macro, clippy::unwrap_used)]
 
 pub mod activation;
-pub mod diff;
 pub mod environment;
 pub mod lock_file;
 pub mod prompt;

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -21,7 +21,6 @@ use std::{
 
 use crate::{
     activation::{CurrentEnvVarBehavior, initialize_env_variables},
-    diff::LockFileDiff,
     lock_file::filter_lock_file,
     repodata::Repodata,
 };
@@ -38,6 +37,7 @@ use pixi_build_frontend::BackendOverride;
 use pixi_command_dispatcher::{CacheDirs, CommandDispatcher, CommandDispatcherBuilder, Limits};
 use pixi_config::{Config, RunPostLinkScripts};
 use pixi_consts::consts;
+use pixi_diff::LockFileDiff;
 use pixi_manifest::{
     AssociateProvenance, EnvironmentName, Environments, ExplicitManifestError,
     HasWorkspaceManifest, LoadManifestsError, ManifestProvenance, Manifests, PackageManifest,
@@ -423,6 +423,14 @@ impl Workspace {
             .environments
             .iter()
             .map(|env| Environment::new(self, env))
+            .collect()
+    }
+
+    /// Returns a HashMap of environments in this project.
+    pub fn named_environments(&self) -> HashMap<EnvironmentName, Environment> {
+        self.environments()
+            .iter()
+            .map(|env| (env.name().clone(), env.clone()))
             .collect()
     }
 

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -15,6 +15,7 @@ use pixi_command_dispatcher::{
     CommandDispatcherError, MissingChannelError, SolvePixiEnvironmentError::MissingChannel,
 };
 use pixi_config::PinningStrategy;
+use pixi_diff::LockFileDiff;
 use pixi_manifest::{
     DependencyOverwriteBehavior, FeatureName, FeaturesExt, HasFeaturesIter, LoadManifestsError,
     ManifestDocument, ManifestKind, PypiDependencyLocation, SpecType, TomlError, WorkspaceManifest,
@@ -28,7 +29,6 @@ use toml_edit::DocumentMut;
 
 use crate::{
     Workspace,
-    diff::LockFileDiff,
     environment::LockFileUsage,
     lock_file::{LockFileDerivedData, ReinstallPackages, UpdateContext, UpdateMode},
     workspace::{

--- a/crates/pixi_diff/Cargo.toml
+++ b/crates/pixi_diff/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "pixi_diff"
+readme.workspace = true
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+ahash = { workspace = true }
+console = { workspace = true }
+indexmap = { workspace = true }
+itertools = { workspace = true }
+pixi_consts = { workspace = true }
+pixi_manifest = { workspace = true }
+rattler_conda_types = { workspace = true }
+rattler_lock = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tabwriter = { workspace = true }


### PR DESCRIPTION
See https://github.com/prefix-dev/pixi/issues/4310

Moving workspace into a `pixi_workspace` crate will be more tricky, as it is very intertwined with `lock_file`. Maybe we could move both the `lock_file` and `workspace` modules together in a `pixi_workspace` crate, would need to check whether that makes sense / works out. 