### PR TITLE
chore(logging): lower cache version conflict log level to debug

### DIFF
--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -174,7 +174,7 @@ impl SourceMetadataSpec {
                 tracing::trace!("Cache updated successfully");
             }
             source_metadata::WriteResult::Conflict(_) => {
-                tracing::warn!(
+                tracing::debug!(
                     "Cache was updated by another process during computation (version conflict), using our computed result"
                 );
             }


### PR DESCRIPTION
### Description

Reduces the log severity for cache version conflicts in `source_metadata/mod.rs`.

Cache conflicts can occur when multiple Pixi processes compute metadata concurrently and attempt to write to the cache. In these cases Pixi already falls back to the locally computed result, so the situation is expected under optimistic concurrency and does not indicate an error.

Previously this condition was logged using `tracing::warn!` in `source_metadata/mod.rs`, while the same condition in `build_backend_metadata/mod.rs` is logged with `tracing::debug!`.

This change aligns the log level in `source_metadata` with the existing behavior in `build_backend_metadata`, preventing unnecessary warnings in CI logs.

Fixes #5626

### How Has This Been Tested?

- Ran `cargo check` to ensure the project builds successfully.
- Ran `cargo fmt` to ensure formatting is correct.
- Verified that the only change is reducing the log level from `warn!` to `debug!` for `WriteResult::Conflict(_)` in `source_metadata/mod.rs`.
- Confirmed the log level now matches the behavior in `build_backend_metadata/mod.rs`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.