### PR TITLE
fix: run pixi_command_dispatcher tests serially to avoid race conditions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,9 @@
+# Nextest configuration
+# https://nexte.st/book/configuration.html
+
+[test-groups]
+serial-integration = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = "package(pixi_command_dispatcher)"
+test-group = "serial-integration"


### PR DESCRIPTION
### Description

Add nextest.toml configuration to run pixi_command_dispatcher package tests serially (max-threads = 1).

Fixes #5260

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->
```shell
pixi run test-fast
pixi run test-all-fast
```

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
No

<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
