### PR TITLE
fix(docs): change environment from 'prod' to 'default' in pixi_pack.md

### DIFF
--- a/docs/deployment/pixi_pack.md
+++ b/docs/deployment/pixi_pack.md
@@ -26,7 +26,7 @@ pixi exec pixi-unpack environment.tar
 You can pack an environment with
 
 ```bash
-pixi-pack --environment prod --platform linux-64 pixi.toml
+pixi-pack --environment default --platform linux-64 pixi.toml
 ```
 
 This will create an `environment.tar` file that contains all conda packages required to create the environment.


### PR DESCRIPTION
Updated the pixi-pack command to use 'default' environment.

The previous value `prod` seems to have no relation to the rest of the documentation, and just fails. 

default works for me. 🙂 

