### PR TITLE
docs: fix broken link to satisfiability source code in lockfile docs

### DIFF
--- a/docs/workspace/lockfile.md
+++ b/docs/workspace/lockfile.md
@@ -129,7 +129,7 @@ Steps to check if the lock file is satisfiable:
 - All hashes for the `pypi` editable packages are correct.
 - There is only a single entry for every package in the lock file.
 
-If you want to get more details checkout the [actual code](https://github.com/prefix-dev/pixi/blob/main/src/lock_file/satisfiability/mod.rs) as this is a simplification of the actual code.
+If you want to get more details checkout the [actual code](https://github.com/prefix-dev/pixi/blob/main/crates/pixi_core/src/lock_file/satisfiability/mod.rs) as this is a simplification of the actual code.
 
 ## The version of the lock file
 


### PR DESCRIPTION
### Description

Fixes #5606

### How Has This Been Tested?

The new link works.


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code