### PR TITLE
chore: use lzma-rust2 instead of xz2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7247,6 +7247,7 @@ dependencies = [
  "fs-err",
  "futures",
  "indicatif",
+ "lzma-rust2",
  "pixi_record",
  "pixi_spec",
  "pixi_utils",
@@ -7260,7 +7261,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "xz2",
  "zip",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ toml = "1.0.0"
 toml-span = "0.7.0"
 toml_edit = "0.23.0"
 tracing = "0.1.41"
-xz2 = "0.1.7"
+lzma-rust2 = { version = "0.16", default-features = false, features = ["xz", "std"] }
 # Forcing the version due to this PR https://github.com/tokio-rs/tracing/pull/3368
 tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"

--- a/crates/pixi_url/Cargo.toml
+++ b/crates/pixi_url/Cargo.toml
@@ -29,7 +29,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
-xz2.workspace = true
+lzma-rust2.workspace = true
 zip.workspace = true
 zstd.workspace = true
 

--- a/crates/pixi_url/src/extract.rs
+++ b/crates/pixi_url/src/extract.rs
@@ -63,11 +63,9 @@ fn ext_to_compression<'a>(
         Some("bz2" | "tbz" | "tbz2" | "tz2") => {
             Ok(TarCompression::Bzip2(bzip2::read::BzDecoder::new(file)))
         }
-        Some("lzma" | "tlz" | "xz" | "txz") => {
-            Ok(TarCompression::Xz2(Box::new(lzma_rust2::XzReader::new(
-                file, false,
-            ))))
-        }
+        Some("lzma" | "tlz" | "xz" | "txz") => Ok(TarCompression::Xz2(Box::new(
+            lzma_rust2::XzReader::new(file, false),
+        ))),
         Some("zst" | "tzst") => Ok(TarCompression::Zstd(
             zstd::stream::read::Decoder::new(file)
                 .map_err(|err| ExtractError::TarExtractionError(err.to_string()))?,

--- a/crates/pixi_url/src/extract.rs
+++ b/crates/pixi_url/src/extract.rs
@@ -10,9 +10,9 @@ use crate::{error::ExtractError, progress::ProgressHandler};
 /// Handle compression formats internally.
 enum TarCompression<'a> {
     PlainTar(Box<dyn BufRead + 'a>),
-    Gzip(flate2::read::GzDecoder<Box<dyn BufRead + 'a>>),
+    Gzip(Box<flate2::read::GzDecoder<Box<dyn BufRead + 'a>>>),
     Bzip2(bzip2::read::BzDecoder<Box<dyn BufRead + 'a>>),
-    Xz2(xz2::read::XzDecoder<Box<dyn BufRead + 'a>>),
+    Xz2(Box<lzma_rust2::XzReader<Box<dyn BufRead + 'a>>>),
     Zstd(zstd::stream::read::Decoder<'a, std::io::BufReader<Box<dyn BufRead + 'a>>>),
 }
 
@@ -57,12 +57,16 @@ fn ext_to_compression<'a>(
         .and_then(|s| s.rsplit_once('.'))
         .map(|(_, s)| s)
     {
-        Some("gz" | "tgz" | "taz") => Ok(TarCompression::Gzip(flate2::read::GzDecoder::new(file))),
+        Some("gz" | "tgz" | "taz") => Ok(TarCompression::Gzip(Box::new(
+            flate2::read::GzDecoder::new(file),
+        ))),
         Some("bz2" | "tbz" | "tbz2" | "tz2") => {
             Ok(TarCompression::Bzip2(bzip2::read::BzDecoder::new(file)))
         }
         Some("lzma" | "tlz" | "xz" | "txz") => {
-            Ok(TarCompression::Xz2(xz2::read::XzDecoder::new(file)))
+            Ok(TarCompression::Xz2(Box::new(lzma_rust2::XzReader::new(
+                file, false,
+            ))))
         }
         Some("zst" | "tzst") => Ok(TarCompression::Zstd(
             zstd::stream::read::Decoder::new(file)


### PR DESCRIPTION
This switches to the pure rust implementation of `xz` / `lzma`.

Unfortunately, async-compression still pulls in `xz2` (which links to a system library).