### PR TITLE
fix: fallback behaviour added to atomic writes

### DIFF
--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -1,8 +1,5 @@
 use std::path::Path;
 
-/// Build a [`tempfile::NamedTempFile`] in the same directory as `path`, using
-/// the original filename as the prefix so the temp file is easily identifiable
-/// (e.g. `.pixi.toml.XXXXXX`).
 fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
     let dir = path.parent().ok_or_else(|| {
         std::io::Error::new(
@@ -16,11 +13,19 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
         path.file_name().and_then(|n| n.to_str()).unwrap_or("tmp")
     );
 
-    tempfile::Builder::new().prefix(&prefix).tempfile_in(dir)
+    match tempfile::Builder::new().prefix(&prefix).tempfile_in(dir) {
+        Ok(file) => Ok(file),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            tempfile::Builder::new()
+                .prefix(&prefix)
+                .tempfile_in(std::env::temp_dir())
+        }
+        Err(e) => Err(e),
+    }
 }
 
-/// Atomically write contents to a file by first writing to a temporary file in
-/// the same directory and then renaming it to the target path.
+/// Atomically write contents to a file by first writing to a temporary file and
+/// then renaming it to the target path.
 ///
 /// This ensures that the target file is never left in a partially-written state.
 /// If the write fails (e.g., due to disk full), the original file remains

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -18,11 +18,9 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
 
     match tempfile::Builder::new().prefix(&prefix).tempfile_in(dir) {
         Ok(file) => Ok(file),
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-            tempfile::Builder::new()
-                .prefix(&prefix)
-                .tempfile_in(std::env::temp_dir())
-        }
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => tempfile::Builder::new()
+            .prefix(&prefix)
+            .tempfile_in(std::env::temp_dir()),
         Err(e) => Err(e),
     }
 }
@@ -80,14 +78,14 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("pixi.toml");
-        fs::write(&target, b"[project]").unwrap(); 
+        fs::write(&target, b"[project]").unwrap();
 
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
 
         let temp = temp_file_for(&target).unwrap();
 
         assert_eq!(temp.path().parent().unwrap(), std::env::temp_dir());
-        // resetting the permissions for cleanup 
+        // resetting the permissions for cleanup
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
     }
 

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -123,4 +123,25 @@ mod tests {
             .await
             .unwrap();
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_atomic_write_sync_falls_back() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("pixi.toml");
+        let contents = b"[project]\nname = \"test\"";
+
+        fs_err::write(&target, b"").unwrap();
+        fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        atomic_write_sync(&target, contents).unwrap();
+
+        let written = fs_err::read(&target).unwrap();
+        assert_eq!(written, contents);
+
+        // Reset permissions for clean up
+        fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
 }

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -83,7 +83,6 @@ pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Re
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
 
     #[test]
     fn test_temp_file_created_in_same_dir_when_writable() {
@@ -118,14 +117,14 @@ mod tests {
         let target = dir.path().join("pixi.toml");
         fs_err::write(&target, b"[project]").unwrap();
 
-        fs_err::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
+        fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let temp = temp_file_for(&target).unwrap();
 
         assert_eq!(temp.path().parent().unwrap(), std::env::temp_dir());
 
         // resetting the permissions for cleanup
-        fs_err::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     /// Integration test: when the parent directory is read-only, `atomic_write`
@@ -144,7 +143,7 @@ mod tests {
         let contents = b"[project]\nname = \"test\"";
 
         tokio_fs::write(&target, b"").await.unwrap();
-        tokio_fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555))
+        tokio_fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555))
             .await
             .unwrap();
 
@@ -154,7 +153,7 @@ mod tests {
         assert_eq!(written, contents);
 
         // Reset permissions for clean up
-        tokio_fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755))
+        tokio_fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755))
             .await
             .unwrap();
     }

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -1,5 +1,8 @@
 use std::path::Path;
 
