### PR TITLE
feat: pixi workspace export conda-environment handles env variables

### DIFF
--- a/crates/pixi_cli/src/workspace/export/conda_environment.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_environment.rs
@@ -208,6 +208,12 @@ fn build_env_yaml(
             ));
     }
 
+    // Add environment variables from activation
+    let activation_vars = environment.activation_env(Some(*platform));
+    if !activation_vars.is_empty() {
+        env_yaml.variables = activation_vars;
+    }
+
     Ok(env_yaml)
 }
 

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -315,7 +315,7 @@ impl<'p> Environment<'p> {
     ///
     /// The environment variables of all features are combined in the order they
     /// are defined for the environment.
-    pub(crate) fn activation_env(&self, platform: Option<Platform>) -> IndexMap<String, String> {
+    pub fn activation_env(&self, platform: Option<Platform>) -> IndexMap<String, String> {
         self.features()
             .map(|f| f.activation_env(platform))
             .fold(IndexMap::new(), |mut acc, env| {


### PR DESCRIPTION
### Description

This PR adds support for exporting environment variables to the conda-environment YAML output.
Previously, when running pixi workspace export conda-environment, variables defined under [activation.env] in the pixi.toml were ignored. This change ensures that all activation environment variables associated with the environment's features for the target platform are correctly included in the variables: section of the generated environment.yml.

<img width="202" height="198" alt="image" src="https://github.com/user-attachments/assets/c7afd62d-0a21-4044-9bae-4d35ac89124e" />


Fixes #5381

### How Has This Been Tested?

I executed pixi workspace export conda-environment in cases both with and without environment variables set

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas