### PR TITLE
fix: allow `pixi config unset` to remove unknown keys

### DIFF
--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -317,7 +317,43 @@ fn alter_config(
                 }
             }
         }
-        AlterMode::Set | AlterMode::Unset => config.set(key, value)?,
+        AlterMode::Set => config.set(key, value)?,
+        AlterMode::Unset => {
+            // Try the typed config path first for known keys
+            match config.set(key, value) {
+                Ok(()) => {}
+                Err(_) => {
+                    // For unknown keys, edit the TOML file directly so users
+                    // can remove deprecated or unrecognized config entries.
+                    let contents = if to.exists() {
+                        fs_err::read_to_string(&to).into_diagnostic()?
+                    } else {
+                        return Err(miette::miette!(
+                            "Config file does not exist: {}",
+                            to.display()
+                        ));
+                    };
+                    let mut doc: toml_edit::DocumentMut =
+                        contents.parse().into_diagnostic()?;
+
+                    // Walk dotted key path (e.g. "repodata-config.disable-jlap")
+                    let parts: Vec<&str> = key.split('.').collect();
+                    let removed = remove_toml_key(&mut doc, &parts);
+
+                    if !removed {
+                        return Err(miette::miette!(
+                            "Key '{}' not found in {}",
+                            key,
+                            to.display()
+                        ));
+                    }
+
+                    fs_err::write(&to, doc.to_string()).into_diagnostic()?;
+                    eprintln!("✅ Updated config at {}", to.display());
+                    return Ok(());
+                }
+            }
+        }
     }
 
     config.save(&to)?;
@@ -357,4 +393,25 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
     *config = new;
 
     Ok(())
+}
+
+/// Remove a dotted key path from a TOML document.
+fn remove_toml_key(doc: &mut toml_edit::DocumentMut, parts: &[&str]) -> bool {
+    if parts.len() == 1 {
+        return doc.remove(parts[0]).is_some();
+    }
+
+    // Navigate to the parent table, then remove the leaf key
+    let leaf = parts[parts.len() - 1];
+    let mut current = doc.as_item_mut();
+    for &segment in &parts[..parts.len() - 1] {
+        match current.get_mut(segment) {
+            Some(item) => current = item,
+            None => return false,
+        }
+    }
+    match current.as_table_like_mut() {
+        Some(table) => table.remove(leaf).is_some(),
+        None => false,
+    }
 }


### PR DESCRIPTION
## Summary

When `pixi config unset` encounters an unknown key (e.g., a deprecated config field), it now falls back to directly editing the TOML file instead of erroring. Known keys still go through the typed `Config::set()` path.

## Why this matters

Per #5672, after `repodata-config.disable-jlap` was removed from the config struct, users get a warning about the unknown value but `pixi config unset repodata-config.disable-jlap` errors because `Config::set()` rejects unknown keys. Users should be able to remove any TOML key from their config file, especially deprecated ones.

## Changes

- `crates/pixi_cli/src/config.rs`: For `AlterMode::Unset`, try `config.set()` first (for known keys), and on failure fall back to parsing the config file as a `toml_edit::DocumentMut`, walking the dotted key path, and removing the leaf key directly.
- Added `remove_toml_key()` helper for navigating dotted paths in TOML documents.

## Testing

`cargo check -p pixi_cli` passes. The fallback path handles:
- Single keys (e.g., `some-key`)
- Dotted keys (e.g., `repodata-config.disable-jlap`)
- Missing keys (returns error "Key not found")

Fixes #5672

This contribution was developed with AI assistance (Claude Code).