### PR TITLE
feat: add skip_pyc_compilation configuration option

### DIFF
--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -5,68 +5,30 @@ use std::path::{Path, PathBuf};
 
 /// Represents skip-pyc-compilation config: either `true` (skip all) or a list
 /// of glob patterns.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum SkipPycCompilation {
-    #[default]
-    None,
-    All,
+    All(bool),
     Globs(Vec<String>),
+}
+
+impl Default for SkipPycCompilation {
+    fn default() -> Self {
+        SkipPycCompilation::All(false)
+    }
 }
 
 impl SkipPycCompilation {
     pub fn globs(&self) -> Vec<String> {
         match self {
-            SkipPycCompilation::None => vec![],
-            SkipPycCompilation::All => vec!["**/*.py".to_string()],
+            SkipPycCompilation::All(true) => vec!["**/*.py".to_string()],
+            SkipPycCompilation::All(false) => vec![],
             SkipPycCompilation::Globs(g) => g.clone(),
         }
     }
 
     pub fn is_none(&self) -> bool {
-        matches!(self, SkipPycCompilation::None)
-    }
-}
-
-impl Serialize for SkipPycCompilation {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            SkipPycCompilation::None => serializer.serialize_none(),
-            SkipPycCompilation::All => serializer.serialize_bool(true),
-            SkipPycCompilation::Globs(g) => g.serialize(serializer),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for SkipPycCompilation {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        use serde::de;
-
-        struct Visitor;
-        impl<'de> de::Visitor<'de> for Visitor {
-            type Value = SkipPycCompilation;
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("true or a list of glob patterns")
-            }
-            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
-                if v {
-                    Ok(SkipPycCompilation::All)
-                } else {
-                    Ok(SkipPycCompilation::None)
-                }
-            }
-            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-                let mut globs = Vec::new();
-                while let Some(g) = seq.next_element::<String>()? {
-                    globs.push(g);
-                }
-                if globs.is_empty() {
-                    Ok(SkipPycCompilation::None)
-                } else {
-                    Ok(SkipPycCompilation::Globs(globs))
-                }
-            }
-        }
-        deserializer.deserialize_any(Visitor)
+        self.globs().is_empty()
     }
 }
 
@@ -214,7 +176,7 @@ mod tests {
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
             abi3: Some(true),
-            skip_pyc_compilation: SkipPycCompilation::All,
+            skip_pyc_compilation: SkipPycCompilation::All(true),
         };
 
         let mut target_env = indexmap::IndexMap::new();
