### PR TITLE
fix: set GIT_TERMINAL_PROMPT=0 so invalid git deps fail fast

### DIFF
--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -25,6 +25,7 @@ use crate::{
 /// checkout is ready to go. See [`GitCheckout::reset`] for why we need this.
 const CHECKOUT_READY_LOCK: &str = ".ok";
 pub const GIT_DIR: &str = "GIT_DIR";
+pub const GIT_TERMINAL_PROMPT: &str = "GIT_TERMINAL_PROMPT";
 
 #[derive(Debug, thiserror::Error, Clone)]
 pub enum GitBinaryError {
@@ -625,6 +626,10 @@ fn fetch_with_cli(
         //     // location (this takes precedence over the cwd). Make sure this is
         //     // unset so git will look at cwd for the repo.
         .env_remove(GIT_DIR)
+        // Disable interactive credential prompts so an unreachable or
+        // non-existent remote fails fast instead of hanging waiting for
+        // input on the controlling TTY.
+        .env(GIT_TERMINAL_PROMPT, "0")
         .current_dir(&repo.path);
 
     // // We capture the output to avoid streaming it to the user's console during clones.
@@ -761,7 +766,6 @@ fn github_fast_path(
         }
 
         let response = request.send().await?;
-        response.error_for_status_ref()?;
         let response_code = response.status();
         if response_code == StatusCode::NOT_MODIFIED {
             Ok(FastPathRev::UpToDate)
@@ -769,9 +773,11 @@ fn github_fast_path(
             let oid_to_fetch = response.text().await?.parse()?;
             Ok(FastPathRev::NeedsFetch(oid_to_fetch))
         } else {
-            // Usually response_code == 404 if the repository does not exist, and
-            // response_code == 422 if exists but GitHub is unable to resolve the
-            // requested rev.
+            // The fast path is only an optimization; any non-success status
+            // (404 for a missing repo, 422 when the rev cannot be resolved,
+            // 403 when rate-limited, 5xx, etc.) just falls back to a normal
+            // git fetch.
+            tracing::debug!("GitHub fast path returned {response_code}, falling back to git fetch");
             Ok(FastPathRev::Indeterminate)
         }
     })


### PR DESCRIPTION
### Description

When a host- or source-dependency points at a non-existent GitHub repository, the GitHub API fast path returns 404 and pixi falls back to shelling out to `git fetch`. Without `GIT_TERMINAL_PROMPT=0`, git reaches for the controlling TTY to prompt for HTTPS credentials and hangs forever on `cmd.output()`. Setting the env var makes git fail fast with a normal error.

While in the area, also stop using `error_for_status_ref()?` in `github_fast_path`. The fast path is just an optimization, so any non-success status (404 missing repo, 422 unresolvable rev, 403 rate-limit, 5xx) should cleanly return `Indeterminate` and let the caller fall back to a real fetch instead of bubbling an error up only to be swallowed at the call site. The trailing `Indeterminate` branch was effectively dead code before this change.

Fixes #5503

### How Has This Been Tested?

- `cargo build -p pixi_git` succeeds.
- `cargo test -p pixi_git --lib` passes (4/4).
- Reproducing the original hang against `https://github.com/crosaderky/cpython` (a 404 repo) now surfaces a normal git error instead of hanging indefinitely on the credential prompt.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas