### PR TITLE
refactor: the uv client to be created in a single place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6047,6 +6047,7 @@ dependencies = [
  "uv-dispatch",
  "uv-distribution-types",
  "uv-normalize",
+ "uv-pep508",
  "uv-preview",
  "uv-types",
  "uv-workspace",

--- a/crates/pixi_uv_context/Cargo.toml
+++ b/crates/pixi_uv_context/Cargo.toml
@@ -23,6 +23,7 @@ uv-configuration = { workspace = true }
 uv-dispatch = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-normalize = { workspace = true }
+uv-pep508 = { workspace = true }
 uv-preview = { workspace = true }
 uv-types = { workspace = true }
 uv-workspace = { workspace = true }


### PR DESCRIPTION
### Description

This refactors the creation of the reqwest client for uv to take place in a single place.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

This should not change any behavior and should basically only move the registry client creation.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Opus 4.5

