### PR TITLE
Make pixi upgrade also upgrade the lock file format

### DIFF
--- a/crates/pixi/tests/integration_rust/upgrade_tests.rs
+++ b/crates/pixi/tests/integration_rust/upgrade_tests.rs
@@ -77,6 +77,7 @@ async fn pypi_dependency_index_preserved_on_upgrade() {
             &[],
             true,
             args.dry_run,
+            false,
         )
         .await
         .unwrap();

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -90,6 +90,7 @@ pub async fn add_conda_dep(
         &dep_options.platforms,
         false,
         dry_run,
+        false,
     ))
     .await
     {
@@ -133,6 +134,7 @@ pub async fn add_pypi_dep(
         &options.platforms,
         editable,
         dry_run,
+        false,
     ))
     .await
     {

--- a/crates/pixi_api/src/workspace/list/mod.rs
+++ b/crates/pixi_api/src/workspace/list/mod.rs
@@ -36,6 +36,7 @@ pub async fn list(
             lock_file_usage,
             no_install,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         })
         .await?
         .0

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -47,6 +47,7 @@ pub async fn reinstall<I: Interface>(
                 lock_file_usage,
                 no_install: false,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                ..Default::default()
             },
             options.reinstall_packages.clone(),
             &InstallFilter::default(),

--- a/crates/pixi_api/src/workspace/remove/mod.rs
+++ b/crates/pixi_api/src/workspace/remove/mod.rs
@@ -60,6 +60,7 @@ pub async fn remove_conda_deps(
                 lock_file_usage: options.lock_file_usage,
                 no_install: options.no_install,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                ..Default::default()
             },
             ReinstallPackages::default(),
             &InstallFilter::default(),
@@ -97,6 +98,7 @@ pub async fn remove_pypi_deps(
                 lock_file_usage: options.lock_file_usage,
                 no_install: options.no_install,
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                ..Default::default()
             },
             ReinstallPackages::default(),
             &InstallFilter::default(),

--- a/crates/pixi_api/src/workspace/workspace/channel.rs
+++ b/crates/pixi_api/src/workspace/workspace/channel.rs
@@ -57,6 +57,7 @@ pub async fn add<I: Interface>(
             lock_file_usage: options.lock_file_usage,
             no_install: options.no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &InstallFilter::default(),
@@ -98,6 +99,7 @@ pub async fn remove<I: Interface>(
             lock_file_usage: options.lock_file_usage,
             no_install: options.no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &InstallFilter::default(),
@@ -137,6 +139,7 @@ pub async fn set<I: Interface>(
             lock_file_usage: options.lock_file_usage,
             no_install: options.no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &InstallFilter::default(),

--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -44,6 +44,7 @@ pub async fn add<I: Interface>(
             lock_file_usage: LockFileUsage::Update,
             no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &InstallFilter::default(),
@@ -88,6 +89,7 @@ pub async fn remove<I: Interface>(
             lock_file_usage: LockFileUsage::Update,
             no_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &InstallFilter::default(),

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -117,6 +117,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_file_usage.to_usage(),
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &filter,

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -58,6 +58,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 LockFileUsage::Update
             },
             no_install: args.no_install_config.no_install || args.dry_run,
+            upgrade_lock_file_format: true,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
         })
         .await?;

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -169,6 +169,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_and_install_config.lock_file_usage()?,
             no_install: args.lock_and_install_config.no_install(),
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         })
         .await?
         .0;

--- a/crates/pixi_cli/src/shell.rs
+++ b/crates/pixi_cli/src/shell.rs
@@ -340,6 +340,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_and_install_config.lock_file_usage()?,
             no_install: args.lock_and_install_config.no_install(),
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &InstallFilter::default(),

--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -172,6 +172,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_and_install_config.lock_file_usage()?,
             no_install: args.lock_and_install_config.no_install(),
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         },
         ReinstallPackages::default(),
         &pixi_core::environment::InstallFilter::default(),

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -78,6 +78,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
             no_install: args.no_install_config.no_install,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         })
         .await
         .wrap_err("Failed to update lock file")?

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -166,6 +166,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_lock_file(relaxed_lock_file.clone())
         .with_no_install(args.no_install)
         .with_update_targets(specs.packages.clone())
