### PR TITLE
feat: add build number and build string prefix override options

### DIFF
--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -753,6 +753,8 @@ impl PixiControl {
                 build_dir: None,
                 clean: false,
                 path: Some(self.manifest_path()),
+                build_number: None,
+                build_string_prefix: None,
             },
         }
     }

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -28,7 +28,7 @@ use rattler_build_core::{
     tool_configuration::Configuration,
     types::{Directories, PackageIdentifier, PackagingSettings},
 };
-use rattler_build_recipe::variant_render::RenderConfig;
+use rattler_build_recipe::{stage0::Value, variant_render::RenderConfig};
 use rattler_build_types::NormalizedKey;
 use rattler_build_variant_config::VariantConfig;
 use rattler_conda_types::NoArchType;
@@ -256,7 +256,7 @@ where
         variant_config.variants.append(&mut param_variants);
 
         // Construct the intermediate recipe
-        let generated_recipe = self
+        let mut generated_recipe = self
             .generate_recipe
             .generate_recipe(
                 &self.project_model,
@@ -269,6 +269,12 @@ where
                 self.cache_dir.clone(),
             )
             .await?;
+
+        // Apply build number override before rendering so the build string is
+        // automatically updated.
+        if let Some(build_number) = params.build_number_override {
+            generated_recipe.recipe.build.number = Some(Value::new_concrete(build_number, None));
+        }
 
         // Convert the recipe to source code.
         // TODO(baszalmstra): In the future it would be great if we could just
@@ -309,7 +315,7 @@ where
             render_config,
         )?;
 
