### PR TITLE
fix: Remove pypi-prerelease-mode from lockfile if not specified

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -620,19 +620,15 @@ pub fn verify_environment_satisfiability(
         });
     }
 
-    let locked_prerelease_mode = locked_environment
+    let locked_prerelease_mode: Option<PrereleaseMode> = locked_environment
         .solve_options()
         .pypi_prerelease_mode
-        .unwrap_or_default()
-        .into();
-    let expected_prerelease_mode = grouped_env
-        .pypi_options()
-        .prerelease_mode
-        .unwrap_or_default();
+        .map(Into::into);
+    let expected_prerelease_mode = grouped_env.pypi_options().prerelease_mode;
     if locked_prerelease_mode != expected_prerelease_mode {
         return Err(EnvironmentUnsat::PypiPrereleaseModeMismatch {
-            locked_mode: locked_prerelease_mode,
-            expected_mode: expected_prerelease_mode,
+            locked_mode: locked_prerelease_mode.unwrap_or_default(),
+            expected_mode: expected_prerelease_mode.unwrap_or_default(),
         });
     }
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -2033,8 +2033,6 @@ impl<'p> UpdateContext<'p> {
             let environment_name = environment.name().to_string();
             let grouped_env = GroupedEnvironment::from(environment.clone());
             let grouped_pypi_options = grouped_env.pypi_options();
-            let pypi_prerelease_mode = grouped_pypi_options.prerelease_mode.unwrap_or_default();
-
             let channel_config = project.channel_config();
             let channels: Vec<String> = grouped_env
                 .channels()
@@ -2058,7 +2056,9 @@ impl<'p> UpdateContext<'p> {
                         .unwrap_or_default()
                         .unwrap_or_default()
                         .into(),
-                    pypi_prerelease_mode: Some(pypi_prerelease_mode.into()),
+                    pypi_prerelease_mode: grouped_pypi_options
+                        .prerelease_mode
+                        .map(Into::into),
                 },
             );
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -2056,9 +2056,7 @@ impl<'p> UpdateContext<'p> {
                         .unwrap_or_default()
                         .unwrap_or_default()
                         .into(),
-                    pypi_prerelease_mode: grouped_pypi_options
-                        .prerelease_mode
-                        .map(Into::into),
+                    pypi_prerelease_mode: grouped_pypi_options.prerelease_mode.map(Into::into),
                 },
             );
 

--- a/crates/pixi_glob/src/snapshots/pixi_glob__glob_hash__test__glob_hash_case_1_satisfiability.snap
+++ b/crates/pixi_glob/src/snapshots/pixi_glob__glob_hash__test__glob_hash_case_1_satisfiability.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 Globs:
 - tests/data/satisfiability/source-dependency/**/*
-Hash: d8110813232260680c4d6f66a70849132b265539d100068626fd970d158bb3ff
+Hash: aed00eb035e5cae66b990586880308101b677d4029f96f7acedde036da33abca
 Matched files:
 - tests/data/satisfiability/source-dependency/child-package/pixi.toml
 - tests/data/satisfiability/source-dependency/pixi.lock

--- a/docs/source_files/pixi_workspaces/pixi_build/advanced_cpp/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/advanced_cpp/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/cpp/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/cpp/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/dev/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/dev/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/getting_started/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/getting_started/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/python/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/python/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/ros_ws/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/ros_ws/pixi.lock
@@ -4,8 +4,6 @@ environments:
     channels:
     - url: https://prefix.dev/robostack-jazzy/
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -121,8 +119,6 @@ environments:
   py311:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -239,8 +235,6 @@ environments:
   py312:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda

--- a/examples/develop/cpp-sdl/pixi.lock
+++ b/examples/develop/cpp-sdl/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/examples/docker/pixi.lock
+++ b/examples/docker/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -140,8 +138,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/examples/jupyterlab/pixi.lock
+++ b/examples/jupyterlab/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda

