### PR TITLE
fix(test): mark `test_add_url_no_channel` as slow

### DIFF
--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -3,10 +3,10 @@ import platform
 import shutil
 import sys
 import tomllib
-import tomli_w
 from pathlib import Path
 
 import pytest
+import tomli_w
 from dirty_equals import AnyThing, IsList, IsStr
 from inline_snapshot import snapshot
 
@@ -1372,6 +1372,7 @@ def test_quiet_flag_with_rust_log_env(
     )
 
 
+@pytest.mark.slow
 def test_add_url_no_channel(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """
     Check that a helpful error message is raised when attempting to


### PR DESCRIPTION


### Description

In debug mode, this test times out on my machine


### How Has This Been Tested?

```
pixi run test-specific-test test_add_url
pixi run test-integration-slow 
```
