### PR TITLE
fix: don't false-positive on transitive pypi deps from a custom index

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -311,13 +311,32 @@ pub async fn verify_platform_satisfiability(
     package_verification_future.await
 }
 
+/// Where a pypi requirement came from. The `index` semantics of a
+/// [`uv_distribution_types::Requirement`] depend on this: a `None` index from
+/// the manifest means the user did not pin a per-package index, while a
+/// `None` index from a parent's `requires_dist` simply means pep508 cannot
+/// encode an index at all.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum RequirementOrigin {
+    /// A direct pypi-dependency declared in the workspace manifest.
+    Manifest,
+    /// A transitive requirement parsed from another package's
+    /// `requires_dist`. The originating pep508 syntax carries no `index`
+    /// information.
+    RequiresDist,
+}
+
 #[allow(clippy::large_enum_variant)]
 /// A dependency that needs to be checked in the lock file
 pub enum Dependency {
     Input(PackageName, PixiSpec, Cow<'static, str>),
     Conda(MatchSpec, Cow<'static, str>),
     CondaSource(PackageName, SourceSpec, Cow<'static, str>),
-    PyPi(uv_distribution_types::Requirement, Cow<'static, str>),
+    PyPi(
+        uv_distribution_types::Requirement,
+        Cow<'static, str>,
+        RequirementOrigin,
+    ),
 }
 
 impl Dependency {
@@ -328,7 +347,7 @@ impl Dependency {
             Dependency::Input(name, _, _) => Some(name.clone()),
             Dependency::Conda(spec, _) => spec.name.as_exact().cloned(),
             Dependency::CondaSource(name, _, _) => Some(name.clone()),
-            Dependency::PyPi(_, _) => None,
+            Dependency::PyPi(_, _, _) => None,
         }
     }
 }
@@ -562,6 +581,7 @@ async fn verify_package_platform_satisfiability(
                             ))
                         })?,
                         "<environment>".into(),
+                        RequirementOrigin::Manifest,
                     ))
                 })
         })
@@ -663,7 +683,7 @@ async fn verify_package_platform_satisfiability(
     let mut pypi_requirements_visited = pypi_requirements
         .iter()
         .filter_map(|r| match r {
-            Dependency::PyPi(req, _) => Some(req.clone()),
+            Dependency::PyPi(req, _, _) => Some(req.clone()),
             _ => None,
         })
         .collect::<HashSet<_>>();
@@ -737,7 +757,7 @@ async fn verify_package_platform_satisfiability(
                         .map_err(CommandDispatcherError::Failed)?,
                 )
             }
