### PR TITLE
docs: add mise to tool comparison

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,13 +58,16 @@ pixi global install gh nvim ipython btop ripgrep
 
 ## How Tools Compare to Pixi
 
-| Builtin Core Features       | Pixi | Conda | Pip | Poetry | uv |
-|-----------------------------|------|-------|-----|--------|----|
-| Installs Python             | ✅    | ✅     | ❌   | ❌      | ✅  |
-| Supports Multiple Languages | ✅    | ✅     | ❌   | ❌      | ❌  |
-| Lockfiles                   | ✅    | ❌     | ❌   | ✅      | ✅  |
-| Task runner                 | ✅    | ❌     | ❌   | ❌      | ❌  |
-| Workspace Management        | ✅    | ❌     | ❌   | ✅      | ✅  |
+| Builtin Core Features       | Pixi | Conda | Pip | Poetry | uv | mise |
+|-----------------------------|------|-------|-----|--------|----|------|
+| Installs Python             | ✅    | ✅     | ❌   | ❌      | ✅  | ✅    |
+| Supports Multiple Languages | ✅    | ✅     | ❌   | ❌      | ❌  | ✅    |
+| Lockfiles                   | ✅    | ❌     | ❌   | ✅      | ✅  | ⚠️    |
+| Task runner                 | ✅    | ❌     | ❌   | ❌      | ❌  | ✅    |
+| Workspace Management        | ✅    | ❌     | ❌   | ✅      | ✅  | ✅    |
+
+`mise` focuses on development tool version management and task running. Pixi is a package manager built on the
+Conda ecosystem, with dependency solving, lockfiles, environments, and package building support.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `mise` to the homepage tool comparison table and includes a short note distinguishing mise's tool/task focus from Pixi's Conda-backed package management, dependency solving, lockfiles, environments, and package building support.

Closes #5609.

## Testing

- `git diff --check`