### PR TITLE
docs: task default-environment field

### DIFF
--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -401,14 +401,15 @@ Pixi's tasks are run in a Pixi environment using `pixi run` and are executed usi
 ```toml
 [tasks]
 simple = "echo This is a simple task"
-cmd = { cmd="echo Same as a simple task but now more verbose"}
-depending = { cmd="echo run after simple", depends-on="simple"}
-alias = { depends-on=["depending"]}
-download = { cmd="curl -o file.txt https://example.com/file.txt" , outputs=["file.txt"]}
-build = { cmd="npm build", cwd="frontend", inputs=["frontend/package.json", "frontend/*.js"]}
-run = { cmd="python run.py $ARGUMENT", env={ ARGUMENT="value" }}
+cmd = { cmd="echo Same as a simple task but now more verbose" }
+depending = { cmd="echo run after simple", depends-on="simple" }
+alias = { depends-on=["depending"] }
+download = { cmd="curl -o file.txt https://example.com/file.txt" , outputs=["file.txt"] }
+build = { cmd="npm build", cwd="frontend", inputs=["frontend/package.json", "frontend/*.js"] }
+run = { cmd="python run.py $ARGUMENT", env={ ARGUMENT="value" }} # Set an environment variable
 format = { cmd="black $INIT_CWD" } # runs black where you run pixi run format
-clean-env = { cmd = "python isolated.py", clean-env = true} # Only on Unix!
+clean-env = { cmd="python isolated.py", clean-env=true } # Only on Unix!
+test = { cmd="pytest", default-environment="test" }  # Set a default pixi environment
 ```
 
 You can modify this table using [`pixi task`](cli/pixi/task.md).

--- a/docs/source_files/pixi_tomls/task_default_environment.toml
+++ b/docs/source_files/pixi_tomls/task_default_environment.toml
@@ -1,0 +1,14 @@
+[workspace]
+channels = ["conda-forge"]
+name = "task-default-environment"
+
+# --8<-- [start:default-environment]
+[feature.test.dependencies]
+pytest = "*"
+
+[environments]
+test = ["test"]  # An environment covering the "test" feature
+
+[tasks]
+test = { cmd = "pytest", default-environment = "test" }
+# --8<-- [end:default-environment]

--- a/docs/workspace/advanced_tasks.md
+++ b/docs/workspace/advanced_tasks.md
@@ -31,6 +31,9 @@ set = "export VAR=hello && echo $VAR"
 copy = "cp pixi.toml pixi_backup.toml"
 clean = "rm pixi_backup.toml"
 move = "mv pixi.toml backup.toml"
+
+# Setting a default environment for the task
+test = { cmd = "pytest", default-environment = "test" }
 ```
 
 ## Depends on
@@ -155,6 +158,18 @@ This will add the following line to [manifest file](../reference/pixi_manifest.m
 ```toml title="pixi.toml"
 [tasks]
 bar = { cmd = "python bar.py", cwd = "scripts" }
+```
+
+## Default environment
+
+You can set the default Pixi [environment](../tutorials/multi_environment.md#adding-an-environment) used by a task using the `default-environment` field:
+```toml title="pixi.toml"
+--8<-- "docs/source_files/pixi_tomls/task_default_environment.toml:default-environment"
+```
+
+The default environment can be overridden as usual with the `--environment` argument:
+```shell
+pixi run -e other_environment test
 ```
 
 ## Task Arguments


### PR DESCRIPTION
### Description

Adds missing documentation for the recently added `default-environment` field to `task`s
Fixes #{issue}

### How Has This Been Tested?

Passes `pixi run lint`, `pixi run test-all-fast`

### Checklist:
<!--- Remove the non relevant items. --->
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
