### PR TITLE
docs: Some minor improvements to the python tutorial

### DIFF
--- a/docs/python/tutorial.md
+++ b/docs/python/tutorial.md
@@ -226,7 +226,7 @@ This means that you can have multiple environments with the same packages but on
 ### Multiple environments
 Pixi can also create multiple environments, this works well together with the `dependency-groups` feature in the `pyproject.toml` file.
 
-Let's add a dependency-group, which Pixi calls a `feature`, named `test`.
+Before creating an environment, let's add a dependency-group, which Pixi calls a `feature`, named `test`.
 And add the `pytest` package to this group.
 
 ```shell
@@ -242,6 +242,8 @@ test = ["pytest"]
 
 After we have added the `dependency-groups` to the `pyproject.toml`, Pixi sees these as a [`feature`](../reference/pixi_manifest.md/#the-feature-and-environments-tables), which can contain a collection of `dependencies`, `tasks`, `channels`, and more.
 
+We now set up the `default` environment as well as the `test` environment.
+Notice how the `test` environment is set up using the `test` feature.
 
 ```shell
 pixi workspace environment add default --solve-group default --force
@@ -254,6 +256,20 @@ Which results in:
 [tool.pixi.environments]
 default = { solve-group = "default" }
 test = { features = ["test"], solve-group = "default" }
+```
+
+This will then run the `pytest` command, using the dependencies from the `test` environment.
+As the project does not have any tests yet, the output should look like the following:
+
+```shell
+✔ The test environment has been installed.
+============================== test session starts ==============================
+platform darwin -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
+rootdir: <path_to_your_environment>/pixi-py
+configfile: pyproject.toml
+collected 0 items                                                                                                                                           
+
+============================ no tests ran in 0.00s ==============================
 ```
 
 ??? note "Solve Groups"
@@ -353,16 +369,16 @@ pixi run test
 ```
 results in the following output:
 ```shell
-✨ Pixi task (test): pytest .
-================================================================================================= test session starts =================================================================================================
-platform darwin -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0
-rootdir: /private/tmp/pixi-py
+✨ Pixi task (test in test): pytest
+================================= test session starts =================================
+platform darwin -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0
+rootdir: <path_to_your_environment>/pixi-py
 configfile: pyproject.toml
-collected 1 item
+collected 1 item                                                                                                                                            
 
-test_me.py .                                                                                                                                                                                                    [100%]
+tests/test_me.py .                                                                [100%]
 
-================================================================================================== 1 passed in 0.00s =================================================================================================
+================================== 1 passed in 0.00s ===================================
 ```
 
 ??? question "Why didn't I have to specify the environment?"


### PR DESCRIPTION
### Description

This PR adds a little additional more explanation to the `python` example and also fixes some formatting. All of those are things that confused me when going through the documentation, so I thought that adding some more explanations might be helpful. It changes the following:
1. Be more explicit that the `pixi add --pypi --feature test pytest` does *not* already create an environment, but that this is done by the following.
2. Show the output of the command `pixi workspace environment add test --feature test --solve-group default`. When running the scripts from the documentation, this command will run and actually create an output on the shell. I thought that it might be nice to add what this output is suspected to look like.
3. Reformatting of the `pytest` outputs: It looked way too wide for me, so I just manually trimmed down the `==========` lines.

Note that this has been developed during the PyconDE sprint session 2026, so any sort feedback is welcome! This PR will also be linked to an issue that the participants will use to track their work which I will create soon.

### How Has This Been Tested?

Local investigation of the docs after running `pix run docs`.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
- [x] I used Claude Code for spell checking, but no edits where made by Claude Code

### Checklist:
<!--- Remove the non relevant items. --->
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
