### PR TITLE
feat(pixi-build-rattler-build): add context variable

### DIFF
--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -490,7 +490,10 @@ fn inject_pixi_version_into_context(source_code: &str, version: &str) -> miette:
 
     // Find context: as a top-level key (at start of line, not indented)
     let insert_after = if source_code.starts_with("context:") {
-        source_code.find('\n').map(|i| i + 1).unwrap_or(source_code.len())
+        source_code
+            .find('\n')
+            .map(|i| i + 1)
+            .unwrap_or(source_code.len())
     } else if let Some(pos) = source_code.find("\ncontext:") {
         let after = pos + "\ncontext:".len();
         source_code[after..]

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -493,8 +493,10 @@ fn inject_pixi_version_into_context(source_code: &str, version: &str) -> miette:
         source_code.find('\n').map(|i| i + 1).unwrap_or(source_code.len())
     } else if let Some(pos) = source_code.find("\ncontext:") {
         let after = pos + "\ncontext:".len();
-        let eol = source_code[after..].find('\n').map(|i| after + i + 1).unwrap_or(source_code.len());
-        eol
+        source_code[after..]
+            .find('\n')
+            .map(|i| after + i + 1)
+            .unwrap_or(source_code.len())
     } else {
         // No context: block — prepend one
         return Ok(format!("context:\n{injected_line}\n{source_code}"));

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -77,9 +77,14 @@ impl Protocol for RattlerBuildBackend {
         .extend_with_input_variants(params.variant_configuration.unwrap_or_default());
 
         // Create source for error reporting
+        let recipe_code = if let Some(ref version) = self.package_version {
+            inject_pixi_version_into_context(&self.recipe_source.code, version)?
+        } else {
+            self.recipe_source.code.to_string()
+        };
         let source = rattler_build_recipe::source_code::Source::from_string(
             self.recipe_source.name.clone(),
-            self.recipe_source.code.to_string(),
+            recipe_code,
         );
 
         // Parse the recipe into stage0
@@ -328,9 +333,14 @@ impl Protocol for RattlerBuildBackend {
         };
 
         // Create source for error reporting
+        let recipe_code = if let Some(ref version) = self.package_version {
+            inject_pixi_version_into_context(&self.recipe_source.code, version)?
+        } else {
+            self.recipe_source.code.to_string()
+        };
         let source = rattler_build_recipe::source_code::Source::from_string(
             self.recipe_source.name.clone(),
-            self.recipe_source.code.to_string(),
+            recipe_code,
         );
 
         // Parse the recipe into stage0
@@ -468,6 +478,33 @@ impl Protocol for RattlerBuildBackend {
     }
 }
 
+/// Injects `PIXI_PACKAGE_VERSION` as a Jinja2 context variable into the recipe YAML source.
+/// If the variable is already defined in the `context:` block, it is not overridden.
+fn inject_pixi_version_into_context(source_code: &str, version: &str) -> miette::Result<String> {
+    // If already explicitly defined by the user, respect it
+    if source_code.contains("PIXI_PACKAGE_VERSION:") {
+        return Ok(source_code.to_string());
+    }
+
+    let injected_line = format!("  PIXI_PACKAGE_VERSION: \"{version}\"\n");
+
+    // Find context: as a top-level key (at start of line, not indented)
+    let insert_after = if source_code.starts_with("context:") {
+        source_code.find('\n').map(|i| i + 1).unwrap_or(source_code.len())
+    } else if let Some(pos) = source_code.find("\ncontext:") {
+        let after = pos + "\ncontext:".len();
+        let eol = source_code[after..].find('\n').map(|i| after + i + 1).unwrap_or(source_code.len());
+        eol
+    } else {
+        // No context: block — prepend one
+        return Ok(format!("context:\n{injected_line}\n{source_code}"));
+    };
+
+    let mut result = source_code.to_string();
+    result.insert_str(insert_after, &injected_line);
+    Ok(result)
+}
+
 /// Extracts the package sources from an `Output` object that are mutable and
 /// should be watched for changes.
 fn extract_mutable_package_sources(output: &Output) -> Option<Vec<PathBuf>> {
@@ -588,8 +625,14 @@ impl ProtocolInstantiator for RattlerBuildBackendInstantiator {
         }
 
         let mut workspace_dependencies = HashMap::new();
+        let project_model = params.project_model;
 
-        if let Some(target) = params.project_model.and_then(|m| m.targets) {
+        let package_version = project_model
+            .as_ref()
+            .and_then(|m| m.version.as_ref())
+            .map(|v| v.to_string());
+
+        if let Some(target) = project_model.and_then(|m| m.targets) {
             fn extract_workspace_deps(
                 target: Target,
                 workspace_deps: &mut HashMap<String, SourcePackageSpec>,
@@ -650,6 +693,7 @@ impl ProtocolInstantiator for RattlerBuildBackendInstantiator {
 
         // Set the workspace dependencies
         instance.workspace_dependencies = workspace_dependencies;
+        instance.package_version = package_version;
 
         Ok((Box::new(instance), InitializeResult {}))
     }
@@ -1324,5 +1368,96 @@ numpy:
 
         // Verify that the basic manifest glob is still present
         assert!(globs.contains("**"));
+    }
+
+    #[tokio::test]
+    async fn test_pixi_package_version_injected_from_project_model() {
+        use pixi_build_types::ProjectModel;
+        use rattler_conda_types::Version;
+        use std::str::FromStr;
+    
+        let temp_dir = tempdir().unwrap();
+        let recipe_path = temp_dir.path().join("recipe.yaml");
+    
+        // Recipe using ${{ PIXI_PACKAGE_VERSION }} directly — no hardcoded version
+        let recipe = "package:\n  name: my-pkg\n  version: ${{ PIXI_PACKAGE_VERSION }}\n\nbuild:\n  number: 0\n";
+        tokio::fs::write(&recipe_path, recipe)
+            .await
+            .expect("Failed to write recipe");
+    
+        let project_model = ProjectModel {
+            name: Some("my-pkg".to_string()),
+            version: Some(Version::from_str("1.2.3").unwrap()),
+            ..Default::default()
+        };
+    
+        let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
+            .initialize(InitializeParams {
+                workspace_directory: None,
+                source_directory: None,
+                manifest_path: recipe_path,
+                project_model: Some(project_model),
+                configuration: None,
+                target_configuration: None,
+                cache_directory: None,
+            })
+            .await
+            .unwrap();
+    
+        let result = factory
+            .0
+            .conda_outputs(CondaOutputsParams {
+                channels: vec![],
+                host_platform: Platform::Linux64,
+                build_platform: Platform::Linux64,
+                variant_configuration: None,
+                variant_files: None,
+                work_directory: temp_dir.path().to_path_buf(),
+            })
+            .await
+            .unwrap();
+    
+        assert_eq!(result.outputs.len(), 1);
+        assert_eq!(
+            result.outputs[0].metadata.version.to_string(),
+            "1.2.3",
+            "Package version should be injected from PIXI_PACKAGE_VERSION"
+        );
+        assert_eq!(result.outputs[0].metadata.name.as_normalized(), "my-pkg");
+    }
+
+    #[test]
+    fn test_inject_version_no_context_block() {
+        let recipe = "package:\n  name: foo\n  version: 0.1.0\n";
+        let result = super::inject_pixi_version_into_context(recipe, "1.2.3").unwrap();
+        assert!(result.contains("PIXI_PACKAGE_VERSION: \"1.2.3\""));
+    }
+
+    #[test]
+    fn test_inject_version_prepended_before_existing_keys() {
+        let recipe = "context:\n  version: ${{ PIXI_PACKAGE_VERSION }}\npackage:\n  name: foo\n";
+        let result = super::inject_pixi_version_into_context(recipe, "1.2.3").unwrap();
+        let pixi_pos = result.find("PIXI_PACKAGE_VERSION:").unwrap();
+        let ver_pos = result.find("version: ${{ PIXI_PACKAGE_VERSION }}").unwrap();
+        assert!(pixi_pos < ver_pos);
+        assert!(result.contains("PIXI_PACKAGE_VERSION: \"1.2.3\""));
+        assert!(result.contains("version: ${{ PIXI_PACKAGE_VERSION }}"));
+    }
+
+    #[test]
+    fn test_inject_version_does_not_override_existing() {
+        let recipe = "context:\n  PIXI_PACKAGE_VERSION: \"my-custom\"\npackage:\n  name: foo\n";
+        let result = super::inject_pixi_version_into_context(recipe, "9.9.9").unwrap();
+        assert!(result.contains("PIXI_PACKAGE_VERSION: \"my-custom\""));
+        assert!(!result.contains("9.9.9"));
+    }
+
+    #[test]
+    fn test_inject_version_existing_context_other_keys_preserved() {
+        let recipe = "context:\n  lib_version: \"2.0\"\n  suffix: \"-dev\"\npackage:\n  name: foo\n";
+        let result = super::inject_pixi_version_into_context(recipe, "3.0.0").unwrap();
+        assert!(result.contains("PIXI_PACKAGE_VERSION: \"3.0.0\""));
+        assert!(result.contains("lib_version: \"2.0\""));
+        assert!(result.contains("suffix: \"-dev\""));
     }
 }

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -1380,22 +1380,22 @@ numpy:
         use pixi_build_types::ProjectModel;
         use rattler_conda_types::Version;
         use std::str::FromStr;
-    
+
         let temp_dir = tempdir().unwrap();
         let recipe_path = temp_dir.path().join("recipe.yaml");
-    
+
         // Recipe using ${{ PIXI_PACKAGE_VERSION }} directly — no hardcoded version
         let recipe = "package:\n  name: my-pkg\n  version: ${{ PIXI_PACKAGE_VERSION }}\n\nbuild:\n  number: 0\n";
         tokio::fs::write(&recipe_path, recipe)
             .await
             .expect("Failed to write recipe");
-    
+
         let project_model = ProjectModel {
             name: Some("my-pkg".to_string()),
             version: Some(Version::from_str("1.2.3").unwrap()),
             ..Default::default()
         };
-    
+
         let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 workspace_directory: None,
@@ -1408,7 +1408,7 @@ numpy:
             })
             .await
             .unwrap();
-    
+
         let result = factory
             .0
             .conda_outputs(CondaOutputsParams {
@@ -1421,7 +1421,7 @@ numpy:
             })
             .await
             .unwrap();
-    
+
         assert_eq!(result.outputs.len(), 1);
         assert_eq!(
             result.outputs[0].metadata.version.to_string(),
@@ -1459,7 +1459,8 @@ numpy:
 
     #[test]
     fn test_inject_version_existing_context_other_keys_preserved() {
-        let recipe = "context:\n  lib_version: \"2.0\"\n  suffix: \"-dev\"\npackage:\n  name: foo\n";
+        let recipe =
+            "context:\n  lib_version: \"2.0\"\n  suffix: \"-dev\"\npackage:\n  name: foo\n";
         let result = super::inject_pixi_version_into_context(recipe, "3.0.0").unwrap();
         assert!(result.contains("PIXI_PACKAGE_VERSION: \"3.0.0\""));
         assert!(result.contains("lib_version: \"2.0\""));

--- a/crates/pixi_build_rattler_build/src/rattler_build.rs
+++ b/crates/pixi_build_rattler_build/src/rattler_build.rs
@@ -22,6 +22,7 @@ pub struct RattlerBuildBackend {
     pub(crate) config: RattlerBuildBackendConfig,
     /// Workspace dependencies from the project model
     pub(crate) workspace_dependencies: HashMap<String, SourcePackageSpec>,
+	pub(crate) package_version: Option<String>,
 }
 
 impl RattlerBuildBackend {
@@ -97,6 +98,7 @@ impl RattlerBuildBackend {
             cache_dir,
             config,
             workspace_dependencies: HashMap::new(),
+			package_version: None,
         })
     }
 }

--- a/crates/pixi_build_rattler_build/src/rattler_build.rs
+++ b/crates/pixi_build_rattler_build/src/rattler_build.rs
@@ -22,7 +22,7 @@ pub struct RattlerBuildBackend {
     pub(crate) config: RattlerBuildBackendConfig,
     /// Workspace dependencies from the project model
     pub(crate) workspace_dependencies: HashMap<String, SourcePackageSpec>,
-	pub(crate) package_version: Option<String>,
+    pub(crate) package_version: Option<String>,
 }
 
 impl RattlerBuildBackend {
@@ -98,7 +98,7 @@ impl RattlerBuildBackend {
             cache_dir,
             config,
             workspace_dependencies: HashMap::new(),
-			package_version: None,
+            package_version: None,
         })
     }
 }

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -63,13 +63,13 @@ pixi_utils = { workspace = true, default-features = false }
 pixi_uv_conversions = { workspace = true }
 rattler = { workspace = true, features = ["cli-tools", "indicatif"] }
 rattler_conda_types = { workspace = true }
