### PR TITLE
chore: Introduce vouch

### DIFF
--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -20,6 +20,7 @@ jobs:
        contains(github.event.comment.body, '/recheck'))
     steps:
       - uses: mitchellh/vouch/action/check-pr@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        id: check-pr
         with:
           pr-number: ${{ github.event.pull_request.number || github.event.issue.number }}
           auto-close: true
@@ -28,3 +29,27 @@ jobs:
           require-vouch: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label PR
+        if: steps.check-pr.outputs.status == 'vouched'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['vouched']
+            })
+
+      - name: Label PR
+        if: steps.check-pr.outputs.status == 'closed'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['denounced']
+            })

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -36,9 +36,38 @@ jobs:
           persist-credentials: true
 
       - uses: mitchellh/vouch/action/manage-by-issue@c6d80ead49839655b61b422700b7a3bc9d0804a9 # v1.4.2
+        id: manage-by-issue
         with:
           issue-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
           repo: prefix-dev/pixi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Close PR
+        if: >-
+          steps.manage-by-issue.outputs.status == 'denounced' &&
+            github.event.issue.pull_request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            })
+
+      - name: Label PR
+        if: >-
+          steps.manage-by-issue.outputs.status == 'denounced' &&
+            github.event.issue.pull_request
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['denounced']
+            })


### PR DESCRIPTION
### Description

Tested this out in the rattler repository. Maintainers can comment "vouch" to put the Issue creator/pr creator on `VOUCHED.td` and comment "denounce" to block PR authors. The `VOUCHED.td` lives in https://github.com/prefix-dev/vouched/blob/main/VOUCHED.td.

see https://github.com/conda/rattler/pull/2079#issuecomment-3966804337 for example usage.

At the moment, this is configured to just block denounced people. One can also configure it to only allow vouched people by setting `require-vouch: true`. Let's hope this is not needed.

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

tested all use cases in the rattler repository: https://github.com/conda/rattler/pull/2130, https://github.com/conda/rattler/pull/2079, https://github.com/conda/rattler/issues/775#issuecomment-3966690271 https://github.com/conda/rattler/pull/2126

see also https://github.com/conda/rattler/actions/workflows/vouch-check-pr.yml and https://github.com/conda/rattler/actions/workflows/vouch-manage-by-issue.yml

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
