### PR TITLE
refactor: convert Reporter trait hierarchy from `&mut self` to `&self`

### DIFF
--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/backend_source_build.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/backend_source_build.rs
@@ -57,7 +57,7 @@ impl CommandDispatcherProcessor {
             // Notify the reporter that the solve has started.
             if let Some((reporter, id)) = self
                 .reporter
-                .as_deref_mut()
+                .as_deref()
                 .and_then(Reporter::as_backend_source_build_reporter)
                 .zip(reporter_id)
             {

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/build_backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/build_backend_metadata.rs
@@ -45,7 +45,7 @@ impl CommandDispatcherProcessor {
 
         if let Some((reporter, reporter_id)) = self
             .reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(Reporter::as_build_backend_metadata_reporter)
             .zip(
                 self.build_backend_metadata_reporters

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/git.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/git.rs
@@ -44,7 +44,7 @@ impl CommandDispatcherProcessor {
             .get(&id)
             .and_then(|ids| ids.last().copied())
         {
-            pixi_git::GitUrl::report_started(&mut self.reporter, reporter_id);
+            pixi_git::GitUrl::report_started(&self.reporter, reporter_id);
         }
 
         let resolver = self.inner.git_resolver.clone();

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/install_pixi.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/install_pixi.rs
@@ -34,7 +34,7 @@ impl CommandDispatcherProcessor {
 
         // Notify the reporter that the solve has started.
         if let Some(id) = reporter_id {
-            InstallPixiEnvironmentSpec::report_started(&mut self.reporter, id);
+            InstallPixiEnvironmentSpec::report_started(&self.reporter, id);
         }
 
         // Create a reporter for the installation task.
@@ -42,7 +42,7 @@ impl CommandDispatcherProcessor {
         let reporter_context = self.reporter_context(dispatcher_context);
         let install_reporter = self
             .reporter
-            .as_mut()
+            .as_ref()
             .and_then(|reporter| reporter.create_install_reporter(reporter_context));
 
         // Store the cancellation token for this context so child tasks can link to it.

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/instantiate_tool_env.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/instantiate_tool_env.rs
@@ -48,7 +48,7 @@ impl CommandDispatcherProcessor {
             .get(&id)
             .and_then(|ids| ids.last().copied())
         {
-            InstantiateToolEnvironmentSpec::report_started(&mut self.reporter, reporter_id);
+            InstantiateToolEnvironmentSpec::report_started(&self.reporter, reporter_id);
         }
 
         let command_queue = self.create_task_command_dispatcher(context);

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/mod.rs
@@ -422,7 +422,7 @@ impl CommandDispatcherProcessor {
     /// will run until all dispatchers have been dropped.
     async fn run(mut self) {
         tracing::trace!("Dispatch background task has started");
-        if let Some(reporter) = self.reporter.as_mut() {
+        if let Some(reporter) = self.reporter.as_ref() {
             reporter.on_start();
         }
         loop {
@@ -446,7 +446,7 @@ impl CommandDispatcherProcessor {
                 }
             }
         }
-        if let Some(reporter) = self.reporter.as_mut() {
+        if let Some(reporter) = self.reporter.as_ref() {
             reporter.on_finished();
         }
         tracing::trace!("Dispatch background task has finished");
@@ -698,7 +698,7 @@ impl CommandDispatcherProcessor {
 
     /// Called to clear the reporter.
     fn clear_reporter(&mut self, sender: oneshot::Sender<()>) {
-        if let Some(reporter) = self.reporter.as_mut() {
+        if let Some(reporter) = self.reporter.as_ref() {
             reporter.on_clear()
         }
         let _ = sender.send(());
@@ -750,7 +750,7 @@ impl HasDedupTaskFields for BuildBackendMetadataSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.build_backend_metadata_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.build_backend_metadata,
@@ -767,7 +767,7 @@ impl HasDedupTaskFields for SourceBuildSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.source_build_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.source_build,
@@ -784,7 +784,7 @@ impl HasDedupTaskFields for pixi_git::GitUrl {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.git_checkout_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.git_checkouts,
@@ -801,7 +801,7 @@ impl HasDedupTaskFields for pixi_spec::UrlSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.url_checkout_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.url_checkouts,
@@ -818,7 +818,7 @@ impl HasDedupTaskFields for SourceRecordSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.source_record_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.source_record,
@@ -835,7 +835,7 @@ impl HasDedupTaskFields for InstantiateToolEnvironmentSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.instantiated_tool_envs_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.instantiated_tool_envs,
@@ -852,7 +852,7 @@ impl HasDedupTaskFields for SourceMetadataSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.source_metadata_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.source_metadata,
@@ -869,7 +869,7 @@ impl HasDedupTaskFields for DevSourceMetadataSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.dev_source_metadata_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.dev_source_metadata,
@@ -886,7 +886,7 @@ impl HasDedupTaskFields for SourceBuildCacheStatusSpec {
     ) -> DedupTaskFields<'_, Self::Id, Self::ReporterId, Self::Ok, Self::Err> {
         DedupTaskFields {
             parent_contexts: &mut proc.parent_contexts,
-            reporter: &mut proc.reporter,
+            reporter: &proc.reporter,
             reporter_map: &mut proc.source_build_cache_status_reporters,
             monitor_futures: &mut proc.monitor_futures,
             dedup: &mut proc.source_build_cache_status,
@@ -909,7 +909,7 @@ struct NewDedupTask<Id> {
 /// `complete_dedup_task`.
 pub(crate) struct DedupTaskFields<'a, Id, ReporterId, Ok, Err> {
     parent_contexts: &'a mut HashMap<CommandDispatcherContext, CommandDispatcherContext>,
-    reporter: &'a mut Option<Box<dyn Reporter>>,
+    reporter: &'a Option<Box<dyn Reporter>>,
     reporter_map: &'a mut HashMap<Id, Vec<ReporterId>>,
     monitor_futures: &'a mut ExecutorFutures<LocalBoxFuture<'static, CommandDispatcherContext>>,
     dedup: &'a mut dyn ErasedDedupRegistry<Id, Ok, Err>,
@@ -1036,7 +1036,7 @@ impl CommandDispatcherProcessor {
         task_cancellation_token: CancellationToken,
     ) -> (Option<S::ReporterId>, CancellationToken) {
         let parent_context = task_parent.and_then(|ctx| self.reporter_context(ctx));
-        let reporter_id = spec.report_queued(&mut self.reporter, parent_context, None);
+        let reporter_id = spec.report_queued(&self.reporter, parent_context, None);
         let cancellation_token =
             self.get_child_cancellation_token(task_parent, task_cancellation_token);
         (reporter_id, cancellation_token)
@@ -1080,7 +1080,7 @@ impl CommandDispatcherProcessor {
         self.parent_contexts.remove(&context);
         self.complete_task_token(context, &result);
         if let Some(reporter_id) = reporter_id {
-            S::report_finished(&mut self.reporter, reporter_id, result.is_err());
+            S::report_finished(&self.reporter, reporter_id, result.is_err());
         }
         if let Some(result) = result.into_ok_or_failed() {
             let _ = tx.send(result);

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_conda.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_conda.rs
@@ -56,7 +56,7 @@ impl CommandDispatcherProcessor {
 
             // Notify the reporter that the solve has started.
             if let Some(id) = reporter_id {
-                SolveCondaEnvironmentSpec::report_started(&mut self.reporter, id);
+                SolveCondaEnvironmentSpec::report_started(&self.reporter, id);
             }
 
             // Store the cancellation token for this context so child tasks can link to it.

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_pixi.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/solve_pixi.rs
@@ -31,14 +31,14 @@ impl CommandDispatcherProcessor {
 
         // Notify the reporter that the solve has started.
         if let Some(id) = reporter_id {
-            PixiEnvironmentSpec::report_started(&mut self.reporter, id);
+            PixiEnvironmentSpec::report_started(&self.reporter, id);
         }
 
         let dispatcher_context = CommandDispatcherContext::SolvePixiEnvironment(pending_env_id);
         let reporter_context = self.reporter_context(dispatcher_context);
         let gateway_reporter = self
             .reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|reporter| reporter.create_gateway_reporter(reporter_context));
 
         self.store_cancellation_token(dispatcher_context, cancellation_token.clone());

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/source_build.rs
@@ -44,7 +44,7 @@ impl CommandDispatcherProcessor {
         let (tx, rx) = futures::channel::mpsc::unbounded::<String>();
 
         let mut run_exports_reporter: Option<Arc<dyn RunExportsReporter>> = None;
-        if let Some(reporter) = self.reporter.as_mut() {
+        if let Some(reporter) = self.reporter.as_ref() {
             let created = reporter.create_run_exports_reporter(reporter_context);
             if let Some((source_reporter, reporter_id)) = reporter.as_source_build_reporter().zip(
                 self.source_build_reporters

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/source_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/source_metadata.rs
@@ -52,7 +52,7 @@ impl CommandDispatcherProcessor {
             .get(&id)
             .and_then(|ids| ids.last().copied())
         {
-            SourceMetadataSpec::report_started(&mut self.reporter, reporter_id);
+            SourceMetadataSpec::report_started(&self.reporter, reporter_id);
         }
 
         let dispatcher = self.create_task_command_dispatcher(context);

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/source_record.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/source_record.rs
@@ -64,14 +64,14 @@ impl CommandDispatcherProcessor {
             .get(&id)
             .and_then(|ids| ids.last().copied())
         {
-            SourceRecordSpec::report_started(&mut self.reporter, reporter_id);
+            SourceRecordSpec::report_started(&self.reporter, reporter_id);
         }
 
         let dispatcher = self.create_task_command_dispatcher(context);
         let reporter_context = self.reporter_context(context);
         let run_exports_reporter = self
             .reporter
-            .as_mut()
+            .as_ref()
             .and_then(|reporter| reporter.create_run_exports_reporter(reporter_context));
 
         self.pending_futures.push(

--- a/crates/pixi_command_dispatcher/src/command_dispatcher_processor/url.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher_processor/url.rs
@@ -45,7 +45,7 @@ impl CommandDispatcherProcessor {
             .get(&id)
             .and_then(|ids| ids.last().copied())
         {
-            pixi_spec::UrlSpec::report_started(&mut self.reporter, reporter_id);
+            pixi_spec::UrlSpec::report_started(&self.reporter, reporter_id);
         }
 
         let resolver = self.inner.url_resolver.clone();

--- a/crates/pixi_command_dispatcher/src/reporter.rs
+++ b/crates/pixi_command_dispatcher/src/reporter.rs
@@ -33,16 +33,16 @@ pub trait PixiInstallReporter {
     /// particular installation. Other functions in this trait will use this
     /// identifier to link the events to the particular solve.
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &InstallPixiEnvironmentSpec,
     ) -> PixiInstallId;
 
     /// Called when installation of the specified environment has started.
-    fn on_started(&mut self, solve_id: PixiInstallId);
+    fn on_started(&self, solve_id: PixiInstallId);
 
     /// Called when solving of the specified environment has finished.
-    fn on_finished(&mut self, solve_id: PixiInstallId);
+    fn on_finished(&self, solve_id: PixiInstallId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -60,17 +60,13 @@ pub trait PixiSolveReporter {
     /// This function should return an identifier which is used to identify this
     /// particular solve. Other functions in this trait will use this identifier
     /// to link the events to the particular solve.
-    fn on_queued(
-        &mut self,
-        reason: Option<ReporterContext>,
-        env: &PixiEnvironmentSpec,
-    ) -> PixiSolveId;
+    fn on_queued(&self, reason: Option<ReporterContext>, env: &PixiEnvironmentSpec) -> PixiSolveId;
 
     /// Called when solving of the specified environment has started.
-    fn on_started(&mut self, solve_id: PixiSolveId);
+    fn on_started(&self, solve_id: PixiSolveId);
 
     /// Called when solving of the specified environment has finished.
-    fn on_finished(&mut self, solve_id: PixiSolveId);
+    fn on_finished(&self, solve_id: PixiSolveId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -89,16 +85,16 @@ pub trait CondaSolveReporter {
     /// particular solve. Other functions in this trait will use this identifier
     /// to link the events to the particular solve.
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &SolveCondaEnvironmentSpec,
     ) -> CondaSolveId;
 
     /// Called when solving of the specified environment has started.
-    fn on_started(&mut self, solve_id: CondaSolveId);
+    fn on_started(&self, solve_id: CondaSolveId);
 
     /// Called when solving of the specified environment has finished.
-    fn on_finished(&mut self, solve_id: CondaSolveId);
+    fn on_finished(&self, solve_id: CondaSolveId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -109,17 +105,17 @@ pub trait GitCheckoutReporter {
     /// Called when a git checkout was queued on the
     /// [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &RepositoryReference,
         dedup_id: DedupGroupId,
     ) -> GitCheckoutId;
 
     /// Called when the git checkout has started.
-    fn on_started(&mut self, checkout_id: GitCheckoutId);
+    fn on_started(&self, checkout_id: GitCheckoutId);
 
     /// Called when the git checkout has finished.
-    fn on_finished(&mut self, checkout_id: GitCheckoutId);
+    fn on_finished(&self, checkout_id: GitCheckoutId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -130,17 +126,17 @@ pub trait UrlCheckoutReporter {
     /// Called when a url checkout was queued on the
     /// [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &Url,
         dedup_id: DedupGroupId,
     ) -> UrlCheckoutId;
 
     /// Called when the url checkout has started.
-    fn on_started(&mut self, checkout_id: UrlCheckoutId);
+    fn on_started(&self, checkout_id: UrlCheckoutId);
 
     /// Called when the url checkout has finished.
-    fn on_finished(&mut self, checkout_id: UrlCheckoutId);
+    fn on_finished(&self, checkout_id: UrlCheckoutId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -150,17 +146,17 @@ pub struct InstantiateToolEnvId(pub usize);
 pub trait InstantiateToolEnvironmentReporter {
     /// Called when an operation was queued on the [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &InstantiateToolEnvironmentSpec,
         dedup_id: DedupGroupId,
     ) -> InstantiateToolEnvId;
 
     /// Called when the operation has started.
-    fn on_started(&mut self, id: InstantiateToolEnvId);
+    fn on_started(&self, id: InstantiateToolEnvId);
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: InstantiateToolEnvId);
+    fn on_finished(&self, id: InstantiateToolEnvId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -170,7 +166,7 @@ pub struct BuildBackendMetadataId(pub usize);
 pub trait BuildBackendMetadataReporter {
     /// Called when an operation was queued on the [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &BuildBackendMetadataSpec,
         dedup_id: DedupGroupId,
@@ -178,13 +174,13 @@ pub trait BuildBackendMetadataReporter {
 
     /// Called when the operation has started.
     fn on_started(
-        &mut self,
+        &self,
         id: BuildBackendMetadataId,
         backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     );
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: BuildBackendMetadataId, failed: bool);
+    fn on_finished(&self, id: BuildBackendMetadataId, failed: bool);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -194,17 +190,17 @@ pub struct SourceRecordId(pub usize);
 pub trait SourceRecordReporter {
     /// Called when an operation was queued on the [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         spec: &SourceRecordSpec,
         dedup_id: DedupGroupId,
     ) -> SourceRecordId;
 
     /// Called when the operation has started.
-    fn on_started(&mut self, id: SourceRecordId);
+    fn on_started(&self, id: SourceRecordId);
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: SourceRecordId);
+    fn on_finished(&self, id: SourceRecordId);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
@@ -214,17 +210,17 @@ pub struct SourceMetadataId(pub usize);
 pub trait SourceMetadataReporter {
     /// Called when an operation was queued on the [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         spec: &SourceMetadataSpec,
         dedup_id: DedupGroupId,
     ) -> SourceMetadataId;
 
     /// Called when the operation has started.
-    fn on_started(&mut self, id: SourceMetadataId);
+    fn on_started(&self, id: SourceMetadataId);
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: SourceMetadataId);
+    fn on_finished(&self, id: SourceMetadataId);
 }
 
 /// A trait that is used to report the progress of a source build performed by
@@ -236,7 +232,7 @@ pub struct SourceBuildId(pub usize);
 pub trait SourceBuildReporter {
     /// Called when an operation was queued on the [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &SourceBuildSpec,
         dedup_id: DedupGroupId,
@@ -244,13 +240,13 @@ pub trait SourceBuildReporter {
 
     /// Called when the operation has started.
     fn on_started(
-        &mut self,
+        &self,
         id: SourceBuildId,
         backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     );
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: SourceBuildId, failed: bool);
+    fn on_finished(&self, id: SourceBuildId, failed: bool);
 }
 
 /// A trait that is used to report the progress of a source build performed by
@@ -262,7 +258,7 @@ pub struct BackendSourceBuildId(pub usize);
 pub trait BackendSourceBuildReporter {
     /// Called when an operation was queued on the [`crate::CommandDispatcher`].
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &BackendSourceBuildSpec,
     ) -> BackendSourceBuildId;
@@ -270,86 +266,84 @@ pub trait BackendSourceBuildReporter {
     /// Called when the operation has started. The `backend_output_stream`
     /// stream can be used to capture the output of the build process.
     fn on_started(
-        &mut self,
+        &self,
         id: BackendSourceBuildId,
         backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     );
 
     /// Called when the operation has finished.
-    fn on_finished(&mut self, id: BackendSourceBuildId, failed: bool);
+    fn on_finished(&self, id: BackendSourceBuildId, failed: bool);
 }
 
 /// A trait that is used to report the progress of the
 /// [`crate::CommandDispatcher`].
 ///
-/// The reporter has to be `Send` but does not require `Sync`.
-pub trait Reporter: Send {
+/// The reporter has to be `Send + Sync`.
+pub trait Reporter: Send + Sync {
     /// Called when the command dispatcher thread starts.
-    fn on_start(&mut self) {}
+    fn on_start(&self) {}
 
     /// Called to clear the current progress.
-    fn on_clear(&mut self) {}
+    fn on_clear(&self) {}
 
     /// Called when the command dispatcher thread is about to close.
-    fn on_finished(&mut self) {}
+    fn on_finished(&self) {}
 
-    /// Returns a mutable reference to a reporter that reports on any git
+    /// Returns a reference to a reporter that reports on any git
     /// progress.
-    fn as_git_reporter(&mut self) -> Option<&mut dyn GitCheckoutReporter> {
+    fn as_git_reporter(&self) -> Option<&dyn GitCheckoutReporter> {
         None
     }
-    /// Returns a mutable reference to a reporter that reports on any git
+    /// Returns a reference to a reporter that reports on any git
     /// progress.
-    fn as_url_reporter(&mut self) -> Option<&mut dyn UrlCheckoutReporter> {
+    fn as_url_reporter(&self) -> Option<&dyn UrlCheckoutReporter> {
         None
     }
-    /// Returns a mutable reference to a reporter that reports on conda solve
+    /// Returns a reference to a reporter that reports on conda solve
     /// progress.
-    fn as_conda_solve_reporter(&mut self) -> Option<&mut dyn CondaSolveReporter> {
+    fn as_conda_solve_reporter(&self) -> Option<&dyn CondaSolveReporter> {
         None
     }
-    /// Returns a mutable reference to a reporter that reports on an entire pixi
+    /// Returns a reference to a reporter that reports on an entire pixi
     /// solve progress. so that can mean solves for multiple ecosystems for
     /// an environment.
-    fn as_pixi_solve_reporter(&mut self) -> Option<&mut dyn PixiSolveReporter> {
+    fn as_pixi_solve_reporter(&self) -> Option<&dyn PixiSolveReporter> {
         None
     }
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of actual package installation.
-    fn as_pixi_install_reporter(&mut self) -> Option<&mut dyn PixiInstallReporter> {
+    fn as_pixi_install_reporter(&self) -> Option<&dyn PixiInstallReporter> {
         None
     }
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of instantiating a tool environment.
     fn as_instantiate_tool_environment_reporter(
-        &mut self,
-    ) -> Option<&mut dyn InstantiateToolEnvironmentReporter> {
+        &self,
+    ) -> Option<&dyn InstantiateToolEnvironmentReporter> {
         None
     }
 
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of fetching build backend metadata.
-    fn as_build_backend_metadata_reporter(
-        &mut self,
-    ) -> Option<&mut dyn BuildBackendMetadataReporter> {
+    fn as_build_backend_metadata_reporter(&self) -> Option<&dyn BuildBackendMetadataReporter> {
         None
     }
 
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of resolving source metadata (all variants for a package).
-    fn as_source_metadata_reporter(&mut self) -> Option<&mut dyn SourceMetadataReporter> {
+    fn as_source_metadata_reporter(&self) -> Option<&dyn SourceMetadataReporter> {
         None
     }
 
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of resolving source records.
-    fn as_source_record_reporter(&mut self) -> Option<&mut dyn SourceRecordReporter> {
+    fn as_source_record_reporter(&self) -> Option<&dyn SourceRecordReporter> {
         None
     }
 
     /// Returns a reporter that reports gateway progress.
     fn create_gateway_reporter(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
     ) -> Option<Box<dyn rattler_repodata_gateway::Reporter>> {
         None
@@ -357,7 +351,7 @@ pub trait Reporter: Send {
 
     /// Returns a reporter that run exports fetching progress.
     fn create_run_exports_reporter(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
     ) -> Option<Arc<dyn RunExportsReporter>> {
         None
@@ -365,21 +359,21 @@ pub trait Reporter: Send {
 
     /// Returns a reporter that reports installation progress.
     fn create_install_reporter(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
     ) -> Option<Box<dyn rattler::install::Reporter>> {
         None
     }
 
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of building source packages.
-    fn as_source_build_reporter(&mut self) -> Option<&mut dyn SourceBuildReporter> {
+    fn as_source_build_reporter(&self) -> Option<&dyn SourceBuildReporter> {
         None
     }
 
-    /// Returns a mutable reference to a reporter that reports on the progress
+    /// Returns a reference to a reporter that reports on the progress
     /// of a backend that is building source packages.
-    fn as_backend_source_build_reporter(&mut self) -> Option<&mut dyn BackendSourceBuildReporter> {
+    fn as_backend_source_build_reporter(&self) -> Option<&dyn BackendSourceBuildReporter> {
         None
     }
 }
@@ -403,20 +397,16 @@ pub(crate) trait Reportable {
     /// `dedup_group_id` is `Some` for deduplicated tasks, `None` otherwise.
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId>;
 
     /// Notify the reporter that this task has started.
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId);
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId);
 
     /// Notify the reporter that this task has finished.
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        failed: bool,
-    );
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, failed: bool);
 }
 
 // --- Reportable implementations ---
@@ -428,19 +418,19 @@ macro_rules! impl_reportable {
             type ReporterId = $id;
             fn report_queued(
                 &self,
-                reporter: &mut Option<Box<dyn Reporter>>,
+                reporter: &Option<Box<dyn Reporter>>,
                 parent: Option<ReporterContext>,
                 dedup_group_id: Option<DedupGroupId>,
             ) -> Option<Self::ReporterId> {
-                reporter.as_deref_mut()
+                reporter.as_deref()
                     .and_then(|r| r.$accessor())
                     .map(|r| r.on_queued(parent, impl_reportable!(@queued_spec self $(, $arg)?), dedup_group_id.expect("dedup tasks must provide a DedupGroupId")))
             }
-            fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
-                if let Some(r) = reporter.as_deref_mut().and_then(|r| r.$accessor()) { r.on_started(id); }
+            fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+                if let Some(r) = reporter.as_deref().and_then(|r| r.$accessor()) { r.on_started(id); }
             }
-            fn report_finished(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
-                if let Some(r) = reporter.as_deref_mut().and_then(|r| r.$accessor()) { r.on_finished(id); }
+            fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
+                if let Some(r) = reporter.as_deref().and_then(|r| r.$accessor()) { r.on_finished(id); }
             }
         }
     };
@@ -464,13 +454,13 @@ impl Reportable for pixi_git::GitUrl {
     type ReporterId = GitCheckoutId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         let repo_ref = pixi_git::resolver::RepositoryReference::from(self);
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_git_reporter())
             .map(|r| {
                 r.on_queued(
@@ -480,17 +470,13 @@ impl Reportable for pixi_git::GitUrl {
                 )
             })
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
-        if let Some(r) = reporter.as_deref_mut().and_then(|r| r.as_git_reporter()) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+        if let Some(r) = reporter.as_deref().and_then(|r| r.as_git_reporter()) {
             r.on_started(id);
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        _failed: bool,
-    ) {
-        if let Some(r) = reporter.as_deref_mut().and_then(|r| r.as_git_reporter()) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
+        if let Some(r) = reporter.as_deref().and_then(|r| r.as_git_reporter()) {
             r.on_finished(id);
         }
     }
@@ -500,12 +486,12 @@ impl Reportable for pixi_spec::UrlSpec {
     type ReporterId = UrlCheckoutId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_url_reporter())
             .map(|r| {
                 r.on_queued(
@@ -515,17 +501,13 @@ impl Reportable for pixi_spec::UrlSpec {
                 )
             })
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
-        if let Some(r) = reporter.as_deref_mut().and_then(|r| r.as_url_reporter()) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+        if let Some(r) = reporter.as_deref().and_then(|r| r.as_url_reporter()) {
             r.on_started(id);
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        _failed: bool,
-    ) {
-        if let Some(r) = reporter.as_deref_mut().and_then(|r| r.as_url_reporter()) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
+        if let Some(r) = reporter.as_deref().and_then(|r| r.as_url_reporter()) {
             r.on_finished(id);
         }
     }
@@ -535,12 +517,12 @@ impl Reportable for BuildBackendMetadataSpec {
     type ReporterId = BuildBackendMetadataId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_build_backend_metadata_reporter())
             .map(|r| {
                 r.on_queued(
@@ -550,21 +532,17 @@ impl Reportable for BuildBackendMetadataSpec {
                 )
             })
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_build_backend_metadata_reporter())
         {
             r.on_started(id, Box::new(futures::stream::empty()));
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        failed: bool,
-    ) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, failed: bool) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_build_backend_metadata_reporter())
         {
             r.on_finished(id, failed);
@@ -576,12 +554,12 @@ impl Reportable for SourceBuildSpec {
     type ReporterId = SourceBuildId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_source_build_reporter())
             .map(|r| {
                 r.on_queued(
@@ -591,21 +569,17 @@ impl Reportable for SourceBuildSpec {
                 )
             })
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_source_build_reporter())
         {
             r.on_started(id, Box::new(futures::stream::empty()));
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        failed: bool,
-    ) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, failed: bool) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_source_build_reporter())
         {
             r.on_finished(id, failed);
@@ -617,32 +591,22 @@ impl Reportable for crate::PixiEnvironmentSpec {
     type ReporterId = PixiSolveId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         _dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_pixi_solve_reporter())
             .map(|r| r.on_queued(parent, self))
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
-        if let Some(r) = reporter
-            .as_deref_mut()
-            .and_then(|r| r.as_pixi_solve_reporter())
-        {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+        if let Some(r) = reporter.as_deref().and_then(|r| r.as_pixi_solve_reporter()) {
             r.on_started(id);
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        _failed: bool,
-    ) {
-        if let Some(r) = reporter
-            .as_deref_mut()
-            .and_then(|r| r.as_pixi_solve_reporter())
-        {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
+        if let Some(r) = reporter.as_deref().and_then(|r| r.as_pixi_solve_reporter()) {
             r.on_finished(id);
         }
     }
@@ -652,30 +616,26 @@ impl Reportable for SolveCondaEnvironmentSpec {
     type ReporterId = CondaSolveId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         _dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_conda_solve_reporter())
             .map(|r| r.on_queued(parent, self))
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_conda_solve_reporter())
         {
             r.on_started(id);
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        _failed: bool,
-    ) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_conda_solve_reporter())
         {
             r.on_finished(id);
@@ -687,30 +647,26 @@ impl Reportable for InstallPixiEnvironmentSpec {
     type ReporterId = PixiInstallId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         _dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_pixi_install_reporter())
             .map(|r| r.on_queued(parent, self))
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_pixi_install_reporter())
         {
             r.on_started(id);
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        _failed: bool,
-    ) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, _failed: bool) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_pixi_install_reporter())
         {
             r.on_finished(id);
@@ -722,30 +678,26 @@ impl Reportable for BackendSourceBuildSpec {
     type ReporterId = BackendSourceBuildId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         _dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_backend_source_build_reporter())
             .map(|r| r.on_queued(parent, self))
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_backend_source_build_reporter())
         {
             r.on_started(id, Box::new(futures::stream::empty()));
         }
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        failed: bool,
-    ) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, failed: bool) {
         if let Some(r) = reporter
-            .as_deref_mut()
+            .as_deref()
             .and_then(|r| r.as_backend_source_build_reporter())
         {
             r.on_finished(id, failed);
@@ -758,20 +710,16 @@ impl Reportable for Box<BackendSourceBuildSpec> {
     type ReporterId = BackendSourceBuildId;
     fn report_queued(
         &self,
-        reporter: &mut Option<Box<dyn Reporter>>,
+        reporter: &Option<Box<dyn Reporter>>,
         parent: Option<ReporterContext>,
         dedup_group_id: Option<DedupGroupId>,
     ) -> Option<Self::ReporterId> {
         (**self).report_queued(reporter, parent, dedup_group_id)
     }
-    fn report_started(reporter: &mut Option<Box<dyn Reporter>>, id: Self::ReporterId) {
+    fn report_started(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId) {
         BackendSourceBuildSpec::report_started(reporter, id);
     }
-    fn report_finished(
-        reporter: &mut Option<Box<dyn Reporter>>,
-        id: Self::ReporterId,
-        failed: bool,
-    ) {
+    fn report_finished(reporter: &Option<Box<dyn Reporter>>, id: Self::ReporterId, failed: bool) {
         BackendSourceBuildSpec::report_finished(reporter, id, failed);
     }
 }
@@ -781,14 +729,14 @@ impl Reportable for DevSourceMetadataSpec {
     type ReporterId = ();
     fn report_queued(
         &self,
-        _: &mut Option<Box<dyn Reporter>>,
+        _: &Option<Box<dyn Reporter>>,
         _: Option<ReporterContext>,
         _: Option<DedupGroupId>,
     ) -> Option<()> {
         None
     }
-    fn report_started(_: &mut Option<Box<dyn Reporter>>, _: ()) {}
-    fn report_finished(_: &mut Option<Box<dyn Reporter>>, _: (), _: bool) {}
+    fn report_started(_: &Option<Box<dyn Reporter>>, _: ()) {}
+    fn report_finished(_: &Option<Box<dyn Reporter>>, _: (), _: bool) {}
 }
 
 /// No-op reportable for tasks that have no reporter.
@@ -796,14 +744,14 @@ impl Reportable for crate::source_build_cache_status::SourceBuildCacheStatusSpec
     type ReporterId = ();
     fn report_queued(
         &self,
-        _: &mut Option<Box<dyn Reporter>>,
+        _: &Option<Box<dyn Reporter>>,
         _: Option<ReporterContext>,
         _: Option<DedupGroupId>,
     ) -> Option<()> {
         None
     }
-    fn report_started(_: &mut Option<Box<dyn Reporter>>, _: ()) {}
-    fn report_finished(_: &mut Option<Box<dyn Reporter>>, _: (), _: bool) {}
+    fn report_started(_: &Option<Box<dyn Reporter>>, _: ()) {}
+    fn report_finished(_: &Option<Box<dyn Reporter>>, _: (), _: bool) {}
 }
 
 #[derive(Debug, Clone, Copy, Serialize, derive_more::From)]

--- a/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/event_reporter.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -164,15 +167,36 @@ pub enum Event {
     },
 }
 
-#[derive(Clone)]
 pub struct EventReporter {
     events: EventStore,
-    next_conda_solve_id: usize,
-    next_pixi_solve_id: usize,
-    next_pixi_install_id: usize,
-    next_git_checkout_id: usize,
-    next_source_metadata_id: usize,
-    next_instantiate_tool_env_id: usize,
+    next_conda_solve_id: AtomicUsize,
+    next_pixi_solve_id: AtomicUsize,
+    next_pixi_install_id: AtomicUsize,
+    next_git_checkout_id: AtomicUsize,
+    next_source_metadata_id: AtomicUsize,
+    next_instantiate_tool_env_id: AtomicUsize,
+}
+
+impl Clone for EventReporter {
+    fn clone(&self) -> Self {
+        Self {
+            events: self.events.clone(),
+            next_conda_solve_id: AtomicUsize::new(self.next_conda_solve_id.load(Ordering::Relaxed)),
+            next_pixi_solve_id: AtomicUsize::new(self.next_pixi_solve_id.load(Ordering::Relaxed)),
+            next_pixi_install_id: AtomicUsize::new(
+                self.next_pixi_install_id.load(Ordering::Relaxed),
+            ),
+            next_git_checkout_id: AtomicUsize::new(
+                self.next_git_checkout_id.load(Ordering::Relaxed),
+            ),
+            next_source_metadata_id: AtomicUsize::new(
+                self.next_source_metadata_id.load(Ordering::Relaxed),
+            ),
+            next_instantiate_tool_env_id: AtomicUsize::new(
+                self.next_instantiate_tool_env_id.load(Ordering::Relaxed),
+            ),
+        }
+    }
 }
 
 #[derive(Default, Clone)]
@@ -239,12 +263,12 @@ impl EventReporter {
         (
             Self {
                 events: events.clone(),
-                next_conda_solve_id: 0,
-                next_pixi_solve_id: 0,
-                next_pixi_install_id: 0,
-                next_git_checkout_id: 0,
-                next_source_metadata_id: 0,
-                next_instantiate_tool_env_id: 0,
+                next_conda_solve_id: AtomicUsize::new(0),
+                next_pixi_solve_id: AtomicUsize::new(0),
+                next_pixi_install_id: AtomicUsize::new(0),
+                next_git_checkout_id: AtomicUsize::new(0),
+                next_source_metadata_id: AtomicUsize::new(0),
+                next_instantiate_tool_env_id: AtomicUsize::new(0),
             },
             events,
         )
@@ -253,12 +277,11 @@ impl EventReporter {
 
 impl CondaSolveReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         env: &SolveCondaEnvironmentSpec,
     ) -> CondaSolveId {
-        let next_id = CondaSolveId(self.next_conda_solve_id);
-        self.next_conda_solve_id += 1;
+        let next_id = CondaSolveId(self.next_conda_solve_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::CondaSolveQueued {
             id: next_id,
@@ -270,13 +293,13 @@ impl CondaSolveReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, solve_id: CondaSolveId) {
+    fn on_started(&self, solve_id: CondaSolveId) {
         let event = Event::CondaSolveStarted { id: solve_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, solve_id: CondaSolveId) {
+    fn on_finished(&self, solve_id: CondaSolveId) {
         let event = Event::CondaSolveFinished { id: solve_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -285,12 +308,11 @@ impl CondaSolveReporter for EventReporter {
 
 impl PixiSolveReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         env: &PixiEnvironmentSpec,
     ) -> PixiSolveId {
-        let next_id = PixiSolveId(self.next_pixi_solve_id);
-        self.next_pixi_solve_id += 1;
+        let next_id = PixiSolveId(self.next_pixi_solve_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::PixiSolveQueued {
             id: next_id,
@@ -302,13 +324,13 @@ impl PixiSolveReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, solve_id: PixiSolveId) {
+    fn on_started(&self, solve_id: PixiSolveId) {
         let event = Event::PixiSolveStarted { id: solve_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, solve_id: PixiSolveId) {
+    fn on_finished(&self, solve_id: PixiSolveId) {
         let event = Event::PixiSolveFinished { id: solve_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -317,12 +339,11 @@ impl PixiSolveReporter for EventReporter {
 
 impl PixiInstallReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         env: &InstallPixiEnvironmentSpec,
     ) -> PixiInstallId {
-        let next_id = PixiInstallId(self.next_pixi_install_id);
-        self.next_pixi_install_id += 1;
+        let next_id = PixiInstallId(self.next_pixi_install_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::PixiInstallQueued {
             id: next_id,
@@ -334,13 +355,13 @@ impl PixiInstallReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, solve_id: PixiInstallId) {
+    fn on_started(&self, solve_id: PixiInstallId) {
         let event = Event::PixiInstallStarted { id: solve_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, solve_id: PixiInstallId) {
+    fn on_finished(&self, solve_id: PixiInstallId) {
         let event = Event::PixiInstallFinished { id: solve_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -349,13 +370,12 @@ impl PixiInstallReporter for EventReporter {
 
 impl GitCheckoutReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         env: &RepositoryReference,
         _dedup_id: DedupGroupId,
     ) -> GitCheckoutId {
-        let next_id = GitCheckoutId(self.next_git_checkout_id);
-        self.next_git_checkout_id += 1;
+        let next_id = GitCheckoutId(self.next_git_checkout_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::GitCheckoutQueued {
             id: next_id,
@@ -367,13 +387,13 @@ impl GitCheckoutReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, checkout_id: GitCheckoutId) {
+    fn on_started(&self, checkout_id: GitCheckoutId) {
         let event = Event::GitCheckoutStarted { id: checkout_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, checkout_id: GitCheckoutId) {
+    fn on_finished(&self, checkout_id: GitCheckoutId) {
         let event = Event::GitCheckoutFinished { id: checkout_id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -382,13 +402,13 @@ impl GitCheckoutReporter for EventReporter {
 
 impl BuildBackendMetadataReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         spec: &BuildBackendMetadataSpec,
         _dedup_id: DedupGroupId,
     ) -> BuildBackendMetadataId {
-        let next_id = BuildBackendMetadataId(self.next_source_metadata_id);
-        self.next_source_metadata_id += 1;
+        let next_id =
+            BuildBackendMetadataId(self.next_source_metadata_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::BuildBackendMetadataQueued {
             id: next_id,
@@ -401,7 +421,7 @@ impl BuildBackendMetadataReporter for EventReporter {
     }
 
     fn on_started(
-        &mut self,
+        &self,
         id: BuildBackendMetadataId,
         mut backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     ) {
@@ -416,7 +436,7 @@ impl BuildBackendMetadataReporter for EventReporter {
         });
     }
 
-    fn on_finished(&mut self, id: BuildBackendMetadataId, _failed: bool) {
+    fn on_finished(&self, id: BuildBackendMetadataId, _failed: bool) {
         let event = Event::BuildBackendMetadataFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -425,13 +445,13 @@ impl BuildBackendMetadataReporter for EventReporter {
 
 impl SourceMetadataReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         spec: &SourceMetadataSpec,
         _dedup_id: DedupGroupId,
     ) -> SourceMetadataId {
-        let next_id = SourceMetadataId(self.next_source_metadata_id);
-        self.next_source_metadata_id += 1;
+        let next_id =
+            SourceMetadataId(self.next_source_metadata_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::SourceMetadataQueued {
             id: next_id,
@@ -443,13 +463,13 @@ impl SourceMetadataReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, id: SourceMetadataId) {
+    fn on_started(&self, id: SourceMetadataId) {
         let event = Event::SourceMetadataStarted { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, id: SourceMetadataId) {
+    fn on_finished(&self, id: SourceMetadataId) {
         let event = Event::SourceMetadataFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -458,13 +478,12 @@ impl SourceMetadataReporter for EventReporter {
 
 impl SourceRecordReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         spec: &SourceRecordSpec,
         _dedup_id: DedupGroupId,
     ) -> SourceRecordId {
-        let next_id = SourceRecordId(self.next_source_metadata_id);
-        self.next_source_metadata_id += 1;
+        let next_id = SourceRecordId(self.next_source_metadata_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::SourceRecordQueued {
             id: next_id,
@@ -476,13 +495,13 @@ impl SourceRecordReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, id: SourceRecordId) {
+    fn on_started(&self, id: SourceRecordId) {
         let event = Event::SourceRecordStarted { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, id: SourceRecordId) {
+    fn on_finished(&self, id: SourceRecordId) {
         let event = Event::SourceRecordFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -491,13 +510,15 @@ impl SourceRecordReporter for EventReporter {
 
 impl InstantiateToolEnvironmentReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         spec: &InstantiateToolEnvironmentSpec,
         _dedup_id: DedupGroupId,
     ) -> InstantiateToolEnvId {
-        let next_id = InstantiateToolEnvId(self.next_instantiate_tool_env_id);
-        self.next_instantiate_tool_env_id += 1;
+        let next_id = InstantiateToolEnvId(
+            self.next_instantiate_tool_env_id
+                .fetch_add(1, Ordering::Relaxed),
+        );
 
         let event = Event::InstantiateToolEnvQueued {
             id: next_id,
@@ -509,13 +530,13 @@ impl InstantiateToolEnvironmentReporter for EventReporter {
         next_id
     }
 
-    fn on_started(&mut self, id: InstantiateToolEnvId) {
+    fn on_started(&self, id: InstantiateToolEnvId) {
         let event = Event::InstantiateToolEnvStarted { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
     }
 
-    fn on_finished(&mut self, id: InstantiateToolEnvId) {
+    fn on_finished(&self, id: InstantiateToolEnvId) {
         let event = Event::InstantiateToolEnvFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -524,13 +545,12 @@ impl InstantiateToolEnvironmentReporter for EventReporter {
 
 impl SourceBuildReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         spec: &SourceBuildSpec,
         _dedup_id: DedupGroupId,
     ) -> SourceBuildId {
-        let next_id = SourceBuildId(self.next_source_metadata_id);
-        self.next_source_metadata_id += 1;
+        let next_id = SourceBuildId(self.next_source_metadata_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::SourceBuildQueued {
             id: next_id,
@@ -543,7 +563,7 @@ impl SourceBuildReporter for EventReporter {
     }
 
     fn on_started(
-        &mut self,
+        &self,
         id: SourceBuildId,
         backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     ) {
@@ -559,7 +579,7 @@ impl SourceBuildReporter for EventReporter {
         });
     }
 
-    fn on_finished(&mut self, id: SourceBuildId, _failed: bool) {
+    fn on_finished(&self, id: SourceBuildId, _failed: bool) {
         let event = Event::SourceBuildFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -568,12 +588,12 @@ impl SourceBuildReporter for EventReporter {
 
 impl BackendSourceBuildReporter for EventReporter {
     fn on_queued(
-        &mut self,
+        &self,
         context: Option<ReporterContext>,
         spec: &BackendSourceBuildSpec,
     ) -> BackendSourceBuildId {
-        let next_id = BackendSourceBuildId(self.next_source_metadata_id);
-        self.next_source_metadata_id += 1;
+        let next_id =
+            BackendSourceBuildId(self.next_source_metadata_id.fetch_add(1, Ordering::Relaxed));
 
         let event = Event::BackendSourceBuildQueued {
             id: next_id,
@@ -586,7 +606,7 @@ impl BackendSourceBuildReporter for EventReporter {
     }
 
     fn on_started(
-        &mut self,
+        &self,
         id: BackendSourceBuildId,
         backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     ) {
@@ -602,7 +622,7 @@ impl BackendSourceBuildReporter for EventReporter {
         });
     }
 
-    fn on_finished(&mut self, id: BackendSourceBuildId, _failed: bool) {
+    fn on_finished(&self, id: BackendSourceBuildId, _failed: bool) {
         let event = Event::BackendSourceBuildFinished { id };
         eprintln!("{}", serde_json::to_string_pretty(&event).unwrap());
         self.events.push(event);
@@ -610,44 +630,42 @@ impl BackendSourceBuildReporter for EventReporter {
 }
 
 impl Reporter for EventReporter {
-    fn as_git_reporter(&mut self) -> Option<&mut dyn GitCheckoutReporter> {
+    fn as_git_reporter(&self) -> Option<&dyn GitCheckoutReporter> {
         Some(self)
     }
 
-    fn as_conda_solve_reporter(&mut self) -> Option<&mut dyn CondaSolveReporter> {
+    fn as_conda_solve_reporter(&self) -> Option<&dyn CondaSolveReporter> {
         Some(self)
     }
 
-    fn as_pixi_solve_reporter(&mut self) -> Option<&mut dyn PixiSolveReporter> {
+    fn as_pixi_solve_reporter(&self) -> Option<&dyn PixiSolveReporter> {
         Some(self)
     }
 
-    fn as_pixi_install_reporter(&mut self) -> Option<&mut dyn PixiInstallReporter> {
+    fn as_pixi_install_reporter(&self) -> Option<&dyn PixiInstallReporter> {
         Some(self)
     }
 
     fn as_instantiate_tool_environment_reporter(
-        &mut self,
-    ) -> Option<&mut dyn InstantiateToolEnvironmentReporter> {
+        &self,
+    ) -> Option<&dyn InstantiateToolEnvironmentReporter> {
         Some(self)
     }
 
-    fn as_build_backend_metadata_reporter(
-        &mut self,
-    ) -> Option<&mut dyn BuildBackendMetadataReporter> {
+    fn as_build_backend_metadata_reporter(&self) -> Option<&dyn BuildBackendMetadataReporter> {
         Some(self)
     }
-    fn as_source_metadata_reporter(&mut self) -> Option<&mut dyn SourceMetadataReporter> {
+    fn as_source_metadata_reporter(&self) -> Option<&dyn SourceMetadataReporter> {
         Some(self)
     }
-    fn as_source_record_reporter(&mut self) -> Option<&mut dyn SourceRecordReporter> {
+    fn as_source_record_reporter(&self) -> Option<&dyn SourceRecordReporter> {
         Some(self)
     }
-    fn as_source_build_reporter(&mut self) -> Option<&mut dyn SourceBuildReporter> {
+    fn as_source_build_reporter(&self) -> Option<&dyn SourceBuildReporter> {
         Some(self)
     }
 
-    fn as_backend_source_build_reporter(&mut self) -> Option<&mut dyn BackendSourceBuildReporter> {
+    fn as_backend_source_build_reporter(&self) -> Option<&dyn BackendSourceBuildReporter> {
         Some(self)
     }
 }

--- a/crates/pixi_reporters/src/git.rs
+++ b/crates/pixi_reporters/src/git.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use indexmap::IndexMap;
 use indicatif::{MultiProgress, ProgressBar};
+use parking_lot::Mutex;
 use pixi_command_dispatcher::{
     ReporterContext,
     reporter::{DedupGroupId, GitCheckoutId},
@@ -9,20 +10,20 @@ use pixi_command_dispatcher::{
 use pixi_git::{GIT_SSH_CLONING_WARNING_MSG, resolver::RepositoryReference, url::RepositoryUrl};
 use pixi_progress::style_warning_pb;
 
+struct GitCheckoutProgressInner {
+    next_id: usize,
+    bars: IndexMap<GitCheckoutId, ProgressBar>,
+    repository_references: HashMap<GitCheckoutId, RepositoryReference>,
+    checkout_helper_pb: Option<(ProgressBar, usize)>,
+}
+
 /// A reporter implementation for source checkouts.
 pub struct GitCheckoutProgress {
     /// The multi-progress bar. Usually, this is the global multi-progress bar.
     multi_progress: MultiProgress,
     /// The progress bar that is used as an anchor for placing other progress.
     anchor: ProgressBar,
-    /// The id of the next checkout
-    next_id: usize,
-    /// A map of progress bars, by ID.
-    bars: IndexMap<GitCheckoutId, ProgressBar>,
-    /// References to the repository info
-    repository_references: HashMap<GitCheckoutId, RepositoryReference>,
-    /// Helper checkout progress bar for git SSH operations
-    checkout_helper_pb: Option<(ProgressBar, usize)>,
+    inner: Mutex<GitCheckoutProgressInner>,
 }
 
 impl GitCheckoutProgress {
@@ -31,18 +32,13 @@ impl GitCheckoutProgress {
         Self {
             multi_progress,
             anchor,
-            next_id: 0,
-            bars: Default::default(),
-            repository_references: Default::default(),
-            checkout_helper_pb: None,
+            inner: Mutex::new(GitCheckoutProgressInner {
+                next_id: 0,
+                bars: Default::default(),
+                repository_references: Default::default(),
+                checkout_helper_pb: None,
+            }),
         }
-    }
-
-    /// Returns a unique ID for a new progress bar.
-    fn next_checkout_id(&mut self) -> GitCheckoutId {
-        let id = GitCheckoutId(self.next_id);
-        self.next_id += 1;
-        id
     }
 
     /// Similar to the default pixi_progress::default_progress_style, but with a
@@ -50,18 +46,6 @@ impl GitCheckoutProgress {
     pub fn spinner_style() -> indicatif::ProgressStyle {
         indicatif::ProgressStyle::with_template("  {spinner:.green} {prefix:30!} {wide_msg:.dim}")
             .expect("should be able to create a progress bar style")
-    }
-
-    /// Returns the repository reference for the given checkout ID.
-    pub fn repo_reference(&self, id: GitCheckoutId) -> &RepositoryReference {
-        self.repository_references
-            .get(&id)
-            .expect("the progress bar needs to be inserted for this checkout")
-    }
-
-    /// Returns the progress bar at the bottom
-    pub fn last_progress_bar(&self) -> Option<&ProgressBar> {
-        self.bars.last().map(|(_, pb)| pb)
     }
 
     /// Returns true if the specified URL refers to a checkout that might cause
@@ -74,22 +58,28 @@ impl GitCheckoutProgress {
 impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
     /// Called when a git checkout was queued on the [`CommandQueue`].
     fn on_queued(
-        &mut self,
+        &self,
         _context: Option<ReporterContext>,
         env: &RepositoryReference,
         _dedup_id: DedupGroupId,
     ) -> GitCheckoutId {
-        let checkout_id = self.next_checkout_id();
-        self.repository_references.insert(checkout_id, env.clone());
-        checkout_id
+        let mut inner = self.inner.lock();
+        let id = GitCheckoutId(inner.next_id);
+        inner.next_id += 1;
+        inner.repository_references.insert(id, env.clone());
+        id
     }
 
-    fn on_started(&mut self, checkout_id: GitCheckoutId) {
-        let pb = self.multi_progress.insert_after(
-            self.last_progress_bar().unwrap_or(&self.anchor),
-            ProgressBar::hidden(),
-        );
-        let repo = self.repo_reference(checkout_id);
+    fn on_started(&self, checkout_id: GitCheckoutId) {
+        let mut inner = self.inner.lock();
+        let repo = inner
+            .repository_references
+            .get(&checkout_id)
+            .expect("the progress bar needs to be inserted for this checkout");
+        let last_pb = inner.bars.last().map(|(_, pb)| pb).unwrap_or(&self.anchor);
+        let pb = self
+            .multi_progress
+            .insert_after(last_pb, ProgressBar::hidden());
         pb.set_style(GitCheckoutProgress::spinner_style());
         pb.set_prefix("fetching git dependencies");
         pb.set_message(format!(
@@ -100,7 +90,7 @@ impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
         pb.enable_steady_tick(Duration::from_millis(100));
 
         if Self::is_dangerous_ssh(&repo.url) {
-            match &mut self.checkout_helper_pb {
+            match &mut inner.checkout_helper_pb {
                 Some((_, count)) => {
                     *count += 1;
                 }
@@ -110,20 +100,24 @@ impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
                             .insert_before(&pb, ProgressBar::hidden()),
                         GIT_SSH_CLONING_WARNING_MSG.to_string(),
                     );
-                    self.checkout_helper_pb = Some((warning_pb, 1));
+                    inner.checkout_helper_pb = Some((warning_pb, 1));
                 }
             }
         };
 
-        self.bars.insert(checkout_id, pb);
+        inner.bars.insert(checkout_id, pb);
     }
 
-    fn on_finished(&mut self, checkout_id: GitCheckoutId) {
-        let removed_pb = self
+    fn on_finished(&self, checkout_id: GitCheckoutId) {
+        let mut inner = self.inner.lock();
+        let removed_pb = inner
             .bars
             .shift_remove(&checkout_id)
             .expect("the progress bar needs to be inserted for this checkout");
-        let repo = self.repo_reference(checkout_id);
+        let repo = inner
+            .repository_references
+            .get(&checkout_id)
+            .expect("the progress bar needs to be inserted for this checkout");
         removed_pb.finish_with_message(format!(
             "checkout complete {}@{}",
             repo.url.as_url(),
@@ -132,13 +126,13 @@ impl pixi_command_dispatcher::GitCheckoutReporter for GitCheckoutProgress {
         removed_pb.finish_and_clear();
 
         if Self::is_dangerous_ssh(&repo.url) {
-            let Some((pb, count)) = &mut self.checkout_helper_pb else {
+            let Some((pb, count)) = &mut inner.checkout_helper_pb else {
                 panic!("checkout helper progress bar should be present");
             };
             *count -= 1;
             if *count == 0 {
                 pb.finish_and_clear();
-                self.checkout_helper_pb = None;
+                inner.checkout_helper_pb = None;
             }
         }
     }

--- a/crates/pixi_reporters/src/lib.rs
+++ b/crates/pixi_reporters/src/lib.rs
@@ -70,63 +70,59 @@ impl pixi_command_dispatcher::Reporter for TopLevelProgress {
     /// Called when the command dispatcher is closing down.
     ///
     /// We want to make sure that we clean up all the progress bars.
-    fn on_finished(&mut self) {
+    fn on_finished(&self) {
         self.on_clear()
     }
 
     /// Clears the current progress bars.
-    fn on_clear(&mut self) {
+    fn on_clear(&self) {
         self.conda_solve_reporter.clear();
         self.repodata_reporter.clear();
         self.sync_reporter.clear();
     }
 
-    fn as_git_reporter(&mut self) -> Option<&mut dyn pixi_command_dispatcher::GitCheckoutReporter> {
-        Some(&mut self.source_checkout_reporter)
+    fn as_git_reporter(&self) -> Option<&dyn pixi_command_dispatcher::GitCheckoutReporter> {
+        Some(&self.source_checkout_reporter)
     }
 
-    fn as_source_build_reporter(&mut self) -> Option<&mut dyn SourceBuildReporter> {
-        Some(&mut self.sync_reporter)
+    fn as_source_build_reporter(&self) -> Option<&dyn SourceBuildReporter> {
+        Some(&self.sync_reporter)
     }
 
-    fn as_backend_source_build_reporter(&mut self) -> Option<&mut dyn BackendSourceBuildReporter> {
-        Some(&mut self.sync_reporter)
+    fn as_backend_source_build_reporter(&self) -> Option<&dyn BackendSourceBuildReporter> {
+        Some(&self.sync_reporter)
     }
 
-    fn as_conda_solve_reporter(
-        &mut self,
-    ) -> Option<&mut dyn pixi_command_dispatcher::CondaSolveReporter> {
+    fn as_conda_solve_reporter(&self) -> Option<&dyn pixi_command_dispatcher::CondaSolveReporter> {
         Some(self)
     }
 
-    fn as_pixi_solve_reporter(
-        &mut self,
-    ) -> Option<&mut dyn pixi_command_dispatcher::PixiSolveReporter> {
+    fn as_pixi_solve_reporter(&self) -> Option<&dyn pixi_command_dispatcher::PixiSolveReporter> {
         Some(self)
     }
 
     fn as_pixi_install_reporter(
-        &mut self,
-    ) -> Option<&mut dyn pixi_command_dispatcher::PixiInstallReporter> {
+        &self,
+    ) -> Option<&dyn pixi_command_dispatcher::PixiInstallReporter> {
         Some(self)
     }
 
     fn create_gateway_reporter(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
     ) -> Option<Box<dyn Reporter>> {
         Some(Box::new(self.repodata_reporter.clone()))
     }
 
     fn create_install_reporter(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
     ) -> Option<Box<dyn rattler::install::Reporter>> {
         Some(Box::new(self.sync_reporter.create_reporter()))
     }
 
     fn create_run_exports_reporter(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
     ) -> Option<Arc<dyn RunExportsReporter>> {
         Some(Arc::new(run_exports::RunExportsReporter::new(
@@ -138,7 +134,7 @@ impl pixi_command_dispatcher::Reporter for TopLevelProgress {
 
 impl pixi_command_dispatcher::PixiInstallReporter for TopLevelProgress {
     fn on_queued(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
         _env: &InstallPixiEnvironmentSpec,
     ) -> PixiInstallId {
@@ -148,14 +144,14 @@ impl pixi_command_dispatcher::PixiInstallReporter for TopLevelProgress {
         PixiInstallId(0)
     }
 
-    fn on_started(&mut self, _install_id: PixiInstallId) {}
+    fn on_started(&self, _install_id: PixiInstallId) {}
 
-    fn on_finished(&mut self, _install_id: PixiInstallId) {}
+    fn on_finished(&self, _install_id: PixiInstallId) {}
 }
 
 impl pixi_command_dispatcher::PixiSolveReporter for TopLevelProgress {
     fn on_queued(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
         env: &PixiEnvironmentSpec,
     ) -> PixiSolveId {
@@ -180,14 +176,14 @@ impl pixi_command_dispatcher::PixiSolveReporter for TopLevelProgress {
         PixiSolveId(id)
     }
 
-    fn on_started(&mut self, _solve_id: PixiSolveId) {}
+    fn on_started(&self, _solve_id: PixiSolveId) {}
 
-    fn on_finished(&mut self, _solve_id: PixiSolveId) {}
+    fn on_finished(&self, _solve_id: PixiSolveId) {}
 }
 
 impl pixi_command_dispatcher::CondaSolveReporter for TopLevelProgress {
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         env: &SolveCondaEnvironmentSpec,
     ) -> CondaSolveId {
@@ -202,11 +198,11 @@ impl pixi_command_dispatcher::CondaSolveReporter for TopLevelProgress {
         }
     }
 
-    fn on_started(&mut self, solve_id: CondaSolveId) {
+    fn on_started(&self, solve_id: CondaSolveId) {
         self.conda_solve_reporter.start(solve_id.0);
     }
 
-    fn on_finished(&mut self, solve_id: CondaSolveId) {
+    fn on_finished(&self, solve_id: CondaSolveId) {
         self.conda_solve_reporter.finish(solve_id.0);
     }
 }

--- a/crates/pixi_reporters/src/sync_reporter.rs
+++ b/crates/pixi_reporters/src/sync_reporter.rs
@@ -41,7 +41,7 @@ impl SyncReporter {
         }
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         let mut inner = self.combined_inner.lock();
         inner.preparing_progress_bar.clear();
         inner.install_progress_bar.clear();
@@ -76,7 +76,7 @@ impl SyncReporter {
 
 impl BackendSourceBuildReporter for SyncReporter {
     fn on_queued(
-        &mut self,
+        &self,
         reason: Option<ReporterContext>,
         _env: &BackendSourceBuildSpec,
     ) -> BackendSourceBuildId {
@@ -89,7 +89,7 @@ impl BackendSourceBuildReporter for SyncReporter {
     }
 
     fn on_started(
-        &mut self,
+        &self,
         _id: BackendSourceBuildId,
         mut backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     ) {
@@ -122,7 +122,7 @@ impl BackendSourceBuildReporter for SyncReporter {
         });
     }
 
-    fn on_finished(&mut self, _id: BackendSourceBuildId, failed: bool) {
+    fn on_finished(&self, _id: BackendSourceBuildId, failed: bool) {
         // Take the stream that receives the output from the backend so we can drop the
         // memory.
         let build_output_receiver = {
@@ -145,7 +145,7 @@ impl BackendSourceBuildReporter for SyncReporter {
 
 impl SourceBuildReporter for SyncReporter {
     fn on_queued(
-        &mut self,
+        &self,
         _reason: Option<ReporterContext>,
         env: &SourceBuildSpec,
         _dedup_id: DedupGroupId,
@@ -156,7 +156,7 @@ impl SourceBuildReporter for SyncReporter {
     }
 
     fn on_started(
-        &mut self,
+        &self,
         id: SourceBuildId,
         mut backend_output_stream: Box<dyn Stream<Item = String> + Unpin + Send>,
     ) {
@@ -184,7 +184,7 @@ impl SourceBuildReporter for SyncReporter {
         });
     }
 
-    fn on_finished(&mut self, id: SourceBuildId, failed: bool) {
+    fn on_finished(&self, id: SourceBuildId, failed: bool) {
         let build_output_receiver = {
             let mut inner = self.combined_inner.lock();
             inner.preparing_progress_bar.on_build_finished(id.0);


### PR DESCRIPTION
### Description

Switch the `Reporter` trait and all 11 sub-reporter traits from `&mut self` to `&self`. This removes the exclusive-borrow requirement so that reporters can be shared (e.g. via `Arc<dyn Reporter>`) across concurrent tasks, giving more flexibility in how we execute tasks in the command dispatcher.

The `Reporter` bound is tightened from `Send` to `Send + Sync`. Implementations that held mutable state now use interior mutability. Implementations that already locked internally only needed signature changes.

### How Has This Been Tested?

`cargo clippy -p pixi_command_dispatcher -p pixi_reporters -- -D warnings` and `cargo test -p pixi_command_dispatcher -p pixi_reporters` both pass (34 unit tests + 23 integration tests).

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code