### PR TITLE
feat: improve error message when converting in between pypi types

### DIFF
--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -145,6 +145,6 @@ pub enum ConversionError {
     #[error(transparent)]
     FmtError(#[from] std::fmt::Error),
 
-    #[error("expected an archive but found path")]
-    ExpectedArchiveButFoundPath(PathBuf, #[source] ExtensionError),
+    #[error("expected an (.whl or sdist) but found: '{}'", ._0.display())]
+    ExpectedDistButFoundPath(PathBuf, #[source] ExtensionError),
 }


### PR DESCRIPTION
While debugging: https://github.com/prefix-dev/pixi/issues/4680 the error message was very unclear. 

### Before
```
 INFO pixi_core::lock_file::outdated: the dependencies of environment 'default' for platform linux-64 are out of date because failed to convert between pep508 and uv types: expected an archive but found path
```

### After
```
 INFO pixi_core::lock_file::outdated: the dependencies of environment 'default' for platform linux-64 are out of date because failed to convert between pep508 and uv types: expected an (.whl or sdist) but found: '/private/tmp/repros/pixi/source-dependencies/modules/b'
```