### PR TITLE
fix: editability check during pypi install

### DIFF
--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -709,11 +709,7 @@ impl<'p> LockFileDerivedData<'p> {
                     .filter_map(LockedPackageRef::as_pypi)
                     .map(|(data, env_data)| {
                         let mut data = data.clone();
-                        data.editable = manifest_pypi_deps
-                            .get(&data.name)
-                            .and_then(|specs| specs.last())
-                            .and_then(|spec| spec.editable())
-                            .unwrap_or(false);
+                        data.editable = is_editable_from_manifest(&manifest_pypi_deps, &data.name);
                         (data, env_data.clone())
                     })
                     .collect::<Vec<_>>();
@@ -2681,4 +2677,102 @@ async fn spawn_solve_pypi_task<'p>(
         duration,
         prefix_task_result,
     ))
+}
+
+/// Check if a package should be installed as editable based on the manifest's
+/// pypi dependencies.
+///
+/// When multiple specs exist for a package (from merged features or duplicate
+/// entries from `project.dependencies` and `tool.pixi.pypi-dependencies`),
+/// we take the first spec that has an explicit editable value. This respects
+/// feature priority ordering (non-default features come first) while also
+/// handling the same-feature case where a registry spec from
+/// `project.dependencies` lacks an editable field.
+fn is_editable_from_manifest(
+    manifest_pypi_deps: &pixi_manifest::PyPiDependencies,
+    package_name: &pep508_rs::PackageName,
+) -> bool {
+    manifest_pypi_deps
+        .get(package_name)
+        .and_then(|specs| specs.iter().find_map(|spec| spec.editable()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pixi_manifest::PyPiDependencies;
+    use pixi_pypi_spec::PixiPypiSpec;
+
+    #[test]
+    fn test_editable_path_spec_with_registry_spec() {
+        let mut deps = PyPiDependencies::default();
+        let name = pixi_pypi_spec::PypiPackageName::from_str("requests").unwrap();
+        let pep508_name = pep508_rs::PackageName::new("requests".to_string()).unwrap();
+
+        // Simulate tool.pixi.pypi-dependencies (added first)
+        let path_spec = PixiPypiSpec::new(pixi_pypi_spec::PixiPypiSource::Path {
+            path: "./requests".into(),
+            editable: Some(true),
+        });
+        deps.insert(name.clone(), path_spec);
+
+        // Simulate project.dependencies (added second, no editable field)
+        let registry_spec: PixiPypiSpec = pep508_rs::Requirement::from_str("requests>=2.0")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        deps.insert(name.clone(), registry_spec);
+
+        // The first explicit editable value (Some(true)) should win
+        assert!(
+            is_editable_from_manifest(&deps, &pep508_name),
+            "Package should be editable when an editable path spec exists alongside a registry spec"
+        );
+    }
+
+    #[test]
+    fn test_not_editable_when_only_registry_spec() {
+        let mut deps = PyPiDependencies::default();
+        let name = pixi_pypi_spec::PypiPackageName::from_str("requests").unwrap();
+        let pep508_name = pep508_rs::PackageName::new("requests".to_string()).unwrap();
+
+        let registry_spec: PixiPypiSpec = pep508_rs::Requirement::from_str("requests>=2.0")
+            .unwrap()
+            .try_into()
+            .unwrap();
+        deps.insert(name.clone(), registry_spec);
+
+        assert!(
+            !is_editable_from_manifest(&deps, &pep508_name),
+            "Package should not be editable when no spec has editable=true"
+        );
+    }
+
+    #[test]
+    fn test_feature_priority_explicit_non_editable_wins() {
+        let mut deps = PyPiDependencies::default();
+        let name = pixi_pypi_spec::PypiPackageName::from_str("requests").unwrap();
+        let pep508_name = pep508_rs::PackageName::new("requests".to_string()).unwrap();
+
+        // Higher-priority feature explicitly sets editable=false (inserted first)
+        let non_editable_spec = PixiPypiSpec::new(pixi_pypi_spec::PixiPypiSource::Path {
+            path: "./requests".into(),
+            editable: Some(false),
+        });
+        deps.insert(name.clone(), non_editable_spec);
+
+        // Lower-priority feature has editable=true (inserted second)
+        let editable_spec = PixiPypiSpec::new(pixi_pypi_spec::PixiPypiSource::Path {
+            path: "./requests".into(),
+            editable: Some(true),
+        });
+        deps.insert(name.clone(), editable_spec);
+
+        // The first explicit editable value (Some(false)) should win
+        assert!(
+            !is_editable_from_manifest(&deps, &pep508_name),
+            "Higher-priority feature's explicit editable=false should take precedence"
+        );
+    }
 }


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #5604 

This happened because the spec is duplicated and so both the registry `requests` and the local `requests` got passed into the solver. uv prefers the local one, so all good. However, we selected the *registry* requests version when determining editability. Now we just select by looking at all duplicates, as you cannot set editability directly in pep508 it should be good.

In the case of pixi features:

```toml
  [project]
  name = "myproject"
  version = "0.1.0"
  requires-python = ">= 3.11"
  dependencies = ["requests"]

  [build-system]
  build-backend = "hatchling.build"
  requires = ["hatchling"]

  [tool.pixi.workspace]
  channels = ["conda-forge"]
  platforms = ["osx-arm64"]

  [tool.pixi.pypi-dependencies]
  requests = { path = "./requests", editable = true }

  [tool.pixi.feature.prod.pypi-dependencies]
  requests = { path = "./requests", editable = false }

  [tool.pixi.environments]
  prod = ["prod"]
```

The `false` should be taken as it has higher precedence

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

Manually by using:

1. clone requests from github.

2. Use:
```toml
[project]
authors = [{name = "Tim de Jager", email = "tdejager89@gmail.com"}]
dependencies = ["requests"]
name = "5604"
requires-python = ">= 3.11"
version = "0.1.0"

[build-system]
build-backend = "hatchling.build"
requires = ["hatchling"]

[tool.pixi.workspace]
channels = ["conda-forge"]
platforms = ["osx-arm64"]

[tool.pixi.pypi-dependencies]
requests = { path = "./requests", editable = true }
```

3. run `pixi install` <-- Built version of pixi
4. Note the pth file is there for the dev version
```bash
/tmp/5604 is 📦 v0.1.0 via 🐍 took 57s
❯ ls .pixi/envs/default/lib/python3.14/site-packages/ | grep .pth
__editable__.requests-2.33.0.dev1.pth
```

5. With the *released* version of pixi this used a non-editable install.
6.  For the second, prod case, we see:

```bash
❯ ls .pixi/envs/prod/lib/python3.14/site-packages/ | grep .pth
conda-site.pth
```

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Opus 4.6

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
