### PR TITLE
perf: make uv the default installer in pixi-build-python

### DIFF
--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -5,6 +5,7 @@ use pixi_build_types::SourcePackageName;
 use serde::Serialize;
 
 const UV: &str = "uv";
+const PIP: &str = "pip";
 #[derive(Serialize)]
 pub struct BuildScriptContext {
     pub installer: Installer,
@@ -17,8 +18,8 @@ pub struct BuildScriptContext {
 #[derive(Default, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Installer {
-    Uv,
     #[default]
+    Uv,
     Pip,
 }
 
@@ -31,17 +32,27 @@ impl Installer {
     }
 
     /// Determine the installer from an iterator of dependency package names.
-    /// Checks if "uv" is present in the package names.
+    ///
+    /// `uv` is the default installer. `pip` is selected only when `pip` is
+    /// present in the dependencies and `uv` is not. If both are present, `uv`
+    /// wins.
     pub fn determine_installer_from_names<'a>(
-        mut package_names: impl Iterator<Item = &'a str>,
+        package_names: impl Iterator<Item = &'a str>,
     ) -> Installer {
-        // Check all dependency names for "uv" package
-        let has_uv = package_names.any(|name| name == UV);
+        let mut has_uv = false;
+        let mut has_pip = false;
+        for name in package_names {
+            if name == UV {
+                has_uv = true;
+            } else if name == PIP {
+                has_pip = true;
+            }
+        }
 
-        if has_uv {
-            Installer::Uv
-        } else {
+        if has_pip && !has_uv {
             Installer::Pip
+        } else {
+            Installer::Uv
         }
     }
 }

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -658,7 +658,7 @@ version = "0.1.0"
     }
 
     #[tokio::test]
-    async fn test_pip_is_in_host_requirements() {
+    async fn test_uv_is_in_host_requirements() {
         let project_model = project_fixture!({
             "name": "foobar",
             "version": "0.1.0",
@@ -1125,7 +1125,7 @@ build-backend = "hatchling.build"
             "run deps should only contain python when ignore_pypi_mapping=true"
         );
 
-        // Host requirements should only contain pip (auto-added installer) and python
+        // Host requirements should only contain uv (auto-added default installer) and python
         let host_deps: Vec<String> = generated_recipe
             .recipe
             .requirements
@@ -1136,8 +1136,8 @@ build-backend = "hatchling.build"
 
         assert_eq!(
             host_deps,
-            vec!["pip", "python"],
-            "host deps should only contain pip and python when ignore_pypi_mapping=true"
+            vec!["uv", "python"],
+            "host deps should only contain uv and python when ignore_pypi_mapping=true"
         );
     }
 

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__metadata__tests__generated_recipe_contains_pyproject_values.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__metadata__tests__generated_recipe_contains_pyproject_values.snap
@@ -35,7 +35,7 @@ build:
   post_process: []
 requirements:
   host:
-    - pip
+    - uv
     - python
   run:
     - boltons

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__python_is_not_added_if_already_present.snap
@@ -36,7 +36,7 @@ build:
 requirements:
   host:
     - python
-    - pip
+    - uv
   run:
     - boltons
     - python

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__uv_is_in_host_requirements.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__uv_is_in_host_requirements.snap
@@ -35,7 +35,7 @@ build:
   post_process: []
 requirements:
   host:
-    - pip
+    - uv
     - python
   run:
     - boltons

--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -20,7 +20,7 @@ This backend automatically generates conda packages from Python projects by:
 - **PyPI-to-conda mapping** (opt-in): Maps `project.dependencies` and `build-system.requires` from `pyproject.toml` to conda packages (see [`ignore-pypi-mapping`](#ignore-pypi-mapping))
 - **Automatic compiler detection**: Detects build tools like `maturin` or `setuptools-rust` and automatically adds required compilers
 - **Cross-platform support**: Works consistently across Linux, macOS, and Windows
-- **Flexible installation**: Automatically selects between `pip` and `uv` for package installation
+- **Flexible installation**: Uses `uv` by default and falls back to `pip` when explicitly requested
 
 ## Basic Usage
 
@@ -42,7 +42,7 @@ channels = ["https://prefix.dev/conda-forge"]
 The backend automatically includes the following build tools:
 
 - `python` - The Python interpreter
-- `pip` - Python package installer (or `uv` if specified)
+- `uv` - Python package installer used by default (or `pip` if explicitly added to dependencies)
 
 You can add these to your [`host-dependencies`](https://pixi.sh/latest/build/dependency_types/) if you need specific versions:
 
@@ -224,7 +224,7 @@ The version bounds are computed from the lower bound of `requires-python`:
 - **Default**: `[]`
 - **Target Merge Behavior**: `Overwrite` - Platform-specific globs completely replace base globs
 
-Extra arguments to pass to `pip`.
+Extra arguments to pass to the selected installer (`uv` by default, or `pip` if selected).
 A use-case could be [`pip`'s `--config-settings` parameter](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-C).
 
 ```toml
@@ -382,7 +382,7 @@ At the moment, only `platform_system`, `os_name`, `platform_machine` and `sys_pl
 
 The Python backend follows this build process:
 
-1. **Installer Detection**: Automatically chooses between `uv` and `pip` based on available dependencies
+1. **Installer Detection**: Uses `uv` by default and selects `pip` only when it is explicitly present in the dependencies (and `uv` is not)
 2. **Environment Setup**: Configures Python environment variables for the build
 3. **Package Installation**: Executes the selected installer with the following options:
    - `--no-deps`: Don't install dependencies (handled by conda)
@@ -394,14 +394,15 @@ The Python backend follows this build process:
 
 The backend automatically detects which Python installer to use:
 
-- **uv**: Used if `uv` is present in the build or host dependencies
-- **pip**: Used as the default fallback installer
+- **uv**: Used by default. Also used when both `uv` and `pip` are present in the build or host dependencies.
+- **pip**: Used only when `pip` is present in the build or host dependencies and `uv` is not.
 
-To use `uv` for faster installations, add it to your dependencies:
+`uv` is auto-added to host dependencies when neither `pip` nor `uv` is specified.
+To explicitly opt into `pip`, add it to your dependencies:
 
 ```toml
 [package.host-dependencies]
-uv = "*"
+pip = "*"
 ```
 
 # Editable Installations


### PR DESCRIPTION
uv is now selected by default. pip is selected only when pip is explicitly present in the dependencies and uv is not. When both are present, uv wins.

Also updates the backend documentation and code comments to reflect the new selection rule, and renames the stale `pip_is_in_host_requirements` test/snapshot.

Based on the work in #5669 by @suleman1412.

Fixes #5666