### PR TITLE
fix: skip installing unsupported environments with `--all`

### DIFF
--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -502,6 +502,11 @@ impl InstallBuilder {
         self.args.environment = Some(env);
         self
     }
+
+    pub fn with_all(mut self, all: bool) -> Self {
+        self.args.all = all;
+        self
+    }
 }
 
 impl IntoFuture for InstallBuilder {

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -1940,5 +1940,7 @@ async fn install_all_skips_unsupported_environments() {
     pixi.install()
         .with_environment(vec!["other".to_string()])
         .await
-        .expect_err("install -e other should fail because it does not support the current platform");
+        .expect_err(
+            "install -e other should fail because it does not support the current platform",
+        );
 }

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -1877,3 +1877,68 @@ async fn test_uv_skip_wheel_filename_check() {
         "Package should be installed when env var takes precedence"
     );
 }
+
+/// Verifies that `pixi install --all` skips environments that do not support
+/// the current platform instead of failing the entire install. See issue #5760.
+#[tokio::test]
+async fn install_all_skips_unsupported_environments() {
+    setup_tracing();
+
+    let current_platform = Platform::current();
+    // Pick a platform from a different OS family so that no `best_platform`
+    // fallback (e.g. osx-arm64 -> osx-64) accidentally rescues the env.
+    let other_platform = if current_platform.is_linux() {
+        Platform::Osx64
+    } else {
+        Platform::Linux64
+    };
+
+    let mut db = MockRepoData::default();
+    db.add_package(
+        Package::build("foo", "1")
+            .with_subdir(current_platform)
+            .with_materialize(true)
+            .finish(),
+    );
+    db.add_package(
+        Package::build("foo", "1")
+            .with_subdir(other_platform)
+            .with_materialize(true)
+            .finish(),
+    );
+    let channel = db.into_channel().await.unwrap();
+
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+        [workspace]
+        name = "test-filter-unsupported"
+        channels = ["{channel}"]
+        platforms = ["{current_platform}", "{other_platform}"]
+
+        [dependencies]
+        foo = "*"
+
+        [feature.other-only]
+        platforms = ["{other_platform}"]
+
+        [environments]
+        other = ["other-only"]
+        "#,
+        channel = channel.url(),
+    ))
+    .unwrap();
+
+    // `pixi install --all` should succeed because the unsupported `other`
+    // environment is filtered out instead of failing the whole command.
+    pixi.install()
+        .with_all(true)
+        .await
+        .expect("install --all should skip environments that do not support the current platform");
+
+    // Explicitly requesting the unsupported environment should still fail so
+    // that the user gets a clear error rather than silently doing nothing.
+    pixi.install()
+        .with_environment(vec!["other".to_string()])
+        .await
+        .expect_err("install -e other should fail because it does not support the current platform");
+}

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -7,6 +7,7 @@ use pixi_core::{
     environment::{InstallFilter, get_update_lock_file_and_prefixes},
     lock_file::{LockFileDerivedData, PackageFilterNames, ReinstallPackages, UpdateMode},
 };
+use pixi_manifest::FeaturesExt;
 use std::fmt::Write;
 
 use crate::cli_config::WorkspaceConfig;
@@ -98,10 +99,31 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     // Get the environments by name
-    let environments = envs
+    let mut environments = envs
         .into_iter()
         .map(|env| workspace.environment_from_name_or_env_var(Some(env)))
         .collect::<Result<Vec<_>, _>>()?;
+
+    // When installing all environments, silently skip any that don't support
+    // the current platform. When the user explicitly asks for an environment
+    // (or the default), we still want to surface the platform error.
+    if args.all {
+        let (supported, skipped): (Vec<_>, Vec<_>) = environments
+            .into_iter()
+            .partition(|env| env.platforms().contains(&env.best_platform()));
+
+        if !skipped.is_empty() {
+            tracing::warn!(
+                "Skipping environment(s) that do not support the current platform: {}",
+                skipped
+                    .iter()
+                    .map(|env| env.name().fancy_display().to_string())
+                    .join(", ")
+            );
+        }
+
+        environments = supported;
+    }
 
     // Build the install filter from CLI args
     let filter = InstallFilter::new()


### PR DESCRIPTION
### Description

Previously `pixi install --all` would error out as soon as one of the workspace environments didn't support the current platform, forcing users to manually filter the environment list. Now `--all` silently skips environments whose `best_platform` is not in their supported platforms (logging a warning), and only installs the ones that can run on the current platform.

Explicitly requesting an unsupported environment with `--environment` still produces the original error, so users get clear feedback when they ask for a specific env that can't run here.

Closes #5760

### How Has This Been Tested?

CI

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Code Opus 4.7

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.