### PR TITLE
docs: clarify scheduled CVE scanning and two threat models in security guide

### DIFF
--- a/docs/integration/extensions/pixi_diff.md
+++ b/docs/integration/extensions/pixi_diff.md
@@ -67,9 +67,6 @@ pixi diff <(git show HEAD~20:pixi.lock) pixi.lock | pixi diff-to-markdown > diff
 !!!tip "pixi-diff-to-markdown in GitHub Actions updates"
     For other usages of [`pixi-diff-to-markdown`](https://github.com/pavelzw/pixi-diff-to-markdown), see also our page about [updating lockfiles using GitHub Actions](../ci/updates_github_actions.md).
 
-!!! note "Diff detection is not vulnerability scanning"
-    `pixi-diff` and `pixi-diff-to-markdown` show what changed in your lockfile, but they do not detect whether any of those changes introduce known vulnerabilities. For CVE scanning and broader supply chain security guidance, see the [Supply Chain Security](../../security.md) page.
-
 You can view this generated markdown file in your terminal using [`glow`](https://github.com/charmbracelet/glow).
 
 ```bash

--- a/docs/integration/extensions/pixi_diff.md
+++ b/docs/integration/extensions/pixi_diff.md
@@ -67,6 +67,9 @@ pixi diff <(git show HEAD~20:pixi.lock) pixi.lock | pixi diff-to-markdown > diff
 !!!tip "pixi-diff-to-markdown in GitHub Actions updates"
     For other usages of [`pixi-diff-to-markdown`](https://github.com/pavelzw/pixi-diff-to-markdown), see also our page about [updating lockfiles using GitHub Actions](../ci/updates_github_actions.md).
 
+!!! note "Diff detection is not vulnerability scanning"
+    `pixi-diff` and `pixi-diff-to-markdown` show what changed in your lockfile, but they do not detect whether any of those changes introduce known vulnerabilities. For CVE scanning and broader supply chain security guidance, see the [Supply Chain Security](../../security.md) page.
+
 You can view this generated markdown file in your terminal using [`glow`](https://github.com/charmbracelet/glow).
 
 ```bash

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,7 @@ Pixi does not eliminate these risks, and it does not include a vulnerability sca
 These risks fall into two broad categories, each requiring a different response:
 
 - **A newly published package is malicious or broken.** The threat arrives with a future install. Steps like `exclude-newer` (step 2) and lock file review (step 1) help you avoid pulling it in.
-- **A package you already depend on is found to be vulnerable.** The threat is already in your environment. Unlike ecosystems with registry-integrated alert services (e.g. GitHub Dependabot, `npm audit`), the conda ecosystem does not yet have an event-driven notification mechanism. The primary way to detect this today is to scan your installed environment on a recurring schedule (step 5) and then respond by constraining or overriding dependencies (step 3).
+- **A package you already depend on is found to be vulnerable.** The threat is already in your environment. You can detect this by scanning your installed environment on a recurring schedule (step 5) and then respond by constraining or overriding dependencies (step 3). GitHub Dependabot already [supports conda as an ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#supported-ecosystems-maintained-by-github), though lockfile-based update support is not yet available.
 
 This is the security model we recommend, step by step:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,12 @@ Typical risks include:
 - known-vulnerable dependencies that stay in your environment because nothing forces an update;
 - poor visibility into what actually changed between one environment revision and the next.
 
-Pixi does not eliminate these risks, and it does not include a vulnerability scanner for conda environments. What it does provide is a set of practical controls that help you reduce exposure, review changes more clearly, and respond faster when something goes wrong.
+Pixi does not eliminate these risks, and it does not include a vulnerability scanner or advisory notification system for conda environments. What it does provide is a set of practical controls that help you reduce exposure, review changes more clearly, and respond faster when something goes wrong.
+
+These risks fall into two broad categories, each requiring a different response:
+
+- **A newly published package is malicious or broken.** The threat arrives with a future install. Steps like `exclude-newer` (step 2) and lock file review (step 1) help you avoid pulling it in.
+- **A package you already depend on is found to be vulnerable.** The threat is already in your environment. Unlike ecosystems with registry-integrated alert services (e.g. GitHub Dependabot, `npm audit`), the conda ecosystem does not yet have an event-driven notification mechanism. The primary way to detect this today is to scan your installed environment on a recurring schedule (step 5) and then respond by constraining or overriding dependencies (step 3).
 
 This is the security model we recommend, step by step:
 
@@ -18,7 +23,7 @@ This is the security model we recommend, step by step:
 2. delay very fresh uploads when a cooldown is appropriate;
 3. respond to advisories by constraining or overriding dependencies;
 4. treat package installation and activation hooks as code execution surfaces;
-5. scan the installed environment with tooling that understands what is actually on disk;
+5. scan the installed environment on a schedule with tooling that understands what is actually on disk;
 6. add attestations when you publish your own artifacts.
 
 ## 1. Make Dependency Resolution Reproducible
@@ -139,6 +144,8 @@ For conda packages specifically, Syft currently tends to emit CPEs but not PURLs
 
 !!! tip ""
     If you only want to scan your environment for CVEs, you can also run `grype .pixi/envs/default` directly.
+
+Run these scans on a recurring schedule in CI, not only on pull requests. Advisories can be published at any time, so a periodic scan (e.g. a daily or weekly cron job) is needed to catch vulnerabilities in dependencies that have not changed recently.
 
 For Rust packages on conda-forge, building with `cargo-auditable` remains the current recommendation because it makes those shadow dependencies visible to downstream scanning tools. See the conda-forge [Rust packaging guide](https://conda-forge.org/docs/maintainer/example_recipes/rust) or the [conda-forge agent skill](https://prefix.dev/channels/skill-forge/packages/agent-skill-conda-forge) for the recommended recipe pattern.
 


### PR DESCRIPTION
### Description

The supply chain security page explains how to delay fresh uploads with `exclude-newer` but does not address the more common scenario where a package already in the lockfile is later found to be vulnerable.

This PR:

- Adds an introduction that distinguishes both threat models (malicious new package vs. CVE in existing dependency) and points readers to the relevant steps
- Adds a paragraph in section 5 recommending periodic CI scans
- Adds a note in the pixi-diff docs clarifying that diff detection is not vulnerability scanning, with a link to the security page

### AI Disclosure

- [x] This PR contains AI-generated content. (Japanese-English Translation)
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation