### PR TITLE
feat(pixi-build-python): add abi3 (Stable ABI) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5785,6 +5785,7 @@ dependencies = [
  "miette 7.6.0",
  "minijinja",
  "once_cell",
+ "pep440_rs",
  "pep508_rs",
  "pixi_build_backend",
  "pixi_build_types",

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = { workspace = true }
 miette = { workspace = true }
 minijinja = { workspace = true }
 once_cell = { workspace = true }
+pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 pixi_build_backend = { workspace = true }
 pixi_build_types = { workspace = true }

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -34,6 +34,11 @@ pub struct PythonBackendConfig {
     /// Defaults to `true` (mapping disabled).
     #[serde(default)]
     pub ignore_pypi_mapping: Option<bool>,
+    /// Whether the package uses the Python Stable ABI (abi3).
+    /// When true, adds `python_abi` to host requirements.
+    /// Only meaningful for packages with compiled extensions (non-noarch).
+    #[serde(default)]
+    pub abi3: Option<bool>,
 }
 
 impl PythonBackendConfig {
@@ -104,6 +109,7 @@ impl BackendConfig for PythonBackendConfig {
             ignore_pypi_mapping: target_config
                 .ignore_pypi_mapping
                 .or(self.ignore_pypi_mapping),
+            abi3: target_config.abi3.or(self.abi3),
         })
     }
 }
@@ -136,6 +142,7 @@ mod tests {
             compilers: Some(vec!["c".to_string()]),
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
+            abi3: Some(true),
         };
 
         let mut target_env = indexmap::IndexMap::new();
@@ -151,6 +158,7 @@ mod tests {
             compilers: Some(vec!["cxx".to_string(), "rust".to_string()]),
             ignore_pyproject_manifest: Some(false),
             ignore_pypi_mapping: Some(false),
+            abi3: Some(false),
         };
 
         let merged = base_config
@@ -186,6 +194,8 @@ mod tests {
         assert_eq!(merged.ignore_pyproject_manifest, Some(false));
         // ignore_pypi_mapping should use target value
         assert_eq!(merged.ignore_pypi_mapping, Some(false));
+        // abi3 should use target value
+        assert_eq!(merged.abi3, Some(false));
     }
 
     #[test]
@@ -202,6 +212,7 @@ mod tests {
             compilers: None,
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
+            abi3: None,
         };
 
         let empty_target_config = PythonBackendConfig::default();
@@ -218,6 +229,50 @@ mod tests {
         assert_eq!(merged.compilers, None);
         assert_eq!(merged.ignore_pyproject_manifest, Some(true));
         assert_eq!(merged.ignore_pypi_mapping, Some(true));
+    }
+
+    #[test]
+    fn test_merge_abi3_behavior() {
+        // Target overrides base
+        let base = PythonBackendConfig {
+            abi3: Some(true),
+            ..Default::default()
+        };
+        let target = PythonBackendConfig {
+            abi3: Some(false),
+            ..Default::default()
+        };
+        let merged = base.merge_with_target_config(&target).unwrap();
+        assert_eq!(merged.abi3, Some(false));
+
+        // Target None keeps base
+        let target_none = PythonBackendConfig {
+            abi3: None,
+            ..Default::default()
+        };
+        let merged = base.merge_with_target_config(&target_none).unwrap();
+        assert_eq!(merged.abi3, Some(true));
+
+        // Both None stays None
+        let base_none = PythonBackendConfig::default();
+        let merged = base_none.merge_with_target_config(&target_none).unwrap();
+        assert_eq!(merged.abi3, None);
+    }
+
+    #[test]
+    fn test_deserialize_abi3_field() {
+        let json_data = json!({"abi3": true});
+        let config: PythonBackendConfig = serde_json::from_value(json_data).unwrap();
+        assert_eq!(config.abi3, Some(true));
+
+        let json_data = json!({"abi3": false});
+        let config: PythonBackendConfig = serde_json::from_value(json_data).unwrap();
+        assert_eq!(config.abi3, Some(false));
+
+        // Not specified should be None
+        let json_data = json!({});
+        let config: PythonBackendConfig = serde_json::from_value(json_data).unwrap();
+        assert_eq!(config.abi3, None);
     }
 
     #[test]

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -15,7 +15,7 @@ use pixi_build_backend::{
     traits::ProjectModel,
 };
 use pyproject_toml::PyProjectToml;
