### PR TITLE
ci: fix docs-dev post setup-pixi run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -138,5 +138,5 @@ jobs:
           git push origin gh-pages
 
       - name: Checkout main branch
-        # Important to run the post setup-pixi steps
+        # Important to run the post setup-pixi steps, we want to cache based on the `main` branch and we checked out another in the step above.
         run: git checkout main


### PR DESCRIPTION
### Description

https://github.com/prefix-dev/pixi/actions/runs/19986577146/job/57321398137

Runs like these are failing because the post setup-pixi run needs the pixi.toml and pixi.lock to function. checking out the main branch should do the trick. 


### How Has This Been Tested?
Didn't ... It should fix the main branch CI

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