--- a/examples/pixi-build/array-api-extra/pixi.lock
+++ b/examples/pixi-build/array-api-extra/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/examples/pixi-build/cpp-git-source/pixi.lock
+++ b/examples/pixi-build/cpp-git-source/pixi.lock
@@ -3,8 +3,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/examples/pixi-build/cpp-sdl/pixi.lock
+++ b/examples/pixi-build/cpp-sdl/pixi.lock
@@ -4,8 +4,6 @@ environments:
     channels:
     - url: https://prefix.dev/pixi-build-backends/
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/examples/pixi-build/dev/pixi.lock
+++ b/examples/pixi-build/dev/pixi.lock
@@ -4,8 +4,6 @@ environments:
     channels:
     - url: https://prefix.dev/pixi-build-backends/
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/examples/pixi-build/recursive-run-dependencies/pixi.lock
+++ b/examples/pixi-build/recursive-run-dependencies/pixi.lock
@@ -4,8 +4,6 @@ environments:
     channels:
     - url: https://prefix.dev/pixi-build-backends/
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,8 +3,6 @@ environments:
   backends-release:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -188,8 +186,6 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -875,8 +871,6 @@ environments:
   dist:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -941,8 +935,6 @@ environments:
   docs:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1758,8 +1750,6 @@ environments:
   lefthook:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/lefthook-2.1.0-hfc2019e_0.conda
@@ -1774,8 +1764,6 @@ environments:
   python-test:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2131,8 +2119,6 @@ environments:
   recipes:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2168,8 +2154,6 @@ environments:
   release:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2466,8 +2450,6 @@ environments:
   rust-build:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2807,8 +2789,6 @@ environments:
   rust-test:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3147,8 +3127,6 @@ environments:
   schema:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3383,14 +3361,10 @@ environments:
   test:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages: {}
   trampoline:
     channels:
     - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/tests/data/non-satisfiability/changed-env-marker/pixi.lock
+++ b/tests/data/non-satisfiability/changed-env-marker/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda

--- a/tests/data/non-satisfiability/wheels-with-wrong-tags/pixi.lock
+++ b/tests/data/non-satisfiability/wheels-with-wrong-tags/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/tests/data/satisfiability/added-env-marker/pixi.lock
+++ b/tests/data/satisfiability/added-env-marker/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda

--- a/tests/data/satisfiability/source-dependency/pixi.lock
+++ b/tests/data/satisfiability/source-dependency/pixi.lock
@@ -4,8 +4,6 @@ environments:
     channels:
       - url: https://prefix.dev/pixi-build-backends/
       - url: https://prefix.dev/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
         - conda: child-package

--- a/tests/data/satisfiability/wheel-with-correct-tags/pixi.lock
+++ b/tests/data/satisfiability/wheel-with-correct-tags/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2

--- a/tests/data/workspaces/host-dependency/pixi.lock
+++ b/tests/data/workspaces/host-dependency/pixi.lock
@@ -2,7 +2,5 @@ version: 6
 environments:
   default:
     channels: []
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages: {}
 packages: []


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #5130

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: claude

prompt

```
pixi init && pixi add k9s always adds `pypi-prerelease-mode: if-necessary-or-explicit` to `pixi.lock`. this is not what i want. if i don't specify it in pixi.toml, it shouldn't get persisted in pixi.lock
```

answer by claude

```
  Problem: pixi init && pixi add k9s always wrote pypi-prerelease-mode: if-necessary-or-explicit into pixi.lock, even when the user never specified it in pixi.toml.

  Root cause: In update.rs:2036, grouped_pypi_options.prerelease_mode.unwrap_or_default() eagerly collapsed None into the default value, which then got wrapped in
  Some(...) and written to the lock file. The rattler_lock serializer correctly skips None values, but it was never given None.

  Fix (2 files + lock file cleanup):

  1. crates/pixi_core/src/lock_file/update.rs — Instead of unwrap_or_default() + Some(...), use .map(Into::into) to propagate None when the user didn't specify a
  prerelease mode.
  2. crates/pixi_core/src/lock_file/satisfiability/mod.rs — Compare Option<PrereleaseMode> values directly instead of unwrapping both sides to defaults. This correctly
  detects when a user adds/removes the setting.
  3. All pixi.lock files — Removed the spuriously persisted pypi-prerelease-mode: if-necessary-or-explicit + empty options: blocks from 23 lock files that never
  specified it in their manifests.

```

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
