### PR TITLE
test: skip all tests in test_git.py on Windows

### DIFF
--- a/tests/integration_python/pixi_build/test_git.py
+++ b/tests/integration_python/pixi_build/test_git.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,10 @@ from .common import (
     copy_manifest,
     copytree_with_local_backend,
     verify_cli_command,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="git tests are not supported on Windows"
 )
 
 

--- a/tests/integration_python/pixi_build/test_specified_build_source/test_git.py
+++ b/tests/integration_python/pixi_build/test_specified_build_source/test_git.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import sys
 import tomllib
 from collections.abc import Iterator
 from pathlib import Path
@@ -14,6 +15,10 @@ from ..common import (
     verify_cli_command,
 )
 from .conftest import LocalGitRepo
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="git tests are not supported on Windows"
+)
 
 
 def _git_source_entries(lock_file: Path) -> list[dict[str, Any]]:


### PR DESCRIPTION
### Description

Windows flakyness on CI seems to be related to Pixi Build git tests. Let's skip them for now on Windows
