### PR TITLE
fix: improve python version specifier handling in pypi.rs

### DIFF
--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -379,6 +379,7 @@ pub async fn resolve_pypi(
     // requires_python specifier is used to determine the python version of the
     // wheel. So make sure the interpreter does not touch the solve parts of
     // this function
+    // A python-3.10.6-xxx.conda package record becomes a "==3.10.6.*" requires python specifier.
     let python_specifier = uv_pep440::VersionSpecifier::from_version(
         uv_pep440::Operator::EqualStar,
         uv_pep440::Version::from_str(&python_record.version().as_str()).into_diagnostic()?,


### PR DESCRIPTION
### Description

Pixi has to create a `requires-python` value for the pypi solve. It bases that on the Python record from the conda solve. 

We normally transfrom `python-3.12.4` into `requires-python = ">=3.12"` But this doesn't work in the `uv` solve when it also checks the actually `requires-python` in the pyproject.toml and it doesn't match. e.g. in the case of issue #5202. Where  `==3.10.6` doesn't satisfy `>=3.10.*`. This is all happening somewhere in the UV code. I checked what uv does with that information and it seems to use the installed python version directly. So change in this PR should do the same. 

What would be a better fix is to actually get the information from the `requires_python` spec. This would be more correct. But I don't see a nice way to transfer that information to this solving function. 

Fixes #5205

**Draft because I don't trust the fix yet, @tdejager could you take a critical look?**

### How Has This Been Tested?

I've tested the issue and tried to break the wheel fetching that is described in the comment above the removed code. 

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
