### PR TITLE
fix!: implement feature activation environment precedence

### DIFF
--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -336,7 +336,9 @@ impl<'p> Environment<'p> {
         self.features()
             .map(|f| f.activation_env(platform))
             .fold(IndexMap::new(), |mut acc, env| {
-                acc.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
+                for (k, v) in env {
+                    acc.entry(k).or_insert(v);
+                }
                 acc
             })
     }
@@ -651,6 +653,43 @@ mod tests {
                 "DEFAULT_VAR".to_string() => "1".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn test_activation_env_feature_precedence() {
+        // First-listed feature should win when multiple features define the same key,
+        // matching task resolution precedence (see issue #5926).
+        let manifest = Workspace::from_str(
+            Path::new("pixi.toml"),
+            r#"
+            [project]
+            name = "foobar"
+            channels = []
+            platforms = ["linux-64"]
+
+            [activation.env]
+            SHARED_VAR = "default"
+
+            [feature.test1.activation.env]
+            SHARED_VAR = "test1"
+            TEST1_VAR = "1"
+
+            [feature.test2.activation.env]
+            SHARED_VAR = "test2"
+            TEST2_VAR = "2"
+
+            [environments]
+            myenv = ["test1", "test2"]
+            "#,
+        )
+        .unwrap();
+
+        let env = manifest.environment("myenv").unwrap();
+        let activation = env.activation_env(None);
+        // test1 is listed first, so its value must win over test2 and default
+        assert_eq!(activation.get("SHARED_VAR").map(String::as_str), Some("test1"));
+        assert_eq!(activation.get("TEST1_VAR").map(String::as_str), Some("1"));
+        assert_eq!(activation.get("TEST2_VAR").map(String::as_str), Some("2"));
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -687,7 +687,10 @@ mod tests {
         let env = manifest.environment("myenv").unwrap();
         let activation = env.activation_env(None);
         // test1 is listed first, so its value must win over test2 and default
-        assert_eq!(activation.get("SHARED_VAR").map(String::as_str), Some("test1"));
+        assert_eq!(
+            activation.get("SHARED_VAR").map(String::as_str),
+            Some("test1")
+        );
         assert_eq!(activation.get("TEST1_VAR").map(String::as_str), Some("1"));
         assert_eq!(activation.get("TEST2_VAR").map(String::as_str), Some("2"));
     }


### PR DESCRIPTION
### Description

This is a **breaking change**! We're changing the logic of what environment variable takes precedence in the feature logic. 

The activation.env variable logic was different from the other merging logic. Where the last feature would win instead of the first. This is now reversed in this PR.

Fixes #5926

### How Has This Been Tested?

Tested the example in the issue.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
