### PR TITLE
docs: use custom search separator

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,7 +249,8 @@ plugins:
         # crates/pixi_cli/src/init.rs
         "init_getting_started.md": "first_workspace.md"
 
-  - search
+  - search:
+      separator: '[\s\u200b\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
   - social
   - mike:
     # These fields are all optional; the defaults are as below...


### PR DESCRIPTION
Let's use the same search separator as material for mkdocs

https://github.com/squidfunk/mkdocs-material/blob/master/mkdocs.yml#L97-L98

Thanks @dhirschfeld 