### PR TITLE
fix: loading of uv certificates

### DIFF
--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -69,20 +69,14 @@ static DEFAULT_REQWEST_IDLE_PER_HOST: usize = 20;
 ///
 /// For `native-tls` builds, this always returns `true` since the system TLS library is used.
 /// For `rustls-tls` builds, this returns `true` if the config is set to `Native` or `All`.
-pub fn should_use_native_tls_for_uv(config: &Config) -> bool {
-    #[cfg(feature = "native-tls")]
-    {
-        let _ = config;
-        return true;
-    }
+pub fn should_use_native_tls_for_uv() -> bool {
+    tls_backend() == "native-tls"
+}
 
-    #[cfg(not(feature = "native-tls"))]
-    {
-        matches!(
-            config.tls_root_certs(),
-            pixi_config::TlsRootCerts::Native | pixi_config::TlsRootCerts::All
-        )
-    }
+/// Determines whether we should load all builtin certificates
+/// for uv
+pub fn should_use_builtin_certs_uv(config: &Config) -> bool {
+    matches!(config.tls_root_certs(), pixi_config::TlsRootCerts::All)
 }
 
 /// Returns the name of the TLS backend used by this build.


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes: https://github.com/prefix-dev/pixi-docker/issues/134

This changes the way when we tell uv to load the built-in certificates.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

Test reproduction:
```Dockerfile
FROM ghcr.io/prefix-dev/pixi:0.63.1
COPY pyproject.toml ./
RUN pixi install
```
With a pyproject.toml containing a PyPI dependency (e.g., polars).

E.g

```toml
# pyproject.toml
[project]
dependencies = []
name = "tmp.s5BuMt3dvU"
requires-python = ">= 3.11"
version = "0.1.0"

[build-system]
build-backend = "hatchling.build"
requires = ["hatchling"]

[tool.pixi.workspace]
channels = ["conda-forge"]
platforms = ["osx-arm64", "linux-aarch64", "linux-64"]

[tool.pixi.pypi-dependencies]
polars = "*"
```
  
*Verified this by*: Built pixi from this branch inside a Docker container and confirmed pixi install now succeeds without certificate errors. Like this

```Dockerfile
# Build stage - compile pixi from source
FROM rust:1.86 AS builder
WORKDIR /build
COPY pixi-src/ .
RUN cargo build -p pixi

# Runtime stage
FROM ghcr.io/prefix-dev/pixi:0.63.1
COPY --from=builder /build/target/debug/pixi /usr/local/bin/pixi
COPY pyproject.toml ./
# COPY pixi.lock ./
RUN pixi install
```

This means `pixi-src` needs to be available :)


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
