### PR TITLE
Propagate target-platform flags for pixi build

### DIFF
--- a/crates/pixi_command_dispatcher/src/source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build/mod.rs
@@ -516,7 +516,7 @@ impl SourceBuildSpec {
                             .map_err(CommandDispatcherError::Failed)?,
                         installed: None,
                         ignore_packages: None,
-                        build_environment: self.build_environment.to_build_from_build(),
+                        build_environment: self.build_environment.clone(),
                         force_reinstall: Default::default(),
                         channels: self.channels.clone(),
                         channel_config: self.channel_config.clone(),


### PR DESCRIPTION
During some experimentation with `pixi build --target-platform <target>` I noticed if I had multiple packages in a workspace with dependencies they would build fine with just `pixi build` but adding `--target-platform` would fail. If it was just a single independent package it worked fine but the dependencies would report as not existing for the target platform.

After a bit of digging I discovered this fix would propagate the target platform correctly so that transitive dependencies would build for my target platform.