### PR TITLE
chore: revert lower cache version conflict log level to debug

### DIFF
--- a/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_metadata/mod.rs
@@ -174,7 +174,7 @@ impl SourceMetadataSpec {
                 tracing::trace!("Cache updated successfully");
             }
             source_metadata::WriteResult::Conflict(_) => {
-                tracing::debug!(
+                tracing::warn!(
                     "Cache was updated by another process during computation (version conflict), using our computed result"
                 );
             }


### PR DESCRIPTION
Reverts prefix-dev/pixi#5630