### PR TITLE
feat: expose paths to activation scripts as a field in pixi shell-hook --json

### DIFF
--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, default::Default};
+use std::{collections::HashMap, default::Default, path::PathBuf};
 
 use clap::Parser;
 use miette::IntoDiagnostic;
 use pixi_config::{ConfigCli, ConfigCliActivation, ConfigCliPrompt};
+use rattler_conda_types::Platform;
 use rattler_lock::LockFile;
 use rattler_shell::{
     activation::{ActivationVariables, PathModificationBehavior},
@@ -60,6 +61,7 @@ pub struct Args {
 #[derive(Serialize)]
 struct ShellEnv<'a> {
     environment_variables: &'a HashMap<String, String>,
+    activation_scripts: Vec<PathBuf>,
 }
 
 /// Generates the activation script.
@@ -134,8 +136,17 @@ async fn generate_environment_json(
     )
     .await?;
 
+    let platform = Platform::current();
+    let activation_scripts: Vec<PathBuf> = environment
+        .activation_scripts(Some(platform))
+        .into_iter()
+        .map(|s| environment.workspace().root().join(s))
+        .filter(|p| p.is_file())
+        .collect();
+
     let shell_env = ShellEnv {
         environment_variables,
+        activation_scripts,
     };
 
     serde_json::to_string(&shell_env).into_diagnostic()

--- a/crates/pixi_core/src/activation.rs
+++ b/crates/pixi_core/src/activation.rs
@@ -13,7 +13,7 @@ use rattler_shell::{
         ActivationError, ActivationError::FailedToRunActivationScript, ActivationVariables,
         Activator, PathModificationBehavior,
     },
-    shell::{Shell, ShellEnum},
+    shell::ShellEnum,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -154,13 +154,6 @@ pub fn get_activator<'p>(
         }
     }
 
-    // Build the PIXI_ACTIVATION_SCRIPTS env var from the pixi.toml-defined scripts.
-    let pixi_activation_scripts_value = additional_activation_scripts
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect::<Vec<_>>()
-        .join(shell.path_separator(&platform));
-
     let mut activator =
         Activator::from_path(environment.dir().as_path(), shell, Platform::current())?;
 
@@ -173,13 +166,6 @@ pub fn get_activator<'p>(
     activator
         .env_vars
         .extend(get_static_environment_variables(environment));
-
-    // Set PIXI_ACTIVATION_SCRIPTS to the shell-separator-delimited list of
-    // pixi.toml-defined activation script paths.
-    activator.env_vars.insert(
-        "PIXI_ACTIVATION_SCRIPTS".to_string(),
-        pixi_activation_scripts_value,
-    );
 
     // Add environment variables that should be applied after activation scripts run.
     activator

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -302,7 +302,7 @@ impl<'p> Environment<'p> {
     ///
     /// The activation scripts of all features are combined in the order they
     /// are defined for the environment.
-    pub(crate) fn activation_scripts(&self, platform: Option<Platform>) -> Vec<String> {
+    pub fn activation_scripts(&self, platform: Option<Platform>) -> Vec<String> {
         self.features()
             .filter_map(|f| f.activation_scripts(platform))
             .flatten()


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

This PR adds a new field when invoking `pixi shell-hook --json` called `activation_scripts` which includes a list of all the activation scripts that have been defined in `pixi.toml`

I'm working on a plugin for mise to integrate Pixi into it (https://github.com/esteve/mise-env-pixi), and everything works except running the activation scripts, as I use `pixi shell-hook --json` to capture the Pixi environment. This PR exposes the paths to the scripts so that an external tool that invokes it (e.g. like my mise plugin) can find out what activation scripts are part of the current Pixi project.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

I ran cargo build and run the resulting binary in a project that had activation scripts.

```sh
/tmp/c via 🧚 v0.65.0 
❯ cat pixi.toml 
[workspace]
authors = ["Esteve Fernandez <esteve@apache.org>"]
channels = ["conda-forge"]
name = "c"
platforms = ["linux-64"]
version = "0.1.0"

[tasks]

[dependencies]
requests = ">=2.32.5,<3"

[activation]
scripts = ["env_setup.sh", "foobar.sh"]
env = { ENV_VAR = "value" }
```

```sh
❯ pixi.json shell-hook --json|jq .
{
  "environment_variables": {
    "PIXI_PROJECT_ROOT": "/tmp/c",
    "PIXI_PROJECT_VERSION": "0.1.0",
    "PIXI_PROJECT_NAME": "c",
    "CONDA_SHLVL": "1",
    "PIXI_EXE": "/var/home/esteve/.local/share/mise/installs/pixi/0.65.0/pixi.json",
    "PATH": "/tmp/c/.pixi/envs/default/bin:/var/home/esteve/.local/share/mise/installs/pixi/0.65.0:/var/home/esteve/.local/share/mise/installs/bitwarden/2026.2.0:/var/home/esteve/.local/share/mise/installs/fnox/1.18.0:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/var/home/esteve/.local/bin:/var/home/esteve/bin:/var/home/esteve/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/bin:/var/home/esteve/.local/bin",
    "PIXI_ENVIRONMENT_PLATFORMS": "linux-64",
    "PIXI_IN_SHELL": "1",
    "PIXI_ENVIRONMENT_NAME": "default",
    "PIXI_PROMPT": "(c) ",
    "PIXI_PROJECT_MANIFEST": "/tmp/c/pixi.toml",
    "CONDA_PREFIX": "/tmp/c/.pixi/envs/default",
    "CONDA_DEFAULT_ENV": "c",
    "ENV_VAR": "value"
  },
  "activation_scripts": [
    "/tmp/c/env_setup.sh",
    "/tmp/c/foobar.sh"
  ]
}
```

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