+        .with_upgrade_lock_file_format(true)
         .finish()
         .await?
         .update()

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -9,6 +9,7 @@ use pep508_rs::Requirement;
 use pixi_config::ConfigCli;
 use pixi_core::{
     WorkspaceLocator,
+    environment::LockFileUsage,
     lock_file::UpdateContext,
     workspace::{MatchSpecs, PypiDeps, WorkspaceMut},
 };
@@ -168,6 +169,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     &[],
                     false,
                     args.dry_run,
+                    true,
                 )
                 .await?
         {
@@ -196,6 +198,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     &[platform],
                     false,
                     args.dry_run,
+                    true,
                 )
                 .await?
             {
@@ -211,6 +214,25 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 printed_any = true;
             }
         }
+    }
+
+    // If no packages were upgraded, the lock file may still use an older
+    // format. Force a format upgrade so that `pixi upgrade` always produces
+    // a lock file in the latest format.
+    if !printed_any
+        && !args.dry_run
+        && lock_file_usage == LockFileUsage::Update
+        && original_lock_file.version() < rattler_lock::FileFormatVersion::LATEST
+    {
+        let derived = UpdateContext::builder(workspace.workspace(), None)?
+            .with_lock_file(original_lock_file.clone())
+            .with_no_install(args.no_install_config.no_install)
+            .with_upgrade_lock_file_format(true)
+            .finish()
+            .await?
+            .update()
+            .await?;
+        derived.write_to_disk()?;
     }
 
     // If JSON is requested, emit a single combined diff once.

--- a/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
@@ -181,6 +181,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
             no_install: args.no_install_config.no_install,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
         })
         .await?
         .0

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -589,6 +589,7 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
             lock_file_usage: update_lock_file_options.lock_file_usage,
             no_install,
             max_concurrent_solves: update_lock_file_options.max_concurrent_solves,
+            ..Default::default()
         })
         .await?
         .0;

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -300,14 +300,24 @@ impl Workspace {
         }
 
         // Check which environments are out of date.
+        let needs_format_upgrade = lock_file.version() < rattler_lock::FileFormatVersion::LATEST;
         let outdated = OutdatedEnvironments::from_workspace_and_lock_file(
             self,
             command_dispatcher.clone(),
             &lock_file,
         )
         .await;
