### PR TITLE
docs: Add "basic idea" overview to basic usage

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,6 +3,19 @@
 Pixi can do a lot of things, but it is designed to be simple to use.
 Let's go through the basic usage of Pixi.
 
+## How Pixi works
+
+When you use Pixi, it manages three aspects in your project directory:
+- `pixi.toml` - the manifest file, listing the dependencies you want in your project
+- `pixi.lock` - the lockfile, containing the resolved versions of dependencies (including transitive ones), you should commit this file to version control
+- `.pixi/` - the installed environment on your machine
+  
+The following commands interact with these files in sequence:
+- [`pixi add`](./reference/cli/pixi/add.md) - adds a dependency to `pixi.toml`
+- [`pixi lock`](./reference/cli/pixi/lock.md) - resolves the dependencies in `pixi.toml` and writes the exact versions to `pixi.lock`
+- [`pixi install`](./reference/cli/pixi/install.md) - installs the packages listed in `pixi.lock` into the `.pixi/` directory
+- [`pixi run`](./reference/cli/pixi/run.md) - activates the `.pixi/` environment and runs given command
+
 ## Managing workspaces
 
 - [`pixi init`](./reference/cli/pixi/init.md) - create a new Pixi manifest in the current directory

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,8 +18,6 @@ The following commands interact with these files in sequence:
 - [`pixi install`](./reference/cli/pixi/install.md) - installs the packages listed in `pixi.lock` into the `.pixi/` directory
 - [`pixi run`](./reference/cli/pixi/run.md) - activates the `.pixi/` environment and runs given command
 
-You rarely need to run these commands manually. pixi run, pixi shell, and pixi add will automatically update the lockfile and install the environment if anything is missing or out of date.
-
 
 ## Managing workspaces
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,6 +18,9 @@ The following commands interact with these files in sequence:
 - [`pixi install`](./reference/cli/pixi/install.md) - installs the packages listed in `pixi.lock` into the `.pixi/` directory
 - [`pixi run`](./reference/cli/pixi/run.md) - activates the `.pixi/` environment and runs given command
 
+You rarely need to run these commands manually. pixi run, pixi shell, and pixi add will automatically update the lockfile and install the environment if anything is missing or out of date.
+
+
 ## Managing workspaces
 
 - [`pixi init`](./reference/cli/pixi/init.md) - create a new Pixi manifest in the current directory

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ When you use Pixi, it manages three aspects in your project directory:
 - `pixi.lock` - the lockfile, containing the resolved versions of dependencies (including transitive ones), you should commit this file to version control
 - `.pixi/` - the installed environment on your machine
   
-The following commands interact with these files in sequence:
+The commands you'll use the most:
 
 - [`pixi add`](./reference/cli/pixi/add.md) - adds a dependency to `pixi.toml`
 - [`pixi lock`](./reference/cli/pixi/lock.md) - resolves the dependencies in `pixi.toml` and writes the exact versions to `pixi.lock`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -7,7 +7,7 @@ Let's go through the basic usage of Pixi.
 
 When you use Pixi, it manages three aspects in your project directory:
 
-- `pixi.toml` - the manifest file, listing the dependencies you want in your project
+- `pixi.toml`( or `pyproject.toml`) - the manifest file, listing the dependencies you want in your project
 - `pixi.lock` - the lockfile, containing the resolved versions of dependencies (including transitive ones), you should commit this file to version control
 - `.pixi/` - the installed environment on your machine
   

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,11 +6,13 @@ Let's go through the basic usage of Pixi.
 ## How Pixi works
 
 When you use Pixi, it manages three aspects in your project directory:
+
 - `pixi.toml` - the manifest file, listing the dependencies you want in your project
 - `pixi.lock` - the lockfile, containing the resolved versions of dependencies (including transitive ones), you should commit this file to version control
 - `.pixi/` - the installed environment on your machine
   
 The following commands interact with these files in sequence:
+
 - [`pixi add`](./reference/cli/pixi/add.md) - adds a dependency to `pixi.toml`
 - [`pixi lock`](./reference/cli/pixi/lock.md) - resolves the dependencies in `pixi.toml` and writes the exact versions to `pixi.lock`
 - [`pixi install`](./reference/cli/pixi/install.md) - installs the packages listed in `pixi.lock` into the `.pixi/` directory


### PR DESCRIPTION
### Description
Added a high level overview explaining the relationship between pixi.toml, pixi.lock and .pixi/ as well as the commands interacting with those.

Fixes #3383

### How Has This Been Tested?
Built locally and tested as preview.


### Checklist:
- [x] Made only changes in the documentation