### PR TITLE
fix: improve quoting in build script for paths with spaces

### DIFF
--- a/crates/pixi_build_cmake/pixi.toml
+++ b/crates/pixi_build_cmake/pixi.toml
@@ -8,3 +8,6 @@ version = "*"
 
 [package.run-dependencies]
 pixi-build-api-version = ">=4,<5"
+
+[package.build.config]
+extra-input-globs = ["src/build_script.j2"]

--- a/crates/pixi_build_mojo/pixi.toml
+++ b/crates/pixi_build_mojo/pixi.toml
@@ -8,3 +8,6 @@ version = "*"
 
 [package.run-dependencies]
 pixi-build-api-version = ">=4,<5"
+
+[package.build.config]
+extra-input-globs = ["src/build_script.j2"]

--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -12,11 +12,11 @@ mojo --version
 {#- Build any binaries -#}
 {% if bins %}
 {% for bin in bins %}
-mojo build {{ bin.extra_args | join(" ")  }} {{ bin.path }} -o {{ library_prefix }}/bin/{{ bin.name }}
+mojo build {{ bin.extra_args | join(" ")  }} "{{ bin.path }}" -o {{ library_prefix }}/bin/{{ bin.name }}
 {% endfor %}
 {% endif %}
 
 {#- Build pkg -#}
 {% if pkg %}
-mojo package {{ pkg.extra_args | join(" ") }} {{ pkg.path }} -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
+mojo package {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
 {% endif %}

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
@@ -9,7 +9,7 @@ package:
 build:
   script:
     content:
-      - "mojo --version\n\nmojo build -I . ./main.mojo -o $PREFIX/bin/example"
+      - "mojo --version\n\nmojo build -I . \"./main.mojo\" -o $PREFIX/bin/example"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
@@ -9,7 +9,7 @@ package:
 build:
   script:
     content:
-      - "mojo --version\n\nmojo build -i . ./main.mojo -o $PREFIX/bin/example\n\n\nmojo package -i . mylib -o $PREFIX/lib/mojo/lib.mojopkg"
+      - "mojo --version\n\nmojo build -i . \"./main.mojo\" -o $PREFIX/bin/example\n\n\nmojo package -i . \"mylib\" -o $PREFIX/lib/mojo/lib.mojopkg"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_python/pixi.toml
+++ b/crates/pixi_build_python/pixi.toml
@@ -8,3 +8,6 @@ version = "*"
 
 [package.run-dependencies]
 pixi-build-api-version = ">=4,<5"
+
+[package.build.config]
+extra-input-globs = ["src/build_script.j2"]

--- a/crates/pixi_build_python/src/build_script.j2
+++ b/crates/pixi_build_python/src/build_script.j2
@@ -1,10 +1,9 @@
 {% set PYTHON="%PYTHON%" if build_platform == "windows" else "$PYTHON" -%}
-{% set EDITABLE_OPTION = "--editable" if editable else "" -%}
 {%- set OPTIONS = [
     "-vv",
     "--no-deps",
     "--no-build-isolation"
-] + extra_args + [EDITABLE_OPTION, manifest_root]
+] + extra_args + (["--editable"] if editable else [])
 -%}
 
 {% if build_platform == "windows" -%}
@@ -14,9 +13,11 @@
 {% endif -%}
 
 {% if installer == "uv" -%}
-uv pip install --python "{{ PYTHON }}" {{ OPTIONS }}
+uv pip install --python "{{ PYTHON }}" {{ OPTIONS }} "{{ manifest_root }}"
+{% elif build_platform == "windows" -%}
+"{{ PYTHON }}" -m pip install --ignore-installed {{ OPTIONS }} "{{ manifest_root }}"
 {% else %}
-"{{ PYTHON }}" -m pip install --ignore-installed {{ OPTIONS }}
+"{{ PYTHON }}" -m pip install --ignore-installed {{ OPTIONS }} "{{ manifest_root }}"
 {% endif -%}
 
 {% if build_platform == "windows" -%}

--- a/crates/pixi_build_r/pixi.toml
+++ b/crates/pixi_build_r/pixi.toml
@@ -8,3 +8,6 @@ version = "*"
 
 [package.run-dependencies]
 pixi-build-api-version = ">=4,<5"
+
+[package.build.config]
+extra-input-globs = ["src/build_script.j2"]

--- a/crates/pixi_build_r/src/build_script.j2
+++ b/crates/pixi_build_r/src/build_script.j2
@@ -18,7 +18,7 @@
 {%- set install_args = [
     "--library=" ~ LIBRARY_DIR,
     "--no-lock",
-] + extra_args + [source_dir]
+] + extra_args
 -%}
 
 {# Output version information for debugging #}
@@ -38,7 +38,7 @@ mkdir -p "{{ LIBRARY_DIR }}"
 {% endif %}
 
 {# Run R CMD INSTALL #}
-{{ R_CMD }} INSTALL {{ install_args | join(" " ~ LINE_CONT ~ "\n    ") }}
+{{ R_CMD }} INSTALL {{ install_args | join(" " ~ LINE_CONT ~ "\n    ") }} "{{ source_dir }}"
 
 {# Check for errors #}
 {% if is_cmd_exe -%}

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-native-no-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-native-no-extra-args.snap
@@ -11,8 +11,7 @@ mkdir -p "$PREFIX/lib/R/library"
 
 
 R CMD INSTALL --library=$PREFIX/lib/R/library \
-    --no-lock \
-    /path/to/package
+    --no-lock "/path/to/package"
 
 
 if [ $? -ne 0 ]; then

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-native-with-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-native-with-extra-args.snap
@@ -12,8 +12,7 @@ mkdir -p "$PREFIX/lib/R/library"
 
 R CMD INSTALL --library=$PREFIX/lib/R/library \
     --no-lock \
-    --no-multiarch \
-    /path/to/package
+    --no-multiarch "/path/to/package"
 
 
 if [ $? -ne 0 ]; then

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-pure-no-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-pure-no-extra-args.snap
@@ -11,8 +11,7 @@ mkdir -p "$PREFIX/lib/R/library"
 
 
 R CMD INSTALL --library=$PREFIX/lib/R/library \
-    --no-lock \
-    /path/to/package
+    --no-lock "/path/to/package"
 
 
 if [ $? -ne 0 ]; then

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-pure-with-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@unix-pure-with-extra-args.snap
@@ -12,8 +12,7 @@ mkdir -p "$PREFIX/lib/R/library"
 
 R CMD INSTALL --library=$PREFIX/lib/R/library \
     --no-lock \
-    --no-multiarch \
-    /path/to/package
+    --no-multiarch "/path/to/package"
 
 
 if [ $? -ne 0 ]; then

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-native-no-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-native-no-extra-args.snap
@@ -13,8 +13,7 @@ if not exist "%LIBRARY_PREFIX%\R\library" mkdir "%LIBRARY_PREFIX%\R\library"
 
 
 R.exe CMD INSTALL --library=%LIBRARY_PREFIX%\R\library ^
-    --no-lock ^
-    /path/to/package
+    --no-lock "/path/to/package"
 
 
 @if errorlevel 1 exit 1

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-native-with-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-native-with-extra-args.snap
@@ -14,8 +14,7 @@ if not exist "%LIBRARY_PREFIX%\R\library" mkdir "%LIBRARY_PREFIX%\R\library"
 
 R.exe CMD INSTALL --library=%LIBRARY_PREFIX%\R\library ^
     --no-lock ^
-    --no-multiarch ^
-    /path/to/package
+    --no-multiarch "/path/to/package"
 
 
 @if errorlevel 1 exit 1

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-pure-no-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-pure-no-extra-args.snap
@@ -13,8 +13,7 @@ if not exist "%LIBRARY_PREFIX%\R\library" mkdir "%LIBRARY_PREFIX%\R\library"
 
 
 R.exe CMD INSTALL --library=%LIBRARY_PREFIX%\R\library ^
-    --no-lock ^
-    /path/to/package
+    --no-lock "/path/to/package"
 
 
 @if errorlevel 1 exit 1

--- a/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-pure-with-extra-args.snap
+++ b/crates/pixi_build_r/src/snapshots/pixi_build_r__build_script__tests__build_script@windows-pure-with-extra-args.snap
@@ -14,8 +14,7 @@ if not exist "%LIBRARY_PREFIX%\R\library" mkdir "%LIBRARY_PREFIX%\R\library"
 
 R.exe CMD INSTALL --library=%LIBRARY_PREFIX%\R\library ^
     --no-lock ^
-    --no-multiarch ^
-    /path/to/package
+    --no-multiarch "/path/to/package"
 
 
 @if errorlevel 1 exit 1

--- a/crates/pixi_build_ros/pixi.toml
+++ b/crates/pixi_build_ros/pixi.toml
@@ -1,0 +1,14 @@
+[package.build.backend]
+channels = [
+    "https://prefix.dev/pixi-build-backends",
+    "https://prefix.dev/conda-forge",
+]
+name = "pixi-build-ros"
+version = "*"
+
+[package.run-dependencies]
+pixi-build-api-version = ">=4,<5"
+
+[package.build.config]
+extra-input-globs = ["templates/*", "robostack.yaml"]
+

--- a/crates/pixi_build_rust/pixi.toml
+++ b/crates/pixi_build_rust/pixi.toml
@@ -8,3 +8,6 @@ version = "*"
 
 [package.run-dependencies]
 pixi-build-api-version = ">=4,<5"
+
+[package.build.config]
+extra-input-globs = ["src/build_script.j2"]

--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -16,7 +16,7 @@ SET {{ key }}={{ value }}
 {{ export("RUSTC_WRAPPER", "sccache") }}
 {%- endif %}
 
-cargo install --locked --root "{{ env("PREFIX") }}" --path {{ source_dir }} --target-dir target --no-track {{ extra_args | join(" ") }} --force
+cargo install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
 {%- if not is_bash %}
 if errorlevel 1 exit 1
 {%- endif %}

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -2,4 +2,4 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-cargo install --locked --root "$PREFIX" --path my-prefix-dir --target-dir target --no-track  --force
+cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,5 +2,5 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-cargo install --locked --root "%PREFIX%" --path my-prefix-dir --target-dir target --no-track  --force
+cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -4,4 +4,4 @@ expression: script
 ---
 export OPENSSL_DIR="$PREFIX"
 
-cargo install --locked --root "$PREFIX" --path my-prefix-dir --target-dir target --no-track  --force
+cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -4,5 +4,5 @@ expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
 
-cargo install --locked --root "%PREFIX%" --path my-prefix-dir --target-dir target --no-track  --force
+cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -4,6 +4,6 @@ expression: script
 ---
 export RUSTC_WRAPPER=sccache
 
-cargo install --locked --root "$PREFIX" --path my-prefix-dir --target-dir target --no-track  --force
+cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
 
 sccache --show-stats

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -4,7 +4,7 @@ expression: script
 ---
 SET RUSTC_WRAPPER=sccache
 
-cargo install --locked --root "%PREFIX%" --path my-prefix-dir --target-dir target --no-track  --force
+cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1
 
 sccache --show-stats

--- a/tests/data/pixi-build/multi-output/pixi.toml
+++ b/tests/data/pixi-build/multi-output/pixi.toml
@@ -1,8 +1,8 @@
 [workspace]
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 channels = ["https://prefix.dev/conda-forge"]
-exclude-newer = "7d"
 description = "Add a short description here"
+exclude-newer = "7d"
 name = "multi-output"
 platforms = ["osx-arm64", "linux-64", "win-64"]
 preview = ["pixi-build"]

--- a/tests/data/pixi-build/rattler-build-backend/smokey/pixi.toml
+++ b/tests/data/pixi-build/rattler-build-backend/smokey/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-exclude-newer = "7d"
 description = "Add a short description here"
+exclude-newer = "7d"
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 preview = ["pixi-build"]
 

--- a/tests/data/pixi-build/rattler-build-backend/smokey2/pixi.toml
+++ b/tests/data/pixi-build/rattler-build-backend/smokey2/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["https://prefix.dev/conda-forge"]
-exclude-newer = "7d"
 description = "Add a short description here"
+exclude-newer = "7d"
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 preview = ["pixi-build"]
 


### PR DESCRIPTION
### Description

I've modified the build script to put the paths in qoutes to help with spaces in the manifest paths.

Fixes #5350 

### How Has This Been Tested?

Tested it on the example in #5350 

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

Claude helped me translate it to all backends that had this issue with the build script.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [na] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
