### PR TITLE
test: isolate pixi cache per xdist worker to avoid shared bld/ races

### DIFF
--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -29,6 +29,20 @@ def pixi(request: pytest.FixtureRequest) -> Path:
     return Path(exec_extension(str(pixi_path)))
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolated_pixi_cache_per_worker(
+    tmp_path_factory: pytest.TempPathFactory, worker_id: str
+) -> None:
+    # Parallel xdist workers all share the user's `~/.cache/rattler/` by default,
+    # which causes hash mismatches when two workers race to build the same source
+    # package into the same `bld/` path. Give each worker its own cache root.
+    # Single-process runs (worker_id == "master") keep the user's cache for speed.
+    if worker_id == "master":
+        return
+    cache_dir = tmp_path_factory.mktemp("pixi-cache", numbered=False)
+    os.environ["PIXI_CACHE_DIR"] = str(cache_dir)
+
+
 @pytest.fixture
 def tmp_pixi_workspace(tmp_path: Path):
     """Create a temporary workspace for tests, with a .pixi config.


### PR DESCRIPTION
Parallel xdist workers sharing ~/.cache/rattler/cache/bld/ raced when two workers built the same source package concurrently, producing hash mismatches on extraction. Set PIXI_CACHE_DIR to a per-worker tmp dir for any session running under xdist; single-process runs keep the user's cache for speed.

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
