### PR TITLE
docs(installation): add PATH configuration note for alternative installations

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,6 +59,10 @@ pixi self-update --version x.y.z
 
 Although we recommend installing Pixi through the above method we also provide additional installation methods.
 
+!!! note "PATH Configuration for Alternative Installations"
+    When installing Pixi through alternative methods (such as Homebrew, Scoop, Winget, or from source), you may need to manually configure your `PATH` environment variable to make `pixi` and executables installed via `pixi global` available in your shell.
+    The executables are located in [`PIXI_HOME`](reference/environment_variables.md)/bin (default: `~/.pixi/bin` on Unix or `%UserProfile%\.pixi\bin` on Windows).
+
 ### Homebrew
 
 Pixi is available via homebrew. To install Pixi via homebrew simply run:


### PR DESCRIPTION
## Summary

Closes #4613

Adds a note to the **Alternative Installation Methods** section explaining that PATH may need to be manually configured when using non-standard installation methods like Homebrew, Scoop, Winget, or building from source.

## Problem

Users installing Pixi through alternative methods (such as Homebrew) reported confusion about why  or executables installed via  were not available in their shell. This is because these installation methods don't automatically configure the PATH environment variable.

## Solution

Added a prominent note at the beginning of the Alternative Installation Methods section that:
- Explains PATH may need manual configuration
- Lists the affected installation methods (Homebrew, Scoop, Winget, source)
- Provides the default locations where executables are stored
- Links to the PIXI_HOME environment variable documentation

## Changes

- Modified  to add a note block explaining PATH configuration requirements

## Testing

- [x] Verified markdown syntax is correct
- [x] Checked that the note renders properly in documentation format
- [x] Confirmed the link to environment_variables.md is correct