### PR TITLE
perf: Making UV the default installer, unless specified explicitly

### DIFF
--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use minijinja::Environment;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
 pub struct BuildScriptContext {
@@ -12,7 +12,7 @@ pub struct BuildScriptContext {
     pub manifest_root: PathBuf,
 }
 
-#[derive(Default, Serialize)]
+#[derive(Default, Serialize, Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Installer {
     Pip,

--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -12,7 +12,7 @@ pub struct BuildScriptContext {
     pub manifest_root: PathBuf,
 }
 
-#[derive(Default, Serialize, Clone, Debug, Deserialize)]
+#[derive(Default, Serialize, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Installer {
     Pip,

--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use minijinja::Environment;
 use serde::Serialize;
 
-const UV: &str = "uv";
 #[derive(Serialize)]
 pub struct BuildScriptContext {
     pub installer: Installer,
@@ -26,21 +25,6 @@ impl Installer {
         match self {
             Installer::Uv => "uv",
             Installer::Pip => "pip",
-        }
-    }
-
-    /// Determine the installer from an iterator of dependency package names.
-    /// Checks if "uv" is present in the package names.
-    pub fn determine_installer_from_names<'a>(
-        mut package_names: impl Iterator<Item = &'a str>,
-    ) -> Installer {
-        // Check all dependency names for "uv" package
-        let has_uv = package_names.any(|name| name == UV);
-
-        if has_uv {
-            Installer::Uv
-        } else {
-            Installer::Pip
         }
     }
 }

