### PR TITLE
perf(test): optimize pypi add tests

### DIFF
--- a/tests/data/git-fixtures/pypi-boltons/001_initial/pyproject.toml
+++ b/tests/data/git-fixtures/pypi-boltons/001_initial/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "boltons"
+version = "24.0.0"
+description = "Test fixture for boltons"
+requires-python = ">=3.8"

--- a/tests/data/git-fixtures/pypi-httpx/001_initial/pyproject.toml
+++ b/tests/data/git-fixtures/pypi-httpx/001_initial/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "httpx"
+version = "0.27.0"
+description = "Test fixture for httpx"
+requires-python = ">=3.8"

--- a/tests/data/git-fixtures/pypi-isort/001_initial/pyproject.toml
+++ b/tests/data/git-fixtures/pypi-isort/001_initial/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "isort"
+version = "5.13.0"
+description = "Test fixture for isort"
+requires-python = ">=3.8"


### PR DESCRIPTION
### Description

Optimizes two slow PyPI add integration tests by using local mocks instead of network calls.

**Performance improvements:**
| Test | Before | After |
|------|--------|-------|
| `add_pypi_functionality` | ~85s | ~5s |
| `add_pypi_extra_functionality` | ~72s | ~0.4s |

This PR builds on top of #5047 

### How Has This Been Tested?

```bash
cargo nextest run -p pixi add_pypi_functionality add_pypi_extra_functionality
```

Both tests pass in ~5 seconds total.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Code

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
