### PR TITLE
feat: add  option to force re-running activation scripts between depe…

### DIFF
--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -292,11 +292,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             }
         };
 
-        // Invalidate cached environment if task requires reactivation
-        if executable_task.task().reactivate() {
-            task_envs.remove(&executable_task.run_environment);
-        }
-
         // If we don't have a command environment yet, we need to compute it. We lazily
         // compute the task environment because we only need the environment if
         // a task is actually executed.
@@ -353,6 +348,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 std::process::exit(code);
             }
             Err(err) => return Err(err.into()),
+        }
+
+        // Invalidate cached environment if task modifies it
+        if executable_task.task().reactivate() {
+            task_envs.remove(&executable_task.run_environment);
         }
 
         // Compute post-run hash, warn on missing globs, and update the cache

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -292,6 +292,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             }
         };
 
+        // Invalidate cached environment if task requires reactivation
+        if executable_task.task().reactivate() {
+            task_envs.remove(&executable_task.run_environment);
+        }
+
         // If we don't have a command environment yet, we need to compute it. We lazily
         // compute the task environment because we only need the environment if
         // a task is actually executed.

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -351,7 +351,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
 
         // Invalidate cached environment if task modifies it
-        if executable_task.task().reactivate() {
+        if executable_task.task().modifies_env() {
             task_envs.remove(&executable_task.run_environment);
         }
 

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -222,7 +222,7 @@ impl From<AddArgs> for Task {
                 default_environment,
                 description,
                 clean_env,
-                reactivate: false,
+                modifies_env: false,
                 args,
             }))
         }

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -222,6 +222,7 @@ impl From<AddArgs> for Task {
                 default_environment,
                 description,
                 clean_env,
+                reactivate: false,
                 args,
             }))
         }

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -303,8 +303,8 @@ impl Task {
         }
     }
 
-    /// Returns whether this task requires re-running activation scripts.
-    pub fn reactivate(&self) -> bool {
+    /// Returns whether this task modifies the environment.
+    pub fn modifies_env(&self) -> bool {
         match self {
             Task::Execute(exe) => exe.modifies_env,
             _ => false,

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -306,7 +306,7 @@ impl Task {
     /// Returns whether this task requires re-running activation scripts.
     pub fn reactivate(&self) -> bool {
         match self {
-            Task::Execute(exe) => exe.reactivate,
+            Task::Execute(exe) => exe.modifies_env,
             _ => false,
         }
     }
@@ -379,8 +379,8 @@ pub struct Execute {
     /// The arguments to pass to the task
     pub args: Option<Vec<TaskArg>>,
 
-    /// Force re-running activation scripts before this task
-    pub reactivate: bool,
+    /// Indicates this task modifies the environment (e.g., generates files read by activation scripts)
+    pub modifies_env: bool,
 }
 
 impl From<Execute> for Task {
@@ -924,8 +924,8 @@ impl From<Task> for Item {
                 if let Some(description) = &process.description {
                     table.insert("description", description.into());
                 }
-                if process.reactivate {
-                    table.insert("reactivate", true.into());
+                if process.modifies_env {
+                    table.insert("modifies-env", true.into());
                 }
                 Item::Value(Value::InlineTable(table))
             }

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -302,6 +302,14 @@ impl Task {
             _ => None,
         }
     }
+
+    /// Returns whether this task requires re-running activation scripts.
+    pub fn reactivate(&self) -> bool {
+        match self {
+            Task::Execute(exe) => exe.reactivate,
+            _ => false,
+        }
+    }
 }
 
 /// A list of glob patterns that can be used as input or output for a task
@@ -370,6 +378,9 @@ pub struct Execute {
 
     /// The arguments to pass to the task
     pub args: Option<Vec<TaskArg>>,
+
+    /// Force re-running activation scripts before this task
+    pub reactivate: bool,
 }
 
 impl From<Execute> for Task {
@@ -912,6 +923,9 @@ impl From<Task> for Item {
                 }
                 if let Some(description) = &process.description {
                     table.insert("description", description.into());
+                }
+                if process.reactivate {
+                    table.insert("reactivate", true.into());
                 }
                 Item::Value(Value::InlineTable(table))
             }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
@@ -2,7 +2,7 @@
 source: crates/pixi_manifest/src/toml/task.rs
 expression: "expect_parse_failure(r#\"\n            cmd = \"test\"\n            depends = [\"a\", \"b\"]\n        \"#)"
 ---
-  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'default-environment', 'description', 'clean-env', 'args'
+  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'default-environment', 'description', 'clean-env', 'reactivate', 'args'
    ╭─[pixi.toml:3:13]
  2 │             cmd = "test"
  3 │             depends = ["a", "b"]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
@@ -2,7 +2,7 @@
 source: crates/pixi_manifest/src/toml/task.rs
 expression: "expect_parse_failure(r#\"\n            cmd = \"test\"\n            depends = [\"a\", \"b\"]\n        \"#)"
 ---
-  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'default-environment', 'description', 'clean-env', 'reactivate', 'args'
+  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'default-environment', 'description', 'clean-env', 'modifies-env', 'args'
    ╭─[pixi.toml:3:13]
  2 │             cmd = "test"
  3 │             depends = ["a", "b"]

--- a/crates/pixi_manifest/src/toml/task.rs
+++ b/crates/pixi_manifest/src/toml/task.rs
@@ -224,7 +224,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 .map(TomlFromStr::into_inner);
             let description = th.optional("description");
             let clean_env = th.optional("clean-env").unwrap_or(false);
-            let reactivate = th.optional("reactivate").unwrap_or(false);
+            let modifies_env = th.optional("modifies-env").unwrap_or(false);
             let args = th.optional::<Vec<TaskArg>>("args");
 
             let mut have_default = false;
@@ -254,7 +254,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 default_environment,
                 description,
                 clean_env,
-                reactivate,
+                modifies_env,
                 args,
             }))
         } else {

--- a/crates/pixi_manifest/src/toml/task.rs
+++ b/crates/pixi_manifest/src/toml/task.rs
@@ -224,6 +224,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 .map(TomlFromStr::into_inner);
             let description = th.optional("description");
             let clean_env = th.optional("clean-env").unwrap_or(false);
+            let reactivate = th.optional("reactivate").unwrap_or(false);
             let args = th.optional::<Vec<TaskArg>>("args");
 
             let mut have_default = false;
@@ -253,6 +254,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 default_environment,
                 description,
                 clean_env,
+                reactivate,
                 args,
             }))
         } else {


### PR DESCRIPTION
### Description

Adds `reactivate `option to tasks. When set to `true`, it forces re-running activation scripts before the task executes.
activation:
`scripts = ["ros2_ws/install/setup.sh"]`

tasks:
`build-ros2 = { cwd = "ros2_ws", cmd = "colcon build" }`
`pyright-ros2 = { cmd = "basedpyright", depends-on = ["build-ros2"], reactivate = true }`


Fixes #5433

### How Has This Been Tested?

All existing tests pass (`cargo test --package pixi_manifest --package pixi_task --package pixi_cli`)

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: claude 
### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
