### PR TITLE
docs: improve sidebar rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,7 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.tracking
-    - navigation.sections
+    - navigation.indexes
     - navigation.top
     - navigation.footer
 


### PR DESCRIPTION
### Description

Before:
<img width="236" height="650" alt="Bildschirmfoto vom 2026-02-24 09-28-30" src="https://github.com/user-attachments/assets/b7043f8b-3d9d-4212-8a73-3610ede10e57" />
After:
<img width="236" height="650" alt="Bildschirmfoto vom 2026-02-24 09-28-21" src="https://github.com/user-attachments/assets/57dee358-8a5f-4f08-afac-7799a05decbf" />




### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure

I asked Claude to check what Pixi does differently from rattler-build

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code