### PR TITLE
refactor: rename pixi_build_* crates to pixi-build-*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,6 +5642,157 @@ dependencies = [
 ]
 
 [[package]]
+name = "pixi-build-cmake"
+version = "0.3.10"
+dependencies = [
+ "async-trait",
+ "indexmap 2.13.0",
+ "insta",
+ "miette 7.6.0",
+ "minijinja",
+ "pixi_build_backend",
+ "pixi_build_types",
+ "rattler_build_core",
+ "rattler_build_jinja",
+ "rattler_build_types",
+ "rattler_conda_types",
+ "recipe_stage0",
+ "rstest",
+ "serde",
+ "serde_json",
+ "strum",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "pixi-build-mojo"
+version = "0.1.10"
+dependencies = [
+ "async-trait",
+ "fs-err",
+ "indexmap 2.13.0",
+ "insta",
+ "miette 7.6.0",
+ "minijinja",
+ "pixi_build_backend",
+ "pixi_build_types",
+ "rattler_build_core",
+ "rattler_build_jinja",
+ "rattler_build_types",
+ "rattler_conda_types",
+ "recipe_stage0",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "pixi-build-python"
+version = "0.4.7"
+dependencies = [
+ "async-trait",
+ "fs-err",
+ "indexmap 2.13.0",
+ "insta",
+ "miette 7.6.0",
+ "minijinja",
+ "once_cell",
+ "pep440_rs",
+ "pep508_rs",
+ "pixi_build_backend",
+ "pixi_build_types",
+ "pyproject-toml",
+ "rattler_conda_types",
+ "recipe_stage0",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "spdx 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "pixi-build-r"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "fs-err",
+ "indexmap 2.13.0",
+ "insta",
+ "miette 7.6.0",
+ "minijinja",
+ "once_cell",
+ "pixi_build_backend",
+ "pixi_build_types",
+ "rattler_conda_types",
+ "recipe_stage0",
+ "rstest",
+ "serde",
+ "serde_json",
+ "strum",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "pixi-build-rattler-build"
+version = "0.3.9"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "fs-err",
+ "indexmap 2.13.0",
+ "insta",
+ "miette 7.6.0",
+ "pathdiff",
+ "pixi_build_backend",
+ "pixi_build_types",
+ "rattler_build_core",
+ "rattler_build_recipe",
+ "rattler_build_variant_config",
+ "rattler_conda_types",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "pixi-build-rust"
+version = "0.4.7"
+dependencies = [
+ "async-trait",
+ "cargo_toml",
+ "fs-err",
+ "indexmap 2.13.0",
+ "insta",
+ "miette 7.6.0",
+ "minijinja",
+ "once_cell",
+ "pathdiff",
+ "pixi_build_backend",
+ "pixi_build_types",
+ "rattler_conda_types",
+ "recipe_stage0",
+ "rstest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "pixi_allocator"
 version = "0.1.0"
 dependencies = [
@@ -5756,30 +5907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pixi_build_cmake"
-version = "0.3.10"
-dependencies = [
- "async-trait",
- "indexmap 2.13.0",
- "insta",
- "miette 7.6.0",
- "minijinja",
- "pixi_build_backend",
- "pixi_build_types",
- "rattler_build_core",
- "rattler_build_jinja",
- "rattler_build_types",
- "rattler_conda_types",
- "recipe_stage0",
- "rstest",
- "serde",
- "serde_json",
- "strum",
- "tempfile",
- "tokio",
-]
-
-[[package]]
 name = "pixi_build_discovery"
 version = "0.1.0"
 dependencies = [
@@ -5822,133 +5949,6 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.18",
  "tracing",
-]
-
-[[package]]
-name = "pixi_build_mojo"
-version = "0.1.10"
-dependencies = [
- "async-trait",
- "fs-err",
- "indexmap 2.13.0",
- "insta",
- "miette 7.6.0",
- "minijinja",
- "pixi_build_backend",
- "pixi_build_types",
- "rattler_build_core",
- "rattler_build_jinja",
- "rattler_build_types",
- "rattler_conda_types",
- "recipe_stage0",
- "rstest",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
-]
-
-[[package]]
-name = "pixi_build_python"
-version = "0.4.7"
-dependencies = [
- "async-trait",
- "fs-err",
- "indexmap 2.13.0",
- "insta",
- "miette 7.6.0",
- "minijinja",
- "once_cell",
- "pep440_rs",
- "pep508_rs",
- "pixi_build_backend",
- "pixi_build_types",
- "pyproject-toml",
- "rattler_conda_types",
- "recipe_stage0",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "spdx 0.10.9",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "toml 0.9.12+spec-1.1.0",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "pixi_build_r"
-version = "0.1.1"
-dependencies = [
- "async-trait",
- "fs-err",
- "indexmap 2.13.0",
- "insta",
- "miette 7.6.0",
- "minijinja",
- "once_cell",
- "pixi_build_backend",
- "pixi_build_types",
- "rattler_conda_types",
- "recipe_stage0",
- "rstest",
- "serde",
- "serde_json",
- "strum",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
-name = "pixi_build_rattler_build"
-version = "0.3.9"
-dependencies = [
- "async-trait",
- "chrono",
- "fs-err",
- "indexmap 2.13.0",
- "insta",
- "miette 7.6.0",
- "pathdiff",
- "pixi_build_backend",
- "pixi_build_types",
- "rattler_build_core",
- "rattler_build_recipe",
- "rattler_build_variant_config",
- "rattler_conda_types",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "pixi_build_rust"
-version = "0.4.7"
-dependencies = [
- "async-trait",
- "cargo_toml",
- "fs-err",
- "indexmap 2.13.0",
- "insta",
- "miette 7.6.0",
- "minijinja",
- "once_cell",
- "pathdiff",
- "pixi_build_backend",
- "pixi_build_types",
- "rattler_conda_types",
- "recipe_stage0",
- "rstest",
- "serde",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
 ]
 
 [[package]]

--- a/crates/pixi_build_cmake/Cargo.toml
+++ b/crates/pixi_build_cmake/Cargo.toml
@@ -2,12 +2,8 @@
 description = "CMake build backend for Pixi"
 edition.workspace = true
 license.workspace = true
-name = "pixi_build_cmake"
-version = "0.3.10"
-
-[[bin]]
 name = "pixi-build-cmake"
-path = "src/main.rs"
+version = "0.3.10"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_mojo/Cargo.toml
+++ b/crates/pixi_build_mojo/Cargo.toml
@@ -1,12 +1,8 @@
 [package]
 edition.workspace = true
 license.workspace = true
-name = "pixi_build_mojo"
-version = "0.1.10"
-
-[[bin]]
 name = "pixi-build-mojo"
-path = "src/main.rs"
+version = "0.1.10"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -1,12 +1,8 @@
 [package]
 edition.workspace = true
 license.workspace = true
-name = "pixi_build_python"
-version = "0.4.7"
-
-[[bin]]
 name = "pixi-build-python"
-path = "src/main.rs"
+version = "0.4.7"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_r/Cargo.toml
+++ b/crates/pixi_build_r/Cargo.toml
@@ -2,12 +2,8 @@
 description = "R build backend for Pixi"
 edition.workspace = true
 license.workspace = true
-name = "pixi_build_r"
-version = "0.1.1"
-
-[[bin]]
 name = "pixi-build-r"
-path = "src/main.rs"
+version = "0.1.1"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rattler_build/Cargo.toml
+++ b/crates/pixi_build_rattler_build/Cargo.toml
@@ -1,12 +1,8 @@
 [package]
 edition.workspace = true
 license.workspace = true
-name = "pixi_build_rattler_build"
-version = "0.3.9"
-
-[[bin]]
 name = "pixi-build-rattler-build"
-path = "src/main.rs"
+version = "0.3.9"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rust/Cargo.toml
+++ b/crates/pixi_build_rust/Cargo.toml
@@ -3,13 +3,9 @@ description = "A Rust build backend for Pixi"
 documentation = "https://prefix-dev.github.io/pixi-build-backends/backends/pixi-build-rust/"
 edition.workspace = true
 license.workspace = true
-name = "pixi_build_rust"
+name = "pixi-build-rust"
 repository.workspace = true
 version = "0.4.7"
-
-[[bin]]
-name = "pixi-build-rust"
-path = "src/main.rs"
 
 [package.metadata.dist]
 dist = false

--- a/pixi-build-backends/recipe/all-backends/recipe.yaml
+++ b/pixi-build-backends/recipe/all-backends/recipe.yaml
@@ -58,7 +58,7 @@ outputs:
               - set RUSTC_WRAPPER=sccache
               - set "CARGO_TARGET_DIR=${{ SRC_DIR }}\..\..\..\\target-cache-rust-backends"
           # Build all Rust backends at once
-          - cargo auditable build --locked --release --bins -p pixi_build_cmake -p pixi_build_mojo -p pixi_build_python -p pixi_build_r -p pixi_build_rattler_build -p pixi_build_rust
+          - cargo auditable build --locked --release --bins -p pixi-build-cmake -p pixi-build-mojo -p pixi-build-python -p pixi-build-r -p pixi-build-rattler-build -p pixi-build-rust
           # Install binaries to prefix
           - if: unix
             then:

--- a/pixi-build-backends/scripts/generate-versions.py
+++ b/pixi-build-backends/scripts/generate-versions.py
@@ -44,12 +44,12 @@ def main():
 
     # Rust backends
     rust_packages = [
-        "pixi_build_cmake",
-        "pixi_build_mojo",
-        "pixi_build_python",
-        "pixi_build_r",
-        "pixi_build_rattler_build",
-        "pixi_build_rust",
+        "pixi-build-cmake",
+        "pixi-build-mojo",
+        "pixi-build-python",
+        "pixi-build-r",
+        "pixi-build-rattler-build",
+        "pixi-build-rust",
     ]
     for package in cargo_metadata.get("packages", []):
         if package["name"] in rust_packages:


### PR DESCRIPTION
### Description

Rename the 6 build backend crates (cmake, mojo, python, r, rattler_build, rust) from underscore to hyphen naming (e.g. pixi_build_cmake → pixi-build-cmake). 

This way we still have the nice folder sorting, but building with Pixi Build infers the correct package name

### How Has This Been Tested?

Ran locally

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code