### PR TITLE
docs: clarify how activation works in practice

### DIFF
--- a/docs/reference/cli/pixi/shell-hook_extender
+++ b/docs/reference/cli/pixi/shell-hook_extender
@@ -14,6 +14,24 @@ pixi shell-hook --environment cuda
 pixi shell-hook --json
 ```
 
+Sourcing the script in bash and similar shells:
+
+```shell
+eval "$(pixi shell-hook)"
+```
+
+or in fish shell:
+
+```shell
+pixi shell-hook | source
+```
+
+or in powershell:
+
+```shell
+(pixi shell-hook) | Out-String | Invoke-Expression
+```
+
 Example use-case, when you want to get rid of the `pixi` executable in a Docker container.
 
 ```shell

--- a/docs/reference/cli/pixi/shell_extender
+++ b/docs/reference/cli/pixi/shell_extender
@@ -1,3 +1,14 @@
+--8<-- [start:description]
+
+!!! note
+    Never put the `pixi shell` command inside one of your shell's startup files (.profile, .bashrc and the likes):
+    the command starts a new shell without special arguments so the new shell will again execute your startup files,
+    which in turn will again run `pixi shell` and so on, recursively until failure.
+
+    Use [shell-hook](./shell-hook.md) instead if you want to activate a pixi environment when your shell starts.
+
+--8<-- [end:description]
+
 --8<-- [start:example]
 
 ## Examples


### PR DESCRIPTION
### Description

Add basic examples of `pixi shell-hook` usage since those seemed to be missing so far and make it clear that `pixi shell` should never be put in a shell's startup file.

Fixes part of #5510.

Note: theare are also other documents touching on activation, like https://pixi.prefix.dev/latest/workspace/environment/#activation and https://pixi.prefix.dev/latest/advanced/pixi_shell/, but I left those as-is because imo this basic yet important information should be put where it is most likely to be looked for i.e. next to the command's own explanation.

On the other hand something like https://pixi.prefix.dev/latest/advanced/pixi_shell/#issues-with-pixi-shell is almost about the exact same change I made in shell.md so please advise if this needs to be structured in a different way.
Perhaps simply linking directly to the relevant .md files in the aformentiond links would already help? It's a bit weird to have a page dedicated to `shell` without actually linking to its core documentation?

### How Has This Been Tested?

I only looked at the docs in a markdown previewer: don't know how else to check.
