### PR TITLE
chore: only warn about metadata cache once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,6 +4773,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "miette 7.6.0",
+ "once_cell",
  "ordermap",
  "pathdiff",
  "pin-project-lite",

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -20,6 +20,7 @@ fs-err = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }
+once_cell = { workspace = true }
 ordermap = { workspace = true }
 pathdiff = { workspace = true }
 pin-project-lite = { workspace = true }


### PR DESCRIPTION
Quick ux improvement to go from:
```
➜ pixi i
 WARN overriding build backend with system prefixed tools
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
▪ solving              [────────────────────]  0/2
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
✔ The default environment has been installed.
```

to 

```
➜ pixi i
 WARN overriding build backend with system prefixed tools
 WARN metadata cache disabled for build backend 'pixi-build-ros' (system/path-based backends always regenerate metadata)
✔ The default environment has been installed.
```