### PR TITLE
perf(test): use local git fixtures for tests

### DIFF
--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -421,7 +421,7 @@ impl PixiControl {
             args: add::Args {
                 workspace_config: WorkspaceConfig {
                     manifest_path: Some(self.manifest_path()),
-                    ..Default::default()
+                    backend_override: self.backend_override.clone(),
                 },
                 dependency_config: AddBuilder::dependency_config_with_specs(specs),
                 no_install_config: NoInstallConfig { no_install: true },

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -123,10 +123,15 @@ impl From<&Args> for GitOptions {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let workspace = WorkspaceLocator::for_cli()
+    let mut workspace = WorkspaceLocator::for_cli()
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(args.config.clone());
+
+    // Apply backend override if provided (primarily for testing)
+    if let Some(backend_override) = args.workspace_config.backend_override.clone() {
+        workspace = workspace.with_backend_override(backend_override);
+    }
 
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
 

--- a/crates/pixi_command_dispatcher/src/build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build/mod.rs
@@ -8,7 +8,7 @@ mod move_file;
 pub(crate) mod source_metadata_cache;
 mod work_dir_key;
 
-use std::hash::{Hash, Hasher};
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 pub use build_cache::{
@@ -97,18 +97,18 @@ impl std::fmt::Display for SourceCodeLocation {
 
 /// Try to deduce a name from a url.
 fn pretty_url_name(url: &Url) -> String {
-    if let Some(last_segment) = url
-        .path_segments()
-        .and_then(|mut segments| segments.next_back())
-    {
-        // Strip known suffixes
-        for suffix in KNOWN_SUFFIXES {
-            if let Some(segment) = last_segment.strip_suffix(suffix) {
-                return segment.to_string();
+    if let Some(segments) = url.path_segments() {
+        // Collect path segments, filtering out empty ones (e.g., from trailing slashes)
+        let non_empty_segments: Vec<_> = segments.filter(|s| !s.is_empty()).collect();
+
+        if let Some(last_segment) = non_empty_segments.last() {
+            // Strip known suffixes
+            for suffix in KNOWN_SUFFIXES {
+                if let Some(segment) = last_segment.strip_suffix(suffix) {
+                    return segment.to_string();
+                }
             }
-        }
-        if !last_segment.is_empty() {
-            return last_segment.to_string();
+            return (*last_segment).to_string();
         }
     }
 
@@ -116,7 +116,10 @@ fn pretty_url_name(url: &Url) -> String {
         // If the URL has no path segments, we can use the host as a fallback
         host.to_string()
     } else {
-        url.to_string()
+        // Final fallback: use a hash of the URL to avoid invalid path characters
+        let mut hasher = DefaultHasher::new();
+        url.as_str().hash(&mut hasher);
+        URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes())
     }
 }
 

--- a/tests/data/git-fixtures/conda-build-package/001_initial/boost-check/pixi.toml
+++ b/tests/data/git-fixtures/conda-build-package/001_initial/boost-check/pixi.toml
@@ -1,0 +1,11 @@
+[workspace]
+channels = ["conda-forge"]
+platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
+preview = ["pixi-build"]
+
+[package]
+name = "boost-check"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }

--- a/tests/data/git-fixtures/conda-build-package/002_v0.1.0/boost-check/pixi.toml
+++ b/tests/data/git-fixtures/conda-build-package/002_v0.1.0/boost-check/pixi.toml
@@ -1,0 +1,12 @@
+[workspace]
+channels = ["conda-forge"]
+platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
+preview = ["pixi-build"]
+
+[package]
+name = "boost-check"
+version = "0.1.0"
+description = "Test package for git dependency tests"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }


### PR DESCRIPTION
### Description

Optimizes three slow git conda package integration tests by using local git fixtures and the passthrough backend
instead of making network calls to GitHub.

**Performance improvements:**
| Test | Before | After |
|------|--------|-------|
| `add_git_deps` | ~86s | ~2s |
| `add_git_with_specific_commit` | ~83s | ~2s |
| `add_git_with_tag` | ~92s | ~2s |

This is a follow-up to #5035 which optimized the git pypi update tests using the same approach.

### How Has This Been Tested?

```bash
cargo nextest run -p pixi add_git_deps add_git_with_specific_commit add_git_with_tag
```

All three tests pass in ~2 seconds each.

### AI Disclosure

- [x] This PR contains AI-generated content.
  -  [x] I have tested any AI-generated content in my PR.
  -  [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.