### PR TITLE
chore: bump backend versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-cmake"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "async-trait",
  "indexmap 2.13.0",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-mojo"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rattler-build"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5791,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-ros"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rust"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "cargo_toml",

--- a/crates/pixi_build_cmake/Cargo.toml
+++ b/crates/pixi_build_cmake/Cargo.toml
@@ -3,7 +3,7 @@ description = "CMake build backend for Pixi"
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-cmake"
-version = "0.3.10"
+version = "0.3.11"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_mojo/Cargo.toml
+++ b/crates/pixi_build_mojo/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-mojo"
-version = "0.1.10"
+version = "0.1.11"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-python"
-version = "0.4.7"
+version = "0.4.8"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rattler_build/Cargo.toml
+++ b/crates/pixi_build_rattler_build/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-rattler-build"
-version = "0.3.9"
+version = "0.3.10"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-ros"
 repository.workspace = true
-version = "0.3.6"
+version = "0.4.0"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_ros/pixi.toml
+++ b/crates/pixi_build_ros/pixi.toml
@@ -1,7 +1,7 @@
 [package.build.backend]
 channels = [
-    "https://prefix.dev/pixi-build-backends",
-    "https://prefix.dev/conda-forge",
+  "https://prefix.dev/pixi-build-backends",
+  "https://prefix.dev/conda-forge",
 ]
 name = "pixi-build-ros"
 version = "*"
@@ -11,4 +11,3 @@ pixi-build-api-version = ">=4,<5"
 
 [package.build.config]
 extra-input-globs = ["templates/*", "robostack.yaml"]
-

--- a/crates/pixi_build_rust/Cargo.toml
+++ b/crates/pixi_build_rust/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-rust"
 repository.workspace = true
-version = "0.4.7"
+version = "0.4.8"
 
 [package.metadata.dist]
 dist = false

--- a/scripts/release_backends.py
+++ b/scripts/release_backends.py
@@ -107,7 +107,7 @@ class Backend:
     @property
     def cargo_name(self) -> str:
         """Cargo package name for `cargo update --package`."""
-        return self.binary.replace("-", "_")
+        return self.binary
 
     @property
     def version_path(self) -> Path:


### PR DESCRIPTION
Release backends PR

Main changes:
- `pixi-build-ros` is now a rust package.
- We're using the rattler-build intermediate recipe.
- We've fixed the spaces in path issue.
- We've fixed the license files issue.