### PR TITLE
fix: add `compiler(c)` per default with `pixi-build-rust`

### DIFF
--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -80,12 +80,13 @@ impl GenerateRecipe for RustGenerator {
         // rattler-build selectors with simple string comparison.
         let model_dependencies = model.dependencies(Some(host_platform));
 
-        // Get the list of compilers from config, defaulting to ["rust"] if not
-        // specified
+        // Get the list of compilers from config, defaulting to ["rust", "c"] if not
+        // specified. The rust compilers already depend on the c compiler.
+        // Adding it here allows to version the c compiler through the variant `c_compiler_version`.
         let compilers = config
             .compilers
             .clone()
-            .unwrap_or_else(|| vec!["rust".to_string()]);
+            .unwrap_or_else(|| vec!["rust".to_string(), "c".to_string()]);
 
         // Add configured compilers to build requirements
         pixi_build_backend::compilers::add_compilers_to_requirements(
@@ -731,15 +732,19 @@ mod tests {
             })
             .collect();
 
-        // Should have exactly one compiler: rust
+        // Should have exactly two compilers: rust and c
         assert_eq!(
             compiler_templates.len(),
-            1,
-            "Should have exactly one compiler when not specified"
+            2,
+            "Should have exactly two compilers when not specified"
         );
-        assert_eq!(
-            compiler_templates[0], "${{ compiler('rust') }}",
-            "Default compiler should be rust"
+        assert!(
+            compiler_templates.contains(&"${{ compiler('rust') }}".to_string()),
+            "Default compilers should include rust"
+        );
+        assert!(
+            compiler_templates.contains(&"${{ compiler('c') }}".to_string()),
+            "Default compilers should include c"
         );
     }
 

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__tests__rust_is_in_build_requirements.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__tests__rust_is_in_build_requirements.snap
@@ -13,6 +13,7 @@ build:
 requirements:
   build:
     - "${{ compiler('rust') }}"
+    - "${{ compiler('c') }}"
   host: []
   run:
     - boltons

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__tests__rust_is_not_added_if_already_present.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__tests__rust_is_not_added_if_already_present.snap
@@ -13,6 +13,7 @@ build:
 requirements:
   build:
     - rust
+    - "${{ compiler('c') }}"
   host: []
   run:
     - boltons

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__tests__sccache_is_enabled.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__tests__sccache_is_enabled.snap
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - "${{ compiler('rust') }}"
+    - "${{ compiler('c') }}"
     - sccache
   host: []
   run: []

--- a/docs/build/backends/pixi-build-rust.md
+++ b/docs/build/backends/pixi-build-rust.md
@@ -211,7 +211,7 @@ ignore-cargo-manifest = true
 ### `compilers`
 
 - **Type**: `Array<String>`
-- **Default**: `["rust"]`
+- **Default**: `["rust", "c"]`
 - **Target Merge Behavior**: `Overwrite` - Platform-specific compilers completely replace base compilers
 
 List of compilers to use for the build. The backend automatically generates appropriate compiler dependencies using conda-forge's compiler infrastructure.
@@ -225,7 +225,7 @@ For target-specific configuration, platform compilers completely replace the bas
 
 ```toml
 [package.build.config]
-compilers = ["rust"]
+compilers = ["rust", "c"]
 
 [package.build.target.linux-64.config]
 compilers = ["rust", "c", "cxx"]


### PR DESCRIPTION
### Description

All Rust compilers depend on a C compiler on conda-forge. For example, `rust_linux_64` depends on `gcc_linux-64` without version bounds.

If that is already the case it makes sense to just add the c compiler per default. That way, you can the c_compiler_version variant will actually affect the version of the used C compiler



### How Has This Been Tested?

`pixi run test-fast`


### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
