### PR TITLE
fix(manifest): quote shell-special characters in task arguments

### DIFF
--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -866,7 +866,10 @@ impl Display for Task {
 pub fn quote(in_str: &str) -> Cow<'_, str> {
     if in_str.is_empty() {
         "\"\"".into()
-    } else if in_str.contains(['\t', '\r', '\n', ' ', '"', '[', ']', '(', ')', '{', '}', '&', '|', ';', '<', '>', '$', '*', '?', '!', '`']) {
+    } else if in_str.contains([
+        '\t', '\r', '\n', ' ', '"', '[', ']', '(', ')', '{', '}', '&', '|', ';', '<', '>', '$',
+        '*', '?', '!', '`',
+    ]) {
         let mut out: String = String::with_capacity(in_str.len() + 2);
         out.push('"');
         for c in in_str.chars() {

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -866,12 +866,12 @@ impl Display for Task {
 pub fn quote(in_str: &str) -> Cow<'_, str> {
     if in_str.is_empty() {
         "\"\"".into()
-    } else if in_str.contains(['\t', '\r', '\n', ' ', '[', ']']) {
+    } else if in_str.contains(['\t', '\r', '\n', ' ', '[', ']', '(', ')', '{', '}', '&', '|', ';', '<', '>', '$', '*', '?', '!', '`']) {
         let mut out: String = String::with_capacity(in_str.len() + 2);
         out.push('"');
         for c in in_str.chars() {
             match c {
-                '"' | '\\' => out.push('\\'),
+                '"' | '\\' | '$' | '`' => out.push('\\'),
                 _ => (),
             }
             out.push(c);
@@ -1102,15 +1102,21 @@ mod tests {
     fn test_quote() {
         assert_eq!(quote("foobar"), "foobar");
         assert_eq!(quote("foo bar"), "\"foo bar\"");
-        assert_eq!(quote("\""), "\"");
+        assert_eq!(quote("\""), "\"\\\"\"");
         assert_eq!(quote("foo \" bar"), "\"foo \\\" bar\"");
         assert_eq!(quote(""), "\"\"");
-        assert_eq!(quote("$PATH"), "$PATH");
+        // $ now triggers quoting and gets escaped
+        assert_eq!(quote("$PATH"), "\"\\$PATH\"");
         assert_eq!(
             quote("PATH=\"$PATH;build/Debug\""),
-            "PATH=\"$PATH;build/Debug\""
+            "\"PATH=\\\"\\$PATH;build/Debug\\\"\""
         );
         assert_eq!(quote("name=[64,64]"), "\"name=[64,64]\"");
+        // Shell-special characters now trigger quoting
+        assert_eq!(quote("(echo hello)"), "\"(echo hello)\"");
+        assert_eq!(quote("foo|bar"), "\"foo|bar\"");
+        assert_eq!(quote("a&&b"), "\"a&&b\"");
+        assert_eq!(quote("cmd`whoami`"), "\"cmd\\`whoami\\`\"");
     }
 
     #[test]

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -866,7 +866,7 @@ impl Display for Task {
 pub fn quote(in_str: &str) -> Cow<'_, str> {
     if in_str.is_empty() {
         "\"\"".into()
-    } else if in_str.contains(['\t', '\r', '\n', ' ', '[', ']', '(', ')', '{', '}', '&', '|', ';', '<', '>', '$', '*', '?', '!', '`']) {
+    } else if in_str.contains(['\t', '\r', '\n', ' ', '"', '[', ']', '(', ')', '{', '}', '&', '|', ';', '<', '>', '$', '*', '?', '!', '`']) {
         let mut out: String = String::with_capacity(in_str.len() + 2);
         out.push('"');
         for c in in_str.chars() {


### PR DESCRIPTION
## Problem

Task arguments containing shell metacharacters like `(`, `)`, `|`, `&`, `$`, `` ` ``, etc. are emitted unquoted, causing unexpected shell behavior. For example:

```toml
[tasks]
subshell = "echo (hello)"
```

Running `pixi run subshell` executes `(hello)` as a subshell instead of printing it literally.

## Root Cause

`task::quote()` in `crates/pixi_manifest/src/task.rs` only checks for `\t`, `\r`, `\n`, space, `[`, `]` when deciding whether to quote. It misses these shell-special characters: `(` `)` `{` `}` `&` `|` `;` `<` `>` `$` `*` `?` `!` `` ` ``.

Additionally, inside double-quoted strings, `$` and `` ` `` are not escaped, so even quoted strings can have unintended variable expansion or command substitution.

## Fix

1. Add all common shell metacharacters to the `contains()` trigger set
2. Escape `$` and `` ` `` inside double-quoted strings (alongside existing `"` and `\` escaping)
3. Update `test_quote()` to reflect new behavior

Fixes #5818