### PR TITLE
feat: add platform override 

### DIFF
--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -66,6 +66,8 @@ pub const PIXI_DIR: &str = match option_env!("PIXI_DIR") {
     Some(dir) => dir,
     None => ".pixi",
 };
+/// Environment variable to override the detected platform.
+pub const PIXI_OVERRIDE_PLATFORM: &str = "PIXI_OVERRIDE_PLATFORM";
 /// The default manifest name for the global manifest file in the pixi config directory.
 pub const GLOBAL_MANIFEST_DEFAULT_NAME: &str =
     match option_env!("PIXI_GLOBAL_MANIFEST_DEFAULT_NAME") {

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -126,8 +126,10 @@ impl<'p> Environment<'p> {
     fn best_platform_with_current(&self, current: Platform) -> Platform {
         let current = std::env::var(consts::PIXI_OVERRIDE_PLATFORM)
             .map(|val| {
-                val.parse::<Platform>()
-                    .unwrap_or_else(|_| panic!("Invalid value for PIXI_OVERRIDE_PLATFORM='{val}'."))
+                val.parse::<Platform>().unwrap_or_else(|_| {
+                    tracing::warn!("Invalid value for PIXI_OVERRIDE_PLATFORM='{val}', ignoring.");
+                    current
+                })
             })
             .unwrap_or(current);
 
@@ -1408,7 +1410,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Invalid value for PIXI_OVERRIDE_PLATFORM")]
     fn test_best_platform_override_invalid_value() {
         let _lock = ENV_VAR_MUTEX.lock().unwrap();
 
@@ -1426,6 +1427,7 @@ mod tests {
         let _guard = EnvVarGuard;
 
         let env = workspace.default_environment();
-        env.best_platform();
+        let result = env.best_platform();
+        assert_eq!(result, Platform::current());
     }
 }

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -121,7 +121,16 @@ impl<'p> Environment<'p> {
         self.best_platform_with_current(Platform::current())
     }
 
+    /// If the PIXI_OVERRIDE_PLATFORM environment variable is set to a valid
+    /// platform string, that platform is used instead.
     fn best_platform_with_current(&self, current: Platform) -> Platform {
+        let current = std::env::var(consts::PIXI_OVERRIDE_PLATFORM)
+        .map(|val| {
+            val.parse::<Platform>()
+                .unwrap_or_else(|_| panic!("Invalid value for PIXI_OVERRIDE_PLATFORM='{val}'."))
+        })
+        .unwrap_or(current);
+
         // If the current platform is supported, return it.
         if self.platforms().contains(&current) {
             return current;
@@ -164,6 +173,10 @@ impl<'p> Environment<'p> {
     /// installed or activated — not during lock file solving, which is
     /// cross-platform and does not use emulation.
     pub fn emit_emulation_warning(&self) {
+        if std::env::var(consts::PIXI_OVERRIDE_PLATFORM).is_ok() {
+            return;
+        }
+
         let current = Platform::current();
         let best = self.best_platform();
         if current == best {
@@ -1357,5 +1370,64 @@ mod tests {
                 "Channel priorities were expected to be compatible"
             );
         }
+    }
+
+    struct EnvVarGuard;
+
+    // prevents race conditions on the env variable PIXI_OVERRIDE_PLATFORM
+    static ENV_VAR_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var(consts::PIXI_OVERRIDE_PLATFORM);
+            }
+        }
+    }
+
+    #[test]
+    fn test_best_platform_override_env_var() {
+        let _lock = ENV_VAR_MUTEX.lock().unwrap();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let contents = r#"
+        [project]
+        name = "test"
+        channels = []
+        platforms = []
+        "#;
+        let workspace = Workspace::from_str(&temp_dir.path().join("pixi.toml"), contents).unwrap();
+    
+        unsafe {
+            std::env::set_var(consts::PIXI_OVERRIDE_PLATFORM, "linux-aarch64");
+        }
+        let _guard = EnvVarGuard;
+
+        let env = workspace.default_environment();
+        let result = env.best_platform();
+        assert_eq!(result, Platform::LinuxAarch64);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid value for PIXI_OVERRIDE_PLATFORM")]
+    fn test_best_platform_override_invalid_value() {
+        let _lock = ENV_VAR_MUTEX.lock().unwrap();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let contents = r#"
+        [project]
+        name = "test"
+        channels = []
+        platforms = []
+        "#;
+        let workspace = Workspace::from_str(&temp_dir.path().join("pixi.toml"), contents).unwrap();
+    
+        unsafe {
+            std::env::set_var(consts::PIXI_OVERRIDE_PLATFORM, "not-a-platform");
+        }
+        let _guard = EnvVarGuard;
+
+        let env = workspace.default_environment();
+        let result = env.best_platform();
     }
 }

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -1428,6 +1428,6 @@ mod tests {
         let _guard = EnvVarGuard;
 
         let env = workspace.default_environment();
-        let result = env.best_platform();
+        env.best_platform();
     }
 }

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -125,11 +125,11 @@ impl<'p> Environment<'p> {
     /// platform string, that platform is used instead.
     fn best_platform_with_current(&self, current: Platform) -> Platform {
         let current = std::env::var(consts::PIXI_OVERRIDE_PLATFORM)
-        .map(|val| {
-            val.parse::<Platform>()
-                .unwrap_or_else(|_| panic!("Invalid value for PIXI_OVERRIDE_PLATFORM='{val}'."))
-        })
-        .unwrap_or(current);
+            .map(|val| {
+                val.parse::<Platform>()
+                    .unwrap_or_else(|_| panic!("Invalid value for PIXI_OVERRIDE_PLATFORM='{val}'."))
+            })
+            .unwrap_or(current);
 
         // If the current platform is supported, return it.
         if self.platforms().contains(&current) {
@@ -1397,7 +1397,6 @@ mod tests {
         platforms = []
         "#;
         let workspace = Workspace::from_str(&temp_dir.path().join("pixi.toml"), contents).unwrap();
-    
         unsafe {
             std::env::set_var(consts::PIXI_OVERRIDE_PLATFORM, "linux-aarch64");
         }
@@ -1421,7 +1420,6 @@ mod tests {
         platforms = []
         "#;
         let workspace = Workspace::from_str(&temp_dir.path().join("pixi.toml"), contents).unwrap();
-    
         unsafe {
             std::env::set_var(consts::PIXI_OVERRIDE_PLATFORM, "not-a-platform");
         }

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -93,7 +93,7 @@ pub fn verify_current_platform_can_run_environment(
     environment: &Environment<'_>,
     lockfile: Option<&LockFile>,
 ) -> Result<(), VerifyCurrentPlatformError> {
-    // When overriding platform skip validation entirely. 
+    // When overriding platform skip validation entirely.
     // The host platform wouldn't satisfy the requirements
     if std::env::var(pixi_consts::consts::PIXI_OVERRIDE_PLATFORM).is_ok() {
         return Ok(());

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -93,6 +93,12 @@ pub fn verify_current_platform_can_run_environment(
     environment: &Environment<'_>,
     lockfile: Option<&LockFile>,
 ) -> Result<(), VerifyCurrentPlatformError> {
+    // When overriding platform skip validation entirely. 
+    // The host platform wouldn't satisfy the requirements
+    if std::env::var(pixi_consts::consts::PIXI_OVERRIDE_PLATFORM).is_ok() {
+        return Ok(());
+    }
+
     let current_platform = environment.best_platform();
 
     // Are there dependencies and is the current platform in the list of supported platforms?

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -29,6 +29,14 @@ Pixi can also be configured via environment variables.
       </td>
     </tr>
     <tr>
+      <td><code>PIXI_OVERRIDE_PLATFORM</code></td>
+      <td>
+        Overrides the detected host platform used to select and install environments.
+        Accepts any valid platform string (e.g. <code>linux-aarch64</code>, <code>osx-arm64</code>, <code>win-64</code>).
+      </td>
+      <td>Not set, pixi detects the current platform automatically.</td>
+    </tr>
+    <tr>
       <td><code>RATTLER_AUTH_FILE</code></td>
       <td>Overrides the default location of the credentials file. When set, this is the only source of authentication data used by pixi. See <a href="../../deployment/authentication/#override-the-authentication-storage">authentication docs</a> for the file format.</td>
       <td>


### PR DESCRIPTION
### Description

Adds support for the `PIXI_OVERRIDE_PLATFORM` environment variable, allowing users to install packages for a foreign architecture. It is useful for cross-compilation workflows where target dependencies need to be present on the host machine.

As suggested in #5918, I went with an env var rather than a new CLI flag.

A few design choices worth mentioning:
- If the value doesn't match a valid `Platform`, pixi raises a warning ~panics. Silently falling back to the host platform felt wrong since the user clearly has a different intention~.
- The emulation warning is skipped when the override is set. To my understanding, the warning exists to notify users of an automatic fallback they didn't ask for. With an explicit override, there's no implicit fallback, so the warning doesn't apply.

Note: I'm not familiar with Rust at all, so feel free to point out if something can be improved!
Fixes #5918

### How Has This Been Tested?

Added two unit tests: `test_best_platform_override_env_var` and `test_best_platform_override_invalid_value`.
I also manually tested it on a `linux-64` host by running: 
```bash
PIXI_OVERRIDE_PLATFORM=linux-aarch64 pixi install
```
and verified the installed libraries are `aarch64`.

### AI Disclosure
This PR doesn't contain AI-generated code.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
