### PR TITLE
fix: expand extras self-refs, drop PEP 517 fallback

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use dashmap::DashMap;
+use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 use pep440_rs::VersionSpecifiers;
 use pixi_command_dispatcher::{CommandDispatcher, CommandDispatcherError};
@@ -29,10 +30,7 @@ use url::Url;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::RAYON_INITIALIZE;
 use uv_distribution::DistributionDatabase;
-use uv_distribution_types::{
-    ConfigSettings, DependencyMetadata, DirectorySourceDist, Dist, HashPolicy, IndexUrl,
-    RequirementSource, SourceDist,
-};
+use uv_distribution_types::{ConfigSettings, DependencyMetadata, IndexUrl, RequirementSource};
 use uv_git_types::GitReference;
 use uv_pypi_types::PyProjectToml;
 use uv_resolver::FlatIndex;
@@ -385,8 +383,8 @@ pub(super) async fn lock_pypi_packages(
     for record in &unresolved_pypi_environment.records {
         let pkg = record.as_package_data();
 
-        // For path-based directories, read metadata from the source tree.
-        // The result is cached in ctx.static_metadata_cache for later use.
+        // Only local directories can drift. Git/URL/archive sources are
+        // content-pinned by the lock and trusted as-is.
         let metadata = if let UrlOrPath::Path(path) = &**pkg.location() {
             let absolute_path = if path.is_absolute() {
                 Cow::Borrowed(Path::new(path.as_str()))
@@ -395,6 +393,15 @@ pub(super) async fn lock_pypi_packages(
             };
 
             if absolute_path.is_dir() {
+                // Lock says wheel but path is a directory, needs re-solve.
+                if pkg.as_wheel().is_some() {
+                    return Err(CommandDispatcherError::Failed(Box::new(
+                        PlatformUnsat::DistributionShouldBeSource {
+                            name: pkg.name().clone(),
+                        },
+                    )));
+                }
+
                 let uv_ctx = ctx
                     .uv_context
                     .get_or_try_init(|| {
@@ -425,34 +432,22 @@ pub(super) async fn lock_pypi_packages(
                     static_metadata_cache: ctx.static_metadata_cache,
                 };
 
-                match read_local_package_metadata(&absolute_path, pkg.name(), &build_ctx).await {
-                    Ok(m) => Some(m),
-                    Err(e) => {
-                        return Err(CommandDispatcherError::Failed(Box::new(
+                read_local_package_metadata(&absolute_path, pkg.name(), &build_ctx)
+                    .await
+                    .map_err(|e| {
+                        CommandDispatcherError::Failed(Box::new(
                             PlatformUnsat::FailedToReadLocalMetadata(
                                 pkg.name().clone(),
                                 format!("failed to read metadata: {e}"),
                             ),
-                        )));
-                    }
-                }
+                        ))
+                    })?
             } else {
                 None
             }
         } else {
             None
         };
-
-        // A path-based directory that was parsed as Distribution (e.g. a
-        // directory named `foo.tar.gz`) needs a re-solve — it should be a
-        // Source package.
-        if pkg.as_wheel().is_some() && metadata.is_some() {
-            return Err(CommandDispatcherError::Failed(Box::new(
-                PlatformUnsat::DistributionShouldBeSource {
-                    name: pkg.name().clone(),
-                },
-            )));
-        }
 
         // Determine the version: prefer the wheel version from the lock file,
         // fall back to the version read from the source tree metadata.
@@ -484,36 +479,28 @@ struct BuildMetadataContext<'a> {
     static_metadata_cache: &'a DashMap<PathBuf, pypi_metadata::LocalPackageMetadata>,
 }
 
-/// Read metadata for a local directory package using UV's DistributionDatabase.
+/// Statically read metadata for a local directory PyPI package via
+/// [`DistributionDatabase::requires_dist`]. Returns `Ok(None)` when uv
+/// can't extract statically (dynamic deps, missing or unparsable
+/// pyproject), in which case the caller trusts the lock. Result is
+/// cached platform-independently in `static_metadata_cache`.
 ///
-/// This first tries to extract metadata statically via `database.requires_dist()`,
-/// which parses the pyproject.toml without building. If static extraction fails
-/// (e.g., dynamic dependencies), it falls back to building the wheel metadata.
-///
-/// Static metadata is cached across platforms since it doesn't depend on the platform.
+/// Building wheel metadata as a fallback would need Python in the host
+/// conda prefix, which is not guaranteed under cross-platform
+/// satisfiability, so we deliberately don't fall back to a build.
 #[allow(clippy::result_large_err)]
 async fn read_local_package_metadata(
     directory: &Path,
     package_name: &pep508_rs::PackageName,
     ctx: &BuildMetadataContext<'_>,
-) -> Result<pypi_metadata::LocalPackageMetadata, PlatformUnsat> {
+) -> Result<Option<pypi_metadata::LocalPackageMetadata>, PlatformUnsat> {
     // Check if we already have static metadata cached for this directory
     if let Some(cached_metadata) = ctx.static_metadata_cache.get(directory) {
-        tracing::debug!("Package {} - using cached static metadata", package_name);
-        return Ok(cached_metadata.value().clone());
+        tracing::debug!(package = %package_name, "using cached static metadata");
+        return Ok(Some(cached_metadata.value().clone()));
     }
 
     let pypi_options = ctx.environment.pypi_options();
-
-    // Look up editability from the manifest (not stored in lock file).
-    // This affects which PEP 517 hook uv calls
-    // (prepare_metadata_for_build_editable vs prepare_metadata_for_build_wheel).
-    let editable = ctx
-        .environment
-        .pypi_dependencies(Some(ctx.platform))
-        .get(package_name)
-        .and_then(|specs| specs.iter().find_map(|spec| spec.editable()))
-        .unwrap_or(false);
 
     // Find the Python interpreter from locked records
     let python_record = ctx
@@ -710,137 +697,89 @@ async fn read_local_package_metadata(
         ctx.uv_context.concurrency.downloads,
     );
 
-    // Try to read pyproject.toml and use requires_dist() first
+    // Missing or unparsable pyproject -> trust the lock.
     let pyproject_path = directory.join("pyproject.toml");
-    if let Ok(contents) = fs_err::read_to_string(&pyproject_path) {
-        // Parse with toml_edit for version/requires_python
-        if let Ok(toml) = contents.parse::<toml_edit::DocumentMut>() {
-            let version = toml
-                .get("project")
-                .and_then(|p| p.get("version"))
-                .and_then(|v| v.as_str())
-                .and_then(|v| v.parse::<pep440_rs::Version>().ok());
-
-            let requires_python = toml
-                .get("project")
-                .and_then(|p| p.get("requires-python"))
-                .and_then(|v| v.as_str())
-                .and_then(|rp| rp.parse::<VersionSpecifiers>().ok());
-
-            // Parse pyproject.toml with UV's parser for requires_dist
-            if let Ok(pyproject_toml) = PyProjectToml::from_toml(&contents) {
-                // Try to extract requires_dist statically using UV's database
-                // The `dynamic` flag on `RequiresDist` is true when any
-                // field is listed in `[project.dynamic]`, not just
-                // dependencies. Since we handle version separately (and
-                // skip comparison when it's `None`), we accept the
-                // statically extracted deps regardless of the flag.
-                match database.requires_dist(directory, &pyproject_toml).await {
-                    Ok(Some(requires_dist)) => {
-                        tracing::debug!(
-                            "Package {} - extracted requires_dist using database.requires_dist(). Dynamic: {}",
-                            package_name,
-                            requires_dist.dynamic
-                        );
-
-                        // Convert uv requirements to pep508_rs requirements
-                        let requires_dist_converted: Result<Vec<pep508_rs::Requirement>, _> =
-                            requires_dist
-                                .requires_dist
-                                .iter()
-                                .map(|req| {
-                                    let req_str = req.to_string();
-                                    req_str.parse::<pep508_rs::Requirement>().map_err(|e| {
-                                        PlatformUnsat::FailedToReadLocalMetadata(
-                                            package_name.clone(),
-                                            format!("Invalid requirement: {e}"),
-                                        )
-                                    })
-                                })
-                                .collect();
-
-                        if let Ok(requires_dist_vec) = requires_dist_converted {
-                            let metadata = pypi_metadata::LocalPackageMetadata {
-                                version,
-                                requires_dist: requires_dist_vec,
-                                requires_python,
-                            };
-                            // Cache the static metadata for reuse on other platforms
-                            ctx.static_metadata_cache
-                                .insert(directory.to_path_buf(), metadata.clone());
-                            return Ok(metadata);
-                        }
-                    }
-                    Ok(None) => {
-                        tracing::debug!(
-                            "Package {} - requires_dist() returned None, falling back to build",
-                            package_name
-                        );
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            "Package {} - requires_dist() failed: {}, falling back to build",
-                            package_name,
-                            e
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    // Fall back to building the wheel metadata
-    tracing::debug!(
-        "Package {} - building wheel metadata with get_or_build_wheel_metadata()",
-        package_name
-    );
-
-    // Create the directory source dist
-    let uv_package_name =
-        uv_normalize::PackageName::from_str(package_name.as_ref()).map_err(|e| {
-            PlatformUnsat::FailedToReadLocalMetadata(
-                package_name.clone(),
-                format!("Invalid package name: {e}"),
-            )
-        })?;
-
-    let install_path = directory.to_path_buf();
-    let file_url = url::Url::from_file_path(&install_path).map_err(|_| {
-        PlatformUnsat::FailedToReadLocalMetadata(
-            package_name.clone(),
-            format!("Failed to convert path to URL: {}", install_path.display()),
-        )
-    })?;
-    let verbatim_url = uv_pep508::VerbatimUrl::from_url(file_url.into());
-    let source_dist = DirectorySourceDist {
-        name: uv_package_name,
-        install_path: install_path.into_boxed_path(),
-        editable: Some(editable),
-        r#virtual: Some(false),
-        url: verbatim_url,
+    let Ok(contents) = fs_err::read_to_string(&pyproject_path) else {
+        tracing::debug!(package = %package_name, "no readable pyproject.toml");
+        return Ok(None);
+    };
+    let Ok(pyproject_toml) = PyProjectToml::from_toml(&contents) else {
+        tracing::debug!(package = %package_name, "pyproject.toml could not be parsed");
+        return Ok(None);
     };
 
-    // Build the metadata
-    let metadata_response = database
-        .get_or_build_wheel_metadata(
-            &Dist::Source(SourceDist::Directory(source_dist)),
-            HashPolicy::None,
-        )
-        .await
-        .map_err(|e| {
-            PlatformUnsat::FailedToReadLocalMetadata(
-                package_name.clone(),
-                format!("Failed to build metadata: {e}"),
-            )
-        })?;
+    // Read version and requires-python ourselves; uv's types differ so
+    // we round-trip via string.
+    let project = pyproject_toml.project.as_ref();
+    let version = project
+        .and_then(|p| p.version.as_ref())
+        .and_then(|v| v.to_string().parse::<pep440_rs::Version>().ok());
+    let requires_python = project
+        .and_then(|p| p.requires_python.as_ref())
+        .and_then(|rp| rp.parse::<VersionSpecifiers>().ok());
 
-    // Convert UV metadata to our format
-    pypi_metadata::from_uv_metadata(&metadata_response.metadata).map_err(|e| {
-        PlatformUnsat::FailedToReadLocalMetadata(
-            package_name.clone(),
-            format!("Failed to convert metadata: {e}"),
-        )
-    })
+    // `dynamic` is set when *any* `[project.dynamic]` field is listed,
+    // not just dependencies, so we accept the deps regardless.
+    let requires_dist = match database.requires_dist(directory, &pyproject_toml).await {
+        Ok(Some(rd)) => {
+            tracing::debug!(
+                package = %package_name,
+                dynamic = rd.dynamic,
+                "extracted requires_dist statically",
+            );
+            rd
+        }
+        // uv: "static doesn't apply", trust lock.
+        Ok(None) => {
+            tracing::debug!(
+                package = %package_name,
+                "requires_dist returned None, trusting lock",
+            );
+            return Ok(None);
+        }
+        // uv: hard error, source diverged, force re-solve.
+        Err(e) => {
+            return Err(PlatformUnsat::FailedToReadLocalMetadata(
+                package_name.clone(),
+                format!("static metadata extraction failed: {e}"),
+            ));
+        }
+    };
+
+    // A round-trip failure here would be a uv bug, not "static doesn't
+    // apply", so propagate rather than swallow as `Ok(None)`.
+    let requires_dist_vec: Vec<pep508_rs::Requirement> = requires_dist
+        .requires_dist
+        .iter()
+        .map(|req| {
+            req.to_string()
+                .parse::<pep508_rs::Requirement>()
+                .map_err(|e| {
+                    PlatformUnsat::FailedToReadLocalMetadata(
+                        package_name.clone(),
+                        format!("Invalid requirement: {e}"),
+                    )
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    // Match the wheel METADATA shape used at lock time.
+    let empty_optional_deps = IndexMap::new();
+    let optional_deps = project
+        .and_then(|p| p.optional_dependencies.as_ref())
+        .unwrap_or(&empty_optional_deps);
+    let expanded =
+        pypi_metadata::expand_self_extras(requires_dist_vec, package_name, optional_deps);
+    let metadata = pypi_metadata::LocalPackageMetadata {
+        version,
+        requires_dist: expanded,
+        requires_python,
+    };
+
+    ctx.static_metadata_cache
+        .insert(directory.to_path_buf(), metadata.clone());
+
+    Ok(Some(metadata))
 }
 
 #[cfg(test)]
@@ -1020,7 +959,13 @@ mod tests {
 
         // The manifest spec must satisfy the lockfile entry pixi wrote for
         // the very same dependency.
-        pypi_satisfies_requirement(&uv_req, &locked_data, &project_root).unwrap();
+        pypi_satisfies_requirement(
+            &uv_req,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
     }
 
     // Do not use unix paths on windows: The path gets normalized to something

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
@@ -3,13 +3,14 @@
 //! This module provides functionality to:
 //! 1. Read metadata from local pyproject.toml files
 //! 2. Compare locked metadata against current source tree metadata
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 
+use indexmap::IndexMap;
 use pep440_rs::{Version, VersionSpecifiers};
-use pep508_rs::Requirement;
+use pep508_rs::{PackageName, Requirement};
 use pixi_install_pypi::LockedPypiRecord;
-use thiserror::Error;
+use uv_normalize::ExtraName;
 
 /// Metadata extracted from a local package source tree.
 #[derive(Debug, Clone)]
@@ -21,14 +22,6 @@ pub struct LocalPackageMetadata {
     pub requires_dist: Vec<Requirement>,
     /// The Python version requirement.
     pub requires_python: Option<VersionSpecifiers>,
-}
-
-/// Error that can occur when reading metadata from a source tree.
-#[derive(Debug, Error)]
-pub enum MetadataReadError {
-    /// Failed to parse the pyproject.toml file.
-    #[error("failed to parse pyproject.toml: {0}")]
-    ParseError(String),
 }
 
 /// The result of comparing locked metadata against current metadata.
@@ -131,44 +124,60 @@ fn normalize_requirement(req: &Requirement) -> String {
     req.to_string()
 }
 
-/// Convert UV metadata to LocalPackageMetadata for comparison.
-///
-/// This is used when we build metadata using UV's DistributionDatabase
-/// for packages with dynamic metadata.
-pub fn from_uv_metadata(
-    metadata: &uv_distribution::Metadata,
-) -> Result<LocalPackageMetadata, MetadataReadError> {
-    // Convert version
-    let version = pep440_rs::Version::from_str(&metadata.version.to_string())
-        .map_err(|e| MetadataReadError::ParseError(format!("invalid version: {e}")))?;
-
-    // Convert requires_dist
-    let requires_dist: Vec<Requirement> = metadata
-        .requires_dist
+/// Replace each `pkg[group]` self-reference with the raw entries of
+/// `optional_dependencies[group]`, carrying the outer marker. Matches
+/// what build backends bake into wheel METADATA; UV's static parse
+/// leaves the self-references intact. Cycles in the optional-deps
+/// graph are broken on the path that closes them.
+pub fn expand_self_extras(
+    requires_dist: Vec<Requirement>,
+    package_name: &PackageName,
+    optional_dependencies: &IndexMap<ExtraName, Vec<String>>,
+) -> Vec<Requirement> {
+    let parsed: HashMap<&str, Vec<Requirement>> = optional_dependencies
         .iter()
-        .map(|req| {
-            let req_str = req.to_string();
-            req_str
-                .parse::<Requirement>()
-                .map_err(|e| MetadataReadError::ParseError(format!("invalid requirement: {e}")))
+        .map(|(extra, raws)| {
+            let reqs = raws
+                .iter()
+                .filter_map(|s| Requirement::from_str(s).ok())
+                .collect::<Vec<_>>();
+            (extra.as_ref(), reqs)
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect();
 
-    // Convert requires_python
-    let requires_python = metadata
-        .requires_python
-        .as_ref()
-        .map(|rp| {
-            pep440_rs::VersionSpecifiers::from_str(&rp.to_string())
-                .map_err(|e| MetadataReadError::ParseError(format!("invalid requires-python: {e}")))
-        })
-        .transpose()?;
+    let mut result: Vec<Requirement> = Vec::new();
+    let mut path: HashSet<&str> = HashSet::new();
+    for req in &requires_dist {
+        expand_into(req, package_name, &parsed, &mut path, &mut result);
+    }
+    result
+}
 
-    Ok(LocalPackageMetadata {
-        version: Some(version),
-        requires_dist,
-        requires_python,
-    })
+fn expand_into<'a>(
+    req: &Requirement,
+    package_name: &PackageName,
+    parsed: &'a HashMap<&'a str, Vec<Requirement>>,
+    path: &mut HashSet<&'a str>,
+    result: &mut Vec<Requirement>,
+) {
+    if req.name != *package_name || req.extras.is_empty() {
+        result.push(req.clone());
+        return;
+    }
+    for extra in &req.extras {
+        let Some((&key, group_reqs)) = parsed.get_key_value(extra.as_ref()) else {
+            continue;
+        };
+        if !path.insert(key) {
+            continue;
+        }
+        for child in group_reqs {
+            let mut expanded = child.clone();
+            expanded.marker.and(req.marker.clone());
+            expand_into(&expanded, package_name, parsed, path, result);
+        }
+        path.remove(key);
+    }
 }
 
 #[cfg(test)]
@@ -245,5 +254,105 @@ mod tests {
 
         let mismatch = compare_metadata(&locked, &current);
         assert!(matches!(mismatch, Some(MetadataMismatch::RequiresDist(_))));
+    }
+
+    fn pkg_name(s: &str) -> PackageName {
+        PackageName::from_str(s).unwrap()
+    }
+
+    fn extra(s: &str) -> ExtraName {
+        ExtraName::from_str(s).unwrap()
+    }
+
+    fn req(s: &str) -> Requirement {
+        Requirement::from_str(s).unwrap()
+    }
+
+    fn render(reqs: &[Requirement]) -> String {
+        let mut lines: Vec<String> = reqs.iter().map(|r| r.to_string()).collect();
+        lines.sort();
+        lines.join("\n")
+    }
+
+    #[test]
+    fn expand_self_extras_replaces_ribasim_style_self_refs() {
+        // Mirrors Deltares/Ribasim: `delwaq` references `ribasim[netcdf]`
+        // and `all` composes the other groups.
+        let mut optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
+        optional.insert(extra("tests"), vec!["pytest".into()]);
+        optional.insert(extra("netcdf"), vec!["xugrid".into()]);
+        optional.insert(
+            extra("delwaq"),
+            vec!["jinja2".into(), "networkx".into(), "ribasim[netcdf]".into()],
+        );
+        optional.insert(
+            extra("all"),
+            vec![
+                "ribasim[tests]".into(),
+                "ribasim[netcdf]".into(),
+                "ribasim[delwaq]".into(),
+            ],
+        );
+
+        let static_parsed = vec![
+            req("pandas"),
+            req("pytest ; extra == 'tests'"),
+            req("xugrid ; extra == 'netcdf'"),
+            req("jinja2 ; extra == 'delwaq'"),
+            req("networkx ; extra == 'delwaq'"),
+            req("ribasim[netcdf] ; extra == 'delwaq'"),
+            req("ribasim[tests] ; extra == 'all'"),
+            req("ribasim[netcdf] ; extra == 'all'"),
+            req("ribasim[delwaq] ; extra == 'all'"),
+        ];
+
+        let expanded = expand_self_extras(static_parsed, &pkg_name("ribasim"), &optional);
+        insta::assert_snapshot!(render(&expanded), @r"
+        jinja2 ; extra == 'all'
+        jinja2 ; extra == 'delwaq'
+        networkx ; extra == 'all'
+        networkx ; extra == 'delwaq'
+        pandas
+        pytest ; extra == 'all'
+        pytest ; extra == 'tests'
+        xugrid ; extra == 'all'
+        xugrid ; extra == 'all'
+        xugrid ; extra == 'delwaq'
+        xugrid ; extra == 'netcdf'
+        ");
+    }
+
+    #[test]
+    fn expand_self_extras_preserves_non_self_references() {
+        let optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
+        let input = vec![req("requests"), req("other[gpu] ; extra == 'all'")];
+        let expanded = expand_self_extras(input, &pkg_name("mypkg"), &optional);
+        insta::assert_snapshot!(render(&expanded), @r"
+        other[gpu] ; extra == 'all'
+        requests
+        ");
+    }
+
+    #[test]
+    fn expand_self_extras_drops_unknown_extras_silently() {
+        // A self-reference to an extra that doesn't exist (typo, stale
+        // metadata) is dropped.
+        let optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
+        let input = vec![req("pandas"), req("mypkg[missing] ; extra == 'all'")];
+        let expanded = expand_self_extras(input, &pkg_name("mypkg"), &optional);
+        insta::assert_snapshot!(render(&expanded), @"pandas");
+    }
+
+    #[test]
+    fn expand_self_extras_breaks_cycles() {
+        // a -> b -> a; expansion must terminate. The non-cyclic dep
+        // `actual` is still emitted with the outer marker.
+        let mut optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
+        optional.insert(extra("a"), vec!["actual".into(), "mypkg[b]".into()]);
+        optional.insert(extra("b"), vec!["mypkg[a]".into()]);
+
+        let input = vec![req("mypkg[a] ; extra == 'X'")];
+        let expanded = expand_self_extras(input, &pkg_name("mypkg"), &optional);
+        insta::assert_snapshot!(render(&expanded), @"actual ; extra == 'x'");
     }
 }

--- a/tests/integration_python/test_build.py
+++ b/tests/integration_python/test_build.py
@@ -36,15 +36,14 @@ def test_workspace_variants_separate_work_directories(
         [pixi, "build", "--path", tmp_pixi_workspace, "--output-dir", str(tmp_pixi_workspace)],
     )
 
-    # Check that work directories exist and are separate for each variant
-    work_dir = tmp_pixi_workspace / ".pixi" / "build" / "work"
-    assert work_dir.exists(), "Work directory should exist"
+    # Check that the package's bld root exists.
+    # Layout: .pixi/bld/<pkg>/<workspace_key>/ (one workspace_key per variant).
+    package_bld_dir = tmp_pixi_workspace / ".pixi" / "bld" / "python_rich"
+    assert package_bld_dir.exists(), "Package build directory should exist"
 
-    # Get all work directories (should be different for py311 and py312)
-    work_dirs = list(work_dir.glob("python_rich-*"))
-
-    # Should have at least 2 work directories (one per Python variant)
-    assert len(work_dirs) >= 2, (
-        f"Expected at least 2 work directories for different Python variants, "
-        f"found {len(work_dirs)}: {[d.name for d in work_dirs]}"
+    # Should have at least 2 workspace directories (one per Python variant).
+    workspace_dirs = [d for d in package_bld_dir.iterdir() if d.is_dir()]
+    assert len(workspace_dirs) >= 2, (
+        f"Expected at least 2 workspace directories for different Python variants, "
+        f"found {len(workspace_dirs)}: {[d.name for d in workspace_dirs]}"
     )


### PR DESCRIPTION
### Description

After the lockfile-v7 refactor (#5607), `pixi install --locked` started reporting false drift on a couple of common shapes. This PR fixes the satisfiability check end-to-end and adapts one stale test path along the way.

**`test_workspace_variants_separate_work_directories`**: work directories moved from `.pixi/build/work/<pkg>--<hash>/` to `.pixi/bld/<pkg>/<workspace_key>/` in the lockfile-v7 refactor. The test now looks in the new location.

**Expand `pkg[group]` self-references in static `requires_dist`**: uv's static `database.requires_dist` keeps `pkg[group]` self-references from `[project.optional-dependencies]` as-is, while build backends like hatchling write the expanded contents into the wheel METADATA at lock time. The two views compare as different, so satisfiability falsely reports the lock-file as out-of-date for any project that composes its extras (e.g. Deltares/Ribasim's `all = ["pkg[a]", "pkg[b]"]`).

We now run the same expansion ourselves: each `pkg[a, b]; <outer marker>` is replaced by the raw entries of groups `a` and `b` carrying the outer marker. Cycles in the optional-deps graph (e.g. `a -> b -> a`) are broken on the path that closes them. The requires-dist diff message is also de-duplicated and includes extras, so `added: [pkg, pkg, pkg]` becomes `added: [pkg[a], pkg[b]]`.

**Skip PEP 517 build during the satisfiability check**: `read_local_package_metadata` previously fell back to `get_or_build_wheel_metadata` when uv's static `requires_dist` declined. That fallback needs the host conda prefix to have Python, but cross-platform satisfiability runs on platforms that may not be in the lock at all. The resulting `PythonMissingError` panicked through `LazyBuildDispatch::interpreter` past this path's missing `catch_unwind`, aborting `pixi run` / `pixi reinstall` on hosts whose platform was missing from the lock (e.g. macOS arm64 against a linux-64-only lock).

The function is now restricted to uv's static path. `Ok(Some)` feeds drift detection (then runs through the self-extras expansion); `Ok(None)` (uv's "static doesn't apply" classification) trusts the lock; `Err` surfaces as `PlatformUnsat::FailedToReadLocalMetadata` to force a re-solve. Verified for uv 0.9.5 that `database.requires_dist` itself does not invoke the interpreter.

### How Has This Been Tested?

- All 131 satisfiability unit tests pass; new unit tests cover the Ribasim-shape expansion, non-self-references, unknown extras, and the cycle-break case (inline insta snapshots).
- Built `target/release/pixi` from the branch and ran `pixi install --locked` against `Deltares/Ribasim@main` (v6 lockfile): exit 0, install completes, no `lock-file not up-to-date` and no `metadata for local package 'ribasim' has changed` in the trace. The static-only path is exercised for `ribasim`, `ribasim-api`, and `ribasim-testmodels` per the debug log.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
