### PR TITLE
fix: use global config tls setting with `self-update`

### DIFF
--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -5,6 +5,7 @@ use flate2::read::GzDecoder;
 use tar::Archive;
 
 use miette::IntoDiagnostic;
+use pixi_config::Config;
 use pixi_consts::consts;
 use pixi_utils::reqwest::{build_reqwest_clients, reqwest_client_builder};
 use reqwest::redirect::Policy;
@@ -89,8 +90,11 @@ async fn latest_version() -> miette::Result<Version> {
     // Uses the public Github Releases /latest endpoint to get the latest tag from the URL
     let url = format!("{}/latest", consts::RELEASES_URL);
 
+    // Load global config to respect TLS settings (e.g., tls-root-certs = "native")
+    let config = Config::load_global();
+
     // Create a client with a redirect policy
-    let no_redirect_client = reqwest_client_builder(None)?
+    let no_redirect_client = reqwest_client_builder(Some(&config))?
         .redirect(Policy::none())
         .build()
         .into_diagnostic()?; // Prevent automatic redirects


### PR DESCRIPTION
The `latest_version()` function was calling `reqwest_client_builder(None)` which doesn't load global configuration and defaults to using webpki bundled certificates. This caused the version check to fail with TLS errors for users who have configured `tls-root-certs = "native"` for corporate firewall compatibility.

The fix loads the global config using `Config::load_global()` and passes it to `reqwest_client_builder()`, consistent with how `build_reqwest_clients()` handles the None case.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->
Fixes #5117

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

Not sure how to test this I would hope the OP of the issue couid give it a try.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Opus 4.5

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
