### PR TITLE
docs(add): new examples for using channels with `pixi add`

### DIFF
--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -71,6 +71,10 @@ use crate::{
 /// packages that are not following the semver versioning scheme but will use
 /// the minor version by default:
 /// Python, Rust, Julia, GCC, GXX, GFortran, NodeJS, Deno, R, R-Base, Perl
+/// 
+/// It is also possible to configure custom channels (or mirrors) for dependencies within your workspace. 
+/// These channels can be scoped to a specific feature, allowing you to group dependencies that should be resolved from a particular source.
+
 #[derive(Parser, Debug, Default)]
 #[clap(arg_required_else_help = true, verbatim_doc_comment)]
 pub struct Args {

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -71,8 +71,8 @@ use crate::{
 /// packages that are not following the semver versioning scheme but will use
 /// the minor version by default:
 /// Python, Rust, Julia, GCC, GXX, GFortran, NodeJS, Deno, R, R-Base, Perl
-/// 
-/// It is also possible to configure custom channels (or mirrors) for dependencies within your workspace. 
+///
+/// It is also possible to configure custom channels (or mirrors) for dependencies within your workspace.
 /// These channels can be scoped to a specific feature, allowing you to group dependencies that should be resolved from a particular source.
 
 #[derive(Parser, Debug, Default)]

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -143,5 +143,8 @@ packages that are not following the semver versioning scheme but will use
 the minor version by default:
 Python, Rust, Julia, GCC, GXX, GFortran, NodeJS, Deno, R, R-Base, Perl
 
+It is also possible to configure custom channels (or mirrors) for dependencies within your workspace.
+These channels can be scoped to a specific feature, allowing you to group dependencies that should be resolved from a particular source.
+
 
 --8<-- "docs/reference/cli/pixi/add_extender:example"

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -18,6 +18,7 @@ pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (11)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (12)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (13)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (14)!
+pixi workspace channel add https://prefix.dev/bioconda && pixi add https://prefix.dev/bioconda::htslib
 pixi workspace channel add https://my-mirror.example.com --feature=my-awesome-mirror && pixi add --feature=my-awesome-mirror numpy-mirrored
 
 # Add a pypi dependency

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -18,6 +18,7 @@ pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (11)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (12)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (13)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (14)!
+pixi workspace channel add https://my-mirror.example.com --feature=my-awesome-mirror
 
 # Add a pypi dependency
 pixi add --pypi requests[security] # (15)!

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -19,21 +19,21 @@ pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subd
 pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (13)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (14)!
 pixi workspace channel add https://prefix.dev/bioconda && pixi add https://prefix.dev/bioconda::htslib
-pixi workspace channel add https://my-mirror.example.com --feature=my-awesome-mirror && pixi add --feature=my-awesome-mirror numpy-mirrored
+pixi workspace channel add https://my-mirror.example.com --feature=my-awesome-mirror && pixi add --feature=my-awesome-mirror numpy-mirrored # (15)!
 
 # Add a pypi dependency
-pixi add --pypi requests[security] # (15)!
-pixi add --pypi Django==5.1rc1 # (16)!
-pixi add --pypi "boltons>=24.0.0" --feature lint # (17)!
-pixi add --pypi "boltons @ https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl" # (18)!
-pixi add --pypi "exchangelib @ git+https://github.com/ecederstrand/exchangelib" # (19)!
-pixi add --pypi "project @ file:///absolute/path/to/project" # (20)!
-pixi add --pypi "project@file:///absolute/path/to/project" --editable # (21)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --pypi # (22)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --branch main --pypi # (23)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --rev e50d4a1 --pypi # (24)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi # (25)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdir boltons # (26)!
+pixi add --pypi requests[security] # (16)!
+pixi add --pypi Django==5.1rc1 # (17)!
+pixi add --pypi "boltons>=24.0.0" --feature lint # (18)!
+pixi add --pypi "boltons @ https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl" # (19)!
+pixi add --pypi "exchangelib @ git+https://github.com/ecederstrand/exchangelib" # (20)!
+pixi add --pypi "project @ file:///absolute/path/to/project" # (21)!
+pixi add --pypi "project@file:///absolute/path/to/project" --editable # (22)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --pypi # (23)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --branch main --pypi # (24)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --rev e50d4a1 --pypi # (25)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi # (26)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdir boltons # (27)!
 ```
 
 1. This will add the `numpy` package to the project with the latest available for the solved environment.
@@ -50,18 +50,19 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pyp
 12. This will add the `boost-check` source package to the dependencies from the git repository using `main` branch and the `boost-check` folder in the repository.
 13. This will add the `boost-check` source package to the dependencies from the git repository using `v0.1.0` tag.
 14. This will add the `boost-check` source package to the dependencies from the git repository using `e50d4a1` revision.
-15. This will add the `requests` package as `pypi` dependency with the `security` extra.
-16. This will add the `pre-release` version of `Django` to the project as a `pypi` dependency.
-17. This will add the `boltons` package in the feature `lint` as `pypi` dependency.
-18. This will add the `boltons` package with the given `url` as `pypi` dependency.
-19. This will add the `exchangelib` package with the given `git` url as `pypi` dependency.
-20. This will add the `project` package with the given `file` url as `pypi` dependency.
-21. This will add the `project` package with the given `file` url as an `editable` package as `pypi` dependency.
-22. This will add the `boltons` package with the given `git` url as `pypi` dependency.
-23. This will add the `boltons` package with the given `git` url and `main` branch as `pypi` dependency.
-24. This will add the `boltons` package with the given `git` url and `e50d4a1` revision as `pypi` dependency.
-25. This will add the `boltons` package with the given `git` url and `v0.1.0` tag as `pypi` dependency.
-26. This will add the `boltons` package with the given `git` url, `v0.1.0` tag and the `boltons` folder in the repository as `pypi` dependency.
+15. This will add the `https://my-mirror.example.com` dependency to your work channel and the feature `my-awesome-mirror`.
+16. This will add the `requests` package as `pypi` dependency with the `security` extra.
+17. This will add the `pre-release` version of `Django` to the project as a `pypi` dependency.
+18. This will add the `boltons` package in the feature `lint` as `pypi` dependency.
+19. This will add the `boltons` package with the given `url` as `pypi` dependency.
+20. This will add the `exchangelib` package with the given `git` url as `pypi` dependency.
+21. This will add the `project` package with the given `file` url as `pypi` dependency.
+22. This will add the `project` package with the given `file` url as an `editable` package as `pypi` dependency.
+23. This will add the `boltons` package with the given `git` url as `pypi` dependency.
+24. This will add the `boltons` package with the given `git` url and `main` branch as `pypi` dependency.
+25. This will add the `boltons` package with the given `git` url and `e50d4a1` revision as `pypi` dependency.
+26. This will add the `boltons` package with the given `git` url and `v0.1.0` tag as `pypi` dependency.
+27. This will add the `boltons` package with the given `git` url, `v0.1.0` tag and the `boltons` folder in the repository as `pypi` dependency.
 
 !!! tip "Need to specify build strings or hardware-specific packages?"
     For advanced package specifications including build strings, see the [Package Specifications](../../../concepts/package_specifications.md) guide.

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -18,7 +18,7 @@ pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (11)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (12)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (13)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (14)!
-pixi workspace channel add https://my-mirror.example.com --feature=my-awesome-mirror
+pixi workspace channel add https://my-mirror.example.com --feature=my-awesome-mirror && pixi add --feature=my-awesome-mirror numpy-mirrored
 
 # Add a pypi dependency
 pixi add --pypi requests[security] # (15)!

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -50,7 +50,7 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pyp
 12. This will add the `boost-check` source package to the dependencies from the git repository using `main` branch and the `boost-check` folder in the repository.
 13. This will add the `boost-check` source package to the dependencies from the git repository using `v0.1.0` tag.
 14. This will add the `boost-check` source package to the dependencies from the git repository using `e50d4a1` revision.
-15. This will add the `https://my-mirror.example.com` dependency to your work channel and the feature `my-awesome-mirror`.
+15. This will add the `https://my-mirror.example.com` channel to the `my-awesome-mirror` feature in your workspace, and add the `numpy-mirrored` package from that channel as a dependency.
 16. This will add the `requests` package as `pypi` dependency with the `security` extra.
 17. This will add the `pre-release` version of `Django` to the project as a `pypi` dependency.
 18. This will add the `boltons` package in the feature `lint` as `pypi` dependency.

--- a/tests/data/pixi-build/multi-output/pixi.toml
+++ b/tests/data/pixi-build/multi-output/pixi.toml
@@ -1,8 +1,8 @@
 [workspace]
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 channels = ["https://prefix.dev/conda-forge"]
-exclude-newer = "7d"
 description = "Add a short description here"
+exclude-newer = "7d"
 name = "multi-output"
 platforms = ["osx-arm64", "linux-64", "win-64"]
 preview = ["pixi-build"]

--- a/tests/data/pixi-build/rattler-build-backend/smokey/pixi.toml
+++ b/tests/data/pixi-build/rattler-build-backend/smokey/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-exclude-newer = "7d"
 description = "Add a short description here"
+exclude-newer = "7d"
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 preview = ["pixi-build"]
 

--- a/tests/data/pixi-build/rattler-build-backend/smokey2/pixi.toml
+++ b/tests/data/pixi-build/rattler-build-backend/smokey2/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-exclude-newer = "7d"
 description = "Add a short description here"
+exclude-newer = "7d"
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 preview = ["pixi-build"]
 


### PR DESCRIPTION
Fixed Issue #4231

Adding a small text and example on how to add a custom mirror / channel to a pixi work space.
**NB!** Its actually not easy to find the relevant docs due to text auto-generation, examples stored in a different file etc. As a beginner I could have not contributed without Nathans help. Is there a Guide on how to contribute/Pixi architecture help navigating. 


Fixes #4231

### How Has This Been Tested?

Tested/previewed by @lucascolley within the issue




### Checklist:
- [X ] I have made corresponding changes to the documentation