### PR TITLE
test(pixi_command_dispatcher): isolate the integration cache to a per…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6176,7 +6176,6 @@ dependencies = [
  "pixi_build_frontend",
  "pixi_build_types",
  "pixi_compute_engine",
- "pixi_config",
  "pixi_consts",
  "pixi_git",
  "pixi_glob",

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -67,7 +67,6 @@ pixi_variant = { workspace = true }
 indexmap = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 pixi_build_backend_passthrough = { workspace = true }
-pixi_config = { workspace = true }
 pixi_test_utils = { workspace = true }
 regex = { workspace = true }
 slotmap = { workspace = true }

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -129,9 +129,25 @@ fn env_ref_of(channels: Vec<ChannelUrl>, build_environment: BuildEnvironment) ->
 }
 
 /// Returns a default set of cache directories for the test.
+///
+/// Backed by a per-process tempdir kept alive in a `OnceLock`, so tests
+/// running in this binary share one cache root across each other but stay
+/// isolated from the user's `~/.cache/rattler/` and from any other
+/// concurrent test binary. The previous version handed out the user's
+/// real cache, which made parallel `pixi run test-slow` invocations race
+/// on the bld/repodata/pkgs caches and silently reshape `simple_test`'s
+/// EventTree snapshot (e.g. a deduped `Conda solve` migrated between
+/// parents) under contention.
 fn default_cache_dirs() -> CacheDirs {
-    let cache_dir = pixi_config::get_cache_dir().unwrap();
-    CacheDirs::new(to_abs_dir(cache_dir))
+    use std::sync::OnceLock;
+    static CACHE_TMPDIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+    let dir = CACHE_TMPDIR.get_or_init(|| {
+        tempfile::Builder::new()
+            .prefix("pixi-cmd-dispatcher-test-cache-")
+            .tempdir()
+            .expect("create cache tempdir")
+    });
+    CacheDirs::new(to_abs_dir(dir.path()))
 }
 
 /// Returns the tool platform that is appropriate for the current platform.


### PR DESCRIPTION
…-process tempdir

default_cache_dirs() pointed at the user's real `~/.cache/rattler/`. Two parallel test-binary processes (e.g. concurrent `pixi run test-slow` invocations) shared the bld/repodata/pkgs caches and raced on solve dedup, which surfaced as an unstable simple_test snapshot — a deduped "Conda solve" sometimes attached to foobar-desktop's instantiate-backend chain and sometimes only at the top level.

Back the default cache by a per-process `tempfile::TempDir` kept alive in a OnceLock. Tests in the same binary still share one cache, but parallel binaries are now independent.

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.