-        // Convert to DiscoveredOutputs
+        // Convert to DiscoveredOutputs, applying build string prefix if set.
         let discovered_outputs: IndexSet<DiscoveredOutput> = rendered_variants
             .into_iter()
             .map(|rendered| {
@@ -320,12 +326,17 @@ where
                 } else {
                     Platform::NoArch
                 };
-                let build_string = recipe
+                let original_build_string = recipe
                     .build()
                     .string
                     .as_resolved()
                     .expect("build string should be resolved")
                     .to_string();
+                let build_string = if let Some(prefix) = &params.build_string_prefix {
+                    format!("{prefix}_{original_build_string}")
+                } else {
+                    original_build_string
+                };
                 DiscoveredOutput {
                     name: recipe.package().name().as_normalized().to_string(),
                     version: recipe.package().version().to_string(),
@@ -365,7 +376,9 @@ where
                 continue;
             }
 
-            let build_number = recipe.build().number.unwrap_or(0);
+            let build_number = params
+                .build_number_override
+                .unwrap_or_else(|| recipe.build().number.unwrap_or(0));
 
             let directories = output_directory(
                 if num_of_outputs == 1 {
@@ -606,6 +619,12 @@ where
             )
             .await?;
 
+        // Apply build number override before rendering so the build string is
+        // automatically updated.
+        if let Some(build_number) = params.output.build_number_override {
+            recipe.recipe.build.number = Some(Value::new_concrete(build_number, None));
+        }
+
         // Convert the recipe to source code.
         // TODO(baszalmstra): In the future it would be great if we could just
         // immediately use the intermediate recipe for some of this rattler-build
@@ -646,23 +665,31 @@ where
             render_config,
         )?;
 
-        // Convert to DiscoveredOutputs
+        // Convert to DiscoveredOutputs, applying build string prefix if set.
         let discovered_outputs: IndexSet<DiscoveredOutput> = rendered_variants
             .into_iter()
             .map(|rendered| {
-                let r = rendered.recipe;
+                let mut r = rendered.recipe;
                 let variant = rendered.variant;
                 let effective_target_platform = if r.build().noarch.is_none() {
                     host_platform
                 } else {
                     Platform::NoArch
                 };
-                let build_string = r
+                let original_build_string = r
                     .build()
                     .string
                     .as_resolved()
                     .expect("build string should be resolved")
                     .to_string();
+                let build_string = if let Some(prefix) = &params.output.build_string_prefix {
+                    let new_bs = format!("{prefix}_{original_build_string}");
+                    // Update the recipe's build string so the built package gets the right name.
+                    r.build.string = new_bs.clone().into();
+                    new_bs
+                } else {
+                    original_build_string
+                };
                 DiscoveredOutput {
                     name: r.package().name().as_normalized().to_string(),
                     version: r.package().version().to_string(),

--- a/crates/pixi_build_backend/src/utils/test.rs
+++ b/crates/pixi_build_backend/src/utils/test.rs
@@ -87,6 +87,8 @@ where
             variant_configuration,
             variant_files,
             work_directory: current_dir,
+            build_number_override: None,
+            build_string_prefix: None,
         })
         .await
         .unwrap()

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -108,6 +108,8 @@ async fn test_conda_build_v1() {
             build: None,
             subdir: Platform::current(),
             variant: Default::default(),
+            build_number_override: None,
+            build_string_prefix: None,
         },
         work_directory: build_dir.clone(),
         output_directory: None,

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -425,6 +425,8 @@ mod tests {
                 variant_configuration: None,
                 variant_files: None,
                 work_directory: current_dir,
+                build_number_override: None,
+                build_string_prefix: None,
             })
             .await
             .unwrap();

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -90,7 +90,11 @@ impl Protocol for RattlerBuildBackend {
         // Apply build number override before rendering so the build string is
         // automatically updated.
         if let Some(build_number) = params.build_number_override {
-            stage0_recipe.build.number = Some(Stage0Value::new_concrete(build_number, None));
+            if let rattler_build_recipe::stage0::Recipe::SingleOutput(ref mut single) =
+                stage0_recipe
+            {
+                single.build.number = Some(Stage0Value::new_concrete(build_number, None));
+            }
         }
 
         // Build render config
@@ -354,7 +358,11 @@ impl Protocol for RattlerBuildBackend {
         // Apply build number override before rendering so the build string is
         // automatically updated.
         if let Some(build_number) = params.output.build_number_override {
-            stage0_recipe.build.number = Some(Stage0Value::new_concrete(build_number, None));
+            if let rattler_build_recipe::stage0::Recipe::SingleOutput(ref mut single) =
+                stage0_recipe
+            {
+                single.build.number = Some(Stage0Value::new_concrete(build_number, None));
+            }
         }
 
         // Build render config

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -89,12 +89,11 @@ impl Protocol for RattlerBuildBackend {
 
         // Apply build number override before rendering so the build string is
         // automatically updated.
-        if let Some(build_number) = params.build_number_override {
-            if let rattler_build_recipe::stage0::Recipe::SingleOutput(ref mut single) =
+        if let Some(build_number) = params.build_number_override
+            && let rattler_build_recipe::stage0::Recipe::SingleOutput(ref mut single) =
                 stage0_recipe
-            {
-                single.build.number = Some(Stage0Value::new_concrete(build_number, None));
-            }
+        {
+            single.build.number = Some(Stage0Value::new_concrete(build_number, None));
         }
 
         // Build render config
@@ -357,12 +356,11 @@ impl Protocol for RattlerBuildBackend {
 
         // Apply build number override before rendering so the build string is
         // automatically updated.
-        if let Some(build_number) = params.output.build_number_override {
-            if let rattler_build_recipe::stage0::Recipe::SingleOutput(ref mut single) =
+        if let Some(build_number) = params.output.build_number_override
+            && let rattler_build_recipe::stage0::Recipe::SingleOutput(ref mut single) =
                 stage0_recipe
-            {
-                single.build.number = Some(Stage0Value::new_concrete(build_number, None));
-            }
+        {
+            single.build.number = Some(Stage0Value::new_concrete(build_number, None));
         }
 
         // Build render config

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -36,7 +36,9 @@ use rattler_build_core::{
     tool_configuration::Configuration,
     types::{PackageIdentifier, PackagingSettings},
 };
-use rattler_build_recipe::{stage1::Source as RecipeSource, variant_render::RenderConfig};
+use rattler_build_recipe::{
+    stage0::Value as Stage0Value, stage1::Source as RecipeSource, variant_render::RenderConfig,
+};
 use rattler_build_variant_config::VariantConfig;
 use rattler_conda_types::NoArchType;
 use rattler_conda_types::{
@@ -83,7 +85,13 @@ impl Protocol for RattlerBuildBackend {
         );
 
         // Parse the recipe into stage0
-        let stage0_recipe = rattler_build_recipe::parse_recipe(&source)?;
+        let mut stage0_recipe = rattler_build_recipe::parse_recipe(&source)?;
+
+        // Apply build number override before rendering so the build string is
+        // automatically updated.
+        if let Some(build_number) = params.build_number_override {
+            stage0_recipe.build.number = Some(Stage0Value::new_concrete(build_number, None));
+        }
 
         // Build render config
         let render_config = RenderConfig::new()
@@ -101,7 +109,7 @@ impl Protocol for RattlerBuildBackend {
             render_config,
         )?;
 
-        // Convert to DiscoveredOutputs
+        // Convert to DiscoveredOutputs, applying build string prefix if set.
         let discovered_outputs: indexmap::IndexSet<DiscoveredOutput> = rendered_variants
             .into_iter()
             .map(|rendered| {
@@ -112,12 +120,17 @@ impl Protocol for RattlerBuildBackend {
                 } else {
                     Platform::NoArch
                 };
-                let build_string = recipe
+                let original_build_string = recipe
                     .build()
                     .string
                     .as_resolved()
                     .expect("build string should be resolved")
                     .to_string();
+                let build_string = if let Some(prefix) = &params.build_string_prefix {
+                    format!("{prefix}_{original_build_string}")
+                } else {
+                    original_build_string
+                };
                 DiscoveredOutput {
                     name: recipe.package().name().as_normalized().to_string(),
                     version: recipe.package().version().to_string(),
@@ -167,7 +180,9 @@ impl Protocol for RattlerBuildBackend {
             );
 
             let build = recipe.build();
-            let build_number = build.number.unwrap_or(0);
+            let build_number = params
+                .build_number_override
+                .unwrap_or_else(|| build.number.unwrap_or(0));
             let noarch = build.noarch.unwrap_or(NoArchType::none());
             let python_site_packages_path = build.python.site_packages_path.clone();
 
@@ -334,7 +349,13 @@ impl Protocol for RattlerBuildBackend {
         );
 
         // Parse the recipe into stage0
-        let stage0_recipe = rattler_build_recipe::parse_recipe(&source)?;
+        let mut stage0_recipe = rattler_build_recipe::parse_recipe(&source)?;
+
+        // Apply build number override before rendering so the build string is
+        // automatically updated.
+        if let Some(build_number) = params.output.build_number_override {
+            stage0_recipe.build.number = Some(Stage0Value::new_concrete(build_number, None));
+        }
 
         // Build render config
         let render_config = RenderConfig::new()
@@ -352,23 +373,30 @@ impl Protocol for RattlerBuildBackend {
             render_config,
         )?;
 
-        // Convert to DiscoveredOutputs
+        // Convert to DiscoveredOutputs, applying build string prefix if set.
         let discovered_outputs: indexmap::IndexSet<DiscoveredOutput> = rendered_variants
             .into_iter()
             .map(|rendered| {
-                let recipe = rendered.recipe;
+                let mut recipe = rendered.recipe;
                 let variant = rendered.variant;
                 let effective_target_platform = if recipe.build().noarch.is_none() {
                     host_platform
                 } else {
                     Platform::NoArch
                 };
-                let build_string = recipe
+                let original_build_string = recipe
                     .build()
                     .string
                     .as_resolved()
                     .expect("build string should be resolved")
                     .to_string();
+                let build_string = if let Some(prefix) = &params.output.build_string_prefix {
+                    let new_bs = format!("{prefix}_{original_build_string}");
+                    recipe.build.string = new_bs.clone().into();
+                    new_bs
+                } else {
+                    original_build_string
+                };
                 DiscoveredOutput {
                     name: recipe.package().name().as_normalized().to_string(),
                     version: recipe.package().version().to_string(),
@@ -713,6 +741,8 @@ mod tests {
                         variant_configuration: None,
                         variant_files: None,
                         work_directory: current_dir,
+                        build_number_override: None,
+                        build_string_prefix: None,
                     })
                     .await
                     .unwrap();
@@ -776,6 +806,8 @@ mod tests {
                 variant_configuration: None,
                 variant_files: Some(vec![variant_file.clone()]),
                 work_directory: temp_dir.path().to_path_buf(),
+                build_number_override: None,
+                build_string_prefix: None,
             })
             .await
             .unwrap();
@@ -822,6 +854,8 @@ mod tests {
                 variant_configuration: Some(variant_configuration),
                 variant_files: None,
                 work_directory: temp_dir.path().to_path_buf(),
+                build_number_override: None,
+                build_string_prefix: None,
             })
             .await
             .unwrap();
@@ -887,6 +921,8 @@ numpy:
                 variant_configuration: Some(variant_configuration),
                 variant_files: Some(vec![variant_file.clone()]),
                 work_directory: temp_dir.path().to_path_buf(),
+                build_number_override: None,
+                build_string_prefix: None,
             })
             .await
             .unwrap();
@@ -960,6 +996,8 @@ numpy:
                 variant_configuration: None,
                 variant_files: Some(vec![variant_file.clone()]),
                 work_directory: temp_dir.path().to_path_buf(),
+                build_number_override: None,
+                build_string_prefix: None,
             })
             .await
             .unwrap();

--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -177,6 +177,17 @@ pub struct CondaBuildV1Output {
 
     /// The variant configuration for the package.
     pub variant: BTreeMap<String, VariantValue>,
+
+    /// Override the build number for the output. If `None`, the build number
+    /// from the recipe is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_number_override: Option<u64>,
+
+    /// A string to prepend to the build string (e.g., a git hash or PR
+    /// identifier). If set, the build string will be
+    /// `<prefix>_<original_build_string>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_string_prefix: Option<String>,
 }
 
 /// Contains the result of the `conda/build_v1` request.

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -58,6 +58,17 @@ pub struct CondaOutputsParams {
     ///
     /// The directory may not yet exist.
     pub work_directory: PathBuf,
+
+    /// Override the build number for all outputs. If `None`, the build number
+    /// from the recipe is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_number_override: Option<u64>,
+
+    /// A string to prepend to the build string of all outputs (e.g., a git
+    /// hash or PR identifier). If set, the build string will be
+    /// `<prefix>_<original_build_string>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_string_prefix: Option<String>,
 }
 
 /// Contains the result of the `conda/outputs` request.

--- a/crates/pixi_cli/src/build.rs
+++ b/crates/pixi_cli/src/build.rs
@@ -67,6 +67,20 @@ pub struct Args {
     /// When a directory is provided, the command will search for supported manifest files within it.
     #[arg(long)]
     pub path: Option<PathBuf>,
+
+    /// Override the build number for the package (e.g., `--build-number 5`).
+    ///
+    /// When set, this replaces the build number in the recipe and updates the
+    /// build string accordingly.
+    #[arg(long)]
+    pub build_number: Option<u64>,
+
+    /// A string to prepend to the build string (e.g., `--build-string-prefix pr42`).
+    ///
+    /// When set, the build string becomes `<prefix>_<original_build_string>`.
+    /// This can be used to tag builds with a git hash, PR number, or other identifier.
+    #[arg(long)]
+    pub build_string_prefix: Option<String>,
 }
 
 /// Validate that the full path of package manifest exists and is a supported format.
@@ -287,6 +301,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         variant_configuration: Some(variant_configuration.clone()),
         variant_files: Some(variant_files.clone()),
         enabled_protocols: Default::default(),
+        build_number_override: args.build_number,
+        build_string_prefix: args.build_string_prefix.clone(),
     };
     let backend_metadata = command_dispatcher
         .build_backend_metadata(backend_metadata_spec.clone())
@@ -324,6 +340,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 clean: args.clean,
                 force: false,
                 build_profile: BuildProfile::Release,
+                build_number_override: args.build_number,
+                build_string_prefix: args.build_string_prefix.clone(),
             })
             .await?;
 

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -92,6 +92,20 @@ pub struct Args {
     /// Generate sigstore attestation (prefix.dev only)
     #[arg(long)]
     pub generate_attestation: bool,
+
+    /// Override the build number for the package (e.g., `--build-number 5`).
+    ///
+    /// When set, this replaces the build number in the recipe and updates the
+    /// build string accordingly.
+    #[arg(long)]
+    pub build_number: Option<u64>,
+
+    /// A string to prepend to the build string (e.g., `--build-string-prefix pr42`).
+    ///
+    /// When set, the build string becomes `<prefix>_<original_build_string>`.
+    /// This can be used to tag builds with a git hash, PR number, or other identifier.
+    #[arg(long)]
+    pub build_string_prefix: Option<String>,
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
@@ -199,6 +213,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         variant_configuration: Some(variant_configuration.clone()),
         variant_files: Some(variant_files.clone()),
         enabled_protocols: Default::default(),
+        build_number_override: args.build_number,
+        build_string_prefix: args.build_string_prefix.clone(),
     };
     let backend_metadata = command_dispatcher
         .build_backend_metadata(backend_metadata_spec.clone())
@@ -243,6 +259,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 clean: args.clean,
                 force: false,
                 build_profile: BuildProfile::Release,
+                build_number_override: args.build_number,
+                build_string_prefix: args.build_string_prefix.clone(),
             })
             .await?;
 

--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -92,6 +92,12 @@ pub struct BackendSourceBuildV1Method {
 
     /// Whether to build the package in editable mode.
     pub editable: bool,
+
+    /// Override the build number for this package.
+    pub build_number_override: Option<u64>,
+
+    /// A string to prepend to the build string of this package.
+    pub build_string_prefix: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -261,6 +267,8 @@ impl BackendSourceBuildSpec {
                             .parse()
                             .expect("found a package record with an unparsable subdir"),
                         variant: params.variant,
+                        build_number_override: params.build_number_override,
+                        build_string_prefix: params.build_string_prefix,
                     },
                     work_directory: work_directory.clone(),
                     output_directory: params.output_directory,

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -84,6 +84,12 @@ pub struct BuildBackendMetadataSpec {
     /// The protocols that are enabled for this source
     #[serde(skip_serializing_if = "crate::is_default")]
     pub enabled_protocols: EnabledProtocols,
+
+    /// Override the build number for all outputs.
+    pub build_number_override: Option<u64>,
+
+    /// A string to prepend to the build string of all outputs.
+    pub build_string_prefix: Option<String>,
 }
 
 /// The metadata of a source checkout.
@@ -205,6 +211,8 @@ impl BuildBackendMetadataSpec {
             build_environment: self.build_environment.clone(),
             enabled_protocols: self.enabled_protocols.clone(),
             source: manifest_source_location.clone().into(),
+            build_number_override: self.build_number_override,
+            build_string_prefix: self.build_string_prefix.clone(),
         };
         let cache_read_result = command_dispatcher
             .build_backend_metadata_cache()
@@ -550,6 +558,8 @@ impl BuildBackendMetadataSpec {
             channels: self.channels,
             host_platform: self.build_environment.host_platform,
             build_platform: self.build_environment.build_platform,
+            build_number_override: self.build_number_override,
+            build_string_prefix: self.build_string_prefix,
             variant_configuration: self.variant_configuration.clone().map(|variants| {
                 variants
                     .iter()

--- a/crates/pixi_command_dispatcher/src/cache/build_backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/build_backend_metadata.rs
@@ -59,6 +59,12 @@ pub struct BuildBackendMetadataCacheShard {
 
     /// The pinned source location
     pub source: CanonicalSourceCodeLocation,
+
+    /// Build number override, if any.
+    pub build_number_override: Option<u64>,
+
+    /// Build string prefix, if any.
+    pub build_string_prefix: Option<String>,
 }
 
 impl BuildBackendMetadataCache {

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -236,6 +236,8 @@ impl InstallPixiEnvironmentSpec {
                 force,
                 // When we install a pixi environment we always build in development mode.
                 build_profile: BuildProfile::Development,
+                build_number_override: None,
+                build_string_prefix: None,
             })
             .await?;
 

--- a/crates/pixi_command_dispatcher/src/solve_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/mod.rs
@@ -296,6 +296,8 @@ impl PixiEnvironmentSpec {
                         variant_configuration,
                         variant_files,
                         enabled_protocols,
+                        build_number_override: None,
+                        build_string_prefix: None,
                     },
                 };
 

--- a/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/source_metadata_collector.rs
@@ -201,6 +201,8 @@ impl SourceMetadataCollector {
                     variant_configuration: self.variant_configuration.clone(),
                     variant_files: self.variant_files.clone(),
                     enabled_protocols: self.enabled_protocols.clone(),
+                    build_number_override: None,
+                    build_string_prefix: None,
                 },
             })
             .await

--- a/crates/pixi_command_dispatcher/src/source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/source_build/mod.rs
@@ -103,6 +103,12 @@ pub struct SourceBuildSpec {
 
     /// Force rebuild even if the build cache is up to date.
     pub force: bool,
+
+    /// Override the build number for this package.
+    pub build_number_override: Option<u64>,
+
+    /// A string to prepend to the build string of this package.
+    pub build_string_prefix: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -582,6 +588,8 @@ impl SourceBuildSpec {
                     variant_files: self.variant_files.clone(),
                     work_directory: work_directory.clone(),
                     channels: self.channels.clone(),
+                    build_number_override: self.build_number_override,
+                    build_string_prefix: self.build_string_prefix.clone(),
                 },
                 move |line| {
                     let _err = futures::executor::block_on(log_sink.send(line));
@@ -817,6 +825,8 @@ impl SourceBuildSpec {
                     },
                     variant: output.metadata.variant,
                     output_directory: self.output_directory,
+                    build_number_override: self.build_number_override,
+                    build_string_prefix: self.build_string_prefix.clone(),
                 }),
                 backend,
                 package: self.package,

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -728,6 +728,8 @@ pub async fn test_dev_source_metadata() {
             variant_files: None,
             enabled_protocols: Default::default(),
             preferred_build_source: None,
+            build_number_override: None,
+            build_string_prefix: None,
         },
     };
 
@@ -819,6 +821,8 @@ pub async fn test_dev_source_metadata_package_not_provided() {
             variant_files: None,
             enabled_protocols: Default::default(),
             preferred_build_source: None,
+            build_number_override: None,
+            build_string_prefix: None,
         },
     };
 
@@ -894,6 +898,8 @@ pub async fn test_dev_source_metadata_with_variants() {
             variant_files: None,
             enabled_protocols: Default::default(),
             preferred_build_source: None,
+            build_number_override: None,
+            build_string_prefix: None,
         },
     };
 
