### PR TITLE
test: override XDG_DATA_HOME so menuinst writes shortcuts

### DIFF
--- a/tests/integration_python/pixi_global/test_shortcuts.py
+++ b/tests/integration_python/pixi_global/test_shortcuts.py
@@ -25,6 +25,10 @@ def setup_data(tmp_path: Path) -> SetupData:
     env = {
         "PIXI_HOME": str(pixi_home),
         "HOME": str(data_home),  # Used for macOS and Linux
+        # menuinst follows XDG on Linux and falls back to $HOME/.local/share only when
+        # XDG_DATA_HOME is unset, so override it explicitly to keep the shortcut inside
+        # the per-test data_home.
+        "XDG_DATA_HOME": str(data_home / ".local" / "share"),
         "MENUINST_FAKE_DIRECTORIES": str(data_home),  # Used for Windows
     }
     return SetupData(pixi_home=pixi_home, data_home=data_home, env=env)


### PR DESCRIPTION
…ide the per-test data_home

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
