### PR TITLE
fix: only disable debuginfo in ci

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,8 +26,3 @@ CARGO_WORKSPACE_DIR = { value = "", relative = true }
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"
-
-[profile.ci]
-# Disabling debug info speeds up builds a bunch,
-# and we don't rely on it for debugging that much.
-debug = 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,7 @@ jobs:
       - name: Test pixi
         run: pixi run test-slow --retries 2
         env:
+          CARGO_PROFILE_DEV_DEBUG: 0 # Disable debuginfo only on windows because it takes a lot of space
           CARGO_TARGET_DIR: ${{ env.DEV_DRIVE }}/target
           PIXI_TEST_R2_ACCESS_KEY_ID: ${{ secrets.PIXI_TEST_R2_ACCESS_KEY_ID }}
           PIXI_TEST_R2_SECRET_ACCESS_KEY: ${{ secrets.PIXI_TEST_R2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
### Description

Only disable debuginfo for ci builds.

### How Has This Been Tested?

In this CI