### PR TITLE
docs: absolute path to a conda package in `pixi add`

### DIFF
--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -14,9 +14,10 @@ use crate::{
 
 /// Adds dependencies to the workspace
 ///
-/// The dependencies should be defined as MatchSpec for conda package, or a PyPI
-/// requirement for the `--pypi` dependencies. If no specific version is
-/// provided, the latest version compatible with your workspace will be chosen
+/// The dependencies should be defined as MatchSpec for conda package, a PyPI
+/// requirement for the `--pypi` dependencies, or an absolute path to a local
+/// `.conda` or `.tar.bz2` package file. If no specific version is provided,
+/// the latest version compatible with your workspace will be chosen
 /// automatically or a * will be used.
 ///
 /// Example usage:

--- a/docs/concepts/package_specifications.md
+++ b/docs/concepts/package_specifications.md
@@ -235,6 +235,16 @@ This is rarely needed but useful for:
 file-name = "pytorch-2.0.0-cuda.tar.bz2"
 ```
 
+## Local Package Files
+
+You can install a pre-built `.conda` or `.tar.bz2` package directly from the local filesystem by passing an absolute path:
+
+```shell
+pixi add /path/to/package-1.0-hb0f4dca_0.conda
+```
+
+The package name is extracted from the archive filename, and the path is stored as a `file://` URL in the dependency specification.
+
 ## Source Packages
 
 !!! warning

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -86,9 +86,10 @@ pixi add [OPTIONS] <SPEC>...
 ## Description
 Adds dependencies to the workspace
 
-The dependencies should be defined as MatchSpec for conda package, or a PyPI
-requirement for the `--pypi` dependencies. If no specific version is
-provided, the latest version compatible with your workspace will be chosen
+The dependencies should be defined as MatchSpec for conda package, a PyPI
+requirement for the `--pypi` dependencies, or an absolute path to a local
+`.conda` or `.tar.bz2` package file. If no specific version is provided,
+the latest version compatible with your workspace will be chosen
 automatically or a * will be used.
 
 Example usage:

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -14,24 +14,25 @@ pixi add --platform osx-64 clang # (7)!
 pixi add --no-install numpy # (8)!
 pixi add --no-lockfile-update numpy # (9)!
 pixi add --feature featurex numpy # (10)!
-pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (11)!
-pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (12)!
-pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (13)!
-pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (14)!
+pixi add /absolute/path/to/package-1.0-hb0f4dca_0.conda # (11)!
+pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (12)!
+pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (13)!
+pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (14)!
+pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (15)!
 
 # Add a pypi dependency
-pixi add --pypi requests[security] # (15)!
-pixi add --pypi Django==5.1rc1 # (16)!
-pixi add --pypi "boltons>=24.0.0" --feature lint # (17)!
-pixi add --pypi "boltons @ https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl" # (18)!
-pixi add --pypi "exchangelib @ git+https://github.com/ecederstrand/exchangelib" # (19)!
-pixi add --pypi "project @ file:///absolute/path/to/project" # (20)!
-pixi add --pypi "project@file:///absolute/path/to/project" --editable # (21)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --pypi # (22)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --branch main --pypi # (23)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --rev e50d4a1 --pypi # (24)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi # (25)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdir boltons # (26)!
+pixi add --pypi requests[security] # (16)!
+pixi add --pypi Django==5.1rc1 # (17)!
+pixi add --pypi "boltons>=24.0.0" --feature lint # (18)!
+pixi add --pypi "boltons @ https://files.pythonhosted.org/packages/46/35/e50d4a115f93e2a3fbf52438435bb2efcf14c11d4fcd6bdcd77a6fc399c9/boltons-24.0.0-py3-none-any.whl" # (19)!
+pixi add --pypi "exchangelib @ git+https://github.com/ecederstrand/exchangelib" # (20)!
+pixi add --pypi "project @ file:///absolute/path/to/project" # (21)!
+pixi add --pypi "project@file:///absolute/path/to/project" --editable # (22)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --pypi # (23)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --branch main --pypi # (24)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --rev e50d4a1 --pypi # (25)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi # (26)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdir boltons # (27)!
 ```
 
 1. This will add the `numpy` package to the project with the latest available for the solved environment.
@@ -44,22 +45,23 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pyp
 8. This will add the `numpy` package to the manifest and lockfile, without installing it in an environment.
 9. This will add the `numpy` package to the manifest without updating the lockfile or installing it in the environment.
 10. This will add the `numpy` package in the feature `featurex`.
-11. This will add the `boost-check` source package to the dependencies from the git repository.
-12. This will add the `boost-check` source package to the dependencies from the git repository using `main` branch and the `boost-check` folder in the repository.
-13. This will add the `boost-check` source package to the dependencies from the git repository using `v0.1.0` tag.
-14. This will add the `boost-check` source package to the dependencies from the git repository using `e50d4a1` revision.
-15. This will add the `requests` package as `pypi` dependency with the `security` extra.
-16. This will add the `pre-release` version of `Django` to the project as a `pypi` dependency.
-17. This will add the `boltons` package in the feature `lint` as `pypi` dependency.
-18. This will add the `boltons` package with the given `url` as `pypi` dependency.
-19. This will add the `exchangelib` package with the given `git` url as `pypi` dependency.
-20. This will add the `project` package with the given `file` url as `pypi` dependency.
-21. This will add the `project` package with the given `file` url as an `editable` package as `pypi` dependency.
-22. This will add the `boltons` package with the given `git` url as `pypi` dependency.
-23. This will add the `boltons` package with the given `git` url and `main` branch as `pypi` dependency.
-24. This will add the `boltons` package with the given `git` url and `e50d4a1` revision as `pypi` dependency.
-25. This will add the `boltons` package with the given `git` url and `v0.1.0` tag as `pypi` dependency.
-26. This will add the `boltons` package with the given `git` url, `v0.1.0` tag and the `boltons` folder in the repository as `pypi` dependency.
+11. This will install a pre-built `.conda` or `.tar.bz2` package directly from the local filesystem using an absolute path. The package name is extracted from the archive filename.
+12. This will add the `boost-check` source package to the dependencies from the git repository.
+13. This will add the `boost-check` source package to the dependencies from the git repository using `main` branch and the `boost-check` folder in the repository.
+14. This will add the `boost-check` source package to the dependencies from the git repository using `v0.1.0` tag.
+15. This will add the `boost-check` source package to the dependencies from the git repository using `e50d4a1` revision.
+16. This will add the `requests` package as `pypi` dependency with the `security` extra.
+17. This will add the `pre-release` version of `Django` to the project as a `pypi` dependency.
+18. This will add the `boltons` package in the feature `lint` as `pypi` dependency.
+19. This will add the `boltons` package with the given `url` as `pypi` dependency.
+20. This will add the `exchangelib` package with the given `git` url as `pypi` dependency.
+21. This will add the `project` package with the given `file` url as `pypi` dependency.
+22. This will add the `project` package with the given `file` url as an `editable` package as `pypi` dependency.
+23. This will add the `boltons` package with the given `git` url as `pypi` dependency.
+24. This will add the `boltons` package with the given `git` url and `main` branch as `pypi` dependency.
+25. This will add the `boltons` package with the given `git` url and `e50d4a1` revision as `pypi` dependency.
+26. This will add the `boltons` package with the given `git` url and `v0.1.0` tag as `pypi` dependency.
+27. This will add the `boltons` package with the given `git` url, `v0.1.0` tag and the `boltons` folder in the repository as `pypi` dependency.
 
 !!! tip "Need to specify build strings or hardware-specific packages?"
     For advanced package specifications including build strings, see the [Package Specifications](../../../concepts/package_specifications.md) guide.


### PR DESCRIPTION
### Description

`pixi add` can take an absolute path to a `.conda` or `.tar.bz2` file to support installing a built package without needing to add it to a channel. This has come up before on the Discord server but it seems it's not commonly known behavior, probably because it's not documented!


### How Has This Been Tested?

N/A

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code

<!-- Add your prompt here, this helps us understand your results.
```plaintext
❯ where in the docs should we add the fact that `pixi add` can take an absolute path to install a conda package directly from the filesystem, instead of from a channel?
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
