### PR TITLE
fix:  support symlinking trampolines

### DIFF
--- a/trampoline/src/main.rs
+++ b/trampoline/src/main.rs
@@ -78,9 +78,11 @@ fn trampoline() -> miette::Result<()> {
         .wrap_err("Couldn't get the `env::current_exe`")?;
 
     // Resolve symlinks so that config lookup works even when the trampoline is
-    // invoked via a symlink from a different directory (e.g. on macOS,
-    // `current_exe()` returns the symlink path rather than the target).
-    // Hardlinks are unaffected since they are not symlinks.
+    // invoked via a symlink from a different directory. On Linux,
+    // `current_exe()` reads /proc/self/exe which auto-resolves symlinks, but
+    // on macOS (_NSGetExecutablePath) and Windows (GetModuleFileNameW) it
+    // returns the symlink path rather than the target.
+    // https://doc.rust-lang.org/std/env/fn.current_exe.html#platform-specific-behavior
     let current_exe = current_exe.canonicalize().unwrap_or(current_exe);
 
     // ignore any ctrl-c signals


### PR DESCRIPTION
### Description
Fixes #5772 

This adds support for symlinking `pixi global` trampolines, so that doing this works now:
```
pixi global install crane
ln -sf $(which crane) ./crane
./crane
```

Hardlinks other than the ones that pixi creates still won't work, but symlinks are the more common use-case.

### How Has This Been Tested?

I recompiled the trampoline with `cargo build --manifest-path trampoline/Cargo.toml --release --target aarch64-apple-darwin` and then `zstd -f trampoline/target/aarch64-apple-darwin/release/pixi_trampoline -o trampoline/binaries/pixi-trampoline-aarch64-apple-darwin.zst`.

After that I ran `cargo build` and then confirmed the above example works with the debug build of pixi.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
