### PR TITLE
docs: refresh command_dispatcher docs after lockfile-v7 refactor

### DIFF
--- a/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
@@ -1,10 +1,13 @@
-//! Defines the [`CommandDispatcher`] and its associated components for managing
-//! and synchronizing tasks across different environments.
+//! Defines the [`CommandDispatcher`] and its associated components.
 //!
-//! The [`CommandDispatcher`] is a central component for orchestrating tasks
+//! [`CommandDispatcher`] is a thin, cheaply cloneable handle that wraps a
+//! [`ComputeEngine`](pixi_compute_engine::ComputeEngine) together with shared
+//! [`CommandDispatcherData`] (gateway, caches, resolvers, executor, etc.).
+//! Public methods on the handle build the appropriate
+//! [`Key`](pixi_compute_engine::Key) and submit it to the engine, which
+//! handles deduplication, caching, and dependency tracking for operations
 //! such as solving environments, fetching metadata, and managing source
-//! checkouts. It ensures efficient execution by avoiding redundant computations
-//! and supporting concurrent operations.
+//! checkouts.
 
 use std::sync::Arc;
 

--- a/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_tool_env/mod.rs
@@ -155,9 +155,8 @@ pub enum InstantiateToolEnvironmentError {
     #[diagnostic(transparent)]
     InstallEnvironment(Arc<InstallPixiEnvironmentError>),
 
-    /// Error surfaced from the compute-engine ephemeral-env path. Holds
-    /// the original [`crate::EphemeralEnvError`] so callers can inspect
-    /// it. Present to bridge the legacy error shape with the new Key.
+    /// Error surfaced from the ephemeral-env Key. Holds the original
+    /// [`crate::EphemeralEnvError`] so callers can inspect it.
     #[error(transparent)]
     #[diagnostic(transparent)]
     EphemeralEnv(Arc<crate::EphemeralEnvError>),

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -39,10 +39,9 @@ use crate::{
 /// Resolve one variant's [`SourceRecord`] from an assembled
 /// [`CondaOutput`] + pinned source location.
 ///
-/// Mirrors the legacy `resolve_output` flow: solve the build env,
-/// extract build run-exports, solve the host env, extract host
-/// run-exports, assemble the final record with merged run
-/// dependencies.
+/// Solves the build env, extracts build run-exports, solves the host
+/// env, extracts host run-exports, then assembles the final record
+/// with merged run dependencies.
 ///
 /// `preferred_build_source` is the FULL pin map, propagated verbatim
 /// into the nested build/host env solves so pins for every package

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -469,9 +469,8 @@ async fn fetch_matching_output(
             .collect()
     });
 
-    // The backend streams log lines; we drop them here (no reporter is
-    // attached to this Key path yet). Follow-up: wire a SourceBuild
-    // reporter lifecycle mirroring the legacy flow.
+    // The backend streams log lines; we drop them here (no SourceBuild
+    // reporter lifecycle is wired up yet).
     let (mut log_sink, _log_rx) = unbounded::<String>();
     let outputs = backend
         .lock()
@@ -600,8 +599,7 @@ async fn install_prefix(
 }
 
 /// Read index.json out of the freshly-built `.conda` and synthesize a
-/// `RepoDataRecord` for it. Mirrors the legacy construction in
-/// `SourceBuildSpec::build`.
+/// `RepoDataRecord` for it.
 async fn synthesize_repodata(
     output_file: &std::path::Path,
 ) -> Result<RepoDataRecord, SourceBuildError> {
@@ -659,9 +657,8 @@ fn map_cache_err(err: self::cache::ArtifactCacheError) -> SourceBuildError {
     }
 }
 
-/// Mirror of the legacy `Directories` helper: build/host prefixes sit
-/// under the workspace dir with platform-specific padding for non-Windows
-/// hosts.
+/// Build/host prefixes for a source build: both sit under the workspace
+/// dir, with platform-specific padding for non-Windows hosts.
 struct Directories {
     build_prefix: PathBuf,
     host_prefix: PathBuf,

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -17,13 +17,19 @@
 //!
 //! # Architecture
 //!
-//! The [`CommandDispatcher`] is built around a task-based execution model:
+//! The [`CommandDispatcher`] is a thin handle over a generic incremental
+//! computation engine:
 //!
-//! 1. Each operation is represented as a task implementing the `TaskSpec` trait
-//! 2. Tasks are submitted to a central queue and processed asynchronously
-//! 3. Duplicate tasks are detected and consolidated to avoid redundant work
-//! 4. Dependencies between tasks are tracked to ensure proper execution order
-//! 5. Results are cached when appropriate to improve performance
+//! 1. Each operation is a [`pixi_compute_engine::Key`] whose `compute`
+//!    method produces its `Value`.
+//! 2. Keys run through a [`pixi_compute_engine::ComputeEngine`], which
+//!    dedups concurrent requests for the same key and caches results.
+//! 3. Dependencies between keys are tracked implicitly via
+//!    [`ComputeCtx::compute`](pixi_compute_engine::ComputeCtx::compute), and
+//!    cycles are detected by the engine.
+//! 4. Shared resources (gateway, caches, package cache, git/url resolvers,
+//!    etc.) live in a typed [`DataStore`](pixi_compute_engine::DataStore)
+//!    that keys read from via extension traits.
 //!
 //! # Usage
 //!

--- a/crates/pixi_command_dispatcher/src/reporter_context.rs
+++ b/crates/pixi_command_dispatcher/src/reporter_context.rs
@@ -2,11 +2,11 @@
 //! task, for attribution of child operations.
 //!
 //! Pattern is Buck2's `EventDispatcher` via `tokio::task_local!`: when a
-//! processor task handler starts, it wraps its work with
+//! Key's compute body starts, it wraps its work with
 //! [`CURRENT_REPORTER_CONTEXT`]`.scope(Some(own_context), ..)`. Anything
-//! that runs inside then sees that context, including a
-//! [`ComputeEngine`](pixi_compute_engine::ComputeEngine) call whose
-//! freshly spawned task inherits the task-local via the engine's
+//! that runs inside then sees that context, including nested
+//! [`ComputeEngine`](pixi_compute_engine::ComputeEngine) calls whose
+//! freshly spawned tasks inherit the task-local via the engine's
 //! [`SpawnHook`](pixi_compute_engine::SpawnHook) (registered by the
 //! [`CommandDispatcherBuilder`](crate::CommandDispatcherBuilder)).
 //!

--- a/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
@@ -408,12 +408,9 @@ pub enum SolveCondaEnvironmentError {
     #[error(transparent)]
     SpecConversionError(#[from] pixi_spec::SpecConversionError),
 
-    /// Used by the compute-engine path
-    /// ([`crate::keys::SolveCondaKey`]) where the binary repodata
-    /// fetch is done inside the key's compute body. The legacy
-    /// `SolveCondaEnvironmentSpec::solve` receives repodata
-    /// pre-fetched by its caller, so this variant is not produced on
-    /// the legacy path.
+    /// Surfaced when the binary repodata fetch performed inside
+    /// [`SolveCondaKey`](crate::keys::SolveCondaKey)'s compute body
+    /// fails.
     #[error(transparent)]
     Gateway(#[from] rattler_repodata_gateway::GatewayError),
 }

--- a/crates/pixi_command_dispatcher/src/solve_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_pixi/mod.rs
@@ -70,8 +70,7 @@ pub enum SolvePixiEnvironmentError {
     #[diagnostic(transparent)]
     SourceCheckoutError(crate::SourceCheckoutError),
 
-    /// Used by the compute-engine solve path where
-    /// [`SourceMetadata`](crate::SourceMetadata) errors surface
+    /// [`SourceMetadata`](crate::SourceMetadata) error surfaced
     /// directly from [`SourceMetadataKey`](crate::keys::SourceMetadataKey).
     #[error(transparent)]
     #[diagnostic(transparent)]


### PR DESCRIPTION
### Description

Drop stale references to the old TaskSpec/processor task system and "legacy" paths now that everything runs through pixi_compute_engine Keys via the ComputeEngine.