### PR TITLE
feat: add warning if we cannot reach the pypi mapping on prefix.dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -4325,6 +4326,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5113,6 +5131,29 @@ dependencies = [
  "tracing",
  "url",
  "uv-normalize",
+]
+
+[[package]]
+name = "pixi_artifact_server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "fs-err",
+ "hex",
+ "rattler_conda_types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -6393,6 +6434,7 @@ name = "pypi_mapping"
 version = "0.1.0"
 dependencies = [
  "async-once-cell",
+ "console 0.16.2",
  "dashmap",
  "fs-err",
  "futures",
@@ -8966,6 +9008,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -9176,6 +9219,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/pypi_mapping/Cargo.toml
+++ b/crates/pypi_mapping/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 
 [dependencies]
 async-once-cell = { workspace = true }
+console = { workspace = true }
 dashmap = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }


### PR DESCRIPTION
We had a user that seemed to get "stuck" when initializing a `pyproject.toml` on Discord. 

Maybe a function like this could help to print a warning if the domain is not reachable?

I should test this with `mitmproxy`.

Disclaimer: written by Claude Code.