### PR TITLE
fix: Do not error out on empty environments in `pixi list --json`

### DIFF
--- a/crates/pixi_cli/src/list.rs
+++ b/crates/pixi_cli/src/list.rs
@@ -230,7 +230,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
     }
 
-    if packages_to_output.is_empty() {
+    if packages_to_output.is_empty() && !args.json {
         miette::bail!(
             "No packages found in '{}' environment for '{}' platform.",
             environment.name().fancy_display(),


### PR DESCRIPTION
### Description

Just a drive-by as this was tripping up test of 810 repos with pixi.toml in the root ;-)

Thsi should probably be on top of main, but I can test it way easier here and its a tiny change.

### How Has This Been Tested?

By running it.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
