### PR TITLE
feat: process signaler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "deno_task_shell"
 version = "0.26.1"
-source = "git+https://github.com/wolfv/deno_task_shell?branch=process-signaler#f6bf4ed48ad778b17ebaa042caa99775ea6ea52f"
+source = "git+https://github.com/wolfv/deno_task_shell?branch=process-signaler#b6c834af92c4a71570fcccde7834e4af22c721cf"
 dependencies = [
  "anyhow",
  "deno_path_util",
@@ -2143,7 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3123,7 +3123,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3438,7 +3438,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6095,7 +6095,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6132,9 +6132,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7167,7 +7167,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7180,7 +7180,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7247,7 +7247,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8230,7 +8230,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10347,7 +10347,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,8 +1789,7 @@ dependencies = [
 [[package]]
 name = "deno_task_shell"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb3527b0dc64fb6c1cb19023ef92a949b54c735c37af9bfb9fe4095922278da"
+source = "git+https://github.com/wolfv/deno_task_shell?branch=process-signaler#f6bf4ed48ad778b17ebaa042caa99775ea6ea52f"
 dependencies = [
  "anyhow",
  "deno_path_util",
@@ -1798,7 +1797,6 @@ dependencies = [
  "glob",
  "monch",
  "nix 0.29.0",
- "os_pipe",
  "path-dedot",
  "sys_traits",
  "thiserror 2.0.17",
@@ -4395,16 +4393,6 @@ dependencies = [
  "indexmap 2.12.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ crossbeam-channel = "0.5.14"
 csv = "1.3.1"
 ctrlc = "3.4.5"
 dashmap = "6.1.0"
-deno_task_shell = "0.26.0"
+deno_task_shell = { git = "https://github.com/wolfv/deno_task_shell", branch = "process-signaler" }
 derive_more = "2.0.1"
 dialoguer = "0.11.0"
 digest = "0.10"

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -5,9 +5,6 @@ use std::{
     string::String,
 };
 
-#[cfg(unix)]
-use std::io::IsTerminal;
-
 use clap::Parser;
 use deno_task_shell::KillSignal;
 use dialoguer::theme::ColorfulTheme;
@@ -540,13 +537,10 @@ async fn listen_and_forward_all_signals(kill_signal: KillSignal) {
 
     // listen and forward every signal we support
     let mut futures = Vec::with_capacity(SIGNALS.len());
-    let is_interactive = std::io::stdin().is_terminal();
     for signo in SIGNALS.iter().copied() {
-        if signo == libc::SIGKILL
-            || signo == libc::SIGSTOP
-            || (signo == libc::SIGINT && is_interactive)
-        {
-            continue; // skip, can't listen to these
+        // SIGKILL and SIGSTOP cannot be caught or blocked
+        if signo == libc::SIGKILL || signo == libc::SIGSTOP {
+            continue;
         }
 
         let kill_signal = kill_signal.clone();

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use clap::Parser;
-use deno_task_shell::KillSignal;
+use deno_task_shell::{KillSignal, ProcessSignaler};
 use dialoguer::theme::ColorfulTheme;
 use fancy_display::FancyDisplay;
 use indicatif::ProgressDrawTarget;
@@ -400,7 +400,10 @@ async fn execute_task(
         return Ok(());
     };
     let cwd = task.working_directory()?;
-    let execute_future = deno_task_shell::execute(
+
+    // Use execute_with_signaler to get access to child process PIDs for
+    // proper signal forwarding based on process groups.
+    let (process_signaler, execute_future) = deno_task_shell::execute_with_signaler(
         script,
         command_env.clone(),
         cwd,
@@ -409,7 +412,8 @@ async fn execute_task(
     );
 
     // Execute the process and forward signals.
-    let status_code = run_future_forwarding_signals(kill_signal, execute_future).await;
+    let status_code =
+        run_future_forwarding_signals(kill_signal, process_signaler, execute_future).await;
     if status_code != 0 {
         return Err(TaskExecutionError::NonZeroExitCode(status_code));
     }
@@ -477,6 +481,7 @@ fn reset_cursor() {
 /// Signal listeners and ctrl+c listening will be setup.
 pub async fn run_future_forwarding_signals<TOutput>(
     #[cfg_attr(windows, allow(unused_variables))] kill_signal: KillSignal,
+    #[cfg_attr(windows, allow(unused_variables))] process_signaler: ProcessSignaler,
     future: impl std::future::Future<Output = TOutput>,
 ) -> TOutput {
     fn spawn_future_with_cancellation(
@@ -501,7 +506,10 @@ pub async fn run_future_forwarding_signals<TOutput>(
             spawn_future_with_cancellation(listen_ctrl_c_windows(), token.clone());
 
             #[cfg(unix)]
-            spawn_future_with_cancellation(listen_and_forward_all_signals(kill_signal), token);
+            spawn_future_with_cancellation(
+                listen_and_forward_all_signals(kill_signal, process_signaler),
+                token,
+            );
 
             future.await
         })
@@ -517,23 +525,28 @@ async fn listen_ctrl_c_windows() {
     while let Ok(()) = tokio::signal::ctrl_c().await {}
 }
 
-/// Listens to all incoming signals and forwards all of them, except
-/// some cases.
+/// Listens to all incoming signals and forwards them to the child process.
 ///
-/// Note that we don't handle `SIGINT` correctly, if the subprocess changes
-/// its PGID, then the system won't forward CTRL+C automatically.
-/// However, we should do that to ensure consistent behaviour.
+/// For SIGINT in interactive mode when the child is in the same process group,
+/// we add a small delay before forwarding. This gives the terminal driver time
+/// to deliver SIGINT directly to the child (in the case of CTRL+C), while still
+/// ensuring that signals sent via `kill -INT` are forwarded.
 ///
-/// To resolve this we should patch `deno_task_shell` to return PID
-/// from which we could get PGID and do things right.
-///
-/// Resulting approach should mimic
-/// https://github.com/astral-sh/uv/blob/9d17dfa3537312b928f94479f632891f918c4760/crates/uv/src/child.rs#L156C21-L168C77.
+/// This approach mimics UV's signal handling:
+/// https://github.com/astral-sh/uv/blob/9d17dfa3537312b928f94479f632891f918c4760/crates/uv/src/child.rs#L156C21-L168C77
 #[cfg(unix)]
-async fn listen_and_forward_all_signals(kill_signal: KillSignal) {
-    use futures::FutureExt;
+async fn listen_and_forward_all_signals(
+    kill_signal: KillSignal,
+    process_signaler: ProcessSignaler,
+) {
+    use std::io::IsTerminal;
+    use std::time::Duration;
 
+    use futures::FutureExt;
     use pixi_core::signals::SIGNALS;
+
+    let is_interactive = std::io::stdin().is_terminal();
+    let our_pgid = unsafe { libc::getpgid(0) };
 
     // listen and forward every signal we support
     let mut futures = Vec::with_capacity(SIGNALS.len());
@@ -544,6 +557,7 @@ async fn listen_and_forward_all_signals(kill_signal: KillSignal) {
         }
 
         let kill_signal = kill_signal.clone();
+        let process_signaler = process_signaler.clone();
         futures.push(
             async move {
                 let Ok(mut stream) = tokio::signal::unix::signal(signo.into()) else {
@@ -551,6 +565,20 @@ async fn listen_and_forward_all_signals(kill_signal: KillSignal) {
                 };
                 let signal_kind = signo.into();
                 while let Some(()) = stream.recv().await {
+                    // For SIGINT in interactive mode when child is in same process
+                    // group, add a delay to let the terminal deliver the signal first.
+                    // This avoids double-delivery for CTRL+C while ensuring `kill -INT`
+                    // still works (since the child won't have received it from terminal).
+                    if signo == libc::SIGINT && is_interactive {
+                        if let Some(child_pid) = process_signaler.current_pid() {
+                            let child_pgid = unsafe { libc::getpgid(child_pid as i32) };
+                            if child_pgid == our_pgid {
+                                // Child is in same process group. Add a small delay
+                                // to let the terminal deliver the signal first.
+                                tokio::time::sleep(Duration::from_millis(100)).await;
+                            }
+                        }
+                    }
                     kill_signal.send(signal_kind);
                 }
             }


### PR DESCRIPTION
Claude tried to fix our CTRL+C problems by adding a process signaler to deno task shell. 
That should prevent:

- sending the signal twice
- not sending the signal


Blocked by: https://github.com/denoland/deno_task_shell/pull/160

@jonashaag do you think you would be able to take a look at this or try an artifact from the PR?