### PR TITLE
chore: log pypi cache usage at the `info` level

### DIFF
--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -706,26 +706,26 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         }
 
         if !install_missing.is_empty() {
-            tracing::debug!(
+            tracing::info!(
                 "*installing* from remote because no version is cached: {}",
                 install_missing.iter().join(", ")
             );
         }
         if !install_stale.is_empty() {
-            tracing::debug!(
+            tracing::info!(
                 "*installing* from remote because cached version is stale: {}",
                 install_stale.iter().join(", ")
             );
         }
         if !install_cached.is_empty() {
-            tracing::debug!(
+            tracing::info!(
                 "*installing* cached version because cache is up-to-date: {}",
                 install_cached.iter().join(", ")
             );
         }
 
         if !reinstalls.is_empty() {
-            tracing::debug!(
+            tracing::info!(
                 "*re-installing* following packages: {}",
                 reinstalls
                     .iter()


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Partially resolves this issue:
- https://github.com/prefix-dev/pixi/issues/3677#issuecomment-3910871427

Related to my investigations here:
- https://github.com/prefix-dev/pixi/issues/5507

I want to surface this information to developers by default as it's important information to debug performance issues with builds as well as to minimise infrastructure costs.

### How Has This Been Tested?

Manual test below,

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
