### PR TITLE
feat: canonicalize source path in build-backend intialization

### DIFF
--- a/crates/pixi_command_dispatcher/src/command_dispatcher/instantiate_backend.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/instantiate_backend.rs
@@ -58,6 +58,18 @@ impl CommandDispatcher {
             spec.init_params.source_anchor
         };
 
+        // Canonicalize the source_dir to ensure it's a fully resolved absolute path
+        // without any relative components like ".." or "."
+        let source_dir = dunce::canonicalize(&source_dir).map_err(|e| {
+            CommandDispatcherError::Failed(InstantiateBackendError::SpecConversionError(
+                SpecConversionError::InvalidPath(format!(
+                    "failed to canonicalize source directory '{}': {}",
+                    source_dir.display(),
+                    e
+                )),
+            ))
+        })?;
+
         let command_spec = match self.build_backend_overrides() {
             BackendOverride::System(overridden_backends) => overridden_backends
                 .named_backend_override(&backend_spec.name)


### PR DESCRIPTION
This ensures that a toml that contains something like:
```toml
[package.build]
backend = { name = "pixi-build-ros", version = "*" }
source = { path = "../" }
```

Actually works, otherwise the source_dir would still contain `../` and other path components and this would error out when taking a `pathdiff` in the build-backends.

You can write an in-memory test for this, Claude tried, but for my tastes it was too verbose to be very useful.