### PR TITLE
fix: backend release

### DIFF
--- a/.github/workflows/backends-release.yml
+++ b/.github/workflows/backends-release.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'release:backends')}}
-    timeout-minutes: 40
+    timeout-minutes: 80
     permissions:
       id-token: write
       contents: read
@@ -87,22 +87,22 @@ jobs:
         id: attest
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
-          subject-path: "${{ runner.temp }}/**/*.conda"
+          subject-path: "output/**/*.conda"
           predicate-type: "https://schemas.conda.org/attestations-publish-1.schema.json"
           predicate: "{\"targetChannel\": \"https://prefix.dev/pixi-build-backends\"}"
 
       - name: Generate attestations for conda packages
         shell: bash
         if: github.event.pull_request.head.repo.full_name == github.repository
-        run: pixi run -e backends-release generate-attestations "${{ runner.temp }}" "${{ steps.attest.outputs.bundle-path }}"
+        run: pixi run -e backends-release generate-attestations output "${{ steps.attest.outputs.bundle-path }}"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: conda-packages-${{ matrix.target }}
           path: |
-            ${{ runner.temp }}/**/*.conda
-            ${{ runner.temp }}/**/*.sig
+            output/**/*.conda
+            output/**/*.sig
 
       - name: Kill any lingering processes (Windows)
         if: runner.os == 'Windows'

--- a/pixi.toml
+++ b/pixi.toml
@@ -65,8 +65,8 @@ sccache = ">=0.13.0,<0.14"
 [feature.backends-release.tasks]
 generate-versions = { cmd = "python pixi-build-backends/scripts/generate-versions.py", description = "Generate version env vars for CI" }
 [feature.backends-release.tasks.generate-attestations]
-args = ["attestation_bundle"]
-cmd = "python pixi-build-backends/scripts/generate-attestations.py {{ attestation_bundle }}"
+args = ["output_dir", "attestation_bundle"]
+cmd = "python pixi-build-backends/scripts/generate-attestations.py {{ attestation_bundle }} --output-dir {{ output_dir }}"
 description = "Generate attestation files for conda packages"
 
 [feature.backends-release.tasks.build-backend-packages]


### PR DESCRIPTION
1) increase time-out

This should only be necessary with no cache.
As soon as we stop building rattler-build from source we should put it back to 40 minutes.

2) Use correct path when uploading