### PR TITLE
docs: Use `canonical_version: latest` in mike

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -275,14 +275,14 @@ plugins:
       # Set debug to true to help troubleshoot social card generation issues
       debug: false
   - mike:
-    # These fields are all optional; the defaults are as below...
-    # alias_type: symlink
-    # redirect_template: null
-    # deploy_prefix: ''
-    # canonical_version: null
-    # version_selector: true
-    # css_dir: css
-    # javascript_dir: js
+      # These fields are all optional; the defaults are as below...
+      # alias_type: symlink
+      # redirect_template: null
+      # deploy_prefix: ''
+      canonical_version: latest
+      # version_selector: true
+      # css_dir: css
+      # javascript_dir: js
   # llmstxt must come after the mike plugin:
   - llmstxt:
       enabled: !ENV [CI, false]


### PR DESCRIPTION
### Description

This PR uncomments and sets the `canonical_version` for `mike`, the tool for the deployment of multiple versions in `pixi` to latest. This should fix #4635, and the solution to use this was actually proposed in that issue. According to the documentation of `mike`, this should exactly fix the issue of Google not finding the correct version:

<img width="819" height="527" alt="image" src="https://github.com/user-attachments/assets/f14c25ba-1ebb-4188-8f6f-2d6400973ebb" />

Also, according to the github workflow for building the documentation, the deploy workflow already uses `latest` as the alias, so this should work:

```
- name: Deploy with mike 🚀
        run: |
          pixi run -e docs mike deploy --push --update-aliases $RELEASE_VERSION latest
```

### How Has This Been Tested?

Unfortunately, I do not know how to best test this. I built the documentation locally and this worked, but as this is due to deployment, this is expected.

### AI Disclosure

I chatted about this feature and the potential solution with Claude Code.

### Checklist:
<!--- Remove the non relevant items. --->
- [X] I have performed a self-review of my own code
- [X] I have built the documentation locally

### Open question

Is there any way that this can be properly tested? It seems to me like this solution was simply not considered before as none of the arguments has actually been uncommented, is there a reason for this?
