### PR TITLE
fix: include dev dependencies when extracting packages from solve groups

### DIFF
--- a/crates/pixi/tests/integration_rust/develop_dependencies_tests.rs
+++ b/crates/pixi/tests/integration_rust/develop_dependencies_tests.rs
@@ -748,3 +748,105 @@ python = ["3.10", "3.12"]
         "Should select python 3.10 (constrained by dependency <3.12), not 3.12"
     );
 }
+
+/// Test that dev dependencies work correctly with solve groups.
+///
+/// When two environments share a solve group, and one of them has dev dependencies,
+/// the environment with dev dependencies should include the packages that those
+/// dev dependencies bring in.
+///
+/// This test verifies that when extracting packages for each environment from
+/// the solve group's solution, dev dependencies are properly taken into account.
+#[tokio::test]
+async fn test_dev_dependencies_in_solve_group() {
+    setup_tracing();
+
+    let package_database = create_test_package_database();
+
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    // Create a dev package that has run-dependencies
+    let _dev_package = create_source_package(
+        pixi.workspace_path(),
+        "dev-tools",
+        "1.0.0",
+        r#"
+[package.run-dependencies]
+cmake = ">=3.0"
+make = ">=4.0"
+"#,
+    );
+
+    // Create a manifest with:
+    // - Two environments in the same solve-group
+    // - One environment (dev) has dev dependencies
+    // - One environment (prod) does not have dev dependencies
+    let manifest_content = format!(
+        r#"
+[workspace]
+channels = ["{}"]
+platforms = ["{}"]
+preview = ["pixi-build"]
+
+[dependencies]
+python = "*"
+
+[feature.dev-feature.dev]
+dev-tools = {{ path = "./dev-tools" }}
+
+[environments]
+prod = {{ solve-group = "main" }}
+dev = {{ features = ["dev-feature"], solve-group = "main" }}
+"#,
+        channel.url(),
+        Platform::current()
+    );
+
+    fs::write(pixi.manifest_path(), manifest_content).unwrap();
+
+    // Update the lock-file
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    // Both environments should have python (shared dependency)
+    assert!(
+        lock_file.contains_conda_package("prod", Platform::current(), "python"),
+        "prod environment should have python"
+    );
+    assert!(
+        lock_file.contains_conda_package("dev", Platform::current(), "python"),
+        "dev environment should have python"
+    );
+
+    // The dev environment should have the dependencies brought in by dev-tools
+    // (cmake and make are run-dependencies of dev-tools)
+    assert!(
+        lock_file.contains_conda_package("dev", Platform::current(), "cmake"),
+        "dev environment should have cmake (run-dependency of dev-tools)"
+    );
+    assert!(
+        lock_file.contains_conda_package("dev", Platform::current(), "make"),
+        "dev environment should have make (run-dependency of dev-tools)"
+    );
+
+    // The prod environment should NOT have cmake and make
+    // (they are only brought in by dev-tools which is only in the dev environment)
+    assert!(
+        !lock_file.contains_conda_package("prod", Platform::current(), "cmake"),
+        "prod environment should NOT have cmake"
+    );
+    assert!(
+        !lock_file.contains_conda_package("prod", Platform::current(), "make"),
+        "prod environment should NOT have make"
+    );
+
+    // dev-tools itself should NOT be built (it's a dev dependency)
+    assert!(
+        !lock_file.contains_conda_package("dev", Platform::current(), "dev-tools"),
+        "dev-tools should NOT be in the lock-file (it's a dev dependency)"
+    );
+}

--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -18,8 +18,8 @@ use rattler_lock::{PypiPackageData, PypiPackageEnvironmentData};
 pub use records_by_name::{PixiRecordsByName, PypiRecordsByName};
 pub use resolve::pypi::resolve_pypi;
 pub use satisfiability::{
-    EnvironmentUnsat, PlatformUnsat, verify_environment_satisfiability,
-    verify_platform_satisfiability,
+    Dependency, EnvironmentUnsat, PlatformUnsat, resolve_dev_dependencies,
+    verify_environment_satisfiability, verify_platform_satisfiability,
 };
 pub use update::{
     LockFileDerivedData, PackageFilterNames, ReinstallEnvironment, ReinstallPackages,


### PR DESCRIPTION
### Description

Fixes an issue where dependencies from the new `dev` section were removed when using solve groups.

### How Has This Been Tested?

Unit test only.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Opus 4.5

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