--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -16,9 +16,9 @@ pub struct BuildScriptContext {
 #[derive(Default, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Installer {
-    Uv,
-    #[default]
     Pip,
+    #[default]
+    Uv,
 }
 
 impl Installer {

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -126,6 +126,8 @@ impl BackendConfig for PythonBackendConfig {
 #[cfg(test)]
 mod tests {
 
+    use crate::build_script::Installer;
+
     use super::PythonBackendConfig;
     use pixi_build_backend::generated_recipe::BackendConfig;
     use serde_json::json;
@@ -360,5 +362,20 @@ mod tests {
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("`debug_dir` cannot have a target specific value"));
+    }
+
+    #[test]
+    fn test_deserialize_installer_field() {
+        let json_data = json!({"installer": "uv"});
+        let config: PythonBackendConfig = serde_json::from_value(json_data).unwrap();
+        assert_eq!(config.installer, Some(Installer::Uv));
+
+        let json_data = json!({"installer": "pip"});
+        let config: PythonBackendConfig = serde_json::from_value(json_data).unwrap();
+        assert_eq!(config.installer, Some(Installer::Pip));
+
+        let json_data = json!({});
+        let config: PythonBackendConfig = serde_json::from_value(json_data).unwrap();
+        assert_eq!(config.installer, None);
     }
 }

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -64,9 +64,10 @@ impl PythonBackendConfig {
     /// Creates a new [`PythonBackendConfig`] with default values and
     /// `ignore_pyproject_manifest` set to `true`.
     #[cfg(test)]
-    pub fn default_with_ignore_pyproject_manifest() -> Self {
+    pub fn default_with_ignore_pyproject_manifest(installer: Option<Installer>) -> Self {
         Self {
             ignore_pyproject_manifest: Some(true),
+            installer,
             ..Default::default()
         }
     }

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -1,8 +1,8 @@
+use crate::build_script::Installer;
 use indexmap::IndexMap;
 use pixi_build_backend::generated_recipe::BackendConfig;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use crate::build_script::Installer;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 use pixi_build_backend::generated_recipe::BackendConfig;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use crate::build_script::Installer;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -39,6 +40,13 @@ pub struct PythonBackendConfig {
     /// Only meaningful for packages with compiled extensions (non-noarch).
     #[serde(default)]
     pub abi3: Option<bool>,
+
+    /// The package installer to use for building.
+    /// Defaults to `uv` (recommended). Use `pip` only when needed for
+    /// compatibility with packages that require pip-specific behavior.
+    /// Supported values: `"uv"` (default), `"pip"`
+    #[serde(default)]
+    pub installer: Option<Installer>,
 }
 
 impl PythonBackendConfig {
@@ -110,12 +118,14 @@ impl BackendConfig for PythonBackendConfig {
                 .ignore_pypi_mapping
                 .or(self.ignore_pypi_mapping),
             abi3: target_config.abi3.or(self.abi3),
+            installer: target_config.installer.clone().or(self.installer.clone()),
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+
     use super::PythonBackendConfig;
     use pixi_build_backend::generated_recipe::BackendConfig;
     use serde_json::json;
@@ -143,6 +153,7 @@ mod tests {
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
             abi3: Some(true),
+            installer: None,
         };
 
         let mut target_env = indexmap::IndexMap::new();
@@ -159,6 +170,7 @@ mod tests {
             ignore_pyproject_manifest: Some(false),
             ignore_pypi_mapping: Some(false),
             abi3: Some(false),
+            installer: None,
         };
 
         let merged = base_config
@@ -213,6 +225,7 @@ mod tests {
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
             abi3: None,
+            installer: None,
         };
 
         let empty_target_config = PythonBackendConfig::default();

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -650,7 +650,11 @@ version = "0.1.0"
         let generated_recipe = PythonGenerator::default()
             .generate_recipe(
                 &project_model,
-                &PythonBackendConfig::default_with_ignore_pyproject_manifest(),
+                &PythonBackendConfig{
+                    ignore_pyproject_manifest: Some(true),
+                    installer: Some(build_script::Installer::Pip),
+                    ..Default::default()
+                },
                 PathBuf::from("."),
                 Platform::Linux64,
                 None,
@@ -1088,8 +1092,8 @@ build-backend = "hatchling.build"
 
         assert_eq!(
             host_deps,
-            vec!["pip", "python"],
-            "host deps should only contain pip and python when ignore_pypi_mapping=true"
+            vec!["uv", "python"],
+            "host deps should only contain uv and python when ignore_pypi_mapping=true"
         );
     }
 

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -650,7 +650,9 @@ version = "0.1.0"
         let generated_recipe = PythonGenerator::default()
             .generate_recipe(
                 &project_model,
-                &PythonBackendConfig::default_with_ignore_pyproject_manifest(Some(build_script::Installer::Pip)),
+                &PythonBackendConfig::default_with_ignore_pyproject_manifest(Some(
+                    build_script::Installer::Pip,
+                )),
                 PathBuf::from("."),
                 Platform::Linux64,
                 None,
@@ -1277,28 +1279,6 @@ build-backend = "setuptools.build_meta"
         assert!(
             !host_deps.contains(&"pip".to_string()),
             "pip should NOT be in host deps when installer not specified, got: {host_deps:?}"
-        );
-    }
-    #[tokio::test]
-    async fn test_explicit_pip_installer_in_host_requirements() {
-        let config = PythonBackendConfig::default_with_ignore_pyproject_manifest(Some(build_script::Installer::Pip));
-        let recipe = generate_test_recipe(&config)
-            .await
-            .expect("Failed to generate recipe");
-        let host_deps: Vec<String> = recipe
-            .recipe
-            .requirements
-            .host
-            .iter()
-            .map(|item| item.to_string())
-            .collect();
-        assert!(
-            host_deps.contains(&"pip".to_string()),
-            "pip should be in host deps when explicitly specified, got: {host_deps:?}"
-        );
-        assert!(
-            !host_deps.contains(&"uv".to_string()),
-            "uv should NOT be in host deps when pip is explicitly specified, got: {host_deps:?}"
         );
     }
 }

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -3,7 +3,7 @@ mod config;
 mod metadata;
 mod pypi_mapping;
 
-use build_script::{BuildPlatform, BuildScriptContext, Installer};
+use build_script::{BuildPlatform, BuildScriptContext};
 use config::PythonBackendConfig;
 use fs_err as fs;
 use miette::IntoDiagnostic;
@@ -156,8 +156,7 @@ impl GenerateRecipe for PythonGenerator {
         // are added to the `host` requirements, while for cmake/rust they are
         // added to the `build` requirements.
         // We only check build and host dependencies for the installer.
-        let installer =
-            Installer::determine_installer_from_names(model_dependencies.build_and_host_names());
+        let installer = config.installer.clone().unwrap_or_default();
 
         let installer_name = installer.package_name().to_string();
         let installer_pkg = pixi_build_types::SourcePackageName::from(installer_name.as_str());

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -650,11 +650,7 @@ version = "0.1.0"
         let generated_recipe = PythonGenerator::default()
             .generate_recipe(
                 &project_model,
-                &PythonBackendConfig{
-                    ignore_pyproject_manifest: Some(true),
-                    installer: Some(build_script::Installer::Pip),
-                    ..Default::default()
-                },
+                &PythonBackendConfig::default_with_ignore_pyproject_manifest(Some(build_script::Installer::Pip)),
                 PathBuf::from("."),
                 Platform::Linux64,
                 None,
@@ -699,7 +695,7 @@ version = "0.1.0"
         let generated_recipe = PythonGenerator::default()
             .generate_recipe(
                 &project_model,
-                &PythonBackendConfig::default_with_ignore_pyproject_manifest(),
+                &PythonBackendConfig::default_with_ignore_pyproject_manifest(None),
                 PathBuf::from("."),
                 Platform::Linux64,
                 None,
@@ -1258,6 +1254,51 @@ build-backend = "setuptools.build_meta"
         assert!(
             config.ignore_pypi_mapping(),
             "ignore_pypi_mapping should default to true"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_uv_is_default_installer_in_host_requirements() {
+        let config = PythonBackendConfig::default_with_ignore_pyproject_manifest(None);
+        let recipe = generate_test_recipe(&config)
+            .await
+            .expect("Failed to generate recipe");
+        let host_deps: Vec<String> = recipe
+            .recipe
+            .requirements
+            .host
+            .iter()
+            .map(|item| item.to_string())
+            .collect();
+        assert!(
+            host_deps.contains(&"uv".to_string()),
+            "uv should be in host deps when installer not specified, got: {host_deps:?}"
+        );
+        assert!(
+            !host_deps.contains(&"pip".to_string()),
+            "pip should NOT be in host deps when installer not specified, got: {host_deps:?}"
+        );
+    }
+    #[tokio::test]
+    async fn test_explicit_pip_installer_in_host_requirements() {
+        let config = PythonBackendConfig::default_with_ignore_pyproject_manifest(Some(build_script::Installer::Pip));
+        let recipe = generate_test_recipe(&config)
+            .await
+            .expect("Failed to generate recipe");
+        let host_deps: Vec<String> = recipe
+            .recipe
+            .requirements
+            .host
+            .iter()
+            .map(|item| item.to_string())
+            .collect();
+        assert!(
+            host_deps.contains(&"pip".to_string()),
+            "pip should be in host deps when explicitly specified, got: {host_deps:?}"
+        );
+        assert!(
+            !host_deps.contains(&"uv".to_string()),
+            "uv should NOT be in host deps when pip is explicitly specified, got: {host_deps:?}"
         );
     }
 }

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__metadata__tests__generated_recipe_contains_pyproject_values.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__metadata__tests__generated_recipe_contains_pyproject_values.snap
@@ -13,7 +13,7 @@ build:
 requirements:
   build: []
   host:
-    - pip
+    - uv
     - python
   run:
     - boltons

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
@@ -14,7 +14,7 @@ requirements:
   build: []
   host:
     - python
-    - pip
+    - uv
   run:
     - boltons
     - python


### PR DESCRIPTION
### Description

This works on making the uv the default installer in pixi_build_python crate, unless specified in the config file to be pip


Fixes #5666 

### How Has This Been Tested?

`cargo test -p pixi_build_python`
<img width="1172" height="678" alt="image" src="https://github.com/user-attachments/assets/c3f1e915-608a-4207-b346-539b90e6440a" />


### AI Disclosure

- [ x ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
Tools: Claude

### Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
