### PR TITLE
fix(pixi-build-cmake): rebuild when CMakeLists.txt changes

### DIFF
--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -146,6 +146,7 @@ impl GenerateRecipe for CMakeGenerator {
             // CMake files
             "**/*.{cmake,cmake.in}",
             "**/CMakeFiles.txt",
+            "**/CMakeLists.txt",
         ]
         .iter()
         .map(|s: &&str| s.to_string())

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -145,7 +145,6 @@ impl GenerateRecipe for CMakeGenerator {
             "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
             // CMake files
             "**/*.{cmake,cmake.in}",
-            "**/CMakeFiles.txt",
             "**/CMakeLists.txt",
         ]
         .iter()

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
@@ -6,7 +6,6 @@ Ok(
     {
         "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
         "**/*.{cmake,cmake.in}",
-        "**/CMakeFiles.txt",
         "**/CMakeLists.txt",
         "custom/*.c",
     },

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
@@ -7,6 +7,7 @@ Ok(
         "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
         "**/*.{cmake,cmake.in}",
         "**/CMakeFiles.txt",
+        "**/CMakeLists.txt",
         "custom/*.c",
     },
 )

--- a/docs/build/backends/pixi-build-cmake.md
+++ b/docs/build/backends/pixi-build-cmake.md
@@ -117,7 +117,7 @@ The backend always writes JSON-RPC request/response logs and the generated inter
 - **Default**: `[]`
 - **Target Merge Behavior**: `Overwrite` - Platform-specific globs completely replace base globs
 
-Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeFiles.txt`, `**/CMakeLists.txt`), and other build-related files.
+Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeLists.txt`), and other build-related files.
 
 ```toml
 [package.build.config]

--- a/docs/build/backends/pixi-build-cmake.md
+++ b/docs/build/backends/pixi-build-cmake.md
@@ -117,7 +117,7 @@ The backend always writes JSON-RPC request/response logs and the generated inter
 - **Default**: `[]`
 - **Target Merge Behavior**: `Overwrite` - Platform-specific globs completely replace base globs
 
-Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeFiles.txt`), and other build-related files.
+Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeFiles.txt`, `**/CMakeLists.txt`), and other build-related files.
 
 ```toml
 [package.build.config]


### PR DESCRIPTION
### Description

Fix `pixi build` / source builds using **`pixi-build-cmake`** not being invalidated when `CMakeLists.txt` changes.

The root cause is that `pixi-build-cmake`’s declared input globs (used by Pixi to decide whether a cached source build is stale) did not include `CMakeLists.txt`. This PR adds `**/CMakeLists.txt` to the backend’s input globs so edits to CMake configuration trigger a rebuild.

Also removed the mistaken `**/CMakeFiles.txt` input glob and updated snapshot + docs accordingly.

Fixes #5959

### How Has This Been Tested?

- **Rust unit/snapshot tests**
  - Ran: `cargo test -p pixi-build-cmake`
  - Updated and verified the `insta` snapshot for input globs (the snapshot now includes `**/CMakeLists.txt`).

