### PR TITLE
chore: update artifact handling to use array syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           }
           # Recompute .sha256 files for all modified archives (zip and msi)
           # The signing step changes the file content, so checksums computed before signing are stale
-          foreach ($artifact in (Get-ChildItem target/distrib -Filter "*.zip") + (Get-ChildItem target/distrib -Filter "*.msi")) {
+          foreach ($artifact in @(Get-ChildItem target/distrib -Filter "*.zip") + @(Get-ChildItem target/distrib -Filter "*.msi")) {
             $hash = (Get-FileHash $artifact.FullName -Algorithm SHA256).Hash.ToLower()
             "$hash *$($artifact.Name)" | Set-Content "$($artifact.FullName).sha256" -NoNewline
           }


### PR DESCRIPTION
### Description

Hopefully fixes the CI issues with the release. This is hard to test as the signing doesn't work with non main branch workflows, see: https://github.com/prefix-dev/pixi/actions/runs/23187246570/job/67373910263


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude
This was basically claude's idea.
