### PR TITLE
chore(pixi-build-rust): export RUSTC and RUSTDOC

### DIFF
--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -1,22 +1,34 @@
-{% macro env(key) -%}
+{%- macro env(key) -%}
 {%- if is_bash %}{{ "$" ~key }}{% else %}{{ "%" ~ key ~ "%" }}{% endif -%}
 {% endmacro -%}
 {%- macro export(key, value) -%}
 {%- if is_bash -%}
-export {{ key }}={{ value }}
+export {{ key }}={{ value | tojson }}
 {%- else -%}
-SET {{ key }}={{ value }}
+SET "{{ key }}={{ value }}"
 {%- endif -%}
 {%- endmacro -%}
 
-{%- if has_openssl %}
-{{ export("OPENSSL_DIR", env("PREFIX")|tojson) }}
+{%- if is_bash -%}
+  {%- set bin_path=env("BUILD_PREFIX") ~ "/bin/" -%}
+{%- else -%}
+  {%- set bin_path=env("BUILD_PREFIX") ~ "\\Library\\bin\\" -%}
+{%- endif -%}
+
+{% if has_openssl -%}
+{{ export("OPENSSL_DIR", env("PREFIX")) }}
 {%- endif %}
-{%- if has_sccache %}
+
+{% if has_sccache -%}
 {{ export("RUSTC_WRAPPER", "sccache") }}
 {%- endif %}
 
-cargo install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+{{ export("CARGO", bin_path ~ "cargo") }}
+{{ export("RUSTC", bin_path ~ "rustc") }}
+{{ export("RUSTDOC", bin_path ~ "rustdoc") }}
+
+{{ (bin_path ~ "cargo")|tojson }} install --locked --root "{{ env("PREFIX") }}" --path "{{ source_dir }}" --target-dir target --no-track {{ extra_args | join(" ") }} --force
+
 {%- if not is_bash %}
 if errorlevel 1 exit 1
 {%- endif %}

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@bash.snap
@@ -2,4 +2,8 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+export CARGO="$BUILD_PREFIX/bin/cargo"
+export RUSTC="$BUILD_PREFIX/bin/rustc"
+export RUSTDOC="$BUILD_PREFIX/bin/rustdoc"
+
+"$BUILD_PREFIX/bin/cargo" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__build_script@cmdexe.snap
@@ -2,5 +2,9 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc"
+SET "RUSTDOC=%BUILD_PREFIX%\Library\bin\rustdoc"
+
+"%BUILD_PREFIX%\\Library\\bin\\cargo" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@bash.snap
@@ -4,4 +4,10 @@ expression: script
 ---
 export OPENSSL_DIR="$PREFIX"
 
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+
+
+export CARGO="$BUILD_PREFIX/bin/cargo"
+export RUSTC="$BUILD_PREFIX/bin/rustc"
+export RUSTDOC="$BUILD_PREFIX/bin/rustdoc"
+
+"$BUILD_PREFIX/bin/cargo" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__openssl@cmdexe.snap
@@ -2,7 +2,13 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-SET OPENSSL_DIR="%PREFIX%"
+SET "OPENSSL_DIR=%PREFIX%"
 
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+
+
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc"
+SET "RUSTDOC=%BUILD_PREFIX%\Library\bin\rustdoc"
+
+"%BUILD_PREFIX%\\Library\\bin\\cargo" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@bash.snap
@@ -2,8 +2,12 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-export RUSTC_WRAPPER=sccache
+export RUSTC_WRAPPER="sccache"
 
-cargo install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
+export CARGO="$BUILD_PREFIX/bin/cargo"
+export RUSTC="$BUILD_PREFIX/bin/rustc"
+export RUSTDOC="$BUILD_PREFIX/bin/rustdoc"
+
+"$BUILD_PREFIX/bin/cargo" install --locked --root "$PREFIX" --path "my-prefix-dir" --target-dir target --no-track  --force
 
 sccache --show-stats

--- a/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
+++ b/crates/pixi_build_rust/src/snapshots/pixi_build_rust__build_script__test__sccache@cmdexe.snap
@@ -2,9 +2,13 @@
 source: crates/pixi_build_rust/src/build_script.rs
 expression: script
 ---
-SET RUSTC_WRAPPER=sccache
+SET "RUSTC_WRAPPER=sccache"
 
-cargo install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
+SET "CARGO=%BUILD_PREFIX%\Library\bin\cargo"
+SET "RUSTC=%BUILD_PREFIX%\Library\bin\rustc"
+SET "RUSTDOC=%BUILD_PREFIX%\Library\bin\rustdoc"
+
+"%BUILD_PREFIX%\\Library\\bin\\cargo" install --locked --root "%PREFIX%" --path "my-prefix-dir" --target-dir target --no-track  --force
 if errorlevel 1 exit 1
 
 sccache --show-stats


### PR DESCRIPTION
…ript

... and use those to run Cargo.

This should improve the situation for pixi build users that use rust.

The ~/.cargo/config.toml file can still break the build.

I have another change that warns when "spurious" .cargo/config.toml files are "above" the source directory, but that changes the command dispatcher, so I do not want to land it right now.

### How Has This Been Tested?

By running pixi build on mergiraf.

### AI Disclosure

No AI was used for this.