### PR TITLE
chore(ci): switch to non-deprecated macos runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
     timeout-minutes: 15
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - uses: prefix-dev/setup-pixi@main
@@ -219,7 +219,7 @@ jobs:
     timeout-minutes: 30
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test:extra_slow')}} # Only run on the main branch
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - uses: prefix-dev/setup-pixi@main
@@ -296,7 +296,7 @@ jobs:
   build-binary-macos-aarch64:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
-    runs-on: macos-14
+    runs-on: macos-15
     name: "build binary | macos aarch64"
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
@@ -318,7 +318,7 @@ jobs:
   build-binary-macos-x86_64:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.code == 'true' && github.ref == 'refs/heads/main' }} # Only run on the main branch
-    runs-on: macos-13
+    runs-on: macos-15-intel
     name: "build binary | macos x86_64"
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
@@ -434,7 +434,7 @@ jobs:
   test-pytest-macos-aarch64:
     timeout-minutes: 10
     name: Pytest | macos aarch64
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build-binary-macos-aarch64
     env:
       TARGET_RELEASE: "${{ github.workspace }}/target/pixi/release"
@@ -517,7 +517,7 @@ jobs:
   test-integration-macos-aarch64:
     timeout-minutes: 30
     name: Integration tests | macos aarch64
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build-binary-macos-aarch64
     if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test:extra_slow') }}
     env:
@@ -643,7 +643,7 @@ jobs:
   test-downstream-macos-aarch64:
     timeout-minutes: 15
     name: Downstream tests | macos aarch64
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build-binary-macos-aarch64
     if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'test:extra_slow') }}
     env:
@@ -777,7 +777,7 @@ jobs:
     with:
       sha: ${{ github.sha }}
       arch: macos-aarch64
-      runs-on: macos-14
+      runs-on: macos-15
 
   #
   # Test unix installer on some platforms
@@ -786,7 +786,7 @@ jobs:
   test-install-sh-nix:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-15]
     name: install.sh | ${{ matrix.os }}
     needs:
       - determine_changes
@@ -982,7 +982,7 @@ jobs:
   test-build-macos-aarch64:
     timeout-minutes: 10
     name: Test pixi-build macOS aarch64
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build-binary-macos-aarch64
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6

--- a/.github/workflows/trampoline.yaml
+++ b/.github/workflows/trampoline.yaml
@@ -39,11 +39,11 @@ jobs:
 
           - name: "macOS-x86"
             target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
 
           - name: "macOS-arm"
             target: aarch64-apple-darwin
-            os: macos-14
+            os: macos-15
 
           - name: "Windows"
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
### Description

This PR removes the use of deprecated macos-13 runners and switches all runners to either `macos-15` or `macos-15-intel`. More info here: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

### How Has This Been Tested?

CI should succeed.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
