### PR TITLE
feat: always regenerate metadata on override

### DIFF
--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -205,7 +205,7 @@ impl BuildBackendMetadataSpec {
     /// Checks if we should skip the metadata cache for this backend.
     /// Returns true if:
     /// 1. There's a System backend override (either for this specific backend or all backends)
-    /// 2. OR the original backend spec is System or Path-based
+    /// 2. OR the original backend spec is System or mutable (path-based non-binary)
     fn should_skip_metadata_cache(
         backend_spec: &BackendSpec,
         backend_override: &BackendOverride,
@@ -225,12 +225,10 @@ impl BuildBackendMetadataSpec {
             return true;
         }
 
-        // Check if the original backend spec is non-binary (System or Path-based)
+        // Check if the original backend spec is System or mutable
         match &json_rpc_spec.command {
             CommandSpec::System(_) => true,
-            CommandSpec::EnvironmentSpec(env_spec) => {
-                matches!(env_spec.requirement.1, pixi_spec::PixiSpec::Path(_))
-            }
+            CommandSpec::EnvironmentSpec(env_spec) => env_spec.requirement.1.is_mutable(),
         }
     }
 

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -339,6 +339,18 @@ impl PixiSpec {
         !self.is_binary()
     }
 
+    /// Returns true if this spec represents a mutable source.
+    /// A spec is mutable if it points to a local path-based source (non-binary).
+    pub fn is_mutable(&self) -> bool {
+        match self {
+            Self::Version(_) => false,
+            Self::DetailedVersion(_) => false,
+            Self::Url(_) => false,
+            Self::Git(_) => false,
+            Self::Path(path) => !path.is_binary(),
+        }
+    }
+
     /// Converts this instance into a [`toml_edit::Value`].
     pub fn to_toml_value(&self) -> toml_edit::Value {
         ::serde::Serialize::serialize(self, toml_edit::ser::ValueSerializer::new())


### PR DESCRIPTION
Not sure if this is a really excellent idea or not, but this bit me in the ass too many times. When developing a build-backend and you make a mistake in the metadata generation you need to remove the metadata from the cache if you want to rebuild even though the solve failed. 
Metadata generation is relatively fast that if you are developing a backend from source I think we should just skip the cache, for now this makes development less painful.

Maybe the better approach would be to track what you've written tot the cache and evict those entries if the subsequent solve fails, but this is more work and also has other downside, i.e. one of them is is that you might evict even though the metadata is correct and the solve fails for other reasons. 

Anyways, I think this strikes a relatively nice middle ground.

### AI Disclosure
* This was 80% created by claude. But needed a lot of prompting and reviewing to get right.