@@ -1653,6 +1659,8 @@ pub async fn test_metadata_not_refetched_when_no_files_changed() {
             variant_files: None,
             enabled_protocols: Default::default(),
             preferred_build_source: None,
+            build_number_override: None,
+            build_string_prefix: None,
         },
     };
 
@@ -1753,6 +1761,8 @@ pub async fn test_metadata_refetched_when_source_file_modified() {
             variant_files: None,
             enabled_protocols: Default::default(),
             preferred_build_source: None,
+            build_number_override: None,
+            build_string_prefix: None,
         },
     };
 

--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -1247,6 +1247,8 @@ async fn verify_source_metadata(
                     variant_configuration: Some(variants),
                     variant_files: Some(variant_files),
                     enabled_protocols: EnabledProtocols::default(),
+                    build_number_override: None,
+                    build_string_prefix: None,
                 },
             };
 
@@ -1630,6 +1632,8 @@ async fn resolve_single_dev_dependency(
             variant_configuration: Some(variants),
             variant_files: Some(variant_files),
             enabled_protocols: Default::default(),
+            build_number_override: None,
+            build_string_prefix: None,
         },
     };
 

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -1430,6 +1430,8 @@ impl Project {
             variant_configuration: None,
             variant_files: None,
             enabled_protocols: Default::default(),
+            build_number_override: None,
+            build_string_prefix: None,
         };
 
         // Get the metadata using the command dispatcher

