### PR TITLE
docs: Improve system requirements documentation clarity

### DIFF
--- a/docs/workspace/system_requirements.md
+++ b/docs/workspace/system_requirements.md
@@ -28,7 +28,9 @@ This means it affects all environments that include the default feature (which i
 
 This way, Pixi guarantees your environment is consistent and compatible with your machine.
 
-System specifications are closely related to [virtual packages](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html), allowing for flexible and accurate dependency management.
+System requirements are added as [virtual packages](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html).
+Virtual packages are special packages (like `__linux`, `__cuda`, `__glibc`) that don't contain any files.
+They simply declare what features are available on the system, and the solver uses them to filter out incompatible packages.
 
 !!! note "Need to support multiple types of systems that don't share the same specifications?"
     You can define `system-requirements` for different `features` in your workspace.


### PR DESCRIPTION
### Description

- Make clear that `[system-requirements]` belongs to the default feature
- Talk more about envs and less about workspace


### How Has This Been Tested?

Rendered locally

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

### Checklist:
- [x] I have made corresponding changes to the documentation