### PR TITLE
docs: fix backends url

### DIFF
--- a/docs/build/advanced_cpp.md
+++ b/docs/build/advanced_cpp.md
@@ -1,7 +1,7 @@
 In this tutorial, we will show you how to build the same C++ package as from [Building a C++ Package](cpp.md) tutorial using [`rattler-build`](https://rattler.build).
 In this tutorial we assume that you've read the [Building a C++ Package](cpp.md) tutorial.
 If you haven't read it yet, we recommend you to do so before continuing.
-You might also want to check out the [documentation](https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-rattler-build/) for the `pixi-build-rattler-build` backend.
+You might also want to check out the [documentation](backends/pixi-build-rattler-build.md) for the `pixi-build-rattler-build` backend.
 The project structure and the source code will be the same as in the previous tutorial, so we may skip explicit explanations of some parts.
 
 This approach may be useful when no build backend for your language or build system exists.

--- a/docs/build/cpp.md
+++ b/docs/build/cpp.md
@@ -1,6 +1,6 @@
 This example shows how to build a C++ package with CMake and use it together with `pixi-build`.
 To read more about how building packages work with Pixi see the [Getting Started](./getting_started.md) guide.
-You might also want to check out the [documentation](https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-cmake/) for the `pixi-build-cmake` backend.
+You might also want to check out the [documentation](backends/pixi-build-cmake.md) for the `pixi-build-cmake` backend.
 
 We'll start off by creating a workspace that use [nanobind](https://github.com/wjakob/nanobind) to build Python bindings.
 That we can also test using pixi.

--- a/docs/build/getting_started.md
+++ b/docs/build/getting_started.md
@@ -45,7 +45,7 @@ In `package` you specify properties specific to the package you want to build.
 Packages are built by using build backends.
 By specifying `package.build.backend` and `package.build.channels` you determine which backend is used and from which channel it will be downloaded.
 
-There are [different build backends available](https://prefix-dev.github.io/pixi-build-backends/). 
+There are [different build backends available](backends.md). 
 
 Pixi backends describe how to build a conda package, for a certain language or build tool.
 In this example, we are using `pixi-build-python` backend in order to build a Python package.

--- a/docs/build/python.md
+++ b/docs/build/python.md
@@ -1,6 +1,6 @@
 In this tutorial, we will show you how to create a simple Python package with pixi.
 To read more about how building packages work with Pixi see the [Getting Started](./getting_started.md) guide.
-You might also want to check out the [documentation](https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-python/) for the `pixi-build-python` backend.
+You might also want to check out the [documentation](backends/pixi-build-python.md) for the `pixi-build-python` backend.
 
 
 !!! warning

--- a/docs/build/ros.md
+++ b/docs/build/ros.md
@@ -3,7 +3,7 @@ This guide shows how to build a ROS package into a conda package with Pixi using
 
 To understand the build feature, start with the general [Build Getting Started](./getting_started.md) guide.
 For ROS without Pixi building (not packaging), see the [ROS 2 tutorial](../tutorials/ros2.md).
-You may also want to read the backend documentation for [pixi-build-ros](https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-ros/).
+You may also want to read the backend documentation for [pixi-build-ros](backends/pixi-build-ros.md).
 
 !!! warning
     `pixi-build` is a preview feature and may change before stabilization.
@@ -147,7 +147,7 @@ You can now upload these artifacts to a conda channel and depend on them from ot
 
 - ROS distro and platform: pick the correct RoboStack channel (e.g. `robostack-humble`, `robostack-jazzy`) and ensure your platform is supported.
 - Keep `package.xml` accurate: name, version, license, maintainers, URLs, and dependencies are read automatically; but you can override them in the [pixi manifest](https://pixi.sh/latest/reference/pixi_manifest/#the-package-section).
-- Backend docs: see the [pixi-build-ros documentation](https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-ros/) for configuration details like `env`, `distro` and `extra-input-globs`.
+- Backend docs: see the [pixi-build-ros documentation](backends/pixi-build-ros.md) for configuration details like `env`, `distro` and `extra-input-globs`.
 - Colcon vs pixi build: you don’t need `colcon` when using `pixi`; the backend invokes the right build flow. But since you don't have to change your package structure, you can still use `colcon` if you want.
 - Not all ROS packages are available in RoboStack. If you depend on a package not in RoboStack, you can:
   - **Recommended:** Contribute to RoboStack to add it; see the [RoboStack Contributing page](https://robostack.github.io/Contributing.html)


### PR DESCRIPTION
Adapts the backend links to use internal links instead of pointing to the backend repo