### PR TITLE
chore: enable precise builds in dist configuration

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,6 +3,8 @@ members = ["cargo:."]
 
 # Config for 'dist'
 [dist]
+# Build one binary, see: https://axodotdev.github.io/cargo-dist/book/reference/config.html?highlight=binaries#inferring-precise-builds
+precise-builds = true
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "1.0.0-rc.1"
 # CI backends to support
@@ -50,7 +52,7 @@ aarch64-pc-windows-msvc = "windows_x64_2025_large"
 x86_64-pc-windows-msvc = "windows_x64_2025_large"
 # Linux targets
 aarch64-unknown-linux-musl = "8core_ubuntu_latest_runner"
-riscv64gc-unknown-linux-gnu = "ubuntu-latest"
+riscv64gc-unknown-linux-gnu = "8core_ubuntu_latest_runner"
 x86_64-unknown-linux-musl = "8core_ubuntu_latest_runner"
 
 [dist.dependencies.apt]


### PR DESCRIPTION
### Description

Use precise builds should disable the automatic use of `--workspace` in dist IIUC:
https://axodotdev.github.io/cargo-dist/book/reference/config.html?highlight=binaries#inferring-precise-builds

Testing here: 
https://github.com/prefix-dev/pixi/actions/runs/22347724777