### PR TITLE
feat: add Windows manifest to pixi binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "embed-manifest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cdc65b1cf9e871453ce2f86f5aaec24ff2eaa36a1fa3e02e441dddc3613b99"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3456,7 +3462,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3476,7 +3482,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5272,6 +5278,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dunce",
+ "embed-manifest",
  "fs-err",
  "fs_extra",
  "futures",
@@ -6891,7 +6898,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -6928,7 +6935,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9306,7 +9313,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.59.0",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ dialoguer = "0.12.0"
 digest = "0.10"
 dirs = "6.0.0"
 dunce = "1.0.5"
+embed-manifest = "1.5.0"
 fancy_display = { path = "crates/fancy_display" }
 flate2 = "1.1.0"
 fs-err = { version = "3.1.0" }

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -30,6 +30,9 @@ pixi_cli = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 
 
+[build-dependencies]
+embed-manifest = { workspace = true }
+
 [dev-dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/crates/pixi/build.rs
+++ b/crates/pixi/build.rs
@@ -1,0 +1,34 @@
+//! Embeds a Windows application manifest into the pixi binary.
+//!
+//! This enables:
+//! - Long path awareness (paths > 260 characters), requires `LongPathsEnabled`
+//!   registry key to also be set.
+//! - Declared Windows 7-10+ compatibility to avoid legacy compat layers.
+//! - Standard invoker execution levels to disable UAC virtualization.
+//!
+//! Reference: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
+//! Based on: https://github.com/astral-sh/uv/pull/16894
+use embed_manifest::manifest::{ActiveCodePage, ExecutionLevel, Setting, SupportedOS};
+use embed_manifest::{embed_manifest, empty_manifest};
+
+fn main() {
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        let version = env!("CARGO_PKG_VERSION");
+        let [major, minor, patch] = version
+            .splitn(3, '.')
+            .map(str::parse)
+            .collect::<Result<Vec<u16>, _>>()
+            .ok()
+            .and_then(|v| v.try_into().ok())
+            .expect("pixi version must be in x.y.z format");
+        let manifest = empty_manifest()
+            .name("pixi")
+            .version(major, minor, patch, 0)
+            .active_code_page(ActiveCodePage::System)
+            .supported_os(SupportedOS::Windows7..=SupportedOS::Windows10)
+            .requested_execution_level(ExecutionLevel::AsInvoker)
+            .long_path_aware(Setting::Enabled);
+        embed_manifest(manifest).expect("unable to embed manifest");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/trampoline/Cargo.toml
+++ b/trampoline/Cargo.toml
@@ -23,6 +23,9 @@ debug = false
 strip = true
 
 
+[build-dependencies]
+embed-manifest = "1.5.0"
+
 [dependencies]
 ctrlc = "3.5"
 fs-err = "3.1.3"

--- a/trampoline/build.rs
+++ b/trampoline/build.rs
@@ -1,0 +1,34 @@
+//! Embeds a Windows application manifest into the pixi trampoline binary.
+//!
+//! This enables:
+//! - Long path awareness (paths > 260 characters), requires `LongPathsEnabled`
+//!   registry key to also be set.
+//! - Declared Windows 7-10+ compatibility to avoid legacy compat layers.
+//! - Standard invoker execution levels to disable UAC virtualization.
+//!
+//! Reference: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
+//! Based on: https://github.com/astral-sh/uv/pull/16894
+use embed_manifest::manifest::{ActiveCodePage, ExecutionLevel, Setting, SupportedOS};
+use embed_manifest::{embed_manifest, empty_manifest};
+
+fn main() {
+    if std::env::var_os("CARGO_CFG_WINDOWS").is_some() {
+        let version = env!("CARGO_PKG_VERSION");
+        let [major, minor, patch] = version
+            .splitn(3, '.')
+            .map(str::parse)
+            .collect::<Result<Vec<u16>, _>>()
+            .ok()
+            .and_then(|v| v.try_into().ok())
+            .expect("pixi_trampoline version must be in x.y.z format");
+        let manifest = empty_manifest()
+            .name("pixi_trampoline")
+            .version(major, minor, patch, 0)
+            .active_code_page(ActiveCodePage::System)
+            .supported_os(SupportedOS::Windows7..=SupportedOS::Windows10)
+            .requested_execution_level(ExecutionLevel::AsInvoker)
+            .long_path_aware(Setting::Enabled);
+        embed_manifest(manifest).expect("unable to embed manifest");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
### Description

Pixi's Windows binaries don't include a Windows application manifest, which means it is impossible to make use of the `LongPathsEnabled` feature on Windows and one is virtually certain to hit `os error 3` (path not found) on deeply nested paths when doing "serious" work on Windows.

This is the same fix that uv shipped in [astral-sh/uv#16894](https://github.com/astral-sh/uv/pull/16894).

**What the manifest declares:**
- `longPathAware = true` to enable paths >260 chars (still requires the registry key)
- Windows 7-10+ compatibility to prevent legacy compat layers
- `asInvoker` execution level to disable UAC virtualization
- `System` codepage for backwards compatibility

**Changes:**
- Added `embed-manifest` (v1.5.0) as a build dependency
- Created `build.rs` for the `pixi` binary crate
- Created `build.rs` for the `pixi_trampoline` crate
- Updated `Cargo.lock`

### How Has This Been Tested?

- `cargo check -p pixi` passes on Linux
- Windows aarch64 CI build succeeded on fork ([run](https://github.com/PozzettiAndrea/pixi/actions/runs/21798782214))
- Remaining Windows x86_64 CI jobs need prefix-dev's self-hosted runners to validate

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas