### PR TITLE
chore: disable debuginfo in ci builds to save space and speed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,3 +26,8 @@ CARGO_WORKSPACE_DIR = { value = "", relative = true }
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"
+
+[profile.dev]
+# Disabling debug info speeds up builds a bunch,
+# and we don't rely on it for debugging that much.
+debug = 0


### PR DESCRIPTION
### Description

I read that disabling debuginfo can speed up build and save disk space in https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow . Lets try.

### How Has This Been Tested?

In the CI of this PR.