### PR TITLE
test(pixi_global): use deterministic manifest path in project tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,12 +2343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deunicode"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
-
-[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,17 +2695,6 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "fake"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6be833b323a56361118a747470a45a1bcd5c52a2ec9b1e40c83dafe687e453"
-dependencies = [
- "deunicode",
- "either",
- "rand 0.10.1",
 ]
 
 [[package]]
@@ -6457,7 +6440,6 @@ dependencies = [
  "console",
  "dirs",
  "dunce",
- "fake",
  "fancy_display",
  "fs-err",
  "futures",

--- a/crates/pixi_global/Cargo.toml
+++ b/crates/pixi_global/Cargo.toml
@@ -18,11 +18,11 @@ fs-err = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
-ordermap = { workspace = true }
 is_executable = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }
 once_cell = { workspace = true }
+ordermap = { workspace = true }
 pixi_build_frontend = { workspace = true }
 pixi_command_dispatcher = { workspace = true }
 pixi_config = { workspace = true }
@@ -61,5 +61,4 @@ zstd = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 
 [dev-dependencies]
-fake = "5.0.0"
 insta = { workspace = true, features = ["yaml", "glob", "filters"] }

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -1533,7 +1533,6 @@ impl Repodata for Project {
 mod tests {
     use std::{collections::HashMap, io::Write};
 
-    use fake::{Fake, faker::filesystem::en::FilePath};
     use itertools::Itertools;
     use rattler_conda_types::{
         NamedChannelOrUrl, PackageRecord, Platform, RepoDataRecord, VersionWithSource,
@@ -1556,7 +1555,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_project_from_str() {
-        let manifest_path: PathBuf = FilePath().fake();
+        // Use a deterministic path with a parent. `FilePath().fake()` from
+        // the `fake` crate occasionally produces "/" (no parent), which
+        // panics `from_manifest`'s `expect("manifest path should always
+        // have a parent")` and made this test flake under nextest.
+        let manifest_path = PathBuf::from("/fake/pixi-global.toml");
         let env_root = EnvRoot::from_env().await.unwrap();
         let bin_dir = BinDir::from_env().await.unwrap();
 
@@ -1587,7 +1590,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_project_from_manifest() {
-        let manifest_path: PathBuf = FilePath().fake();
+        let manifest_path = PathBuf::from("/fake/pixi-global.toml");
 
         let env_root = EnvRoot::from_env().await.unwrap();
         let bin_dir = BinDir::from_env().await.unwrap();

--- a/crates/pixi_spec/Cargo.toml
+++ b/crates/pixi_spec/Cargo.toml
@@ -15,11 +15,11 @@ dirs = { workspace = true }
 file_url = { workspace = true }
 humantime = { workspace = true }
 itertools = { workspace = true }
+pixi_build_types = { workspace = true, optional = true }
 pixi_consts = { workspace = true }
 pixi_git = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true, features = ["serde"] }
-pixi_build_types = { workspace = true, optional = true }
 rattler_lock = { workspace = true, optional = true }
 rattler_solve = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
FilePath().fake() from the fake crate produces "/" about 0.76% of the time, and Path::new("/").parent() returns None — so test_project_from_str and test_project_from_manifest occasionally panicked at the expect("manifest path should always have a parent") inside from_manifest. Replace the random fake path with a deterministic /fake/pixi-global.toml, which has a parent and exercises the same code path.

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
