### PR TITLE
fix: increase timeout for Windows x86_64 test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,7 +941,7 @@ jobs:
         run: pixi run --locked test-slow
 
   test-build-windows-x86_64:
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: Test pixi-build Windows x86_64
     runs-on: windows-latest
     needs: build-binary-windows-x86_64


### PR DESCRIPTION
### Description

We had a lot of PRs time out on the windows pixi-build tests which take roughly 10 minutes. I did not have time to investigate whether this is a serious regression or something else but for the time being I just increased the timeout to 15minutes.

### How Has This Been Tested?

CI only

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
