### PR TITLE
chore: remove "starting to locate" from pixi build

### DIFF
--- a/crates/pixi_cli/src/build.rs
+++ b/crates/pixi_cli/src/build.rs
@@ -175,7 +175,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // to the path's directory, not the current working directory.
     let workspace_locator = determine_discovery_start(&args.path).await?;
 
-    eprintln!("starting to locate");
     let workspace = WorkspaceLocator::for_cli()
         .with_search_start(workspace_locator.clone())
         .with_closest_package(false)


### PR DESCRIPTION
### Description

Removes `starting to locate` from this output:
```
➜ pixi build
starting to locate

 ╭─ Running build for recipe: simple_cpp-0.1.0-hbf21a9e_0
 ```

### How Has This Been Tested?

Ran locally
