### PR TITLE
fix: preserve cache ID when metadata is content-equivalent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5748,7 +5748,6 @@ dependencies = [
  "pixi_url",
  "pixi_utils",
  "pixi_variant",
- "rand 0.9.2",
  "rattler",
  "rattler_conda_types",
  "rattler_digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,6 +5727,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "miette 7.6.0",
+ "nanoid",
  "once_cell",
  "ordermap",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ pixi_variant = { path = "crates/pixi_variant" }
 pypi_mapping = { path = "crates/pypi_mapping" }
 pypi_modifiers = { path = "crates/pypi_modifiers" }
 pyproject-toml = "0.13.7"
-rand = { version = "0.9.1", default-features = false }
 rattler = { version = "0.39.0", default-features = false }
 rattler-build = { git = "https://github.com/prefix-dev/rattler-build", branch = "main", default-features = false }
 rattler_cache = { version = "0.6.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ marked-yaml = "0.8.0"
 memchr = "2.7.4"
 miette = { version = "7.6.0" }
 minijinja = "2.7.0"
+nanoid = "0.4.0"
 nix = { version = "0.29.0", default-features = false }
 once_cell = "1.20.3"
 ordermap = "1.0.0"

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -74,7 +74,7 @@ pub struct CondaOutputsResult {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CondaOutput {
     /// The identifier of the output.
@@ -116,7 +116,7 @@ pub struct CondaOutput {
 }
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CondaOutputMetadata {
     /// The name of the package.

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -25,7 +25,6 @@ nanoid = { workspace = true }
 once_cell = { workspace = true }
 ordermap = { workspace = true }
 pin-project-lite = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }
+nanoid = { workspace = true }
 once_cell = { workspace = true }
 ordermap = { workspace = true }
 pin-project-lite = { workspace = true }

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -25,7 +25,9 @@ use crate::{
     InstantiateBackendError, InstantiateBackendSpec, SourceCheckout, SourceCheckoutError,
     build::{SourceCodeLocation, SourceRecordOrCheckout, WorkDirKey},
     cache::{
-        build_backend_metadata::{self, BuildBackendMetadataCacheShard, CachedCondaMetadata},
+        build_backend_metadata::{
+            self, BuildBackendMetadataCacheShard, CachedCondaMetadata, CachedCondaMetadataContent,
+        },
         common::MetadataCache,
     },
 };
@@ -219,26 +221,23 @@ impl BuildBackendMetadataSpec {
             .as_ref()
             .map(ProjectModelHash::from);
 
-        // Keep the cached metadata around for potential ID reuse even if it's stale
-        let previous_cached_metadata = cached_metadata.clone();
-
-        if !skip_cache {
-            if let Some(cache_entry) = Self::verify_cache_freshness(
-                cached_metadata,
+        if !skip_cache
+            && let Some(ref cache_entry) = cached_metadata
+            && Self::verify_cache_freshness(
+                cache_entry,
                 &build_source_checkout,
                 project_model_hash,
                 &self.variant_configuration,
             )
             .await?
-            {
-                tracing::debug!("Using cached source metadata for package",);
-                return Ok(BuildBackendMetadata {
-                    source: manifest_source_location.clone(),
-                    metadata: cache_entry,
-                    skip_cache,
-                });
-            }
-        } else {
+        {
+            tracing::debug!("Using cached source metadata for package",);
+            return Ok(BuildBackendMetadata {
+                source: manifest_source_location.clone(),
+                metadata: cache_entry.clone(),
+                skip_cache,
+            });
+        } else if skip_cache {
             let backend_name = match &discovered_backend.backend_spec {
                 BackendSpec::JsonRpc(spec) => &spec.name,
             };
@@ -298,13 +297,11 @@ impl BuildBackendMetadataSpec {
 
         // If the new metadata is content-equivalent to the previous cached metadata,
         // reuse the old ID to avoid invalidating downstream caches (e.g., source metadata).
-        if let Some(ref previous) = previous_cached_metadata {
-            if metadata.is_content_equivalent(previous) {
-                tracing::debug!(
-                    "New metadata is content-equivalent to cached metadata, reusing ID"
-                );
-                metadata.id = previous.id.clone();
-            }
+        if let Some(ref previous) = cached_metadata
+            && metadata.is_content_equivalent(previous)
+        {
+            tracing::debug!("New metadata is content-equivalent to cached metadata, reusing ID");
+            metadata.id = previous.id.clone();
         }
 
         metadata.cache_version = cache_version;
@@ -390,52 +387,51 @@ impl BuildBackendMetadataSpec {
         skip_cache
     }
 
+    /// Verifies if the cached metadata is still fresh.
+    ///
+    /// Returns `true` if the cache is fresh and can be used, `false` if stale.
     async fn verify_cache_freshness(
-        cache_entry: Option<CachedCondaMetadata>,
+        cache_entry: &CachedCondaMetadata,
         build_source_checkout: &SourceCheckout,
         project_model_hash: Option<ProjectModelHash>,
         requested_variants: &Option<BTreeMap<String, Vec<VariantValue>>>,
-    ) -> Result<Option<CachedCondaMetadata>, CommandDispatcherError<BuildBackendMetadataError>>
-    {
-        let Some(cache_entry) = cache_entry else {
-            return Ok(None);
-        };
-
+    ) -> Result<bool, CommandDispatcherError<BuildBackendMetadataError>> {
         // Check the project model
-        if cache_entry.project_model_hash != project_model_hash {
+        if cache_entry.content.project_model_hash != project_model_hash {
             tracing::info!(
                 "found cached outputs with different project model, invalidating cache."
             );
-            return Ok(None);
+            return Ok(false);
         }
 
         // Check if the source location changed.
-        if cache_entry.build_source != build_source_checkout.pinned {
+        if cache_entry.content.build_source != build_source_checkout.pinned {
             tracing::info!(
                 "found cached outputs with different source code location, invalidating cache."
             );
-            return Ok(None);
+            return Ok(false);
         }
 
         // Check if the build variants match
-        if Some(&cache_entry.build_variants) != requested_variants.as_ref() {
+        if Some(&cache_entry.content.build_variants) != requested_variants.as_ref() {
             tracing::info!("found cached outputs with different variants, invalidating cache.");
-            return Ok(None);
+            return Ok(false);
         }
 
         // If the build source is immutable, we don't check the contents of the files.
         if build_source_checkout.is_immutable() {
-            return Ok(Some(cache_entry));
+            return Ok(true);
         }
 
         let build_source_dir = build_source_checkout.path.as_dir_or_file_parent();
 
         // Check the files that were explicitly mentioned.
         for source_file_path in cache_entry
+            .content
             .input_files
             .iter()
             .map(|path| build_source_dir.join(path).into_std_path_buf())
-            .chain(cache_entry.build_variant_files.iter().cloned())
+            .chain(cache_entry.content.build_variant_files.iter().cloned())
         {
             match source_file_path.metadata().and_then(|m| m.modified()) {
                 Ok(modified_date) => {
@@ -444,7 +440,7 @@ impl BuildBackendMetadataSpec {
                             "found cached outputs but '{}' has been modified, invalidating cache.",
                             source_file_path.display()
                         );
-                        return Ok(None);
+                        return Ok(false);
                     }
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -452,7 +448,7 @@ impl BuildBackendMetadataSpec {
                         "found cached outputs but '{}' has been deleted, invalidating cache.",
                         source_file_path.display()
                     );
-                    return Ok(None);
+                    return Ok(false);
                 }
                 Err(err) => {
                     tracing::info!(
@@ -460,28 +456,28 @@ impl BuildBackendMetadataSpec {
                         source_file_path.display(),
                         err
                     );
-                    return Ok(None);
+                    return Ok(false);
                 }
             };
         }
 
-        let glob_set = GlobSet::create(cache_entry.input_globs.iter().map(String::as_str));
+        let glob_set = GlobSet::create(cache_entry.content.input_globs.iter().map(String::as_str));
         for matching_file in glob_set
             .collect_matching(build_source_dir.as_std_path())
             .map_err(BuildBackendMetadataError::from)
             .map_err(CommandDispatcherError::Failed)?
         {
             let path = matching_file.into_path();
-            if cache_entry.input_files.contains(&path) {
+            if cache_entry.content.input_files.contains(&path) {
                 tracing::info!(
                     "found cached outputs but a new matching file at '{}' has been detected, invalidating cache.",
                     path.display()
                 );
-                return Ok(None);
+                return Ok(false);
             }
         }
 
-        Ok(Some(cache_entry))
+        Ok(true)
     }
 
     /// Validates that outputs with the same name have unique variants.
@@ -623,14 +619,16 @@ impl BuildBackendMetadataSpec {
         Ok(CachedCondaMetadata {
             id: CachedCondaMetadataId::random(),
             cache_version: 0,
-            outputs: outputs.outputs,
-            build_variants: self.variant_configuration.unwrap_or_default(),
-            build_variant_files: self.variant_files.into_iter().flatten().collect(),
-            input_globs: outputs.input_globs.into_iter().collect(),
-            input_files: input_glob_files,
-            build_source: build_source_checkout.pinned,
-            project_model_hash,
             timestamp,
+            content: CachedCondaMetadataContent {
+                project_model_hash,
+                build_source: build_source_checkout.pinned,
+                build_variants: self.variant_configuration.unwrap_or_default(),
+                build_variant_files: self.variant_files.into_iter().flatten().collect(),
+                input_globs: outputs.input_globs.into_iter().collect(),
+                input_files: input_glob_files,
+                outputs: outputs.outputs,
+            },
         })
     }
 

--- a/crates/pixi_command_dispatcher/src/cache/source_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/source_metadata.rs
@@ -61,7 +61,7 @@ pub struct SourceMetadataCacheShard {
 
 impl SourceMetadataCache {
     /// The version identifier that should be used for the cache directory.
-    pub const CACHE_SUFFIX: &'static str = "v0";
+    pub const CACHE_SUFFIX: &'static str = "v1";
 
     /// Constructs a new instance.
     pub fn new(root: AbsPathBuf) -> Self {
@@ -82,7 +82,7 @@ impl MetadataCache for SourceMetadataCache {
         "source_metadata.json"
     }
 
-    const CACHE_SUFFIX: &'static str = "v0";
+    const CACHE_SUFFIX: &'static str = "v1";
 }
 
 impl CacheKey for SourceMetadataCacheShard {
@@ -150,12 +150,12 @@ impl VersionedMetadata for CachedSourceMetadata {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
-pub struct CachedSourceMetadataId(u64);
+pub struct CachedSourceMetadataId(String);
 
 impl CachedSourceMetadataId {
     pub fn random() -> Self {
-        Self(rand::random())
+        Self(nanoid::nanoid!())
     }
 }

--- a/crates/pixi_command_dispatcher/src/cache/source_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/source_metadata.rs
@@ -61,7 +61,7 @@ pub struct SourceMetadataCacheShard {
 
 impl SourceMetadataCache {
     /// The version identifier that should be used for the cache directory.
-    pub const CACHE_SUFFIX: &'static str = "v1";
+    pub const CACHE_SUFFIX: &'static str = "v0";
 
     /// Constructs a new instance.
     pub fn new(root: AbsPathBuf) -> Self {
@@ -82,7 +82,7 @@ impl MetadataCache for SourceMetadataCache {
         "source_metadata.json"
     }
 
-    const CACHE_SUFFIX: &'static str = "v1";
+    const CACHE_SUFFIX: &'static str = "v0";
 }
 
 impl CacheKey for SourceMetadataCacheShard {

--- a/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
@@ -153,7 +153,7 @@ impl DevSourceMetadataSpec {
 
         // Create a DevSourceRecord for each output
         let mut records = Vec::new();
-        for output in &build_backend_metadata.metadata.outputs {
+        for output in &build_backend_metadata.metadata.content.outputs {
             if output.metadata.name != self.package_name {
                 continue;
             }
@@ -169,6 +169,7 @@ impl DevSourceMetadataSpec {
         if records.is_empty() {
             let available_names = build_backend_metadata
                 .metadata
+                .content
                 .outputs
                 .iter()
                 .map(|output| output.metadata.name.clone());

--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -102,9 +102,11 @@ impl SourceMetadataSpec {
         };
 
         if !skip_cache
-            && let Some(cached_metadata) =
-                Self::verify_cache_freshness(cached_metadata, build_backend_metadata.metadata.id.clone())
-                    .await?
+            && let Some(cached_metadata) = Self::verify_cache_freshness(
+                cached_metadata,
+                build_backend_metadata.metadata.id.clone(),
+            )
+            .await?
         {
             tracing::debug!("Using cached source metadata for package",);
             return Ok(SourceMetadata {
@@ -115,7 +117,7 @@ impl SourceMetadataSpec {
 
         let mut futures = ExecutorFutures::new(command_dispatcher.executor());
         let source_location = build_backend_metadata.source.clone();
-        for output in &build_backend_metadata.metadata.outputs {
+        for output in &build_backend_metadata.metadata.content.outputs {
             if output.metadata.name != self.package {
                 continue;
             }
@@ -133,6 +135,7 @@ impl SourceMetadataSpec {
         if records.is_empty() {
             let available_names = build_backend_metadata
                 .metadata
+                .content
                 .outputs
                 .iter()
                 .map(|output| output.metadata.name.clone());

--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -103,7 +103,7 @@ impl SourceMetadataSpec {
 
         if !skip_cache
             && let Some(cached_metadata) =
-                Self::verify_cache_freshness(cached_metadata, build_backend_metadata.metadata.id)
+                Self::verify_cache_freshness(cached_metadata, build_backend_metadata.metadata.id.clone())
                     .await?
         {
             tracing::debug!("Using cached source metadata for package",);
@@ -150,7 +150,7 @@ impl SourceMetadataSpec {
             id: CachedSourceMetadataId::random(),
             cache_version,
             records,
-            cached_conda_metadata_id: build_backend_metadata.metadata.id,
+            cached_conda_metadata_id: build_backend_metadata.metadata.id.clone(),
         };
 
         // Try to store the metadata in the cache with version checking


### PR DESCRIPTION
### Description

When the build backend metadata cache is outdated (e.g., due to timestampchanges), pixi would regenerate metadata by calling the build backend again. Previously, this always generated a new random ID, which invalidated downstream caches (like source metadata) even when the actual metadata content was unchanged.

This change:
- Compares new metadata with the previously cached metadata
- Reuses the existing ID if the content is equivalent (excluding id, timestamp, and cache_version fields)
- Switches from random u64 IDs to nanoid strings for better uniqueness

This optimization prevents unnecessary cache invalidation when the build backend returns the same metadata, improving build performance.

### How Has This Been Tested?

- [ ] Manually tested

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Code Opus 4.5

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
