### PR TITLE
fix: use single quotes for CLI arg joining to fix backslash escaping

### DIFF
--- a/crates/pixi_task/src/task_graph.rs
+++ b/crates/pixi_task/src/task_graph.rs
@@ -24,6 +24,25 @@ use crate::{
     task_environment::{FindTaskError, FindTaskSource, SearchEnvironments},
 };
 
+/// Joins command-line arguments into a single shell command string.
+///
+/// Uses single quotes to preserve backslashes literally. This avoids issues
+/// with deno_task_shell which doesn't unescape `\\` to `\` inside double
+/// quotes the way POSIX shells do (see issue #5054).
+///
+/// Single quotes within arguments are handled by ending the single-quoted
+/// section, adding a double-quoted single quote, and continuing:
+/// `it's` becomes `'it'"'"'s'`
+fn join_args_with_single_quotes<'a>(args: impl IntoIterator<Item = &'a str>) -> String {
+    args.into_iter()
+        .map(|arg| {
+            // Use single quotes, replacing any ' with '"'"'
+            // (end single quote, double-quoted single quote, start single quote)
+            format!("'{}'", arg.replace('\'', r#"'"'"'"#))
+        })
+        .join(" ")
+}
+
 /// A task ID is a unique identifier for a [`TaskNode`] in a [`TaskGraph`].
 ///
 /// To get a task from a [`TaskGraph`], you can use the [`TaskId`] as an index.
@@ -271,8 +290,10 @@ impl<'p> TaskGraph<'p> {
         // and clap, so we reconstruct them into a single shell command to avoid double-quoting.
         let (cmd, additional_args) = if verbatim {
             // Multiple CLI arguments: reconstruct as a single shell command
-            let command_string = shlex::try_join(args.iter().map(|s| s.as_str()))
-                .map_err(|_| TaskGraphError::InvalidTask)?;
+            // We use single quotes to preserve backslashes literally, avoiding the
+            // escaping mismatch between shlex's POSIX double-quote escaping and
+            // deno_task_shell's non-POSIX parsing (see issue #5054).
+            let command_string = join_args_with_single_quotes(args.iter().map(|s| s.as_str()));
             (CmdArgs::Single(command_string.into()), vec![])
         } else {
             // Single argument that was shell-parsed: use as multiple args
@@ -590,7 +611,10 @@ mod test {
     use pixi_manifest::EnvironmentName;
     use rattler_conda_types::Platform;
 
-    use crate::{task_environment::SearchEnvironments, task_graph::TaskGraph};
+    use crate::{
+        task_environment::SearchEnvironments,
+        task_graph::{TaskGraph, join_args_with_single_quotes},
+    };
 
     fn commands_in_order(
         project_str: &str,
@@ -885,5 +909,26 @@ mod test {
             commands_in_order(project, &["bar"], None, None, false),
             vec!["echo foo", "echo bar"]
         );
+    }
+
+    /// Regression test for https://github.com/prefix-dev/pixi/issues/5054
+    ///
+    /// Verifies that backslashes in CLI arguments are preserved correctly.
+    #[test]
+    fn test_backslash_escaping_issue_5054() {
+        // Backslashes should be preserved using single quotes
+        let args = ["echo", r"test\ntest"];
+        let result = join_args_with_single_quotes(args.iter().copied());
+        assert_eq!(result, r#"'echo' 'test\ntest'"#);
+
+        // JSON with escaped quotes should use single quotes
+        let json_args = ["python", "-c", "print(1)", r#"{"a": "b\"c"}"#];
+        let json_result = join_args_with_single_quotes(json_args.iter().copied());
+        assert_eq!(json_result, r#"'python' '-c' 'print(1)' '{"a": "b\"c"}'"#);
+
+        // Single quotes in arguments: 'it'"'"'s' (end quote, quoted quote, start quote)
+        let quote_args = ["echo", "it's"];
+        let quote_result = join_args_with_single_quotes(quote_args.iter().copied());
+        assert_eq!(quote_result, r#"'echo' 'it'"'"'s'"#);
     }
 }


### PR DESCRIPTION
### Description

This fixes the double-escaping of backslashes in `pixi run` command arguments.

The issue was a mismatch between `shlex::try_join`'s POSIX double-quote escaping and `deno_task_shell`'s parsing. `deno_task_shell` doesn't unescape `\\` to `\` inside double quotes the way POSIX shells do.

The fix uses single quotes where possible (which preserve backslashes literally), and falls back to double quotes for strings containing single quotes.

Before: `pixi run echo 'test\ntest'` → `test\\ntest` (doubled backslash)
After:  `pixi run echo 'test\ntest'` → `test\ntest` (correct)

Fixes #5054
Fixes #4579 

### How Has This Been Tested?

In CI and manually:

Old:

```
> pixi --version
pixi 0.59.0
> pixi run echo 'bar\qux\'
Error:   × failed to parse shell script. Task: 'echo "bar\\qux\\" '
  ╰─▶ Expected closing double quote.
        "bar\\qux\\"
        ~
> pixi run echo 'test\ntest'
test\\ntest
```

New:

```
> pixi run echo 'bar\qux\'
bar\qux\
> pixi run echo 'test\ntest'
test\ntest
```

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Code Opus 4.5

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