--- a/docs/reference/cli/pixi/build.md
+++ b/docs/reference/cli/pixi/build.md
@@ -29,6 +29,10 @@ pixi build [OPTIONS]
 :  Whether to clean the build directory before building
 - <a id="arg---path" href="#arg---path">`--path <PATH>`</a>
 :  The path to a directory containing a package manifest, or to a specific manifest file
+- <a id="arg---build-number" href="#arg---build-number">`--build-number <BUILD_NUMBER>`</a>
+:  Override the build number for the package (e.g., `--build-number 5`)
+- <a id="arg---build-string-prefix" href="#arg---build-string-prefix">`--build-string-prefix <BUILD_STRING_PREFIX>`</a>
+:  A string to prepend to the build string (e.g., `--build-string-prefix pr42`)
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>

--- a/docs/reference/cli/pixi/publish.md
+++ b/docs/reference/cli/pixi/publish.md
@@ -37,6 +37,10 @@ pixi publish [OPTIONS] --to <TO>
 <br>**options**: `true`, `false`
 - <a id="arg---generate-attestation" href="#arg---generate-attestation">`--generate-attestation`</a>
 :  Generate sigstore attestation (prefix.dev only)
+- <a id="arg---build-number" href="#arg---build-number">`--build-number <BUILD_NUMBER>`</a>
+:  Override the build number for the package (e.g., `--build-number 5`)
+- <a id="arg---build-string-prefix" href="#arg---build-string-prefix">`--build-string-prefix <BUILD_STRING_PREFIX>`</a>
+:  A string to prepend to the build string (e.g., `--build-string-prefix pr42`)
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>


