### PR TITLE
fix: exclude pytest-temp from basedpyright checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ ignore = [
   "site",
   "output",
   "target",
+  "pytest-temp",
 ]
 pythonPlatform = "All"
 pythonVersion = "3.13"


### PR DESCRIPTION
### Description

pytest leaves temporary files in pytest-temp/ that basedpyright scans, causing spurious type-checking errors in CI and local lint runs.

```
✨ Pixi task (lint-slow in lefthook): lefthook run pre-push --all-files --force: (Run all slow linters and formatters)
╭────────────────────────────────────╮
│ 🥊 lefthook v2.1.0  hook: pre-push │
╰────────────────────────────────────╯
/Users/cburr/Development/pixi-requires-newer-pixi/pytest-temp/test_maturin0/fast_math/__main__.py
  /Users/cburr/Development/pixi-requires-newer-pixi/pytest-temp/test_maturin0/fast_math/__main__.py:1:6 - error: Import ".fast_math" could not be resolved (reportMissingImports)
  /Users/cburr/Development/pixi-requires-newer-pixi/pytest-temp/test_maturin0/fast_math/__main__.py:1:24 - error: Type of "sum_as_string" is unknown (reportUnknownVariableType)
2 errors, 0 warnings, 0 notes

summary: (done in 18.87 seconds)
✔️ cargo-clippy (12.98 seconds)
✔️ cargo-deny (1.48 seconds)
✔️ check-openssl (0.49 seconds)
🥊 typecheck-python (3.91 seconds)
```

### How Has This Been Tested?

Running `pixi run lint` in a context that fails without this change and passes with this change.

### Checklist:
- [x] I have performed a self-review of my own code
