### PR TITLE
fix: an issue with source-interdependencies and dev packages

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -1454,6 +1454,12 @@ pub async fn resolve_dev_dependencies(
     variants: &std::collections::BTreeMap<String, Vec<VariantValue>>,
     variant_files: &[PathBuf],
 ) -> Result<Vec<Dependency>, Box<PlatformUnsat>> {
+    // Collect all dev source package names to filter out interdependencies
+    let dev_source_names: HashSet<PackageName> = dev_dependencies
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect();
+
     let futures = dev_dependencies
         .into_iter()
         .map(|(package_name, source_spec)| {
@@ -1463,6 +1469,7 @@ pub async fn resolve_dev_dependencies(
             let build_environment = build_environment.clone();
             let variants = variants.clone();
             let variant_files = variant_files.to_vec();
+            let dev_source_names = dev_source_names.clone();
 
             resolve_single_dev_dependency(
                 package_name,
@@ -1473,6 +1480,7 @@ pub async fn resolve_dev_dependencies(
                 build_environment,
                 variants,
                 variant_files,
+                dev_source_names,
             )
         })
         .collect::<futures::stream::FuturesUnordered<_>>();
@@ -1498,6 +1506,7 @@ async fn resolve_single_dev_dependency(
     build_environment: BuildEnvironment,
     variants: std::collections::BTreeMap<String, Vec<VariantValue>>,
     variant_files: Vec<PathBuf>,
+    dev_source_names: HashSet<PackageName>,
 ) -> Result<Vec<Dependency>, PlatformUnsat> {
     let pinned_source = command_dispatcher
         .pin_and_checkout(source_spec.location)
@@ -1527,20 +1536,25 @@ async fn resolve_single_dev_dependency(
 
     let mut dependencies = Vec::new();
 
-    // Process source dependencies
-    for (dev_name, dep) in dev_source.into_specs() {
-        let string = dep.to_string();
+    // Process source dependencies, filtering out dependencies that are also dev sources
+    for (dep_name, dep) in dev_source
+        .into_specs()
+        .filter(|(name, _)| !dev_source_names.contains(name))
+    {
         let anchored_source = dep.resolve(&SourceAnchor::Workspace);
 
         dependencies.push(Dependency::CondaSource(
-            dev_name.clone(),
+            dep_name.clone(),
             anchored_source,
-            Cow::Owned(format!("{} @ {}", dev_name.as_source(), string)),
+            Cow::Owned(package_name.as_source().to_string()),
         ));
     }
 
-    // Process binary dependencies
-    for (dev_name, binary_spec) in dev_bin.into_specs() {
+    // Process binary dependencies, filtering out dependencies that are also dev sources
+    for (dep_name, binary_spec) in dev_bin
+        .into_specs()
+        .filter(|(name, _)| !dev_source_names.contains(name))
+    {
         // Convert BinarySpec to NamelessMatchSpec
         let nameless_spec = binary_spec
             .try_into_nameless_match_spec(&channel_config)
@@ -1557,16 +1571,16 @@ async fn resolve_single_dev_dependency(
                     SpecConversionError::MissingName => ParseMatchSpecError::MissingPackageName,
                 };
                 PlatformUnsat::FailedToParseMatchSpec(
-                    dev_name.as_source().to_string(),
+                    dep_name.as_source().to_string(),
                     parse_channel_err,
                 )
             })?;
 
-        let spec = MatchSpec::from_nameless(nameless_spec, Some(dev_name.clone().into()));
+        let spec = MatchSpec::from_nameless(nameless_spec, Some(dep_name.clone().into()));
 
         dependencies.push(Dependency::Conda(
             spec,
-            Cow::Owned(dev_name.as_source().to_string()),
+            Cow::Owned(package_name.as_source().to_string()),
         ));
     }
 


### PR DESCRIPTION
### Description

Resolving packages worked fine, but checking satisfiability did not properly sort out dev-dependencies (that shoudl not be installed), which resulted in always saying:

```
INFO pixi_core::lock_file::outdated: the dependencies of environment 'default' for platform osx-arm64 are out of date because the requirement 'ros-humble-ros-pkg-1' could not be satisfied (required by 'ros-humble-ros-pkg-1')
Error:   × lock-file not up-to-date with the workspace
```

Now we are also sorting out the dev dependencies when checking for satisfiability. 

Also fixes the issue that it says `required by 'ros-humble-ros-pkg-1'` instead of `2` which would be correct.

### How Has This Been Tested?

I tested this with the reproducer provided in https://github.com/prefix-dev/pixi-build-backends/issues/531 (https://github.com/EzraBrooks/pixi-build-ros-issue-repro).

### AI Disclosure

100% Claude Code.

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