+/// Build a [`tempfile::NamedTempFile`] in the same directory as `path`, using
+/// the original filename as the prefix so the temp file is easily identifiable
+/// (e.g. `.pixi.toml.XXXXXX`).
 fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
     let dir = path.parent().ok_or_else(|| {
         std::io::Error::new(

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -92,6 +92,20 @@ mod tests {
 
         assert_eq!(temp.path().parent().unwrap(), dir.path());
     }
+    
+    #[test]
+    fn test_temp_file_has_correct_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("pixi.toml");
+
+        let temp = temp_file_for(&target).unwrap();
+        let name = temp.path().file_name().unwrap().to_str().unwrap();
+
+        assert!(
+            name.starts_with(".pixi.toml."),
+            "expected prefix `.pixi.toml.`, got `{name}`"
+        );
+    }
 
     #[test]
     #[cfg(unix)]
@@ -107,21 +121,38 @@ mod tests {
         let temp = temp_file_for(&target).unwrap();
 
         assert_eq!(temp.path().parent().unwrap(), std::env::temp_dir());
+
         // resetting the permissions for cleanup
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
     }
 
-    #[test]
-    fn temp_file_has_correct_prefix() {
+    /// Integration test: when the parent directory is read-only, `atomic_write`
+    /// should fall back to a direct write and the file contents must be correct.
+    ///
+    /// Note: on Unix, a read-only directory still allows writing to existing
+    /// files within it (controlled by the file's own permissions), so the
+    /// fallback `tokio_fs::write` succeeds even though rename cannot.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn test_temp_atomic_write_falls_back_when_dir_not_writable() {
+        use std::os::unix::fs::PermissionsExt;
+ 
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("pixi.toml");
+        let contents = b"[project]\nname = \"test\"";
+ 
+        fs::write(&target, b"").unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
+ 
+        atomic_write(&target, contents).await.unwrap();
+ 
+        let written = fs::read(&target).unwrap();
+        assert_eq!(written, contents);
 
-        let temp = temp_file_for(&target).unwrap();
-        let name = temp.path().file_name().unwrap().to_str().unwrap();
-
-        assert!(
-            name.starts_with(".pixi.toml."),
-            "expected prefix `.pixi.toml.`, got `{name}`"
-        );
+        // Reset permissions for clean up
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
     }
+
+
+
 }

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -60,10 +60,22 @@ pub async fn atomic_write(path: &Path, contents: impl AsRef<[u8]>) -> std::io::R
 /// Synchronous version of [`atomic_write`].
 pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
     let mut temp_file = temp_file_for(path)?;
-    std::io::Write::write_all(&mut temp_file, contents.as_ref())?;
-    temp_file.persist(path).map_err(|e| e.error)?;
-
-    Ok(())
+ 
+    let contents_ref = contents.as_ref();
+    std::io::Write::write_all(&mut temp_file, contents_ref)?;
+ 
+    match temp_file.persist(path) {
+        Ok(_) => Ok(()),
+        Err(e) if e.error.kind() == std::io::ErrorKind::PermissionDenied => {
+            tracing::warn!(
+                path = %path.display(),
+                "atomic rename failed due to permissions; falling back to direct write. \
+                 Write will not be atomic."
+            );
+            std::fs::write(path, contents_ref)
+        }
+        Err(e) => Err(e.error),
+    }
 }
 
 #[cfg(test)]

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -60,7 +60,6 @@ mod tests {
     use super::*;
     use std::fs;
 
-    /// temp file in same dir as pixi.toml.
     #[test]
     fn test_temp_file_created_in_same_dir_when_writable() {
         let dir = tempfile::tempdir().unwrap();
@@ -71,8 +70,6 @@ mod tests {
         assert_eq!(temp.path().parent().unwrap(), dir.path());
     }
 
-    /// to test that if the parent dir is not writeable
-    /// the temp file is created in $TEMPDIR
     #[test]
     #[cfg(unix)]
     fn test_temp_file_falls_back_to_tmp_when_parent_not_writable() {
@@ -90,7 +87,7 @@ mod tests {
         // resetting the permissions for cleanup 
         fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
     }
-    /// To test the prefix
+
     #[test]
     fn temp_file_has_correct_prefix() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use fs_err::tokio as tokio_fs;
+use std::path::Path;
 
 /// Build a [`tempfile::NamedTempFile`] in the same directory as `path`, using
 /// the original filename as the prefix so the temp file is easily identifiable
@@ -11,13 +11,13 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
             "path has no parent directory",
         )
     })?;
