### PR TITLE
fix(search): show only package names when using `-l 0`

### DIFF
--- a/crates/pixi/tests/integration_rust/search_tests.rs
+++ b/crates/pixi/tests/integration_rust/search_tests.rs
@@ -310,6 +310,66 @@ async fn test_search_multiple_packages_compact_view() {
 }
 
 #[tokio::test]
+async fn test_search_limit_zero_names_only() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+
+    package_database.add_package(
+        Package::build("cargo-edit", "1.0.0")
+            .with_subdir(Platform::NoArch)
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("cargo-edit", "2.0.0")
+            .with_subdir(Platform::NoArch)
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("cargo-audit", "0.5.0")
+            .with_subdir(Platform::NoArch)
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("cargo-watch", "3.0.0")
+            .with_subdir(Platform::NoArch)
+            .finish(),
+    );
+
+    let temp_dir = TempDir::new().unwrap();
+    let channel_dir = temp_dir.path().join("channel");
+    package_database.write_repodata(&channel_dir).await.unwrap();
+    let channel = Url::from_file_path(channel_dir).unwrap();
+    let platform = Platform::current();
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+    [project]
+    name = "test-limit-zero"
+    channels = ["{channel}"]
+    platforms = ["{platform}"]
+    "#
+    ))
+    .unwrap();
+
+    // Multi-package: limit=0 should print only names
+    let mut out = Vec::new();
+    let mut builder = pixi.search("cargo*".to_string());
+    builder.args.limit = 0;
+    builder.args.limit_packages = -1;
+    let _result = search::execute_impl(builder.args, &mut out).await.unwrap();
+    let output = strip_ansi(&String::from_utf8(out).unwrap());
+    assert_eq!(output.trim(), "cargo-audit\ncargo-edit\ncargo-watch");
+
+    // Single package: limit=0 should also print only name
+    let mut out = Vec::new();
+    let mut builder = pixi.search("cargo-edit".to_string());
+    builder.args.limit = 0;
+    let _result = search::execute_impl(builder.args, &mut out).await.unwrap();
+    let output = strip_ansi(&String::from_utf8(out).unwrap());
+    assert_eq!(output.trim(), "cargo-edit");
+}
+
+#[tokio::test]
 async fn test_search_json_output() {
     setup_tracing();
 

--- a/crates/pixi_cli/src/search.rs
+++ b/crates/pixi_cli/src/search.rs
@@ -206,7 +206,12 @@ fn print_search_results<W: Write>(
 
     // Single package name => show detailed view
     if by_name.len() == 1 {
-        let (_, records) = by_name.iter().next().expect("by_name has exactly 1 entry");
+        let (name, records) = by_name.iter().next().expect("by_name has exactly 1 entry");
+        // When limit is 0, only print the package name
+        if limit_versions == Some(0) {
+            writeln!(out, "{}", name.as_source())?;
+            return Ok(());
+        }
         let newest = records
             .last()
             .expect("records is non-empty since packages is non-empty");
@@ -223,8 +228,14 @@ fn print_search_results<W: Write>(
         if i >= n_packages {
             break;
         }
-        if i > 0 {
+        if i > 0 && n_versions > 0 {
             writeln!(out)?;
+        }
+
+        // When limit is 0, only print the package name
+        if n_versions == 0 {
+            writeln!(out, "{}", name.as_source())?;
+            continue;
         }
 
         let total_versions = records.len();


### PR DESCRIPTION
Closes #5763

When `pixi search cargo* -l 0` is used, the output now shows a clean list of package names without version info or formatting:

```
cargo-audit
cargo-edit
cargo-watch
```

Works for both single-package and multi-package results. Useful for scripting and piping into other tools.

Test included that verifies both cases.