-            Dependency::PyPi(requirement, source) => {
+            Dependency::PyPi(requirement, source, origin) => {
                 // Check if there is a pypi identifier that matches our requirement.
                 if let Some((identifier, repodata_idx, _)) =
                     locked_conda_pypi_packages.get(&requirement.name)
@@ -815,6 +835,7 @@ async fn verify_package_platform_satisfiability(
                                     &requirement,
                                     record,
                                     ctx.project_root,
+                                    origin,
                                 ) {
                                     delayed_pypi_error.get_or_insert(err);
                                 }
@@ -1005,6 +1026,7 @@ async fn verify_package_platform_satisfiability(
                     pypi_queue.push(Dependency::PyPi(
                         requirement.clone(),
                         pkg.name().as_ref().to_string().into(),
+                        RequirementOrigin::RequiresDist,
                     ));
                 }
             }

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -38,7 +38,7 @@ use uv_pypi_types::PyProjectToml;
 use uv_resolver::FlatIndex;
 
 use super::errors::PlatformUnsat;
-use super::platform::VerifySatisfiabilityContext;
+use super::platform::{RequirementOrigin, VerifySatisfiabilityContext};
 use super::pypi_metadata;
 use crate::{
     lock_file::{
@@ -123,10 +123,18 @@ pub(crate) fn pypi_satisfies_editable(
 /// Check satisfiability of a pypi requirement against a locked pypi package
 /// This also does an additional check for git urls when using direct url
 /// references
+///
+/// `origin` disambiguates the meaning of an absent `index` on the
+/// requirement. For [`RequirementOrigin::Manifest`] a missing index means
+/// the user did not pin one and the strict "removed the index" check
+/// applies. For [`RequirementOrigin::RequiresDist`] the missing index just
+/// reflects that pep508 cannot encode one, so the lock-file's recorded
+/// index is taken as authoritative.
 pub(crate) fn pypi_satisfies_requirement(
     spec: &uv_distribution_types::Requirement,
     locked_record: &LockedPypiRecord,
     project_root: &Path,
+    origin: RequirementOrigin,
 ) -> Result<(), Box<PlatformUnsat>> {
     let locked_data = &locked_record.data;
     if spec.name.to_string() != locked_data.name().to_string() {
@@ -171,7 +179,10 @@ pub(crate) fn pypi_satisfies_requirement(
                         .into());
                     }
                 }
-                (None, Some(locked_url)) if !is_default_pypi_index(locked_url) => {
+                (None, Some(locked_url))
+                    if origin == RequirementOrigin::Manifest
+                        && !is_default_pypi_index(locked_url) =>
+                {
                     return Err(PlatformUnsat::LockedPyPIIndexMismatch {
                         name: spec.name.to_string(),
                         expected_index: "<default>".to_string(),
@@ -179,8 +190,10 @@ pub(crate) fn pypi_satisfies_requirement(
                     }
                     .into());
                 }
-                // No locked index: the lockfile predates per-package
-                // index tracking (pre-v7), so we can't verify the index.
+                // Either the locked index is missing (pre-v7 lockfile) or the
+                // requirement comes from a parent's `requires_dist` (pep508
+                // carries no index info, so we trust the lock-file's
+                // recorded index).
                 (_, None) | (None, _) => {}
             }
 
@@ -848,6 +861,7 @@ mod tests {
     use uv_distribution_types::RequirementSource;
 
     use super::super::PypiNoBuildCheck;
+    use super::super::platform::RequirementOrigin;
     use super::pypi_satisfies_requirement;
     use crate::lock_file::tests::{make_source_package_with, make_wheel_package_with};
 
@@ -882,7 +896,13 @@ mod tests {
         let project_root = PathBuf::from_str("/").unwrap();
         // This will not satisfy because the rev length is different, even being
         // resolved to the same one
-        pypi_satisfies_requirement(&spec, &locked_data, &project_root).unwrap_err();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        )
+        .unwrap_err();
 
         let locked_data = lock_for_test(make_wheel_package_with(
             "mypkg",
@@ -904,12 +924,24 @@ mod tests {
         .unwrap();
         let project_root = PathBuf::from_str("/").unwrap();
         // This will satisfy
-        pypi_satisfies_requirement(&spec, &locked_data, &project_root).unwrap();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
         let non_matching_spec = pep508_requirement_to_uv_requirement(
             pep508_rs::Requirement::from_str("mypkg @ git+https://github.com/mypkg@defgd").unwrap(),
         )
         .unwrap();
-        pypi_satisfies_requirement(&non_matching_spec, &locked_data, &project_root).unwrap_err();
+        pypi_satisfies_requirement(
+            &non_matching_spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        )
+        .unwrap_err();
 
         // Removing the rev from the Requirement should NOT satisfy when lock has
         // explicit Rev. This ensures that when a user removes an explicit ref
@@ -918,7 +950,13 @@ mod tests {
             pep508_rs::Requirement::from_str("mypkg @ git+https://github.com/mypkg").unwrap(),
         )
         .unwrap();
-        pypi_satisfies_requirement(&spec_without_rev, &locked_data, &project_root).unwrap_err();
+        pypi_satisfies_requirement(
+            &spec_without_rev,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        )
+        .unwrap_err();
 
         // When lock has DefaultBranch (no explicit ref), removing rev from manifest
         // should satisfy
@@ -938,6 +976,7 @@ mod tests {
             &spec_without_rev,
             &locked_data_default_branch,
             &project_root,
+            RequirementOrigin::Manifest,
         )
         .unwrap();
     }
@@ -964,7 +1003,13 @@ mod tests {
 
         let spec = pep508_requirement_to_uv_requirement(spec).unwrap();
 
-        pypi_satisfies_requirement(&spec, &locked_data, Path::new("")).unwrap();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -985,7 +1030,13 @@ mod tests {
 
         let spec = pep508_requirement_to_uv_requirement(spec).unwrap();
 
-        pypi_satisfies_requirement(&spec, &locked_data, Path::new("")).unwrap();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1030,7 +1081,13 @@ mod tests {
 
         // A path-based source dependency without a version should still satisfy
         // a path-based requirement.
-        pypi_satisfies_requirement(&spec, &locked_data, Path::new("")).unwrap();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
     }
 
     /// Windows variant of the path-based dynamic version test.
@@ -1056,7 +1113,13 @@ mod tests {
 
         // A path-based source dependency without a version should still satisfy
         // a path-based requirement.
-        pypi_satisfies_requirement(&spec, &locked_data, Path::new("")).unwrap();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
     }
 
     /// Test that `pypi_satisfies_requirement` works with a git-based
@@ -1078,7 +1141,13 @@ mod tests {
         .unwrap();
 
         // A git-based source dependency without a version should still satisfy.
-        pypi_satisfies_requirement(&spec, &locked_data, Path::new("")).unwrap();
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+        )
+        .unwrap();
     }
 
     /// Regression test: removing a PyPI `index` from the manifest should
@@ -1110,12 +1179,71 @@ mod tests {
 
         let project_root = PathBuf::from_str("/").unwrap();
 
-        let result = pypi_satisfies_requirement(&spec, &locked_data, &project_root);
+        let result = pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        );
         assert!(
             result.is_err(),
             "expected index removal to invalidate satisfiability, \
              but pypi_satisfies_requirement returned Ok(())"
         );
+    }
+
+    /// Regression test for a false-positive index mismatch on transitive
+    /// dependencies pulled from a custom index.
+    ///
+    /// When a package resolved from a custom index has a transitive
+    /// `requires_dist` entry, that requirement is materialized from pep508
+    /// and therefore carries no `index` info. The locked record for the
+    /// transitive dep, however, faithfully records the custom index it was
+    /// resolved from. Treating that as a mismatch incorrectly marks the
+    /// environment as out-of-date on every subsequent `pixi lock` run.
+    #[test]
+    fn test_pypi_transitive_custom_index_should_satisfy() {
+        // Locked transitive package was resolved from a custom index.
+        let locked_data = lock_for_test(make_wheel_package_with(
+            "my-dep",
+            "1.0.0",
+            "https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl"
+                .parse()
+                .expect("failed to parse url"),
+            None,
+            Some(Url::parse("https://custom.example.com/simple").unwrap()),
+            vec![],
+            None,
+        ));
+
+        // Transitive requirement: parsed from a parent's `requires_dist`.
+        // pep508 has no concept of an index, so `index` is always None here.
+        let spec = pep508_requirement_to_uv_requirement(
+            pep508_rs::Requirement::from_str("my-dep>=1.0,<2.0").unwrap(),
+        )
+        .unwrap();
+
+        let project_root = PathBuf::from_str("/").unwrap();
+
+        // Direct (non-transitive) check should still flag the mismatch as
+        // before, because the user could have removed the `index` from the
+        // manifest.
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        )
+        .expect_err("direct requirement without index must not satisfy custom-index lock");
+
+        // Transitive check must accept the lock-file's recorded index.
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::RequiresDist,
+        )
+        .expect("transitive requirement with no pep508 index must satisfy a custom-index lock");
     }
 
     /// Helper to build a `uv_distribution_types::Requirement` with an explicit index.
@@ -1168,7 +1296,12 @@ mod tests {
         );
 
         let project_root = PathBuf::from_str("/").unwrap();
-        let result = pypi_satisfies_requirement(&spec, &locked_data, &project_root);
+        let result = pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        );
         assert!(
             result.is_err(),
             "expected index change to invalidate satisfiability"
@@ -1194,7 +1327,12 @@ mod tests {
         let spec = registry_requirement_with_index("my-dep", ">=1.0", index_url);
 
         let project_root = PathBuf::from_str("/").unwrap();
-        let result = pypi_satisfies_requirement(&spec, &locked_data, &project_root);
+        let result = pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        );
         assert!(
             result.is_ok(),
             "expected matching index to satisfy, got: {:?}",
@@ -1222,7 +1360,12 @@ mod tests {
             registry_requirement_with_index("my-dep", ">=1.0", "https://custom.example.com/simple");
 
         let project_root = PathBuf::from_str("/").unwrap();
-        let result = pypi_satisfies_requirement(&spec, &locked_data, &project_root);
+        let result = pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        );
         assert!(
             result.is_err(),
             "expected adding an index to invalidate satisfiability"
@@ -1258,7 +1401,12 @@ mod tests {
         let spec = registry_requirement_with_index("my-dep", ">=1.0", index_url);
 
         let project_root = PathBuf::from_str("/").unwrap();
-        let result = pypi_satisfies_requirement(&spec, &locked_data, &project_root);
+        let result = pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::Manifest,
+        );
         assert!(
             result.is_ok(),
             "v6 lockfile with missing index_url should still satisfy a \

--- a/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@pypi-index-added.snap
+++ b/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@pypi-index-added.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/mod.rs
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
+    Diagnostic severity: error
+    Caused by: 'my-dep' requires index https://custom.example.com/simple but the lock-file has https://pypi.org/simple

--- a/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@pypi-index-removed.snap
+++ b/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@pypi-index-removed.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/mod.rs
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
+    Diagnostic severity: error
+    Caused by: 'my-dep' requires index <default> but the lock-file has https://custom.example.com/simple

--- a/tests/data/non-satisfiability/pypi-index-added/pixi.lock
+++ b/tests/data/non-satisfiability/pypi-index-added/pixi.lock
@@ -1,0 +1,32 @@
+#
+# This lock-file should not satisfy the accompanying pixi.toml file.
+#
+# The user added an explicit `index = "https://custom..."` to the
+# `my-dep` requirement, but the lock-file has `my-dep` resolved from
+# the default PyPI index. The satisfiability check should detect this
+# drift and force a re-resolve.
+
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+      - https://pypi.org/simple
+    packages:
+      win-64:
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+        - pypi: https://pypi.org/simple/packages/my_dep-1.0.0-py3-none-any.whl
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+    sha256: 1a95494abe572a8819c933f978df89f00bde72ea9432d46a70632599e8029ea4
+    md5: f07c8c5dd98767f9a652de5d039b284e
+    # Faked to be empty to reduce the size of the example
+    depends: []
+  - pypi: https://pypi.org/simple/packages/my_dep-1.0.0-py3-none-any.whl
+    name: my-dep
+    version: 1.0.0
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    index: https://pypi.org/simple

--- a/tests/data/non-satisfiability/pypi-index-added/pixi.toml
+++ b/tests/data/non-satisfiability/pypi-index-added/pixi.toml
@@ -1,0 +1,15 @@
+[workspace]
+channels = ["conda-forge"]
+name = "pypi-index-added"
+platforms = ["win-64"]
+
+[dependencies]
+python = "3.12.*"
+
+# The user pinned `my-dep` to a non-default custom index, but the
+# lock-file still has `my-dep` resolved from the default PyPI index.
+# The satisfiability check must invalidate the lock so the package
+# gets re-resolved from the requested index.
+
+[pypi-dependencies]
+my-dep = { version = "==1.0.0", index = "https://custom.example.com/simple" }

--- a/tests/data/non-satisfiability/pypi-index-removed/pixi.lock
+++ b/tests/data/non-satisfiability/pypi-index-removed/pixi.lock
@@ -1,0 +1,32 @@
+#
+# This lock-file should not satisfy the accompanying pixi.toml file.
+#
+# The user removed the explicit `index = "..."` from `my-dep` in the
+# manifest, but the lock-file still records `my-dep` as resolved from
+# a non-default custom index. The satisfiability check should detect
+# this drift and force a re-resolve.
+
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+      - https://pypi.org/simple
+    packages:
+      win-64:
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+        - pypi: https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+    sha256: 1a95494abe572a8819c933f978df89f00bde72ea9432d46a70632599e8029ea4
+    md5: f07c8c5dd98767f9a652de5d039b284e
+    # Faked to be empty to reduce the size of the example
+    depends: []
+  - pypi: https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl
+    name: my-dep
+    version: 1.0.0
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    index: https://custom.example.com/simple

--- a/tests/data/non-satisfiability/pypi-index-removed/pixi.toml
+++ b/tests/data/non-satisfiability/pypi-index-removed/pixi.toml
@@ -1,0 +1,15 @@
+[workspace]
+channels = ["conda-forge"]
+name = "pypi-index-removed"
+platforms = ["win-64"]
+
+[dependencies]
+python = "3.12.*"
+
+# The user removed the explicit `index = "..."` from the requirement,
+# but the lock-file still has the package locked from a non-default
+# custom index. The satisfiability check must invalidate the lock so
+# the package gets re-resolved from the default index list.
+
+[pypi-dependencies]
+my-dep = "==1.0.0"

--- a/tests/data/satisfiability/pypi-index-transitive/pixi.lock
+++ b/tests/data/satisfiability/pypi-index-transitive/pixi.lock
@@ -1,13 +1,16 @@
 #
 # This lock-file should satisfy the accompanying pixi.toml file.
 #
-# Regression test: a direct PyPI dependency `my-root` is requested from a
-# custom index. It transitively pulls in `my-dep`, which is also resolved
-# from the same custom index. The transitive `my-dep` requirement comes
-# through pep508 (which has no concept of an index) and therefore lacks an
-# `index` field, while the locked record correctly stores the resolved
-# index URL. The satisfiability check must trust the lock-file's recorded
-# index for transitive deps and not flag a `<default>` -> custom mismatch.
+# Regression test for a false-positive index mismatch on transitive
+# dependencies. The manifest declares both `foo` and `bar` as direct
+# dependencies pinned to a custom index. `bar` transitively requires
+# `foo` (via its `requires_dist`); the satisfiability walker visits
+# `foo` once as a direct manifest requirement (which carries the
+# custom index) and once as a transitive requirement coming through
+# pep508 (which carries no index). The locked `foo` record correctly
+# stores the resolved custom index, and the check must accept the
+# transitive visit instead of reporting a `<default>` -> custom
+# mismatch.
 
 version: 7
 platforms:
@@ -21,23 +24,23 @@ environments:
     packages:
       win-64:
         - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
-        - pypi: https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl
-        - pypi: https://custom.example.com/simple/packages/my_root-1.0.0-py3-none-any.whl
+        - pypi: https://custom.example.com/simple/packages/bar-1.0.0-py3-none-any.whl
+        - pypi: https://custom.example.com/simple/packages/foo-1.0.0-py3-none-any.whl
 packages:
   - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
     sha256: 1a95494abe572a8819c933f978df89f00bde72ea9432d46a70632599e8029ea4
     md5: f07c8c5dd98767f9a652de5d039b284e
     # Faked to be empty to reduce the size of the example
     depends: []
-  - pypi: https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl
-    name: my-dep
-    version: 1.0.0
-    sha256: 0000000000000000000000000000000000000000000000000000000000000000
-    index: https://custom.example.com/simple
-  - pypi: https://custom.example.com/simple/packages/my_root-1.0.0-py3-none-any.whl
-    name: my-root
+  - pypi: https://custom.example.com/simple/packages/bar-1.0.0-py3-none-any.whl
+    name: bar
     version: 1.0.0
     requires_dist:
-      - my-dep>=1.0,<2.0
+      - foo>=1.0,<2.0
     sha256: 1111111111111111111111111111111111111111111111111111111111111111
+    index: https://custom.example.com/simple
+  - pypi: https://custom.example.com/simple/packages/foo-1.0.0-py3-none-any.whl
+    name: foo
+    version: 1.0.0
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
     index: https://custom.example.com/simple

--- a/tests/data/satisfiability/pypi-index-transitive/pixi.lock
+++ b/tests/data/satisfiability/pypi-index-transitive/pixi.lock
@@ -1,0 +1,43 @@
+#
+# This lock-file should satisfy the accompanying pixi.toml file.
+#
+# Regression test: a direct PyPI dependency `my-root` is requested from a
+# custom index. It transitively pulls in `my-dep`, which is also resolved
+# from the same custom index. The transitive `my-dep` requirement comes
+# through pep508 (which has no concept of an index) and therefore lacks an
+# `index` field, while the locked record correctly stores the resolved
+# index URL. The satisfiability check must trust the lock-file's recorded
+# index for transitive deps and not flag a `<default>` -> custom mismatch.
+
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+      - https://pypi.org/simple
+    packages:
+      win-64:
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+        - pypi: https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl
+        - pypi: https://custom.example.com/simple/packages/my_root-1.0.0-py3-none-any.whl
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+    sha256: 1a95494abe572a8819c933f978df89f00bde72ea9432d46a70632599e8029ea4
+    md5: f07c8c5dd98767f9a652de5d039b284e
+    # Faked to be empty to reduce the size of the example
+    depends: []
+  - pypi: https://custom.example.com/simple/packages/my_dep-1.0.0-py3-none-any.whl
+    name: my-dep
+    version: 1.0.0
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    index: https://custom.example.com/simple
+  - pypi: https://custom.example.com/simple/packages/my_root-1.0.0-py3-none-any.whl
+    name: my-root
+    version: 1.0.0
+    requires_dist:
+      - my-dep>=1.0,<2.0
+    sha256: 1111111111111111111111111111111111111111111111111111111111111111
+    index: https://custom.example.com/simple

--- a/tests/data/satisfiability/pypi-index-transitive/pixi.toml
+++ b/tests/data/satisfiability/pypi-index-transitive/pixi.toml
@@ -1,0 +1,10 @@
+[workspace]
+channels = ["conda-forge"]
+name = "pypi-index-transitive"
+platforms = ["win-64"]
+
+[dependencies]
+python = "3.12.*"
+
+[pypi-dependencies]
+my-root = { version = "==1.0.0", index = "https://custom.example.com/simple" }

--- a/tests/data/satisfiability/pypi-index-transitive/pixi.toml
+++ b/tests/data/satisfiability/pypi-index-transitive/pixi.toml
@@ -6,5 +6,13 @@ platforms = ["win-64"]
 [dependencies]
 python = "3.12.*"
 
+# Both `foo` and `bar` are declared as direct dependencies on the same
+# custom index. `bar` transitively requires `foo` via its
+# `requires_dist`. The transitive copy of the `foo` requirement is
+# parsed from pep508 and therefore lacks an `index` field; the locked
+# `foo` record correctly preserves the index it was resolved from. The
+# satisfiability check must accept that and not report a mismatch.
+
 [pypi-dependencies]
-my-root = { version = "==1.0.0", index = "https://custom.example.com/simple" }
+foo = { version = "==1.0.0", index = "https://custom.example.com/simple" }
+bar = { version = "==1.0.0", index = "https://custom.example.com/simple" }


### PR DESCRIPTION
### Description

The lock-file satisfiability check incorrectly flagged transitive PyPI dependencies as out-of-date when their parent was resolved from a custom index. Transitive requirements come from a parent's
`requires_dist` and are parsed via pep508, which has no concept of an index, so their `RequirementSource::Registry { index, .. }` is always `None`. The check was treating that `None` as "user wants the default index", producing an `'<dep>' requires index <default> but the lock-file has https://...` error on every subsequent `pixi lock`.

The same `None`-index check is still needed for *direct* manifest deps (if the user removes an explicit `index = "..."`, the lock should be invalidated), so the fix introduces a `RequirementOrigin` enum (`Manifest` vs `RequiresDist`) on  `Dependency::PyPi` and threads it through to `pypi_satisfies_requirement`. The strict check fires only for `Manifest`-origin requirements.

### How Has This Been Tested?

CI

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.7)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.