+rattler_index = { workspace = true }
 rattler_lock = { workspace = true }
 rattler_networking = { workspace = true, default-features = false }
-rattler_shell = { workspace = true, features = ["sysinfo"] }
-rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
-rattler_index = { workspace = true }
 rattler_package_streaming = { workspace = true }
 rattler_s3 = { workspace = true }
+rattler_shell = { workspace = true, features = ["sysinfo"] }
+rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
 rattler_upload = { workspace = true }
 rattler_virtual_packages = { workspace = true }
 regex = { workspace = true }

--- a/docs/build/backends/pixi-build-rattler-build.md
+++ b/docs/build/backends/pixi-build-rattler-build.md
@@ -149,6 +149,16 @@ extra-input-globs = ["*.yaml", "*.md", "*.sh", "patches-linux/**/*"]
 # Result for linux-64: ["*.yaml", "*.md", "*.sh", "patches-linux/**/*"]
 ```
 
+## Version specification
+By default, the version needs to be specified in `recipe.yaml` and can be a duplication of the version specified in `pixi.toml`.
+
+To avoid this duplication, you can use the `${{ PIXI_PACKAGE_VERSION }}` Jinja2 variable in your recipe — it is automatically set to the version defined in `pixi.toml`.
+
+```yaml title="recipe.yaml"
+package:
+  name: my-package
+  version: ${{ PIXI_PACKAGE_VERSION }}
+
 ## Build Process
 
 The rattler-build backend follows this build process:


