### PR TITLE
fix: correct PIXI_BIN_DIR variable reference in installation script error message

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -241,7 +241,7 @@ __wrap__() {
 
         *)
             echo "warn: Could not update shell $(basename "$SHELL")" >&2
-            echo "      Please permanently add '${BIN_DIR}' to your \$PATH to enable the 'pixi' command." >&2
+            echo "      Please permanently add '${PIXI_BIN_DIR}' to your \$PATH to enable the 'pixi' command." >&2
             ;;
         esac
     fi


### PR DESCRIPTION
There is a missing variable to update, PIXI_BIN_DIR

### Description

This PR fixes a bug in the Pixi installation script where an incorrect variable name (BIN_DIR) is referenced in an error message, when it should be PIXI_BIN_DIR. This causes the script to fail with "unbound variable" error when running with set -u (strict mode) and the shell type cannot be detected.

The issue occurs in line 244 of the installation script.

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
