### PR TITLE
refactor: don't use debug_dir at all in backend configs

### DIFF
--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -40,11 +40,7 @@ mod imp {
             self.debug_dir.as_deref()
         }
 
-        fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-            if target_config.debug_dir.is_some() {
-                miette::bail!("`debug_dir` cannot have a target specific value");
-            }
-
+        fn merge_with_target_config(&self, _target_config: &Self) -> miette::Result<Self> {
             Ok(Self {
                 debug_dir: self.debug_dir.clone(),
             })

--- a/crates/pixi_build_cmake/src/config.rs
+++ b/crates/pixi_build_cmake/src/config.rs
@@ -34,14 +34,9 @@ impl BackendConfig for CMakeBackendConfig {
     /// Target-specific values override base values using the following rules:
     /// - extra_args: Platform-specific completely replaces base
     /// - env: Platform env vars override base, others merge
-    /// - debug_dir: Not allowed to have target specific value
     /// - extra_input_globs: Platform-specific completely replaces base
     /// - compilers: Platform-specific completely replaces base
     fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
         Ok(Self {
             extra_args: if target_config.extra_args.is_empty() {
                 self.extra_args.clone()
@@ -163,23 +158,5 @@ mod tests {
         assert_eq!(merged.debug_dir, Some(PathBuf::from("/base/debug")));
         assert_eq!(merged.extra_input_globs, vec!["*.base".to_string()]);
         assert_eq!(merged.compilers, Some(vec!["cxx".to_string()]));
-    }
-
-    #[test]
-    fn test_merge_target_debug_dir_error() {
-        let base_config = CMakeBackendConfig {
-            debug_dir: Some(PathBuf::from("/base/debug")),
-            ..Default::default()
-        };
-
-        let target_config = CMakeBackendConfig {
-            debug_dir: Some(PathBuf::from("/target/debug")),
-            ..Default::default()
-        };
-
-        let result = base_config.merge_with_target_config(&target_config);
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-        assert!(error_msg.contains("`debug_dir` cannot have a target specific value"));
     }
 }

--- a/crates/pixi_build_mojo/src/config.rs
+++ b/crates/pixi_build_mojo/src/config.rs
@@ -44,17 +44,12 @@ impl BackendConfig for MojoBackendConfig {
     /// Target-specific values override base values using the following rules:
     ///
     /// - env: Platform env vars override base, others merge
-    /// - debug_dir: Not allowed to have target specific value
     /// - extra_input_globs: Platform-specific completely replaces base
     /// - bins: Any bins with matching not-None names will be merged,
     ///   Any set-settings on the platform specific pkg override base
     ///   Any bins found only in target_config will be kept
     /// - pkg: Any set-settings on the platform specific pkg override base
     fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
         let pkg = if target_config.pkg.is_some() {
             if self.pkg.is_some() {
                 Some(

--- a/crates/pixi_build_python/src/config.rs
+++ b/crates/pixi_build_python/src/config.rs
@@ -74,13 +74,8 @@ impl BackendConfig for PythonBackendConfig {
     /// - noarch: Platform-specific takes precedence (critical for cross-platform)
     /// - env: Platform env vars override base, others merge
     /// - extra_args: Platform-specific completely replaces base
-    /// - debug_dir: Not allowed to have target specific value
     /// - extra_input_globs: Platform-specific completely replaces base
     fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
         Ok(Self {
             noarch: target_config.noarch.or(self.noarch),
             env: {
@@ -329,23 +324,5 @@ mod tests {
 
         // Target value should override base value
         assert_eq!(merged.noarch, Some(false));
-    }
-
-    #[test]
-    fn test_merge_target_debug_dir_error() {
-        let base_config = PythonBackendConfig {
-            debug_dir: Some(PathBuf::from("/base/debug")),
-            ..Default::default()
-        };
-
-        let target_config = PythonBackendConfig {
-            debug_dir: Some(PathBuf::from("/target/debug")),
-            ..Default::default()
-        };
-
-        let result = base_config.merge_with_target_config(&target_config);
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-        assert!(error_msg.contains("`debug_dir` cannot have a target specific value"));
     }
 }

--- a/crates/pixi_build_r/src/config.rs
+++ b/crates/pixi_build_r/src/config.rs
@@ -42,10 +42,6 @@ impl BackendConfig for RBackendConfig {
     }
 
     fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
         Ok(Self {
             extra_args: if target_config.extra_args.is_empty() {
                 self.extra_args.clone()
@@ -151,23 +147,5 @@ mod tests {
 
         // Base channels should be used (target is None)
         assert_eq!(merged.channels, Some(vec!["conda-forge".to_string()]));
-    }
-
-    #[test]
-    fn test_debug_dir_target_specific_error() {
-        let base_config = RBackendConfig::default();
-        let target_config = RBackendConfig {
-            debug_dir: Some(PathBuf::from("/some/path")),
-            ..Default::default()
-        };
-
-        let result = base_config.merge_with_target_config(&target_config);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("debug_dir` cannot have a target specific value")
-        );
     }
 }

--- a/crates/pixi_build_rattler_build/src/config.rs
+++ b/crates/pixi_build_rattler_build/src/config.rs
@@ -27,14 +27,9 @@ impl BackendConfig for RattlerBuildBackendConfig {
 
     /// Merge this configuration with a target-specific configuration.
     /// Target-specific values override base values using the following rules:
-    /// - debug_dir: Not allowed to have target specific value
     /// - extra_input_globs: Platform-specific completely replaces base
     /// - experimental: Not allowed to have target specific value
     fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
         if target_config.experimental.is_some() {
             miette::bail!("`experimental` cannot have a target specific value");
         }
@@ -119,24 +114,6 @@ mod tests {
         assert_eq!(merged.extra_input_globs, vec!["*.base".to_string()]);
         // experimental should be true when base has it enabled
         assert_eq!(merged.experimental, Some(true));
-    }
-
-    #[test]
-    fn test_merge_target_debug_dir_error() {
-        let base_config = RattlerBuildBackendConfig {
-            debug_dir: Some(PathBuf::from("/base/debug")),
-            ..Default::default()
-        };
-
-        let target_config = RattlerBuildBackendConfig {
-            debug_dir: Some(PathBuf::from("/target/debug")),
-            ..Default::default()
-        };
-
-        let result = base_config.merge_with_target_config(&target_config);
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-        assert!(error_msg.contains("`debug_dir` cannot have a target specific value"));
     }
 
     #[test]

--- a/crates/pixi_build_rust/src/config.rs
+++ b/crates/pixi_build_rust/src/config.rs
@@ -89,13 +89,8 @@ impl BackendConfig for RustBackendConfig {
     /// Target-specific values override base values using the following rules:
     /// - extra_args: Platform-specific completely replaces base
     /// - env: Platform env vars override base, others merge
-    /// - debug_dir: Not allowed to have target specific value
     /// - extra_input_globs: Platform-specific completely replaces base
     fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
         Ok(Self {
             extra_args: if target_config.extra_args.is_empty() {
                 self.extra_args.clone()
@@ -271,23 +266,5 @@ mod tests {
         assert_eq!(merged.extra_input_globs, vec!["*.base".to_string()]);
         assert_eq!(merged.compilers, Some(vec!["rust".to_string()]));
         assert!(merged.binaries.is_empty());
-    }
-
-    #[test]
-    fn test_merge_target_debug_dir_error() {
-        let base_config = RustBackendConfig {
-            debug_dir: Some(PathBuf::from("/base/debug")),
-            ..Default::default()
-        };
-
-        let target_config = RustBackendConfig {
-            debug_dir: Some(PathBuf::from("/target/debug")),
-            ..Default::default()
-        };
-
-        let result = base_config.merge_with_target_config(&target_config);
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-        assert!(error_msg.contains("`debug_dir` cannot have a target specific value"));
     }
 }

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -63,13 +63,13 @@ pixi_utils = { workspace = true, default-features = false }
 pixi_uv_conversions = { workspace = true }
 rattler = { workspace = true, features = ["cli-tools", "indicatif"] }
 rattler_conda_types = { workspace = true }
+rattler_index = { workspace = true }
 rattler_lock = { workspace = true }
 rattler_networking = { workspace = true, default-features = false }
-rattler_shell = { workspace = true, features = ["sysinfo"] }
-rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
-rattler_index = { workspace = true }
 rattler_package_streaming = { workspace = true }
 rattler_s3 = { workspace = true }
+rattler_shell = { workspace = true, features = ["sysinfo"] }
+rattler_solve = { workspace = true, features = ["resolvo", "serde"] }
 rattler_upload = { workspace = true }
 rattler_virtual_packages = { workspace = true }
 regex = { workspace = true }

--- a/pixi-build-backends/py-pixi-build-backend/src/types/config.rs
+++ b/pixi-build-backends/py-pixi-build-backend/src/types/config.rs
@@ -57,11 +57,7 @@ impl BackendConfig for PyBackendConfig {
         self.debug_dir.as_deref()
     }
 
-    fn merge_with_target_config(&self, target_config: &Self) -> miette::Result<Self> {
-        if target_config.debug_dir.is_some() {
-            miette::bail!("`debug_dir` cannot have a target specific value");
-        }
-
+    fn merge_with_target_config(&self, _target_config: &Self) -> miette::Result<Self> {
         Ok(self.clone())
     }
 }


### PR DESCRIPTION
### Description

Stop doing things with the `debug_dir` config. We don't use it, so no point in handling errors or testing it out. We still keep the entry for backwards-compatibility.


### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
