### PR TITLE
fix: `tool.pixi.pypi-options.no-build = true` in combination with `--locked`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-default-members = [
-  "crates/pixi",
-]
+default-members = ["crates/pixi"]
 exclude = [
   # Only pulled in when enabling certain features. We do not want to include
   # these crates when running workspace wide commands.


### PR DESCRIPTION
### Description
Fixes #5553
cc @tdejager 

### How Has This Been Tested?
A regression test was added, and verified it was failing. After the fix, verified it was passing.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
