### PR TITLE
docs: Fix the description of `pixi run` with duplicate tasks

### DIFF
--- a/docs/tutorials/multi_environment.md
+++ b/docs/tutorials/multi_environment.md
@@ -104,9 +104,9 @@ Now you don't have to specify the environment when running the test command.
 ```shell
 pixi run test
 ```
-In this example similar to running `pixi run --environment test pytest`
+In this example this is equivalent to running `pixi run --environment test pytest`.
 
-This works as long as there is only one of the environments that has the `test` task.
+If there are multiple environments with the same task, pixi will prompt you for the environment in which it should run the task.
 
 ## Using multiple environments to test multiple versions of a package
 In this example we will use multiple environments to test a package against multiple versions of Python.


### PR DESCRIPTION
### Description

Another tiny fix: The current documentation states that `pixi run <task>` will only work if there is exactly one environment which defines the `<task>`. But it actually works with multiple environments and even gives a nice prompt for which environment to use.

### How Has This Been Tested?

I created a new pixi workspace with the following `pixi.toml`:

```toml
[workspace]
authors = ["AUTHOR <EMAIL>"]
channels = ["conda-forge"]
name = "hello-world2"
platforms = ["linux-64"]
version = "0.1.0"

[tasks]

[dependencies]

[feature.test.dependencies]
pytest = "*"

[feature.test.tasks]
test = "pytest"

[feature.test2.dependencies]
pytest = "*"

[feature.test2.tasks]
test = "pytest"

[environments]
env-with-test = ["test"]
env-with-test2 = ["test2"]
```

I then ran `pixi run test` to see if it works and what the output would be. With pixi 0.67 I get:

```
❯ pixi run test
? The task 'test' can be run in multiple environments.

Please select an environment to run the task in: ›
❯ env-with-test
  env-with-test2
```

which then allows me to select the environment.

### Checklist:
- [x] I have performed a self-review of my own code
