### PR TITLE
fix: cache file path corruption when package name contains dots

### DIFF
--- a/crates/pixi_command_dispatcher/src/cache/common.rs
+++ b/crates/pixi_command_dispatcher/src/cache/common.rs
@@ -221,7 +221,11 @@ pub trait MetadataCache: Clone + Sized {
 
     /// Returns the path to the cache entry with the given key.
     fn cache_file_path(&self, input: &Self::Key) -> PathBuf {
-        self.root().join(input.hash_key()).with_extension("json")
+        // Use string concatenation instead of `with_extension` to avoid issues
+        // with dots in the hash key (e.g., from package names like "my.package").
+        // `with_extension` replaces everything after the last dot, which would
+        // truncate the file name.
+        self.root().join(format!("{}.json", input.hash_key()))
     }
 }
 
@@ -259,4 +263,82 @@ pub enum WriteResult<M> {
 pub trait CacheError: std::error::Error + Sized {
     /// Creates an error from an I/O error with context about the operation
     fn from_io_error(operation: String, path: PathBuf, error: std::io::Error) -> Self;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyKey(String);
+
+    impl CacheKey for DummyKey {
+        fn hash_key(&self) -> String {
+            self.0.clone()
+        }
+    }
+
+    #[derive(Clone, serde::Serialize, serde::Deserialize)]
+    struct DummyMetadata {
+        version: u64,
+    }
+
+    impl CachedMetadata for DummyMetadata {}
+
+    impl VersionedMetadata for DummyMetadata {
+        fn cache_version(&self) -> u64 {
+            self.version
+        }
+        fn set_cache_version(&mut self, version: u64) {
+            self.version = version;
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test error")]
+    struct DummyError;
+
+    impl CacheError for DummyError {
+        fn from_io_error(_operation: String, _path: PathBuf, _error: std::io::Error) -> Self {
+            DummyError
+        }
+    }
+
+    #[derive(Clone)]
+    struct DummyCache {
+        root: PathBuf,
+    }
+
+    impl MetadataCache for DummyCache {
+        type Key = DummyKey;
+        type Metadata = DummyMetadata;
+        type Error = DummyError;
+        const CACHE_SUFFIX: &'static str = "v0";
+        fn root(&self) -> &Path {
+            &self.root
+        }
+    }
+
+    #[test]
+    fn test_cache_file_path_with_dots_in_key() {
+        let cache = DummyCache {
+            root: PathBuf::from("/tmp/cache"),
+        };
+
+        // A key with dots (e.g., from package name "my.package") should NOT
+        // have the part after the dot replaced by `with_extension`.
+        let key = DummyKey("source-dir/my.package-osx-arm64-HASH".to_string());
+        let path = cache.cache_file_path(&key);
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/cache/source-dir/my.package-osx-arm64-HASH.json")
+        );
+
+        // A key without dots should also work correctly.
+        let key = DummyKey("source-dir/my-package-osx-arm64-HASH".to_string());
+        let path = cache.cache_file_path(&key);
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/cache/source-dir/my-package-osx-arm64-HASH.json")
+        );
+    }
 }


### PR DESCRIPTION
### Description

`PathBuf::with_extension("json")` in `MetadataCache::cache_file_path` replaces everything after the **last dot** in the file name. When a package name contains a dot (e.g., `my.package`), the source metadata cache hash key becomes something like `source-dir/my.package-osx-arm64-HASH`, and `with_extension("json")` truncates it to `source-dir/my.json` — discarding the platform and hash entirely.

This causes requests for different platforms (e.g., `osx-arm64` and `linux-64`) to read/write the **same** cache file, producing spurious "Cache was updated by another process" warnings due to version conflicts.

The fix uses string concatenation (`format!("{}.json", ...)`) instead of `with_extension` to append the `.json` suffix, preserving the full file name.

Fixes #5626

### How Has This Been Tested?

- Added a unit test (`test_cache_file_path_with_dots_in_key`) that verifies cache file paths are correctly generated both with and without dots in the hash key.
- All existing tests pass (`cargo test -p pixi_command_dispatcher` — 21 passed).

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.