### PR TITLE
fix: allow config unset for unknown keys

### DIFF
--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -13,6 +13,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use itertools::Itertools;
 
 #[derive(Parser, Debug)]
 enum Subcommand {
@@ -331,9 +332,30 @@ fn alter_config(
     Ok(())
 }
 
+/// Recursively walks `table` following `segments[0..n-1]` as nested table
+/// keys and removes `segments[n-1]` (the leaf) from the innermost table.
+/// Returns `true` if the key was found and removed.
+fn remove_key_from_table(table: &mut dyn toml_edit::TableLike, segments: &[&str]) -> bool {
+    match segments {
+        [] => false,
+        [leaf] => table.remove(leaf).is_some(),
+        [head, rest @ ..] => {
+            if let Some(child) = table.get_mut(head).and_then(|v| v.as_table_like_mut()) {
+                remove_key_from_table(child, rest)
+            } else {
+                false
+            }
+        }
+    }
+}
+
 /// Remove a key from the config TOML file directly, without going through the
 /// [`Config`] struct. This allows unsetting keys that are no longer present in
 /// the struct (e.g., config fields that have been removed in a newer version).
+///
+/// `key` may be a dotted path of arbitrary depth (e.g. `a.b.c`).  Every
+/// segment except the last must resolve to an existing TOML table; the last
+/// segment is the leaf that gets removed.
 fn unset_toml_key(path: &Path, key: &str) -> miette::Result<()> {
     let content = if path.exists() {
         fs::read_to_string(path)
@@ -353,34 +375,40 @@ fn unset_toml_key(path: &Path, key: &str) -> miette::Result<()> {
         .into_diagnostic()
         .wrap_err("failed to parse config file as TOML")?;
 
-    let removed = match key.split_once('.') {
-        None => doc.remove(key).is_some(),
-        Some((table_key, sub_key)) => {
-            if let Some(table) = doc.get_mut(table_key).and_then(|v| v.as_table_like_mut()) {
-                table.remove(sub_key).is_some()
-            } else {
-                false
-            }
-        }
-    };
+    let segments: Vec<&str> = key.split('.').collect();
+
+    // Recursively walk the nested tables and remove the leaf.
+    let removed = remove_key_from_table(&mut *doc, &segments);
 
     if !removed {
+        // Suggest similar keys from the known Config schema.
+        let dummy = Config::default();
+        let known_keys = dummy.get_keys();
+        let mut suggestions: Vec<(f64, &&str)> = known_keys
+            .iter()
+            .filter_map(|k| {
+                let score = strsim::jaro(key, k);
+                if score > 0.8 { Some((score, k)) } else { None }
+            })
+            .collect();
+        suggestions.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        let hint = if suggestions.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n  Similar known keys: {}",
+                suggestions.iter().map(|(_, k)| format!("'{}'", k)).join(", ")
+            )
+        };
         eprintln!(
-            "⚠️  Key '{}' is not set in config '{}'",
+            "⚠️  Key '{}' is not set in config '{}'.{}",
             key,
-            path.display()
+            path.display(),
+            hint
         );
         return Ok(());
     }
 
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .into_diagnostic()
-            .wrap_err(format!(
-                "failed to create directories in '{}'",
-                parent.display()
-            ))?;
-    }
     fs::write(path, doc.to_string())
         .into_diagnostic()
         .wrap_err(format!("failed to write config to '{}'", path.display()))?;

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -233,6 +233,15 @@ def test_config_unset_unknown_key(pixi: Path, tmp_path: Path) -> None:
     )
     assert "disable-jlap" not in config.read_text()
 
+    # Unsetting a deeply-nested key (3+ levels) should also work.
+    config.write_text("[a.b]\nc = true\n")
+    verify_cli_command(
+        [pixi, "config", "unset", "--global", "a.b.c"],
+        env=env,
+        stderr_contains="Updated config",
+    )
+    assert "c = true" not in config.read_text()
+
     # Unsetting a key that is not present at all should also succeed.
     config.write_text("")
     verify_cli_command(


### PR DESCRIPTION
## Description

`pixi config unset` previously errored for any key not present in the `Config` struct — even config fields that existed before but were removed in a newer version (like `repodata-config.disable-jlap`). Users got a cryptic "Unknown key" error with no way to clean up their config files.

Instead of routing through `Config::set()`, the Unset code path now reads the config file directly with `toml_edit`, removes the target key, and writes it back. If the key is already absent the command exits cleanly with a short notice.

**Before:**
```
$ pixi config unset repodata-config.disable-jlap
× Unknown key: repodata-config.disable-jlap
```

**After:**
```
$ pixi config unset repodata-config.disable-jlap
✅ Updated config at ~/.pixi/config.toml
```

Fixes #5672

## How Has This Been Tested?

Added `test_config_unset_unknown_key` in `tests/integration_python/test_main_cli.py` covering:
- top-level unknown key removed from file
- dotted unknown subkey removed from a nested table
- key absent from the file — succeeds with a warning

Local `cargo check` and `cargo clippy` both clean.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Anthropic)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.