### PR TITLE
feat: correctly parse directory requirements

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -1782,7 +1782,7 @@ impl Display for EditablePackagesMismatch {
             format_package_list(f, &self.unexpected_editable)?;
             write!(
                 f,
-                "NOT to be editable but in the lock-file {they} {are}",
+                " NOT to be editable but in the lock-file {they} {are}",
                 they = it_they(self.unexpected_editable.len()),
                 are = is_are(self.unexpected_editable.len())
             )?

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -267,8 +267,8 @@ pub fn pep508_requirement_to_uv_requirement(
                                 // If no extension, treat as a directory
                                 ParsedUrl::Directory(ParsedDirectoryUrl::from_source(
                                     PathBuf::from(path.as_str()).into_boxed_path(),
-                                    Some(false), // Set this to false, might require post-processing on the result
-                                    Some(false), // we do not support this yet
+                                    Some(false), // Set editable to false, might require post-processing on the result
+                                    Some(false), // we do not support virtual packages yet
                                     DisplaySafeUrl::from(verbatim_url.to_url()),
                                 ))
                             }

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -267,8 +267,8 @@ pub fn pep508_requirement_to_uv_requirement(
                                 // If no extension, treat as a directory
                                 ParsedUrl::Directory(ParsedDirectoryUrl::from_source(
                                     PathBuf::from(path.as_str()).into_boxed_path(),
-                                    Some(false), // editable
-                                    Some(false), // virtual
+                                    Some(false), // Set this to false, might require post-processing on the result
+                                    Some(false), // we do not support this yet
                                     DisplaySafeUrl::from(verbatim_url.to_url()),
                                 ))
                             }

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -144,7 +144,4 @@ pub enum ConversionError {
 
     #[error(transparent)]
     FmtError(#[from] std::fmt::Error),
-
-    #[error("expected an (.whl or sdist) but found: '{}'", ._0.display())]
-    ExpectedDistButFoundPath(PathBuf, #[source] ExtensionError),
 }

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -145,6 +145,6 @@ pub enum ConversionError {
     #[error(transparent)]
     FmtError(#[from] std::fmt::Error),
 
-    #[error("expected an archive but found path")]
-    ExpectedArchiveButFoundPath(PathBuf, #[source] ExtensionError),
+    #[error("expected an (.whl or sdist) but found: '{}'", ._0.display())]
+    ExpectedDistButFoundPath(PathBuf, #[source] ExtensionError),
 }

--- a/crates/pixi_uv_conversions/src/types.rs
+++ b/crates/pixi_uv_conversions/src/types.rs
@@ -1,11 +1,6 @@
-// use uv_normalize::PackageName;
-// use pep508_rs::PackageName;
-
 use std::error::Error;
 use std::fmt::{Debug, Display};
-use std::path::PathBuf;
 use thiserror::Error;
-use uv_distribution_filename::ExtensionError;
 use uv_pep440::VersionSpecifierBuildError;
 
 #[derive(Debug)]


### PR DESCRIPTION
While working on this issue: https://github.com/prefix-dev/pixi/issues/4573

I made the first intial fix to parse directory requirements, correctly. Alas, this does not fix that issue as we need to set the editable boolean directly, this however is a bigger change, so I wanted to get this in first.