### PR TITLE
fix: use PackageTarget for package.target definitions

### DIFF
--- a/schema/examples/valid/full.toml
+++ b/schema/examples/valid/full.toml
@@ -104,6 +104,9 @@ pytorch-cpu = { version = "~=1.1", channel = "pytorch" }
 test = "*"
 test1 = "*"
 
+[package.target.linux-64.run-dependencies]
+test = "*"
+
 [tasks]
 build = "conda build ."
 test = { cmd = "pytest", cwd = "tests", depends-on = [

--- a/schema/model.py
+++ b/schema/model.py
@@ -835,7 +835,7 @@ class Package(StrictBaseModel):
     build_dependencies: Dependencies = BuildDependenciesField
     run_dependencies: Dependencies = RunDependenciesField
 
-    target: dict[TargetName, Target] | None = Field(
+    target: dict[TargetName, PackageTarget] | None = Field(
         None,
         description="Machine-specific aspects of the package",
         examples=[{"linux": {"host-dependencies": {"python": "3.8"}}}],

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -1325,7 +1325,7 @@
           "description": "Machine-specific aspects of the package",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/Target"
+            "$ref": "#/$defs/PackageTarget"
           },
           "propertyNames": {
             "minLength": 1
@@ -1358,6 +1358,75 @@
               "workspace": true
             }
           ]
+        }
+      }
+    },
+    "PackageTarget": {
+      "title": "PackageTarget",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "build-dependencies": {
+          "title": "Build-Dependencies",
+          "description": "The build `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "host-dependencies": {
+          "title": "Host-Dependencies",
+          "description": "The host `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "python": ">=3.8"
+            }
+          ]
+        },
+        "run-dependencies": {
+          "title": "Run-Dependencies",
+          "description": "The `conda` dependencies required at runtime. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
         }
       }
     },

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1068,7 +1068,7 @@
           "description": "Machine-specific aspects of the package",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/Target"
+            "$ref": "#/$defs/PackageTarget"
           },
           "propertyNames": {
             "minLength": 1
@@ -1101,6 +1101,75 @@
               "workspace": true
             }
           ]
+        }
+      }
+    },
+    "PackageTarget": {
+      "title": "PackageTarget",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "build-dependencies": {
+          "title": "Build-Dependencies",
+          "description": "The build `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "host-dependencies": {
+          "title": "Host-Dependencies",
+          "description": "The host `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "python": ">=3.8"
+            }
+          ]
+        },
+        "run-dependencies": {
+          "title": "Run-Dependencies",
+          "description": "The `conda` dependencies required at runtime. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
         }
       }
     },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1349,7 +1349,7 @@
           "description": "Machine-specific aspects of the package",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/Target"
+            "$ref": "#/$defs/PackageTarget"
           },
           "propertyNames": {
             "minLength": 1
@@ -1382,6 +1382,75 @@
               "workspace": true
             }
           ]
+        }
+      }
+    },
+    "PackageTarget": {
+      "title": "PackageTarget",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "build-dependencies": {
+          "title": "Build-Dependencies",
+          "description": "The build `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "host-dependencies": {
+          "title": "Host-Dependencies",
+          "description": "The host `conda` dependencies, used in the build process. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "python": ">=3.8"
+            }
+          ]
+        },
+        "run-dependencies": {
+          "title": "Run-Dependencies",
+          "description": "The `conda` dependencies required at runtime. See https://pixi.sh/latest/build/dependency_types/ for more information.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
         }
       }
     },


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

Fix `package.target` in the JSON schema to use PackageTarget instead of Target.


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

Added entry to full.toml

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.