### PR TITLE
fix: lefthook parallel

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,7 +1,7 @@
 lefthook: pixi run --no-progress lefthook
 
 templates:
-  run: run --quiet --no-progress --environment=lint
+  run: run --quiet --no-progress --frozen --environment=lint
 
 colors: true
 


### PR DESCRIPTION
We currently have a problem with Pixi running in parallel on the same environment.

This is especially a problem with lefthook. Let's avoid this by using `--frozen` as discussed here:
https://github.com/prefix-dev/pixi/issues/1482