### PR TITLE
fix(pixi-build-rust): prefer conda cargo over rustup shims

### DIFF
--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -16,6 +16,12 @@ SET {{ key }}={{ value }}
 {{ export("RUSTC_WRAPPER", "sccache") }}
 {%- endif %}
 
+{%- if is_bash %}
+export PATH="{{ env("BUILD_PREFIX") }}/bin:{{ env("PREFIX") }}/bin:$PATH"
+{%- else %}
+SET "PATH={{ env("BUILD_PREFIX") }}\Library\bin;{{ env("BUILD_PREFIX") }}\Scripts;{{ env("BUILD_PREFIX") }}\bin;{{ env("PREFIX") }}\Library\bin;{{ env("PREFIX") }}\Scripts;{{ env("PREFIX") }}\bin;%PATH%"
+{%- endif %}
+
 cargo install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
 {%- if not is_bash %}
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -17,12 +17,31 @@ SET {{ key }}={{ value }}
 {%- endif %}
 
 {%- if is_bash %}
-export PATH="{{ env("BUILD_PREFIX") }}/bin:{{ env("PREFIX") }}/bin:$PATH"
+CARGO="{{ env("BUILD_PREFIX") }}/bin/cargo"
+RUSTC="{{ env("BUILD_PREFIX") }}/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="{{ env("PREFIX") }}/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="{{ env("PREFIX") }}/bin/rustc"
+fi
+export RUSTC="$RUSTC"
 {%- else %}
-SET "PATH={{ env("BUILD_PREFIX") }}\Library\bin;{{ env("BUILD_PREFIX") }}\Scripts;{{ env("BUILD_PREFIX") }}\bin;{{ env("PREFIX") }}\Library\bin;{{ env("PREFIX") }}\Scripts;{{ env("PREFIX") }}\bin;%PATH%"
+SET "CARGO={{ env("BUILD_PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("BUILD_PREFIX") }}\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\Scripts\cargo.exe"
+SET "RUSTC={{ env("BUILD_PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("BUILD_PREFIX") }}\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\Scripts\rustc.exe"
 {%- endif %}
 
-cargo install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{%- if is_bash %}
+"$CARGO" install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{%- else %}
+"%CARGO%" install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{%- endif %}
 {%- if not is_bash %}
 if errorlevel 1 exit 1
 {%- endif %}

--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -27,14 +27,18 @@ if [ ! -x "$RUSTC" ]; then
 fi
 export RUSTC="$RUSTC"
 {%- else %}
-SET "CARGO={{ env("BUILD_PREFIX") }}\bin\cargo.exe"
+SET "CARGO={{ env("BUILD_PREFIX") }}\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO={{ env("BUILD_PREFIX") }}\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("BUILD_PREFIX") }}\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\Scripts\cargo.exe"
-SET "RUSTC={{ env("BUILD_PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO={{ env("PREFIX") }}\bin\cargo.exe"
+SET "RUSTC={{ env("BUILD_PREFIX") }}\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("BUILD_PREFIX") }}\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("BUILD_PREFIX") }}\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC={{ env("PREFIX") }}\bin\rustc.exe"
 {%- endif %}
 
 {%- if is_bash %}

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -2,6 +2,13 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
-
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+CARGO="$BUILD_PREFIX/bin/cargo"
+RUSTC="$BUILD_PREFIX/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="$PREFIX/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="$PREFIX/bin/rustc"
+fi
+export RUSTC="$RUSTC"
+"$CARGO" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -2,4 +2,6 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
+export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
+
 cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,13 +2,17 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
-SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
 "%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,5 +2,7 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
+SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
+
 cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,7 +2,13 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
-
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+"%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -3,5 +3,6 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export OPENSSL_DIR="$PREFIX"
+export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
 
 cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -3,6 +3,13 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export OPENSSL_DIR="$PREFIX"
-export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
-
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+CARGO="$BUILD_PREFIX/bin/cargo"
+RUSTC="$BUILD_PREFIX/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="$PREFIX/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="$PREFIX/bin/rustc"
+fi
+export RUSTC="$RUSTC"
+"$CARGO" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -3,6 +3,7 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
+SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
 
 cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -3,13 +3,17 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
-SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
-SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
 "%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -3,7 +3,13 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET OPENSSL_DIR="%PREFIX%"
-SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
-
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+"%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -3,6 +3,7 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export RUSTC_WRAPPER=sccache
+export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
 
 cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
 

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -3,8 +3,15 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 export RUSTC_WRAPPER=sccache
-export PATH="$BUILD_PREFIX/bin:$PREFIX/bin:$PATH"
-
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+CARGO="$BUILD_PREFIX/bin/cargo"
+RUSTC="$BUILD_PREFIX/bin/rustc"
+if [ ! -x "$CARGO" ]; then
+  CARGO="$PREFIX/bin/cargo"
+fi
+if [ ! -x "$RUSTC" ]; then
+  RUSTC="$PREFIX/bin/rustc"
+fi
+export RUSTC="$RUSTC"
+"$CARGO" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
 
 sccache --show-stats

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -3,9 +3,15 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET RUSTC_WRAPPER=sccache
-SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
-
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+"%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1
 
 sccache --show-stats

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -3,6 +3,7 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET RUSTC_WRAPPER=sccache
+SET "PATH=%BUILD_PREFIX%\Library\bin;%BUILD_PREFIX%\Scripts;%BUILD_PREFIX%\bin;%PREFIX%\Library\bin;%PREFIX%\Scripts;%PREFIX%\bin;%PATH%"
 
 cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -3,14 +3,18 @@ source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
 SET RUSTC_WRAPPER=sccache
-SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\Scripts\cargo.exe"
-IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%BUILD_PREFIX%\bin\cargo.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Library\bin\cargo.exe"
 IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\Scripts\cargo.exe"
-SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%CARGO%" SET "CARGO=%PREFIX%\bin\cargo.exe"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\Scripts\rustc.exe"
-IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%BUILD_PREFIX%\bin\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Library\bin\rustc.exe"
 IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\Scripts\rustc.exe"
+IF NOT EXIST "%RUSTC%" SET "RUSTC=%PREFIX%\bin\rustc.exe"
 "%CARGO%" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1
 


### PR DESCRIPTION
### Description

`pixi-build-rust` can fail on GitHub PRs because the generated build script runs `cargo install` and may end up invoking `cargo` via `rustup` shims from the runner’s `PATH` (instead of the Conda toolchain installed in the build environment). In failing runs, `rustup` attempts to sync/download components and errors (e.g. rename failure / `os error 2`), causing the backend build to fail even though Conda Rust is present.

This PR makes the build script prefer the Conda toolchain by prepending Conda paths to `PATH` before running `cargo`:
- bash: prepend `$BUILD_PREFIX/bin` and `$PREFIX/bin`
- Windows `cmd.exe`: prepend the equivalent `%BUILD_PREFIX%` / `%PREFIX%` bin locations

Snapshot tests for the generated build script are updated accordingly.

Fixes #5965

### How Has This Been Tested?

- `pixi run -e rust-test cargo test -p pixi-build-rust build_script::test`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: ChatGPT (GPT-5.2)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.