### PR DESCRIPTION
### Description

This PR is motivated by the fact that, using `pixi-rattler-build-backend` requires to specify package version in the `recipe.yaml` rather than into the `pixi.toml`. So the idea is to add a context variable that can use the version given in the `pixi.toml` and propagate it into the recipe using `PIXI_PACKAGE_VERSION` jinja variable.

#### Before change
in recipe.yml :
```yml
context:
  version: 1.2.0
```
and in pixi.toml:
```toml
[package]
name    = "cpp_math"
version = "1.2.0"
```

Then, after changes : 
in recipe.yml :
```yml
context:
  version: ${{ PIXI_PACKAGE_VERSION }}
```
and in pixi.toml:
```toml
[package]
name    = "cpp_math"
version = "1.2.0"
```

Closes #5782 

### How Has This Been Tested?

- Tested using the cpp_math example refactored for multi-ouptut processing with nanobind  ([cpp_math.zip](https://github.com/user-attachments/files/26305855/cpp_math.zip))

- Tested using local built pixi executable and `PIXI_BUILD_BACKEND_OVERRIDE` to use local built build-backend
```bash
PIXI_BUILD_BACKEND_OVERRIDE="pixi-build-rattler-build=local-path-build-backend"  && \
./pixi build --path path_to_cpp_math
```
- Unit test for the `inject_pixi_version_into_context` function

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Github Copilot on Claude Sonnet 4.6

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
