### PR TITLE
fix: show requires-newer-pixi error before schema validation errors

### DIFF
--- a/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
@@ -35,15 +35,16 @@ pub enum Command {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
+    let is_verify = matches!(args.command, Command::Verify);
     let workspace_locator = WorkspaceLocator::for_cli()
         .with_search_start(args.workspace_config.workspace_locator_start())
-        .with_ignore_pixi_version_check(true);
+        .with_ignore_pixi_version_check(!is_verify);
 
     match args.command {
         Command::Get => get::execute(workspace_locator.locate()?).await?,
         Command::Set(args) => set::execute(workspace_locator.locate()?, args).await?,
         Command::Unset => unset::execute(workspace_locator.locate()?).await?,
-        Command::Verify => verify::execute(workspace_locator.locate()?).await?,
+        Command::Verify => verify::execute(workspace_locator.locate().map(|_| ()))?,
     }
 
     Ok(())

--- a/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
@@ -1,41 +1,37 @@
-use pixi_core::Workspace;
-use pixi_manifest::ExplicitManifestError;
+use pixi_core::WorkspaceLocatorError;
 
-pub async fn execute(workspace: Workspace) -> miette::Result<()> {
-    // exit code:
-    //   0: success
-    //   1: failed to parse manifest
-    //   2: failed to parse command line arguments
-    //   4: current pixi version is old
-    match workspace.verify_current_pixi_meets_requirement() {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            if let ExplicitManifestError::SelfVersionMatchError { .. } = e {
-                eprintln!(
-                    "Error:   {}{}",
-                    console::style(console::Emoji("× ", "")).red(),
-                    e
-                );
+/// exit code:
+///   0: success
+///   1: failed to parse manifest
+///   2: failed to parse command line arguments
+///   4: current pixi version is old
+pub fn execute(result: Result<(), WorkspaceLocatorError>) -> miette::Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(WorkspaceLocatorError::PixiVersionMismatch(e)) => {
+            eprintln!(
+                "Error:   {}{}",
+                console::style(console::Emoji("× ", "")).red(),
+                e
+            );
 
-                #[cfg(feature = "self_update")]
-                {
-                    eprintln!();
-                    eprintln!("Try running:\n  pixi self-update");
-                }
-
-                #[cfg(not(feature = "self_update"))]
-                {
-                    eprintln!();
-                    eprintln!(
-                        "Please update pixi using your system package manager or reinstall it.\n\
-             See: https://pixi.sh/latest/installation/"
-                    );
-                }
-
-                std::process::exit(4);
-            } else {
-                Err(e.into())
+            #[cfg(feature = "self_update")]
+            {
+                eprintln!();
+                eprintln!("Try running:\n  pixi self-update");
             }
+
+            #[cfg(not(feature = "self_update"))]
+            {
+                eprintln!();
+                eprintln!(
+                    "Please update pixi using your system package manager or reinstall it.\n\
+             See: https://pixi.sh/latest/installation/"
+                );
+            }
+
+            std::process::exit(4);
         }
+        Err(e) => Err(e.into()),
     }
 }

--- a/crates/pixi_core/src/lib.rs
+++ b/crates/pixi_core/src/lib.rs
@@ -11,4 +11,4 @@ pub mod signals;
 
 pub use environment::InstallFilter;
 pub use lock_file::UpdateLockFileOptions;
-pub use workspace::{DependencyType, Workspace, WorkspaceLocator};
+pub use workspace::{DependencyType, Workspace, WorkspaceLocator, WorkspaceLocatorError};

--- a/crates/pixi_core/src/workspace/discovery.rs
+++ b/crates/pixi_core/src/workspace/discovery.rs
@@ -128,6 +128,10 @@ pub enum WorkspaceLocatorError {
     #[error("could not find workspace '{}' at '{}'", .name, .path.display())]
     #[diagnostic(help = "clean the registry with `pixi workspace register prune`")]
     MissingWorkspacePath { name: String, path: PathBuf },
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PixiVersionMismatch(#[from] Box<pixi_manifest::PixiVersionMismatchError>),
 }
 
 impl WorkspaceLocator {
@@ -211,6 +215,7 @@ impl WorkspaceLocator {
         // Discover the workspace manifest for the current path.
         let workspace_manifests = match pixi_manifest::WorkspaceDiscoverer::new(discovery_start)
             .with_closest_package(self.with_closest_package)
+            .with_ignore_pixi_version_check(self.ignore_pixi_version_check)
             .discover()
         {
             Ok(manifests) => manifests,
@@ -223,6 +228,9 @@ impl WorkspaceLocator {
             }
             Err(WorkspaceDiscoveryError::Canonicalize(source, path)) => {
                 return Err(WorkspaceLocatorError::Canonicalize { path, source });
+            }
+            Err(WorkspaceDiscoveryError::PixiVersionMismatch(err)) => {
+                return Err(WorkspaceLocatorError::PixiVersionMismatch(err));
             }
         };
 
@@ -279,10 +287,6 @@ impl WorkspaceLocator {
         }
 
         let workspace = Workspace::from_manifests(discovered_manifests);
-
-        if !self.ignore_pixi_version_check {
-            workspace.verify_current_pixi_meets_requirement()?;
-        }
 
         Ok(workspace)
     }

--- a/crates/pixi_core/src/workspace/discovery.rs
+++ b/crates/pixi_core/src/workspace/discovery.rs
@@ -132,6 +132,10 @@ pub enum WorkspaceLocatorError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     PixiVersionMismatch(#[from] Box<pixi_manifest::PixiVersionMismatchError>),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidRequiresPixi(#[from] Box<pixi_manifest::InvalidRequiresPixiError>),
 }
 
 impl WorkspaceLocator {
@@ -231,6 +235,9 @@ impl WorkspaceLocator {
             }
             Err(WorkspaceDiscoveryError::PixiVersionMismatch(err)) => {
                 return Err(WorkspaceLocatorError::PixiVersionMismatch(err));
+            }
+            Err(WorkspaceDiscoveryError::InvalidRequiresPixi(err)) => {
+                return Err(WorkspaceLocatorError::InvalidRequiresPixi(err));
             }
         };
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -17,7 +17,6 @@ use std::{
     fmt::{Debug, Formatter},
     hash::Hash,
     path::{Path, PathBuf},
-    str::FromStr,
     sync::Arc,
 };
 
@@ -41,9 +40,9 @@ use pixi_config::{Config, RunPostLinkScripts};
 use pixi_consts::consts;
 use pixi_diff::LockFileDiff;
 use pixi_manifest::{
-    AssociateProvenance, BuildVariantSource, EnvironmentName, Environments, ExplicitManifestError,
-    HasWorkspaceManifest, LoadManifestsError, ManifestProvenance, Manifests, PackageManifest,
-    SpecType, WithProvenance, WithWarnings, WorkspaceManifest,
+    AssociateProvenance, BuildVariantSource, EnvironmentName, Environments, HasWorkspaceManifest,
+    LoadManifestsError, ManifestProvenance, Manifests, PackageManifest, SpecType, WithProvenance,
+    WithWarnings, WorkspaceManifest,
 };
 use pixi_path::AbsPathBuf;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
@@ -54,7 +53,7 @@ use pixi_utils::{
     variants::{VariantConfig, VariantValue},
 };
 use pypi_mapping::{ChannelName, CustomMapping, MappingLocation, MappingSource};
-use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, PackageName, Platform, Version};
+use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, PackageName, Platform};
 use rattler_lock::{LockFile, LockedPackageRef};
 use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
@@ -818,18 +817,6 @@ impl Workspace {
                 true
             }
         })
