### PR TITLE
docs: Fix conda package build string explanation graphic

### DIFF
--- a/docs/conda_ecosystem.md
+++ b/docs/conda_ecosystem.md
@@ -98,10 +98,10 @@ configuration, and a build number:
 
 ```
 numpy-2.1.0-py311h43a39b2_0.conda
-            ^^^^^ ^^^^^^^^ ^
-            │     │        └─ build number
-            │     └────────── configuration hash
-            └──────────────── Python version
+            ^^^^^ ^^^^^^^ ^
+            │     │       └─ build number
+            │     └───────── configuration hash
+            └─────────────── Python version
 ```
 
 The solver picks the right variant automatically based on what's


### PR DESCRIPTION
### Description

This is a super tiny fix of the graphic explaining conda build strings. The underline was one character too long, so I removed it and aligned the underlines with the different build string parts.

### How Has This Been Tested?

I did a local `pixi run docs` to check if the formatting is correct now.

### Checklist:
- [x] I have performed a self-review of my own code
