### PR TITLE
feat(lockfile): skip source tree hash for workspace packages

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -2119,7 +2119,11 @@ pub(crate) async fn verify_package_platform_satisfiability(
                             Cow::Owned(project_root.join(Path::new(path.as_str())))
                         };
 
-                        if absolute_path.is_dir() {
+                        // Only validate hash if one was stored in the lockfile.
+                        // Workspace packages (path = ".") don't store hashes to avoid
+                        // lockfile invalidation on metadata-only changes.
+                        // See: https://github.com/prefix-dev/pixi/discussions/3627
+                        if absolute_path.is_dir() && record.0.hash.is_some() {
                             match PypiSourceTreeHashable::from_directory(&absolute_path)
                                 .map(|hashable| hashable.hash())
                             {


### PR DESCRIPTION
### Description
Don't compute or store the source tree hash for the workspace's own pypi package (path = ".") in the lockfile. This avoids lockfile invalidation when only metadata fields like version or authors change but dependencies remain the same. 

I went with a naive approach here: compare the install path against the project root to detect the workspace
package, then skip hashing for it. Happy to discuss better approaches. I think more tests should be added to cover these changes, but want to make sure this is the right direction before continuing.

Fixes #5438


### How Has This Been Tested?
Via integration test added in `crates/pixi/tests/integration_rust/pypi_tests.rs`. The test installs an environment from a `pyproject.toml`, checks that the generated lockfile does not have a hash for the workspace pypi package. Then the `pyproject.toml` keys `project.version` and `project.authors` are updated, and we install the env again with `--locked`, which succeeds. 

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Opus 4.6

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
