### PR TITLE
feat: add project templates for pixi init

### DIFF
--- a/crates/pixi_api/src/workspace/init/mod.rs
+++ b/crates/pixi_api/src/workspace/init/mod.rs
@@ -11,9 +11,9 @@ use minijinja::{Environment, context};
 use pixi_config::{Config, get_default_author, pixi_home};
 use pixi_consts::consts;
 use pixi_core::{Workspace, workspace::WorkspaceMut};
-use pixi_manifest::{FeatureName, pyproject::PyProjectManifest};
+use pixi_manifest::{FeatureName, Task, pyproject::PyProjectManifest};
 use pixi_utils::conda_environment_file::CondaEnvFile;
-use rattler_conda_types::{NamedChannelOrUrl, Platform};
+use rattler_conda_types::{MatchSpec, NamedChannelOrUrl, Platform};
 use same_file::is_same_file;
 use tokio::fs::OpenOptions;
 use url::Url;
@@ -24,7 +24,7 @@ use crate::interface::Interface;
 mod options;
 mod template;
 
-pub use options::{GitAttributes, InitOptions, ManifestFormat};
+pub use options::{GitAttributes, InitOptions, ManifestFormat, ProjectTemplate};
 
 pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::Result<Workspace> {
     let env = Environment::new();
@@ -320,7 +320,89 @@ pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::
         );
     }
 
+    let mut workspace = workspace;
+    if let Some(template) = options.template {
+        let mut workspace_mut = workspace.modify().into_diagnostic()?;
+        apply_template(&mut workspace_mut, template).await?;
+        workspace = workspace_mut.save().await.into_diagnostic()?;
+    }
+
     Ok(workspace)
