### PR TITLE
fix: DAQ passthrough

### DIFF
--- a/crates/pixi_pty/src/unix/pty_session.rs
+++ b/crates/pixi_pty/src/unix/pty_session.rs
@@ -28,6 +28,8 @@ impl BufferBypass {
         }
     }
 
+    /// Scans the buffer for the configured sequences. If found, writes them to the writer
+    /// immediately and removes them from the buffer.
     fn process(&self, buffer: &mut Vec<u8>, writer: &mut impl Write) -> io::Result<()> {
         for seq in &self.sequences {
             while let Some(pos) = buffer


### PR DESCRIPTION
### Description

This fixes #4846 where pixi shell is slow to spawn a fish shell because as of fish 4.1 it waits for primary device attribute queries to the terminal. This fixes passes them through on the creation of the PTY session 

### How Has This Been Tested?

I have run the recommended tests:
```
pixi run build-debug
pixi run lint
pixi run test-all-fast
```
and they have passed. 

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
GitHub Copilot was used with Gemini 3 Pro. I don't have the original prompt, but the gist was to pass through the DAQ to the terminal and the context was the entire repo, the relevant file was identified. 

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
