### PR TITLE
docs: add documentation for `RATTLER_AUTH_FILE` environment variable

### DIFF
--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -28,6 +28,17 @@ Pixi can also be configured via environment variables.
         </ul>
       </td>
     </tr>
+    <tr>
+      <td><code>RATTLER_AUTH_FILE</code></td>
+      <td>Overrides the default location of the credentials file. When set, this is the only source of authentication data used by pixi. See <a href="../deployment/authentication.md#override-the-authentication-storage">authentication docs</a> for the file format.</td>
+      <td>
+        <ul>
+          <li>If <code>RATTLER_AUTH_FILE</code> is not set, the system keyring is used.</li>
+          <li>If no keyring is available, file storage from <code>~/.rattler/credentials.json</code> is used.</li>
+          <li>Additionally, <code>.netrc</code> file authentication is checked.</li>
+        </ul>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -30,7 +30,7 @@ Pixi can also be configured via environment variables.
     </tr>
     <tr>
       <td><code>RATTLER_AUTH_FILE</code></td>
-      <td>Overrides the default location of the credentials file. When set, this is the only source of authentication data used by pixi. See <a href="../deployment/authentication.md#override-the-authentication-storage">authentication docs</a> for the file format.</td>
+      <td>Overrides the default location of the credentials file. When set, this is the only source of authentication data used by pixi. See <a href="../../deployment/authentication/#override-the-authentication-storage">authentication docs</a> for the file format.</td>
       <td>
         <ul>
           <li>If <code>RATTLER_AUTH_FILE</code> is not set, the system keyring is used.</li>

--- a/docs/switching_from/conda.md
+++ b/docs/switching_from/conda.md
@@ -49,7 +49,7 @@ pixi config set detached-environments true
 # or a specific location
 pixi config set detached-environments /path/to/envs
 ```
-This doesn't allow you to activate the environments using `pixi shell -n` but it will make the installation of the environments go to the same folder.
+This will make the installation of the environments go to the same folder.
 
 `pixi` does have the `pixi global` command to install tools on your machine. (See [global](../reference/cli/pixi/global.md))
 This is not a replacement for `conda` but works the same as [`pipx`](https://pipx.pypa.io/stable/) and [`condax`](https://mariusvniekerk.github.io/condax/).


### PR DESCRIPTION
### Description

Add documentation for `RATTLER_AUTH_FILE `environment variable
Also trims a sentence, since that seems to be confusing to people.

Fixes #5097

### How Has This Been Tested?

I ran the docs locally

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
