### PR TITLE
fix: improve pixi download speed in install.ps1

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -188,9 +188,10 @@ Write-Host "Getting it from this url: $(Mask-Credentials $DOWNLOAD_URL)"
 Write-Host "The binary will be installed into '$BinDir'"
 
 $TEMP_FILE = [System.IO.Path]::GetTempFileName()
+$webClient = New-Object System.Net.WebClient
 
 try {
-    Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TEMP_FILE
+    $webClient.DownloadFile($DOWNLOAD_URL, $TEMP_FILE)
 
     # Create the install dir if it doesn't exist
     if (!(Test-Path -Path $BinDir)) {
@@ -206,6 +207,7 @@ try {
     Write-Host "Error: '$(Mask-Credentials $DOWNLOAD_URL)' is not available or failed to download"
     exit 1
 } finally {
+    $webClient.Dispose()
     Remove-Item -Path $ZIP_FILE
 }
 


### PR DESCRIPTION
### Description

@lucascolley found out that using Invoke-Webrequest is horribly slow in conda-forge azure CI. It took 42 seconds to download pixi. This PR changes the method used to download the file. I expect this to run in ~2 seconds instead of 42. 

I can confirm that locally on my windows machine this is also a _**huge**_ improvement. `install.ps1` on `main` takes 23 seconds on my machine. `install.ps1` from this branches takes 2 seconds.

### How Has This Been Tested?

@lucascolley will test in CI.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code