### PR TITLE
docs: ROS2 tutorial commands for building C++ nodes

### DIFF
--- a/docs/tutorials/ros2.md
+++ b/docs/tutorials/ros2.md
@@ -181,7 +181,7 @@ hello = { cmd = "ros2 run my_package my_node", depends-on = ["build"] }
 To build a C++ node you need to add the `ament_cmake` and some other build dependencies to your manifest file.
 
 ```shell
-pixi add ros-humble-ament-cmake-auto compilers pkg-config cmake ninja colcon-common-extensions
+pixi add ros-humble-ament-cmake-auto compilers pkg-config "cmake<4" ninja colcon-common-extensions
 ```
 
 Now you can create a C++ node with the following command


### PR DESCRIPTION
Updated commands to include 'colcon-common-extensions' and modified build command syntax.

I assume this is what was intended originally since the new package was generated into a `src` folder and because of the arguments that come after `pixi run build`.

### How Has This Been Tested?

I tested this locally on my personal macbook air.

### AI Disclosure

No AI tools used.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
