### PR TITLE
feat(pixi_api): Expose PIXI_VERSION const

### DIFF
--- a/crates/pixi_api/src/lib.rs
+++ b/crates/pixi_api/src/lib.rs
@@ -13,3 +13,5 @@ pub use pixi_manifest as manifest;
 pub use pixi_pypi_spec as pypi_spec;
 pub use pixi_spec as spec;
 pub use rattler_conda_types;
+
+pub use pixi_consts::consts::PIXI_VERSION;


### PR DESCRIPTION
### Description

Adds `PIXI_VERSION` so `pixi_api` consumers can expose the currently used Pixi version. 
