### PR TITLE
docs: Fix pixi-build docs about uv in installer selection

### DIFF
--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -394,7 +394,7 @@ The Python backend follows this build process:
 
 The backend automatically detects which Python installer to use:
 
-- **uv**: Used if `uv` is present in any dependency category (build, host, or run)
+- **uv**: Used if `uv` is present in the build or host dependencies
 - **pip**: Used as the default fallback installer
 
 To use `uv` for faster installations, add it to your dependencies:


### PR DESCRIPTION
### Description
This PR fixes a small detail in the docs about pixi-build-python installer selection which currently say this about uv
https://github.com/prefix-dev/pixi/blob/a4665db78a38c6574cec98200073c30a17ef9d5d/docs/build/backends/pixi-build-python.md?plain=1#L393-L397
but according to the code only the build and host dependencies are checked (not the run dependencies)
https://github.com/prefix-dev/pixi/blob/a4665db78a38c6574cec98200073c30a17ef9d5d/crates/pixi_build_python/src/main.rs#L159-L160
https://github.com/prefix-dev/pixi/blob/a4665db78a38c6574cec98200073c30a17ef9d5d/crates/pixi_build_backend/src/traits/targets.rs#L65-L71