### PR TITLE
fix: don't use a trailing `_` in a pyproject.toml package name.

### DIFF
--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -63,8 +63,7 @@ disable-sharded = false
         # Use no drive letter to avoid issues with different drives
         short_base = Path(r"\.r")
         short_base.mkdir(parents=True, exist_ok=True)
-        # suffix="x" prevents names ending with "_", which breaks some Windows tooling
-        workspace = Path(tempfile.mkdtemp(dir=short_base, suffix="x"))
+        workspace = Path(tempfile.mkdtemp(dir=short_base))
         workspace.joinpath(".pixi").mkdir()
         workspace.joinpath(".pixi/config.toml").write_text(pixi_config)
 


### PR DESCRIPTION
Make sure we don't use `_` as the last part of a python package name when it's based on the folder its in.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [na] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.