### PR TITLE
fix(shell-hook): make prompt modification idempotent to prevent duplication

### DIFF
--- a/crates/pixi_core/src/prompt.rs
+++ b/crates/pixi_core/src/prompt.rs
@@ -13,7 +13,16 @@ pub fn zsh_hook() -> &'static str {
 
 /// Sets default pixi prompt for posix shells
 pub fn posix_prompt(env_name: &str) -> String {
-    format!("export PS1=\"({env_name}) ${{PS1:-}}\"")
+    // Guard against repeated invocations: only modify PS1 if we haven't already
+    // set it for this environment. This prevents the prompt prefix from being
+    // prepended multiple times when shell-hook is evaluated more than once for
+    // the same environment (see #5599).
+    format!(
+        r#"if [ "${{__PIXI_PROMPT_MODIFIED-}}" != "({env_name}) " ]; then
+export PS1="({env_name}) ${{PS1:-}}"
+export __PIXI_PROMPT_MODIFIED="({env_name}) "
+fi"#
+    )
 }
 
 /// Sets default pixi prompt for the fish shell
@@ -72,17 +81,30 @@ pub fn xonsh_prompt() -> String {
 
 /// Sets default pixi prompt for the powershell
 pub fn powershell_prompt(env_name: &str) -> String {
+    // Guard against repeated invocations: only wrap the prompt function if we
+    // haven't already done so for this environment. Without this guard, running
+    // shell-hook multiple times causes infinite recursion in the prompt function,
+    // leading to a stack overflow (see #5599).
     format!(
-        "$old_prompt = $function:prompt\n\
-         function prompt {{\"({env_name}) $($old_prompt.Invoke())\"}}"
+        "if ($Env:__PIXI_PROMPT_MODIFIED -ne '({env_name}) ') {{\n\
+         $__pixi_original_prompt = $function:prompt\n\
+         function prompt {{\"({env_name}) $($__pixi_original_prompt.Invoke())\"}}\n\
+         $Env:__PIXI_PROMPT_MODIFIED = '({env_name}) '\n\
+         }}"
     )
 }
 
 /// Sets default pixi prompt for the Nu shell
 pub fn nu_prompt(env_name: &str) -> String {
+    // Guard against repeated invocations: only wrap PROMPT_COMMAND if we haven't
+    // already done so for this environment. Without this guard, running
+    // shell-hook multiple times nests the prompt indefinitely (see #5599).
     format!(
-        "let old_prompt = $env.PROMPT_COMMAND; \
-         $env.PROMPT_COMMAND = {{|| echo $\"\\({env_name}\\) (do $old_prompt)\"}}"
+        "if ($env | get -i __PIXI_PROMPT_MODIFIED | default '') != '({env_name}) ' {{ \
+         let old_prompt = $env.PROMPT_COMMAND; \
+         $env.PROMPT_COMMAND = {{|| echo $\"\\({env_name}\\) (do $old_prompt)\"}}; \
+         $env.__PIXI_PROMPT_MODIFIED = '({env_name}) ' \
+         }}"
     )
 }
 


### PR DESCRIPTION
## Summary

Fixes #5599

Running `eval "$(pixi shell-hook ...)"` multiple times for the same environment currently causes:
- **Bash/Zsh**: PS1 prefix keeps getting prepended → `(env) (env) (env) $`
- **PowerShell**: Recursive wrapping of the `prompt` function → **stack overflow crash**
- **Nu Shell**: Indefinite nesting of `PROMPT_COMMAND`

### Root cause

The prompt modification functions in `crates/pixi_core/src/prompt.rs` (`posix_prompt`, `powershell_prompt`, `nu_prompt`) unconditionally modify the shell prompt on every invocation, with no check for whether the prompt was already modified.

Notably, the `fish_prompt` function already handles this correctly by checking `if not functions -q __fish_prompt_orig` before wrapping.

### Fix

Add an idempotency guard using a `__PIXI_PROMPT_MODIFIED` environment variable. Each prompt function now:
1. Checks if `__PIXI_PROMPT_MODIFIED` is already set to the expected value for the current environment
2. Only modifies the prompt if the guard is not set (i.e., first activation)
3. Sets the guard after modifying the prompt

This also correctly handles switching between environments — if you activate env A then env B, the guard value changes so the prompt gets updated.

### Shells affected
| Shell | Before | After |
|---|---|---|
| Bash/Zsh | PS1 duplicated on each eval | Idempotent ✅ |
| PowerShell | Stack overflow on repeated eval | Idempotent ✅ |
| Nu Shell | Nested prompt wrapping | Idempotent ✅ |
| Fish | Already idempotent | Unchanged ✅ |
| Cmd.exe | Already idempotent (`@PROMPT` replaces) | Unchanged ✅ |
| Xonsh | No-op | Unchanged ✅ |

## Test plan

- [ ] Run `eval "$(pixi shell-hook -m <project>)"` twice in bash — PS1 should show `(env)` only once
- [ ] Run `(pixi shell-hook) | Out-String | Invoke-Expression` twice in PowerShell — no stack overflow
- [ ] Switch environments: activate env A then env B — prompt should update to B
- [ ] Existing `test_shell_hook_unix` / `test_shell_hook_windows` tests should still pass