### PR TITLE
fix: change binary to source should always select source

### DIFF
--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -105,8 +105,8 @@ impl BuildBackendMetadataSpec {
         skip_all,
         name="backend-metadata",
         fields(
-            manifest_source = ?self.manifest_source,
-            build_source = ?self.preferred_build_source,
+            manifest_source = %self.manifest_source,
+            build_source = self.preferred_build_source.as_ref().map(tracing::field::display),
             platform = %self.build_environment.host_platform,
         )
     )]

--- a/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
@@ -109,6 +113,16 @@ impl SolveCondaEnvironmentSpec {
         // Solving is a CPU-intensive task, we spawn this on a background task to allow
         // for more concurrency.
         let solve_result = tokio::task::spawn_blocking(move || {
+            // Determine for which records we have source records because those records should only
+            //  be installed as source records.
+            let package_names_from_source = self
+                .source_repodata
+                .iter()
+                .flat_map(|metadata| &metadata.records)
+                .map(|metadata| &metadata.package_record.name)
+                .dedup()
+                .collect::<HashSet<_>>();
+
             // Filter all installed packages
             let installed = self
                 .installed
@@ -116,7 +130,7 @@ impl SolveCondaEnvironmentSpec {
                 // Only lock binary records
                 .filter_map(|record| record.into_binary())
                 // Filter any record we want as a source record
-                .filter(|record| !self.source_specs.contains_key(&record.package_record.name))
+                .filter(|record| !package_names_from_source.contains(&record.package_record.name))
                 .collect();
 
             // Create direct dependencies on the source packages to feed to the solver.

--- a/crates/pixi_command_dispatcher/src/source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build/mod.rs
@@ -127,7 +127,7 @@ impl SourceBuildSpec {
         name = "source-build",
         fields(
             manifest_source = %self.source.manifest_source(),
-            build_source = ?self.source.build_source(),
+            build_source = self.source.build_source().as_ref().map(tracing::field::display),
             package = %self.package,
         )
     )]

--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -60,7 +60,7 @@ impl SourceMetadataSpec {
         name = "source-metadata",
         fields(
             manifest_source= %self.backend_metadata.manifest_source,
-            preferred_build_source=?self.backend_metadata.preferred_build_source,
+            preferred_build_source=self.backend_metadata.preferred_build_source.as_ref().map(tracing::field::display),
             name = %self.package.as_source(),
             platform = %self.backend_metadata.build_environment.host_platform,
         )


### PR DESCRIPTION
### Description

This fixes an issue where if a lock-file contained a binary package it would always be selected for transitive dependencies even if a source package was available. This PR changes this behavior to ensure that only source packages are used if they are specified.

Fixes #5065

### How Has This Been Tested?

I tested this manually on the reproducer in the issue.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
