### PR TITLE
docs: document custom build-variant keys as environment variables

### DIFF
--- a/docs/build/variants.md
+++ b/docs/build/variants.md
@@ -90,39 +90,6 @@ python_rich        0.1.0       pyhbf21a9e_0                   conda  python_rich
 ```
 
 
-## Custom Variant Keys as Environment Variables (rattler-build backend)
-
-When using the `pixi-build-rattler-build` backend, build variants are not limited to dependency versions and compiler selection.
-Any variant key that is not a recognized language key (like `python`, `numpy`, `r`, etc.) is automatically exported as an **environment variable** during the build.
-
-This is useful for passing configuration to build scripts without modifying the recipe itself.
-For example, to override the macOS sysroot used during compilation:
-
-```toml title="pixi.toml"
-[workspace.target.osx.build-variants]
-CONDA_BUILD_SYSROOT = ["/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk"]
-```
-
-During the build, `CONDA_BUILD_SYSROOT` will be set as an environment variable and available to the build script.
-This works because `rattler-build` converts all non-language variant keys into environment variables.
-
-!!! note
-    This behavior is specific to the `pixi-build-rattler-build` backend. Other backends may handle custom variant keys differently.
-
-Custom variant keys can also be used in recipe templates via Jinja:
-
-```yaml title="recipe.yaml"
-build:
-  script:
-    env:
-      MY_FLAG: ${{ my_custom_flag }}
-```
-
-```toml title="pixi.toml"
-[workspace.build-variants]
-my_custom_flag = ["enabled"]
-```
-
 ## Conclusion
 
 In this tutorial, we showed how to use variants to build multiple versions of a single package.


### PR DESCRIPTION
### Description

Document that arbitrary build-variant keys (not just compilers/languages) are exported as environment variables during the build. Apparently, this behavior already works via rattler-build's `env_vars_from_variant()` function, which exports all non-language variant keys as env vars — it just wasn't documented.

Discovered while working on conda-forge/tapi-feedstock#16, where we needed to override `CONDA_BUILD_SYSROOT` during a pixi-build source build without modifying the recipe itself. Setting it as a build-variant in the workspace worked out of the box:

```toml
[workspace.target.osx.build-variants]
CONDA_BUILD_SYSROOT = ["/Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk"]
```

Changes:
- Add "Custom Variant Keys as Environment Variables" section to the variants tutorial
- Add a note and example to the manifest reference build-variants section


Relevant repo: https://github.com/tdejager/tapi-arm64e-repro

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation