### PR TITLE
fix: typo in `readthedocs-override` example

### DIFF
--- a/examples/readthedocs-override/.readthedocs.yaml
+++ b/examples/readthedocs-override/.readthedocs.yaml
@@ -1,4 +1,4 @@
-\version: 2
+version: 2
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION


### Description

Spotted while checking for a ReadTheDocs example.

### How Has This Been Tested?

Checking against the ReadTheDocs schema.

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
