### PR TITLE
chore: Use a buffered reader for the trampoline configuration

### DIFF
--- a/trampoline/src/main.rs
+++ b/trampoline/src/main.rs
@@ -32,6 +32,7 @@ fn read_configuration(current_exe: &Path) -> miette::Result<Configuration> {
             .join(TRAMPOLINE_CONFIGURATION)
             .join(format!("{}.json", executable_from_path(current_exe),));
         let configuration_file = File::open(&configuration_path)
+            .map(std::io::BufReader::new)
             .into_diagnostic()
             .wrap_err(format!("Couldn't open {:?}", configuration_path))?;
         let configuration: Configuration =


### PR DESCRIPTION
... to avoid reading the file one byte at a time.

Probably does not make much of a difference, but it's just plain inefficient.


### How Has This Been Tested?

strace says with this there is only one read syscall to read in the trampoline file -- compared to one per character without this change.

### AI Disclosure

No AI was harmed by this PR

### Checklist:
- [x] I have performed a self-review of my own code
