### PR TITLE
docs: add section on pinned package conflicts in conda and PyPI integration

### DIFF
--- a/crates/pixi/tests/integration_rust/pypi_tests.rs
+++ b/crates/pixi/tests/integration_rust/pypi_tests.rs
@@ -942,7 +942,8 @@ async fn test_pinned_help_message() {
     // Should contain pinned help message for pandas==1.0.0
     assert_eq!(
         format!("{}", err.help().unwrap()),
-        "The following PyPI packages have been pinned by the conda solve, and this version may be causing a conflict:\npandas==1.0.0"
+        "The following PyPI packages have been pinned by the conda solve, and this version may be causing a conflict:\npandas==1.0.0
+See https://pixi.sh/latest/concepts/conda_pypi/#pinned-package-conflicts for more information."
     );
 }
 

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -263,7 +263,8 @@ fn create_solve_error(
                 None
             } else {
                 Some(format!(
-                    "The following PyPI packages have been pinned by the conda solve, and this version may be causing a conflict:\n{}",
+                    "The following PyPI packages have been pinned by the conda solve, and this version may be causing a conflict:\n{}
+See https://pixi.sh/latest/concepts/conda_pypi/#pinned-package-conflicts for more information.",
                     conflicting_packages.join("\n")
                 ))
             };


### PR DESCRIPTION
### Description

I added a section explaining pinned package conflicts due to the two-staged solve with conda and pypi-dependencies.
Also, I added a link to the docs in the corresponding error message.

### Motivation

I had to explain this error message to a colleague today, which seemed to imply that the package it was trying to install had two conflicting dependencies.

### How Has This Been Tested?

I have not tested it locally, but corrected the corresponding test that checked that error message.

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
