### PR TITLE
feat(tasks): support multi-line tasks

### DIFF
--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -154,24 +154,63 @@ impl<'p> ExecutableTask<'p> {
     fn as_script(&self) -> Result<Option<String>, FailedToParseShellScript> {
         // Multi-line task strings are joined with `&&` so execution stops on
         // the first failing command. `deno_task_shell` treats bare newlines
-        // as whitespace, so we need to rewrite them before parsing.
+        // as whitespace, so we rewrite unquoted newlines before parsing.
+        // Newlines inside single or double quotes are preserved so that
+        // embedded scripts (e.g. `python -c "..."`) keep working.
         fn join_multiline_command(cmd: &str) -> String {
             if !cmd.contains('\n') {
                 return cmd.to_string();
             }
 
-            let merged = cmd.replace("\\\n", "");
+            let mut logical_lines: Vec<String> = Vec::new();
+            let mut current = String::new();
+            let mut in_single = false;
+            let mut in_double = false;
+            let mut chars = cmd.chars().peekable();
 
-            let lines: Vec<&str> = merged
-                .lines()
-                .map(str::trim)
+            while let Some(c) = chars.next() {
+                match c {
+                    '\\' if !in_single => {
+                        // Backslash line continuation outside single quotes:
+                        // drop both the backslash and the following newline.
+                        if chars.peek() == Some(&'\n') {
+                            chars.next();
+                        } else if let Some(&next) = chars.peek() {
+                            current.push(c);
+                            current.push(next);
+                            chars.next();
+                        } else {
+                            current.push(c);
+                        }
+                    }
+                    '\'' if !in_double => {
+                        in_single = !in_single;
+                        current.push(c);
+                    }
+                    '"' if !in_single => {
+                        in_double = !in_double;
+                        current.push(c);
+                    }
+                    '\n' if !in_single && !in_double => {
+                        logical_lines.push(std::mem::take(&mut current));
+                    }
+                    _ => current.push(c),
+                }
+            }
+            if !current.is_empty() {
+                logical_lines.push(current);
+            }
+
+            let filtered: Vec<String> = logical_lines
+                .into_iter()
+                .map(|line| line.trim().to_string())
                 .filter(|line| !line.is_empty() && !line.starts_with('#'))
                 .collect();
 
             let mut out = String::new();
-            for (i, line) in lines.iter().enumerate() {
+            for (i, line) in filtered.iter().enumerate() {
                 if i > 0 {
-                    let prev = lines[i - 1];
+                    let prev = &filtered[i - 1];
                     let already_terminated = prev.ends_with("&&")
                         || prev.ends_with("||")
                         || prev.ends_with('|')
@@ -773,6 +812,46 @@ mod tests {
 
         let script = executable_task.as_script().unwrap().unwrap();
         assert_eq!(script, "echo hello && echo hello2");
+    }
+
+    #[test]
+    fn test_as_script_multiline_preserves_newlines_inside_quotes() {
+        // Newlines inside a double-quoted argument (e.g. a `python -c` block)
+        // must be preserved, not treated as command separators.
+        let file_contents = r#"
+            [tasks]
+            test = """
+            python -c "import sys
+            print('hi')"
+            echo done
+            """
+            "#;
+
+        let workspace = Workspace::from_str(
+            Path::new("pixi.toml"),
+            &format!("{PROJECT_BOILERPLATE}\n{file_contents}"),
+        )
+        .unwrap();
+
+        let task = workspace
+            .default_environment()
+            .task(&TaskName::from("test"), None)
+            .unwrap();
+
+        let executable_task = ExecutableTask {
+            workspace: &workspace,
+            name: Some("test".into()),
+            task: Cow::Borrowed(task),
+            run_environment: workspace.default_environment(),
+            args: ArgValues::default(),
+            init_cwd: None,
+        };
+
+        let script = executable_task.as_script().unwrap().unwrap();
+        assert_eq!(
+            script,
+            "python -c \"import sys\n            print('hi')\" && echo done"
+        );
     }
 
     #[test]

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -227,7 +227,6 @@ impl<'p> ExecutableTask<'p> {
             out
         }
 
-
         // Convert the task into an executable string
         let context = self.render_context();
         let task = self

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -152,6 +152,43 @@ impl<'p> ExecutableTask<'p> {
 
     /// Returns the task as script
     fn as_script(&self) -> Result<Option<String>, FailedToParseShellScript> {
+        // Multi-line task strings are joined with `&&` so execution stops on
+        // the first failing command. `deno_task_shell` treats bare newlines
+        // as whitespace, so we need to rewrite them before parsing.
+        fn join_multiline_command(cmd: &str) -> String {
+            if !cmd.contains('\n') {
+                return cmd.to_string();
+            }
+
+            let merged = cmd.replace("\\\n", "");
+
+            let lines: Vec<&str> = merged
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .collect();
+
+            let mut out = String::new();
+            for (i, line) in lines.iter().enumerate() {
+                if i > 0 {
+                    let prev = lines[i - 1];
+                    let already_terminated = prev.ends_with("&&")
+                        || prev.ends_with("||")
+                        || prev.ends_with('|')
+                        || prev.ends_with(';')
+                        || prev.ends_with('&');
+                    if already_terminated {
+                        out.push(' ');
+                    } else {
+                        out.push_str(" && ");
+                    }
+                }
+                out.push_str(line);
+            }
+            out
+        }
+
+
         // Convert the task into an executable string
         let context = self.render_context();
         let task = self
@@ -159,6 +196,7 @@ impl<'p> ExecutableTask<'p> {
             .as_single_command(&context)
             .map_err(FailedToParseShellScript::ArgumentReplacement)?;
         if let Some(task) = task {
+            let task = join_multiline_command(&task);
             // Get the export specific environment variables
             let export = get_export_specific_task_env(self.task.as_ref(), &context)
                 .map_err(FailedToParseShellScript::ArgumentReplacement)?;
@@ -701,6 +739,82 @@ mod tests {
 
         let script = executable_task.as_script().unwrap().unwrap();
         assert_eq!(script, "export \"FOO=bar\";\n\ntest");
+    }
+
+    #[test]
+    fn test_as_script_multiline() {
+        let file_contents = r#"
+            [tasks]
+            test = """
+            echo hello
+            echo hello2
+            """
+            "#;
+
+        let workspace = Workspace::from_str(
+            Path::new("pixi.toml"),
+            &format!("{PROJECT_BOILERPLATE}\n{file_contents}"),
+        )
+        .unwrap();
+
+        let task = workspace
+            .default_environment()
+            .task(&TaskName::from("test"), None)
+            .unwrap();
+
+        let executable_task = ExecutableTask {
+            workspace: &workspace,
+            name: Some("test".into()),
+            task: Cow::Borrowed(task),
+            run_environment: workspace.default_environment(),
+            args: ArgValues::default(),
+            init_cwd: None,
+        };
+
+        let script = executable_task.as_script().unwrap().unwrap();
+        assert_eq!(script, "echo hello && echo hello2");
+    }
+
+    #[test]
+    fn test_as_script_multiline_preserves_existing_operator() {
+        let file_contents = r#"
+            [tasks]
+            test = """
+            echo hello &&
+            echo hello2
+            echo hello3 |
+            cat
+            # comment line is skipped
+
+            echo done
+            """
+            "#;
+
+        let workspace = Workspace::from_str(
+            Path::new("pixi.toml"),
+            &format!("{PROJECT_BOILERPLATE}\n{file_contents}"),
+        )
+        .unwrap();
+
+        let task = workspace
+            .default_environment()
+            .task(&TaskName::from("test"), None)
+            .unwrap();
+
+        let executable_task = ExecutableTask {
+            workspace: &workspace,
+            name: Some("test".into()),
+            task: Cow::Borrowed(task),
+            run_environment: workspace.default_environment(),
+            args: ArgValues::default(),
+            init_cwd: None,
+        };
+
+        let script = executable_task.as_script().unwrap().unwrap();
+        assert_eq!(
+            script,
+            "echo hello && echo hello2 && echo hello3 | cat && echo done"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

`deno_task_shell` collapses bare newlines to whitespace, so a multi-line TOML task like

```toml
[tasks]
test = """
echo hello
echo hello2
"""
```

was executed as `echo hello echo hello2`, printing `hello echo hello2`.

The fix joins non-empty, non-comment lines with `&&` before parsing, so each line runs as a separate command and execution stops on the first failure. Backslash line continuations are merged, and lines already ending in a shell control operator (`&&`, `||`, `|`, `;`, `&`) aren't double-separated.

Fixes #5937

### How Has This Been Tested?

- Added unit tests `test_as_script_multiline` and `test_as_script_multiline_preserves_existing_operator` in `crates/pixi_task/src/executable_task.rs`.
- Ran the repro from the issue locally; output is now:
  ```
  Pixi task (test): echo hello
  echo hello2
  hello
  hello2
  ```
- Verified fail-fast: a middle `false` line aborts the task with exit code 1 and the subsequent line is not run.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JFTC8imdYsRkkt3m3Qyohf)_