-        if outdated.is_empty() {
-            tracing::info!("the lock-file is up-to-date");
+        if outdated.is_empty() && !(needs_format_upgrade && options.upgrade_lock_file_format) {
+            if needs_format_upgrade {
+                tracing::warn!(
+                    "the lock file is up-to-date but uses an older format (v{}), \
+                     run `pixi update` to upgrade to v{} for improved reproducibility",
+                    lock_file.version(),
+                    rattler_lock::FileFormatVersion::LATEST,
+                );
+            } else {
+                tracing::info!("the lock-file is up-to-date");
+            }
 
             // If no-environment is outdated we can return early.
             // Pass the build_caches even if empty, in case conda_prefix needs them
@@ -335,12 +345,16 @@ impl Workspace {
         }
 
         // Construct an update context and perform the actual update.
+        // The format upgrade logic (marking all environments as outdated when
+        // the lock file uses an older format) is handled inside
+        // `UpdateContextBuilder::finish()`.
         let lock_file_derived_data = UpdateContext::builder(self, Some(command_dispatcher))?
             .with_package_cache(package_cache)
             .with_no_install(options.no_install)
             .with_outdated_environments(outdated)
             .with_lock_file(lock_file)
             .with_glob_hash_cache(glob_hash_cache)
+            .with_upgrade_lock_file_format(options.upgrade_lock_file_format)
             .finish()
             .await?
             .update()
@@ -450,6 +464,11 @@ pub struct UpdateLockFileOptions {
 
     /// Don't install anything to disk.
     pub no_install: bool,
+
+    /// If true, rewrite the lock file to the latest format version even when
+    /// its content is already up-to-date. The actual logic is handled by
+    /// `UpdateContextBuilder::with_upgrade_lock_file_format`.
+    pub upgrade_lock_file_format: bool,
 
     /// The maximum number of concurrent solves that are allowed to run. If this
     /// value is None a heuristic is used based on the number of cores
@@ -1331,6 +1350,10 @@ pub struct UpdateContextBuilder<'p> {
 
     /// Optional list of package names explicitly targeted for update.
     update_targets: Option<std::collections::HashSet<String>>,
+
+    /// If true, rewrite the lock file to the latest format version even when
+    /// its content is already up-to-date.
+    upgrade_lock_file_format: bool,
 }
 
 impl<'p> UpdateContextBuilder<'p> {
@@ -1386,6 +1409,17 @@ impl<'p> UpdateContextBuilder<'p> {
         }
     }
 
+    /// If true, upgrade the lock file to the latest format version even when
+    /// its content is already up-to-date. This forces a re-solve of all
+    /// environments so that records are rebuilt with the latest fields (e.g.
+    /// source-record timestamps).
+    pub fn with_upgrade_lock_file_format(self, upgrade: bool) -> Self {
+        Self {
+            upgrade_lock_file_format: upgrade,
+            ..self
+        }
+    }
+
     /// Sets the io concurrency semaphore to use when updating environments.
     #[allow(unused)]
     pub fn with_io_concurrency_semaphore(self, io_concurrency_limit: IoConcurrencyLimit) -> Self {
@@ -1421,6 +1455,27 @@ impl<'p> UpdateContextBuilder<'p> {
                 .await
             }
         };
+
+        // When upgrading the lock file format, force a full re-solve of all
+        // environments so that records are rebuilt with the latest fields
+        // (e.g. source-record timestamps). Simply re-serializing the old lock
+        // file would preserve the missing fields.
+        let needs_format_upgrade = lock_file.version() < rattler_lock::FileFormatVersion::LATEST;
+        if needs_format_upgrade && self.upgrade_lock_file_format {
+            tracing::warn!(
+                "the lock file is up-to-date but uses an older format (v{}), \
+                 re-solving all environments using locked content to upgrade to v{}",
+                lock_file.version(),
+                rattler_lock::FileFormatVersion::LATEST,
+            );
+            for env in project.environments() {
+                outdated
+                    .conda
+                    .entry(env.clone())
+                    .or_default()
+                    .extend(env.platforms());
+            }
+        }
 
         // Extract the current conda records from the lock-file.
         let workspace_root = project.root();
@@ -1669,6 +1724,7 @@ impl<'p> UpdateContext<'p> {
             mapping_client: None,
             command_dispatcher,
             update_targets: None,
+            upgrade_lock_file_format: false,
         })
     }
 

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -250,6 +250,7 @@ impl WorkspaceMut {
         platforms: &[Platform],
         editable: bool,
         dry_run: bool,
+        upgrade_lock_file_format: bool,
     ) -> Result<Option<UpdateDeps>, miette::Error> {
         let mut conda_specs_to_add_constraints_for = IndexMap::new();
         let mut pypi_specs_to_add_constraints_for = IndexMap::new();
@@ -381,6 +382,7 @@ impl WorkspaceMut {
         } = UpdateContext::builder(self.workspace(), None)?
             .with_lock_file(unlocked_lock_file)
             .with_no_install(no_install || dry_run)
+            .with_upgrade_lock_file_format(upgrade_lock_file_format)
             .finish()
             .await?
             .update()


### PR DESCRIPTION
### Description

`pixi upgrade` now upgrades the lock file to the latest format version (v7), matching the behavior of `pixi lock` and `pixi update`.

The format upgrade logic has been abstracted into `UpdateContextBuilder::with_upgrade_lock_file_format()` so that all three commands share the same code path.

### How Has This Been Tested?

Compilation and existing tests pass.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code (Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code