### PR TITLE
docs: fix width on small screens

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -565,7 +565,7 @@ table code {
     border-top-right-radius: 0.25rem !important;
 }
 
-/* Fix tab overflow on small screens */
+/* Avoid tab overflow on small screens */
 .md-typeset .tabbed-set {
   max-width: 100%;
   overflow-x: auto;


### PR DESCRIPTION
### Description

The tabs used to overflow

Before:
<img width="378" height="672" alt="grafik" src="https://github.com/user-attachments/assets/8c7b707f-6bd6-4eb4-b100-f184b8ccfee7" />

After:
<img width="378" height="672" alt="grafik" src="https://github.com/user-attachments/assets/347c8316-ee4f-4f6c-9f8b-736f76082040" />


### How Has This Been Tested?

`pixi run docs`

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
