### PR TITLE
fix: Add standard ROS default globs for input file discovery

### DIFF
--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -244,6 +244,11 @@ impl GenerateRecipe for RosGenerator {
             "tests/**/*.py",
             "docs/**/*.rst",
             "docs/**/*.md",
+            "launch/**/*.py",
+            "config/*.yaml",
+            "msg/**/*.msg",
+            "srv/**/*.srv",
+            "action/**/*.action",
         ];
 
         if !editable {

--- a/docs/build/backends/pixi-build-ros.md
+++ b/docs/build/backends/pixi-build-ros.md
@@ -194,17 +194,21 @@ Additional glob patterns to include as input files for the build process. These 
 ```toml title="pixi.toml"
 [package.build.config]
 extra-input-globs = [
-    "launch/**/*.py",
-    "config/*.yaml",
-    "msgs/**/*.msg",
-    "srvs/**/*.srv"
+    "urdf/**/*.urdf",
+    "worlds/**/*.sdf"
 ]
 ```
 
 Default input globs include:
+
 - Source files: `**/*.{c,cpp,h,hpp,rs,sh,py,pyx}`
 - ROS configuration: `package.xml`, `setup.py`, `setup.cfg`, `pyproject.toml`
 - Build files: `CMakeLists.txt`
+- Launch files: `launch/**/*.py`
+- Config files: `config/*.yaml`
+- Message definitions: `msg/**/*.msg`
+- Service definitions: `srv/**/*.srv`
+- Action definitions: `action/**/*.action`
 
 ### `extra-package-mappings`
 


### PR DESCRIPTION
### Description

Add launch files, config, messages, services, and actions to the default input globs so they don't need to be passed via extra-input-globs. Update default input globs documentation. Previously briefly discussed with @Tobias-Fischer on discord.

### How Has This Been Tested?

Ran all unit tests locally with `cargo test -p pixi-build-ros`

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation