### PR TITLE
feat(cli): warn when LD_PRELOAD environment variable is set

### DIFF
--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -428,13 +428,13 @@ fn set_console_colors(args: &Args) {
 /// Check if LD_PRELOAD is set and emit a warning if it is.
 /// LD_PRELOAD can interfere with pixi environments and cause unexpected behavior.
 fn check_ld_preload() {
-    if let Ok(ld_preload) = env::var("LD_PRELOAD") {
-        if !ld_preload.is_empty() {
-            tracing::warn!(
-                "LD_PRELOAD environment variable is set to: {}. Pixi environments might not work correctly.",
-                ld_preload
-            );
-        }
+    if let Ok(ld_preload) = env::var("LD_PRELOAD")
+        && !ld_preload.is_empty()
+    {
+        tracing::warn!(
+            "LD_PRELOAD environment variable is set to: {}. Pixi environments might not work correctly.",
+            ld_preload
+        );
     }
 }
 

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -629,4 +629,28 @@ mod tests {
             },
         );
     }
+
+    #[test]
+    fn test_check_ld_preload_not_set() {
+        // Test that check_ld_preload doesn't panic when LD_PRELOAD is not set
+        temp_env::with_var_unset("LD_PRELOAD", || {
+            check_ld_preload();
+        });
+    }
+
+    #[test]
+    fn test_check_ld_preload_empty() {
+        // Test that check_ld_preload doesn't panic when LD_PRELOAD is empty
+        temp_env::with_var("LD_PRELOAD", Some(""), || {
+            check_ld_preload();
+        });
+    }
+
+    #[test]
+    fn test_check_ld_preload_set() {
+        // Test that check_ld_preload works when LD_PRELOAD is set
+        temp_env::with_var("LD_PRELOAD", Some("/path/to/lib.so"), || {
+            check_ld_preload();
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Closes #4620

Adds a warning when the  environment variable is set, as it can interfere with Pixi environments and cause unexpected behavior.

## Problem

Users have reported issues with Pixi environments when  was set. This environment variable is used to preload shared libraries and can break Pixi environments in subtle ways. Users often aren't aware that this variable is set or that it can cause problems.

## Solution

Added a check during CLI initialization that:
- Detects if  environment variable is set and non-empty
- Emits a warning message explaining that Pixi environments might not work correctly
- Includes the current value of  in the warning for debugging purposes

The warning is emitted early in the application lifecycle (after logging setup) so it will be visible to users before any operations are performed.

## Implementation Details

- Added  function in 
- Called after  to ensure the warning is properly displayed
- Uses  for consistent logging with the rest of the codebase
- Only warns when the variable is set AND non-empty

## Changes

- Modified :
  - Added call to  in  function
  - Added  function with documentation

## Testing

- [x] Code compiles successfully
- [x] Warning appears when LD_PRELOAD is set
- [x] No warning when LD_PRELOAD is not set
- [x] Follows existing code style and patterns

## Example Output

When LD_PRELOAD is set, users will see:
