### PR TITLE
test(compute-engine): gate the cancellation_with_subscribers compute …

### DIFF
--- a/crates/pixi_compute_engine/tests/integration/cancellation.rs
+++ b/crates/pixi_compute_engine/tests/integration/cancellation.rs
@@ -103,22 +103,42 @@ async fn cancellation_drops_task() {
     );
 }
 
-/// A Key whose compute yields a few times, giving the test time to
-/// interleave a `select!`-racing caller and a normal caller.
+/// A Key whose compute parks on an external `Notify` until the test
+/// releases it, so the test can deterministically attach multiple
+/// subscribers to the same in-flight compute before it completes.
+///
+/// The previous incarnation used `tokio::task::yield_now()` five times,
+/// which is "slow" only relative to a single-threaded executor; on a
+/// multi-threaded runtime the spawned task could finish before the
+/// second subscriber even called `engine.compute(..)`. That left the
+/// second subscriber's first poll returning `Ready`, which `poll_once`
+/// silently discarded, and the subsequent `.await` then hit "`async fn`
+/// resumed after completion" inside `compute_root`.
+#[derive(Clone)]
+struct ReleaseGate(Arc<Notify>);
+
+trait HasReleaseGate {
+    fn release_gate(&self) -> &Arc<Notify>;
+}
+
+impl HasReleaseGate for DataStore {
+    fn release_gate(&self) -> &Arc<Notify> {
+        &self.get::<ReleaseGate>().0
+    }
+}
+
 #[derive(Clone, Debug, Display, Hash, PartialEq, Eq)]
 #[display("{id}")]
-struct YieldingKey {
+struct GatedKey {
     id: u32,
 }
-impl Key for YieldingKey {
+impl Key for GatedKey {
     type Value = u32;
     async fn compute(&self, ctx: &mut ComputeCtx) -> Self::Value {
         ctx.global_data()
             .test_counter()
             .fetch_add(1, Ordering::SeqCst);
-        for _ in 0..5 {
-            tokio::task::yield_now().await;
-        }
+        ctx.global_data().release_gate().notified().await;
         self.id * 3
     }
 }
@@ -130,7 +150,11 @@ impl Key for YieldingKey {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn cancellation_with_subscribers() {
     let counter = test_counter();
-    let engine = ComputeEngine::builder().with_data(counter.clone()).build();
+    let release = Arc::new(Notify::new());
+    let engine = ComputeEngine::builder()
+        .with_data(counter.clone())
+        .with_data(ReleaseGate(release.clone()))
+        .build();
 
     // Handshakes: A signals "subscribed", B signals "subscribed",
     // the test tells A "okay to drop now".
@@ -141,7 +165,7 @@ async fn cancellation_with_subscribers() {
     let caller_a = tokio::spawn({
         let engine = engine.clone();
         async move {
-            let key = YieldingKey { id: 42 };
+            let key = GatedKey { id: 42 };
             let mut compute = engine.compute(&key).boxed();
             // Poll once to spawn the task and register as a subscriber.
             poll_once(&mut compute).await;
@@ -156,7 +180,7 @@ async fn cancellation_with_subscribers() {
     let caller_b = tokio::spawn({
         let engine = engine.clone();
         async move {
-            let key = YieldingKey { id: 42 };
+            let key = GatedKey { id: 42 };
             let mut compute = engine.compute(&key).boxed();
             // Poll once to subscribe to the same shared future as A.
             poll_once(&mut compute).await;
@@ -172,6 +196,10 @@ async fn cancellation_with_subscribers() {
     let _ = a_drop_tx.send(());
 
     let _ = caller_a.await;
+    // Release the gated compute only after A has dropped; the spawned
+    // task must still be parked by the time we get here, otherwise B's
+    // poll_once would have observed `Ready` and panicked.
+    release.notify_one();
     assert_eq!(caller_b.await.unwrap(), 126);
     assert_eq!(counter.0.load(Ordering::SeqCst), 1);
 }

--- a/crates/pixi_compute_engine/tests/integration/common.rs
+++ b/crates/pixi_compute_engine/tests/integration/common.rs
@@ -83,10 +83,20 @@ impl Key for PlusTenKey {
 
 /// Poll `fut` exactly once. Used by the cancellation-with-subscribers
 /// test to force a subscription into the dedup store before proceeding.
+///
+/// Panics if the inner future returns `Ready`: callers rely on the
+/// future remaining live afterwards so they can `.await` it (or drop
+/// it) later, and silently swallowing a `Ready` value would leave the
+/// caller polling a completed `async` block — which the compiler turns
+/// into a "`async fn` resumed after completion" panic with a stack
+/// trace that points away from the test bug.
 pub async fn poll_once<F: Future + Unpin>(fut: &mut F) {
-    futures::future::poll_fn(|cx| {
-        let _ = Pin::new(&mut *fut).poll(cx);
-        Poll::Ready(())
+    futures::future::poll_fn(|cx| match Pin::new(&mut *fut).poll(cx) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(_) => panic!(
+            "poll_once: future returned Ready on first poll; \
+                 the test must keep the compute parked until subscribers attach"
+        ),
     })
     .await;
 }


### PR DESCRIPTION
…on a Notify

The test relied on YieldingKey doing 5 yield_now() calls to stay running long enough for two subscribers to attach. On a fast multi-threaded executor the spawned task could finish before the second subscriber's first poll, at which point the compute future returned Ready immediately. poll_once silently discarded the Ready value and the subsequent compute.await re-polled a completed async block, panicking with 'async fn resumed after completion' inside compute_root.

Replace the yield-loop with an explicit Notify gate the test releases only after both subscribers have attached and caller A has dropped, and harden poll_once to panic on Ready so analogous test bugs surface clearly instead of cascading into a confusing engine-side panic.

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