+}
+
+/// Applies a project template to the workspace.
+///
+/// This will add the default dependencies and tasks associated with the
+/// chosen template to the newly created project.
+async fn apply_template(
+    workspace: &mut WorkspaceMut,
+    template: ProjectTemplate,
+) -> miette::Result<()> {
+    match template {
+        ProjectTemplate::Minimal => Ok(()),
+        ProjectTemplate::Python => {
+            let python_spec = MatchSpec::from_str("python").into_diagnostic()?;
+            workspace.add_specs(
+                vec![python_spec],
+                vec![],
+                &[] as &[Platform],
+                &FeatureName::default(),
+            )?;
+            workspace.manifest().add_task(
+                "start".into(),
+                Task::Plain("python main.py".into()),
+                None,
+                &FeatureName::default(),
+            )?;
+            Ok(())
+        }
+        ProjectTemplate::Rust => {
+            let rust_spec = MatchSpec::from_str("rust").into_diagnostic()?;
+            workspace.add_specs(
+                vec![rust_spec],
+                vec![],
+                &[] as &[Platform],
+                &FeatureName::default(),
+            )?;
+            workspace.manifest().add_task(
+                "build".into(),
+                Task::Plain("cargo build".into()),
+                None,
+                &FeatureName::default(),
+            )?;
+            workspace.manifest().add_task(
+                "run".into(),
+                Task::Plain("cargo run".into()),
+                None,
+                &FeatureName::default(),
+            )?;
+            Ok(())
+        }
+        ProjectTemplate::Cpp => {
+            let gcc_spec = MatchSpec::from_str("gcc").into_diagnostic()?;
+            let cmake_spec = MatchSpec::from_str("cmake").into_diagnostic()?;
+            let ninja_spec = MatchSpec::from_str("ninja").into_diagnostic()?;
+            workspace.add_specs(
+                vec![gcc_spec, cmake_spec, ninja_spec],
+                vec![],
+                &[] as &[Platform],
+                &FeatureName::default(),
+            )?;
+            workspace.manifest().add_task(
+                "configure".into(),
+                Task::Plain("cmake -B build".into()),
+                None,
+                &FeatureName::default(),
+            )?;
+            workspace.manifest().add_task(
+                "build".into(),
+                Task::Plain("cmake --build build".into()),
+                None,
+                &FeatureName::default(),
+            )?;
+            Ok(())
+        }
+    }
 }
 
 fn is_init_dir_equal_to_pixi_home_parent(init_dir: &Path) -> bool {

--- a/crates/pixi_api/src/workspace/init/options.rs
+++ b/crates/pixi_api/src/workspace/init/options.rs
@@ -25,6 +25,17 @@ pub struct InitOptions {
 
     /// The conda-pypi-mapping
     pub conda_pypi_mapping: Option<HashMap<NamedChannelOrUrl, String>>,
+
+    /// The project template to use.
+    pub template: Option<ProjectTemplate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ProjectTemplate {
+    Minimal,
+    Python,
+    Rust,
+    Cpp,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/pixi_api/src/workspace/mod.rs
+++ b/crates/pixi_api/src/workspace/mod.rs
@@ -6,7 +6,7 @@ pub use add::{DependencyOptions, GitOptions};
 pub(crate) mod remove;
 
 pub(crate) mod init;
-pub use init::{GitAttributes, InitOptions, ManifestFormat};
+pub use init::{GitAttributes, InitOptions, ManifestFormat, ProjectTemplate};
 
 pub(crate) mod list;
 pub use list::{Package, PackageKind};

--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -54,6 +54,10 @@ pub struct Args {
     /// Set a mapping between conda channels and pypi channels.
     #[arg(long = "conda-pypi-map", value_parser = parse_conda_pypi_mapping, value_delimiter = ',')]
     pub conda_pypi_map: Option<Vec<(NamedChannelOrUrl, String)>>,
+
+    /// The project template to use.
+    #[arg(long, short, ignore_case = true)]
+    pub template: Option<ProjectTemplate>,
 }
 
 fn parse_conda_pypi_mapping(s: &str) -> Result<(NamedChannelOrUrl, String), String> {
@@ -81,6 +85,14 @@ pub enum GitAttributes {
     Codeberg,
 }
 
+#[derive(Parser, Debug, Clone, PartialEq, ValueEnum)]
+pub enum ProjectTemplate {
+    Minimal,
+    Python,
+    Rust,
+    Cpp,
+}
+
 impl From<Args> for InitOptions {
     fn from(args: Args) -> Self {
         let format = args.format.map(|f| match f {
@@ -95,6 +107,13 @@ impl From<Args> for InitOptions {
             GitAttributes::Codeberg => pixi_api::workspace::GitAttributes::Codeberg,
         });
 
+        let template = args.template.map(|t| match t {
+            ProjectTemplate::Minimal => pixi_api::workspace::ProjectTemplate::Minimal,
+            ProjectTemplate::Python => pixi_api::workspace::ProjectTemplate::Python,
+            ProjectTemplate::Rust => pixi_api::workspace::ProjectTemplate::Rust,
+            ProjectTemplate::Cpp => pixi_api::workspace::ProjectTemplate::Cpp,
+        });
+
         InitOptions {
             path: args.path,
             channels: args.channels,
@@ -103,6 +122,7 @@ impl From<Args> for InitOptions {
             format,
             scm,
             conda_pypi_mapping: args.conda_pypi_map.map(|map| map.into_iter().collect()),
+            template,
         }
     }
 }


### PR DESCRIPTION
This PR adds support for project templates to the `pixi init` command. Users can now use the `--template` (or `-t`) flag to bootstrap projects with pre-configured dependencies and tasks for specific ecosystems.

**Supported Templates:**
- `python`: Adds `python` and a `start` task.
- `rust`: Adds `rust` and `build`/`run` tasks.
- `cpp`: Adds a C++ toolchain (`gcc`, `cmake`, `ninja`) and build/configure tasks.
- `minimal`: Default behavior.

**Key Changes:**
- **API**: Implemented `apply_template` logic in `pixi_api/workspace/init/mod.rs` using `WorkspaceMut` for safe manifest modification. Added `ProjectTemplate` to `options.rs`.
- **CLI**: Added the `--template` argument in `pixi_cli/src/init.rs` and handled the mapping from CLI side to the API layer.

### How Has This Been Tested?
- Manual verification of the logic and internal API calls (`add_task`, `add_specs`).
- Verified that default `pixi init` behavior (without templates) remains unaffected.
- Checked that dependencies are correctly resolved via `MatchSpec`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Gemini 3 Flash / Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CLI help)
