### PR TITLE
chore: increase DESIRED_RLIMIT_NOFILE from 1024 to 2048

### DIFF
--- a/crates/pixi_utils/src/rlimit.rs
+++ b/crates/pixi_utils/src/rlimit.rs
@@ -1,7 +1,7 @@
 /// The desired value for the RLIMIT_NOFILE resource limit. This is the number
 /// of file descriptors that pixi should be able to open.
 #[cfg(not(target_os = "windows"))]
-pub const DESIRED_RLIMIT_NOFILE: u64 = 1024;
+pub const DESIRED_RLIMIT_NOFILE: u64 = 2048;
 
 /// Attempt to increase the RLIMIT_NOFILE resource limit to the desired value
 /// for pixi. The desired value is defined by the `DESIRED_RLIMIT_NOFILE`


### PR DESCRIPTION
### Description

Updates the desired rlimit to 2028 as it turns out that 1024 was not enough in some cases.

Fixes #4784

### How Has This Been Tested?

I didnt.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