- 
+
     let prefix = format!(
         ".{}.",
         path.file_name().and_then(|n| n.to_str()).unwrap_or("tmp")
     );
- 
-    let target_dir = if std::fs::metadata(dir)?.permissions().readonly() {
+
+    let target_dir = if fs_err::metadata(dir)?.permissions().readonly() {
         tracing::warn!(
             path = %path.display(),
             "parent directory is read-only; temp file will be created in the system temp dir. \
@@ -27,8 +27,10 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
     } else {
         dir.to_path_buf()
     };
- 
-    tempfile::Builder::new().prefix(&prefix).tempfile_in(target_dir)
+
+    tempfile::Builder::new()
+        .prefix(&prefix)
+        .tempfile_in(target_dir)
 }
 /// Atomically write contents to a file by first writing to a temporary file and
 /// then renaming it to the target path.
@@ -39,10 +41,10 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
 pub async fn atomic_write(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
     let temp_file = temp_file_for(path)?;
     let temp_path = temp_file.into_temp_path();
- 
+
     let contents_ref = contents.as_ref();
     tokio_fs::write(&temp_path, contents_ref).await?;
- 
+
     match temp_path.persist(path) {
         Ok(()) => Ok(()),
         Err(e) if e.error.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -60,10 +62,10 @@ pub async fn atomic_write(path: &Path, contents: impl AsRef<[u8]>) -> std::io::R
 /// Synchronous version of [`atomic_write`].
 pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
     let mut temp_file = temp_file_for(path)?;
- 
+
     let contents_ref = contents.as_ref();
     std::io::Write::write_all(&mut temp_file, contents_ref)?;
- 
+
     match temp_file.persist(path) {
         Ok(_) => Ok(()),
         Err(e) if e.error.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -72,7 +74,7 @@ pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Re
                 "atomic rename failed due to permissions; falling back to direct write. \
                  Write will not be atomic."
             );
-            std::fs::write(path, contents_ref)
+            fs_err::write(path, contents_ref)
         }
         Err(e) => Err(e.error),
     }
@@ -92,7 +94,7 @@ mod tests {
 
         assert_eq!(temp.path().parent().unwrap(), dir.path());
     }
-    
+
     #[test]
     fn test_temp_file_has_correct_prefix() {
         let dir = tempfile::tempdir().unwrap();
@@ -114,16 +116,16 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("pixi.toml");
-        fs::write(&target, b"[project]").unwrap();
+        fs_err::write(&target, b"[project]").unwrap();
 
-        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
+        fs_err::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
 
         let temp = temp_file_for(&target).unwrap();
 
         assert_eq!(temp.path().parent().unwrap(), std::env::temp_dir());
 
         // resetting the permissions for cleanup
-        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        fs_err::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     /// Integration test: when the parent directory is read-only, `atomic_write`
@@ -136,23 +138,24 @@ mod tests {
     #[cfg(unix)]
     async fn test_temp_atomic_write_falls_back_when_dir_not_writable() {
         use std::os::unix::fs::PermissionsExt;
- 
+
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("pixi.toml");
         let contents = b"[project]\nname = \"test\"";
- 
-        fs::write(&target, b"").unwrap();
-        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
- 
+
+        tokio_fs::write(&target, b"").await.unwrap();
+        tokio_fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555))
+            .await
+            .unwrap();
+
         atomic_write(&target, contents).await.unwrap();
- 
-        let written = fs::read(&target).unwrap();
+
+        let written = tokio_fs::read(&target).await.unwrap();
         assert_eq!(written, contents);
 
         // Reset permissions for clean up
-        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        tokio_fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755))
+            .await
+            .unwrap();
     }
-
-
-
 }

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use fs_err::tokio as tokio_fs;
 
 /// Build a [`tempfile::NamedTempFile`] in the same directory as `path`, using
 /// the original filename as the prefix so the temp file is easily identifiable
