### PR TITLE
perf: Making UV default installer in `pixi-build-python`

### DIFF
--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use minijinja::Environment;
 use serde::Serialize;
 
-const UV: &str = "uv";
+const PIP: &str = "pip";
 #[derive(Serialize)]
 pub struct BuildScriptContext {
     pub installer: Installer,
@@ -16,9 +16,9 @@ pub struct BuildScriptContext {
 #[derive(Default, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Installer {
-    Uv,
-    #[default]
     Pip,
+    #[default]
+    Uv,
 }
 
 impl Installer {
@@ -35,12 +35,12 @@ impl Installer {
         mut package_names: impl Iterator<Item = &'a str>,
     ) -> Installer {
         // Check all dependency names for "uv" package
-        let has_uv = package_names.any(|name| name == UV);
+        let has_pip = package_names.any(|name| name == PIP);
 
-        if has_uv {
-            Installer::Uv
-        } else {
+        if has_pip {
             Installer::Pip
+        } else {
+            Installer::Uv
         }
     }
 }

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -1078,7 +1078,7 @@ build-backend = "hatchling.build"
             "run deps should only contain python when ignore_pypi_mapping=true"
         );
 
-        // Host requirements should only contain pip (auto-added installer) and python
+        // Host requirements should only contain uv (auto-added installer) and python
         let host_deps: Vec<String> = generated_recipe
             .recipe
             .requirements
@@ -1089,8 +1089,8 @@ build-backend = "hatchling.build"
 
         assert_eq!(
             host_deps,
-            vec!["pip", "python"],
-            "host deps should only contain pip and python when ignore_pypi_mapping=true"
+            vec!["uv", "python"],
+            "host deps should only contain uv and python when ignore_pypi_mapping=true"
         );
     }
 

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__metadata__tests__generated_recipe_contains_pyproject_values.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__metadata__tests__generated_recipe_contains_pyproject_values.snap
@@ -13,7 +13,7 @@ build:
 requirements:
   build: []
   host:
-    - pip
+    - uv
     - python
   run:
     - boltons

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__pip_is_in_host_requirements.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__pip_is_in_host_requirements.snap
@@ -13,7 +13,7 @@ build:
 requirements:
   build: []
   host:
-    - pip
+    - uv
     - python
   run:
     - boltons

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
@@ -14,7 +14,7 @@ requirements:
   build: []
   host:
     - python
-    - pip
+    - uv
   run:
     - boltons
     - python


### PR DESCRIPTION
### Description

Makes uv the default installer as discussed here: https://discord.com/channels/1082332781146800168/1481753574836015174/1481953664343212073

Fixes #5666

### How Has This Been Tested?

cargo test
cargo insta review 

### Checklist:
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
