### PR TITLE
fix: indicate pixi self-update in requires-pixi error message

### DIFF
--- a/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
@@ -28,7 +28,7 @@ pub async fn execute(workspace: Workspace) -> miette::Result<()> {
                     eprintln!();
                     eprintln!(
                         "Please update pixi using your system package manager or reinstall it.\n\
-             See: https://pixi.sh/install"
+             See: https://pixi.sh/latest/installation/"
                     );
                 }
 


### PR DESCRIPTION
 ## Description

This PR improves the `requires-pixi` error message by suggesting `pixi self-update`
only when the self-update feature is enabled, and providing generic upgrade guidance
otherwise.

Fixes #5293

## How Has This Been Tested?

Manually verified the error output by triggering the `requires-pixi` version
mismatch locally and confirming the correct guidance is shown depending on
whether the `self_update` feature is enabled.

## AI Disclosure

- [ ] This PR contains AI-assisted content.
- [ ] I have reviewed and tested all AI-assisted changes.
- [ ] I take responsibility for all AI-assisted content in this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas 
- [ ] I have made corresponding changes to the documentation 
- [ ] I have added sufficient tests to cover my changes 
- [ ] I have verified that changes impacting the JSON schema have been made in schema/model.py.

