### PR TITLE
fix: show --build and --host params in pixi add --help

### DIFF
--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -275,12 +275,12 @@ pub struct DependencyConfig {
 
     /// The specified dependencies are host dependencies. Conflicts with `build`
     /// and `pypi`
-    #[arg(long, conflicts_with_all = ["build", "pypi"], hide = true)]
+    #[arg(long, conflicts_with_all = ["build", "pypi"])]
     pub host: bool,
 
     /// The specified dependencies are build dependencies. Conflicts with `host`
     /// and `pypi`
-    #[arg(long, conflicts_with_all = ["host", "pypi"], hide = true)]
+    #[arg(long, conflicts_with_all = ["host", "pypi"])]
     pub build: bool,
 
     /// The specified dependencies are pypi dependencies. Conflicts with `host`


### PR DESCRIPTION
Remove `hide = true` from the `--build` and `--host` CLI arguments
so they appear in the help output. These are legitimate options that
should be discoverable by users.

Fixes #5420

https://claude.ai/code/session_017Cij7vZ5DKwnYgKGr7p4wY