- **Manual repro / verification (local workspace)**
  Used a minimal CMake project in `cmake-repro/` that defines a compile-time macro in `CMakeLists.txt` and prints it from C++ (`REPRO_MAGIC`). This lets us detect when Pixi incorrectly reuses a cached build after changing only `CMakeLists.txt`.

  **Project tree**

  ```text
  cmake-repro/
  ├── CMakeLists.txt
  ├── pixi.toml
  └── src/
      └── main.cpp
  ```

  <details>
  <summary>File contents (cmake-repro)</summary>

  #### `cmake-repro/CMakeLists.txt`

  ```cmake
  cmake_minimum_required(VERSION 3.20)
  project(cmake_repro LANGUAGES CXX)

  set(CMAKE_CXX_STANDARD 17)
  set(CMAKE_CXX_STANDARD_REQUIRED ON)

  add_executable(cmake_repro src/main.cpp)
  target_compile_definitions(cmake_repro PRIVATE REPRO_MAGIC=122)

  # Install is important: pixi-build-cmake builds a conda package and expects an install step.
  install(TARGETS cmake_repro)
  ```

  #### `cmake-repro/pixi.toml`

  ```toml
  [package]
  name = "cmake_repro"
  version = "0.1.0"

  [package.build]
  backend = { name = "pixi-build-cmake", version = "*" }

  [workspace]
  channels = ["conda-forge"]
  platforms = ["osx-arm64"]
  preview = ["pixi-build"]

  [dependencies]
  cmake_repro = { path = "." }

  [tasks]
  run = "cmake_repro"
  ```

  #### `cmake-repro/src/main.cpp`

  ```cpp
  #include <iostream>

  #ifndef REPRO_MAGIC
  #define REPRO_MAGIC -1
  #endif

  int main() {
      std::cout << "REPRO_MAGIC____=" << REPRO_MAGIC << "\n";
      return 0;
  }
  ```

  </details>

  **Environment variables used**

  ```bash
  export PIXI_BUILD_BACKEND_OVERRIDE="pixi-build-cmake=/Users/ubaid/projects/repo/pixi/target/debug/pixi-build-cmake"
  ```

  **Commands + output**
  
<details><summary>Before updating CMakeLists.txt</summary>

```bash
(base) ubaid@Mohammeds-MacBook-Pro cmake-repro % ../pixi/target/debug/pixi run run
 WARN overriding build backend with: pixi-build-cmake=/Users/ubaid/projects/repo/pixi/target/debug/pixi-build-cmake
 WARN metadata cache disabled for build backend 'pixi-build-cmake' (system/path-based backends always regenerate metadata)
✨ Pixi task (run): cmake_repro

 ╭─ Running build for recipe: cmake_repro-0.1.0-h60d57d3_0
 │
 │ ╭─ Fetching source code
 │ │ No sources to fetch
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Externally resolved dependencies recipe: cmake_repro-0.1.0-h60d57d3_0
 │ │ 
 │ │ ...
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Running build script
 │ │ ...
 │ ╰─────────────────── (took 2 seconds)
 │
 │ ╭─ Packaging new files
 │ │ Copying done!
 │ │ Relinking "cmake_repro"
 │ │ 
 │ │ [bin/cmake_repro] links against:
 │ │  ├─ /usr/lib/libSystem.B.dylib (system)
 │ │  └─ lib/libc++.1.0.dylib (libcxx)
 │ │ Post-processing done!
 │ │ Writing test files
 │ │ Writing metadata for package
 │ │ Copying license files
 │ │ Copying recipe files
 │ │ 
 │ │ Files in package:
 │ │   ├─ bin/cmake_repro (69.00 KiB)
 │ │   ├─ info/about.json (2 B)
 │ │   ├─ info/hash_input.json (32 B)
 │ │   ├─ info/index.json (228 B)
 │ │   ├─ info/paths.json (232 B)
 │ │   └─ info/tests/tests.yaml (3 B)
 │ │ 
 │ │ Package statistics: 6 files (1 content, 5 metadata), total size: 69.49 KiB
 │ │ Largest files:
 │ │   69.00 KiB - bin/cmake_repro
 │ │ Creating target folder '/Users/ubaid/projects/repo/cmake-repro/.pixi/build/work/cmake_repro-OL-q6p36zFw-ME03ejjoGjs/output/osx-arm64'
 │ │ Compressing archive...
 │ │ Archive written to '/Users/ubaid/projects/repo/cmake-repro/.pixi/build/work/cmake_repro-OL-q6p36zFw-ME03ejjoGjs/output/osx-arm64/cmake_repro-0.1.0-h60d57d3
 │ │ _0.conda'
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 ╰─────────────────── (took 2 seconds)
REPRO_MAGIC____=122
(base) ubaid@Mohammeds-MacBook-Pro cmake-repro % ../pixi/target/debug/pixi run run
 WARN overriding build backend with: pixi-build-cmake=/Users/ubaid/projects/repo/pixi/target/debug/pixi-build-cmake
 WARN metadata cache disabled for build backend 'pixi-build-cmake' (system/path-based backends always regenerate metadata)
✨ Pixi task (run): cmake_repro
REPRO_MAGIC____=122
```

