### PR TITLE
draft: CI test run for CMakeLists + rust cargo PATH

### DIFF
--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -146,6 +146,7 @@ impl GenerateRecipe for CMakeGenerator {
             // CMake files
             "**/*.{cmake,cmake.in}",
             "**/CMakeFiles.txt",
+            "**/CMakeLists.txt",
         ]
         .iter()
         .map(|s: &&str| s.to_string())

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -145,7 +145,6 @@ impl GenerateRecipe for CMakeGenerator {
             "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
             // CMake files
             "**/*.{cmake,cmake.in}",
-            "**/CMakeFiles.txt",
             "**/CMakeLists.txt",
         ]
         .iter()

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
@@ -6,7 +6,6 @@ Ok(
     {
         "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
         "**/*.{cmake,cmake.in}",
-        "**/CMakeFiles.txt",
         "**/CMakeLists.txt",
         "custom/*.c",
     },

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
@@ -7,6 +7,7 @@ Ok(
         "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
         "**/*.{cmake,cmake.in}",
         "**/CMakeFiles.txt",
+        "**/CMakeLists.txt",
         "custom/*.c",
     },
 )

--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -16,6 +16,12 @@ SET {{ key }}={{ value }}
 {{ export("RUSTC_WRAPPER", "sccache") }}
 {%- endif %}
 
+{%- if is_bash %}
+export PATH="{{ env("BUILD_PREFIX") }}/bin:{{ env("PREFIX") }}/bin:$PATH"
+{%- else %}
+SET "PATH={{ env("BUILD_PREFIX") }}\Library\bin;{{ env("BUILD_PREFIX") }}\Scripts;{{ env("BUILD_PREFIX") }}\bin;{{ env("PREFIX") }}\Library\bin;{{ env("PREFIX") }}\Scripts;{{ env("PREFIX") }}\bin;%PATH%"
+{%- endif %}
+
 cargo install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
 {%- if not is_bash %}
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -17,12 +17,31 @@ SET {{ key }}={{ value }}
 {%- endif %}
 
 {%- if is_bash %}
-export PATH="{{ env("BUILD_PREFIX") }}/bin:{{ env("PREFIX") }}/bin:$PATH"
+CARGO="{{ env("BUILD_PREFIX") }}/bin/cargo"
+RUSTC="{{ env("BUILD_PREFIX") }}/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="{{ env("PREFIX") }}/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="{{ env("PREFIX") }}/bin/rustc"
+fi
+export RUSTC="$RUSTC"
 {%- else %}
-SET "PATH={{ env("BUILD_PREFIX") }}\Library\bin;{{ env("BUILD_PREFIX") }}\Scripts;{{ env("BUILD_PREFIX") }}\bin;{{ env("PREFIX") }}\Library\bin;{{ env("PREFIX") }}\Scripts;{{ env("PREFIX") }}\bin;%PATH%"
+SET "CARGO={{ env("BUILD_PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("BUILD_PREFIX") }}\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\Scripts\cargo.exe"
+SET "RUSTC={{ env("BUILD_PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("BUILD_PREFIX") }}\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\Scripts\rustc.exe"
 {%- endif %}
 
-cargo install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{%- if is_bash %}
+"$CARGO" install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{%- else %}
+"%CARGO%" install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{%- endif %}
 {%- if not is_bash %}
 if errorlevel 1 exit 1
 {%- endif %}

--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -27,14 +27,18 @@ if [ ! -x "$RUSTC" ]; then
 fi
 export RUSTC="$RUSTC"
 {%- else %}
-SET "CARGO={{ env("BUILD_PREFIX") }}\bin\cargo.exe"
+SET "CARGO={{ env("BUILD_PREFIX") }}\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO={{ env("BUILD_PREFIX") }}\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("BUILD_PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\Scripts\cargo.exe"
-SET "RUSTC={{ env("BUILD_PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\bin\cargo.exe"
+SET "RUSTC={{ env("BUILD_PREFIX") }}\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("BUILD_PREFIX") }}\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("BUILD_PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\bin\rustc.exe"
 {%- endif %}
 
 {%- if is_bash %}

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -2,6 +2,13 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
-
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+CARGO="$BUILD_PREFIX/bin/cargo"
+RUSTC="$BUILD_PREFIX/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="$PREFIX/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="$PREFIX/bin/rustc"
+fi
+export RUSTC="$RUSTC"
+"$CARGO" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -2,4 +2,6 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
+export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
+
 cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,13 +2,17 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
-SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
 "%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,5 +2,7 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
+SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
+
 cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,7 +2,13 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
-
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+"%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -3,5 +3,6 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export OPENSSL_DIR="$PREFIX"
+export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
 
 cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -3,6 +3,13 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export OPENSSL_DIR="$PREFIX"
-export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
-
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+CARGO="$BUILD_PREFIX/bin/cargo"
+RUSTC="$BUILD_PREFIX/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="$PREFIX/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="$PREFIX/bin/rustc"
+fi
+export RUSTC="$RUSTC"
+"$CARGO" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -3,6 +3,7 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
+SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
 
 cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -3,13 +3,17 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
-SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
-SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
 "%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -3,7 +3,13 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
-SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
-
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+"%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -3,6 +3,7 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export RUSTC_WRAPPER=sccache
+export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
 
 cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
 

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -3,8 +3,15 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export RUSTC_WRAPPER=sccache
-export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
-
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+CARGO="$BUILD_PREFIX/bin/cargo"
+RUSTC="$BUILD_PREFIX/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="$PREFIX/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="$PREFIX/bin/rustc"
+fi
+export RUSTC="$RUSTC"
+"$CARGO" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
 
 sccache --show-stats

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -3,9 +3,15 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET RUSTC_WRAPPER=sccache
-SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
-
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+"%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1
 
 sccache --show-stats

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -3,6 +3,7 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET RUSTC_WRAPPER=sccache
+SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
 
 cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -3,14 +3,18 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET RUSTC_WRAPPER=sccache
-SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
-SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
 "%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1
 

--- a/docs/build/backends/pixi-build-cmake.md
+++ b/docs/build/backends/pixi-build-cmake.md
@@ -117,7 +117,7 @@ The backend always writes JSON-RPC request/response logs and the generated inter
 - **Default**: `[]`
 - **Target Merge Behavior**: `Overwrite` - Platform-specific globs completely replace base globs
 
-Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeFiles.txt`, `**/CMakeLists.txt`), and other build-related files.
+Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeLists.txt`), and other build-related files.
 
 ```toml
 [package.build.config]

--- a/docs/build/backends/pixi-build-cmake.md
+++ b/docs/build/backends/pixi-build-cmake.md
@@ -117,7 +117,7 @@ The backend always writes JSON-RPC request/response logs and the generated inter
 - **Default**: `[]`
 - **Target Merge Behavior**: `Overwrite` - Platform-specific globs completely replace base globs
 
-Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeFiles.txt`), and other build-related files.
+Additional glob patterns to include as input files for the build process. These patterns are added to the default input globs that include source files (`**/*.{c,cc,cxx,cpp,h,hpp,hxx}`), CMake files (`**/*.{cmake,cmake.in}`, `**/CMakeFiles.txt`, `**/CMakeLists.txt`), and other build-related files.
 
 ```toml
 [package.build.config]


### PR DESCRIPTION
Includes the pixi-build-cmake input-glob fix so CMakeLists.txt changes invalidate the build cache.
Includes a pixi-build-rust build-script tweak to prefer Conda toolchain ($BUILD_PREFIX/bin) so cargo doesn’t resolve to rustup shims in CI.
This PR is for integration-test validation only; will be superseded/split as needed.