@@ -291,7 +253,7 @@ mod tests {
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
             abi3: None,
-            skip_pyc_compilation: SkipPycCompilation::All,
+            skip_pyc_compilation: SkipPycCompilation::All(true),
         };
 
         let empty_target_config = PythonBackendConfig::default();

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -17,7 +17,7 @@ impl SkipPycCompilation {
     pub fn globs(&self) -> Vec<String> {
         match self {
             SkipPycCompilation::None => vec![],
-            SkipPycCompilation::All => vec!["**/*.pyc".to_string()],
+            SkipPycCompilation::All => vec!["**/*.py".to_string()],
             SkipPycCompilation::Globs(g) => g.clone(),
         }
     }

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -3,6 +3,73 @@ use pixi_build_backend::generated_recipe::BackendConfig;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+/// Represents skip-pyc-compilation config: either `true` (skip all) or a list
+/// of glob patterns.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum SkipPycCompilation {
+    #[default]
+    None,
+    All,
+    Globs(Vec<String>),
+}
+
+impl SkipPycCompilation {
+    pub fn globs(&self) -> Vec<String> {
+        match self {
+            SkipPycCompilation::None => vec![],
+            SkipPycCompilation::All => vec!["**/*.pyc".to_string()],
+            SkipPycCompilation::Globs(g) => g.clone(),
+        }
+    }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self, SkipPycCompilation::None)
+    }
+}
+
+impl Serialize for SkipPycCompilation {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            SkipPycCompilation::None => serializer.serialize_none(),
+            SkipPycCompilation::All => serializer.serialize_bool(true),
+            SkipPycCompilation::Globs(g) => g.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SkipPycCompilation {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de;
+
+        struct Visitor;
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = SkipPycCompilation;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("true or a list of glob patterns")
+            }
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                if v {
+                    Ok(SkipPycCompilation::All)
+                } else {
+                    Ok(SkipPycCompilation::None)
+                }
+            }
+            fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut globs = Vec::new();
+                while let Some(g) = seq.next_element::<String>()? {
+                    globs.push(g);
+                }
+                if globs.is_empty() {
+                    Ok(SkipPycCompilation::None)
+                } else {
+                    Ok(SkipPycCompilation::Globs(globs))
+                }
+            }
+        }
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct PythonBackendConfig {
@@ -39,6 +106,10 @@ pub struct PythonBackendConfig {
     /// Only meaningful for packages with compiled extensions (non-noarch).
     #[serde(default)]
     pub abi3: Option<bool>,
+    /// Skip .pyc compilation for matching files. Accepts `true` to skip all
+    /// .pyc compilation, or a list of glob patterns (e.g. `["tests/**"]`).
+    #[serde(default)]
+    pub skip_pyc_compilation: SkipPycCompilation,
 }
 
 impl PythonBackendConfig {
@@ -105,13 +176,18 @@ impl BackendConfig for PythonBackendConfig {
                 .ignore_pypi_mapping
                 .or(self.ignore_pypi_mapping),
             abi3: target_config.abi3.or(self.abi3),
+            skip_pyc_compilation: if target_config.skip_pyc_compilation.is_none() {
+                self.skip_pyc_compilation.clone()
+            } else {
+                target_config.skip_pyc_compilation.clone()
+            },
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::PythonBackendConfig;
+    use super::{PythonBackendConfig, SkipPycCompilation};
     use pixi_build_backend::generated_recipe::BackendConfig;
     use serde_json::json;
     use std::path::PathBuf;
@@ -138,6 +214,7 @@ mod tests {
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
             abi3: Some(true),
+            skip_pyc_compilation: SkipPycCompilation::All,
         };
 
         let mut target_env = indexmap::IndexMap::new();
@@ -154,6 +231,7 @@ mod tests {
             ignore_pyproject_manifest: Some(false),
             ignore_pypi_mapping: Some(false),
             abi3: Some(false),
+            skip_pyc_compilation: SkipPycCompilation::Globs(vec!["tests/**".to_string()]),
         };
 
         let merged = base_config
@@ -191,6 +269,11 @@ mod tests {
         assert_eq!(merged.ignore_pypi_mapping, Some(false));
         // abi3 should use target value
         assert_eq!(merged.abi3, Some(false));
+        // skip_pyc_compilation should use target value
+        assert_eq!(
+            merged.skip_pyc_compilation,
+            SkipPycCompilation::Globs(vec!["tests/**".to_string()])
+        );
     }
 
     #[test]
@@ -208,6 +291,7 @@ mod tests {
             ignore_pyproject_manifest: Some(true),
             ignore_pypi_mapping: Some(true),
             abi3: None,
+            skip_pyc_compilation: SkipPycCompilation::All,
         };
 
         let empty_target_config = PythonBackendConfig::default();

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -376,6 +376,13 @@ impl GenerateRecipe for PythonGenerator {
         };
 
         // Construct python specific settings
+        let skip_pyc_globs = config.skip_pyc_compilation.globs();
+        let skip_pyc_compilation = ConditionalList::new(
+            skip_pyc_globs
+                .into_iter()
+                .map(|g| Item::Value(Value::new_concrete(g, None)))
+                .collect(),
+        );
         let python = PythonBuild {
             entry_points: PythonGenerator::entry_points(pyproject_manifest),
             version_independent: if config.abi3 == Some(true) {
@@ -383,6 +390,7 @@ impl GenerateRecipe for PythonGenerator {
             } else {
                 None
             },
+            skip_pyc_compilation,
             ..PythonBuild::default()
         };
 

--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -243,6 +243,39 @@ extra-args = ["-Cbuilddir=foo"]
 # Result for win-64: ["-Cbuilddir=foo"]
 ```
 
+### `skip-pyc-compilation`
+
+- **Type**: `Boolean | Array<String>`
+- **Default**: not set (no files are skipped)
+- **Target Merge Behavior**: `Overwrite` - Platform-specific setting takes precedence over base
+
+Controls whether `.py` files are compiled to `.pyc` bytecode files during package installation. This can be useful for reducing package size or when bytecode caching is not needed.
+
+Accepts either `true` to skip all `.pyc` compilation, or a list of glob patterns for selective skipping:
+
+```toml
+# Skip all .pyc compilation
+[package.build.config]
+skip-pyc-compilation = true
+```
+
+```toml
+# Skip .pyc compilation only for specific paths
+[package.build.config]
+skip-pyc-compilation = ["tests/**", "benchmarks/**"]
+```
+
+For target-specific configuration, the platform-specific value completely replaces the base:
+
+```toml
+[package.build.config]
+skip-pyc-compilation = true
+
+[package.build.target.win-64.config]
+skip-pyc-compilation = ["tests/**"]
+# Result for win-64: ["tests/**"]
+```
+
 ### `ignore-pyproject-manifest`
 
 - **Type**: `Boolean`


### PR DESCRIPTION
### Description

This PR adds a new `skip_pyc_compilation` configuration option to the Python backend that allows users to skip the compilation of `.py` files to `.pyc` bytecode files during package installation.

This is useful to reduce compilation times e.g. for NumPy TSAN builds.

https://claude.ai/code/session_01NHP4pN28RENjggL18o5SST