</details>

Making the following change:

```diff
-target_compile_definitions(cmake_repro PRIVATE REPRO_MAGIC=122)
+target_compile_definitions(cmake_repro PRIVATE REPRO_MAGIC=123)
```

<details><summary>Post updating CMakeLists.txt</summary>

```bash
(base) ubaid@Mohammeds-MacBook-Pro cmake-repro % ../pixi/target/debug/pixi run run
 WARN overriding build backend with: pixi-build-cmake=/Users/ubaid/projects/repo/pixi/target/debug/pixi-build-cmake
 WARN metadata cache disabled for build backend 'pixi-build-cmake' (system/path-based backends always regenerate metadata)
✨ Pixi task (run): cmake_repro

 ╭─ Running build for recipe: cmake_repro-0.1.0-h60d57d3_0
 │
 │ ╭─ Fetching source code
 │ │ No sources to fetch
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Externally resolved dependencies recipe: cmake_repro-0.1.0-h60d57d3_0
 │ │ 
 │ │ ...
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 │ ╭─ Running build script
 │ │ ...
 │ ╰─────────────────── (took 1 second)
 │
 │ ╭─ Packaging new files
 │ │ Copying done!
 │ │ Relinking "cmake_repro"
 │ │ 
 │ │ [bin/cmake_repro] links against:
 │ │  ├─ /usr/lib/libSystem.B.dylib (system)
 │ │  └─ lib/libc++.1.0.dylib (libcxx)
 │ │ Post-processing done!
 │ │ Writing test files
 │ │ Writing metadata for package
 │ │ Copying license files
 │ │ Copying recipe files
 │ │ 
 │ │ Files in package:
 │ │   ├─ bin/cmake_repro (69.00 KiB)
 │ │   ├─ info/about.json (2 B)
 │ │   ├─ info/hash_input.json (32 B)
 │ │   ├─ info/index.json (228 B)
 │ │   ├─ info/paths.json (232 B)
 │ │   └─ info/tests/tests.yaml (3 B)
 │ │ 
 │ │ Package statistics: 6 files (1 content, 5 metadata), total size: 69.49 KiB
 │ │ Largest files:
 │ │   69.00 KiB - bin/cmake_repro
 │ │ Creating target folder '/Users/ubaid/projects/repo/cmake-repro/.pixi/build/work/cmake_repro-OL-q6p36zFw-ME03ejjoGjs/output/osx-arm64'
 │ │ Compressing archive...
 │ │ Archive written to '/Users/ubaid/projects/repo/cmake-repro/.pixi/build/work/cmake_repro-OL-q6p36zFw-ME03ejjoGjs/output/osx-arm64/cmake_repro-0.1.0-h60d57d3
 │ │ _0.conda'
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 ╰─────────────────── (took 1 second)
REPRO_MAGIC____=123
(base) ubaid@Mohammeds-MacBook-Pro cmake-repro % ../pixi/target/debug/pixi run run
 WARN overriding build backend with: pixi-build-cmake=/Users/ubaid/projects/repo/pixi/target/debug/pixi-build-cmake
 WARN metadata cache disabled for build backend 'pixi-build-cmake' (system/path-based backends always regenerate metadata)
✨ Pixi task (run): cmake_repro
REPRO_MAGIC____=123
```

  (When a rebuild occurs, Pixi prints the full “Running build for recipe …” block; when it’s a cache hit it only prints the task line and the program output.)
  
</details>

### AI Disclosure

- [x] This PR involved AI-assisted work.
  - [x] AI was used to understand/navigate the codebase and identify the relevant code paths (backend input globs / cache invalidation).
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Cursor (GPT-5.2)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
