### PR TITLE
fix: hash computation in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,12 @@ jobs:
             $orig = Get-ChildItem target/distrib -Filter $_.Name
             if ($orig) { Copy-Item $_.FullName $orig.FullName -Force }
           }
+          # Recompute .sha256 files for all modified archives (zip and msi)
+          # The signing step changes the file content, so checksums computed before signing are stale
+          foreach ($artifact in (Get-ChildItem target/distrib -Filter "*.zip") + (Get-ChildItem target/distrib -Filter "*.msi")) {
+            $hash = (Get-FileHash $artifact.FullName -Algorithm SHA256).Hash.ToLower()
+            "$hash *$($artifact.Name)" | Set-Content "$($artifact.FullName).sha256" -NoNewline
+          }
       - name: Attest Builds
         id: attest
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0


### PR DESCRIPTION
### Description

Unfortunately, the latest release(s) have a wrong SHA256 for the windows binaries. This is because we started to sign them with proper certificates, which change the hashes.

### How Has This Been Tested?

Not yet, we shoudl run a dry-run release and compare the hashes in the text fiel with the actual files.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
