### PR TITLE
fix: record git ref for transitive Pypi deps

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -940,6 +940,48 @@ mod tests {
         .unwrap();
     }
 
+    /// Reproduces issue #5661: PyPI dependency with full commit hash from a
+    /// `pyproject.toml`-style PEP 508 string roundtrips through pixi's manifest
+    /// types (PixiPypiSpec) and through `as_uv_req` -- which is the path
+    /// actually exercised by the satisfiability check -- and must satisfy a
+    /// lockfile entry that pixi just wrote for the same dependency.
+    #[test]
+    fn test_pypi_git_full_commit_via_as_uv_req() {
+        use pixi_pypi_spec::PixiPypiSpec;
+        use pixi_uv_conversions::as_uv_req;
+
+        // 1. Parse the pyproject.toml-style PEP 508 string the same way pixi
+        //    does when reading the manifest.
+        let pep_req = pep508_rs::Requirement::from_str(
+            "dacite @ git+https://github.com/konradhalas/dacite.git@9898ccbb783e7e6a35ae165e7deb9fa84edfe21c",
+        )
+        .unwrap();
+        let pixi_spec = PixiPypiSpec::try_from(pep_req).unwrap();
+
+        // 2. Convert into a uv Requirement using the same conversion the
+        //    satisfiability check uses for top-level PyPI requirements.
+        let project_root = PathBuf::from_str("/").unwrap();
+        let uv_req = as_uv_req(&pixi_spec, "dacite", &project_root).unwrap();
+
+        // 3. Build the locked record exactly as pixi writes it via
+        //    `into_locked_git_url`: ?rev=<sha>#<sha>.
+        let locked_data = lock_for_test(make_wheel_package_with(
+            "dacite",
+            "1.8.1",
+            "git+https://github.com/konradhalas/dacite.git?rev=9898ccbb783e7e6a35ae165e7deb9fa84edfe21c#9898ccbb783e7e6a35ae165e7deb9fa84edfe21c"
+                .parse()
+                .expect("failed to parse url"),
+            None,
+            None,
+            vec![],
+            None,
+        ));
+
+        // The manifest spec must satisfy the lockfile entry pixi wrote for
+        // the very same dependency.
+        pypi_satisfies_requirement(&uv_req, &locked_data, &project_root).unwrap();
+    }
+
     // Do not use unix paths on windows: The path gets normalized to something
     // unix-y, and the lockfile keeps the "pretty" path the user filled in at
     // all times. So on windows the test fails.

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -302,10 +302,13 @@ pub fn into_pixi_reference(git_reference: uv_git_types::GitReference) -> PixiRef
 /// branch information. If provided, this original reference will be used instead
 /// of the one from uv's resolution.
 ///
-/// If no original reference is provided (user didn't specify branch/tag/rev),
-/// we store the resolved commit as `Rev(commit)` rather than `DefaultBranch`.
-/// This ensures the lock file has a precise reference that doesn't require
-/// cache lookups when re-resolving (similar to how uv's lockfile works).
+/// If no original reference is provided, which happens for git deps that
+/// aren't top-level workspace deps (e.g. transitive deps coming in through an
+/// editable self-package's `requires_dist`, issue #5661), fall back to
+/// whatever reference uv resolved. That keeps the lock-file
+/// `?branch=/?tag=/?rev=` in sync with what the manifest's PEP 508 string
+/// actually says, so the satisfiability check matches without relying on the
+/// no-ref fallback.
 pub fn into_pinned_git_spec(
     dist: GitSourceDist,
     original_reference: Option<PixiReference>,
@@ -320,11 +323,8 @@ pub fn into_pinned_git_spec(
     )
     .expect("we expect it to be a valid sha");
 
-    // Use the original reference from the manifest if provided.
-    // If no explicit reference was specified, use DefaultBranch.
-    // The precise commit is already captured in the fragment (`#commit`),
-    // so we don't need to duplicate it in the query string as `?rev=commit`.
-    let reference = original_reference.unwrap_or(PixiReference::DefaultBranch);
+    let reference =
+        original_reference.unwrap_or_else(|| into_pixi_reference(dist.git.reference().clone()));
 
     let pinned_checkout = PinnedGitCheckout::new(
         git_sha,


### PR DESCRIPTION
### Description

When a workspace contains both `pixi.toml` and `pyproject.toml`, pixi uses `pixi.toml` as the workspace manifest and ignores `pyproject.toml`'s `[project].dependencies`. Git dependencies declared there (e.g. `pkg @ git+https://repo.git@<sha>`) only enter resolution as transitive deps via the editable self-package's `requires_dist`.

`resolve_pypi` builds `original_git_references` from the workspace's top-level PyPI deps only, so transitive git deps reach `into_pinned_git_spec` with `original_reference = None`, which then defaulted to `DefaultBranch`. The lockfile recorded the URL without `?rev=`, but the satisfiability check later parses the same dep's PEP 508 string into `BranchOrTagOrCommit(<sha>)`, so the references disagree. The result: `pixi update` reports the lockfile is up-to-date while `pixi install --locked` immediately rejects it with "lock-file not up-to-date with the workspace".

Fall back to uv's resolved `dist.git.reference()` instead of `DefaultBranch`. uv parses `git+https://repo.git@<sha>` into `BranchOrTagOrCommit(<sha>)`, which round-trips to `pixi_spec::Rev(<sha>)`, so the lockfile now stores `?rev=<sha>` and the satisfiability check matches naturally rather than relying on the no-ref escape clause. When the manifest specifies no ref at all, uv keeps `DefaultBranch` and behaviour is unchanged.

Also adds a regression test that exercises the actual code path used at runtime (`PixiPypiSpec::try_from` -> `as_uv_req` -> `pypi_satisfies_requirement`), since the existing test only covered the `pep508_requirement_to_uv_requirement` path.

Fixes #5661 