-use rattler_conda_types::{ChannelUrl, Platform, package::EntryPoint};
+use rattler_conda_types::{ChannelUrl, Platform, Version, VersionBumpType, package::EntryPoint};
 use recipe_stage0::matchspec::PackageDependency;
 use recipe_stage0::recipe::{Item, NoArchKind, Python, Script};
 use std::collections::HashSet;
@@ -31,6 +31,47 @@ use crate::pypi_mapping::{
     detect_compilers_from_build_requirements, filter_mapped_pypi_deps,
     map_requirements_with_channels,
 };
+
+/// Compute the `python_abi` version spec from an optional `requires-python`
+/// specifier string.
+///
+/// Extracts the lower bound (first `>=` specifier) and pins it to a single
+/// minor version:
+/// - `">=3.9"`     → `">=3.9,<3.10.0a0"`
+/// - `">=3.9.3"`   → `">=3.9.3,<3.10.0a0"`
+/// - `">=3.11,<4"` → `">=3.11,<3.12.0a0"`
+/// - `None`        → `">=3.8,<3.9.0a0"` (default)
+fn python_abi_spec_from_requires_python(requires_python: Option<&str>) -> miette::Result<String> {
+    let lower_bound = requires_python
+        .and_then(|s| {
+            let specifiers = pep440_rs::VersionSpecifiers::from_str(s).ok()?;
+            specifiers
+                .iter()
+                .find(|spec| *spec.operator() == pep440_rs::Operator::GreaterThanEqual)
+                .map(|spec| {
+                    let pep_version = spec.version();
+                    // Convert pep440 version to rattler Version via string round-trip
+                    Version::from_str(&pep_version.to_string())
+                        .expect("pep440 version should be a valid conda version")
+                })
+        })
+        .unwrap_or_else(|| Version::from_str("3.8").expect("valid version"));
+
+    // Truncate to major.minor for the upper bound computation
+    let major_minor = lower_bound
+        .clone()
+        .with_segments(..std::cmp::min(lower_bound.segment_count(), 2))
+        .ok_or_else(|| miette::miette!("failed to truncate version to major.minor"))?;
+
+    let upper_bound = major_minor
+        .bump(VersionBumpType::Minor)
+        .into_diagnostic()?
+        .with_alpha()
+        .remove_local()
+        .into_owned();
+
+    Ok(format!(">={lower_bound},<{upper_bound}"))
+}
 
 #[derive(Default, Clone)]
 pub struct PythonGenerator {}
@@ -178,6 +219,23 @@ impl GenerateRecipe for PythonGenerator {
             true
         };
 