@@ -36,19 +37,24 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
 /// If the write fails (e.g., due to disk full), the original file remains
 /// untouched.
 pub async fn atomic_write(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
-    // Create a temp file in the same directory to ensure it's on the same
-    // filesystem, which is required for atomic rename.
     let temp_file = temp_file_for(path)?;
     let temp_path = temp_file.into_temp_path();
-
-    // Write contents to the temp file. If this fails (e.g. disk full), the temp
-    // file is automatically cleaned up when `temp_path` is dropped.
-    tokio::fs::write(&temp_path, contents).await?;
-
-    // Atomically rename the temp file to the target path.
-    temp_path.persist(path).map_err(|e| e.error)?;
-
-    Ok(())
+ 
+    let contents_ref = contents.as_ref();
+    tokio_fs::write(&temp_path, contents_ref).await?;
+ 
+    match temp_path.persist(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.error.kind() == std::io::ErrorKind::PermissionDenied => {
+            tracing::warn!(
+                path = %path.display(),
+                "atomic rename failed due to permissions; falling back to direct write. \
+                 Write will not be atomic."
+            );
+            tokio_fs::write(path, contents_ref).await
+        }
+        Err(e) => Err(e.error),
+    }
 }
 
 /// Synchronous version of [`atomic_write`].

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -54,3 +54,54 @@ pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Re
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// temp file in same dir as pixi.toml.
+    #[test]
+    fn test_temp_file_created_in_same_dir_when_writable() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("pixi.toml");
+
+        let temp = temp_file_for(&target).unwrap();
+
+        assert_eq!(temp.path().parent().unwrap(), dir.path());
+    }
+
+    /// to test that if the parent dir is not writeable
+    /// the temp file is created in $TEMPDIR
+    #[test]
+    #[cfg(unix)]
+    fn test_temp_file_falls_back_to_tmp_when_parent_not_writable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("pixi.toml");
+        fs::write(&target, b"[project]").unwrap(); 
+
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
+
+        let temp = temp_file_for(&target).unwrap();
+
+        assert_eq!(temp.path().parent().unwrap(), std::env::temp_dir());
+        // resetting the permissions for cleanup 
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    /// To test the prefix
+    #[test]
+    fn temp_file_has_correct_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("pixi.toml");
+
+        let temp = temp_file_for(&target).unwrap();
+        let name = temp.path().file_name().unwrap().to_str().unwrap();
+
+        assert!(
+            name.starts_with(".pixi.toml."),
+            "expected prefix `.pixi.toml.`, got `{name}`"
+        );
+    }
+}

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -17,20 +17,7 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
         path.file_name().and_then(|n| n.to_str()).unwrap_or("tmp")
     );
 
-    let target_dir = if fs_err::metadata(dir)?.permissions().readonly() {
-        tracing::warn!(
-            path = %path.display(),
-            "parent directory is read-only; temp file will be created in the system temp dir. \
-             Write will not be atomic."
-        );
-        std::env::temp_dir()
-    } else {
-        dir.to_path_buf()
-    };
-
-    tempfile::Builder::new()
-        .prefix(&prefix)
-        .tempfile_in(target_dir)
+    tempfile::Builder::new().prefix(&prefix).tempfile_in(dir)
 }
 /// Atomically write contents to a file by first writing to a temporary file and
 /// then renaming it to the target path.
@@ -39,45 +26,43 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
 /// If the write fails (e.g., due to disk full), the original file remains
 /// untouched.
 pub async fn atomic_write(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
-    let temp_file = temp_file_for(path)?;
-    let temp_path = temp_file.into_temp_path();
-
-    let contents_ref = contents.as_ref();
-    tokio_fs::write(&temp_path, contents_ref).await?;
-
-    match temp_path.persist(path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.error.kind() == std::io::ErrorKind::PermissionDenied => {
+    let temp_file = match temp_file_for(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
             tracing::warn!(
                 path = %path.display(),
-                "atomic rename failed due to permissions; falling back to direct write. \
-                 Write will not be atomic."
+                "cannot create temp file in parent directory; falling back to direct write. \
+                Write will not be atomic."
             );
-            tokio_fs::write(path, contents_ref).await
+            return tokio_fs::write(path, contents.as_ref()).await;
         }
-        Err(e) => Err(e.error),
-    }
+        Err(e) => return Err(e),
+    };
+
+    let temp_path = temp_file.into_temp_path();
+    tokio_fs::write(&temp_path, contents.as_ref()).await?;
+    temp_path.persist(path).map_err(|e| e.error)?;
+
+    Ok(())
 }
 
 /// Synchronous version of [`atomic_write`].
 pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
