### PR TITLE
feat: add --json flag to pixi global list

### DIFF
--- a/crates/pixi_cli/src/global/list.rs
+++ b/crates/pixi_cli/src/global/list.rs
@@ -2,8 +2,7 @@ use clap::Parser;
 use fancy_display::FancyDisplay;
 use pixi_config::{Config, ConfigCli};
 use pixi_global::list::{
-    list_all_global_environments, list_global_environments_json,
-    list_specific_global_environment,
+    list_all_global_environments, list_global_environments_json, list_specific_global_environment,
 };
 use pixi_global::{EnvironmentName, Project};
 use std::str::FromStr;
@@ -59,7 +58,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_cli_config(config.clone());
 
     if args.json {
-        return list_global_environments_json(&project, args.regex).await;
+        let env_name = args
+            .environment
+            .map(|e| EnvironmentName::from_str(e.as_str()))
+            .transpose()?;
+        return list_global_environments_json(&project, env_name.as_ref(), args.regex).await;
     }
 
     if let Some(environment) = args.environment {

--- a/docs/reference/cli/pixi/global/list.md
+++ b/docs/reference/cli/pixi/global/list.md
@@ -24,6 +24,8 @@ pixi global list [OPTIONS] [REGEX]
 :  Sorting strategy for the package table of an environment
 <br>**default**: `name`
 <br>**options**: `size`, `name`
+- <a id="arg---json" href="#arg---json">`--json`</a>
+:  Whether to output in JSON format
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>

--- a/tests/integration_python/pixi_global/test_global.py
+++ b/tests/integration_python/pixi_global/test_global.py
@@ -1446,6 +1446,21 @@ def test_list_json(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
         ]
     )
 
+    # Verify JSON list with environment filter
+    result = verify_cli_command(
+        [pixi, "global", "list", "--json", "--environment", "dummy-b"],
+        env=env,
+    )
+    assert json.loads(result.stdout) == snapshot(
+        [
+            {
+                "name": "dummy-b",
+                "dependencies": [{"name": "dummy-b", "version": "0.1.0"}],
+                "exposed": [{"exposed_name": "dummy-b", "executable": "dummy-b"}],
+            }
+        ]
+    )
+
 
 # Test that we correctly uninstall the required packages
 # - Checking that the binaries are removed


### PR DESCRIPTION
### Description

Add `--json` flag to pixi global list
This is useful for scripting and completions


### How Has This Been Tested?

Tested it locally with `pixi run install-as pixid`

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code