### PR TITLE
refactor: Round-trip build- and host-packages of conda source packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "coalesced_map"
 version = "0.1.2"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2747,7 +2747,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "file_url"
 version = "0.2.7"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -5435,7 +5435,7 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.7"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "ahash",
  "fs-err",
@@ -7495,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.40.4"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "anyhow",
  "clap",
@@ -7809,7 +7809,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.6.19"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7841,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.44.4"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "ahash",
  "chrono",
@@ -7883,7 +7883,7 @@ dependencies = [
 [[package]]
 name = "rattler_config"
 version = "0.3.7"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "console",
  "fs-err",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.2.3"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "blake2",
  "digest",
@@ -7939,7 +7939,7 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.27.21"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7976,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.27.5"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "ahash",
  "chrono",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.12"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "quote",
  "syn",
@@ -8012,7 +8012,7 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.54"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "chrono",
  "configparser",
@@ -8042,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.26.7"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -8075,7 +8075,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.24.7"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "astral-tokio-tar 0.6.0",
  "astral_async_zip",
@@ -8127,7 +8127,7 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.9"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -8138,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.1.13"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "reqwest 0.12.28",
  "reqwest-middleware",
@@ -8148,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.27.4"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8210,7 +8210,7 @@ dependencies = [
 [[package]]
 name = "rattler_s3"
 version = "0.1.30"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.26.7"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "5.2.0"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "chrono",
  "futures",
@@ -8265,7 +8265,7 @@ dependencies = [
 [[package]]
 name = "rattler_upload"
 version = "0.5.5"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -8301,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.3.16"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "archspec",
  "libloading",
@@ -9968,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#f54edf6153ffdf38f347448a764108e93284e61b"
+source = "git+https://github.com/conda/rattler?branch=feature%2Flockfile-v7#7b7f53e0be5ee6fba98effd636b1abc2f57760da"
 dependencies = [
  "tokio",
 ]

--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -29,6 +29,7 @@ use pixi_command_dispatcher::executor::CancellationAwareFutures;
 use pixi_command_dispatcher::{CommandDispatcher, CommandDispatcherError};
 use pixi_consts::consts;
 use pixi_manifest::{EnvironmentName, FeaturesExt};
+use pixi_record::LockFileResolver;
 use pixi_uv_context::UvResolutionContext;
 use rattler_conda_types::Platform;
 use rattler_lock::{LockFile, LockedPackage};
@@ -124,6 +125,7 @@ impl<'p> OutdatedEnvironments<'p> {
         workspace: &'p Workspace,
         command_dispatcher: CommandDispatcher,
         lock_file: &LockFile,
+        resolver: &LockFileResolver,
     ) -> Self {
         // Find all targets that are not satisfied by the lock-file
         let (
@@ -136,7 +138,7 @@ impl<'p> OutdatedEnvironments<'p> {
             build_caches,
             static_metadata_cache,
             locked_pypi_records,
-        ) = find_unsatisfiable_targets(workspace, command_dispatcher, lock_file).await;
+        ) = find_unsatisfiable_targets(workspace, command_dispatcher, lock_file, resolver).await;
 
         // Extend the outdated targets to include the solve groups
         let (mut conda_solve_groups_out_of_date, mut pypi_solve_groups_out_of_date) =
@@ -221,6 +223,7 @@ async fn find_unsatisfiable_targets<'p>(
     project: &'p Workspace,
     command_dispatcher: CommandDispatcher,
     lock_file: &LockFile,
+    resolver: &LockFileResolver,
 ) -> (
     UnsatisfiableTargets<'p>,
     OnceCell<UvResolutionContext>,
@@ -347,6 +350,7 @@ async fn find_unsatisfiable_targets<'p>(
                 project_env_vars: project.env_vars().clone(),
                 build_caches: &build_caches,
                 static_metadata_cache: &static_metadata_cache,
+                resolver,
             };
             platform_futures.push(async move {
                 let result = verify_platform_satisfiability(&ctx, locked_environment).await;

--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -33,9 +33,9 @@ use pixi_manifest::{
 };
 use pixi_pypi_spec::PixiPypiSource;
 use pixi_record::{
-    DevSourceRecord, LockedGitUrl, ParseLockFileError, PinnedBuildSourceSpec, PinnedSourceSpec,
-    PixiRecord, SourceMismatchError, SourceRecord, SourceRecordData, UnresolvedPixiRecord,
-    UnresolvedSourceRecord, VariantValue,
+    DevSourceRecord, LockFileResolver, LockedGitUrl, ParseLockFileError, PinnedBuildSourceSpec,
+    PinnedSourceSpec, PixiRecord, SourceMismatchError, SourceRecord, SourceRecordData,
+    UnresolvedPixiRecord, UnresolvedSourceRecord, VariantValue,
 };
 use pixi_spec::{
     PixiSpec, SourceAnchor, SourceLocationSpec, SourceSpec, SpecConversionError, Subdirectory,
@@ -1033,6 +1033,10 @@ pub struct VerifySatisfiabilityContext<'a> {
     /// Cache for static metadata extracted from pyproject.toml files.
     /// This is shared across platforms since static metadata is platform-independent.
     pub static_metadata_cache: &'a DashMap<PathBuf, pypi_metadata::LocalPackageMetadata>,
+    /// Resolver for the lock-file being verified. Built once at the top of
+    /// `find_unsatisfiable_targets` and shared across all per-platform
+    /// contexts.
+    pub resolver: &'a LockFileResolver,
 }
 
 pub type PlatformSatisfiabilityResult = Result<
@@ -1120,6 +1124,7 @@ pub async fn verify_platform_satisfiability(
     // Read as UnresolvedPixiRecord first, then resolve any partial source records.
     let mut unresolved_records: Vec<UnresolvedPixiRecord> = Vec::new();
     let mut pypi_packages: Vec<UnresolvedPypiRecord> = Vec::new();
+    let resolver = ctx.resolver;
     let lock_platform = locked_environment
         .lock_file()
         .platform(&ctx.platform.to_string());
@@ -1129,23 +1134,10 @@ pub async fn verify_platform_satisfiability(
         .flatten()
     {
         match package {
-            LockedPackage::Conda(conda) => {
-                let url = conda.location().clone();
-                let record = match UnresolvedPixiRecord::from_conda_package_data(
-                    conda.clone(),
-                    ctx.project_root,
-                    // TODO: resolve build/host packages once the lock-file
-                    // exposes the package table publicly.
-                    Vec::new(),
-                    Vec::new(),
-                ) {
-                    Ok(record) => record,
-                    Err(e) => {
-                        return Err(CommandDispatcherError::Failed(Box::new(
-                            PlatformUnsat::CorruptedEntry(url.to_string(), e),
-                        )));
-                    }
-                };
+            LockedPackage::Conda(_) => {
+                let record = resolver
+                    .get_for_package(package)
+                    .expect("conda package from lock file not found in resolver");
                 unresolved_records.push(record);
             }
             LockedPackage::Pypi(pypi) => {
@@ -1271,22 +1263,10 @@ pub async fn verify_platform_satisfiability(
                 .into_iter()
                 .flatten()
             {
-                if let LockedPackage::Conda(conda) = package {
-                    let url = conda.location().clone();
-                    let record = UnresolvedPixiRecord::from_conda_package_data(
-                        conda.clone(),
-                        ctx.project_root,
-                        // TODO: resolve build/host packages once the lock-file
-                        // exposes the package table publicly.
-                        Vec::new(),
-                        Vec::new(),
-                    )
-                    .map_err(|e| {
-                        CommandDispatcherError::Failed(Box::new(PlatformUnsat::CorruptedEntry(
-                            url.to_string(),
-                            e,
-                        )))
-                    })?;
+                if let LockedPackage::Conda(_) = package {
+                    let record = resolver
+                        .get_for_package(package)
+                        .expect("conda package from lock file not found in resolver");
                     // Partial source records (e.g. packages that haven't
                     // been built yet) cannot be resolved. Skip them — only
                     // fully resolved records are needed as build
@@ -3197,8 +3177,8 @@ pub fn verify_solve_group_satisfiability(
 
     // Group all conda requested packages and pypi requested packages
     for env in environments {
-        expected_conda_packages.extend(env.expected_conda_packages.into_iter());
-        conda_packages_used_by_pypi.extend(env.conda_packages_used_by_pypi.into_iter());
+        expected_conda_packages.extend(env.expected_conda_packages);
+        conda_packages_used_by_pypi.extend(env.conda_packages_used_by_pypi);
     }
 
     // Check if all conda packages are also requested by another conda package.
@@ -3336,6 +3316,9 @@ mod tests {
             "solve group '{0}' does not satisfy the requirements of the project for platform '{1}'"
         )]
         SolveGroupUnsat(String, Platform, #[source] SolveGroupUnsat),
+
+        #[error("failed to build the lock-file resolver: {0}")]
+        ResolverBuild(String),
     }
 
     async fn verify_lockfile_satisfiability(
@@ -3379,6 +3362,9 @@ mod tests {
         let static_metadata_cache: DashMap<PathBuf, pypi_metadata::LocalPackageMetadata> =
             DashMap::new();
 
+        let resolver = LockFileResolver::build(lock_file, project.root())
+            .map_err(|err| LockfileUnsat::ResolverBuild(err.to_string()))?;
+
         // Verify individual environment satisfiability
         for env in project.environments() {
             let locked_env = lock_file
@@ -3398,6 +3384,7 @@ mod tests {
                     project_env_vars: project.env_vars().clone(),
                     build_caches: &build_caches,
                     static_metadata_cache: &static_metadata_cache,
+                    resolver: &resolver,
                 };
                 let (verified_env, _locked_pypi) = verify_platform_satisfiability(&ctx, locked_env)
                     .await

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -2287,12 +2287,9 @@ impl<'p> UpdateContext<'p> {
                 let platform_str = platform.to_string();
                 if let Some(records) = self.take_latest_repodata_records(&environment, platform) {
                     for record in records.into_inner() {
+                        let data = record.into_conda_package_data(&mut builder, project.root());
                         builder
-                            .add_conda_package(
-                                &environment_name,
-                                &platform_str,
-                                record.into_conda_package_data(project.root()),
-                            )
+                            .add_conda_package(&environment_name, &platform_str, data)
                             .expect("platform was registered");
                     }
                 }

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -34,7 +34,7 @@ use pixi_install_pypi::{
 };
 use pixi_manifest::{ChannelPriority, EnvironmentName, FeaturesExt};
 use pixi_progress::global_multi_progress;
-use pixi_record::{ParseLockFileError, PixiRecord, UnresolvedPixiRecord};
+use pixi_record::{LockFileResolver, ParseLockFileError, PixiRecord, UnresolvedPixiRecord};
 use pixi_utils::{prefix::Prefix, variants::VariantConfig};
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
@@ -280,32 +280,29 @@ impl Workspace {
         // Get the package cache from the dispatcher.
         let package_cache = command_dispatcher.package_cache().clone();
 
+        // Stage the input lock-file into a derived-data wrapper so that
+        // every downstream consumer shares one lazily-built resolver.
+        let mut derived = LockFileDerivedData::from_input_lock_file(
+            self,
+            lock_file,
+            package_cache,
+            command_dispatcher.clone(),
+            glob_hash_cache,
+        );
+
         // should we check the lock-file in the first place?
         if !options.lock_file_usage.should_check_if_out_of_date() {
             tracing::info!("skipping check if lock-file is up-to-date");
-
-            return Ok((
-                LockFileDerivedData {
-                    workspace: self,
-                    lock_file,
-                    package_cache,
-                    updated_conda_prefixes: Default::default(),
-                    updated_pypi_prefixes: Default::default(),
-                    uv_context: Default::default(),
-                    io_concurrency_limit: IoConcurrencyLimit::default(),
-                    command_dispatcher,
-                    glob_hash_cache,
-                    build_caches: Default::default(),
-                },
-                false,
-            ));
+            return Ok((derived, false));
         }
 
         // Check which environments are out of date.
+        let resolver = derived.resolver()?;
         let mut outdated = OutdatedEnvironments::from_workspace_and_lock_file(
             self,
             command_dispatcher.clone(),
-            &lock_file,
+            &derived.lock_file,
+            &resolver,
         )
         .await;
         if outdated.is_empty() && !(needs_format_upgrade && options.upgrade_lock_file_format) {
@@ -313,30 +310,18 @@ impl Workspace {
                 tracing::warn!(
                     "the lock file is up-to-date but uses an older format (v{}), \
                      run `pixi update` to upgrade to v{} for improved reproducibility",
-                    lock_file.version(),
+                    derived.lock_file.version(),
                     rattler_lock::FileFormatVersion::LATEST,
                 );
             } else {
                 tracing::info!("the lock-file is up-to-date");
             }
 
-            // If no-environment is outdated we can return early.
-            // Pass the build_caches even if empty, in case conda_prefix needs them
-            return Ok((
-                LockFileDerivedData {
-                    workspace: self,
-                    lock_file,
-                    package_cache,
-                    updated_conda_prefixes: Default::default(),
-                    updated_pypi_prefixes: Default::default(),
-                    uv_context: outdated.uv_context,
-                    io_concurrency_limit: IoConcurrencyLimit::default(),
-                    command_dispatcher,
-                    glob_hash_cache,
-                    build_caches: outdated.build_caches,
-                },
-                false,
-            ));
+            // If no-environment is outdated we can return early. Pass the
+            // build_caches even if empty, in case conda_prefix needs them.
+            derived.uv_context = outdated.uv_context;
+            derived.build_caches = outdated.build_caches;
+            return Ok((derived, false));
         }
 
         // When upgrading the lock file format, force a full re-solve of all
@@ -347,7 +332,7 @@ impl Workspace {
             tracing::warn!(
                 "the lock file is up-to-date but uses an older format (v{}), \
                  re-solving all environments using locked content to upgrade to v{}",
-                lock_file.version(),
+                derived.lock_file.version(),
                 rattler_lock::FileFormatVersion::LATEST,
             );
             for env in self.environments() {
@@ -365,6 +350,13 @@ impl Workspace {
             miette::bail!("lock-file not up-to-date with the workspace");
         }
 
+        let LockFileDerivedData {
+            lock_file,
+            package_cache,
+            glob_hash_cache,
+            ..
+        } = derived;
+
         // Construct an update context and perform the actual update.
         let lock_file_derived_data = UpdateContext::builder(self, Some(command_dispatcher))?
             .with_package_cache(package_cache)
@@ -372,6 +364,7 @@ impl Workspace {
             .with_outdated_environments(outdated)
             .with_lock_file(lock_file)
             .with_glob_hash_cache(glob_hash_cache)
+            .with_resolver(resolver)
             .finish()
             .await?
             .update()
@@ -548,6 +541,11 @@ pub struct LockFileDerivedData<'p> {
         lock_file::outdated::BuildCacheKey,
         Arc<lock_file::outdated::PypiEnvironmentBuildCache>,
     >,
+
+    /// Lazily-built resolver for `lock_file`. Built once on first access to
+    /// [`Self::resolver`] and reused across all downstream consumers. Kept
+    /// private so all interaction goes through the accessor method.
+    resolver: once_cell::sync::OnceCell<Arc<LockFileResolver>>,
 }
 
 /// The mode to use when updating a prefix.
@@ -565,6 +563,53 @@ pub enum UpdateMode {
 }
 
 impl<'p> LockFileDerivedData<'p> {
+    /// Construct a derived-data wrapper whose runtime state is empty. Intended
+    /// for the start of an update flow or any caller that needs the lazy
+    /// resolver cache but has no prefixes, caches, or solved records yet.
+    pub fn from_input_lock_file(
+        workspace: &'p Workspace,
+        lock_file: LockFile,
+        package_cache: PackageCache,
+        command_dispatcher: CommandDispatcher,
+        glob_hash_cache: GlobHashCache,
+    ) -> Self {
+        Self {
+            workspace,
+            lock_file,
+            package_cache,
+            updated_conda_prefixes: Default::default(),
+            updated_pypi_prefixes: Default::default(),
+            uv_context: Default::default(),
+            io_concurrency_limit: IoConcurrencyLimit::default(),
+            command_dispatcher,
+            glob_hash_cache,
+            build_caches: Default::default(),
+            resolver: Default::default(),
+        }
+    }
+
+    /// Returns a resolver for the current lock-file, building it on first
+    /// access and caching the result.
+    pub fn resolver(&self) -> miette::Result<Arc<LockFileResolver>> {
+        self.resolver
+            .get_or_try_init(|| {
+                LockFileResolver::build(&self.lock_file, self.workspace.root())
+                    .map(Arc::new)
+                    .into_diagnostic()
+            })
+            .cloned()
+    }
+
+    /// Seeds the resolver cache with a pre-built `Arc`, but only if the
+    /// cache is still empty. Used inside the update flow to forward a
+    /// resolver that was already built for the same lock-file, so later
+    /// `self.resolver()` calls return the same `Arc` without rebuilding.
+    ///
+    /// No-op if the cache already holds a value.
+    fn seed_resolver(&self, resolver: Arc<LockFileResolver>) {
+        let _ = self.resolver.set(resolver);
+    }
+
     /// Write the lock-file to disk.
     pub fn write_to_disk(&self) -> miette::Result<()> {
         let lock_file_path = self.workspace.lock_file_path();
@@ -747,8 +792,8 @@ impl<'p> LockFileDerivedData<'p> {
                         LockedPackage::Pypi(data) => Either::Right(data.name().clone()),
                     });
 
-                let pixi_records =
-                    locked_packages_to_unresolved_records(conda_packages, self.workspace.root())?;
+                let resolver = self.resolver()?;
+                let pixi_records = locked_packages_to_unresolved_records(conda_packages, &resolver);
 
                 // Get the manifest's pypi dependencies for this environment to look up editability.
                 // The lock file always stores editable=false, so we apply the actual
@@ -975,8 +1020,8 @@ impl<'p> LockFileDerivedData<'p> {
                 // source records are NOT resolved here — they are passed
                 // directly to the installer which builds them using
                 // variant-based output matching.
-                let records =
-                    locked_packages_to_unresolved_records(packages, self.workspace.root())?;
+                let resolver = self.resolver()?;
+                let records = locked_packages_to_unresolved_records(packages, &resolver);
 
                 // Update the conda prefix
                 conda_prefix_updater
@@ -1062,26 +1107,12 @@ impl PackageFilterNames {
 
 fn locked_packages_to_unresolved_records(
     conda_packages: Vec<&'_ LockedPackage>,
-    workspace_root: &std::path::Path,
-) -> Result<Vec<UnresolvedPixiRecord>, Report> {
+    resolver: &LockFileResolver,
+) -> Vec<UnresolvedPixiRecord> {
     conda_packages
         .into_iter()
-        .filter_map(LockedPackage::as_conda)
-        .cloned()
-        .map(|data| {
-            // TODO: resolve build_packages/host_packages from `data.source_data`
-            // once the lock-file exposes the full package table for
-            // `PackageHandle::get`. Today only indices are available through
-            // the public API.
-            UnresolvedPixiRecord::from_conda_package_data(
-                data,
-                workspace_root,
-                Vec::new(),
-                Vec::new(),
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()
-        .into_diagnostic()
+        .filter_map(|pkg| resolver.get_for_package(pkg))
+        .collect()
 }
 
 pub struct UpdateContext<'p> {
@@ -1374,6 +1405,10 @@ pub struct UpdateContextBuilder<'p> {
     command_dispatcher: CommandDispatcher,
     /// Optional list of package names explicitly targeted for update.
     update_targets: Option<std::collections::HashSet<String>>,
+
+    /// Pre-built resolver for the input lock-file, shared with the caller.
+    /// When `None`, the builder builds its own resolver in `finish`.
+    resolver: Option<Arc<LockFileResolver>>,
 }
 
 impl<'p> UpdateContextBuilder<'p> {
@@ -1429,6 +1464,16 @@ impl<'p> UpdateContextBuilder<'p> {
         }
     }
 
+    /// Provide a pre-built lock-file resolver to share with any computation
+    /// the builder performs. When omitted, the builder constructs its own
+    /// resolver inside `finish`.
+    pub fn with_resolver(self, resolver: Arc<LockFileResolver>) -> Self {
+        Self {
+            resolver: Some(resolver),
+            ..self
+        }
+    }
+
     /// Sets the io concurrency semaphore to use when updating environments.
     #[allow(unused)]
     pub fn with_io_concurrency_semaphore(self, io_concurrency_limit: IoConcurrencyLimit) -> Self {
@@ -1447,11 +1492,25 @@ impl<'p> UpdateContextBuilder<'p> {
                 pixi_config::get_cache_dir()?.join(consts::CONDA_PACKAGE_CACHE_DIR),
             ),
         };
-        let lock_file = self.lock_file;
         let glob_hash_cache = self.glob_hash_cache.unwrap_or_default();
 
         let multi_progress = pixi_progress::global_multi_progress();
         let anchor_pb = multi_progress.add(indicatif::ProgressBar::hidden());
+
+        // Route resolver construction through a `LockFileDerivedData`, seeding
+        // it with the caller's `Arc` when one was provided so we never build
+        // a second resolver for the same lock-file.
+        let input = LockFileDerivedData::from_input_lock_file(
+            project,
+            self.lock_file,
+            package_cache.clone(),
+            self.command_dispatcher.clone(),
+            glob_hash_cache.clone(),
+        );
+        if let Some(resolver) = self.resolver {
+            input.seed_resolver(resolver);
+        }
+        let resolver = input.resolver()?;
 
         let mut outdated = match self.outdated_environments {
             Some(outdated) => outdated,
@@ -1459,14 +1518,15 @@ impl<'p> UpdateContextBuilder<'p> {
                 OutdatedEnvironments::from_workspace_and_lock_file(
                     project,
                     self.command_dispatcher.clone(),
-                    &lock_file,
+                    &input.lock_file,
+                    &resolver,
                 )
                 .await
             }
         };
+        let lock_file = input.lock_file;
 
         // Extract the current conda records from the lock-file.
-        let workspace_root = project.root();
 
         // Collect unresolved records per environment and platform.
         #[allow(clippy::type_complexity)]
@@ -1478,31 +1538,19 @@ impl<'p> UpdateContextBuilder<'p> {
             .into_iter()
             .filter_map(|env| {
                 let locked_env = lock_file.environment(env.name().as_str())?;
-                let platforms: Result<Vec<_>, _> = locked_env
-                    .conda_packages_by_platform()
-                    .map(|(lock_platform, records)| {
+                let platforms: Vec<_> = locked_env
+                    .packages_by_platform()
+                    .map(|(lock_platform, packages)| {
                         let platform = lock_platform.subdir();
-                        let unresolved = records
-                            .cloned()
-                            .map(|data| {
-                                // TODO: resolve build/host packages from the
-                                // lock file once `PackageHandle` resolution is
-                                // exposed publicly.
-                                UnresolvedPixiRecord::from_conda_package_data(
-                                    data,
-                                    workspace_root,
-                                    Vec::new(),
-                                    Vec::new(),
-                                )
-                            })
-                            .collect::<Result<Vec<_>, _>>()?;
-                        Ok((platform, unresolved))
+                        let unresolved = packages
+                            .filter_map(|pkg| resolver.get_for_package(pkg))
+                            .collect::<Vec<_>>();
+                        (platform, unresolved)
                     })
                     .collect();
-                Some(platforms.map(|p| (env, p)))
+                Some((env, platforms))
             })
-            .collect::<Result<Vec<_>, ParseLockFileError>>()
-            .into_diagnostic()?;
+            .collect();
 
         // Step 2: Store the unresolved records directly. Partial source records
         // are kept as-is and resolved lazily only when needed. This avoids a
@@ -1720,6 +1768,7 @@ impl<'p> UpdateContext<'p> {
             mapping_client: None,
             command_dispatcher,
             update_targets: None,
+            resolver: None,
         })
     }
 
@@ -2283,6 +2332,7 @@ impl<'p> UpdateContext<'p> {
             command_dispatcher: self.command_dispatcher,
             glob_hash_cache: self.glob_hash_cache,
             build_caches: self.outdated_envs.build_caches,
+            resolver: Default::default(),
         })
     }
 }

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -378,6 +378,7 @@ impl WorkspaceMut {
             glob_hash_cache,
             io_concurrency_limit,
             build_caches,
+            ..
         } = UpdateContext::builder(self.workspace(), None)?
             .with_lock_file(unlocked_lock_file)
             .with_no_install(no_install || dry_run)
@@ -433,18 +434,20 @@ impl WorkspaceMut {
             self.save_inner().await.into_diagnostic()?;
         }
 
-        let updated_lock_file = LockFileDerivedData {
-            workspace: self.workspace(),
+        // Re-wrap the derived data under the longer-lived workspace
+        // reference.
+        let mut updated_lock_file = LockFileDerivedData::from_input_lock_file(
+            self.workspace(),
             lock_file,
             package_cache,
-            updated_conda_prefixes,
-            updated_pypi_prefixes,
-            uv_context,
-            io_concurrency_limit,
             command_dispatcher,
             glob_hash_cache,
-            build_caches,
-        };
+        );
+        updated_lock_file.updated_conda_prefixes = updated_conda_prefixes;
+        updated_lock_file.updated_pypi_prefixes = updated_pypi_prefixes;
+        updated_lock_file.uv_context = uv_context;
+        updated_lock_file.io_concurrency_limit = io_concurrency_limit;
+        updated_lock_file.build_caches = build_caches;
         if !dry_run {
             updated_lock_file.write_to_disk()?;
         }

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -18,7 +18,10 @@ pub use pixi_variant::VariantValue;
 use rattler_conda_types::{
     MatchSpec, Matches, NamelessMatchSpec, PackageName, PackageRecord, RepoDataRecord,
 };
-use rattler_lock::{CondaPackageData, ConversionError, UrlOrPath};
+use rattler_lock::{
+    CondaPackageData, ConversionError, EnvironmentPackages, LockFileBuilder, PackageHandle,
+    SourceData, UrlOrPath,
+};
 use serde::Serialize;
 pub use source_record::{
     FullSourceRecord as SourceRecord, FullSourceRecordData, PartialSourceRecord,
@@ -50,14 +53,24 @@ impl PixiRecord {
         }
     }
 
-    /// Convert to CondaPackageData with paths made relative to workspace_root.
-    /// This should be used when writing to the lock file.
-    pub fn into_conda_package_data(self, workspace_root: &Path) -> CondaPackageData {
+    /// Convert to `CondaPackageData` with paths made relative to
+    /// `workspace_root`. For source records, each entry of `build_packages` /
+    /// `host_packages` is registered into `builder` first (recursively) so
+    /// the returned source data's `source_data` references them by handle.
+    pub fn into_conda_package_data(
+        self,
+        builder: &mut LockFileBuilder,
+        workspace_root: &Path,
+    ) -> CondaPackageData {
         match self {
             PixiRecord::Binary(record) => Arc::unwrap_or_clone(record).into(),
-            PixiRecord::Source(record) => CondaPackageData::Source(Box::new(
-                Arc::unwrap_or_clone(record).into_conda_source_data(workspace_root),
-            )),
+            PixiRecord::Source(record) => {
+                let mut source = Arc::unwrap_or_clone(record);
+                let source_data = register_source_deps(builder, &mut source, workspace_root);
+                let mut data = source.into_conda_source_data(workspace_root);
+                data.source_data = source_data;
+                CondaPackageData::Source(Box::new(data))
+            }
         }
     }
 
@@ -240,13 +253,24 @@ impl UnresolvedPixiRecord {
         }
     }
 
-    /// Convert to `CondaPackageData` for lock-file write.
-    pub fn into_conda_package_data(self, workspace_root: &Path) -> CondaPackageData {
+    /// Convert to `CondaPackageData` for lock-file write. For source records,
+    /// `build_packages` / `host_packages` are registered into `builder`
+    /// (recursively) so the returned source data's `source_data` references
+    /// them by handle.
+    pub fn into_conda_package_data(
+        self,
+        builder: &mut LockFileBuilder,
+        workspace_root: &Path,
+    ) -> CondaPackageData {
         match self {
             UnresolvedPixiRecord::Binary(record) => Arc::unwrap_or_clone(record).into(),
-            UnresolvedPixiRecord::Source(record) => CondaPackageData::Source(Box::new(
-                Arc::unwrap_or_clone(record).into_conda_source_data(workspace_root),
-            )),
+            UnresolvedPixiRecord::Source(record) => {
+                let mut source = Arc::unwrap_or_clone(record);
+                let source_data = register_source_deps(builder, &mut source, workspace_root);
+                let mut data = source.into_conda_source_data(workspace_root);
+                data.source_data = source_data;
+                CondaPackageData::Source(Box::new(data))
+            }
         }
     }
 
@@ -277,6 +301,46 @@ impl UnresolvedPixiRecord {
             }
         }
     }
+}
+
+/// Register a source record's `build_packages` / `host_packages` into
+/// `builder` (recursively) and build a [`SourceData`] referencing the
+/// resulting handles. Leaves `source` with empty build/host package vecs —
+/// the canonical form lives in the lockfile from this point on.
+fn register_source_deps<D>(
+    builder: &mut LockFileBuilder,
+    source: &mut source_record::SourceRecord<D>,
+    workspace_root: &Path,
+) -> SourceData {
+    let build_handles = register_handles(
+        builder,
+        std::mem::take(&mut source.build_packages),
+        workspace_root,
+    );
+    let host_handles = register_handles(
+        builder,
+        std::mem::take(&mut source.host_packages),
+        workspace_root,
+    );
+    SourceData {
+        build_packages: EnvironmentPackages::from_handles(build_handles)
+            .expect("handles just produced by this builder"),
+        host_packages: EnvironmentPackages::from_handles(host_handles)
+            .expect("handles just produced by this builder"),
+    }
+}
+
+fn register_handles(
+    builder: &mut LockFileBuilder,
+    deps: Vec<UnresolvedPixiRecord>,
+    workspace_root: &Path,
+) -> Vec<PackageHandle> {
+    deps.into_iter()
+        .map(|dep| {
+            let data = dep.into_conda_package_data(builder, workspace_root);
+            builder.register_conda_package(data)
+        })
+        .collect()
 }
 
 impl From<PixiRecord> for UnresolvedPixiRecord {

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -1,10 +1,12 @@
 mod canonical_spec;
 mod dev_source_record;
+mod lock_file_resolver;
 mod pinned_source;
 mod source_record;
 
 pub use canonical_spec::{CanonicalGit, CanonicalPath, CanonicalSourceLocation, CanonicalUrl};
 pub use dev_source_record::DevSourceRecord;
+pub use lock_file_resolver::{LockFileResolver, LockFileResolverError};
 
 use std::{path::Path, sync::Arc};
 

--- a/crates/pixi_record/src/lock_file_resolver.rs
+++ b/crates/pixi_record/src/lock_file_resolver.rs
@@ -1,0 +1,272 @@
+//! Index-based lookup of [`UnresolvedPixiRecord`]s for every package in a
+//! [`LockFile`].
+//!
+//! Building a source record requires access to its `build_packages` and
+//! `host_packages` as [`UnresolvedPixiRecord`] values. The lockfile stores
+//! those as index sets; this resolver walks the full package table once in
+//! topological order and produces an `UnresolvedPixiRecord` per entry with
+//! `build_packages` / `host_packages` populated from already-built
+//! predecessors.
+
+use std::path::Path;
+
+use rattler_lock::{LockFile, LockedPackage, PackageHandle};
+use thiserror::Error;
+
+use crate::{ParseLockFileError, UnresolvedPixiRecord};
+
+/// Maps every package in a [`LockFile`] to an `UnresolvedPixiRecord`.
+///
+/// Conda packages are represented. Pypi packages occupy a slot so that
+/// positional indexing lines up with [`LockFile::packages`], but the slot is
+/// `None`.
+#[derive(Debug)]
+pub struct LockFileResolver {
+    records: Vec<Option<UnresolvedPixiRecord>>,
+    /// Start address of the source lockfile's `packages()` slice, stored as
+    /// a `usize` so the struct stays `Send + Sync`. Used to map an incoming
+    /// `&LockedPackage` back to its index via pointer-offset arithmetic —
+    /// same fragility as any pointer-identity scheme: callers must pass
+    /// references into the same, still-alive lockfile.
+    packages_start_addr: usize,
+    packages_len: usize,
+}
+
+impl LockFileResolver {
+    /// Build a resolver from every package in `lock_file`. Source records
+    /// have their `build_packages` and `host_packages` populated with the
+    /// corresponding records from the same resolver.
+    ///
+    /// The traversal is a DFS post-order over the build/host dependency
+    /// graph, so each record is constructed once with its final state. A
+    /// cycle in the graph (which shouldn't occur for a valid build DAG)
+    /// surfaces as [`LockFileResolverError::Cycle`].
+    pub fn build(
+        lock_file: &LockFile,
+        workspace_root: &Path,
+    ) -> Result<Self, LockFileResolverError> {
+        let packages = lock_file.packages();
+        let packages_start_addr = packages.as_ptr() as usize;
+        let packages_len = packages.len();
+        let mut records: Vec<Option<UnresolvedPixiRecord>> =
+            (0..packages_len).map(|_| None).collect();
+
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum State {
+            Unvisited,
+            Visiting,
+            Done,
+        }
+        let mut state = vec![State::Unvisited; packages.len()];
+
+        // Iterative DFS post-order. The stack frame is
+        // `(node, deps, cursor)`; when `cursor == deps.len()` we've processed
+        // every dependency and can emit the node.
+        for root in 0..packages.len() {
+            if state[root] != State::Unvisited {
+                continue;
+            }
+            let mut stack: Vec<(usize, Vec<usize>, usize)> = Vec::new();
+            let deps = dep_indices(&packages[root]);
+            stack.push((root, deps, 0));
+            state[root] = State::Visiting;
+
+            while let Some((_, deps, cursor)) = stack.last_mut() {
+                if *cursor < deps.len() {
+                    let next = deps[*cursor];
+                    *cursor += 1;
+                    match state[next] {
+                        State::Done => {}
+                        State::Visiting => {
+                            return Err(LockFileResolverError::Cycle(format_cycle(
+                                &stack, next, packages,
+                            )));
+                        }
+                        State::Unvisited => {
+                            state[next] = State::Visiting;
+                            let next_deps = dep_indices(&packages[next]);
+                            stack.push((next, next_deps, 0));
+                        }
+                    }
+                } else {
+                    let (node, _, _) = stack.pop().expect("stack is non-empty in this branch");
+                    state[node] = State::Done;
+                    records[node] = build_record(&packages[node], workspace_root, &records)?;
+                }
+            }
+        }
+
+        Ok(Self {
+            records,
+            packages_start_addr,
+            packages_len,
+        })
+    }
+
+    /// Returns the resolver's record for a package. The reference must point
+    /// into the same lockfile that built the resolver — references from
+    /// clones or other lockfiles yield `None`.
+    pub fn get_for_package(&self, package: &LockedPackage) -> Option<UnresolvedPixiRecord> {
+        let addr = package as *const LockedPackage as usize;
+        let offset = addr.checked_sub(self.packages_start_addr)?;
+        let stride = size_of::<LockedPackage>();
+        if offset % stride != 0 {
+            return None;
+        }
+        let idx = offset / stride;
+        if idx >= self.packages_len {
+            return None;
+        }
+        self.records[idx].clone()
+    }
+}
+
+/// Construct the final `UnresolvedPixiRecord` for a package. For conda source
+/// packages, `build_packages` and `host_packages` are populated from
+/// already-built slots in `records`.
+fn build_record(
+    locked: &LockedPackage,
+    workspace_root: &Path,
+    records: &[Option<UnresolvedPixiRecord>],
+) -> Result<Option<UnresolvedPixiRecord>, LockFileResolverError> {
+    let LockedPackage::Conda(data) = locked else {
+        return Ok(None);
+    };
+
+    let (build_packages, host_packages) = match data.as_source() {
+        Some(source) => (
+            collect_records(records, source.source_data.build_packages.raw_handles()),
+            collect_records(records, source.source_data.host_packages.raw_handles()),
+        ),
+        None => (Vec::new(), Vec::new()),
+    };
+
+    let unresolved = UnresolvedPixiRecord::from_conda_package_data(
+        data.clone(),
+        workspace_root,
+        build_packages,
+        host_packages,
+    )
+    .map_err(LockFileResolverError::Parse)?;
+    Ok(Some(unresolved))
+}
+
+/// Collect an iterator of handles into a vector of `UnresolvedPixiRecord`,
+/// skipping any handle that resolves to `None` (i.e. a pypi package or,
+/// defensively, an out-of-bounds slot).
+fn collect_records<'a>(
+    records: &[Option<UnresolvedPixiRecord>],
+    handles: impl IntoIterator<Item = &'a PackageHandle>,
+) -> Vec<UnresolvedPixiRecord> {
+    handles
+        .into_iter()
+        .filter_map(|h| records.get(h.as_usize())?.clone())
+        .collect()
+}
+
+/// Build and host dependency indices for a package. Empty for binary and pypi
+/// packages.
+fn dep_indices(package: &LockedPackage) -> Vec<usize> {
+    let Some(source) = package.as_conda().and_then(|c| c.as_source()) else {
+        return Vec::new();
+    };
+    source
+        .source_data
+        .build_packages
+        .raw_handles()
+        .chain(source.source_data.host_packages.raw_handles())
+        .map(PackageHandle::as_usize)
+        .collect()
+}
+
+/// Build a human-readable description of the cycle that was just detected.
+/// `stack` contains every node currently being visited (from the DFS root down
+/// to the caller of the back-edge), and `back_edge_target` is the node the
+/// back-edge points to — i.e. the node that closes the cycle. Walks the stack
+/// from that target to the top and formats the names as `a -> b -> c -> a`.
+fn format_cycle(
+    stack: &[(usize, Vec<usize>, usize)],
+    back_edge_target: usize,
+    packages: &[LockedPackage],
+) -> String {
+    let mut names: Vec<&str> = stack
+        .iter()
+        .skip_while(|(n, _, _)| *n != back_edge_target)
+        .map(|(n, _, _)| packages[*n].name())
+        .collect();
+    names.push(packages[back_edge_target].name());
+    names.join(" -> ")
+}
+
+#[derive(Debug, Error)]
+pub enum LockFileResolverError {
+    #[error(transparent)]
+    Parse(#[from] ParseLockFileError),
+
+    #[error("the lockfile's build/host package graph contains a cycle: {0}")]
+    Cycle(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use rattler_lock::LockFile;
+
+    use super::{LockFileResolver, LockFileResolverError};
+
+    /// Two source packages that list each other as a build dependency.
+    /// `LockFileResolver::build` should detect the back-edge during DFS
+    /// and surface a `Cycle` error whose payload names both packages.
+    #[test]
+    fn cycle_error_reports_path() {
+        let lock_source = r#"version: 7
+platforms:
+- name: noarch
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      noarch:
+      - conda_source: foo[11111111] @ git+https://github.com/example/foo.git?tag=v1#0000000000000000000000000000000000000001
+      - conda_source: bar[22222222] @ git+https://github.com/example/bar.git?tag=v1#0000000000000000000000000000000000000002
+packages:
+- conda_source: foo[11111111] @ git+https://github.com/example/foo.git?tag=v1#0000000000000000000000000000000000000001
+  version: 1.0.0
+  build: h0
+  subdir: noarch
+  build_packages:
+  - conda_source: bar[22222222] @ git+https://github.com/example/bar.git?tag=v1#0000000000000000000000000000000000000002
+- conda_source: bar[22222222] @ git+https://github.com/example/bar.git?tag=v1#0000000000000000000000000000000000000002
+  version: 2.0.0
+  build: h0
+  subdir: noarch
+  build_packages:
+  - conda_source: foo[11111111] @ git+https://github.com/example/foo.git?tag=v1#0000000000000000000000000000000000000001
+"#;
+
+        let lock_file =
+            LockFile::from_str_with_base_directory(lock_source, Some(Path::new("/workspace")))
+                .expect("cyclic lockfile should still parse");
+
+        let err = LockFileResolver::build(&lock_file, Path::new("/workspace"))
+            .expect_err("resolver should reject a cyclic build graph");
+
+        let LockFileResolverError::Cycle(path) = err else {
+            panic!("expected Cycle error, got {err:?}");
+        };
+        let segments: Vec<&str> = path.split(" -> ").collect();
+        assert!(
+            segments.len() >= 3,
+            "cycle path should have at least start -> mid -> start: {path}"
+        );
+        assert_eq!(
+            segments.first(),
+            segments.last(),
+            "cycle path should close on itself: {path}"
+        );
+        assert!(path.contains("foo"), "cycle path should mention foo: {path}");
+        assert!(path.contains("bar"), "cycle path should mention bar: {path}");
+    }
+}

--- a/crates/pixi_record/src/lock_file_resolver.rs
+++ b/crates/pixi_record/src/lock_file_resolver.rs
@@ -266,7 +266,13 @@ packages:
             segments.last(),
             "cycle path should close on itself: {path}"
         );
-        assert!(path.contains("foo"), "cycle path should mention foo: {path}");
-        assert!(path.contains("bar"), "cycle path should mention bar: {path}");
+        assert!(
+            path.contains("foo"),
+            "cycle path should mention foo: {path}"
+        );
+        assert!(
+            path.contains("bar"),
+            "cycle path should mention bar: {path}"
+        );
     }
 }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -754,10 +754,94 @@ mod tests {
         });
     }
 
+    /// Round-trip a lock file whose conda source package carries build and
+    /// host package handles. Uses [`LockFileResolver`] to rebuild records
+    /// with their build/host packages populated from the lockfile's package
+    /// table, then writes them back via [`UnresolvedPixiRecord::into_conda_package_data`]
+    /// — the path that should serialize the handles again. A diff against
+    /// the fixture fails if the round-trip drops build/host information.
+    #[test]
+    fn roundtrip_source_records_with_build_host_packages() {
+        assert_roundtrip_identity("source_with_build_host_packages.lock");
+    }
+
+    /// Same contract as [`roundtrip_source_records_with_build_host_packages`],
+    /// but the outer source has another source in its `build_packages`. This
+    /// exercises the recursive branch of `register_source_deps` — the only
+    /// path that actually fires when a source depends on a source at build
+    /// time.
+    #[test]
+    fn roundtrip_source_records_with_nested_source_build_dep() {
+        assert_roundtrip_identity("nested_source_build_dep.lock");
+    }
+
+    fn assert_roundtrip_identity(fixture_name: &str) {
+        use crate::LockFileResolver;
+
+        let workspace_root = Path::new("/workspace");
+
+        let lock_source = fixture_source(fixture_name);
+        let lock_file = LockFile::from_str_with_base_directory(&lock_source, Some(workspace_root))
+            .expect("failed to load lock file fixture");
+
+        let resolver =
+            LockFileResolver::build(&lock_file, workspace_root).expect("resolver should build");
+
+        let environment = lock_file
+            .default_environment()
+            .expect("expected default environment");
+
+        let mut builder = LockFileBuilder::new()
+            .with_platforms(
+                lock_file
+                    .platforms()
+                    .map(|p| rattler_lock::PlatformData {
+                        name: p.name().clone(),
+                        subdir: p.subdir(),
+                        virtual_packages: p.virtual_packages().to_vec(),
+                    })
+                    .collect(),
+            )
+            .expect("platforms should be unique");
+        builder.set_channels(
+            DEFAULT_ENVIRONMENT_NAME,
+            [Channel::from("https://conda.anaconda.org/conda-forge/")],
+        );
+
+        for (platform, packages) in environment.packages_by_platform() {
+            let platform_str = platform.subdir().to_string();
+            for package in packages {
+                let Some(record) = resolver.get_for_package(package) else {
+                    continue;
+                };
+                let data = record.into_conda_package_data(&mut builder, workspace_root);
+                builder
+                    .add_conda_package(DEFAULT_ENVIRONMENT_NAME, &platform_str, data)
+                    .expect("platform was registered");
+            }
+        }
+
+        let roundtrip_lock = builder
+            .finish()
+            .render_to_string()
+            .expect("failed to render lock file");
+
+        assert_eq!(
+            roundtrip_lock.trim_end().replace("\r\n", "\n"),
+            lock_source.trim_end().replace("\r\n", "\n"),
+            "round-trip of {fixture_name} through LockFileResolver + into_conda_package_data should be identity"
+        );
+    }
+
     /// Load the lock file body from a static fixture file with full metadata.
     fn lock_source_from_fixture() -> String {
+        fixture_source("full_source_records.lock")
+    }
+
+    fn fixture_source(name: &str) -> String {
         let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("src/test_fixtures/full_source_records.lock");
+            .join("src/test_fixtures")
+            .join(name);
         #[allow(clippy::disallowed_methods)]
         std::fs::read_to_string(fixture_path).expect("failed to read fixture file")
     }

--- a/crates/pixi_record/src/test_fixtures/nested_source_build_dep.lock
+++ b/crates/pixi_record/src/test_fixtures/nested_source_build_dep.lock
@@ -1,0 +1,32 @@
+version: 7
+platforms:
+- name: linux-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda
+      - conda_source: inner[aaaaaaaa] @ git+https://github.com/example/inner.git?tag=v1#0000000000000000000000000000000000000011
+      - conda_source: outer[bbbbbbbb] @ git+https://github.com/example/outer.git?tag=v1#0000000000000000000000000000000000000022
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda
+- conda_source: inner[aaaaaaaa] @ git+https://github.com/example/inner.git?tag=v1#0000000000000000000000000000000000000011
+  version: 1.0.0
+  build: h0
+  subdir: noarch
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda
+- conda_source: outer[bbbbbbbb] @ git+https://github.com/example/outer.git?tag=v1#0000000000000000000000000000000000000022
+  version: 2.0.0
+  build: h0
+  subdir: noarch
+  build_packages:
+  - conda_source: inner[aaaaaaaa] @ git+https://github.com/example/inner.git?tag=v1#0000000000000000000000000000000000000011
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda

--- a/crates/pixi_record/src/test_fixtures/source_with_build_host_packages.lock
+++ b/crates/pixi_record/src/test_fixtures/source_with_build_host_packages.lock
@@ -1,0 +1,23 @@
+version: 7
+platforms:
+- name: linux-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda
+      - conda_source: my-package[12345678] @ git+https://github.com/example/my-package.git?tag=v0.1.0#abc123def456abc123def456abc123def456abc1
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda
+- conda_source: my-package[12345678] @ git+https://github.com/example/my-package.git?tag=v0.1.0#abc123def456abc123def456abc123def456abc1
+  version: 0.1.0
+  build: py_0
+  subdir: noarch
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda


### PR DESCRIPTION
### Description

Round trip build- and host packages from the LockFile all the way through pixi.

The biggest challenge is to not map the same data into the different Arcs (inside *PixiRecord) over and over again.

### How Has This Been Tested?

Some new tests:-)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
