### PR TITLE
docs(cli): improve `pixi list` description

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Commands:
   init         Creates a new workspace
   import       Imports a file into an environment in an existing workspace.
   install      Install an environment, both updating the lockfile and installing the environment [aliases: i]
-  list         List workspace's packages [aliases: ls]
+  list         List the packages of the current workspace [aliases: ls]
   lock         Solve environment and update the lock file without installing the environments
   reinstall    Re-install an environment, both updating the lockfile and re-installing the environment
   remove       Removes dependencies from the workspace [aliases: rm]


### PR DESCRIPTION
This corrects the rendering in the --help preview.

It is suggested , to also change the text in the actual CLI help text, as it is grammatically incorrect.

Since a previous PR was rejected, because the maintainer insisted on incorrect grammar, might this not be considered to be important either. 🤷🏻‍♂️