### PR TITLE
chore(cli): improve how we handle duplicate channel addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,6 +4732,7 @@ dependencies = [
  "sha2",
  "signal-hook",
  "strsim",
+ "strum",
  "tabwriter",
  "tar",
  "temp-env",

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -106,6 +106,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["indexmap"] }
 strsim = { workspace = true }
+strum = { workspace = true }
 tabwriter = { workspace = true, features = ["ansi_formatting"] }
 tar = { workspace = true }
 temp-env = { workspace = true }

--- a/crates/pixi_cli/src/workspace/channel/remove.rs
+++ b/crates/pixi_cli/src/workspace/channel/remove.rs
@@ -5,6 +5,8 @@ use pixi_core::{
     lock_file::{ReinstallPackages, UpdateMode},
 };
 
+use crate::workspace::channel::ReportOperation;
+
 use super::AddRemoveArgs;
 
 pub async fn execute(args: AddRemoveArgs) -> miette::Result<()> {
@@ -35,7 +37,7 @@ pub async fn execute(args: AddRemoveArgs) -> miette::Result<()> {
     let workspace = workspace.save().await.into_diagnostic()?;
 
     // Report back to the user
-    args.report("Removed", &workspace.channel_config())?;
+    args.report(&ReportOperation::Remove, &workspace.channel_config())?;
 
     Ok(())
 }

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -581,7 +581,7 @@ impl WorkspaceManifestMut<'_> {
         channels: impl IntoIterator<Item = PrioritizedChannel>,
         feature_name: &FeatureName,
         prepend: bool,
-    ) -> miette::Result<()> {
+    ) -> miette::Result<IndexSet<PrioritizedChannel>> {
         // First collect all the new channels
         let to_add: IndexSet<_> = channels.into_iter().collect();
 
@@ -625,7 +625,7 @@ impl WorkspaceManifestMut<'_> {
             channels.push(Value::from(channel));
         }
 
-        Ok(())
+        Ok(new)
     }
 
     /// Remove the specified channels to the manifest.


### PR DESCRIPTION
## Overview 
Running `workspace channel add already-existing-channel-in-manifest`, will always print that the channel is added, even if it was already there.

This change a little bit the UX ( and add a ReportOperation enum so we know for sure `what` we want to report.)

![Uploading image.png…]()