### PR DESCRIPTION
### Description

This is a slight modification to teh `--build-string` argument. In this one we allow only modifying a prefix of the build string in order to keep the variant hash intact.

  - `--build-number <N>`: Overrides the build number in the recipe before rendering, so the build string is automatically updated (e.g., `pyh4616a5c_5` instead of `pyh4616a5c_0`).
  - `--build-string-prefix <PREFIX>`: Prepends a custom string to the final build string (e.g., `pr42_pyh4616a5c_0`). Useful for tagging CI builds with a git hash, PR number, or branch name.
  - Both flags work together: `--build-number 5 --build-string-prefix pr42` → `pr42_pyh4616a5c_5`.

### How Has This Been Tested?

I've tested it with the cpp_sdl example, eg.

```
cargo b --package pixi-build-cmake
export PIXI_BUILD_BACKEND_OVERRIDE=pixi-build-cmake=/Users/wolfv/Programs/pixi/target/debug/pixi-build-cmake

cargo r -- build --build-string-prefix xxx --build-number 1324
 WARN overriding build backend with: pixi-build-python=/Users/wolfv/Programs/pixi/target/debug/pixi-build-python,pixi-build-cmake=/Users/wolfv/Programs/pixi/target/debug/pixi-build-cmake
 WARN metadata cache disabled for build backend 'pixi-build-cmake' (system/path-based backends always regenerate metadata)

 ╭─ Running build for recipe: sdl_example-0.1.0-xxx_h60d57d3_1324
 │
 │ ╭─ Fetching source code
 │ │ No sources to fetch
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Externally resolved dependencies recipe: sdl_example-0.1.0-xxx_h60d57d3_1324
 │ │
 │ │ Resolved build dependencies(sdl_example-0.1.0-xxx_h60d57d3_1324):
```

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
