### PR TITLE
fix: disable diff driver for pixi lock in generated `.gitattributes`

### DIFF
--- a/crates/pixi_api/src/workspace/init/options.rs
+++ b/crates/pixi_api/src/workspace/init/options.rs
@@ -42,12 +42,12 @@ impl GitAttributes {
         match self {
             GitAttributes::Github | GitAttributes::Codeberg => {
                 r#"# SCM syntax highlighting & preventing 3-way merges
-pixi.lock merge=binary linguist-language=YAML linguist-generated=true
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff
 "#
             }
             GitAttributes::Gitlab => {
                 r#"# GitLab syntax highlighting & preventing 3-way merges
-pixi.lock merge=binary gitlab-language=yaml gitlab-generated=true
+pixi.lock merge=binary gitlab-language=yaml gitlab-generated=true -diff
 "#
             }
         }


### PR DESCRIPTION
Fixes #4892