### PR TITLE
Hide version info in `pixi search -l 0` output

### DIFF
--- a/crates/pixi_cli/src/search.rs
+++ b/crates/pixi_cli/src/search.rs
@@ -223,6 +223,13 @@ fn print_search_results<W: Write>(
         if i >= n_packages {
             break;
         }
+
+        // When limit is 0, show only package names with no version info
+        if n_versions == 0 {
+            writeln!(out, "{}", console::style(name.as_source()).green().bold())?;
+            continue;
+        }
+
         if i > 0 {
             writeln!(out)?;
         }


### PR DESCRIPTION
When the version limit is set to 0 (`-l 0`), only bare package names are
printed - no version counts, no version lines, no "more versions" hints.

Before:
```
> pixi search cargo* -l 0
cargo-audit (15 versions)
... and 15 more versions (use -l to show more)

cargo-auditable (8 versions)
... and 8 more versions (use -l to show more)
```

After:
```
> pixi search cargo* -l 0
cargo-audit
cargo-auditable
cargo-binutils
cargo-bundle-licenses
cargo-c
```

This gives a clean list suitable for piping or scripting.

Fixes #5763