### PR TITLE
fix: update ROS backend snapshots and CI change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
           files_yaml: |
             code:
               - "pixi-build-backends/backends/pixi-build-ros/**"
+              - "pixi-build-backends/py-pixi-build-backend/**"
+              - "crates/recipe_stage0/**"
+              - "crates/pixi_build_backend/**"
 
   lint:
     name: "lint"

--- a/pixi-build-backends/backends/pixi-build-ros/tests/unit/__snapshots__/test_package_xml.ambr
+++ b/pixi-build-backends/backends/pixi-build-ros/tests/unit/__snapshots__/test_package_xml.ambr
@@ -83,7 +83,6 @@
     version: 0.0.1
   source: []
   build:
-    number: null
     script:
       content: ''
       env: {}
@@ -124,12 +123,9 @@
   about:
     homepage: https://test.io/custom_ros
     license: LicenseRef-Apache License 2.0
-    license_file: null
     summary: Demo
     description: Demo
-    documentation: null
     repository: https://github.com/test/custom_ros
-  extra: null
   
   '''
 # ---

--- a/pixi-build-backends/backends/pixi-build-ros/tests/unit/__snapshots__/test_version_constraints.ambr
+++ b/pixi-build-backends/backends/pixi-build-ros/tests/unit/__snapshots__/test_version_constraints.ambr
@@ -7,7 +7,6 @@
     version: 0.0.1
   source: []
   build:
-    number: null
     script:
       content: ''
       env: {}
@@ -65,15 +64,10 @@
     run_constraints: []
   tests: []
   about:
-    homepage: null
     license: LicenseRef-Apache License 2.0
-    license_file: null
     summary: Demo
     description: Demo
-    documentation: null
-    repository: null
-  extra: null
-  
+
   '''
 # ---
 # name: test_generate_recipe_with_mutex_version
@@ -84,7 +78,6 @@
     version: 0.0.1
   source: []
   build:
-    number: null
     script:
       content: ''
       env: {}
@@ -143,15 +136,10 @@
     run_constraints: []
   tests: []
   about:
-    homepage: null
     license: LicenseRef-Apache License 2.0
-    license_file: null
     summary: Demo
     description: Demo
-    documentation: null
-    repository: null
-  extra: null
-  
+
   '''
 # ---
 # name: test_generate_recipe_with_versions
@@ -162,7 +150,6 @@
     version: 0.0.1
   source: []
   build:
-    number: null
     script:
       content: ''
       env: {}
@@ -220,15 +207,10 @@
     run_constraints: []
   tests: []
   about:
-    homepage: null
     license: LicenseRef-Apache License 2.0
-    license_file: null
     summary: Demo
     description: Demo
-    documentation: null
-    repository: null
-  extra: null
-  
+
   '''
 # ---
 # name: test_generate_recipe_with_versions_in_model_and_package
@@ -239,7 +221,6 @@
     version: 0.0.1
   source: []
   build:
-    number: null
     script:
       content: ''
       env: {}
@@ -297,14 +278,9 @@
     run_constraints: []
   tests: []
   about:
-    homepage: null
     license: LicenseRef-Apache License 2.0
-    license_file: null
     summary: Demo
     description: Demo
-    documentation: null
-    repository: null
-  extra: null
-  
+
   '''
 # ---


### PR DESCRIPTION
This should fix main

PR #5513 changed recipe YAML serialization to omit null fields, but missed updating ROS backend snapshots. The ROS tests were skipped on the PR because CI only checked for changes under pixi-build-ros/.

Update snapshots to match new serialization and broaden CI change detection to include py-pixi-build-backend, recipe_stage0, and pixi_build_backend crates.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code