### PR TITLE
fix: fish shell integration is broken on older version of fish

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -221,7 +221,8 @@ __wrap__() {
             ;;
 
         fish)
-            LINE="fish_add_path ${PIXI_BIN_DIR}"
+            # Use 'set -gx PATH' for compatibility with Fish < 3.2.0 (which lacks fish_add_path)
+            LINE="set -gx PATH \"${PIXI_BIN_DIR}\" \$PATH"
             update_shell ~/.config/fish/config.fish "$LINE"
             ;;
 


### PR DESCRIPTION
Replace `fish_add_path` with `set -gx PATH` for compatibility with Fish versions older than 3.2.0 (e.g., Fish 3.1.0 on Ubuntu 20.04).

This is consistent with how bash/zsh PATH setup is handled in the same script.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #5210

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Sonnet 

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