+        // Validate abi3 + noarch conflict
+        if config.abi3 == Some(true) && is_noarch {
+            miette::bail!(
+                "abi3 = true is incompatible with noarch packages. \
+                 The stable ABI is only meaningful for packages with compiled extensions."
+            );
+        }
+
+        // Add python_abi host dependency when abi3 is enabled
+        if config.abi3 == Some(true) {
+            let requires_python_str = pyproject_metadata_provider.requires_python().ok().flatten();
+            let abi_spec = python_abi_spec_from_requires_python(requires_python_str.as_deref())?;
+            let python_abi_req: Item<PackageDependency> =
+                format!("python_abi {abi_spec}").parse().into_diagnostic()?;
+            requirements.host.push(python_abi_req);
+        }
+
         // Use NoArch platform for mapping if this is a noarch package
         let mapping_platform = if is_noarch {
             Platform::NoArch
@@ -290,6 +348,7 @@ impl GenerateRecipe for PythonGenerator {
         // Construct python specific settings
         let python = Python {
             entry_points: PythonGenerator::entry_points(pyproject_manifest),
+            version_independent: config.abi3 == Some(true),
         };
 
         generated_recipe.recipe.build.python = python;
@@ -1032,6 +1091,160 @@ build-backend = "hatchling.build"
             host_deps,
             vec!["pip", "python"],
             "host deps should only contain pip and python when ignore_pypi_mapping=true"
+        );
+    }
+
+    #[test]
+    fn test_python_abi_spec_from_requires_python() {
+        // Basic lower bound
+        assert_eq!(
+            python_abi_spec_from_requires_python(Some(">=3.9")).unwrap(),
+            ">=3.9,<3.10.0a0"
+        );
+        // With patch version
+        assert_eq!(
+            python_abi_spec_from_requires_python(Some(">=3.9.3")).unwrap(),
+            ">=3.9.3,<3.10.0a0"
+        );
+        // Multiple specifiers - uses the >= bound
+        assert_eq!(
+            python_abi_spec_from_requires_python(Some(">=3.11,<4")).unwrap(),
+            ">=3.11,<3.12.0a0"
+        );
+        // 3.8 lower bound
+        assert_eq!(
+            python_abi_spec_from_requires_python(Some(">=3.8")).unwrap(),
+            ">=3.8,<3.9.0a0"
+        );
+        // None defaults to 3.8
+        assert_eq!(
+            python_abi_spec_from_requires_python(None).unwrap(),
+            ">=3.8,<3.9.0a0"
+        );
+        // Extra segments are preserved in lower bound but upper bound still pins to major.minor
+        assert_eq!(
+            python_abi_spec_from_requires_python(Some(">=3.9.3.4")).unwrap(),
+            ">=3.9.3.4,<3.10.0a0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_abi3_adds_python_abi_to_host() {
+        let project_model = project_fixture!({
+            "name": "foobar",
+            "version": "0.1.0",
+            "targets": {
+                "defaultTarget": {}
+            }
+        });
+
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+
+        fs::write(
+            temp_dir.path().join("pyproject.toml"),
+            r#"[project]
+name = "foobar"
+version = "0.1.0"
+requires-python = ">=3.9"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+"#,
+        )
+        .await
+        .expect("Failed to write pyproject.toml");
+
+        let config = PythonBackendConfig {
+            abi3: Some(true),
+            noarch: Some(false),
+            compilers: Some(vec!["c".to_string()]),
+            ..Default::default()
+        };
+
+        let generated_recipe = PythonGenerator::default()
+            .generate_recipe(
+                &project_model,
+                &config,
+                temp_dir.path().to_path_buf(),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+            )
+            .await
+            .expect("Failed to generate recipe");
+
+        let host_deps: Vec<String> = generated_recipe
+            .recipe
+            .requirements
+            .host
+            .iter()
+            .map(|item| item.to_string())
+            .collect();
+
+        assert!(
+            host_deps.iter().any(|d| d.contains("python_abi")),
+            "host deps should contain python_abi when abi3=true, got: {host_deps:?}"
+        );
+        // Check the version spec
+        let abi_dep = host_deps.iter().find(|d| d.contains("python_abi")).unwrap();
+        assert!(
+            abi_dep.contains(">=3.9") && abi_dep.contains("<3.10.0a0"),
+            "python_abi should have >=3.9,<3.10.0a0 spec, got: {abi_dep}"
+        );
+        // Check version_independent is set
+        assert!(
+            generated_recipe.recipe.build.python.version_independent,
+            "version_independent should be true when abi3=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_abi3_with_noarch_errors() {
+        let config = PythonBackendConfig {
+            abi3: Some(true),
+            noarch: Some(true),
+            ignore_pyproject_manifest: Some(true),
+            ..Default::default()
+        };
+
+        let result = generate_test_recipe(&config).await;
+        assert!(result.is_err(), "abi3=true with noarch=true should error");
+    }
+
+    #[tokio::test]
+    async fn test_abi3_without_requires_python_defaults() {
+        let config = PythonBackendConfig {
+            abi3: Some(true),
+            noarch: Some(false),
+            compilers: Some(vec!["c".to_string()]),
+            ignore_pyproject_manifest: Some(true),
+            ..Default::default()
+        };
+
+        let generated_recipe = generate_test_recipe(&config)
+            .await
+            .expect("Failed to generate recipe");
+
+        let host_deps: Vec<String> = generated_recipe
+            .recipe
+            .requirements
+            .host
+            .iter()
+            .map(|item| item.to_string())
+            .collect();
+
+        let abi_dep = host_deps.iter().find(|d| d.contains("python_abi"));
+        assert!(
+            abi_dep.is_some(),
+            "host deps should contain python_abi, got: {host_deps:?}"
+        );
+        let abi_dep = abi_dep.unwrap();
+        assert!(
+            abi_dep.contains(">=3.8") && abi_dep.contains("<3.9.0a0"),
+            "python_abi should default to >=3.8,<3.9.0a0, got: {abi_dep}"
         );
     }
 

--- a/crates/recipe_stage0/src/recipe.rs
+++ b/crates/recipe_stage0/src/recipe.rs
@@ -513,12 +513,17 @@ pub struct Python {
     /// executable and the module + function that should be executed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entry_points: Vec<EntryPoint>,
+    /// When true, indicates the package is Python version independent (e.g.
+    /// uses the stable ABI / abi3). This tells the solver that the package
+    /// does not need to be rebuilt for different Python minor versions.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub version_independent: bool,
 }
 
 impl Python {
     /// Returns true if this is the default python configuration.
     pub fn is_default(&self) -> bool {
-        self.entry_points.is_empty()
+        self.entry_points.is_empty() && !self.version_independent
     }
 }
 

--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -193,6 +193,31 @@ compilers = ["c", "cxx"]
 !!! info "Comprehensive Compiler Documentation"
     For detailed information about available compilers, platform-specific behavior, and how conda-forge compilers work, see the [Compilers Documentation](../key_concepts/compilers.md).
 
+### `abi3`
+
+- **Type**: `Boolean`
+- **Default**: `false`
+- **Target Merge Behavior**: `Overwrite` - Platform-specific setting takes precedence over base
+
+Controls whether the package uses the [Python Stable ABI (abi3)](https://docs.python.org/3/c-api/stable.html). When set to `true`, a `python_abi` dependency is added to the host requirements with version bounds derived from `requires-python` in your `pyproject.toml`.
+
+The `python_abi` package has `run_exports` that automatically propagate the ABI constraint to the run environment, so only a host dependency is needed.
+
+```toml
+[package.build.config]
+abi3 = true
+compilers = ["c"]
+```
+
+The version bounds are computed from the lower bound of `requires-python`:
+
+- `requires-python = ">=3.9"` → `python_abi >=3.9,<3.10.0a0`
+- `requires-python = ">=3.11,<4"` → `python_abi >=3.11,<3.12.0a0`
+- If `requires-python` is not specified, defaults to `python_abi >=3.8,<3.9.0a0`
+
+!!! warning "Incompatible with noarch"
+    Setting `abi3 = true` with `noarch = true` will produce an error, since the stable ABI is only meaningful for packages with compiled extensions.
+
 ### `extra-args`
 
 - **Type**: `Array<String>`

--- a/pixi-build-backends/py-pixi-build-backend/src/recipe_stage0/recipe.rs
+++ b/pixi-build-backends/py-pixi-build-backend/src/recipe_stage0/recipe.rs
@@ -634,7 +634,10 @@ impl PyPython {
 
         match entry_points {
             Ok(entry_points) => Ok(PyPython {
-                inner: RecipePython { entry_points },
+                inner: RecipePython {
+                    entry_points,
+                    version_independent: false,
+                },
             }),
             Err(_) => Err(pyo3::exceptions::PyValueError::new_err(
                 "Invalid entry point format",


### PR DESCRIPTION
### Description

Add a new `abi3` config option to `pixi-build-python` that enables Python Stable ABI support. When `abi3 = true`, a `python_abi` host dependency is added with version bounds derived from `requires-python`, allowing compiled extensions to declare compatibility across Python minor versions.

- `abi3: Option<bool>` field on `PythonBackendConfig` with target merge support
- Extracts lower bound from `requires-python` to pin `python_abi` to a single minor version (e.g., `>=3.9,<3.10a0`)
- Defaults to `python_abi >=3.8,<3.9a0` when `requires-python` is absent
- Errors if combined with `noarch = true` (abi3 only applies to compiled extensions)
- Documentation added for the new config option

### How Has This Been Tested?

- Unit test for version spec extraction from various `requires-python` patterns (`>=3.9`, `>=3.9.3`, `>=3.11,<4`, `None`)
- Integration test: `abi3 = true` with compilers adds `python_abi >=3.9,<3.10a0` to host
- Integration test: `abi3 = true` + `noarch = true` produces error
- Integration test: `abi3 = true` without `requires-python` defaults to `>=3.8,<3.9a0`
- Config merge and deserialization tests for the new field
- All 73 existing tests continue to pass

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.