### PR TITLE
fix(dispatcher): avoid panic from stale SlotMap keys in reporter_context

### DIFF
--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
@@ -301,7 +301,7 @@ impl<T: Clone, E: Clone> PendingDeduplicatingTask<T, E> {
     ///
     /// Both success and error results are cloned and sent to all waiting channels.
     pub fn on_pending_result(&mut self, result: Result<T, CommandDispatcherError<E>>) {
-        let Self::Pending(pending, context) = self else {
+        let Self::Pending(pending, _context) = self else {
             unreachable!("cannot get a result for a task that is not pending");
         };
 


### PR DESCRIPTION
## Description

Fix a panic in `reporter_context()` caused by accessing stale `SlotMap` keys.

When a solve/install task finishes, its entry is removed from the corresponding `SlotMap`. However, child tasks may still reference the parent context while the dispatcher walks the reporter hierarchy. Previously this used direct indexing (`slotmap[id]`), which panics if the key was already removed.

This PR replaces those accesses with `SlotMap::get()` so that finished tasks safely return `None` instead of panicking.

Fixes #5675

## How Has This Been Tested?

* Ran `cargo check -p pixi_command_dispatcher`
* Verified the change only affects reporter context lookup and does not alter task logic

## AI Disclosure

* This PR does not contain AI-generated content.
  * [ ] I have tested any AI-generated content in my PR.
  * [ ] I take responsibility for any AI-generated content in my PR.

## Checklist:

* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added sufficient tests to cover my changes.
* [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`