-    let mut temp_file = temp_file_for(path)?;
-
-    let contents_ref = contents.as_ref();
-    std::io::Write::write_all(&mut temp_file, contents_ref)?;
-
-    match temp_file.persist(path) {
-        Ok(_) => Ok(()),
-        Err(e) if e.error.kind() == std::io::ErrorKind::PermissionDenied => {
+    let mut temp_file = match temp_file_for(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
             tracing::warn!(
                 path = %path.display(),
-                "atomic rename failed due to permissions; falling back to direct write. \
-                 Write will not be atomic."
+                "cannot create temp file in parent directory; falling back to direct write. \
+                Write will not be atomic."
             );
-            fs_err::write(path, contents_ref)
+            return fs_err::write(path, contents.as_ref());
         }
-        Err(e) => Err(e.error),
-    }
+        Err(e) => return Err(e),
+    };
+    std::io::Write::write_all(&mut temp_file, contents.as_ref())?;
+    temp_file.persist(path).map_err(|e| e.error)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -108,25 +93,6 @@ mod tests {
         );
     }
 
-    #[test]
-    #[cfg(unix)]
-    fn test_temp_file_falls_back_to_tmp_when_parent_not_writable() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("pixi.toml");
-        fs_err::write(&target, b"[project]").unwrap();
-
-        fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
-
-        let temp = temp_file_for(&target).unwrap();
-
-        assert_eq!(temp.path().parent().unwrap(), std::env::temp_dir());
-
-        // resetting the permissions for cleanup
-        fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
-
     /// Integration test: when the parent directory is read-only, `atomic_write`
     /// should fall back to a direct write and the file contents must be correct.
     ///
@@ -135,7 +101,7 @@ mod tests {
     /// fallback `tokio_fs::write` succeeds even though rename cannot.
     #[tokio::test]
     #[cfg(unix)]
-    async fn test_temp_atomic_write_falls_back_when_dir_not_writable() {
+    async fn test_atomic_write_falls_back() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -10,21 +10,25 @@ fn temp_file_for(path: &Path) -> std::io::Result<tempfile::NamedTempFile> {
             "path has no parent directory",
         )
     })?;
-
+ 
     let prefix = format!(
         ".{}.",
         path.file_name().and_then(|n| n.to_str()).unwrap_or("tmp")
     );
-
-    match tempfile::Builder::new().prefix(&prefix).tempfile_in(dir) {
-        Ok(file) => Ok(file),
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => tempfile::Builder::new()
-            .prefix(&prefix)
-            .tempfile_in(std::env::temp_dir()),
-        Err(e) => Err(e),
-    }
+ 
+    let target_dir = if std::fs::metadata(dir)?.permissions().readonly() {
+        tracing::warn!(
+            path = %path.display(),
+            "parent directory is read-only; temp file will be created in the system temp dir. \
+             Write will not be atomic."
+        );
+        std::env::temp_dir()
+    } else {
+        dir.to_path_buf()
+    };
+ 
+    tempfile::Builder::new().prefix(&prefix).tempfile_in(target_dir)
 }
-
 /// Atomically write contents to a file by first writing to a temporary file and
 /// then renaming it to the target path.
 ///


### PR DESCRIPTION
### Description

Implemented a fallback behaivour for when the parent directory is not writeable, then falls back to $TMPDIR

Added tests to check :
1. NamedTempFile behaivour when created in the same as the parent directory
2. To check the prefix of the generated tempfile
3. To check the file is created in $TMPDIR when the parent is not writeable, implemented permissions control and tested to check the file is deleted propoerly
Fixes #5724 

### How Has This Been Tested?



### AI Disclosure

- [ x ] This PR contains AI-generated content.
  - [ x ] I have tested any AI-generated content in my PR.
  - [ x ] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
