### PR TITLE
fix: more descriptive message for tokio panics

### DIFF
--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -229,6 +229,10 @@ pub enum SolveError {
     BuildDispatchPanic { message: String },
     #[error("unexpected panic during PyPI resolution: {message}")]
     GeneralPanic { message: String },
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    LookAhead(Box<dyn miette::Diagnostic + Send + Sync + 'static>),
 }
 
 /// Creates a custom `SolveError` from a `ResolveError`.
@@ -689,9 +693,7 @@ pub async fn resolve_pypi(
         .resolve(&resolver_env)
         .await
         .into_diagnostic()
-        .map_err(|e| SolveError::GeneralPanic {
-            message: format!("Failed to do lookahead resolution: {e:?}"),
-        })?;
+        .map_err(|e| SolveError::LookAhead(e.into()))?;
 
         // Move manifest and provider setup inside catch_unwind
         let manifest = Manifest::new(


### PR DESCRIPTION
fixes: https://github.com/prefix-dev/pixi/issues/4831

how to test it:

you can use dockerfile

```dockerfile
FROM ubuntu:22.04

# Install build dependencies but NOT git - this is intentional to reproduce the issue
RUN apt-get update && \
    apt-get install -y curl build-essential && \
    rm -rf /var/lib/apt/lists/*

# Install Rust
RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
ENV PATH="/root/.cargo/bin:$PATH"

# Copy the pixi source code from repository root
# Note: Build this with: docker build -f examples/panic-panic/Dockerfile .
COPY . /pixi-source
WORKDIR /pixi-source

# Build pixi from source
RUN cargo build

# Add pixi to PATH
ENV PATH="/pixi-source/target/debug:$PATH"

WORKDIR /app

# Copy the test configuration
COPY examples/panic-panic/pixi.toml pixi.toml

# Try to install - this should fail with a clear error about git being missing
# We don't use RUN here so the container build doesn't fail
CMD ["sh", "-c", "pixi install 2>&1 || true"]
```

and this
```toml
[workspace]
channels = ["conda-forge"]
name = "test-git-error"
platforms = ["linux-64"]
version = "0.1.0"

[dependencies]
python = "3.9"

[pypi-dependencies]
# This requires git to clone - will fail if git is not installed
chumpy = { git = "https://github.com/mattloper/chumpy" }
```
