### PR TITLE
fix(logging): surface logs emitted by the `rattler_upload` crate

### DIFF
--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -311,7 +311,7 @@ fn setup_logging(args: &Args, use_colors: bool) -> miette::Result<()> {
         EnvFilter::builder()
             .with_default_directive(level_filter.into())
             .parse(format!(
-                "apple_codesign=off,pixi={pixi_level},pixi_command_dispatcher={pixi_level},pixi_core={pixi_level},uv_resolver={pixi_level},resolvo={low_level_filter}"
+                "apple_codesign=off,pixi={pixi_level},pixi_command_dispatcher={pixi_level},pixi_core={pixi_level},rattler_upload={pixi_level},uv_resolver={pixi_level},resolvo={low_level_filter}"
             ))
             .into_diagnostic()?
     } else {
@@ -319,7 +319,7 @@ fn setup_logging(args: &Args, use_colors: bool) -> miette::Result<()> {
         // Parse RUST_LOG because we need to set it other our other directives
         let env_directives = env::var("RUST_LOG").unwrap_or_default();
         let original_directives = format!(
-            "apple_codesign=off,pixi={pixi_level},pixi_command_dispatcher={pixi_level},pixi_core={pixi_level},uv_resolver={pixi_level},resolvo={low_level_filter}",
+            "apple_codesign=off,pixi={pixi_level},pixi_command_dispatcher={pixi_level},pixi_core={pixi_level},rattler_upload={pixi_level},uv_resolver={pixi_level},resolvo={low_level_filter}",
         );
         // Concatenate both directives where the LOG overrides the potential original directives
         let final_directives = if env_directives.is_empty() {


### PR DESCRIPTION
### Description

Currently no logs are emitted by `pixi upload` at all:
```
❯ pixi upload cloudsmith -vvv --owner $OWNER--repo conda --api-key $CLOUDSMITH_API_KEY ./output/noarch/*.conda
DEBUG pixi_config: Loading config from /etc/pixi/config.toml
DEBUG pixi_config: Loaded config from: /etc/pixi/config.toml
DEBUG pixi_config: Loading config from ~/.config/pixi/config.toml
DEBUG pixi_config: Loading config from ~/.pixi/config.toml

❯
```
...*despite* logs being emitted by `rattler_upload`:
https://github.com/conda/rattler/blob/d800817f6632c6d6c00e87f5dcda0226e87a3239/crates/rattler_upload/src/upload/mod.rs#L340-L343

----
### How Has This Been Tested?

Manually. Results below - logs are now coming through from `rattler-build`:
```
❯ pixi-dev upload cloudsmith -vvv --owner acme --repo conda --api-key $CLOUDSMITH_API_KEY ./output/noarch/*.conda
DEBUG pixi_config: Loading config from /etc/pixi/config.toml
DEBUG pixi_config: Loaded config from: /etc/pixi/config.toml
DEBUG pixi_config: Loading config from ~/.config/pixi/config.toml
DEBUG pixi_config: Loading config from ~/.pixi/config.toml
DEBUG rattler_upload::upload::cloudsmith: requesting upload slot for agent-skill-async-python-0.0.12-h4616a5c_0.conda
DEBUG rattler_upload::upload::cloudsmith: upload slot assigned for agent-skill-async-python-0.0.12-h4616a5c_0.conda: identifier=hostExFDdOaR
DEBUG rattler_upload::upload::cloudsmith: uploading agent-skill-async-python-0.0.12-h4616a5c_0.conda (single-part) to pre-signed URL
DEBUG rattler_upload::upload::cloudsmith: single-part upload complete for agent-skill-async-python-0.0.12-h4616a5c_0.conda
 INFO rattler_upload::upload::cloudsmith: creating conda package in acme/conda
 INFO rattler_upload::upload: Package created: slug_perm=nrFPZalwp4BE, slug=agent-skill-async-python-0012-h461-a8cg
DEBUG rattler_upload::upload::cloudsmith: requesting upload slot for agent-skill-cachetools-0.0.12-h4616a5c_0.conda
DEBUG rattler_upload::upload::cloudsmith: upload slot assigned for agent-skill-cachetools-0.0.12-h4616a5c_0.conda: identifier=A9CXkcOoc6Vb
DEBUG rattler_upload::upload::cloudsmith: uploading agent-skill-cachetools-0.0.12-h4616a5c_0.conda (single-part) to pre-signed URL
DEBUG rattler_upload::upload::cloudsmith: single-part upload complete for agent-skill-cachetools-0.0.12-h4616a5c_0.conda
 INFO rattler_upload::upload::cloudsmith: creating conda package in acme/conda
 INFO rattler_upload::upload: Package created: slug_perm=78i5KfjlTBzh, slug=agent-skill-cachetools-0012-h4616a-0rmw
```


### AI Disclosure

Opus 4.7 ~~reliably~~ informs me that this should be sufficient to surface logs from the `rattler_upload` crate.

- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.


### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.

----


Fixes #5907
