### PR TITLE
docs(exec): Fix pixi exec example

### DIFF
--- a/docs/reference/cli/pixi/exec_extender
+++ b/docs/reference/cli/pixi/exec_extender
@@ -12,7 +12,7 @@ pixi exec --with py-rattler --with numpy ipython
 pixi exec --spec python=3.9 --spec numpy python
 
 # Install a specific conda package to temporary environment
-pixi exec --spec ./numpy-2.3.4-py314h2b28147_0.conda -- python
+pixi exec --spec "$(pwd)/numpy-2.3.4-py314h2b28147_0.conda" -- python
 pixi exec --spec https://prefix.dev/conda-forge/noarch/polars-1.35.1-pyh6a1acc5_0.conda -- python
 
 # Force reinstall to recreate the environment and get the latest package versions


### PR DESCRIPTION
currently doesn't work with relative paths, xref #4867.
