### PR TITLE
fix: recursive optional dependencies and solve groups infinite loop

### DIFF
--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -2218,7 +2218,7 @@ async fn spawn_extract_environment_task(
                         }
                     }
 
-                    // Also add the dependency without any extras (with dedup check!)
+                    // Also add the dependency without any extras
                     if queued_names.insert(PackageName::Pypi((uv_name.clone(), None))) {
                         queue.push(PackageName::Pypi((uv_name, None)));
                     }


### PR DESCRIPTION
Fixes: https://github.com/prefix-dev/pixi/issues/4786

This was a bug that occured because of the recent addition of recursive optional dependencies for PyPI when depending on your own project. This only occurs in combination with solve-groups. This was because there was a specific bug in the extract task, that basically looks for the overlapping dependencies.

To minimize the issue example:

```toml
 [project]
  name = "itables"
  requires-python = ">= 3.9"
  dependencies = ["IPython", "pandas", "numpy"]

  [project.optional-dependencies]
  # The key: itables[all] depends on itables with other extras
  # This creates self-referential optional dependencies
  all = ["itables[config,widget]"]
  config = ["platformdirs"]
  widget = ["anywidget", "traitlets"]

  [tool.pixi.workspace]
  channels = ["conda-forge"]
  platforms = ["linux-64", "osx-arm64"]

  [tool.pixi.dependencies]
  nodejs = ">=20"

  # The bug triggers when:
  # 1. Multiple environments share a solve-group (triggers extract task)
  # 2. A PyPI package has self-referential extras
  [tool.pixi.environments]
  default = { solve-group = "default" }
  docs = { solve-group = "default" }

  [tool.pixi.pypi-dependencies]
  # itables[all] -> itables[config,widget] -> itables (base)
  # Without dedup: infinite loop adding itables (base) to queue
  itables = {path = ".", editable = true, extras=["all"]}
  ```
  
  Because we added the `itables` dependency unconditionally, this would keep processing itself forever. N.B this did not happen originally because one only uses this structure when using pyproject source dependencies, and the recursive nature of this is only supported since last release.