### PR TITLE
refactor: upgrade to rattler lock v7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,8 +1317,6 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "coalesced_map"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2126,8 +2124,6 @@ dependencies = [
 [[package]]
 name = "file_url"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765662dc0b26e038099a5a1529f5d48443111eea45377c312be892997651710e"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4327,8 +4323,6 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67957e099f5b76f4cad98e0d41dd53746ab3a2debc1da12ee5b1cccb1d7b8dc8"
 dependencies = [
  "fs-err",
  "fxhash",
@@ -5245,6 +5239,7 @@ dependencies = [
 name = "pixi_record"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "file_url",
  "miette 7.6.0",
  "pixi_git",
@@ -5974,8 +5969,6 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8abb6e11a8e0377010bca2f761102bbd9a944cf8a589c4e5726459499f0c48"
 dependencies = [
  "anyhow",
  "clap",
@@ -6019,8 +6012,6 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.3.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9eea243b0d877fe0bbb9a421fb9d8cace8039cfdfbda3d7c0384ff5818d382"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6052,8 +6043,6 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.40.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa6244d54b84269d3121d463db4e154c5664936e98817ef44e4fba1f575c3a"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -6094,8 +6083,6 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "886e9a6254e74a830c2b8555e14862d6b2f4cc498b43767d4adf1c71421a4796"
 dependencies = [
  "blake2",
  "digest",
@@ -6113,8 +6100,6 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0ba96eefd8186a3bd0a603b4b00bb7faa2d6488ea38eae0da198647fe4712"
 dependencies = [
  "chrono",
  "file_url",
@@ -6139,8 +6124,6 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988d5d7ace4fb1d7549008236cf08de95e8ea2f1f80754109324a08c31e6dc6a"
 dependencies = [
  "quote",
  "syn",
@@ -6149,8 +6132,6 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2685a4f23eca7d46249d6775e534a7ff4adffc53af6e702eafe6168282ae0eeb"
 dependencies = [
  "chrono",
  "configparser",
@@ -6179,8 +6160,6 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.25.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de790ad7985f3ee85bae3175b203af2152c1c86d9efe1249ac8ff1863466d2e6"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -6211,8 +6190,6 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.23.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3dfb861d216425ddb768857b7d50bf548c2b1fe9421caa7071ca655b0423af"
 dependencies = [
  "bzip2 0.6.1",
  "chrono",
@@ -6234,15 +6211,13 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "zip 4.0.0",
+ "zip 6.0.0",
  "zstd",
 ]
 
 [[package]]
 name = "rattler_pty"
 version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a84e6b351c46c7588bb8f5c90994be23d5c3c31cf87f9ec903cd91d9fc4246"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -6253,8 +6228,6 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa5057629aeb20861919e9ae56875985d58028f3c6f433a20b5ded086e1cec5"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -6264,8 +6237,6 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.24.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b063b5db3804ea80d0cf991c69d27fd3b1f3be6f8ce4601731ec2583825bb73a"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6324,8 +6295,6 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.25.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3c4475de6e4e22fde5a29e0957622c1665231bc00f1a32be0b8404b412e66c"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -6345,8 +6314,6 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071ca80c7cf13b742f7b08c6199f441cb613db9acc92d5625efc1e4ce84e546d"
 dependencies = [
  "chrono",
  "futures",
@@ -6363,8 +6330,6 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f31e64364d38962c914d91ea00e1d735884dcad285da0082820ea18af611454"
 dependencies = [
  "archspec",
  "libloading",
@@ -7416,8 +7381,6 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
 dependencies = [
  "tokio",
 ]
@@ -10596,9 +10559,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153a6fff49d264c4babdcfa6b4d534747f520e56e8f0f384f3b808c4b64cc1fd"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,7 +4800,6 @@ dependencies = [
  "rattler_virtual_packages",
  "serde",
  "serde_json",
- "serde_with",
  "simple_spawn_blocking",
  "slotmap",
  "strsim",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,17 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "coalesced_map"
 version = "0.1.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
+dependencies = [
+ "dashmap",
+ "tokio",
+]
+
+[[package]]
+name = "coalesced_map"
+version = "0.1.2"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2125,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "file_url"
 version = "0.2.6"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4325,7 +4335,7 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.1"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "fs-err",
  "fxhash",
@@ -4760,7 +4770,7 @@ dependencies = [
  "async-fd-lock",
  "base64 0.22.1",
  "chrono",
- "coalesced_map",
+ "coalesced_map 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more",
  "dirs",
  "dunce",
@@ -5971,7 +5981,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.38.2"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "anyhow",
  "clap",
@@ -6015,7 +6025,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.3.41"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6047,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.40.3"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -6088,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.1.7"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "blake2",
  "digest",
@@ -6106,7 +6116,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.25.3"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "chrono",
  "file_url",
@@ -6131,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.11"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "quote",
  "syn",
@@ -6140,7 +6150,7 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.32"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "chrono",
  "configparser",
@@ -6169,7 +6179,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.25.20"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -6200,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.23.11"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "bzip2 0.6.1",
  "chrono",
@@ -6229,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.7"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -6240,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.12"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -6250,7 +6260,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.24.12"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6261,7 +6271,7 @@ dependencies = [
  "cache_control",
  "cfg-if",
  "chrono",
- "coalesced_map",
+ "coalesced_map 0.1.2 (git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7)",
  "dashmap",
  "dirs",
  "file_url",
@@ -6309,7 +6319,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.25.5"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -6329,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "3.0.8"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "chrono",
  "futures",
@@ -6346,7 +6356,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.2.4"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "archspec",
  "libloading",
@@ -7398,7 +7408,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#807cf90502ed363e3046290711c4f9d94a5e17ee"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 [[package]]
 name = "coalesced_map"
 version = "0.1.2"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2124,6 +2125,7 @@ dependencies = [
 [[package]]
 name = "file_url"
 version = "0.2.6"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4323,6 +4325,7 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.1"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "fs-err",
  "fxhash",
@@ -5969,6 +5972,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.38.2"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "anyhow",
  "clap",
@@ -6012,6 +6016,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.3.41"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6043,6 +6048,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.40.3"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",
@@ -6083,6 +6089,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.1.7"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "blake2",
  "digest",
@@ -6100,6 +6107,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.25.3"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "chrono",
  "file_url",
@@ -6124,6 +6132,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.11"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "quote",
  "syn",
@@ -6132,6 +6141,7 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.32"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "chrono",
  "configparser",
@@ -6160,6 +6170,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.25.20"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -6190,6 +6201,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.23.11"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "bzip2 0.6.1",
  "chrono",
@@ -6218,6 +6230,7 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.7"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -6228,6 +6241,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.12"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -6237,6 +6251,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.24.12"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -6295,6 +6310,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.25.5"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -6314,6 +6330,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "3.0.8"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "chrono",
  "futures",
@@ -6330,6 +6347,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.2.4"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "archspec",
  "libloading",
@@ -7381,6 +7399,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
+source = "git+https://github.com/baszalmstra/rattler?branch=rattler-lock%2Fv7#774cc5b82bd7b9100a585122d066750ef80d45f6"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap = { version = "4.5.31", default-features = false }
 clap_complete = "4.5.46"
 clap_complete_nushell = "4.5.5"
 # Rattler crates
-coalesced_map = "0.1.1"
+coalesced_map = "0.1.2"
 concat-idents = "1.1.5"
 console = "0.15.10"
 console-subscriber = "0.4.1"
@@ -122,7 +122,7 @@ rattler_conda_types = { version = "0.40.3", default-features = false, features =
 ] }
 rattler_digest = { version = "1.1.7", default-features = false }
 rattler_lock = { version = "0.25.3", default-features = false }
-rattler_menuinst = { version = "0.2.23", default-features = false }
+rattler_menuinst = { version = "0.2.32", default-features = false }
 rattler_networking = { version = "0.25.20", default-features = false, features = [
   "dirs",
   "google-cloud-auth",
@@ -212,6 +212,24 @@ reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", 
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f59ffaeb6cf5079c6cb184467da06c9db" }
 
+# pixi-rattler-patches - START
+# pixi-rattler-original-versions: {"coalesced_map": "0.1.1", "file_url": "0.2.6", "rattler": "0.38.2", "rattler_cache": "0.3.41", "rattler_conda_types": "0.40.3", "rattler_digest": "1.1.7", "rattler_lock": "0.25.3", "rattler_menuinst": "0.2.23", "rattler_networking": "0.25.20", "rattler_package_streaming": "0.23.11", "rattler_repodata_gateway": "0.24.12", "rattler_shell": "0.25.5", "rattler_solve": "3.0.8", "rattler_virtual_packages": "2.2.4", "simple_spawn_blocking": "1.1.0"}
+coalesced_map = { path = "../rattler/crates/coalesced_map" }
+file_url = { path = "../rattler/crates/file_url" }
+rattler = { path = "../rattler/crates/rattler" }
+rattler_cache = { path = "../rattler/crates/rattler_cache" }
+rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }
+rattler_digest = { path = "../rattler/crates/rattler_digest" }
+rattler_lock = { path = "../rattler/crates/rattler_lock" }
+rattler_menuinst = { path = "../rattler/crates/rattler_menuinst" }
+rattler_networking = { path = "../rattler/crates/rattler_networking" }
+rattler_package_streaming = { path = "../rattler/crates/rattler_package_streaming" }
+rattler_repodata_gateway = { path = "../rattler/crates/rattler_repodata_gateway" }
+rattler_shell = { path = "../rattler/crates/rattler_shell" }
+rattler_solve = { path = "../rattler/crates/rattler_solve" }
+rattler_virtual_packages = { path = "../rattler/crates/rattler_virtual_packages" }
+simple_spawn_blocking = { path = "../rattler/crates/simple_spawn_blocking" }
+# pixi-rattler-patches - END
 [profile.ci]
 codegen-units = 16
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,22 +214,23 @@ version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f
 
 # pixi-rattler-patches - START
 # pixi-rattler-original-versions: {"coalesced_map": "0.1.1", "file_url": "0.2.6", "rattler": "0.38.2", "rattler_cache": "0.3.41", "rattler_conda_types": "0.40.3", "rattler_digest": "1.1.7", "rattler_lock": "0.25.3", "rattler_menuinst": "0.2.23", "rattler_networking": "0.25.20", "rattler_package_streaming": "0.23.11", "rattler_repodata_gateway": "0.24.12", "rattler_shell": "0.25.5", "rattler_solve": "3.0.8", "rattler_virtual_packages": "2.2.4", "simple_spawn_blocking": "1.1.0"}
-coalesced_map = { path = "../rattler/crates/coalesced_map" }
-file_url = { path = "../rattler/crates/file_url" }
-rattler = { path = "../rattler/crates/rattler" }
-rattler_cache = { path = "../rattler/crates/rattler_cache" }
-rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }
-rattler_digest = { path = "../rattler/crates/rattler_digest" }
-rattler_lock = { path = "../rattler/crates/rattler_lock" }
-rattler_menuinst = { path = "../rattler/crates/rattler_menuinst" }
-rattler_networking = { path = "../rattler/crates/rattler_networking" }
-rattler_package_streaming = { path = "../rattler/crates/rattler_package_streaming" }
-rattler_repodata_gateway = { path = "../rattler/crates/rattler_repodata_gateway" }
-rattler_shell = { path = "../rattler/crates/rattler_shell" }
-rattler_solve = { path = "../rattler/crates/rattler_solve" }
-rattler_virtual_packages = { path = "../rattler/crates/rattler_virtual_packages" }
-simple_spawn_blocking = { path = "../rattler/crates/simple_spawn_blocking" }
+coalesced_map = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+file_url = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_cache = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_menuinst = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_package_streaming = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+simple_spawn_blocking = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
 # pixi-rattler-patches - END
+#
 [profile.ci]
 codegen-units = 16
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,24 +211,22 @@ zstd = { version = "0.13.3", default-features = false }
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "ad8b9d332d1773fde8b4cd008486de5973e0a3f8" }
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "06ec5a5f59ffaeb6cf5079c6cb184467da06c9db" }
-
+#
 # pixi-rattler-patches - START
-# pixi-rattler-original-versions: {"coalesced_map": "0.1.1", "file_url": "0.2.6", "rattler": "0.38.2", "rattler_cache": "0.3.41", "rattler_conda_types": "0.40.3", "rattler_digest": "1.1.7", "rattler_lock": "0.25.3", "rattler_menuinst": "0.2.23", "rattler_networking": "0.25.20", "rattler_package_streaming": "0.23.11", "rattler_repodata_gateway": "0.24.12", "rattler_shell": "0.25.5", "rattler_solve": "3.0.8", "rattler_virtual_packages": "2.2.4", "simple_spawn_blocking": "1.1.0"}
-coalesced_map = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-file_url = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_cache = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_menuinst = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_package_streaming = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
-simple_spawn_blocking = { git = "https://github.com/baszalmstra/rattler", branch = "rattler-lock/v7" }
+file_url = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_cache = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_conda_types = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_digest = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_lock = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_menuinst = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_networking = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_package_streaming = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_repodata_gateway = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_shell = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_solve = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+rattler_virtual_packages = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
+simple_spawn_blocking = { git = "https://github.com/baszalmstra/rattler", branch="rattler-lock/v7" }
 # pixi-rattler-patches - END
 #
 [profile.ci]

--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -137,7 +137,7 @@ impl LockFileExt for LockFile {
             .into_iter()
             .flatten()
             .filter_map(LockedPackageRef::as_conda)
-            .any(|package| package.record().name.as_normalized() == name)
+            .any(|package| package.name().as_normalized() == name)
     }
     fn contains_pypi_package(&self, environment: &str, platform: Platform, name: &str) -> bool {
         let Some(env) = self.environment(environment) else {

--- a/crates/pixi/tests/integration_rust/solve_group_tests.rs
+++ b/crates/pixi/tests/integration_rust/solve_group_tests.rs
@@ -117,8 +117,8 @@ async fn test_purl_are_added_for_pypi() {
         .packages(Platform::current())
         .unwrap()
         .for_each(|dep| {
-            if dep.as_conda().unwrap().record().name == PackageName::from_str("boltons").unwrap() {
-                assert!(dep.as_conda().unwrap().record().purls.is_none());
+            if dep.as_conda().unwrap().name() == &PackageName::from_str("boltons").unwrap() {
+                assert!(dep.as_conda().unwrap().purls().is_none());
             }
         });
 
@@ -138,13 +138,11 @@ async fn test_purl_are_added_for_pypi() {
         .packages(Platform::current())
         .unwrap()
         .for_each(|dep| {
-            if dep.as_conda().unwrap().record().name == PackageName::from_str("boltons").unwrap() {
+            if dep.as_conda().unwrap().name() == &PackageName::from_str("boltons").unwrap() {
                 assert_eq!(
                     dep.as_conda()
                         .unwrap()
-                        .record()
-                        .purls
-                        .as_ref()
+                        .purls()
                         .unwrap()
                         .first()
                         .unwrap()

--- a/crates/pixi_build_types/src/lib.rs
+++ b/crates/pixi_build_types/src/lib.rs
@@ -4,6 +4,7 @@ mod channel_configuration;
 mod conda_package_metadata;
 pub mod procedures;
 mod project_model;
+mod variant;
 
 use std::{fmt::Display, sync::LazyLock};
 
@@ -20,6 +21,7 @@ use rattler_conda_types::{
     version_spec::{LogicalOperator, RangeOperator},
 };
 use serde::{Deserialize, Serialize};
+pub use variant::VariantValue;
 
 // Version 0: Initial version (removed)
 // Version 1: Added conda/outputs and conda/build_v1

--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -16,6 +16,8 @@ use rattler_conda_types::{
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, DisplayFromStr, serde_as};
 
+use crate::variant::VariantValue;
+
 pub const METHOD_NAME: &str = "conda/build_v1";
 
 /// Parameters for the `conda/build_v1` request.
@@ -174,7 +176,7 @@ pub struct CondaBuildV1Output {
     pub subdir: Platform,
 
     /// The variant configuration for the package.
-    pub variant: BTreeMap<String, String>,
+    pub variant: BTreeMap<String, VariantValue>,
 }
 
 /// Contains the result of the `conda/build_v1` request.

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -152,7 +152,7 @@ pub struct CondaOutputMetadata {
     pub python_site_packages_path: Option<String>,
 
     /// The variants that were used for this output.
-    pub variant: BTreeMap<String, String>,
+    pub variant: BTreeMap<String, crate::VariantValue>,
 }
 
 /// Describes dependencies, constraints and source dependencies for a particular

--- a/crates/pixi_build_types/src/variant.rs
+++ b/crates/pixi_build_types/src/variant.rs
@@ -44,9 +44,9 @@ impl Ord for VariantValue {
 impl Display for VariantValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VariantValue::String(s) => write!(f, "{}", s),
-            VariantValue::Int(i) => write!(f, "{}", i),
-            VariantValue::Bool(b) => write!(f, "{}", b),
+            VariantValue::String(s) => write!(f, "{s}"),
+            VariantValue::Int(i) => write!(f, "{i}"),
+            VariantValue::Bool(b) => write!(f, "{b}"),
         }
     }
 }

--- a/crates/pixi_build_types/src/variant.rs
+++ b/crates/pixi_build_types/src/variant.rs
@@ -1,0 +1,52 @@
+use std::cmp::Ordering;
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+/// Represents a conda-build variant value.
+///
+/// Variants are used in conda-build to specify different build configurations.
+/// They can be strings (e.g., "3.11" for python version), integers (e.g., 1 for feature flags),
+/// or booleans (e.g., true/false for optional features).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum VariantValue {
+    /// String variant value (most common, e.g., python version "3.11")
+    String(String),
+    /// Integer variant value (e.g., for numeric feature flags)
+    Int(i64),
+    /// Boolean variant value (e.g., for on/off features)
+    Bool(bool),
+}
+
+impl PartialOrd for VariantValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VariantValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        #[allow(clippy::match_same_arms)]
+        match (self, other) {
+            (VariantValue::String(a), VariantValue::String(b)) => a.cmp(b),
+            (VariantValue::Int(a), VariantValue::Int(b)) => a.cmp(b),
+            (VariantValue::Bool(a), VariantValue::Bool(b)) => a.cmp(b),
+            // Define ordering between different types for deterministic sorting
+            (VariantValue::String(_), _) => Ordering::Less,
+            (_, VariantValue::String(_)) => Ordering::Greater,
+            (VariantValue::Int(_), VariantValue::Bool(_)) => Ordering::Less,
+            (VariantValue::Bool(_), VariantValue::Int(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl Display for VariantValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VariantValue::String(s) => write!(f, "{}", s),
+            VariantValue::Int(i) => write!(f, "{}", i),
+            VariantValue::Bool(b) => write!(f, "{}", b),
+        }
+    }
+}

--- a/crates/pixi_cli/src/build.rs
+++ b/crates/pixi_cli/src/build.rs
@@ -73,7 +73,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Determine the variant configuration for the build.
     let VariantConfig {
-        variants,
+        variants: variant_config,
         variant_files,
     } = workspace.variants(args.target_platform)?;
 
@@ -135,7 +135,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         channels: channels.clone(),
         channel_config: channel_config.clone(),
         build_environment: build_environment.clone(),
-        variants: Some(variants.clone()),
+        variants: Some(variant_config.clone()),
         variant_files: Some(variant_files.clone()),
         enabled_protocols: Default::default(),
     };
@@ -162,17 +162,18 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .context("failed to create temporary output directory for build artifacts")?;
 
     // Build the individual packages
-    for package in packages {
+    for (package_name, package_variant) in packages {
         let built_package = command_dispatcher
             .source_build(SourceBuildSpec {
-                package,
+                package_name,
+                package_variant,
+                source: source.clone(),
                 // Build into a temporary directory first
                 output_directory: Some(temp_output_dir.path().to_path_buf()),
-                source: source.clone(),
                 channels: channels.clone(),
                 channel_config: channel_config.clone(),
                 build_environment: build_environment.clone(),
-                variants: Some(variants.clone()),
+                variant_config: Some(variant_config.clone()),
                 variant_files: Some(variant_files.clone()),
                 enabled_protocols: Default::default(),
                 work_directory: None,

--- a/crates/pixi_cli/src/global/tree.rs
+++ b/crates/pixi_cli/src/global/tree.rs
@@ -66,12 +66,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 .to_string();
             let package = Package {
                 name: name.clone(),
-                version: record
-                    .repodata_record
-                    .package_record
-                    .version
-                    .version()
-                    .to_string(),
+                version: Some(
+                    record
+                        .repodata_record
+                        .package_record
+                        .version
+                        .version()
+                        .to_string(),
+                ),
                 dependencies: record
                     .repodata_record
                     .package_record

--- a/crates/pixi_cli/src/shared/tree.rs
+++ b/crates/pixi_cli/src/shared/tree.rs
@@ -18,7 +18,7 @@ pub enum PackageSource {
 #[derive(Debug, Clone)]
 pub struct Package {
     pub name: String,
-    pub version: String,
+    pub version: Option<String>,
     pub dependencies: Vec<String>,
     pub needed_by: Vec<String>,
     pub source: PackageSource,
@@ -214,7 +214,7 @@ fn print_dependency_node(
                 &format!("{prefix}{symbol} "),
                 &Package {
                     name: dep_name.to_owned(),
-                    version: String::from(""),
+                    version: None,
                     dependencies: Vec::new(),
                     needed_by: Vec::new(),
                     source: PackageSource::Conda,
@@ -256,8 +256,10 @@ pub fn print_package(
             console::style(&package.name)
         },
         match package.source {
-            PackageSource::Conda => console::style(&package.version).fg(Color::Yellow),
-            PackageSource::Pypi => console::style(&package.version).fg(Color::Blue),
+            PackageSource::Conda =>
+                console::style(package.version.as_deref().unwrap_or_default()).fg(Color::Yellow),
+            PackageSource::Pypi =>
+                console::style(package.version.as_deref().unwrap_or_default()).fg(Color::Blue),
         },
         if visited { "(*)" } else { "" }
     )

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -120,11 +120,10 @@ pub(crate) fn extract_package_info(
     package: rattler_lock::LockedPackageRef<'_>,
 ) -> Option<PackageInfo> {
     if let Some(conda_package) = package.as_conda() {
-        let name = conda_package.record().name.as_normalized().to_string();
+        let name = conda_package.name().as_normalized().to_string();
 
         let dependencies: Vec<String> = conda_package
-            .record()
-            .depends
+            .depends()
             .iter()
             .map(|d| {
                 d.split_once(' ')
@@ -179,9 +178,9 @@ pub fn generate_dependency_map(locked_deps: &[LockedPackageRef<'_>]) -> HashMap<
                     name: package_info.name,
                     version: match package {
                         LockedPackageRef::Conda(conda_data) => {
-                            conda_data.record().version.to_string()
+                            conda_data.version().map(|v| v.to_string())
                         }
-                        LockedPackageRef::Pypi(pypi_data, _) => pypi_data.version.to_string(),
+                        LockedPackageRef::Pypi(pypi_data, _) => Some(pypi_data.version.to_string()),
                     },
                     dependencies: package_info
                         .dependencies

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -27,7 +27,6 @@ pin-project-lite = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_with = { workspace = true }
 slotmap = { workspace = true }
 strsim = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -1,19 +1,15 @@
 //! See [`BackendSourceBuildSpec`]
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Display,
-    path::PathBuf,
-};
+use std::{collections::BTreeSet, path::PathBuf};
 
 use futures::{SinkExt, channel::mpsc::UnboundedSender};
-use itertools::{Either, Itertools};
+use itertools::Either;
 use miette::Diagnostic;
 use pixi_build_frontend::{Backend, json_rpc::CommunicationError};
 use pixi_build_types::procedures::conda_build_v1::{
     CondaBuildV1Dependency, CondaBuildV1DependencyRunExportSource, CondaBuildV1DependencySource,
     CondaBuildV1Output, CondaBuildV1Params, CondaBuildV1Prefix, CondaBuildV1PrefixPackage,
-    CondaBuildV1Result, CondaBuildV1RunExports,
+    CondaBuildV1RunExports,
 };
 use pixi_record::PinnedSourceSpec;
 use pixi_spec::{BinarySpec, PixiSpec, SpecConversionError};
@@ -21,10 +17,9 @@ use rattler_conda_types::{
     ChannelConfig, ChannelUrl, MatchSpec, PackageName, Platform, RepoDataRecord,
 };
 use serde::Serialize;
-use thiserror::Error;
 
 use crate::{
-    CommandDispatcherError, PackageIdentifier,
+    CommandDispatcherError,
     build::{Dependencies, DependencySource, PixiRunExports, WithSource},
 };
 
@@ -144,6 +139,7 @@ impl BackendSourceBuildSpec {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn build_v1(
         backend: Backend,
         package_name: PackageName,
@@ -272,18 +268,6 @@ impl BackendSourceBuildSpec {
             output_file: built_package.output_file,
         })
     }
-}
-
-/// Returns true if the requested package matches the one that was built by a
-/// backend.
-fn v1_built_package_matches_requested(
-    built_package: &CondaBuildV1Result,
-    record: &PackageIdentifier,
-) -> bool {
-    built_package.name != record.name.as_normalized()
-        || built_package.version != record.version
-        || built_package.build != record.build
-        || built_package.subdir.as_str() != record.subdir
 }
 
 fn dependencies_to_protocol(

--- a/crates/pixi_command_dispatcher/src/build/build_cache.rs
+++ b/crates/pixi_command_dispatcher/src/build/build_cache.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     fmt::Display,
     hash::{Hash, Hasher},
     io::SeekFrom,
@@ -12,12 +12,10 @@ use itertools::Itertools;
 use ordermap::OrderMap;
 use pixi_build_discovery::{BackendInitializationParams, DiscoveredBackend};
 use pixi_build_types::{ProjectModelV1, TargetSelectorV1};
-use pixi_record::{PinnedSourceSpec, VariantValue};
+use pixi_record::PinnedSourceSpec;
 use pixi_stable_hash::{StableHashBuilder, json::StableJson, map::StableMap};
 use rattler_conda_types::{ChannelUrl, GenericVirtualPackage, Platform, RepoDataRecord};
-use rattler_digest::Sha256Hash;
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use xxhash_rust::xxh3::Xxh3;

--- a/crates/pixi_command_dispatcher/src/build/build_cache.rs
+++ b/crates/pixi_command_dispatcher/src/build/build_cache.rs
@@ -47,7 +47,7 @@ pub struct BuildInput {
     pub name: String,
 
     /// The specific variant of the package (from the lock file)
-    pub package_variant: std::collections::BTreeMap<String, pixi_record::VariantValue>,
+    pub package_variant: crate::SelectedVariant,
 
     /// The host platform
     pub host_platform: Platform,
@@ -234,32 +234,28 @@ pub struct BuildHostEnvironment {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum BuildHostPackage {
-    Source(BuildHostSourcePackage),
-    Binary(RepoDataRecord),
+pub struct BuildHostPackage {
+    #[serde(flatten)]
+    pub repodata_record: RepoDataRecord,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<BuildHostSourcePackage>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BuildHostSourcePackage {
-    pub name: rattler_conda_types::PackageName,
-
     /// The location of the source code.
     pub source: PinnedSourceSpec,
 
     /// The package variant to build the package
-    pub package_variant: BTreeMap<String, VariantValue>,
-
-    /// The hash of the package that was build and include in the build/host environment.
-    pub sha256: Sha256Hash,
+    pub package_variant: crate::SelectedVariant,
 }
 
 impl Display for BuildHostSourcePackage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}{}({})",
-            self.name.as_normalized(),
+            "{}({})",
             self.source,
             self.package_variant
                 .iter()

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -1,9 +1,9 @@
 use pixi_build_types::{
     BinaryPackageSpecV1, CondaPackageMetadata, PackageSpecV1, SourcePackageSpecV1,
 };
-use pixi_record::{InputHash, PinnedSourceSpec, SourceRecord, SourceRecordWithMetadata};
+use pixi_record::{InputHash, PinnedSourceSpec, SourcePackageRecord, SourceRecord};
 use pixi_spec::{BinarySpec, DetailedSpec, SourceLocationSpec, UrlBinarySpec};
-use rattler_conda_types::{NamedChannelOrUrl, PackageName, PackageRecord};
+use rattler_conda_types::{NamedChannelOrUrl, PackageName};
 
 /// Converts a [`SourcePackageSpecV1`] to a [`pixi_spec::SourceSpec`].
 pub fn from_source_spec_v1(source: SourcePackageSpecV1) -> pixi_spec::SourceSpec {
@@ -102,13 +102,13 @@ pub(crate) fn package_metadata_to_source_records(
     packages: &[CondaPackageMetadata],
     package: &PackageName,
     input_hash: &Option<InputHash>,
-) -> Vec<SourceRecordWithMetadata> {
+) -> Vec<SourcePackageRecord> {
     // Convert the metadata to source records with metadata
 
     packages
         .iter()
         .filter(|pkg| pkg.name == *package)
-        .map(|p| SourceRecordWithMetadata {
+        .map(|p| SourcePackageRecord {
             source_record: SourceRecord {
                 name: p.name.clone(),
                 source: source.clone(),

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -108,43 +108,41 @@ pub(crate) fn package_metadata_to_source_records(
     packages
         .iter()
         .filter(|pkg| pkg.name == *package)
-        .map(|p| {
-            SourceRecordWithMetadata {
-                source_record: SourceRecord {
-                    name: p.name.clone(),
-                    source: source.clone(),
-                    variants: Default::default(),
-                    depends: p.depends.iter().map(|c| c.to_string()).collect(),
-                    constrains: p.constraints.iter().map(|c| c.to_string()).collect(),
-                    experimental_extra_depends: Default::default(),
-                    license: p.license.clone(),
-                    purls: None,
-                    input_hash: input_hash.clone(),
-                    sources: p
-                        .sources
-                        .iter()
-                        .map(|(name, source)| (name.clone(), from_source_spec_v1(source.clone())))
-                        .collect(),
-                    python_site_packages_path: None,
-                },
-                version: p.version.clone(),
-                build: p.build.clone(),
-                build_number: p.build_number,
-                subdir: p.subdir.to_string(),
-                arch: p.subdir.arch().as_ref().map(ToString::to_string),
-                platform: p.subdir.only_platform().map(ToString::to_string),
-                md5: None,
-                sha256: None,
-                size: None,
-                track_features: vec![],
-                features: None,
-                license_family: p.license_family.clone(),
-                timestamp: None,
-                run_exports: None,
-                noarch: p.noarch,
-                legacy_bz2_md5: None,
-                legacy_bz2_size: None,
-            }
+        .map(|p| SourceRecordWithMetadata {
+            source_record: SourceRecord {
+                name: p.name.clone(),
+                source: source.clone(),
+                variants: Default::default(),
+                depends: p.depends.iter().map(|c| c.to_string()).collect(),
+                constrains: p.constraints.iter().map(|c| c.to_string()).collect(),
+                experimental_extra_depends: Default::default(),
+                license: p.license.clone(),
+                purls: None,
+                input_hash: input_hash.clone(),
+                sources: p
+                    .sources
+                    .iter()
+                    .map(|(name, source)| (name.clone(), from_source_spec_v1(source.clone())))
+                    .collect(),
+                python_site_packages_path: None,
+            },
+            version: p.version.clone(),
+            build: p.build.clone(),
+            build_number: p.build_number,
+            subdir: p.subdir.to_string(),
+            arch: p.subdir.arch().as_ref().map(ToString::to_string),
+            platform: p.subdir.only_platform().map(ToString::to_string),
+            md5: None,
+            sha256: None,
+            size: None,
+            track_features: vec![],
+            features: None,
+            license_family: p.license_family.clone(),
+            timestamp: None,
+            run_exports: None,
+            noarch: p.noarch,
+            legacy_bz2_md5: None,
+            legacy_bz2_size: None,
         })
         .collect()
 }

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -1,9 +1,6 @@
-use pixi_build_types::{
-    BinaryPackageSpecV1, CondaPackageMetadata, PackageSpecV1, SourcePackageSpecV1,
-};
-use pixi_record::{InputHash, PinnedSourceSpec, SourcePackageRecord, SourceRecord};
+use pixi_build_types::{BinaryPackageSpecV1, PackageSpecV1, SourcePackageSpecV1};
 use pixi_spec::{BinarySpec, DetailedSpec, SourceLocationSpec, UrlBinarySpec};
-use rattler_conda_types::{NamedChannelOrUrl, PackageName};
+use rattler_conda_types::NamedChannelOrUrl;
 
 /// Converts a [`SourcePackageSpecV1`] to a [`pixi_spec::SourceSpec`].
 pub fn from_source_spec_v1(source: SourcePackageSpecV1) -> pixi_spec::SourceSpec {
@@ -95,54 +92,4 @@ pub fn from_package_spec_v1(source: PackageSpecV1) -> pixi_spec::PixiSpec {
         PackageSpecV1::Source(source) => from_source_spec_v1(source).into(),
         PackageSpecV1::Binary(binary) => from_binary_spec_v1(*binary).into(),
     }
-}
-
-pub(crate) fn package_metadata_to_source_records(
-    source: &PinnedSourceSpec,
-    packages: &[CondaPackageMetadata],
-    package: &PackageName,
-    input_hash: &Option<InputHash>,
-) -> Vec<SourcePackageRecord> {
-    // Convert the metadata to source records with metadata
-
-    packages
-        .iter()
-        .filter(|pkg| pkg.name == *package)
-        .map(|p| SourcePackageRecord {
-            source_record: SourceRecord {
-                name: p.name.clone(),
-                source: source.clone(),
-                variants: Default::default(),
-                depends: p.depends.iter().map(|c| c.to_string()).collect(),
-                constrains: p.constraints.iter().map(|c| c.to_string()).collect(),
-                experimental_extra_depends: Default::default(),
-                license: p.license.clone(),
-                purls: None,
-                input_hash: input_hash.clone(),
-                sources: p
-                    .sources
-                    .iter()
-                    .map(|(name, source)| (name.clone(), from_source_spec_v1(source.clone())))
-                    .collect(),
-                python_site_packages_path: None,
-            },
-            version: p.version.clone(),
-            build: p.build.clone(),
-            build_number: p.build_number,
-            subdir: p.subdir.to_string(),
-            arch: p.subdir.arch().as_ref().map(ToString::to_string),
-            platform: p.subdir.only_platform().map(ToString::to_string),
-            md5: None,
-            sha256: None,
-            size: None,
-            track_features: vec![],
-            features: None,
-            license_family: p.license_family.clone(),
-            timestamp: None,
-            run_exports: None,
-            noarch: p.noarch,
-            legacy_bz2_md5: None,
-            legacy_bz2_size: None,
-        })
-        .collect()
 }

--- a/crates/pixi_command_dispatcher/src/build/dependencies.rs
+++ b/crates/pixi_command_dispatcher/src/build/dependencies.rs
@@ -226,10 +226,10 @@ impl Dependencies {
         let mut relevant_records = records
             .iter_mut()
             // Only record run exports for packages that are direct dependencies.
-            .filter(|r| self.dependencies.contains_key(&r.package_record().name))
+            .filter(|r| self.dependencies.contains_key(r.name()))
             // Filter based on whether we want to ignore run exports for a particular
             // package.
-            .filter(|r| !ignore.from_package.contains(&r.package_record().name))
+            .filter(|r| !ignore.from_package.contains(r.name()))
             .collect::<Vec<_>>();
 
         // Determine the records that have missing run exports.
@@ -246,21 +246,22 @@ impl Dependencies {
 
         for record in relevant_records {
             // Only record run exports for packages that are direct dependencies.
-            if !self
-                .dependencies
-                .contains_key(&record.package_record().name)
-            {
+            if !self.dependencies.contains_key(record.name()) {
                 continue;
             }
 
             // Filter based on whether we want to ignore run exports for a particular
             // package.
-            if ignore.from_package.contains(&record.package_record().name) {
+            if ignore.from_package.contains(record.name()) {
                 continue;
             }
 
             // Make sure we have valid run exports.
-            let Some(run_exports) = &record.package_record().run_exports else {
+            // Only binary packages have run_exports
+            let Some(package_record) = record.package_record() else {
+                continue;
+            };
+            let Some(run_exports) = &package_record.run_exports else {
                 // No run-exports found
                 continue;
             };

--- a/crates/pixi_command_dispatcher/src/build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build/mod.rs
@@ -13,7 +13,7 @@ use std::hash::{Hash, Hasher};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 pub use build_cache::{
     BuildCache, BuildCacheEntry, BuildCacheError, BuildHostEnvironment, BuildHostPackage,
-    BuildInput, CachedBuild, CachedBuildSourceInfo, PackageBuildInputHash,
+    BuildHostSourcePackage, BuildInput, CachedBuild, CachedBuildSourceInfo, PackageBuildInputHash,
     PackageBuildInputHashBuilder,
 };
 pub use build_environment::BuildEnvironment;

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     InstantiateBackendError, InstantiateBackendSpec, SourceCheckout, SourceCheckoutError,
     build::{
         SourceRecordOrCheckout, WorkDirKey,
-        source_metadata_cache::{self, CachedCondaMetadata, MetadataKind, SourceMetadataKey},
+        source_metadata_cache::{self, CachedCondaMetadata, SourceMetadataKey},
     },
 };
 use pixi_build_discovery::BackendSpec;
@@ -276,12 +276,7 @@ impl BuildBackendMetadataSpec {
             return Ok(None);
         };
 
-        let metadata_kind = match metadata.metadata {
-            MetadataKind::GetMetadata { .. } => "conda/getMetadata",
-            MetadataKind::Outputs { .. } => {
-                pixi_build_types::procedures::conda_outputs::METHOD_NAME
-            }
-        };
+        let metadata_kind = pixi_build_types::procedures::conda_outputs::METHOD_NAME;
 
         let Some(input_globs) = &metadata.input_hash else {
             // No input hash so just assume it is still valid.
@@ -377,9 +372,7 @@ impl BuildBackendMetadataSpec {
         Ok(CachedCondaMetadata {
             id: random(),
             input_hash: input_hash.clone(),
-            metadata: MetadataKind::Outputs {
-                outputs: outputs.outputs,
-            },
+            outputs: outputs.outputs,
         })
     }
 

--- a/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
@@ -19,7 +19,7 @@ use pixi_build_discovery::{DiscoveredBackend, EnabledProtocols};
 use pixi_build_frontend::BackendOverride;
 use pixi_git::resolver::GitResolver;
 use pixi_glob::GlobHashCache;
-use pixi_record::{PinnedPathSpec, PinnedSourceSpec, PixiRecord};
+use pixi_record::{PinnedPathSpec, PinnedSourceSpec, PixiPackageRecord};
 use pixi_spec::{SourceLocationSpec, SourceSpec};
 use rattler::package_cache::PackageCache;
 use rattler_conda_types::{ChannelConfig, GenericVirtualPackage, Platform};
@@ -244,7 +244,7 @@ pub(crate) enum ForegroundMessage {
 /// pixi environment.
 pub(crate) type SolvePixiEnvironmentTask = Task<PixiEnvironmentSpec>;
 impl TaskSpec for PixiEnvironmentSpec {
-    type Output = Vec<PixiRecord>;
+    type Output = Vec<PixiPackageRecord>;
     type Error = SolvePixiEnvironmentError;
 }
 
@@ -260,7 +260,7 @@ impl TaskSpec for InstallPixiEnvironmentSpec {
 /// conda environment.
 pub(crate) type SolveCondaEnvironmentTask = Task<SolveCondaEnvironmentSpec>;
 impl TaskSpec for SolveCondaEnvironmentSpec {
-    type Output = Vec<PixiRecord>;
+    type Output = Vec<PixiPackageRecord>;
     type Error = SolveCondaEnvironmentError;
 }
 
@@ -509,7 +509,7 @@ impl CommandDispatcher {
     pub async fn solve_pixi_environment(
         &self,
         spec: PixiEnvironmentSpec,
-    ) -> Result<Vec<PixiRecord>, CommandDispatcherError<SolvePixiEnvironmentError>> {
+    ) -> Result<Vec<PixiPackageRecord>, CommandDispatcherError<SolvePixiEnvironmentError>> {
         self.execute_task(spec).await
     }
 
@@ -539,7 +539,7 @@ impl CommandDispatcher {
     pub async fn solve_conda_environment(
         &self,
         spec: SolveCondaEnvironmentSpec,
-    ) -> Result<Vec<PixiRecord>, CommandDispatcherError<SolveCondaEnvironmentError>> {
+    ) -> Result<Vec<PixiPackageRecord>, CommandDispatcherError<SolveCondaEnvironmentError>> {
         self.execute_task(spec).await
     }
 

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
@@ -31,7 +31,7 @@ use crate::{
 use futures::{StreamExt, future::LocalBoxFuture};
 use itertools::Itertools;
 use pixi_git::{GitError, resolver::RepositoryReference, source::Fetch};
-use pixi_record::PixiRecord;
+use pixi_record::PixiPackageRecord;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
@@ -149,11 +149,11 @@ type BoxedDispatcherResult<T, E> = Box<Result<T, CommandDispatcherError<E>>>;
 enum TaskResult {
     SolveCondaEnvironment(
         SolveCondaEnvironmentId,
-        BoxedDispatcherResult<Vec<PixiRecord>, SolveCondaEnvironmentError>,
+        BoxedDispatcherResult<Vec<PixiPackageRecord>, SolveCondaEnvironmentError>,
     ),
     SolvePixiEnvironment(
         SolvePixiEnvironmentId,
-        BoxedDispatcherResult<Vec<PixiRecord>, SolvePixiEnvironmentError>,
+        BoxedDispatcherResult<Vec<PixiPackageRecord>, SolvePixiEnvironmentError>,
     ),
     BuildBackendMetadata(
         BuildBackendMetadataId,
@@ -205,7 +205,7 @@ enum PendingGitCheckout {
 /// background task to keep track of which command_dispatcher is awaiting the
 /// result.
 struct PendingSolveCondaEnvironment {
-    tx: oneshot::Sender<Result<Vec<PixiRecord>, SolveCondaEnvironmentError>>,
+    tx: oneshot::Sender<Result<Vec<PixiPackageRecord>, SolveCondaEnvironmentError>>,
     reporter_id: Option<reporter::CondaSolveId>,
 }
 
@@ -218,7 +218,7 @@ struct PendingBackendSourceBuild {
 /// background task to keep track of which command_dispatcher is awaiting the
 /// result.
 struct PendingPixiEnvironment {
-    tx: oneshot::Sender<Result<Vec<PixiRecord>, SolvePixiEnvironmentError>>,
+    tx: oneshot::Sender<Result<Vec<PixiPackageRecord>, SolvePixiEnvironmentError>>,
     reporter_id: Option<reporter::PixiSolveId>,
 }
 

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_conda.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_conda.rs
@@ -1,5 +1,5 @@
 use futures::FutureExt;
-use pixi_record::PixiRecord;
+use pixi_record::PixiPackageRecord;
 
 use super::{CommandDispatcherProcessor, PendingSolveCondaEnvironment, TaskResult};
 use crate::{
@@ -90,7 +90,7 @@ impl CommandDispatcherProcessor {
     pub(crate) fn on_solve_conda_environment_result(
         &mut self,
         id: SolveCondaEnvironmentId,
-        result: Result<Vec<PixiRecord>, CommandDispatcherError<SolveCondaEnvironmentError>>,
+        result: Result<Vec<PixiPackageRecord>, CommandDispatcherError<SolveCondaEnvironmentError>>,
     ) {
         self.parent_contexts.remove(&id.into());
         let env = self

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_pixi.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_pixi.rs
@@ -1,5 +1,5 @@
 use futures::FutureExt;
-use pixi_record::PixiRecord;
+use pixi_record::PixiPackageRecord;
 
 use super::{CommandDispatcherProcessor, PendingPixiEnvironment, TaskResult};
 use crate::{
@@ -74,7 +74,7 @@ impl CommandDispatcherProcessor {
     pub(crate) fn on_solve_pixi_environment_result(
         &mut self,
         id: SolvePixiEnvironmentId,
-        result: Result<Vec<PixiRecord>, CommandDispatcherError<SolvePixiEnvironmentError>>,
+        result: Result<Vec<PixiPackageRecord>, CommandDispatcherError<SolvePixiEnvironmentError>>,
     ) {
         self.parent_contexts.remove(&id.into());
         let env = self

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -215,7 +215,7 @@ impl InstallPixiEnvironmentSpec {
             .source_build(SourceBuildSpec {
                 source: source_record.source.clone(),
                 package_name: source_record.name.clone(),
-                package_variant: source_record.variants.clone(),
+                package_variant: source_record.variants.clone().into(),
                 channel_config: self.channel_config.clone(),
                 channels: self.channels.clone(),
                 build_environment: self.build_environment.clone(),

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -210,9 +210,7 @@ impl InstallPixiEnvironmentSpec {
     ) -> Result<RepoDataRecord, CommandDispatcherError<SourceBuildError>> {
         // Build the source package.
         // Verify if we need to force the build even if the cache is up to date.
-        let force = self
-            .force_reinstall
-            .contains(&source_record.name);
+        let force = self.force_reinstall.contains(&source_record.name);
         let built_source = command_dispatcher
             .source_build(SourceBuildSpec {
                 source: source_record.source.clone(),

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -139,7 +139,7 @@ impl InstallPixiEnvironmentSpec {
             if self
                 .ignore_packages
                 .as_ref()
-                .is_some_and(|ignore| ignore.contains(&source_record.package_record.name))
+                .is_some_and(|ignore| ignore.contains(&source_record.name))
             {
                 continue;
             }
@@ -212,15 +212,16 @@ impl InstallPixiEnvironmentSpec {
         // Verify if we need to force the build even if the cache is up to date.
         let force = self
             .force_reinstall
-            .contains(&source_record.package_record.name);
+            .contains(&source_record.name);
         let built_source = command_dispatcher
             .source_build(SourceBuildSpec {
                 source: source_record.source.clone(),
-                package: source_record.into(),
+                package_name: source_record.name.clone(),
+                package_variant: source_record.variants.clone(),
                 channel_config: self.channel_config.clone(),
                 channels: self.channels.clone(),
                 build_environment: self.build_environment.clone(),
-                variants: self.variants.clone(),
+                variant_config: self.variants.clone(),
                 variant_files: self.variant_files.clone(),
                 enabled_protocols: self.enabled_protocols.clone(),
                 output_directory: None,
@@ -247,7 +248,7 @@ pub enum InstallPixiEnvironmentError {
     Installer(InstallerError),
 
     #[error("failed to build '{}' from '{}'",
-        .0.package_record.name.as_source(),
+        .0.name.as_source(),
         .0.source)]
     BuildSourceError(
         Box<SourceRecord>,

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -95,14 +95,14 @@ pub struct InstallPixiEnvironmentResult {
 }
 
 impl InstallPixiEnvironmentSpec {
-    pub fn new(records: Vec<PixiRecord>, prefix: Prefix) -> Self {
+    pub fn new<R: Into<PixiRecord>>(records: Vec<R>, prefix: Prefix) -> Self {
         InstallPixiEnvironmentSpec {
             name: prefix
                 .file_name()
                 .map(OsStr::to_string_lossy)
                 .map(Cow::into_owned)
                 .unwrap_or_default(),
-            records,
+            records: records.into_iter().map(Into::into).collect(),
             prefix,
             installed: None,
             ignore_packages: None,

--- a/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
@@ -224,8 +224,9 @@ impl InstantiateToolEnvironmentSpec {
         // Ensure that the solution contains matching api version package
         let Some(api_version) = solved_environment
             .iter()
-            .find(|r| r.package_record().name == *PIXI_BUILD_API_VERSION_NAME)
-            .map(|r| r.package_record().version.as_ref())
+            .find(|r| r.name() == &*PIXI_BUILD_API_VERSION_NAME)
+            .and_then(|r| r.package_record())
+            .map(|pr| pr.version.as_ref())
             .and_then(PixiBuildApiVersion::from_version)
         else {
             return Err(CommandDispatcherError::Failed(
@@ -238,9 +239,10 @@ impl InstantiateToolEnvironmentSpec {
         // Extract the version of the main requirement package.
         let version = solved_environment
             .iter()
-            .find(|r| r.package_record().name == self.requirement.0)
+            .find(|r| r.name() == &self.requirement.0)
             .expect("The solved environment should always contain the main requirement package")
             .package_record()
+            .expect("The main requirement should be a binary package")
             .version
             .clone();
 

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -51,6 +51,7 @@ mod source_build;
 mod source_build_cache_status;
 mod source_checkout;
 mod source_metadata;
+mod variant;
 
 pub use backend_source_build::{
     BackendBuiltSource, BackendSourceBuildError, BackendSourceBuildMethod,
@@ -87,6 +88,7 @@ pub use source_build_cache_status::{
 };
 pub use source_checkout::{InvalidPathError, SourceCheckout, SourceCheckoutError};
 pub use source_metadata::{Cycle, SourceMetadata, SourceMetadataError, SourceMetadataSpec};
+pub use variant::{SelectedVariant, VariantValue};
 
 /// A helper function to check if a value is the default value for its type.
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {

--- a/crates/pixi_command_dispatcher/src/package_identifier.rs
+++ b/crates/pixi_command_dispatcher/src/package_identifier.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, hash::Hash};
 
-use pixi_record::{SourceRecord, SourceRecordWithMetadata};
+use pixi_record::SourcePackageRecord;
 use rattler_conda_types::{PackageName, PackageRecord, VersionWithSource};
 use serde::{Deserialize, Serialize};
 
@@ -57,8 +57,8 @@ impl<'a> From<&'a PackageRecord> for PackageIdentifier {
     }
 }
 
-impl From<SourceRecordWithMetadata> for PackageIdentifier {
-    fn from(record: SourceRecordWithMetadata) -> Self {
+impl From<SourcePackageRecord> for PackageIdentifier {
+    fn from(record: SourcePackageRecord) -> Self {
         Self {
             name: record.source_record.name,
             version: record.version,
@@ -68,8 +68,8 @@ impl From<SourceRecordWithMetadata> for PackageIdentifier {
     }
 }
 
-impl<'a> From<&'a SourceRecordWithMetadata> for PackageIdentifier {
-    fn from(record: &'a SourceRecordWithMetadata) -> Self {
+impl<'a> From<&'a SourcePackageRecord> for PackageIdentifier {
+    fn from(record: &'a SourcePackageRecord) -> Self {
         Self {
             name: record.source_record.name.clone(),
             version: record.version.clone(),

--- a/crates/pixi_command_dispatcher/src/package_identifier.rs
+++ b/crates/pixi_command_dispatcher/src/package_identifier.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, hash::Hash};
 
-use pixi_record::SourceRecord;
+use pixi_record::{SourceRecord, SourceRecordWithMetadata};
 use rattler_conda_types::{PackageName, PackageRecord, VersionWithSource};
 use serde::{Deserialize, Serialize};
 
@@ -57,14 +57,24 @@ impl<'a> From<&'a PackageRecord> for PackageIdentifier {
     }
 }
 
-impl From<SourceRecord> for PackageIdentifier {
-    fn from(record: SourceRecord) -> Self {
-        record.package_record.into()
+impl From<SourceRecordWithMetadata> for PackageIdentifier {
+    fn from(record: SourceRecordWithMetadata) -> Self {
+        Self {
+            name: record.source_record.name,
+            version: record.version,
+            build: record.build,
+            subdir: record.subdir,
+        }
     }
 }
 
-impl<'a> From<&'a SourceRecord> for PackageIdentifier {
-    fn from(record: &'a SourceRecord) -> Self {
-        (&record.package_record).into()
+impl<'a> From<&'a SourceRecordWithMetadata> for PackageIdentifier {
+    fn from(record: &'a SourceRecordWithMetadata) -> Self {
+        Self {
+            name: record.source_record.name.clone(),
+            version: record.version.clone(),
+            build: record.build.clone(),
+            subdir: record.subdir.clone(),
+        }
     }
 }

--- a/crates/pixi_command_dispatcher/src/solve_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/mod.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use itertools::{Either, Itertools};
 use miette::Diagnostic;
 use pixi_build_discovery::EnabledProtocols;
-use pixi_record::PixiRecord;
+use pixi_record::{PixiPackageRecord, PixiRecord};
 use pixi_spec::{BinarySpec, PixiSpec, SourceSpec, SpecConversionError};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::{Channel, ChannelConfig, ChannelUrl, ParseChannelError, Platform};
@@ -121,7 +121,7 @@ impl PixiEnvironmentSpec {
         self,
         command_queue: CommandDispatcher,
         gateway_reporter: Option<Box<dyn rattler_repodata_gateway::Reporter>>,
-    ) -> Result<Vec<PixiRecord>, CommandDispatcherError<SolvePixiEnvironmentError>> {
+    ) -> Result<Vec<PixiPackageRecord>, CommandDispatcherError<SolvePixiEnvironmentError>> {
         // Split the requirements into source and binary requirements.
         let (source_specs, binary_specs) =
             Self::split_into_source_and_binary_requirements(self.dependencies);

--- a/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
@@ -123,7 +123,8 @@ impl SourceMetadataCollector {
             // Process transitive dependencies
             for record in &source_metadata.records {
                 chain.push(record.source_record.name.clone());
-                let anchor = SourceAnchor::from(SourceSpec::from(record.source_record.source.clone()));
+                let anchor =
+                    SourceAnchor::from(SourceSpec::from(record.source_record.source.clone()));
                 for depend in &record.source_record.depends {
                     if let Ok(spec) = MatchSpec::from_str(depend, ParseStrictness::Lenient) {
                         if let Some((name, source_spec)) = spec.name.as_ref().and_then(|name| {

--- a/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
@@ -122,12 +122,13 @@ impl SourceMetadataCollector {
 
             // Process transitive dependencies
             for record in &source_metadata.records {
-                chain.push(record.package_record.name.clone());
-                let anchor = SourceAnchor::from(SourceSpec::from(record.source.clone()));
-                for depend in &record.package_record.depends {
+                chain.push(record.source_record.name.clone());
+                let anchor = SourceAnchor::from(SourceSpec::from(record.source_record.source.clone()));
+                for depend in &record.source_record.depends {
                     if let Ok(spec) = MatchSpec::from_str(depend, ParseStrictness::Lenient) {
                         if let Some((name, source_spec)) = spec.name.as_ref().and_then(|name| {
                             record
+                                .source_record
                                 .sources
                                 .get(name.as_normalized())
                                 .map(|source_spec| (name.clone(), source_spec.clone()))

--- a/crates/pixi_command_dispatcher/src/source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    fmt::Display,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -8,7 +9,7 @@ use miette::Diagnostic;
 use pixi_build_discovery::EnabledProtocols;
 use pixi_build_frontend::Backend;
 use pixi_build_types::procedures::conda_outputs::CondaOutputsParams;
-use pixi_record::{PinnedSourceSpec, PixiRecord};
+use pixi_record::{PinnedSourceSpec, PixiPackageRecord, PixiRecord};
 use pixi_spec::{SourceAnchor, SourceSpec};
 use rattler_conda_types::{
     ChannelConfig, ChannelUrl, ConvertSubdirError, InvalidPackageNameError, PackageName,
@@ -415,7 +416,7 @@ impl SourceBuildSpec {
 
         // Request the metadata from the backend.
         // TODO: Can we somehow cache this metadata?
-        let outputs = backend
+        let mut outputs = backend
             .conda_outputs(CondaOutputsParams {
                 host_platform,
                 build_platform,
@@ -430,19 +431,23 @@ impl SourceBuildSpec {
             .map_err(CommandDispatcherError::Failed)?;
 
         // Find the output that we want to build by matching name and variants.
-        let output = outputs
-            .outputs
-            .into_iter()
-            .find(|output| {
-                output.metadata.name == self.package_name
-                    && self.package_variant == output.metadata.variant
-            })
-            .ok_or_else(|| {
-                CommandDispatcherError::Failed(SourceBuildError::MissingOutput {
-                    name: self.package_name.as_normalized().to_string(),
-                    variant: self.package_variant.clone().into(),
-                })
-            })?;
+        let Some(output) = outputs.outputs.iter().position(|output| {
+            output.metadata.name == self.package_name
+                && self.package_variant == output.metadata.variant
+        }) else {
+            return Err(CommandDispatcherError::Failed(
+                SourceBuildError::MissingOutput(MissingOutput {
+                    name: self.package_name,
+                    variant: self.package_variant.clone(),
+                    outputs: outputs
+                        .outputs
+                        .into_iter()
+                        .map(|output| (output.metadata.name, output.metadata.variant.into()))
+                        .collect(),
+                }),
+            ));
+        };
+        let output = outputs.outputs.swap_remove(output);
 
         // Determine final directories for everything.
         let directories = Directories::new(&work_directory, host_platform);
@@ -519,7 +524,11 @@ impl SourceBuildSpec {
                 command_dispatcher
                     .install_pixi_environment(InstallPixiEnvironmentSpec {
                         name: format!("{} (build)", self.package_name.as_source()),
-                        records: build_records.clone(),
+                        records: build_records
+                            .iter()
+                            .cloned()
+                            .map(PixiRecord::from)
+                            .collect(),
                         prefix: Prefix::create(&directories.build_prefix)
                             .map_err(SourceBuildError::CreateBuildEnvironmentDirectory)
                             .map_err(CommandDispatcherError::Failed)?,
@@ -552,7 +561,7 @@ impl SourceBuildSpec {
                 command_dispatcher
                     .install_pixi_environment(InstallPixiEnvironmentSpec {
                         name: format!("{} (host)", self.package_name.as_source()),
-                        records: host_records.clone(),
+                        records: host_records.iter().cloned().map(PixiRecord::from).collect(),
                         prefix: host_prefix_directory,
                         installed: None,
                         ignore_packages: None,
@@ -650,7 +659,7 @@ impl SourceBuildSpec {
     /// Little helper function the build a `BuildHostPackage` from expected and
     /// installed records.
     fn extract_prefix_repodata(
-        records: Vec<PixiRecord>,
+        records: Vec<PixiPackageRecord>,
         prefix: Option<InstallPixiEnvironmentResult>,
     ) -> Vec<BuildHostPackage> {
         let Some(prefix) = prefix else {
@@ -660,21 +669,21 @@ impl SourceBuildSpec {
         records
             .into_iter()
             .map(|record| match record {
-                PixiRecord::Binary(repodata_record) => BuildHostPackage {
+                PixiPackageRecord::Binary(repodata_record) => BuildHostPackage {
                     repodata_record,
                     source: None,
                 },
-                PixiRecord::Source(source) => {
+                PixiPackageRecord::Source(source) => {
                     let repodata_record = prefix
                         .resolved_source_records
-                        .get(&source.name)
+                        .get(&source.source_record.name)
                         .cloned()
                         .expect("the source record should be present in the result sources");
                     BuildHostPackage {
                         repodata_record,
                         source: Some(BuildHostSourcePackage {
-                            source: source.source,
-                            package_variant: source.variants.into(),
+                            source: source.source_record.source,
+                            package_variant: source.source_record.variants.into(),
                         }),
                     }
                 }
@@ -688,7 +697,7 @@ impl SourceBuildSpec {
         command_dispatcher: &CommandDispatcher,
         dependencies: Dependencies,
         build_environment: BuildEnvironment,
-    ) -> Result<Vec<PixiRecord>, CommandDispatcherError<SolvePixiEnvironmentError>> {
+    ) -> Result<Vec<PixiPackageRecord>, CommandDispatcherError<SolvePixiEnvironmentError>> {
         if dependencies.dependencies.is_empty() {
             return Ok(vec![]);
         }
@@ -822,13 +831,8 @@ pub enum SourceBuildError {
     #[error("failed to install the host environment")]
     InstallHostEnvironment(#[source] Box<InstallPixiEnvironmentError>),
 
-    #[error(
-        "The build backend does not provide the requested output for package '{name}' with variant {variant:?}."
-    )]
-    MissingOutput {
-        name: String,
-        variant: crate::SelectedVariant,
-    },
+    #[error(transparent)]
+    MissingOutput(#[from] MissingOutput),
 
     #[error(
         "The build backend returned a path for the build package ({0}), but the path does not exist."
@@ -883,5 +887,214 @@ impl From<SourceBuildCacheStatusError> for SourceBuildError {
                 unreachable!("a build time cycle should never happen")
             }
         }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub struct MissingOutput {
+    pub name: PackageName,
+    pub variant: crate::SelectedVariant,
+
+    pub outputs: Vec<(PackageName, crate::SelectedVariant)>,
+}
+
+impl Display for MissingOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "The build backend did not provide the requested output for package '{}' with variant {}\n\n",
+            self.name.as_normalized(),
+            self.variant,
+        )?;
+
+        // Separate outputs into matching name and other packages
+        let matching_outputs: Vec<_> = self
+            .outputs
+            .iter()
+            .filter(|(name, _)| name == &self.name)
+            .collect();
+
+        let other_packages: std::collections::BTreeSet<_> = self
+            .outputs
+            .iter()
+            .filter(|(name, _)| name != &self.name)
+            .map(|(name, _)| name.as_normalized().to_string())
+            .collect();
+
+        // Show available variants for the matching package name
+        if !matching_outputs.is_empty() {
+            writeln!(f, "Available variants for {}:", self.name.as_normalized())?;
+            for (_, variant) in &matching_outputs {
+                // Calculate how many variant keys match
+                let matching_keys = variant
+                    .iter()
+                    .filter(|(key, val)| self.variant.get(key).map(|v| v == *val).unwrap_or(false))
+                    .count();
+                let total_keys = variant.iter().count();
+
+                write!(f, "  - {variant}")?;
+                if matching_keys > 0 && matching_keys < total_keys {
+                    write!(f, "  ← {matching_keys}/{total_keys} keys match")?;
+                }
+                writeln!(f)?;
+            }
+        }
+
+        // Show other available packages if any
+        if !other_packages.is_empty() {
+            if !matching_outputs.is_empty() {
+                writeln!(f)?;
+            }
+            writeln!(f, "Other available packages:")?;
+            for pkg in &other_packages {
+                writeln!(f, "  - {pkg}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SelectedVariant;
+    use rattler_conda_types::PackageName;
+
+    #[test]
+    fn test_missing_output_with_matching_package_name() {
+        let requested_name = PackageName::new_unchecked("scipy");
+        let requested_variant = SelectedVariant::from([("python", "3.11"), ("blas", "mkl")]);
+
+        let outputs = vec![
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.10"), ("blas", "mkl")]),
+            ),
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.11"), ("blas", "openblas")]),
+            ),
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.12"), ("blas", "mkl")]),
+            ),
+        ];
+
+        let error = MissingOutput {
+            name: requested_name,
+            variant: requested_variant,
+            outputs,
+        };
+
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn test_missing_output_with_matching_and_other_packages() {
+        let requested_name = PackageName::new_unchecked("scipy");
+        let requested_variant = SelectedVariant::from([("python", "3.11"), ("blas", "mkl")]);
+
+        let outputs = vec![
+            (
+                PackageName::new_unchecked("numpy"),
+                SelectedVariant::from([("python", "3.10")]),
+            ),
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.10"), ("blas", "mkl")]),
+            ),
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.11"), ("blas", "openblas")]),
+            ),
+            (
+                PackageName::new_unchecked("tensorflow"),
+                SelectedVariant::from([("cuda", "12.0")]),
+            ),
+        ];
+
+        let error = MissingOutput {
+            name: requested_name,
+            variant: requested_variant,
+            outputs,
+        };
+
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn test_missing_output_no_matching_package() {
+        let requested_name = PackageName::new_unchecked("scipy");
+        let requested_variant = SelectedVariant::from([("python", "3.11")]);
+
+        let outputs = vec![
+            (
+                PackageName::new_unchecked("numpy"),
+                SelectedVariant::from([("python", "3.11")]),
+            ),
+            (
+                PackageName::new_unchecked("tensorflow"),
+                SelectedVariant::from([("cuda", "12.0")]),
+            ),
+        ];
+
+        let error = MissingOutput {
+            name: requested_name,
+            variant: requested_variant,
+            outputs,
+        };
+
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn test_missing_output_empty_variant() {
+        let requested_name = PackageName::new_unchecked("scipy");
+        let requested_variant = SelectedVariant::default();
+
+        let outputs = vec![
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.10")]),
+            ),
+            (
+                PackageName::new_unchecked("scipy"),
+                SelectedVariant::from([("python", "3.11")]),
+            ),
+        ];
+
+        let error = MissingOutput {
+            name: requested_name,
+            variant: requested_variant,
+            outputs,
+        };
+
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn test_missing_output_single_variant_key() {
+        let requested_name = PackageName::new_unchecked("numpy");
+        let requested_variant = SelectedVariant::from([("python", "3.12")]);
+
+        let outputs = vec![
+            (
+                PackageName::new_unchecked("numpy"),
+                SelectedVariant::from([("python", "3.10")]),
+            ),
+            (
+                PackageName::new_unchecked("numpy"),
+                SelectedVariant::from([("python", "3.11")]),
+            ),
+        ];
+
+        let error = MissingOutput {
+            name: requested_name,
+            variant: requested_variant,
+            outputs,
+        };
+
+        insta::assert_snapshot!(error.to_string());
     }
 }

--- a/crates/pixi_command_dispatcher/src/source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build/mod.rs
@@ -123,7 +123,7 @@ impl SourceBuildSpec {
         name = "source-build",
         fields(
             source= %self.source,
-            package = %self.package,
+            package = %self.package_name,
         )
     )]
     pub(crate) async fn build(
@@ -173,7 +173,7 @@ impl SourceBuildSpec {
                 }
                 tracing::debug!(
                     "source build for {} is up to date, but force rebuild is set, rebuilding anyway",
-                    self.package.name.as_normalized()
+                    self.package_name.as_normalized()
                 );
             }
             if let CachedBuildStatus::New(cached_build) = &*build_cache.cached_build.lock().await {
@@ -459,7 +459,7 @@ impl SourceBuildSpec {
             .unwrap_or_default();
         let mut build_records = self
             .solve_dependencies(
-                format!("{} (build)", self.package.name.as_source()),
+                format!("{} (build)", self.package_name.as_source()),
                 &command_dispatcher,
                 build_dependencies.clone(),
                 self.build_environment.to_build_from_build(),
@@ -519,7 +519,7 @@ impl SourceBuildSpec {
             Some(
                 command_dispatcher
                     .install_pixi_environment(InstallPixiEnvironmentSpec {
-                        name: format!("{} (build)", self.package.name.as_source()),
+                        name: format!("{} (build)", self.package_name.name.as_source()),
                         records: build_records.clone(),
                         prefix: Prefix::create(&directories.build_prefix)
                             .map_err(SourceBuildError::CreateBuildEnvironmentDirectory)
@@ -530,7 +530,7 @@ impl SourceBuildSpec {
                         force_reinstall: Default::default(),
                         channels: self.channels.clone(),
                         channel_config: self.channel_config.clone(),
-                        variants: self.variants.clone(),
+                        variants: self.variant_config.clone(),
                         variant_files: self.variant_files.clone(),
                         enabled_protocols: self.enabled_protocols.clone(),
                     })
@@ -552,7 +552,7 @@ impl SourceBuildSpec {
             Some(
                 command_dispatcher
                     .install_pixi_environment(InstallPixiEnvironmentSpec {
-                        name: format!("{} (host)", self.package.name.as_source()),
+                        name: format!("{} (host)", self.package_name.name.as_source()),
                         records: host_records.clone(),
                         prefix: host_prefix_directory,
                         installed: None,
@@ -561,7 +561,7 @@ impl SourceBuildSpec {
                         force_reinstall: Default::default(),
                         channels: self.channels.clone(),
                         channel_config: self.channel_config.clone(),
-                        variants: self.variants.clone(),
+                        variants: self.variant_config.clone(),
                         variant_files: self.variant_files.clone(),
                         enabled_protocols: self.enabled_protocols.clone(),
                     })
@@ -623,7 +623,7 @@ impl SourceBuildSpec {
                     output_directory: self.output_directory,
                 }),
                 backend,
-                package: self.package,
+                package: self.package_name,
                 source: self.source,
                 work_directory,
                 channels: self.channels,
@@ -709,7 +709,7 @@ impl SourceBuildSpec {
                 channel_priority: Default::default(),
                 exclude_newer: None,
                 channel_config: self.channel_config.clone(),
-                variants: self.variants.clone(),
+                variants: self.variant_config.clone(),
                 variant_files: self.variant_files.clone(),
                 enabled_protocols: self.enabled_protocols.clone(),
             })

--- a/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_empty_variant.snap
+++ b/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_empty_variant.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pixi_command_dispatcher/src/source_build/mod.rs
+expression: error.to_string()
+---
+The build backend did not provide the requested output for package 'scipy' with variant { }
+
+Available variants for scipy:
+  - {"python":"3.10"}
+  - {"python":"3.11"}

--- a/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_no_matching_package.snap
+++ b/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_no_matching_package.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pixi_command_dispatcher/src/source_build/mod.rs
+expression: error.to_string()
+---
+The build backend did not provide the requested output for package 'scipy' with variant {"python":"3.11"}
+
+Other available packages:
+  - numpy
+  - tensorflow

--- a/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_single_variant_key.snap
+++ b/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_single_variant_key.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pixi_command_dispatcher/src/source_build/mod.rs
+expression: error.to_string()
+---
+The build backend did not provide the requested output for package 'numpy' with variant {"python":"3.12"}
+
+Available variants for numpy:
+  - {"python":"3.10"}
+  - {"python":"3.11"}

--- a/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_with_matching_and_other_packages.snap
+++ b/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_with_matching_and_other_packages.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_command_dispatcher/src/source_build/mod.rs
+expression: error.to_string()
+---
+The build backend did not provide the requested output for package 'scipy' with variant {"blas":"mkl","python":"3.11"}
+
+Available variants for scipy:
+  - {"blas":"mkl","python":"3.10"}  ← 1/2 keys match
+  - {"blas":"openblas","python":"3.11"}  ← 1/2 keys match
+
+Other available packages:
+  - numpy
+  - tensorflow

--- a/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_with_matching_package_name.snap
+++ b/crates/pixi_command_dispatcher/src/source_build/snapshots/pixi_command_dispatcher__source_build__tests__missing_output_with_matching_package_name.snap
@@ -1,0 +1,10 @@
+---
+source: crates/pixi_command_dispatcher/src/source_build/mod.rs
+expression: error.to_string()
+---
+The build backend did not provide the requested output for package 'scipy' with variant {"blas":"mkl","python":"3.11"}
+
+Available variants for scipy:
+  - {"blas":"mkl","python":"3.10"}  ← 1/2 keys match
+  - {"blas":"openblas","python":"3.11"}  ← 1/2 keys match
+  - {"blas":"mkl","python":"3.12"}  ← 1/2 keys match

--- a/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
@@ -1,21 +1,20 @@
-use std::{collections::BTreeMap, fmt, path::PathBuf};
+use std::{fmt, path::PathBuf};
 
 use chrono::Utc;
 use itertools::chain;
 use miette::Diagnostic;
 use pixi_build_discovery::EnabledProtocols;
 use pixi_glob::GlobModificationTime;
-use pixi_record::{PinnedSourceSpec, VariantValue};
-use rattler_conda_types::{ChannelConfig, ChannelUrl, HasArtifactIdentificationRefs};
+use pixi_record::PinnedSourceSpec;
+use rattler_conda_types::{ChannelConfig, ChannelUrl};
 use tokio::sync::Mutex;
 use tracing::instrument;
 
 use crate::{
     BuildEnvironment, CommandDispatcher, CommandDispatcherError, CommandDispatcherErrorResultExt,
-    PackageIdentifier, SourceCheckoutError,
+    SourceCheckoutError,
     build::{
-        BuildCacheEntry, BuildCacheError, BuildHostPackage, BuildInput, CachedBuild,
-        PackageBuildInputHashBuilder,
+        BuildCacheEntry, BuildCacheError, BuildInput, CachedBuild, PackageBuildInputHashBuilder,
     },
 };
 

--- a/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
@@ -265,7 +265,6 @@ impl SourceBuildCacheStatusSpec {
                         CachedBuildStatus::Missing | CachedBuildStatus::Stale(_) => {
                             tracing::debug!(
                                 "package is stale because its build dependency '{identifier}' is missing or stale",
-                                identifier = source.name.as_source()
                             );
                             return Ok(CachedBuildStatus::Stale(cached_build));
                         }
@@ -281,7 +280,6 @@ impl SourceBuildCacheStatusSpec {
                             {
                                 tracing::debug!(
                                     "package is stale because its build dependency '{identifier}' has changed",
-                                    identifier = source.name.as_source()
                                 );
                                 return Ok(CachedBuildStatus::Stale(cached_build));
                             }

--- a/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build_cache_status/mod.rs
@@ -31,8 +31,11 @@ use crate::{
 /// 2. A build dependency changed.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SourceBuildCacheStatusSpec {
-    /// Describes the package to query in the source build cache.
-    pub package: PackageIdentifier,
+    /// The name of the package to query in the source build cache.
+    pub package_name: rattler_conda_types::PackageName,
+
+    /// The specific variant of the package to query (from the lock file)
+    pub package_variant: std::collections::BTreeMap<String, pixi_record::VariantValue>,
 
     /// Describes the source location of the package to query.
     pub source: PinnedSourceSpec,

--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -7,7 +7,9 @@ use futures::TryStreamExt;
 use itertools::{Either, Itertools};
 use miette::Diagnostic;
 use pixi_build_types::procedures::conda_outputs::CondaOutput;
-use pixi_record::{InputHash, PinnedSourceSpec, PixiRecord, SourceRecord, SourceRecordWithMetadata};
+use pixi_record::{
+    InputHash, PinnedSourceSpec, PixiRecord, SourceRecord, SourceRecordWithMetadata,
+};
 use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceSpec, SpecConversionError};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::{

--- a/crates/pixi_command_dispatcher/src/variant.rs
+++ b/crates/pixi_command_dispatcher/src/variant.rs
@@ -34,6 +34,10 @@ impl SelectedVariant {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &VariantValue)> {
         self.0.iter()
     }
+
+    pub fn get(&self, key: &str) -> Option<&VariantValue> {
+        self.0.get(key)
+    }
 }
 
 impl PartialEq<BTreeMap<String, pixi_build_types::VariantValue>> for SelectedVariant {
@@ -54,6 +58,17 @@ impl PartialEq<BTreeMap<String, pixi_build_types::VariantValue>> for SelectedVar
 impl std::fmt::Debug for SelectedVariant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_map().entries(self.0.iter()).finish()
+    }
+}
+
+impl std::fmt::Display for SelectedVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            write!(f, "{{ }}")
+        } else {
+            let str = serde_json::to_string(&self.0).unwrap_or_default();
+            write!(f, "{str}")
+        }
     }
 }
 
@@ -97,10 +112,34 @@ impl Ord for VariantValue {
 impl Display for VariantValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VariantValue::String(s) => write!(f, "{}", s),
-            VariantValue::Int(i) => write!(f, "{}", i),
-            VariantValue::Bool(b) => write!(f, "{}", b),
+            VariantValue::String(s) => write!(f, "{s}"),
+            VariantValue::Int(i) => write!(f, "{i}"),
+            VariantValue::Bool(b) => write!(f, "{b}"),
         }
+    }
+}
+
+impl From<bool> for VariantValue {
+    fn from(value: bool) -> Self {
+        VariantValue::Bool(value)
+    }
+}
+
+impl From<i64> for VariantValue {
+    fn from(value: i64) -> Self {
+        VariantValue::Int(value)
+    }
+}
+
+impl From<String> for VariantValue {
+    fn from(value: String) -> Self {
+        VariantValue::String(value)
+    }
+}
+
+impl From<&str> for VariantValue {
+    fn from(value: &str) -> Self {
+        VariantValue::String(value.to_string())
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/variant.rs
+++ b/crates/pixi_command_dispatcher/src/variant.rs
@@ -1,0 +1,167 @@
+use std::fmt::Display;
+use std::{cmp::Ordering, collections::BTreeMap};
+
+use serde::{Deserialize, Serialize};
+
+/// A collection of key-value pairs representing selected conda-build variants for a package.
+#[derive(Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SelectedVariant(pub BTreeMap<String, VariantValue>);
+
+impl<K: Into<String>, V: Into<VariantValue>, I: IntoIterator<Item = (K, V)>> From<I>
+    for SelectedVariant
+{
+    fn from(iter: I) -> Self {
+        Self(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
+impl<V: From<VariantValue>> From<SelectedVariant> for BTreeMap<String, V> {
+    fn from(selected: SelectedVariant) -> Self {
+        selected
+            .0
+            .into_iter()
+            .map(|(k, v)| (k, V::from(v)))
+            .collect()
+    }
+}
+
+impl SelectedVariant {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &VariantValue)> {
+        self.0.iter()
+    }
+}
+
+impl PartialEq<BTreeMap<String, pixi_build_types::VariantValue>> for SelectedVariant {
+    fn eq(&self, other: &BTreeMap<String, pixi_build_types::VariantValue>) -> bool {
+        if self.0.len() != other.len() {
+            return false;
+        }
+        for (key, value) in &self.0 {
+            match other.get(key) {
+                Some(other_value) if value == other_value => continue,
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+impl std::fmt::Debug for SelectedVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entries(self.0.iter()).finish()
+    }
+}
+
+///
+/// Variants are used in conda-build to specify different build configurations.
+/// They can be strings (e.g., "3.11" for python version), integers (e.g., 1 for feature flags),
+/// or booleans (e.g., true/false for optional features).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum VariantValue {
+    /// String variant value (most common, e.g., python version "3.11")
+    String(String),
+    /// Integer variant value (e.g., for numeric feature flags)
+    Int(i64),
+    /// Boolean variant value (e.g., for on/off features)
+    Bool(bool),
+}
+
+impl PartialOrd for VariantValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VariantValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        #[allow(clippy::match_same_arms)]
+        match (self, other) {
+            (VariantValue::String(a), VariantValue::String(b)) => a.cmp(b),
+            (VariantValue::Int(a), VariantValue::Int(b)) => a.cmp(b),
+            (VariantValue::Bool(a), VariantValue::Bool(b)) => a.cmp(b),
+            // Define ordering between different types for deterministic sorting
+            (VariantValue::String(_), _) => Ordering::Less,
+            (_, VariantValue::String(_)) => Ordering::Greater,
+            (VariantValue::Int(_), VariantValue::Bool(_)) => Ordering::Less,
+            (VariantValue::Bool(_), VariantValue::Int(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl Display for VariantValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VariantValue::String(s) => write!(f, "{}", s),
+            VariantValue::Int(i) => write!(f, "{}", i),
+            VariantValue::Bool(b) => write!(f, "{}", b),
+        }
+    }
+}
+
+impl From<pixi_build_types::VariantValue> for VariantValue {
+    fn from(value: pixi_build_types::VariantValue) -> Self {
+        match value {
+            pixi_build_types::VariantValue::String(s) => VariantValue::String(s),
+            pixi_build_types::VariantValue::Int(i) => VariantValue::Int(i),
+            pixi_build_types::VariantValue::Bool(b) => VariantValue::Bool(b),
+        }
+    }
+}
+
+impl From<VariantValue> for pixi_build_types::VariantValue {
+    fn from(value: VariantValue) -> Self {
+        match value {
+            VariantValue::String(s) => Self::String(s),
+            VariantValue::Int(i) => Self::Int(i),
+            VariantValue::Bool(b) => Self::Bool(b),
+        }
+    }
+}
+
+impl From<VariantValue> for pixi_record::VariantValue {
+    fn from(value: VariantValue) -> Self {
+        match value {
+            VariantValue::String(s) => pixi_record::VariantValue::String(s),
+            VariantValue::Int(i) => pixi_record::VariantValue::Int(i),
+            VariantValue::Bool(b) => pixi_record::VariantValue::Bool(b),
+        }
+    }
+}
+
+impl From<pixi_record::VariantValue> for VariantValue {
+    fn from(value: pixi_record::VariantValue) -> Self {
+        match value {
+            pixi_record::VariantValue::String(s) => Self::String(s),
+            pixi_record::VariantValue::Int(i) => Self::Int(i),
+            pixi_record::VariantValue::Bool(b) => Self::Bool(b),
+        }
+    }
+}
+
+impl PartialEq<pixi_build_types::VariantValue> for VariantValue {
+    fn eq(&self, other: &pixi_build_types::VariantValue) -> bool {
+        match (self, other) {
+            (VariantValue::String(a), pixi_build_types::VariantValue::String(b)) => a == b,
+            (VariantValue::Int(a), pixi_build_types::VariantValue::Int(b)) => a == b,
+            (VariantValue::Bool(a), pixi_build_types::VariantValue::Bool(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<pixi_record::VariantValue> for VariantValue {
+    fn eq(&self, other: &pixi_record::VariantValue) -> bool {
+        match (self, other) {
+            (VariantValue::String(a), pixi_record::VariantValue::String(b)) => a == b,
+            (VariantValue::Int(a), pixi_record::VariantValue::Int(b)) => a == b,
+            (VariantValue::Bool(a), pixi_record::VariantValue::Bool(b)) => a == b,
+            _ => false,
+        }
+    }
+}

--- a/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
@@ -124,7 +124,7 @@ pub enum Event {
         id: BackendSourceBuildId,
         #[serde(skip_serializing_if = "Option::is_none")]
         context: Option<ReporterContext>,
-        package: PackageIdentifier,
+        package_name: rattler_conda_types::PackageName,
     },
     BackendSourceBuildStarted {
         id: BackendSourceBuildId,
@@ -502,7 +502,7 @@ impl BackendSourceBuildReporter for EventReporter {
         let event = Event::BackendSourceBuildQueued {
             id: next_id,
             context,
-            package: spec.package.clone(),
+            package_name: spec.package_name.clone(),
         };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);

--- a/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
@@ -6,9 +6,9 @@ use std::{
 use futures::{Stream, StreamExt};
 use pixi_command_dispatcher::{
     BackendSourceBuildSpec, BuildBackendMetadataSpec, CondaSolveReporter, GitCheckoutReporter,
-    InstallPixiEnvironmentSpec, InstantiateToolEnvironmentSpec, PackageIdentifier,
-    PixiEnvironmentSpec, PixiInstallReporter, PixiSolveReporter, Reporter, ReporterContext,
-    SolveCondaEnvironmentSpec, SourceBuildSpec, SourceMetadataSpec,
+    InstallPixiEnvironmentSpec, InstantiateToolEnvironmentSpec, PixiEnvironmentSpec,
+    PixiInstallReporter, PixiSolveReporter, Reporter, ReporterContext, SolveCondaEnvironmentSpec,
+    SourceBuildSpec, SourceMetadataSpec,
     reporter::{
         BackendSourceBuildId, BackendSourceBuildReporter, BuildBackendMetadataId,
         BuildBackendMetadataReporter, CondaSolveId, GitCheckoutId, InstantiateToolEnvId,

--- a/crates/pixi_command_dispatcher/tests/integration/event_tree.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_tree.rs
@@ -162,7 +162,7 @@ impl EventTree {
                 Event::SourceBuildQueued { id, context, spec } => {
                     source_build_label.insert(
                         *id,
-                        format!("{} @ {}", spec.package.name.as_source(), spec.source),
+                        format!("{} @ {}", spec.package_name.as_source(), spec.source),
                     );
                     builder.set_event_parent((*id).into(), *context);
                 }
@@ -175,10 +175,10 @@ impl EventTree {
                 Event::SourceBuildFinished { .. } => {}
                 Event::BackendSourceBuildQueued {
                     id,
-                    package,
+                    package_name,
                     context,
                 } => {
-                    backend_source_build_labels.insert(*id, package.name.as_source().to_owned());
+                    backend_source_build_labels.insert(*id, package_name.as_source().to_owned());
                     builder.set_event_parent((*id).into(), *context);
                 }
                 Event::BackendSourceBuildStarted { id } => {

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -18,7 +18,7 @@ use pixi_command_dispatcher::{
     SourceBuildCacheStatusSpec,
 };
 use pixi_config::default_channel_config;
-use pixi_record::PinnedPathSpec;
+use pixi_record::{PinnedPathSpec, PixiRecord};
 use pixi_spec::{GitReference, GitSpec, PathSpec, PixiSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_test_utils::format_diagnostic;
@@ -112,10 +112,10 @@ pub async fn simple_test() {
         .await
         .unwrap();
 
-    dispatcher
+    if let Err(err) = dispatcher
         .install_pixi_environment(InstallPixiEnvironmentSpec {
             name: "test-env".to_owned(),
-            records: records.clone(),
+            records: records.iter().cloned().map(PixiRecord::from).collect(),
             prefix: Prefix::create(&prefix_dir).unwrap(),
             installed: None,
             build_environment: build_env,
@@ -132,7 +132,9 @@ pub async fn simple_test() {
             enabled_protocols: Default::default(),
         })
         .await
-        .unwrap();
+    {
+        panic!("{}", format_diagnostic(&err))
+    }
 
     println!(
         "Built the environment successfully: {}",

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -14,7 +14,7 @@ use pixi_build_backend_passthrough::PassthroughBackend;
 use pixi_build_frontend::{BackendOverride, InMemoryOverriddenBackends};
 use pixi_command_dispatcher::{
     BuildEnvironment, CacheDirs, CommandDispatcher, Executor, InstallPixiEnvironmentSpec,
-    InstantiateToolEnvironmentSpec, PackageIdentifier, PixiEnvironmentSpec,
+    InstantiateToolEnvironmentSpec, PackageIdentifier, PixiEnvironmentSpec, SelectedVariant,
     SourceBuildCacheStatusSpec,
 };
 use pixi_config::default_channel_config;
@@ -492,8 +492,8 @@ pub async fn test_stale_host_dependency_triggers_rebuild() {
     let rebuild_packages = second_events
         .iter()
         .filter_map(|event| match event {
-            event_reporter::Event::BackendSourceBuildQueued { package, .. } => {
-                Some(package.name.as_normalized())
+            event_reporter::Event::BackendSourceBuildQueued { package_name, .. } => {
+                Some(package_name.as_normalized())
             }
             _ => None,
         })
@@ -562,7 +562,8 @@ async fn source_build_cache_status_clear_works() {
     };
 
     let spec = SourceBuildCacheStatusSpec {
-        package: pkg,
+        package_name: pkg.name,
+        package_variant: SelectedVariant::default(),
         source: PinnedPathSpec {
             path: tmp_dir.path().to_string_lossy().into_owned().into(),
         }
@@ -690,8 +691,8 @@ pub async fn test_force_rebuild() {
     let rebuild_packages = second_events
         .iter()
         .filter_map(|event| match event {
-            event_reporter::Event::BackendSourceBuildQueued { package, .. } => {
-                Some(package.name.as_normalized())
+            event_reporter::Event::BackendSourceBuildQueued { package_name, .. } => {
+                Some(package_name.as_normalized())
             }
             _ => None,
         })
@@ -722,8 +723,8 @@ pub async fn test_force_rebuild() {
     let rebuild_packages = second_events
         .iter()
         .filter_map(|event| match event {
-            event_reporter::Event::BackendSourceBuildQueued { package, .. } => {
-                Some(package.name.as_normalized())
+            event_reporter::Event::BackendSourceBuildQueued { package_name, .. } => {
+                Some(package_name.as_normalized())
             }
             _ => None,
         })
@@ -750,8 +751,8 @@ pub async fn test_force_rebuild() {
     let rebuild_packages = last_events
         .iter()
         .filter_map(|event| match event {
-            event_reporter::Event::BackendSourceBuildQueued { package, .. } => {
-                Some(package.name.as_normalized())
+            event_reporter::Event::BackendSourceBuildQueued { package_name, .. } => {
+                Some(package_name.as_normalized())
             }
             _ => None,
         })

--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -263,6 +263,26 @@ async fn find_unsatisfiable_targets<'p>(
                         .insert(platform);
                 }
             }
+
+            if lock_file.version() < rattler_lock::FileFormatVersion::V7
+                && locked_environment
+                    .packages(platform)
+                    .into_iter()
+                    .flatten()
+                    .any(|p| p.as_source_conda().is_some())
+            {
+                tracing::info!(
+                    "environment '{0}' for platform {platform} is out of date because the lock-file contains source packages in an old specification (v{1}) which is not longer supported",
+                    environment.name().fancy_display(),
+                    lock_file.version()
+                );
+
+                unsatisfiable_targets
+                    .outdated_conda
+                    .entry(environment.clone())
+                    .or_default()
+                    .insert(platform);
+            }
         }
     }
 

--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -415,18 +415,16 @@ fn find_inconsistent_solve_groups<'p>(
 
             for package in locked_env.packages(platform).into_iter().flatten() {
                 match package {
-                    LockedPackageRef::Conda(pkg) => {
-                        match conda_packages_by_name.get(&pkg.record().name) {
-                            None => {
-                                conda_packages_by_name
-                                    .insert(pkg.record().name.clone(), pkg.location().clone());
-                            }
-                            Some(url) if pkg.location() != url => {
-                                conda_package_mismatch = true;
-                            }
-                            _ => {}
+                    LockedPackageRef::Conda(pkg) => match conda_packages_by_name.get(pkg.name()) {
+                        None => {
+                            conda_packages_by_name
+                                .insert(pkg.name().clone(), pkg.location().clone());
                         }
-                    }
+                        Some(url) if pkg.location() != url => {
+                            conda_package_mismatch = true;
+                        }
+                        _ => {}
+                    },
                     LockedPackageRef::Pypi(pkg, _) => match pypi_packages_by_name.get(&pkg.name) {
                         None => {
                             pypi_packages_by_name.insert(pkg.name.clone(), pkg.location.clone());

--- a/crates/pixi_core/src/lock_file/resolve/resolver_provider.rs
+++ b/crates/pixi_core/src/lock_file/resolve/resolver_provider.rs
@@ -42,7 +42,7 @@ impl<Context: BuildContext> ResolverProvider for CondaResolverProvider<'_, Conte
     ) -> impl Future<Output = uv_resolver::PackageVersionsResult> + 'io {
         if let Some((repodata_record, identifier)) = self.conda_python_identifiers.get(package_name)
         {
-            let version = repodata_record.package_record().version.to_string();
+            let version = &identifier.version.to_string();
 
             tracing::debug!(
                 "overriding PyPI package version request {}=={}",

--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -710,7 +710,7 @@ pub async fn verify_platform_satisfiability(
         Ok(pixi_records) => pixi_records,
         Err(duplicate) => {
             return Err(Box::new(PlatformUnsat::DuplicateEntry(
-                duplicate.package_record().name.as_source().to_string(),
+                duplicate.name().as_source().to_string(),
             )));
         }
     };
@@ -1306,7 +1306,7 @@ pub(crate) async fn verify_package_platform_satisfiability(
                 }
 
                 let record = &locked_pixi_records.records[idx.0];
-                for depends in &record.package_record().depends {
+                for depends in record.depends() {
                     let spec = MatchSpec::from_str(depends.as_str(), Lenient)
                         .map_err(|e| PlatformUnsat::FailedToParseMatchSpec(depends.clone(), e))?;
 
@@ -1316,11 +1316,7 @@ pub(crate) async fn verify_package_platform_satisfiability(
                             SourceAnchor::Workspace,
                         ),
                         PixiRecord::Source(record) => (
-                            Cow::Owned(format!(
-                                "{} @ {}",
-                                record.package_record.name.as_source(),
-                                &record.source
-                            )),
+                            Cow::Owned(format!("{} @ {}", record.name.as_source(), &record.source)),
                             SourceSpec::from(record.source.clone()).into(),
                         ),
                     };
@@ -1478,9 +1474,9 @@ pub(crate) async fn verify_package_platform_satisfiability(
         .iter()
         .filter_map(PixiRecord::as_source)
     {
-        if !expected_conda_source_dependencies.contains(&record.package_record.name) {
+        if !expected_conda_source_dependencies.contains(&record.name) {
             return Err(Box::new(PlatformUnsat::RequiredBinaryIsSource(
-                record.package_record.name.as_source().to_string(),
+                record.name.as_source().to_string(),
             )));
         }
     }

--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -1995,6 +1995,8 @@ mod tests {
     async fn test_failing_satisiability(
         #[files("../../tests/data/non-satisfiability/*/pixi.toml")] manifest_path: PathBuf,
     ) {
+        eprintln!("Path to pixi.toml: {}", manifest_path.display());
+
         let report_handler = NarratableReportHandler::new().with_cause_chain();
 
         let project = Workspace::from_path(&manifest_path).unwrap();

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -30,7 +30,7 @@ use pixi_install_pypi::{
 };
 use pixi_manifest::{ChannelPriority, EnvironmentName, FeaturesExt};
 use pixi_progress::global_multi_progress;
-use pixi_record::{ParseLockFileError, PixiRecord};
+use pixi_record::{ParseLockFileError, PixiPackageRecord, PixiRecord};
 use pixi_utils::{prefix::Prefix, variants::VariantConfig};
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
@@ -1994,7 +1994,9 @@ async fn spawn_solve_conda_environment_task(
         mapping_client
             .amend_purls(
                 &pypi_name_mapping_location,
-                records.iter_mut().filter_map(PixiRecord::as_binary_mut),
+                records
+                    .iter_mut()
+                    .filter_map(PixiPackageRecord::as_binary_mut),
                 None,
             )
             .await
@@ -2002,7 +2004,9 @@ async fn spawn_solve_conda_environment_task(
     }
 
     // Turn the records into a map by name
-    let records_by_name = PixiRecordsByName::from(records);
+    let records_by_name =
+        PixiRecordsByName::from_unique_iter(records.into_iter().map(PixiRecord::from))
+            .expect("records returned by solve must have unique names");
 
     let end = Instant::now();
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -734,9 +734,7 @@ impl Workspace {
         filter_lock_file(self, lock_file, |env, platform, package| {
             if affected_environments.contains(&(env.name().as_str(), platform)) {
                 match package {
-                    LockedPackageRef::Conda(package) => {
-                        !conda_packages.contains(&package.record().name)
-                    }
+                    LockedPackageRef::Conda(package) => !conda_packages.contains(package.name()),
                     LockedPackageRef::Pypi(package, _env) => !pypi_packages.contains(&package.name),
                 }
             } else {

--- a/crates/pixi_diff/src/lib.rs
+++ b/crates/pixi_diff/src/lib.rs
@@ -333,9 +333,15 @@ impl LockFileDiff {
                                     console::style("~").yellow(),
                                     consts::CondaEmoji,
                                     name,
-                                    choose_style(&previous.version.as_str(), &current.version.as_str()),
+                                    choose_style(
+                                        &previous.version.as_str(),
+                                        &current.version.as_str()
+                                    ),
                                     choose_style(previous.build.as_str(), current.build.as_str()),
-                                    choose_style(&current.version.as_str(), &previous.version.as_str()),
+                                    choose_style(
+                                        &current.version.as_str(),
+                                        &previous.version.as_str()
+                                    ),
                                     choose_style(current.build.as_str(), previous.build.as_str()),
                                 )
                             }

--- a/crates/pixi_diff/src/lib.rs
+++ b/crates/pixi_diff/src/lib.rs
@@ -9,7 +9,7 @@ use itertools::{Either, Itertools};
 use pixi_consts::consts;
 use pixi_manifest::{EnvironmentName, FeaturesExt};
 use rattler_conda_types::Platform;
-use rattler_lock::{LockFile, LockedPackage, LockedPackageRef};
+use rattler_lock::{CondaPackageData, LockFile, LockedPackage, LockedPackageRef};
 use serde::Serialize;
 use serde_json::Value;
 use tabwriter::TabWriter;
@@ -57,10 +57,9 @@ impl LockFileDiff {
                     .into_iter()
                     .flatten()
                     .partition_map(|p| match p {
-                        LockedPackageRef::Conda(conda_package_data) => Either::Left((
-                            conda_package_data.record().name.clone(),
-                            conda_package_data,
-                        )),
+                        LockedPackageRef::Conda(conda_package_data) => {
+                            Either::Left((conda_package_data.name(), conda_package_data))
+                        }
                         LockedPackageRef::Pypi(pypi_package_data, pypi_env_data) => {
                             Either::Right((
                                 pypi_package_data.name.clone(),
@@ -75,7 +74,7 @@ impl LockFileDiff {
                 for package in packages {
                     match package {
                         LockedPackageRef::Conda(data) => {
-                            let name = &data.record().name;
+                            let name = &data.name();
                             match previous_conda_packages.remove(name) {
                                 Some(previous) if previous.location() != data.location() => {
                                     diff.changed
@@ -254,9 +253,22 @@ impl LockFileDiff {
 
         fn format_package_identifier(package: &LockedPackage) -> String {
             match package {
-                LockedPackage::Conda(p) => {
-                    format!("{} {}", &p.record().version.as_str(), &p.record().build)
-                }
+                LockedPackage::Conda(p) => match p {
+                    CondaPackageData::Binary(binary) => {
+                        format!(
+                            "{} {}",
+                            &binary.package_record.version.as_str(),
+                            &binary.package_record.build
+                        )
+                    }
+                    CondaPackageData::Source(conda_source_data) => {
+                        format!(
+                            "{} @ {}",
+                            conda_source_data.name.as_source(),
+                            conda_source_data.location
+                        )
+                    }
+                },
                 LockedPackage::Pypi(p, _) => p.version.to_string(),
             }
         }
@@ -310,19 +322,48 @@ impl LockFileDiff {
                 let name = previous.name();
                 let line = match (previous, current) {
                     (LockedPackage::Conda(previous), LockedPackage::Conda(current)) => {
-                        let previous = previous.record();
-                        let current = current.record();
+                        // Handle both Binary and Source variants
+                        match (previous.as_binary(), current.as_binary()) {
+                            (Some(prev_binary), Some(curr_binary)) => {
+                                let previous = &prev_binary.package_record;
+                                let current = &curr_binary.package_record;
 
-                        format!(
-                            "{} {} {}\t{} {}\t->\t{} {}",
-                            console::style("~").yellow(),
-                            consts::CondaEmoji,
-                            name,
-                            choose_style(&previous.version.as_str(), &current.version.as_str()),
-                            choose_style(previous.build.as_str(), current.build.as_str()),
-                            choose_style(&current.version.as_str(), &previous.version.as_str()),
-                            choose_style(current.build.as_str(), previous.build.as_str()),
-                        )
+                                format!(
+                                    "{} {} {}\t{} {}\t->\t{} {}",
+                                    console::style("~").yellow(),
+                                    consts::CondaEmoji,
+                                    name,
+                                    choose_style(&previous.version.as_str(), &current.version.as_str()),
+                                    choose_style(previous.build.as_str(), current.build.as_str()),
+                                    choose_style(&current.version.as_str(), &previous.version.as_str()),
+                                    choose_style(current.build.as_str(), previous.build.as_str()),
+                                )
+                            }
+                            // For source packages, show location instead of version/build
+                            (Some(_), None) | (None, Some(_)) => {
+                                // Transition between binary and source
+                                format!(
+                                    "{} {} {} (binary <-> source)",
+                                    console::style("~").yellow(),
+                                    consts::CondaEmoji,
+                                    name,
+                                )
+                            }
+                            (None, None) => {
+                                // Both are source packages, show location
+                                let prev_location = previous.location().to_string();
+                                let curr_location = current.location().to_string();
+
+                                format!(
+                                    "{} {} {}\t{}\t->\t{}",
+                                    console::style("~").yellow(),
+                                    consts::CondaEmoji,
+                                    name,
+                                    choose_style(&prev_location, &curr_location),
+                                    choose_style(&curr_location, &prev_location),
+                                )
+                            }
+                        }
                     }
                     (LockedPackage::Pypi(previous, _), LockedPackage::Pypi(current, _)) => {
                         format!(
@@ -404,13 +445,13 @@ impl LockFileJsonDiff {
 
                 let add_diffs = packages_diff.added.into_iter().map(|new| match new {
                     LockedPackage::Conda(pkg) => JsonPackageDiff {
-                        name: pkg.record().name.as_normalized().to_string(),
+                        name: pkg.name().as_normalized().to_string(),
                         before: None,
                         after: Some(
                             serde_json::to_value(&pkg).expect("should be able to serialize"),
                         ),
                         ty: JsonPackageType::Conda,
-                        explicit: conda_dependencies.contains_key(&pkg.record().name),
+                        explicit: conda_dependencies.contains_key(pkg.name()),
                     },
                     LockedPackage::Pypi(pkg, _) => JsonPackageDiff {
                         name: pkg.name.as_dist_info_name().into_owned(),
@@ -425,13 +466,13 @@ impl LockFileJsonDiff {
 
                 let removed_diffs = packages_diff.removed.into_iter().map(|old| match old {
                     LockedPackage::Conda(pkg) => JsonPackageDiff {
-                        name: pkg.record().name.as_normalized().to_string(),
+                        name: pkg.name().as_normalized().to_string(),
                         before: Some(
                             serde_json::to_value(&pkg).expect("should be able to serialize"),
                         ),
                         after: None,
                         ty: JsonPackageType::Conda,
-                        explicit: conda_dependencies.contains_key(&pkg.record().name),
+                        explicit: conda_dependencies.contains_key(pkg.name()),
                     },
 
                     LockedPackage::Pypi(pkg, _) => JsonPackageDiff {
@@ -452,11 +493,11 @@ impl LockFileJsonDiff {
                             let after = serde_json::to_value(&new).expect("should be able to serialize");
                             let (before, after) = compute_json_diff(before, after);
                             JsonPackageDiff {
-                                name: old.record().name.as_normalized().to_string(),
+                                name: old.name().as_normalized().to_string(),
                                 before: Some(before),
                                 after: Some(after),
                                 ty: JsonPackageType::Conda,
-                                explicit: conda_dependencies.contains_key(&old.record().name),
+                                explicit: conda_dependencies.contains_key(old.name()),
                             }
                         }
                     (LockedPackage::Pypi(old, _), LockedPackage::Pypi(new, _)) => {

--- a/crates/pixi_glob/src/snapshots/pixi_glob__glob_hash__test__glob_hash_case_1_satisfiability.snap
+++ b/crates/pixi_glob/src/snapshots/pixi_glob__glob_hash__test__glob_hash_case_1_satisfiability.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 Globs:
 - tests/data/satisfiability/source-dependency/**/*
-Hash: 3ed91dc28b0561c516e9e9eccd7f977f3ec45fe8b36883f5201389fced4a7aaa
+Hash: e9b1ff09360893cd09292a2fce60f80174b76716c7c125735527263d4f5db23f
 Matched files:
 - tests/data/satisfiability/source-dependency/child-package/pixi.toml
 - tests/data/satisfiability/source-dependency/pixi.lock

--- a/crates/pixi_global/src/common.rs
+++ b/crates/pixi_global/src/common.rs
@@ -1259,7 +1259,7 @@ mod tests {
         #[cfg(windows)]
         {
             for script_name in script_names {
-                let script_path = bin_dir.path().join(format!("{}.bat", script_name));
+                let script_path = bin_dir.path().join(format!("{script_name}.bat"));
                 let script = format!(
                     r#"
             @"{}" %*
@@ -1267,7 +1267,7 @@ mod tests {
                     env_dir
                         .path()
                         .join("bin")
-                        .join(format!("{}.exe", script_name))
+                        .join(format!("{script_name}.exe"))
                         .to_string_lossy()
                 );
                 tokio_fs::write(&script_path, script).await.unwrap();

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -612,7 +612,7 @@ impl Project {
         let result = command_dispatcher
             .install_pixi_environment(InstallPixiEnvironmentSpec {
                 name: env_name.to_string(),
-                records: pixi_records,
+                records: pixi_records.into_iter().map(From::from).collect(),
                 prefix: rattler_conda_types::prefix::Prefix::create(prefix.root())
                     .into_diagnostic()?,
                 build_environment,
@@ -1408,11 +1408,14 @@ impl Project {
         match packages.len() {
             0 => Err(InferPackageNameError::NoPackageOutputs),
             1 => {
-                let package = &packages[0];
-                Ok(package.name.clone())
+                let (package_name, _) = &packages[0];
+                Ok(package_name.clone())
             }
             _ => {
-                let package_names: Vec<_> = packages.iter().map(|p| p.name.as_source()).collect();
+                let package_names: Vec<_> = packages
+                    .iter()
+                    .map(|(package_name, _)| package_name.as_source())
+                    .collect();
                 Err(InferPackageNameError::MultiplePackageOutputs {
                     package_names: package_names.join(", "),
                 })

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -26,10 +26,7 @@ use pixi_uv_conversions::{
     to_exclude_newer, to_index_strategy,
 };
 use plan::{InstallPlanner, InstallReason, NeedReinstall, PyPIInstallationPlan};
-use pypi_modifiers::{
-    Tags,
-    pypi_tags::{get_pypi_tags, is_python_record},
-};
+use pypi_modifiers::{Tags, pypi_tags::get_pypi_tags};
 use rattler_conda_types::Platform;
 use rattler_lock::{PypiIndexes, PypiPackageData, PypiPackageEnvironmentData};
 use rayon::prelude::*;

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use conda_pypi_clobber::PypiCondaClobberRegistry;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
-use miette::{IntoDiagnostic, WrapErr};
+use miette::{IntoDiagnostic, WrapErr, miette};
 use pixi_consts::consts;
 use pixi_manifest::{
     EnvironmentName, SystemRequirements,
@@ -318,14 +318,17 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         // Determine the current environment markers.
         let python_record = pixi_records
             .iter()
-            .find(|r| is_python_record(r))
+            .find(|r| r.name() == &rattler_conda_types::PackageName::new_unchecked("python"))
             .cloned()
             .ok_or_else(|| miette::miette!("could not resolve pypi dependencies because no python interpreter is added to the dependencies of the project.\nMake sure to add a python interpreter to the [dependencies] section of the {manifest}, or run:\n\n\tpixi add python", manifest=consts::WORKSPACE_MANIFEST))?;
 
+        // TODO: resolve python record if its a source record
         let tags = get_pypi_tags(
             self.config.platform,
             self.config.system_requirements,
-            python_record.package_record(),
+            python_record
+                .package_record()
+                .ok_or_else(|| miette!("python from source is not yet supported"))?,
         )?;
 
         let index_locations = self

--- a/crates/pixi_record/Cargo.toml
+++ b/crates/pixi_record/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
+chrono = { workspace = true }
 file_url = { workspace = true }
 miette = { workspace = true }
 pixi_git = { workspace = true }

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -40,6 +40,15 @@ impl PixiRecord {
         }
     }
 
+    /// Returns the version of the package if it is known.
+    pub fn version(&self) -> Option<&VersionWithSource> {
+        match self {
+            PixiRecord::Binary(record) => Some(&record.package_record.version),
+            PixiRecord::Source(record) => record.version.as_ref(),
+        }
+    }
+
+    /// The dependencies of the package
     pub fn depends(&self) -> &[String] {
         match self {
             PixiRecord::Binary(record) => &record.package_record.depends,
@@ -47,6 +56,7 @@ impl PixiRecord {
         }
     }
 
+    /// The constraints of the package
     pub fn constrains(&self) -> &[String] {
         match self {
             PixiRecord::Binary(record) => &record.package_record.constrains,
@@ -179,6 +189,7 @@ impl Matches<PixiRecord> for MatchSpec {
 /// is persisted).
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum PixiPackageRecord {
     Binary(RepoDataRecord),
     Source(SourcePackageRecord),

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -11,6 +11,10 @@ use serde::Serialize;
 pub use source_record::{InputHash, SourceRecord, SourceRecordWithMetadata};
 // Re-export VariantValue for convenience
 pub use rattler_lock::VariantValue;
+
+/// A map of variant keys to their selected values.
+/// Used to uniquely identify which output variant of a source package to build.
+pub type SelectedVariant = std::collections::BTreeMap<String, VariantValue>;
 use thiserror::Error;
 
 /// A record of a conda package that is either something installable from a
@@ -29,6 +33,20 @@ impl PixiRecord {
         match self {
             PixiRecord::Binary(record) => &record.package_record.name,
             PixiRecord::Source(record) => &record.name,
+        }
+    }
+
+    pub fn depends(&self) -> &[String] {
+        match self {
+            PixiRecord::Binary(record) => &record.package_record.depends,
+            PixiRecord::Source(record) => &record.depends,
+        }
+    }
+
+    pub fn constrains(&self) -> &[String] {
+        match self {
+            PixiRecord::Binary(record) => &record.package_record.constrains,
+            PixiRecord::Source(record) => &record.constrains,
         }
     }
 

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -6,10 +6,10 @@ use rattler_conda_types::{
     package::RunExportsJson,
 };
 use rattler_digest::{Md5Hash, Sha256, Sha256Hash};
-use rattler_lock::{CondaPackageData, CondaSourceData, VariantValue};
+use rattler_lock::{CondaPackageData, CondaSourceData};
 use serde::{Deserialize, Serialize};
 
-use crate::{ParseLockFileError, PinnedSourceSpec};
+use crate::{ParseLockFileError, PinnedSourceSpec, SelectedVariant};
 
 /// A record of a conda package that still requires building.
 /// This is stored in the lock file and doesn't include version/build information.
@@ -23,7 +23,7 @@ pub struct SourceRecord {
 
     /// Conda-build variants used to disambiguate between multiple source packages
     /// at the same location.
-    pub variants: BTreeMap<String, VariantValue>,
+    pub variants: SelectedVariant,
 
     /// Specification of packages this package depends on
     pub depends: Vec<String>,

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use pixi_spec::SourceSpec;
 use rattler_conda_types::{
-    package::RunExportsJson, MatchSpec, Matches, NoArchType, PackageName, PackageRecord,
-    PackageUrl, VersionWithSource,
+    MatchSpec, Matches, NoArchType, PackageName, PackageRecord, PackageUrl, VersionWithSource,
+    package::RunExportsJson,
 };
 use rattler_digest::{Md5Hash, Sha256, Sha256Hash};
 use rattler_lock::{CondaPackageData, CondaSourceData, VariantValue};

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -1,22 +1,45 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use pixi_spec::SourceSpec;
-use rattler_conda_types::{MatchSpec, Matches, NamelessMatchSpec, PackageRecord};
-use rattler_digest::{Sha256, Sha256Hash};
-use rattler_lock::{CondaPackageData, CondaSourceData};
+use rattler_conda_types::{
+    package::RunExportsJson, MatchSpec, Matches, NoArchType, PackageName, PackageRecord,
+    PackageUrl, VersionWithSource,
+};
+use rattler_digest::{Md5Hash, Sha256, Sha256Hash};
+use rattler_lock::{CondaPackageData, CondaSourceData, VariantValue};
 use serde::{Deserialize, Serialize};
 
 use crate::{ParseLockFileError, PinnedSourceSpec};
 
 /// A record of a conda package that still requires building.
+/// This is stored in the lock file and doesn't include version/build information.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SourceRecord {
-    /// Information about the conda package. This is metadata of the package
-    /// after it has been build.
-    pub package_record: PackageRecord,
+    /// The name of the package
+    pub name: PackageName,
 
     /// Exact definition of the source of the package.
     pub source: PinnedSourceSpec,
+
+    /// Conda-build variants used to disambiguate between multiple source packages
+    /// at the same location.
+    pub variants: BTreeMap<String, VariantValue>,
+
+    /// Specification of packages this package depends on
+    pub depends: Vec<String>,
+
+    /// Additional constraints on packages
+    pub constrains: Vec<String>,
+
+    /// Experimental: additional dependencies grouped by feature name
+    pub experimental_extra_depends: BTreeMap<String, Vec<String>>,
+
+    /// The specific license of the package
+    pub license: Option<String>,
+
+    /// Package identifiers of packages that are equivalent to this package but
+    /// from other ecosystems (e.g., PyPI)
+    pub purls: Option<BTreeSet<PackageUrl>>,
 
     /// The hash of the input that was used to build the metadata of the
     /// package. This can be used to verify that the metadata is still valid.
@@ -28,6 +51,107 @@ pub struct SourceRecord {
     /// Specifies which packages are expected to be installed as source packages
     /// and from which location.
     pub sources: HashMap<String, SourceSpec>,
+
+    /// Python site-packages path if this is a Python package
+    pub python_site_packages_path: Option<String>,
+}
+
+/// A source record with full metadata contains the complete package information after it has been
+/// resolved/built, including version and build information.
+/// This is used during solving and building, but not stored in the lock file.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SourceRecordWithMetadata {
+    /// The base source record
+    pub source_record: SourceRecord,
+
+    /// The version of the package
+    pub version: VersionWithSource,
+
+    /// The build string of the package
+    pub build: String,
+
+    /// The build number of the package
+    pub build_number: rattler_conda_types::BuildNumber,
+
+    /// The subdir of the package
+    pub subdir: String,
+
+    /// Optionally the architecture the package supports
+    pub arch: Option<String>,
+
+    /// Optionally the platform the package supports
+    pub platform: Option<String>,
+
+    /// MD5 hash of the package archive
+    pub md5: Option<Md5Hash>,
+
+    /// SHA256 hash of the package archive
+    pub sha256: Option<Sha256Hash>,
+
+    /// Size of the package archive in bytes
+    pub size: Option<u64>,
+
+    /// Track features
+    pub track_features: Vec<String>,
+
+    /// Features (deprecated)
+    pub features: Option<String>,
+
+    /// License family
+    pub license_family: Option<String>,
+
+    /// Timestamp of when the package was built
+    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+
+    /// Run exports information
+    pub run_exports: Option<RunExportsJson>,
+
+    /// NoArch type
+    pub noarch: NoArchType,
+
+    /// Legacy bz2 MD5 hash
+    pub legacy_bz2_md5: Option<Md5Hash>,
+
+    /// Legacy bz2 size
+    pub legacy_bz2_size: Option<u64>,
+}
+
+impl From<SourceRecordWithMetadata> for PackageRecord {
+    fn from(value: SourceRecordWithMetadata) -> Self {
+        PackageRecord {
+            name: value.source_record.name,
+            version: value.version,
+            build: value.build,
+            build_number: value.build_number,
+            subdir: value.subdir,
+            depends: value.source_record.depends,
+            constrains: value.source_record.constrains,
+            arch: value.arch,
+            platform: value.platform,
+            md5: value.md5,
+            sha256: value.sha256,
+            size: value.size,
+            license: value.source_record.license,
+            license_family: value.license_family,
+            purls: value.source_record.purls,
+            track_features: value.track_features,
+            features: value.features,
+            timestamp: value.timestamp,
+            run_exports: value.run_exports,
+            experimental_extra_depends: value.source_record.experimental_extra_depends,
+            noarch: value.noarch,
+            legacy_bz2_md5: value.legacy_bz2_md5,
+            legacy_bz2_size: value.legacy_bz2_size,
+            python_site_packages_path: value.source_record.python_site_packages_path,
+        }
+    }
+}
+
+impl SourceRecordWithMetadata {
+    /// Convert to a PackageRecord
+    pub fn as_package_record(&self) -> PackageRecord {
+        self.clone().into()
+    }
 }
 
 /// Defines the hash of the input files that were used to build the metadata of
@@ -49,19 +173,25 @@ pub struct InputHash {
 impl From<SourceRecord> for CondaPackageData {
     fn from(value: SourceRecord) -> Self {
         CondaPackageData::Source(CondaSourceData {
-            package_record: value.package_record,
+            name: value.name,
             location: value.source.into(),
-            input: value.input_hash.map(|i| rattler_lock::InputHash {
-                hash: i.hash,
-                // TODO: fix this in rattler
-                globs: Vec::from_iter(i.globs),
-            }),
+            variants: value.variants,
+            depends: value.depends,
+            constrains: value.constrains,
+            experimental_extra_depends: value.experimental_extra_depends,
+            license: value.license,
+            purls: value.purls,
             sources: value
                 .sources
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
+            input: value.input_hash.map(|i| rattler_lock::InputHash {
+                hash: i.hash,
+                globs: Vec::from_iter(i.globs),
+            }),
             package_build_source: None,
+            python_site_packages_path: value.python_site_packages_path,
         })
     }
 }
@@ -71,8 +201,14 @@ impl TryFrom<CondaSourceData> for SourceRecord {
 
     fn try_from(value: CondaSourceData) -> Result<Self, Self::Error> {
         Ok(Self {
-            package_record: value.package_record,
+            name: value.name,
             source: value.location.try_into()?,
+            variants: value.variants,
+            depends: value.depends,
+            constrains: value.constrains,
+            experimental_extra_depends: value.experimental_extra_depends,
+            license: value.license,
+            purls: value.purls,
             input_hash: value.input.map(|hash| InputHash {
                 hash: hash.hash,
                 globs: BTreeSet::from_iter(hash.globs),
@@ -82,30 +218,18 @@ impl TryFrom<CondaSourceData> for SourceRecord {
                 .into_iter()
                 .map(|(k, v)| (k, SourceSpec::from(v)))
                 .collect(),
+            python_site_packages_path: value.python_site_packages_path,
         })
-    }
-}
-
-impl Matches<SourceRecord> for NamelessMatchSpec {
-    fn matches(&self, pkg: &SourceRecord) -> bool {
-        if !self.matches(&pkg.package_record) {
-            return false;
-        }
-
-        if self.channel.is_some() {
-            // We don't have a channel in a source record. So if a matchspec requires that
-            // information it can't match.
-            return false;
-        }
-
-        true
     }
 }
 
 impl Matches<SourceRecord> for MatchSpec {
     fn matches(&self, pkg: &SourceRecord) -> bool {
-        if !self.matches(&pkg.package_record) {
-            return false;
+        // Check if the name matches
+        if let Some(ref name) = self.name {
+            if name != &pkg.name {
+                return false;
+            }
         }
 
         if self.channel.is_some() {
@@ -114,12 +238,8 @@ impl Matches<SourceRecord> for MatchSpec {
             return false;
         }
 
+        // For source packages, version, build, and build_number are not stored
+        // in the lock file, so we only match by name
         true
-    }
-}
-
-impl AsRef<PackageRecord> for SourceRecord {
-    fn as_ref(&self) -> &PackageRecord {
-        &self.package_record
     }
 }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -36,6 +36,9 @@ pub struct SourceRecord {
     /// at the same location.
     pub variants: SelectedVariant,
 
+    /// Optionally the version of the package
+    pub version: Option<VersionWithSource>,
+
     /// Specification of packages this package depends on
     pub depends: Vec<String>,
 
@@ -201,6 +204,7 @@ impl From<SourceRecord> for CondaPackageData {
             name: value.name,
             location: value.source.into(),
             variants: value.variants,
+            version: value.version,
             depends: value.depends,
             constrains: value.constrains,
             experimental_extra_depends: value.experimental_extra_depends,
@@ -228,6 +232,7 @@ impl TryFrom<CondaSourceData> for SourceRecord {
         Ok(Self {
             name: value.name,
             source: value.location.try_into()?,
+            version: value.version,
             variants: value.variants,
             depends: value.depends,
             constrains: value.constrains,

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -262,6 +262,12 @@ impl Matches<SourceRecord> for MatchSpec {
             }
         }
 
+        if let (Some(version_spec), Some(version)) = (&self.version, &pkg.version) {
+            if !version_spec.matches(version) {
+                return false;
+            }
+        }
+
         if self.channel.is_some() {
             // We don't have a channel in a source record. So if a matchspec requires that
             // information it can't match.

--- a/crates/pixi_reporters/src/download_verify_reporter.rs
+++ b/crates/pixi_reporters/src/download_verify_reporter.rs
@@ -146,7 +146,7 @@ impl BuildDownloadVerifyReporter {
         entries.insert(
             id,
             Entry {
-                name: format!("building {}", spec.package.name.as_source()),
+                name: format!("building {}", spec.package_name.as_source()),
                 size: None,
                 state: EntryState::Pending,
             },

--- a/examples/pixi-build/array-api-extra/pixi.lock
+++ b/examples/pixi-build/array-api-extra/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -10,9 +10,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/array-api-compat-1.12.0-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.44-ha97dd6f_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
@@ -23,7 +23,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.0-h5989046_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.0-h32b2ec7_102_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
@@ -35,14 +35,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.5.2-h750e83c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libmpdec-4.0.0-h6e16a3a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.5.4-h230baf5_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/python-3.14.0-h759804c_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/python-3.14.0-hf88997e_102_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-hf689a15_2.conda
@@ -55,14 +55,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h5505292_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.4-h5503f6c_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.0-h8929636_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.0-h40d2674_102_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
@@ -74,13 +74,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.4-h725018a_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/python-3.14.0-h6fd79ff_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/win-64/python-3.14.0-h4b44e0e_102_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
@@ -122,19 +122,17 @@ packages:
   timestamp: 1747403732947
 - conda: .
   name: array-api-extra
-  version: 0.8.0
-  build: pyh4616a5c_0
-  subdir: noarch
   depends:
   - python >=3.10
   - python *
   - array-api-compat
   license: MIT
   input:
-    hash: 1101422a995a18b9c73ca5617a726f185782e5329c2739d754b921baaf16b7ca
+    hash: fe9f9c29f1f198e2c28d9586f19a7ae6762b0f867789c6a91ed9948620b0f2c3
     globs:
-    - recipe.yaml
     - variants.yaml
+  variants:
+    target_platform: noarch
 - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
   sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
   md5: 51a19bba1b8ebfb60df25cde030b7ebc
@@ -199,17 +197,17 @@ packages:
   license_family: MIT
   size: 11857802
   timestamp: 1720853997952
-- conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.44-ha97dd6f_2.conda
-  sha256: 707dfb8d55d7a5c6f95c772d778ef07a7ca85417d9971796f7d3daad0b615de8
-  md5: 14bae321b8127b63cba276bd53fac237
+- conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_3.conda
+  sha256: e26f4435c372264136a9c71e19f7620ec7f107abe73134ff305d26bfaeabb0b3
+  md5: 72cc69c30de0b6d39c7f97f501fdbb1c
   depends:
   - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
   constrains:
   - binutils_impl_linux-64 2.44
   license: GPL-3.0-only
-  license_family: GPL
-  size: 747158
-  timestamp: 1758810907507
+  size: 741904
+  timestamp: 1761248509961
 - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
   sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
   md5: 4211416ecba1866fab0c6470986c22d6
@@ -257,45 +255,45 @@ packages:
   license_family: MIT
   size: 141322
   timestamp: 1752719767870
-- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
-  md5: ede4673863426c0883c0063d853bbd85
+- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
+  md5: 35f29eec58405aaf55e01cb470d8c26a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 57433
-  timestamp: 1743434498161
-- conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-  sha256: 6394b1bc67c64a21a5cc73d1736d1d4193a64515152e861785c44d2cfc49edf3
-  md5: 4ca9ea59839a9ca8df84170fab4ceb41
+  size: 57821
+  timestamp: 1760295480630
+- conda: https://prefix.dev/conda-forge/osx-64/libffi-3.5.2-h750e83c_0.conda
+  sha256: 277dc89950f5d97f1683f26e362d6dca3c2efa16cb2f6fdb73d109effa1cd3d0
+  md5: d214916b24c625bcc459b245d509f22e
   depends:
   - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 51216
-  timestamp: 1743434595269
-- conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
-  md5: c215a60c2935b517dcda8cad4705734d
+  size: 52573
+  timestamp: 1760295626449
+- conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+  sha256: 9b8acdf42df61b7bfe8bdc545c016c29e61985e79748c64ad66df47dbc2e295f
+  md5: 411ff7cd5d1472bba0f55c0faf04453b
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 39839
-  timestamp: 1743434670405
-- conda: https://prefix.dev/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
-  sha256: d3b0b8812eab553d3464bbd68204f007f1ebadf96ce30eb0cbc5159f72e353f5
-  md5: 85d8fa5e55ed8f93f874b3b23ed54ec6
+  size: 40251
+  timestamp: 1760295839166
+- conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+  sha256: ddff25aaa4f0aa535413f5d831b04073789522890a4d8626366e43ecde1534a3
+  md5: ba4ad812d2afc22b9a34ce8327a0930f
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
-  size: 44978
-  timestamp: 1743435053850
+  size: 44866
+  timestamp: 1760295760649
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
   sha256: 08f9b87578ab981c7713e4e6a7d935e40766e10691732bba376d4964562bcb45
   md5: c0374badb3a5d4b1372db28d19462c53
@@ -576,16 +574,16 @@ packages:
   license_family: Apache
   size: 9218823
   timestamp: 1759326176247
-- conda: https://prefix.dev/conda-forge/linux-64/python-3.14.0-h5989046_101_cp314.conda
-  build_number: 101
-  sha256: 61ae2c29b1097c12161a09a4061be8f909bc1387d8388e875d8ed5e357ef0824
-  md5: b2ad21488149ec2c4d83640619de2430
+- conda: https://prefix.dev/conda-forge/linux-64/python-3.14.0-h32b2ec7_102_cp314.conda
+  build_number: 102
+  sha256: 76d750045b94fded676323bfd01975a26a474023635735773d0e4d80aaa72518
+  md5: 0a19d2cc6eb15881889b0c6fa7d6a78d
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libexpat >=2.7.1,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
@@ -600,18 +598,18 @@ packages:
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 36692257
-  timestamp: 1760299587505
+  size: 36681389
+  timestamp: 1761176838143
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://prefix.dev/conda-forge/osx-64/python-3.14.0-h759804c_101_cp314.conda
-  build_number: 101
-  sha256: a93cf6bbd5bf2fe0ddab09f5dadad49b41bc13eb85c35d8ae84d3989624fca2f
-  md5: 9eca06d9b62b949495b072df4ac1d2a2
+- conda: https://prefix.dev/conda-forge/osx-64/python-3.14.0-hf88997e_102_cp314.conda
+  build_number: 102
+  sha256: 2470866eee70e75d6be667aa537424b63f97c397a0a90f05f2bab347b9ed5a51
+  md5: 7917d1205eed3e72366a3397dca8a2af
   depends:
   - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.7.1,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
   - libsqlite >=3.50.4,<4.0a0
@@ -624,18 +622,18 @@ packages:
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 14431661
-  timestamp: 1760300228434
+  size: 14427639
+  timestamp: 1761177864469
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.0-h8929636_101_cp314.conda
-  build_number: 101
-  sha256: 0b821bbff81b0735d94aca62958b152ad9565773f99760fe0dd59db8e7154245
-  md5: 01a476ede0de7e71c2e9b178315cc7f1
+- conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.0-h40d2674_102_cp314.conda
+  build_number: 102
+  sha256: 3ca1da026fe5df8a479d60e1d3ed02d9bc50fcbafd5f125d86abe70d21a34cc7
+  md5: a9ff09231c555da7e30777747318321b
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.7.1,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
   - libsqlite >=3.50.4,<4.0a0
@@ -648,17 +646,17 @@ packages:
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 13530883
-  timestamp: 1760298885457
+  size: 13590581
+  timestamp: 1761177195716
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://prefix.dev/conda-forge/win-64/python-3.14.0-h6fd79ff_101_cp314.conda
-  build_number: 101
-  sha256: 469a62c550143b30f26bdbb445d2596c7299ad8e278763388793ed106773a1ee
-  md5: 834cb790da2cbee272bf888e4558c92a
+- conda: https://prefix.dev/conda-forge/win-64/python-3.14.0-h4b44e0e_102_cp314.conda
+  build_number: 102
+  sha256: 2b8c8fcafcc30690b4c5991ee28eb80c962e50e06ce7da03b2b302e2d39d6a81
+  md5: 3e1ce2fb0f277cebcae01a3c418eb5e2
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libexpat >=2.7.1,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
   - libsqlite >=3.50.4,<4.0a0
@@ -672,8 +670,8 @@ packages:
   - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 16903251
-  timestamp: 1760298231628
+  size: 16706286
+  timestamp: 1761175439068
   python_site_packages_path: Lib/site-packages
 - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   build_number: 8

--- a/examples/pixi-build/cpp-sdl/pixi.lock
+++ b/examples/pixi-build/cpp-sdl/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -7,8 +7,8 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gettext-0.25.1-h3f43e3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gettext-tools-0.25.1-h3f43e3d_1.conda
@@ -16,21 +16,21 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libcap-2.76-h0b2e76d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-0.25.1-h3f43e3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgettextpo-devel-0.25.1-h3f43e3d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.84.3-hf39c6af_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.86.0-h32235b2_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
@@ -38,8 +38,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_4.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libudev1-257.9-h085a93f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
@@ -48,18 +48,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libvulkan-loader-1.4.328.1-h5279c79_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.11.0-he8b52b9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.8-h2cb61b6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.12.2-hca5e8e5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.1-hf2a90c1_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.1-h031cc0b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sdl3-3.2.24-h68140b3_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.45-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
@@ -71,52 +72,56 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - conda: .
-        subdir: linux-64
+        variants:
+          target_platform: linux-64
       osx-64:
-      - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://prefix.dev/conda-forge/osx-64/dbus-1.16.2-h27bd348_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libcxx-21.1.3-h3d58e20_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libcxx-21.1.4-h3d58e20_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libexpat-2.7.1-h21dd04a_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libffi-3.5.2-h750e83c_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libglib-2.86.0-h6ca3a76_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libusb-1.0.29-h2287256_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libvulkan-loader-1.4.328.1-hfc0b2d5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.46-ha3e7e28_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/sdl2-2.32.56-h53ec75d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/sdl3-3.2.24-h53c92ef_0.conda
       - conda: .
-        subdir: osx-64
+        variants:
+          target_platform: osx-64
       osx-arm64:
-      - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/dbus-1.16.2-hda038a8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-21.1.3-hf598326_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-21.1.4-hf598326_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.86.0-he69a767_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libvulkan-loader-1.4.328.1-h49c215f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.46-h7125dd6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sdl2-2.32.56-h248ca61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sdl3-3.2.24-h919df07_0.conda
       - conda: .
-        subdir: osx-arm64
+        variants:
+          target_platform: osx-arm64
       win-64:
       - conda: https://prefix.dev/conda-forge/win-64/libusb-1.0.29-h1839187_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libvulkan-loader-1.4.328.1-h477610d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/sdl2-2.32.56-h5112557_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/sdl3-3.2.24-h5112557_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: .
-        build: h9352c13_0
+        variants:
+          cxx_compiler: vs2019
 packages:
 - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -137,43 +142,44 @@ packages:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- conda: https://prefix.dev/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-  sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
-  md5: d9c69a24ad678ffce24c6543a0176b00
-  depends:
-  - libgcc-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 71042
-  timestamp: 1660065501192
-- conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
-  md5: 62ee74e96c5ebb0af99386de58cf9553
+- conda: https://prefix.dev/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
+  sha256: a9c114cbfeda42a226e2db1809a538929d2f118ef855372293bd188f71711c48
+  md5: 791365c5f65975051e4e017b5da3abf5
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
+  - libgcc >=13
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 68072
+  timestamp: 1756738968573
+- conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+  sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
+  md5: 51a19bba1b8ebfb60df25cde030b7ebc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
-  size: 252783
-  timestamp: 1720974456583
-- conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
-  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
-  md5: 7ed4301d437b59045be7e051a0308211
+  size: 260341
+  timestamp: 1757437258798
+- conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
+  sha256: 8f50b58efb29c710f3cecf2027a8d7325ba769ab10c746eff75cea3ac050b10c
+  md5: 97c4b3bd8a90722104798175a1bdddbf
   depends:
   - __osx >=10.13
   license: bzip2-1.0.6
   license_family: BSD
-  size: 134188
-  timestamp: 1720974491916
-- conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  size: 132607
+  timestamp: 1757437730085
+- conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+  sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
+  md5: 58fd217444c2a5701a44244faf518206
   depends:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
-  size: 122909
-  timestamp: 1720974522888
+  size: 125061
+  timestamp: 1757437486465
 - conda: https://prefix.dev/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
   sha256: 3b988146a50e165f0fa4e839545c679af88e4782ec284cc7b6d07dd226d6a068
   md5: 679616eb5ad4e521c83da4650860aba7
@@ -282,35 +288,35 @@ packages:
   license_family: BSD
   size: 121852
   timestamp: 1744577167992
-- conda: https://prefix.dev/conda-forge/osx-64/libcxx-21.1.3-h3d58e20_0.conda
-  sha256: 9bba2ce10e1c390a4091ca48fab0c71c010f6526c27ac2da53399940ad4c113f
-  md5: 432d125a340932454d777b66b09c32a1
+- conda: https://prefix.dev/conda-forge/osx-64/libcxx-21.1.4-h3d58e20_0.conda
+  sha256: 64f58f7ad9076598ae4a19f383f6734116d96897032c77de599660233f2924f9
+  md5: 17c4292004054f6783b16b55b499f086
   depends:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 571632
-  timestamp: 1760166417842
-- conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-21.1.3-hf598326_0.conda
-  sha256: b9bad452e3e1d0cc597d907681461341209cb7576178d5c1933026a650b381d1
-  md5: e976227574dfcd0048324576adf8d60d
+  size: 571252
+  timestamp: 1761043932993
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-21.1.4-hf598326_0.conda
+  sha256: df55e80dda21f2581366f66cf18a6c11315d611f6fb01e56011c5199f983c0d9
+  md5: 6002a2ba796f1387b6a5c6d77051d1db
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 568715
-  timestamp: 1760166479630
-- conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
-  sha256: f53458db897b93b4a81a6dbfd7915ed8fa4a54951f97c698dde6faa028aadfd2
-  md5: 4c0ab57463117fbb8df85268415082f5
+  size: 567892
+  timestamp: 1761043967532
+- conda: https://prefix.dev/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+  sha256: c076a213bd3676cc1ef22eeff91588826273513ccc6040d9bea68bccdc849501
+  md5: 9314bc5a1fe7d1044dc9dfd3ef400535
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - libpciaccess >=0.18,<0.19.0a0
   license: MIT
   license_family: MIT
-  size: 246161
-  timestamp: 1749904704373
+  size: 310785
+  timestamp: 1757212153962
 - conda: https://prefix.dev/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
   sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
   md5: c151d5eb730e9b7480e6d48c0fc44048
@@ -354,34 +360,34 @@ packages:
   license_family: MIT
   size: 65971
   timestamp: 1752719657566
-- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
-  md5: ede4673863426c0883c0063d853bbd85
+- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
+  md5: 35f29eec58405aaf55e01cb470d8c26a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 57433
-  timestamp: 1743434498161
-- conda: https://prefix.dev/conda-forge/osx-64/libffi-3.4.6-h281671d_1.conda
-  sha256: 6394b1bc67c64a21a5cc73d1736d1d4193a64515152e861785c44d2cfc49edf3
-  md5: 4ca9ea59839a9ca8df84170fab4ceb41
+  size: 57821
+  timestamp: 1760295480630
+- conda: https://prefix.dev/conda-forge/osx-64/libffi-3.5.2-h750e83c_0.conda
+  sha256: 277dc89950f5d97f1683f26e362d6dca3c2efa16cb2f6fdb73d109effa1cd3d0
+  md5: d214916b24c625bcc459b245d509f22e
   depends:
   - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 51216
-  timestamp: 1743434595269
-- conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
-  md5: c215a60c2935b517dcda8cad4705734d
+  size: 52573
+  timestamp: 1760295626449
+- conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+  sha256: 9b8acdf42df61b7bfe8bdc545c016c29e61985e79748c64ad66df47dbc2e295f
+  md5: 411ff7cd5d1472bba0f55c0faf04453b
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 39839
-  timestamp: 1743434670405
+  size: 40251
+  timestamp: 1760295839166
 - conda: https://prefix.dev/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
   sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
   md5: ee48bf17cc83a00f59ca1494d5646869
@@ -395,28 +401,28 @@ packages:
   license_family: BSD
   size: 394383
   timestamp: 1687765514062
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_4.conda
-  sha256: 144e35c1c2840f2dc202f6915fc41879c19eddbb8fa524e3ca4aa0d14018b26f
-  md5: f406dcbb2e7bef90d793e50e79a2882b
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+  sha256: 08f9b87578ab981c7713e4e6a7d935e40766e10691732bba376d4964562bcb45
+  md5: c0374badb3a5d4b1372db28d19462c53
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.1.0=*_4
-  - libgomp 15.1.0 h767d61c_4
+  - libgomp 15.2.0 h767d61c_7
+  - libgcc-ng ==15.2.0=*_7
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 824153
-  timestamp: 1753903866511
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_4.conda
-  sha256: 76ceac93ed98f208363d6e9c75011b0ff7b97b20f003f06461a619557e726637
-  md5: 28771437ffcd9f3417c66012dc49a3be
+  size: 822552
+  timestamp: 1759968052178
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
+  sha256: 2045066dd8e6e58aaf5ae2b722fb6dfdbb57c862b5f34ac7bfb58c40ef39b6ad
+  md5: 280ea6eee9e2ddefde25ff799c4f0363
   depends:
-  - libgcc 15.1.0 h767d61c_4
+  - libgcc 15.2.0 h767d61c_7
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 29249
-  timestamp: 1753903872571
+  size: 29313
+  timestamp: 1759968065504
 - conda: https://prefix.dev/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
   sha256: dc9c7d7a6c0e6639deee6fde2efdc7e119e7739a6b229fa5f9049a449bae6109
   md5: 8504a291085c9fb809b66cabd5834307
@@ -460,51 +466,51 @@ packages:
   license: LicenseRef-libglvnd
   size: 134712
   timestamp: 1731330998354
-- conda: https://prefix.dev/conda-forge/linux-64/libglib-2.84.3-hf39c6af_0.conda
-  sha256: e1ad3d9ddaa18f95ff5d244587fd1a37aca6401707f85a37f7d9b5002fcf16d0
-  md5: 467f23819b1ea2b89c3fc94d65082301
+- conda: https://prefix.dev/conda-forge/linux-64/libglib-2.86.0-h32235b2_1.conda
+  sha256: 8f4ccf81ebde248f8a8070a987e2dc7caa02471ae3506667da8e02176a8e0060
+  md5: a400fd9bad095c7cdf74661552ef802f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - libiconv >=1.18,<2.0a0
   - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.45,<10.46.0a0
+  - pcre2 >=10.46,<10.47.0a0
   constrains:
-  - glib 2.84.3 *_0
+  - glib 2.86.0 *_1
   license: LGPL-2.1-or-later
-  size: 3961899
-  timestamp: 1754315006443
-- conda: https://prefix.dev/conda-forge/osx-64/libglib-2.84.3-h5fed8df_0.conda
-  sha256: 28d60cfaa74dd5427b35941ea28069bfd87d4dfdaaae79b13e569b4b4c21098d
-  md5: 2bb92de7159f9c47a4455eb3c08484d8
+  size: 3963505
+  timestamp: 1761244787601
+- conda: https://prefix.dev/conda-forge/osx-64/libglib-2.86.0-h6ca3a76_1.conda
+  sha256: 1203396d3e367efcb38ae1500ff26d48459ebdbbec57ab811ad1406078e35bd0
+  md5: 030b0493f4bcabc77e5a56d03169a0bc
   depends:
   - __osx >=10.13
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libiconv >=1.18,<2.0a0
   - libintl >=0.25.1,<1.0a0
   - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.45,<10.46.0a0
+  - pcre2 >=10.46,<10.47.0a0
   constrains:
-  - glib 2.84.3 *_0
+  - glib 2.86.0 *_1
   license: LGPL-2.1-or-later
-  size: 3735183
-  timestamp: 1754315274931
-- conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.84.3-h587fa63_0.conda
-  sha256: a30510a18f0b85a036f99c744750611b5f26b972cfa70cc9f130b9f42e5bbc18
-  md5: bb98995c244b6038892fd59a694a93ed
+  size: 3685678
+  timestamp: 1761246545220
+- conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.86.0-he69a767_1.conda
+  sha256: 58b0ccce58b6503cd9448d332c46de9b0757bee6251eb14ac5dd95f7ad3e83fe
+  md5: 16edb7fa702df38c414e1638de3596de
   depends:
   - __osx >=11.0
-  - libffi >=3.4.6,<3.5.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - libiconv >=1.18,<2.0a0
   - libintl >=0.25.1,<1.0a0
   - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.45,<10.46.0a0
+  - pcre2 >=10.46,<10.47.0a0
   constrains:
-  - glib 2.84.3 *_0
+  - glib 2.86.0 *_1
   license: LGPL-2.1-or-later
-  size: 3661135
-  timestamp: 1754315631978
+  size: 3656888
+  timestamp: 1761246684692
 - conda: https://prefix.dev/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
   sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
   md5: 434ca7e50e40f4918ab701e3facd59a0
@@ -523,15 +529,15 @@ packages:
   license: LicenseRef-libglvnd
   size: 75504
   timestamp: 1731330988898
-- conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_4.conda
-  sha256: e0487a8fec78802ac04da0ac1139c3510992bc58a58cde66619dde3b363c2933
-  md5: 3baf8976c96134738bba224e9ef6b1e5
+- conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
+  sha256: e9fb1c258c8e66ee278397b5822692527c5f5786d372fe7a869b900853f3f5ca
+  md5: f7b4d76975aac7e5d9e6ad13845f92fe
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 447289
-  timestamp: 1753903801049
+  size: 447919
+  timestamp: 1759967942498
 - conda: https://prefix.dev/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
   sha256: 697334de4786a1067ea86853e520c64dd72b11a05137f5b318d8a444007b5e60
   md5: 2bd47db5807daade8500ed7ca4c512a4
@@ -643,25 +649,27 @@ packages:
   license_family: LGPL
   size: 354372
   timestamp: 1695747735668
-- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_4.conda
-  sha256: b5b239e5fca53ff90669af1686c86282c970dd8204ebf477cf679872eb6d48ac
-  md5: 3c376af8888c386b9d3d1c2701e2f3ab
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+  sha256: 1b981647d9775e1cdeb2fab0a4dd9cd75a6b0de2963f6c3953dbd712f78334b3
+  md5: 5b767048b1b3ee9a954b06f4084f93dc
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.1.0 h767d61c_4
+  - libgcc 15.2.0 h767d61c_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3903453
-  timestamp: 1753903894186
-- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_4.conda
-  sha256: 81c841c1cf4c0d06414aaa38a249f9fdd390554943065c3a0b18a9fb7e8cc495
-  md5: 2d34729cbc1da0ec988e57b13b712067
+  size: 3898269
+  timestamp: 1759968103436
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
+  sha256: 024fd46ac3ea8032a5ec3ea7b91c4c235701a8bf0e6520fe5e6539992a6bd05f
+  md5: f627678cf829bd70bccf141a19c3ad3e
   depends:
-  - libstdcxx 15.1.0 h8f9b012_4
+  - libstdcxx 15.2.0 h8f9b012_7
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 29317
-  timestamp: 1753903924491
+  size: 29343
+  timestamp: 1759968157195
 - conda: https://prefix.dev/conda-forge/linux-64/libsystemd0-257.9-h996ca69_0.conda
   sha256: 6b063df2d13dc9cedeae7b1591b1917ced7f4e1b04f7246e66cc7fb0088dea07
   md5: b6d222422c17dc11123e63fae4ad4178
@@ -829,24 +837,41 @@ packages:
   license_family: MIT
   size: 395888
   timestamp: 1727278577118
-- conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.11.0-he8b52b9_0.conda
-  sha256: 23f47e86cc1386e7f815fa9662ccedae151471862e971ea511c5c886aa723a54
-  md5: 74e91c36d0eef3557915c68b6c2bef96
+- conda: https://prefix.dev/conda-forge/linux-64/libxkbcommon-1.12.2-hca5e8e5_0.conda
+  sha256: e11e8890a097c9e16a3fc40f2540d887ef2497e7f31f6e5a744aa951f82dbeea
+  md5: 3c3e5ccbb2d96ac75e1b8b028586db5c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   - libxcb >=1.17.0,<2.0a0
-  - libxml2 >=2.13.8,<2.14.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - xkeyboard-config
   - xorg-libxau >=1.0.12,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
-  size: 791328
-  timestamp: 1754703902365
-- conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.13.8-h2cb61b6_1.conda
-  sha256: 2c80ef042b47dfddb1f425d57d367e0657f8477d80111644c88b172ff2f99151
-  md5: 42a8e4b54e322b4cd1dbfb30a8a7ce9e
+  size: 830418
+  timestamp: 1760990182307
+- conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.1-h031cc0b_0.conda
+  sha256: ee64e507b37b073e0bdad739e35330933dd5be7c639600a096551a6968f1035d
+  md5: a67cd8f7b0369bbf2c40411f05a62f3b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 hf2a90c1_0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 45292
+  timestamp: 1761015784683
+- conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.1-hf2a90c1_0.conda
+  sha256: f5220ff49efc31431279859049199b9250e79f98c1dee1da12feb74bda2d9cf1
+  md5: 23720d17346b21efb08d68c2255c8431
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -854,11 +879,12 @@ packages:
   - liblzma >=5.8.1,<6.0a0
   - libzlib >=1.3.1,<2.0a0
   constrains:
+  - libxml2 2.15.1
   - icu <0.0a0
   license: MIT
   license_family: MIT
-  size: 697020
-  timestamp: 1754315347913
+  size: 554734
+  timestamp: 1761015772672
 - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -915,40 +941,40 @@ packages:
   license_family: LGPL
   size: 491140
   timestamp: 1730581373280
-- conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
-  sha256: 27c4014f616326240dcce17b5f3baca3953b6bc5f245ceb49c3fa1e6320571eb
-  md5: b90bece58b4c2bf25969b70f3be42d25
+- conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
+  sha256: 5c7380c8fd3ad5fc0f8039069a45586aa452cf165264bc5a437ad80397b32934
+  md5: 7fa07cb0fb1b625a089ccc01218ee5b1
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=13
+  - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1197308
-  timestamp: 1745955064657
-- conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.45-hf733adb_0.conda
-  sha256: 5b2c93ee8714c17682cd926127f1e712efef00441a79732635a80b24f5adc212
-  md5: d9f1976154f2f45588251dcfc48bcdda
+  size: 1209177
+  timestamp: 1756742976157
+- conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.46-ha3e7e28_0.conda
+  sha256: cb262b7f369431d1086445ddd1f21d40003bb03229dfc1d687e3a808de2663a6
+  md5: 3b504da3a4f6d8b2b1f969686a0bf0c0
   depends:
   - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1086588
-  timestamp: 1745955211398
-- conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.45-ha881caa_0.conda
-  sha256: e9ecb706b58b5a2047c077b3a1470e8554f3aad02e9c3c00cfa35d537420fea3
-  md5: a52385b93558d8e6bbaeec5d61a21cd7
+  size: 1097626
+  timestamp: 1756743061564
+- conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.46-h7125dd6_0.conda
+  sha256: 5bf2eeaa57aab6e8e95bea6bd6bb2a739f52eb10572d8ed259d25864d3528240
+  md5: 0e6e82c3cc3835f4692022e9b9cd5df8
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 837826
-  timestamp: 1745955207242
+  size: 835080
+  timestamp: 1756743041908
 - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -959,24 +985,24 @@ packages:
   license_family: MIT
   size: 8252
   timestamp: 1726802366959
-- conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
-  sha256: d2377bb571932f2373f593b7b2fc3b9728dc6ae5b993b1b65d7f2c8bb39a0b49
-  md5: 66b1fa9608d8836e25f9919159adc9c6
+- conda: https://prefix.dev/conda-forge/linux-64/pulseaudio-client-17.0-h9a8bead_2.conda
+  sha256: 8a6729861c9813a756b0438c30bd271722fb3f239ded3afc3bf1cb03327a640e
+  md5: b6f21b1c925ee2f3f7fc37798c5988db
   depends:
   - __glibc >=2.17,<3.0.a0
-  - dbus >=1.13.6,<2.0a0
-  - libgcc >=13
-  - libglib >=2.82.2,<3.0a0
+  - dbus >=1.16.2,<2.0a0
+  - libgcc >=14
+  - libglib >=2.86.0,<3.0a0
   - libiconv >=1.18,<2.0a0
   - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=257.4
+  - libsystemd0 >=257.7
   - libxcb >=1.17.0,<2.0a0
   constrains:
-  - pulseaudio 17.0 *_1
+  - pulseaudio 17.0 *_2
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 764231
-  timestamp: 1742507189208
+  size: 761857
+  timestamp: 1757472971364
 - conda: https://prefix.dev/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
   sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
   md5: cdd138897d94dc07d99afe7113a07bec
@@ -1093,9 +1119,6 @@ packages:
   timestamp: 1759445836649
 - conda: .
   name: sdl_example
-  version: 0.1.0
-  build: h9352c13_0
-  subdir: win-64
   depends:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -1104,11 +1127,11 @@ packages:
   input:
     hash: edfac7bd3233d95d1173e54bb2b8900757a662b8a553d89225c1a81ea98796af
     globs: []
+  variants:
+    cxx_compiler: vs2019
+    target_platform: win-64
 - conda: .
   name: sdl_example
-  version: 0.1.0
-  build: hbf21a9e_0
-  subdir: linux-64
   depends:
   - libstdcxx >=15
   - libgcc >=15
@@ -1116,94 +1139,95 @@ packages:
   input:
     hash: edfac7bd3233d95d1173e54bb2b8900757a662b8a553d89225c1a81ea98796af
     globs: []
+  variants:
+    target_platform: linux-64
 - conda: .
   name: sdl_example
-  version: 0.1.0
-  build: hbf21a9e_0
-  subdir: osx-64
   depends:
   - libcxx >=21
   - sdl2 >=2.32.56,<3.0a0
   input:
     hash: edfac7bd3233d95d1173e54bb2b8900757a662b8a553d89225c1a81ea98796af
     globs: []
+  variants:
+    target_platform: osx-64
 - conda: .
   name: sdl_example
-  version: 0.1.0
-  build: hbf21a9e_0
-  subdir: osx-arm64
   depends:
   - libcxx >=21
   - sdl2 >=2.32.56,<3.0a0
   input:
     hash: edfac7bd3233d95d1173e54bb2b8900757a662b8a553d89225c1a81ea98796af
     globs: []
-- conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
-  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
-  md5: 6797b005cd0f439c4c5c9ac565783700
+  variants:
+    target_platform: osx-arm64
+- conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
   constrains:
+  - vc14_runtime >=14.29.30037
   - vs2015_runtime >=14.29.30037
   license: LicenseRef-MicrosoftWindowsSDK10
-  size: 559710
-  timestamp: 1728377334097
-- conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
-  sha256: cb357591d069a1e6cb74199a8a43a7e3611f72a6caed9faa49dbb3d7a0a98e0b
-  md5: 28f4ca1e0337d0f27afb8602663c5723
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
+  sha256: 82250af59af9ff3c6a635dd4c4764c631d854feb334d6747d356d949af44d7cf
+  md5: ef02bbe151253a72b8eda264a935db66
   depends:
-  - vc14_runtime >=14.44.35208
+  - vc14_runtime >=14.42.34433
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 18249
-  timestamp: 1753739241465
-- conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
-  sha256: af4b4b354b87a9a8d05b8064ff1ea0b47083274f7c30b4eb96bc2312c9b5f08f
-  md5: 603e41da40a765fd47995faa021da946
+  size: 18861
+  timestamp: 1760418772353
+- conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
+  sha256: e3a3656b70d1202e0d042811ceb743bd0d9f7e00e2acdf824d231b044ef6c0fd
+  md5: 378d5dcec45eaea8d303da6f00447ac0
   depends:
   - ucrt >=10.0.20348.0
-  - vcomp14 14.44.35208 h818238b_31
+  - vcomp14 14.44.35208 h818238b_32
   constrains:
-  - vs2015_runtime 14.44.35208.* *_31
+  - vs2015_runtime 14.44.35208.* *_32
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  size: 682424
-  timestamp: 1753739239305
-- conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
-  sha256: 67b317b64f47635415776718d25170a9a6f9a1218c0f5a6202bfd687e07b6ea4
-  md5: a6b1d5c1fc3cb89f88f7179ee6a9afe3
+  size: 682706
+  timestamp: 1760418629729
+- conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
+  sha256: f3790c88fbbdc55874f41de81a4237b1b91eab75e05d0e58661518ff04d2a8a1
+  md5: 58f67b437acbf2764317ba273d731f1d
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.44.35208.* *_31
+  - vs2015_runtime 14.44.35208.* *_32
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  size: 113963
-  timestamp: 1753739198723
-- conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
-  sha256: ba673427dcd480cfa9bbc262fd04a9b1ad2ed59a159bd8f7e750d4c52282f34c
-  md5: 0f2ca7906bf166247d1d760c3422cb8a
+  size: 114846
+  timestamp: 1760418593847
+- conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+  sha256: 3aa04ae8e9521d9b56b562376d944c3e52b69f9d2a0667f77b8953464822e125
+  md5: 035da2e4f5770f036ff704fa17aace24
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.0,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
-  - libgcc >=13
-  - libstdcxx >=13
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 330474
-  timestamp: 1751817998141
-- conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.45-hb9d3cd8_0.conda
-  sha256: a5d4af601f71805ec67403406e147c48d6bad7aaeae92b0622b7e2396842d3fe
-  md5: 397a013c2dc5145a70737871aaa87e98
+  size: 329779
+  timestamp: 1761174273487
+- conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
+  sha256: aa03b49f402959751ccc6e21932d69db96a65a67343765672f7862332aa32834
+  md5: 71ae752a748962161b4740eaff510258
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - xorg-libx11 >=1.8.12,<2.0a0
   license: MIT
   license_family: MIT
-  size: 392406
-  timestamp: 1749375847832
+  size: 396975
+  timestamp: 1759543819846
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
   sha256: 51909270b1a6c5474ed3978628b341b4d4472cd22610e5f22b506855a5e20f67
   md5: db038ce880f100acc74dba10302b5630

--- a/examples/pixi-build/recursive-run-dependencies/pixi.lock
+++ b/examples/pixi-build/recursive-run-dependencies/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -8,66 +8,71 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-h4bc722e_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/python-3.13.3-hf636f53_101_cp313.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.13-7_cp313.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.0-h32b2ec7_102_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - conda: src/depend
       - conda: src/root
       osx-arm64:
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.49.2-h3f77e49_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h5505292_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.13.3-h81fe080_101_cp313.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.13-7_cp313.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.4-h5503f6c_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.0-h40d2674_102_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
       - conda: src/depend
       - conda: src/root
       win-64:
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.0-he0c23c2_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.49.2-h67fdade_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/python-3.13.3-h261c0b1_101_cp313.conda
-      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.13-7_cp313.conda
-      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.4-h725018a_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/python-3.14.0-h4b44e0e_102_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_26.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_26.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
+      - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
       - conda: src/depend
       - conda: src/root
 packages:
@@ -90,237 +95,232 @@ packages:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- conda: https://prefix.dev/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
-  sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
-  md5: d88c38e66d85ecc9c7e2c4110676bbf4
+- conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+  sha256: ea5f4c876eff2ed469551b57f1cc889a3c01128bf3e2e10b1fea11c3ef39eac2
+  md5: c7eb87af73750d6fd97eff8bbee8cb9c
   depends:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
-  size: 297459
-  timestamp: 1733827374270
-- conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
-  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
-  md5: 62ee74e96c5ebb0af99386de58cf9553
+  size: 302296
+  timestamp: 1749686302834
+- conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
+  sha256: c30daba32ddebbb7ded490f0e371eae90f51e72db620554089103b4a6934b0d5
+  md5: 51a19bba1b8ebfb60df25cde030b7ebc
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
+  - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
-  size: 252783
-  timestamp: 1720974456583
-- conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
-  sha256: adfa71f158cbd872a36394c56c3568e6034aa55c623634b37a4836bd036e6b91
-  md5: fc6948412dbbbe9a4c9ddbbcfe0a79ab
+  size: 260341
+  timestamp: 1757437258798
+- conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
+  sha256: b456200636bd5fecb2bec63f7e0985ad2097cf1b83d60ce0b6968dffa6d02aa1
+  md5: 58fd217444c2a5701a44244faf518206
   depends:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
-  size: 122909
-  timestamp: 1720974522888
-- conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
-  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
-  md5: 276e7ffe9ffe39688abc665ef0f45596
+  size: 125061
+  timestamp: 1757437486465
+- conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
+  sha256: d882712855624641f48aa9dc3f5feea2ed6b4e6004585d3616386a18186fe692
+  md5: 1077e9333c41ff0be8edd1a5ec0ddace
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: bzip2-1.0.6
   license_family: BSD
-  size: 54927
-  timestamp: 1720974860185
-- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
-  sha256: 1454f3f53a3b828d3cb68a3440cb0fa9f1cc0e3c8c26e9e023773dc19d88cc06
-  md5: 23c7fd5062b48d8294fc7f61bf157fba
+  size: 55977
+  timestamp: 1757437738856
+- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
+  sha256: bfb7f9f242f441fdcd80f1199edd2ecf09acea0f2bcef6f07d7cbb1a8131a345
+  md5: e54200a1cd1fe33d61c9df8d3b00b743
   depends:
   - __win
   license: ISC
-  size: 152945
-  timestamp: 1745653639656
-- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
-  sha256: 2a70ed95ace8a3f8a29e6cd1476a943df294a7111dfb3e152e3478c4c889b7ac
-  md5: 95db94f75ba080a22eb623590993167b
+  size: 156354
+  timestamp: 1759649104842
+- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
+  sha256: 3b5ad78b8bb61b6cdc0978a6a99f8dfb2cc789a451378d054698441005ecbdb6
+  md5: f9e5fbc24009179e8b0409624691758a
   depends:
   - __unix
   license: ISC
-  size: 152283
-  timestamp: 1745653616541
+  size: 155907
+  timestamp: 1759649036195
 - conda: src/depend
   name: depend
-  version: 0.1.0
-  build: pyh4616a5c_0
-  subdir: noarch
   depends:
   - boltons
-  - python >=3.11
+  - python
   - python *
   input:
-    hash: d3f1cccaf86d7fdee5dd02d003d58293d9ba97e005544c9936160c26f5131ec0
-    globs:
-    - pyproject.toml
-- conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
-  sha256: db73f38155d901a610b2320525b9dd3b31e4949215c870685fd92ea61b5ce472
-  md5: 01f8d123c96816249efd255a31ad7712
+    hash: c33f206dfc06551f0242c7037fe4d8f019bf8fbb3473b626f808d8947b8671f7
+    globs: []
+  variants:
+    target_platform: noarch
+- conda: https://prefix.dev/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
+  sha256: 9ba12c93406f3df5ab0a43db8a4b4ef67a5871dfd401010fbe29b218b2cbe620
+  md5: 5eb22c1d7b3fc4abb50d92d621583137
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 11857802
+  timestamp: 1720853997952
+- conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_3.conda
+  sha256: e26f4435c372264136a9c71e19f7620ec7f107abe73134ff305d26bfaeabb0b3
+  md5: 72cc69c30de0b6d39c7f97f501fdbb1c
   depends:
   - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-64 2.43
+  - binutils_impl_linux-64 2.44
   license: GPL-3.0-only
-  license_family: GPL
-  size: 671240
-  timestamp: 1740155456116
-- conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
-  sha256: 33ab03438aee65d6aa667cf7d90c91e5e7d734c19a67aa4c7040742c0a13d505
-  md5: db0bfbe7dd197b68ad5f30333bae6ce0
+  size: 741904
+  timestamp: 1761248509961
+- conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
+  md5: 4211416ecba1866fab0c6470986c22d6
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   constrains:
-  - expat 2.7.0.*
+  - expat 2.7.1.*
   license: MIT
   license_family: MIT
-  size: 74427
-  timestamp: 1743431794976
-- conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
-  sha256: ee550e44765a7bbcb2a0216c063dcd53ac914a7be5386dd0554bd06e6be61840
-  md5: 6934bbb74380e045741eb8637641a65b
+  size: 74811
+  timestamp: 1752719572741
+- conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+  sha256: 8fbb17a56f51e7113ed511c5787e0dec0d4b10ef9df921c4fd1cccca0458f648
+  md5: b1ca5f21335782f71a8bd69bdc093f67
   depends:
   - __osx >=11.0
   constrains:
-  - expat 2.7.0.*
+  - expat 2.7.1.*
   license: MIT
   license_family: MIT
-  size: 65714
-  timestamp: 1743431789879
-- conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.0-he0c23c2_0.conda
-  sha256: 1a227c094a4e06bd54e8c2f3ec40c17ff99dcf3037d812294f842210aa66dbeb
-  md5: b6f5352fdb525662f4169a0431d2dd7a
+  size: 65971
+  timestamp: 1752719657566
+- conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
+  sha256: 8432ca842bdf8073ccecf016ccc9140c41c7114dc4ec77ca754551c01f780845
+  md5: 3608ffde260281fa641e70d6e34b1b96
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   constrains:
-  - expat 2.7.0.*
+  - expat 2.7.1.*
   license: MIT
   license_family: MIT
-  size: 140896
-  timestamp: 1743432122520
-- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
-  sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
-  md5: ede4673863426c0883c0063d853bbd85
+  size: 141322
+  timestamp: 1752719767870
+- conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+  sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
+  md5: 35f29eec58405aaf55e01cb470d8c26a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: MIT
   license_family: MIT
-  size: 57433
-  timestamp: 1743434498161
-- conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
-  sha256: c6a530924a9b14e193ea9adfe92843de2a806d1b7dbfd341546ece9653129e60
-  md5: c215a60c2935b517dcda8cad4705734d
+  size: 57821
+  timestamp: 1760295480630
+- conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
+  sha256: 9b8acdf42df61b7bfe8bdc545c016c29e61985e79748c64ad66df47dbc2e295f
+  md5: 411ff7cd5d1472bba0f55c0faf04453b
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 39839
-  timestamp: 1743434670405
-- conda: https://prefix.dev/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
-  sha256: d3b0b8812eab553d3464bbd68204f007f1ebadf96ce30eb0cbc5159f72e353f5
-  md5: 85d8fa5e55ed8f93f874b3b23ed54ec6
+  size: 40251
+  timestamp: 1760295839166
+- conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
+  sha256: ddff25aaa4f0aa535413f5d831b04073789522890a4d8626366e43ecde1534a3
+  md5: ba4ad812d2afc22b9a34ce8327a0930f
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
-  size: 44978
-  timestamp: 1743435053850
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
-  sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
-  md5: ea8ac52380885ed41c1baa8f1d6d2b93
+  size: 44866
+  timestamp: 1760295760649
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
+  sha256: 08f9b87578ab981c7713e4e6a7d935e40766e10691732bba376d4964562bcb45
+  md5: c0374badb3a5d4b1372db28d19462c53
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.1.0=*_2
-  - libgomp 15.1.0 h767d61c_2
+  - libgomp 15.2.0 h767d61c_7
+  - libgcc-ng ==15.2.0=*_7
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 829108
-  timestamp: 1746642191935
-- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
-  sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
-  md5: ddca86c7040dd0e73b2b69bd7833d225
-  depends:
-  - libgcc 15.1.0 h767d61c_2
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 34586
-  timestamp: 1746642200749
-- conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
-  sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
-  md5: fbe7d535ff9d3a168c148e07358cd5b1
+  size: 822552
+  timestamp: 1759968052178
+- conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-h767d61c_7.conda
+  sha256: e9fb1c258c8e66ee278397b5822692527c5f5786d372fe7a869b900853f3f5ca
+  md5: f7b4d76975aac7e5d9e6ad13845f92fe
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 452635
-  timestamp: 1746642113092
-- conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_1.conda
-  sha256: eeff241bddc8f1b87567dd6507c9f441f7f472c27f0860a07628260c000ef27c
-  md5: a76fd702c93cd2dfd89eff30a5fd45a8
+  size: 447919
+  timestamp: 1759967942498
+- conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
+  md5: 1a580f7796c7bf6393fddb8bbbde58dc
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   constrains:
   - xz 5.8.1.*
-  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 112845
-  timestamp: 1746531470399
-- conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_1.conda
-  sha256: 5ab62c179229640c34491a7de806ad4ab7bec47ea2b5fc2136e3b8cf5ef26a57
-  md5: 4e8ef3d79c97c9021b34d682c24c2044
+  size: 112894
+  timestamp: 1749230047870
+- conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
+  sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
+  md5: d6df911d4564d77c4374b02552cb17d1
   depends:
   - __osx >=11.0
   constrains:
   - xz 5.8.1.*
-  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 92218
-  timestamp: 1746531818330
-- conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_1.conda
-  sha256: adbf6c7bde70536ada734a81b8b5aa23654f2b95445204404622e0cc40e921a0
-  md5: 14a1042c163181e143a7522dfb8ad6ab
+  size: 92286
+  timestamp: 1749230283517
+- conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+  sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
+  md5: c15148b2e18da456f5108ccb5e411446
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
   - xz 5.8.1.*
-  - xz ==5.8.1=*_1
   license: 0BSD
-  size: 104699
-  timestamp: 1746531718026
-- conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-h4bc722e_0.conda
-  sha256: d02d1d3304ecaf5c728e515eb7416517a0b118200cd5eacbe829c432d1664070
-  md5: aeb98fdeb2e8f25d43ef71fbacbeec80
+  size: 104935
+  timestamp: 1749230611612
+- conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb9d3cd8_0.conda
+  sha256: 3aa92d4074d4063f2a162cd8ecb45dccac93e543e565c01a787e16a43501f7ee
+  md5: c7e925f37e3b40d893459e625f6a53f1
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
+  - libgcc >=13
   license: BSD-2-Clause
   license_family: BSD
-  size: 89991
-  timestamp: 1723817448345
-- conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h99b78c6_0.conda
-  sha256: f7917de9117d3a5fe12a39e185c7ce424f8d5010a6f97b4333e8a1dcb2889d16
-  md5: 7476305c35dd9acef48da8f754eedb40
+  size: 91183
+  timestamp: 1748393666725
+- conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h5505292_0.conda
+  sha256: 0a1875fc1642324ebd6c4ac864604f3f18f57fbcf558a8264f6ced028a3c75b2
+  md5: 85ccccb47823dd9f7a99d2c7f530342f
   depends:
   - __osx >=11.0
   license: BSD-2-Clause
   license_family: BSD
-  size: 69263
-  timestamp: 1723817629767
+  size: 71829
+  timestamp: 1748393749336
 - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
   sha256: fc529fc82c7caf51202cc5cec5bb1c2e8d90edbac6d0a4602c966366efe3c7bf
   md5: 74860100b2029e2523cf480804c76b9b
@@ -332,44 +332,58 @@ packages:
   license_family: BSD
   size: 88657
   timestamp: 1723861474602
-- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.49.2-hee588c1_0.conda
-  sha256: 525d4a0e24843f90b3ff1ed733f0a2e408aa6dd18b9d4f15465595e078e104a2
-  md5: 93048463501053a00739215ea3f36324
+- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.50.4-h0c1763c_0.conda
+  sha256: 6d9c32fc369af5a84875725f7ddfbfc2ace795c28f246dc70055a79f9b2003da
+  md5: 0b367fad34931cb79e0d6b7e5c06bb1c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 916313
-  timestamp: 1746637007836
-- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.49.2-h3f77e49_0.conda
-  sha256: d89f979497cf56eccb099b6ab9558da7bba1f1ba264f50af554e0ea293d9dcf9
-  md5: 85f443033cd5b3df82b5cabf79bddb09
+  license: blessing
+  size: 932581
+  timestamp: 1753948484112
+- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
+  sha256: 802ebe62e6bc59fc26b26276b793e0542cfff2d03c086440aeaf72fb8bbcec44
+  md5: 1dcb0468f5146e38fae99aef9656034b
   depends:
   - __osx >=11.0
+  - icu >=75.1,<76.0a0
   - libzlib >=1.3.1,<2.0a0
-  license: Unlicense
-  size: 899462
-  timestamp: 1746637228408
-- conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.49.2-h67fdade_0.conda
-  sha256: 1612baa49124ec1972b085ab9d6bf1855c5f38e8f16e8d8f96c193d6e11688b2
-  md5: a3900c97ba9e03332e9a911fe63f7d64
+  license: blessing
+  size: 902645
+  timestamp: 1753948599139
+- conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
+  sha256: 5dc4f07b2d6270ac0c874caec53c6984caaaa84bc0d3eb593b0edf3dc8492efa
+  md5: ccb20d946040f86f0c05b644d5eadeca
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
-  size: 1081123
-  timestamp: 1746637406471
-- conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 1288499
+  timestamp: 1753948889360
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h8f9b012_7.conda
+  sha256: 1b981647d9775e1cdeb2fab0a4dd9cd75a6b0de2963f6c3953dbd712f78334b3
+  md5: 5b767048b1b3ee9a954b06f4084f93dc
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 h767d61c_7
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_7
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3898269
+  timestamp: 1759968103436
+- conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
+  sha256: e5ec6d2ad7eef538ddcb9ea62ad4346fde70a4736342c4ad87bd713641eb9808
+  md5: 80c07c68d2f6870250959dcc95b209d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
-  size: 33601
-  timestamp: 1680112270483
+  size: 37135
+  timestamp: 1758626800002
 - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -423,121 +437,124 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 797030
   timestamp: 1738196177597
-- conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
-  sha256: b4491077c494dbf0b5eaa6d87738c22f2154e9277e5293175ec187634bd808a0
-  md5: de356753cfdbffcde5bb1e86e3aa6cd0
+- conda: https://prefix.dev/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+  sha256: e807f3bad09bdf4075dbb4168619e14b0c0360bacb2e12ef18641a834c8c5549
+  md5: 14edad12b59ccbfa3910d42c72adc2a0
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
-  - libgcc >=13
+  - libgcc >=14
   license: Apache-2.0
   license_family: Apache
-  size: 3117410
-  timestamp: 1746223723843
-- conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
-  sha256: 73d366c1597a10bcd5f3604b5f0734b31c23225536e03782c6a13f9be9d01bff
-  md5: 5c7aef00ef60738a14e0e612cfc5bcde
+  size: 3119624
+  timestamp: 1759324353651
+- conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.5.4-h5503f6c_0.conda
+  sha256: f0512629f9589392c2fb9733d11e753d0eab8fc7602f96e4d7f3bd95c783eb07
+  md5: 71118318f37f717eefe55841adb172fd
   depends:
   - __osx >=11.0
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  size: 3064197
-  timestamp: 1746223530698
-- conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
-  sha256: 02846553d2a4c9bde850c60824d0f02803eb9c9b674d5c1a8cce25bc387e748f
-  md5: 72c07e46b6766bb057018a9a74861b89
+  size: 3067808
+  timestamp: 1759324763146
+- conda: https://prefix.dev/conda-forge/win-64/openssl-3.5.4-h725018a_0.conda
+  sha256: 5ddc1e39e2a8b72db2431620ad1124016f3df135f87ebde450d235c212a61994
+  md5: f28ffa510fe055ab518cbd9d6ddfea23
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: Apache
-  size: 9025176
-  timestamp: 1746227349882
-- conda: https://prefix.dev/conda-forge/linux-64/python-3.13.3-hf636f53_101_cp313.conda
-  build_number: 101
-  sha256: eecb11ea60f8143deeb301eab2e04d04f7acb83659bb20fdfeacd431a5f31168
-  md5: 10622e12d649154af0bd76bcf33a7c5c
+  size: 9218823
+  timestamp: 1759326176247
+- conda: https://prefix.dev/conda-forge/linux-64/python-3.14.0-h32b2ec7_102_cp314.conda
+  build_number: 102
+  sha256: 76d750045b94fded676323bfd01975a26a474023635735773d0e4d80aaa72518
+  md5: 0a19d2cc6eb15881889b0c6fa7d6a78d
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.7.0,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
-  - libgcc >=13
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.49.1,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libuuid >=2.41.2,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.0,<4.0a0
-  - python_abi 3.13.* *_cp313
+  - openssl >=3.5.4,<4.0a0
+  - python_abi 3.14.* *_cp314
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
+  - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 33268245
-  timestamp: 1744665022734
-  python_site_packages_path: lib/python3.13/site-packages
-- conda: https://prefix.dev/conda-forge/osx-arm64/python-3.13.3-h81fe080_101_cp313.conda
-  build_number: 101
-  sha256: f96468ab1e6f27bda92157bfc7f272d1fbf2ba2f85697bdc5bb106bccba1befb
-  md5: b3240ae8c42a3230e0b7f831e1c72e9f
+  size: 36681389
+  timestamp: 1761176838143
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.0-h40d2674_102_cp314.conda
+  build_number: 102
+  sha256: 3ca1da026fe5df8a479d60e1d3ed02d9bc50fcbafd5f125d86abe70d21a34cc7
+  md5: a9ff09231c555da7e30777747318321b
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.0,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.49.1,<4.0a0
+  - libsqlite >=3.50.4,<4.0a0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.0,<4.0a0
-  - python_abi 3.13.* *_cp313
+  - openssl >=3.5.4,<4.0a0
+  - python_abi 3.14.* *_cp314
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
+  - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 12136505
-  timestamp: 1744663807953
-  python_site_packages_path: lib/python3.13/site-packages
-- conda: https://prefix.dev/conda-forge/win-64/python-3.13.3-h261c0b1_101_cp313.conda
-  build_number: 101
-  sha256: 25cf0113c0e4fa42d31b0ff85349990dc454f1237638ba4642b009b451352cdf
-  md5: 4784d7aecc8996babe9681d017c81b8a
+  size: 13590581
+  timestamp: 1761177195716
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://prefix.dev/conda-forge/win-64/python-3.14.0-h4b44e0e_102_cp314.conda
+  build_number: 102
+  sha256: 2b8c8fcafcc30690b4c5991ee28eb80c962e50e06ce7da03b2b302e2d39d6a81
+  md5: 3e1ce2fb0f277cebcae01a3c418eb5e2
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.0,<3.0a0
-  - libffi >=3.4.6,<3.5.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
   - liblzma >=5.8.1,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.49.1,<4.0a0
+  - libsqlite >=3.50.4,<4.0a0
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.0,<4.0a0
-  - python_abi 3.13.* *_cp313
+  - openssl >=3.5.4,<4.0a0
+  - python_abi 3.14.* *_cp314
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 16614435
-  timestamp: 1744663103022
+  size: 16706286
+  timestamp: 1761175439068
   python_site_packages_path: Lib/site-packages
-- conda: https://prefix.dev/conda-forge/noarch/python_abi-3.13-7_cp313.conda
-  build_number: 7
-  sha256: 0595134584589064f56e67d3de1d8fcbb673a972946bce25fb593fb092fdcd97
-  md5: e84b44e6300f1703cb25d29120c5b1d8
+- conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
   constrains:
-  - python 3.13.* *_cp313
+  - python 3.14.* *_cp314
   license: BSD-3-Clause
   license_family: BSD
-  size: 6988
-  timestamp: 1745258852285
+  size: 6989
+  timestamp: 1752805904792
 - conda: https://prefix.dev/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
   sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
   md5: 283b96675859b20a825f8fa30f311446
@@ -559,83 +576,130 @@ packages:
   timestamp: 1740379663071
 - conda: src/root
   name: root
-  version: 0.1.0
-  build: pyh4616a5c_0
-  subdir: noarch
   depends:
   - depend
-  - python >=3.11
+  - python
   - python *
   input:
-    hash: 960c4783940e6a7bd4f5f557ea68b61d70319c2e9a46947564e9a8e87d64cd81
-    globs:
-    - pyproject.toml
+    hash: d74786cfcf078d97d1c9d5e38440e52418fc4650ee65f4adc27d02afcf50c8d0
+    globs: []
   sources:
     depend:
       path: ../depend
-- conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  variants:
+    target_platform: noarch
+- conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
+  md5: a0116df4f4ed05c303811a837d5b39d8
   depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
-- conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
-  md5: b50a57ba89c32b62428b71a875291c9b
+  size: 3285204
+  timestamp: 1748387766691
+- conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
+  md5: 7362396c170252e7b7b0c8fb37fe9c78
   depends:
-  - libzlib >=1.2.13,<2.0.0a0
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
-  size: 3145523
-  timestamp: 1699202432999
-- conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
-  sha256: 2c4e914f521ccb2718946645108c9bd3fc3216ba69aea20c2c3cedbd8db32bb1
-  md5: fc048363eb8f03cd1737600a5d08aafe
+  size: 3125538
+  timestamp: 1748388189063
+- conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
+  sha256: e3614b0eb4abcc70d98eae159db59d9b4059ed743ef402081151a948dce95896
+  md5: ebd0e761de9aa879a51d22cc721bd095
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: TCL
   license_family: BSD
-  size: 3503410
-  timestamp: 1699202577803
+  size: 3466348
+  timestamp: 1748388121356
 - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
   sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
   md5: 4222072737ccff51314b5ece9c7d6f5a
   license: LicenseRef-Public-Domain
   size: 122968
   timestamp: 1742727099393
-- conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
-  sha256: db8dead3dd30fb1a032737554ce91e2819b43496a0db09927edf01c32b577450
-  md5: 6797b005cd0f439c4c5c9ac565783700
+- conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
   constrains:
+  - vc14_runtime >=14.29.30037
   - vs2015_runtime >=14.29.30037
   license: LicenseRef-MicrosoftWindowsSDK10
-  size: 559710
-  timestamp: 1728377334097
-- conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_26.conda
-  sha256: 7a685b5c37e9713fa314a0d26b8b1d7a2e6de5ab758698199b5d5b6dba2e3ce1
-  md5: d3f0381e38093bde620a8d85f266ae55
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_32.conda
+  sha256: 82250af59af9ff3c6a635dd4c4764c631d854feb334d6747d356d949af44d7cf
+  md5: ef02bbe151253a72b8eda264a935db66
   depends:
   - vc14_runtime >=14.42.34433
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  size: 17893
-  timestamp: 1743195261486
-- conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_26.conda
-  sha256: 30dcb71bb166e351aadbdc18f1718757c32cdaa0e1e5d9368469ee44f6bf4709
-  md5: 91651a36d31aa20c7ba36299fb7068f4
+  size: 18861
+  timestamp: 1760418772353
+- conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
+  sha256: e3a3656b70d1202e0d042811ceb743bd0d9f7e00e2acdf824d231b044ef6c0fd
+  md5: 378d5dcec45eaea8d303da6f00447ac0
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.44.35208 h818238b_32
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_32
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 682706
+  timestamp: 1760418629729
+- conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
+  sha256: f3790c88fbbdc55874f41de81a4237b1b91eab75e05d0e58661518ff04d2a8a1
+  md5: 58f67b437acbf2764317ba273d731f1d
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.42.34438.* *_26
+  - vs2015_runtime 14.44.35208.* *_32
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  size: 750733
-  timestamp: 1743195092905
+  size: 114846
+  timestamp: 1760418593847
+- conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
+  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
+  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 567578
+  timestamp: 1742433379869
+- conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
+  sha256: 0d02046f57f7a1a3feae3e9d1aa2113788311f3cf37a3244c71e61a93177ba67
+  md5: e6f69c7bcccdefa417f056fa593b40f0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 399979
+  timestamp: 1742433432699
+- conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
+  sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
+  md5: 21f56217d6125fb30c3c3f10c786d751
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 354697
+  timestamp: 1742433568506

--- a/tests/data/non-satisfiability/binary-spec-source-record/pixi.lock
+++ b/tests/data/non-satisfiability/binary-spec-source-record/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -13,8 +13,6 @@ packages:
 - conda: source
   name: source
   version: 0.1.0
-  build: hbf21a9e_0
-  subdir: win-64
   depends:
   - vc >=14.1,<15
   - vc14_runtime >=14.16.27033
@@ -27,8 +25,6 @@ packages:
   md5: 6797b005cd0f439c4c5c9ac565783700
   constrains:
   - vs2015_runtime >=14.29.30037
-  arch: x86_64
-  platform: win
   license: LicenseRef-MicrosoftWindowsSDK10
   size: 559710
   timestamp: 1728377334097
@@ -37,8 +33,6 @@ packages:
   md5: 311c9ba1dfdd2895a8cb08346ff26259
   depends:
   - vc14_runtime >=14.38.33135
-  arch: x86_64
-  platform: win
   track_features:
   - vc14
   license: BSD-3-Clause
@@ -52,8 +46,6 @@ packages:
   - ucrt >=10.0.20348.0
   constrains:
   - vs2015_runtime 14.40.33810.* *_22
-  arch: x86_64
-  platform: win
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
   size: 750719

--- a/tests/data/non-satisfiability/explicit-pypi-dependency/pixi.lock
+++ b/tests/data/non-satisfiability/explicit-pypi-dependency/pixi.lock
@@ -6,26 +6,24 @@
 # conda packages reference the boltons conda package, it should be dropped in
 # favor of the pypi package.
 
-version: 6
+version: 7
 environments:
   default:
     channels:
-    - url: https://conda.anaconda.org/conda-forge/
+      - url: https://conda.anaconda.org/conda-forge/
     packages:
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.2-h261c0b1_101_cp313.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.2-h261c0b1_101_cp313.conda
 packages:
-- conda: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
-  sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
-  md5: d88c38e66d85ecc9c7e2c4110676bbf4
-  depends:
-  - python >=3.9
-  purls:
-  - pkg:pypi/boltons?source=hash-mapping
-- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.2-h261c0b1_101_cp313.conda
-  build_number: 101
-  sha256: b6e7a6f314343926b5a236592272e5014edcda150e14d18d0fb9440d8a185c3f
-  md5: 5116c74f5e3e77b915b7b72eea0ec946
-  # Faked to be empty to reduce the size of the example
-  depends: []
+  - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_1.conda
+    sha256: 4d6101f6a900c22495fbaa3c0ca713f1876d11f14aba3f7832bf6e6986ee5e64
+    md5: d88c38e66d85ecc9c7e2c4110676bbf4
+    depends:
+      - python >=3.9
+    purls:
+      - pkg:pypi/boltons?source=hash-mapping
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.2-h261c0b1_101_cp313.conda
+    build_number: 101
+    sha256: b6e7a6f314343926b5a236592272e5014edcda150e14d18d0fb9440d8a185c3f
+    md5: 5116c74f5e3e77b915b7b72eea0ec946

--- a/tests/data/non-satisfiability/mismatch-exclude-newer2/pixi.lock
+++ b/tests/data/non-satisfiability/mismatch-exclude-newer2/pixi.lock
@@ -1,10 +1,10 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     options:
-      exclude-newer: "2023-10-01T00:00:00Z"
+      exclude-newer: 2023-10-01T00:00:00Z
     packages:
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/foobar-0.1.0-h2628c8c_0.conda

--- a/tests/data/non-satisfiability/mismatched-source-spec/pixi.lock
+++ b/tests/data/non-satisfiability/mismatched-source-spec/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -7,10 +7,6 @@ environments:
       win-64:
       - conda: child-package
 packages:
-# This should invalidate the lock-file because the package `child-package` is
-# requested as a git package in the pixi.toml.
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: pyhbf21a9e_0
-  subdir: noarch

--- a/tests/data/non-satisfiability/non-binary-no-build/pixi.lock
+++ b/tests/data/non-satisfiability/non-binary-no-build/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:

--- a/tests/data/non-satisfiability/source-dependency-changed-project-model/pixi.lock
+++ b/tests/data/non-satisfiability/source-dependency-changed-project-model/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -35,8 +35,6 @@ packages:
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: hbf21a9e_0
-  subdir: linux-64
   depends:
   - libstdcxx >=15
   - libgcc >=15

--- a/tests/data/non-satisfiability/source-dependency/pixi.lock
+++ b/tests/data/non-satisfiability/source-dependency/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -11,22 +11,15 @@ packages:
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: pyhbf21a9e_0
-  subdir: noarch
   depends:
   - python
   input:
-    # This should cause the lock-file to be invalid because the hash is
-    # not the same as the expected one.
     hash: b67010bf5bc5608db89c0399e726852b07a7ef4fb26b3aa18171f1d0f6a19c89
     globs:
     - pixi.toml
 - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
   sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
   md5: defd5d375853a2caff36a19d2d81a28e
-  arch: x86_64
-  platform: win
-  channel: https://conda.anaconda.org/conda-forge/
   license: Python-2.0
   size: 16140836
   timestamp: 1696321871976

--- a/tests/data/non-satisfiability/source-recursive-dependency-changed-dir/pixi.lock
+++ b/tests/data/non-satisfiability/source-recursive-dependency-changed-dir/pixi.lock
@@ -1,27 +1,21 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     packages:
       win-64:
-      - conda: foobar
       - conda: child-package
+      - conda: foobar
 packages:
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: pyhbf21a9e_0
-  subdir: noarch
   depends:
   - foobar 0.1.0 baz
-  # This should cause the lock-file to be invalid because the package `foobar`
-  # does not come from the directory `not-foobar`.
   sources:
     foobar:
-      path: "../not-foobar"
+      path: ../not-foobar
 - conda: foobar
   name: foobar
   version: 0.1.0
-  build: baz
-  subdir: noarch

--- a/tests/data/non-satisfiability/source-recursive-dependency-mismatch/pixi.lock
+++ b/tests/data/non-satisfiability/source-recursive-dependency-mismatch/pixi.lock
@@ -1,27 +1,21 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     packages:
       win-64:
-      - conda: foobar
       - conda: child-package
+      - conda: foobar
 packages:
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: pyhbf21a9e_0
-  subdir: noarch
   depends:
   - foobar 0.2.0 baz
-  # This should cause the lock-file to be invalid because the package `foobar`
-  # has a different version.
   sources:
     foobar:
-      path: "../foobar"
+      path: ../foobar
 - conda: foobar
   name: foobar
   version: 0.1.0
-  build: baz
-  subdir: noarch

--- a/tests/data/non-satisfiability/source-recursive-dependency/pixi.lock
+++ b/tests/data/non-satisfiability/source-recursive-dependency/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -11,15 +11,11 @@ packages:
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: pyhbf21a9e_0
-  subdir: noarch
   depends:
   - foobar 0.1.0 baz
-  # This should cause the lock-file to be invalid because `foobar` should be a source package,
-  # but it is installed in the environment as a binary package.
   sources:
     foobar:
-      path: "foobar"
+      path: foobar
 - conda: https://conda.anaconda.org/conda-forge/win-64/foobar-0.1.0-baz.conda
   sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
   md5: defd5d375853a2caff36a19d2d81a28e

--- a/tests/data/satisfiability/source-dependency/pixi.lock
+++ b/tests/data/satisfiability/source-dependency/pixi.lock
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 environments:
   default:
     channels:
@@ -35,8 +35,6 @@ packages:
 - conda: child-package
   name: child-package
   version: 0.1.0
-  build: hbf21a9e_0
-  subdir: linux-64
   depends:
   - libstdcxx >=15
   - libgcc >=15


### PR DESCRIPTION
Currently in progress of updating to `rattler_lock` v7 that includes the variants.

Rattler changes currently live at:

https://github.com/conda/rattler/pull/1775

Some notable changes:

- Using purls is slightly broken for source packages. This is currently not used but is something we should fix down the line.
- The python interpreter must be installed as a binary package atm. 

Depends on

- https://github.com/prefix-dev/pixi-build-backends/pull/438
- https://github.com/prefix-dev/pixi-build-testsuite/pull/88