-    }
-
-    /// Verify the pixi version requirement.
-    pub fn verify_current_pixi_meets_requirement(&self) -> Result<(), ExplicitManifestError> {
-        if let Some(ref requires_pixi) = self.workspace.value.workspace.requires_pixi
-            && !requires_pixi.matches(&Version::from_str(consts::PIXI_VERSION)?)
-        {
-            return Err(ExplicitManifestError::SelfVersionMatchError {
-                requires_pixi: requires_pixi.clone(),
-            });
-        }
-        Ok(())
     }
 }
 

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -592,6 +592,7 @@ mod test {
     #[case::tier_resolution_error("3tier-resolution-error")]
     #[case::invalid_inherit("invalid_inherit")]
     #[case::inherit_readme("inherit_readme/nested")]
+    #[case::requires_newer_pixi("requires-newer-pixi")]
     fn test_workspace_discoverer(#[case] subdir: &str) {
         let test_data_root = dunce::canonicalize(
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery"),

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -191,6 +191,10 @@ pub enum WorkspaceDiscoveryError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     PixiVersionMismatch(#[from] Box<PixiVersionMismatchError>),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidRequiresPixi(#[from] Box<InvalidRequiresPixiError>),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -207,31 +211,70 @@ pub struct PixiVersionMismatchError {
     pub span: SourceSpan,
 }
 
+#[derive(Debug, Error, Diagnostic)]
+#[error("invalid version specifier in 'requires-pixi'")]
+pub struct InvalidRequiresPixiError {
+    #[source_code]
+    pub source_code: NamedSource<Arc<str>>,
+    #[label("could not parse this as a version specifier")]
+    pub span: SourceSpan,
+    #[source]
+    pub parse_error: rattler_conda_types::version_spec::ParseVersionSpecError,
+}
+
+/// Result of the early `requires-pixi` check.
+enum RequiresPixiCheck {
+    /// Field is absent or the current pixi version satisfies the constraint.
+    Satisfied,
+    /// The current pixi version does not satisfy the constraint.
+    Mismatch {
+        requires_pixi: VersionSpec,
+        span: SourceSpan,
+    },
+    /// The `requires-pixi` value could not be parsed as a version specifier.
+    Invalid {
+        span: SourceSpan,
+        parse_error: rattler_conda_types::version_spec::ParseVersionSpecError,
+    },
+}
+
 /// Extract and check the `requires-pixi` field from a parsed TOML tree before
-/// full deserialization. Returns `Some((spec, span))` if the version doesn't
-/// match, `None` if it matches or the field is absent/unparseable.
-fn check_requires_pixi_early(
-    toml: &toml_span::Value<'_>,
-    kind: ManifestKind,
-) -> Option<(VersionSpec, SourceSpan)> {
+/// full deserialization.
+fn check_requires_pixi_early(toml: &toml_span::Value<'_>, kind: ManifestKind) -> RequiresPixiCheck {
     let pointer = match kind {
         ManifestKind::Pixi | ManifestKind::MojoProject => "/workspace/requires-pixi",
         ManifestKind::Pyproject => "/tool/pixi/workspace/requires-pixi",
     };
-    let value = toml.pointer(pointer)?;
-    // Non-string values (e.g. integers, bools) will be caught as schema
-    // errors during full deserialization — skip the version check here.
-    let spec_str = value.as_str()?;
-    let span = value.span;
-    let spec = VersionSpec::from_str(spec_str, ParseStrictness::Strict).ok()?;
-    let current = Version::from_str(consts::PIXI_VERSION).ok()?;
+    let Some(value) = toml.pointer(pointer) else {
+        return RequiresPixiCheck::Satisfied;
+    };
+    let Some(spec_str) = value.as_str() else {
+        // Non-string values (e.g. integers, bools) will be caught as schema
+        // errors during full deserialization — skip the version check here.
+        return RequiresPixiCheck::Satisfied;
+    };
+    let span = SourceSpan::new(value.span.start.into(), value.span.end - value.span.start);
+    let spec = match VersionSpec::from_str(spec_str, ParseStrictness::Strict) {
+        Ok(spec) => spec,
+        Err(e) => {
+            return RequiresPixiCheck::Invalid {
+                span,
+                parse_error: e,
+            }
+        }
+    };
+    let current = match Version::from_str(consts::PIXI_VERSION) {
+        Ok(v) => v,
+        // If our own version can't be parsed, skip the check.
+        Err(_) => return RequiresPixiCheck::Satisfied,
+    };
     if spec.matches(&current) {
-        None
+        RequiresPixiCheck::Satisfied
     } else {
-        Some((
-            spec,
-            SourceSpan::new(span.start.into(), span.end - span.start),
-        ))
+        RequiresPixiCheck::Mismatch {
+            requires_pixi: spec,
+            span,
+        }
     }
 }
 
@@ -442,15 +485,29 @@ impl WorkspaceDiscoverer {
             // Before full deserialization, check requires-pixi so that version
             // mismatches are reported instead of confusing parse errors from
             // fields that only exist in newer manifest formats.
-            if !self.ignore_pixi_version_check
-                && let Some((requires_pixi, span)) =
-                    check_requires_pixi_early(&toml, provenance.kind)
-            {
-                return Err(Box::new(PixiVersionMismatchError {
-                    requires_pixi,
-                    source_code: source,
-                    span,
-                }).into());
+            if !self.ignore_pixi_version_check {
+                match check_requires_pixi_early(&toml, provenance.kind) {
+                    RequiresPixiCheck::Satisfied => {}
+                    RequiresPixiCheck::Mismatch {
+                        requires_pixi,
+                        span,
+                    } => {
+                        return Err(Box::new(PixiVersionMismatchError {
+                            requires_pixi,
+                            source_code: source,
+                            span,
+                        })
+                        .into());
+                    }
+                    RequiresPixiCheck::Invalid { span, parse_error } => {
+                        return Err(Box::new(InvalidRequiresPixiError {
+                            source_code: source,
+                            span,
+                            parse_error,
+                        })
+                        .into());
+                    }
+                }
             }
 
             // Parse the workspace manifest.

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -260,7 +260,7 @@ fn check_requires_pixi_early(toml: &toml_span::Value<'_>, kind: ManifestKind) ->
             return RequiresPixiCheck::Invalid {
                 span,
                 parse_error: e,
-            }
+            };
         }
     };
     let current = match Version::from_str(consts::PIXI_VERSION) {
@@ -718,6 +718,8 @@ mod test {
     #[case::inherit_readme("inherit_readme/nested")]
     #[case::requires_newer_pixi("requires-newer-pixi")]
     #[case::requires_newer_pixi_malformed("requires-newer-pixi-malformed")]
+    #[case::requires_newer_pixi_pyproject("requires-newer-pixi-pyproject")]
+    #[case::requires_newer_pixi_malformed_pyproject("requires-newer-pixi-malformed-pyproject")]
     fn test_workspace_discoverer(#[case] subdir: &str) {
         let test_data_root = dunce::canonicalize(
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery"),

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -660,6 +660,7 @@ mod test {
     #[case::invalid_inherit("invalid_inherit")]
     #[case::inherit_readme("inherit_readme/nested")]
     #[case::requires_newer_pixi("requires-newer-pixi")]
+    #[case::requires_newer_pixi_malformed("requires-newer-pixi-malformed")]
     fn test_workspace_discoverer(#[case] subdir: &str) {
         let test_data_root = dunce::canonicalize(
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/data/workspace-discovery"),

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -3,12 +3,13 @@
 
 use std::{
     path::{Path, PathBuf},
+    str::FromStr,
     sync::Arc,
 };
 
-use miette::{Diagnostic, NamedSource};
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use pixi_consts::consts;
-use rattler_conda_types::VersionSpec;
+use rattler_conda_types::{ParseStrictness, Version, VersionSpec};
 use thiserror::Error;
 use toml_span::Deserialize;
 
@@ -34,6 +35,9 @@ pub struct WorkspaceDiscoverer {
 
     /// Also discover the package closest to the current directory.
     discover_package: bool,
+
+    /// Skip the early `requires-pixi` version check.
+    ignore_pixi_version_check: bool,
 }
 
 /// A workspace discovered by calling [`WorkspaceDiscoverer::discover`].
@@ -166,13 +170,6 @@ pub enum ExplicitManifestError {
 
     #[error(transparent)]
     InvalidManifest(ProvenanceError),
-
-    #[error(transparent)]
-    ParseVersionError(#[from] rattler_conda_types::ParseVersionError),
-
-    /// The pixi version could not match the minimum requirement.
-    #[error("workspace requires pixi '{}', but I am {}", .requires_pixi, consts::PIXI_VERSION)]
-    SelfVersionMatchError { requires_pixi: VersionSpec },
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -190,6 +187,52 @@ pub enum WorkspaceDiscoveryError {
 
     #[error("cannot canonicalize path '{1}' while searching for a manifest.")]
     Canonicalize(#[source] std::io::Error, PathBuf),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PixiVersionMismatch(#[from] Box<PixiVersionMismatchError>),
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "this project requires pixi '{requires_pixi}', but you have pixi {}",
+    consts::PIXI_VERSION
+)]
+#[diagnostic(help("update pixi to a version that satisfies '{requires_pixi}'"))]
+pub struct PixiVersionMismatchError {
+    pub requires_pixi: VersionSpec,
+    #[source_code]
+    pub source_code: NamedSource<Arc<str>>,
+    #[label("this version requirement is not satisfied")]
+    pub span: SourceSpan,
+}
+
+/// Extract and check the `requires-pixi` field from a parsed TOML tree before
+/// full deserialization. Returns `Some((spec, span))` if the version doesn't
+/// match, `None` if it matches or the field is absent/unparseable.
+fn check_requires_pixi_early(
+    toml: &toml_span::Value<'_>,
+    kind: ManifestKind,
+) -> Option<(VersionSpec, SourceSpan)> {
+    let pointer = match kind {
+        ManifestKind::Pixi | ManifestKind::MojoProject => "/workspace/requires-pixi",
+        ManifestKind::Pyproject => "/tool/pixi/workspace/requires-pixi",
+    };
+    let value = toml.pointer(pointer)?;
+    // Non-string values (e.g. integers, bools) will be caught as schema
+    // errors during full deserialization — skip the version check here.
+    let spec_str = value.as_str()?;
+    let span = value.span;
+    let spec = VersionSpec::from_str(spec_str, ParseStrictness::Strict).ok()?;
+    let current = Version::from_str(consts::PIXI_VERSION).ok()?;
+    if spec.matches(&current) {
+        None
+    } else {
+        Some((
+            spec,
+            SourceSpan::new(span.start.into(), span.end - span.start),
+        ))
+    }
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -235,6 +278,7 @@ impl WorkspaceDiscoverer {
         Self {
             start,
             discover_package: false,
+            ignore_pixi_version_check: false,
         }
     }
 
@@ -247,6 +291,15 @@ impl WorkspaceDiscoverer {
     pub fn with_closest_package(self, discover_package: bool) -> Self {
         Self {
             discover_package,
+            ..self
+        }
+    }
+
+    /// If set to `true`, skips the early `requires-pixi` version check that
+    /// runs before full manifest deserialization.
+    pub fn with_ignore_pixi_version_check(self, ignore: bool) -> Self {
+        Self {
+            ignore_pixi_version_check: ignore,
             ..self
         }
     }
@@ -385,6 +438,20 @@ impl WorkspaceDiscoverer {
                     .into());
                 }
             };
+
+            // Before full deserialization, check requires-pixi so that version
+            // mismatches are reported instead of confusing parse errors from
+            // fields that only exist in newer manifest formats.
+            if !self.ignore_pixi_version_check
+                && let Some((requires_pixi, span)) =
+                    check_requires_pixi_early(&toml, provenance.kind)
+            {
+                return Err(Box::new(PixiVersionMismatchError {
+                    requires_pixi,
+                    source_code: source,
+                    span,
+                }).into());
+            }
 
             // Parse the workspace manifest.
             let manifest_dir = provenance.path.parent().expect("a file must have a parent");

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -31,8 +31,8 @@ pub use build_system::PackageBuild;
 pub use channel::PrioritizedChannel;
 pub use dependencies::{CondaConstraints, CondaDependencies, PyPiDependencies};
 pub use discovery::{
-    DiscoveryStart, ExplicitManifestError, LoadManifestsError, Manifests, WorkspaceDiscoverer,
-    WorkspaceDiscoveryError,
+    DiscoveryStart, ExplicitManifestError, LoadManifestsError, Manifests, PixiVersionMismatchError,
+    WorkspaceDiscoverer, WorkspaceDiscoveryError,
 };
 pub use environment::{Environment, EnvironmentName};
 pub use error::TomlError;

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -31,8 +31,8 @@ pub use build_system::PackageBuild;
 pub use channel::PrioritizedChannel;
 pub use dependencies::{CondaConstraints, CondaDependencies, PyPiDependencies};
 pub use discovery::{
-    DiscoveryStart, ExplicitManifestError, LoadManifestsError, Manifests, PixiVersionMismatchError,
-    WorkspaceDiscoverer, WorkspaceDiscoveryError,
+    DiscoveryStart, ExplicitManifestError, InvalidRequiresPixiError, LoadManifestsError, Manifests,
+    PixiVersionMismatchError, WorkspaceDiscoverer, WorkspaceDiscoveryError,
 };
 pub use environment::{Environment, EnvironmentName};
 pub use error::TomlError;

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-malformed-pyproject.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-malformed-pyproject.snap
@@ -1,0 +1,18 @@
+---
+source: crates/pixi_manifest/src/discovery.rs
+assertion_line: 778
+expression: snapshot
+---
+  × invalid version specifier in 'requires-pixi'
+  ╰─▶ 0: at line 1, in Eof:
+      not a valid version spec!!
+         ^
+
+
+   ╭─[<CARGO_ROOT>/tests/data/workspace-discovery/requires-newer-pixi-malformed-pyproject/pyproject.toml:7:18]
+ 6 │ platforms = []
+ 7 │ requires-pixi = "not a valid version spec!!"
+   ·                  ─────────────┬────────────
+   ·                               ╰── could not parse this as a version specifier
+ 8 │ some-future-field = true
+   ╰────

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-malformed.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-malformed.snap
@@ -1,0 +1,18 @@
+---
+source: crates/pixi_manifest/src/discovery.rs
+assertion_line: 771
+expression: snapshot
+---
+  × invalid version specifier in 'requires-pixi'
+  ╰─▶ 0: at line 1, in Eof:
+      not a valid version spec!!
+         ^
+
+
+   ╭─[<CARGO_ROOT>/tests/data/workspace-discovery/requires-newer-pixi-malformed/pixi.toml:5:18]
+ 4 │ platforms = []
+ 5 │ requires-pixi = "not a valid version spec!!"
+   ·                  ─────────────┬────────────
+   ·                               ╰── could not parse this as a version specifier
+ 6 │ some-future-field = true
+   ╰────

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-pyproject.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-pyproject.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pixi_manifest/src/discovery.rs
+assertion_line: 778
+expression: snapshot
+---
+  × this project requires pixi '>=100', but you have pixi 0.67.0
+   ╭─[<CARGO_ROOT>/tests/data/workspace-discovery/requires-newer-pixi-pyproject/pyproject.toml:7:18]
+ 6 │ platforms = []
+ 7 │ requires-pixi = ">=100"
+   ·                  ──┬──
+   ·                    ╰── this version requirement is not satisfied
+ 8 │ some-future-field = true
+   ╰────
+  help: update pixi to a version that satisfies '>=100'

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pixi_manifest/src/discovery.rs
+assertion_line: 705
+expression: snapshot
+---
+  × this project requires pixi '>=100', but you have pixi 0.67.0
+  help: update pixi to a version that satisfies '>=100'

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi.snap
@@ -1,7 +1,13 @@
 ---
 source: crates/pixi_manifest/src/discovery.rs
-assertion_line: 705
 expression: snapshot
 ---
   × this project requires pixi '>=100', but you have pixi 0.67.0
+   ╭─[<CARGO_ROOT>/tests/data/workspace-discovery/requires-newer-pixi/pixi.toml:5:18]
+ 4 │ platforms = []
+ 5 │ requires-pixi = ">=100"
+   ·                  ──┬──
+   ·                    ╰── this version requirement is not satisfied
+ 6 │ some-future-field = true
+   ╰────
   help: update pixi to a version that satisfies '>=100'

--- a/tests/data/workspace-discovery/requires-newer-pixi-malformed-pyproject/pyproject.toml
+++ b/tests/data/workspace-discovery/requires-newer-pixi-malformed-pyproject/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "requires-newer-pixi-malformed-pyproject"
+
+[tool.pixi.workspace]
+channels = []
+platforms = []
+requires-pixi = "not a valid version spec!!"
+some-future-field = true

--- a/tests/data/workspace-discovery/requires-newer-pixi-malformed/pixi.toml
+++ b/tests/data/workspace-discovery/requires-newer-pixi-malformed/pixi.toml
@@ -1,0 +1,6 @@
+[workspace]
+channels = []
+name = "requires-newer-pixi-malformed"
+platforms = []
+requires-pixi = "not a valid version spec!!"
+some-future-field = true

--- a/tests/data/workspace-discovery/requires-newer-pixi-pyproject/pyproject.toml
+++ b/tests/data/workspace-discovery/requires-newer-pixi-pyproject/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "requires-newer-pixi-pyproject"
+
+[tool.pixi.workspace]
+channels = []
+platforms = []
+requires-pixi = ">=100"
+some-future-field = true

--- a/tests/data/workspace-discovery/requires-newer-pixi/pixi.toml
+++ b/tests/data/workspace-discovery/requires-newer-pixi/pixi.toml
@@ -1,0 +1,6 @@
+[workspace]
+name = "requires-newer-pixi"
+channels = []
+platforms = []
+requires-pixi = ">=100"
+some-future-field = true

--- a/tests/data/workspace-discovery/requires-newer-pixi/pixi.toml
+++ b/tests/data/workspace-discovery/requires-newer-pixi/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
-name = "requires-newer-pixi"
 channels = []
+name = "requires-newer-pixi"
 platforms = []
 requires-pixi = ">=100"
 some-future-field = true


### PR DESCRIPTION
### Description

Curently if the pixi.toml has an invalid schema the error is shown, even if `requires-newer-pixi` imposes that the current pixi version is too old. For example, use `pixi <0.67` with pixi itself and you get the following error, despite #5858:

```
Error:   × `7d` is neither a valid date (input contains invalid characters) nor a valid datetime (premature end of input)
    ╭─[/home/cburr/Development/rattler-fs/pixi/pixi.toml:12:18]
 11 │ description = "Package management made easy!"
 12 │ exclude-newer = "7d"
    ·                  ──
 13 │ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]
    ╰────
```

With this change you get an error like:

```
  × this project requires pixi '>=100', but you have pixi 0.67.0
  help: update pixi to a version that satisfies '>=100'
```

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
