### PR TITLE
test: drop hardcoded pytest --basetemp in pytests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,12 @@ format-command = "pixi run -e lint ruff format --stdin-filename {filename}"
 test-dir = "tests/integration_python"
 
 [tool.pytest.ini_options]
-addopts = "--basetemp=pytest-temp --timeout=600 --durations=0"
+# basetemp is set in tests/integration_python/conftest.py to pytest-temp-<pid>
+# so it stays on the same filesystem as the cache (faster than /tmp on a
+# different FS) while still being unique per invocation. A static path
+# would race two concurrent `pixi run test`s on xdist.setup_node's
+# basetemp.mkdir(mode=0o700) call.
+addopts = "--timeout=600 --durations=0"
 markers = ["slow: marks tests as slow", "extra_slow: marks tests as extra slow"]
 testpaths = ["tests/integration_python"]
 tmp_path_retention_policy = "failed"

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -22,6 +22,21 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    # Keep basetemp inside the workspace so it shares a filesystem with the
+    # pixi cache (cross-FS rename/copy in /tmp is much slower). The PID
+    # subdir makes it unique per invocation so two concurrent `pixi run
+    # test`s don't race on xdist.setup_node's basetemp.mkdir(mode=0o700,
+    # exist_ok=False). The fixed `pytest-temp/` parent matches the literal
+    # path in `workspace.exclude` in Cargo.toml (cargo doesn't glob-expand
+    # exclude entries). xdist workers inherit --basetemp from the
+    # controller, so we only set it once.
+    if not config.option.basetemp:
+        parent = Path("pytest-temp")
+        parent.mkdir(exist_ok=True)
+        config.option.basetemp = str(parent / str(os.getpid()))
+
+
 @pytest.fixture
 def pixi(request: pytest.FixtureRequest) -> Path:
     pixi_build = request.config.getoption("--pixi-build")


### PR DESCRIPTION
…vocations don't race

xdist.setup_node() calls basetemp.mkdir(mode=0o700) without exist_ok=True. With `--basetemp=pytest-temp` hardcoded in pytest.ini, the second of two concurrent pixi-test invocations panicked with
  FileExistsError: '/var/home/tobias/src/pixi/pytest-temp'
Removing the override falls back to pytest's default /tmp/pytest-of-USER/pytest-N/, which auto-uniquifies per invocation.

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
