### PR TITLE
test: Mark more tests as `online_tests`

### DIFF
--- a/crates/pixi/tests/integration_rust/pypi_tests.rs
+++ b/crates/pixi/tests/integration_rust/pypi_tests.rs
@@ -16,7 +16,6 @@ use crate::setup_tracing;
 /// before when running `pixi list -e all`, this would have not included numpy
 /// we are now explicitly testing that this works
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn pyproject_optional_dependencies_resolve_recursively() {
     setup_tracing();
 
@@ -877,7 +876,6 @@ async fn test_uv_index_correctly_parsed() {
 /// Tests that prerelease-mode = "allow" allows pre-release versions to be resolved.
 /// Without this setting, the resolver would skip pre-releases unless explicitly requested.
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_prerelease_mode_allow() {
     setup_tracing();
 
@@ -939,7 +937,6 @@ async fn test_prerelease_mode_allow() {
 
 /// Tests that prerelease-mode = "disallow" prevents pre-release versions from being resolved.
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_prerelease_mode_disallow() {
     setup_tracing();
 

--- a/crates/pixi/tests/integration_rust/solve_group_tests.rs
+++ b/crates/pixi/tests/integration_rust/solve_group_tests.rs
@@ -17,6 +17,7 @@ use crate::common::{
     builders::{HasDependencyConfig, HasNoInstallConfig},
     client::OfflineMiddleware,
     package_database::{Package, PackageDatabase},
+    pypi_index::{Database as PyPIDatabase, PyPIPackage},
 };
 use crate::setup_tracing;
 
@@ -207,7 +208,6 @@ async fn test_purl_are_missing_for_non_conda_forge() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_purl_are_generated_using_custom_mapping() {
     setup_tracing();
 
@@ -786,9 +786,29 @@ async fn test_disabled_mapping() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_custom_mapping_ignores_backwards_compatibility() {
     setup_tracing();
+
+    // Create local conda channel with boltons and python packages
+    let mut package_database = PackageDatabase::default();
+    package_database.add_package(
+        Package::build("python", "3.12.0")
+            .with_subdir(Platform::Linux64)
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("boltons", "24.0.0")
+            .with_subdir(Platform::Linux64)
+            .finish(),
+    );
+    let channel = package_database.into_channel().await.unwrap();
+    let channel_url = channel.url();
+
+    // Create local PyPI index with boltons package
+    let pypi_index = PyPIDatabase::new()
+        .with(PyPIPackage::new("boltons", "24.0.0"))
+        .into_simple_index()
+        .expect("failed to create local simple index");
 
     // Create a custom mapping file that only includes specific packages
     let temp_dir = TempDir::new().unwrap();
@@ -799,21 +819,27 @@ async fn test_custom_mapping_ignores_backwards_compatibility() {
         r#"
     [workspace]
     name = "test-custom-mapping"
-    channels = ["https://prefix.dev/conda-forge"]
+    channels = ["{channel_url}"]
     platforms = ["linux-64"]
-    conda-pypi-map = {{ "https://prefix.dev/conda-forge" = "{}" }}
+    conda-pypi-map = {{ "{channel_url}" = "{mapping_file}" }}
 
     [dependencies]
+    python = "3.12.0"
     boltons = "*"
 
     [pypi-dependencies]
     boltons = "*"
+
+    [pypi-options]
+    index-url = "{pypi_url}"
     "#,
-        mapping_file
+        channel_url = channel_url,
+        mapping_file = mapping_file
             .to_str()
             .unwrap()
             .to_string()
-            .replace("\\", "/")
+            .replace("\\", "/"),
+        pypi_url = pypi_index.index_url(),
     ))
     .unwrap();
 

--- a/crates/pixi/tests/integration_rust/update_tests.rs
+++ b/crates/pixi/tests/integration_rust/update_tests.rs
@@ -160,9 +160,22 @@ async fn test_update_single_package() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_update_conda_package_doesnt_update_git_pypi() {
     setup_tracing();
+
+    // Create local package database with Python
+    let mut package_database = PackageDatabase::default();
+    package_database.add_package(
+        Package::build("python", "3.12.0")
+            .with_subdir(Platform::current())
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("python", "3.12.1")
+            .with_subdir(Platform::current())
+            .finish(),
+    );
+    let channel = package_database.into_channel().await.unwrap();
 
     let pixi = PixiControl::new().unwrap();
 
@@ -171,6 +184,7 @@ async fn test_update_conda_package_doesnt_update_git_pypi() {
 
     // Create a new project using our package database.
     pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
         .with_platforms(vec![Platform::current()])
         .await
         .unwrap();
@@ -246,9 +260,22 @@ async fn test_update_conda_package_doesnt_update_git_pypi() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_update_conda_package_doesnt_update_git_pypi_pinned() {
     setup_tracing();
+
+    // Create local package database with Python
+    let mut package_database = PackageDatabase::default();
+    package_database.add_package(
+        Package::build("python", "3.12.0")
+            .with_subdir(Platform::current())
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("python", "3.12.1")
+            .with_subdir(Platform::current())
+            .finish(),
+    );
+    let channel = package_database.into_channel().await.unwrap();
 
     let pixi = PixiControl::new().unwrap();
 
@@ -257,6 +284,7 @@ async fn test_update_conda_package_doesnt_update_git_pypi_pinned() {
 
     // Create a new project using our package database.
     pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
         .with_platforms(vec![Platform::current()])
         .await
         .unwrap();
@@ -295,9 +323,17 @@ async fn test_update_conda_package_doesnt_update_git_pypi_pinned() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "online_tests"), ignore)]
 async fn test_update_git_pypi_when_requested() {
     setup_tracing();
+
+    // Create local package database with Python
+    let mut package_database = PackageDatabase::default();
+    package_database.add_package(
+        Package::build("python", "3.12.0")
+            .with_subdir(Platform::current())
+            .finish(),
+    );
+    let channel = package_database.into_channel().await.unwrap();
 
     let pixi = PixiControl::new().unwrap();
 
@@ -306,6 +342,7 @@ async fn test_update_git_pypi_when_requested() {
 
     // Create a new project using our package database.
     pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
         .with_platforms(vec![Platform::current()])
         .await
         .unwrap();


### PR DESCRIPTION
### Description

Mark more tests as needing Internet.

### How Has This Been Tested?

Applied the patch to the Gentoo ebuild where `pixi` is tested offline.

### AI Disclosure
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
