### PR TITLE
fix: preserve relative paths in lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7028,6 +7028,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dunce",
+ "fs-err",
  "jiff",
  "miette 7.6.0",
  "pep440_rs",
@@ -7039,6 +7040,7 @@ dependencies = [
  "pixi_spec",
  "rattler_lock",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "url",

--- a/crates/pixi_uv_conversions/Cargo.toml
+++ b/crates/pixi_uv_conversions/Cargo.toml
@@ -39,3 +39,7 @@ uv-python = { workspace = true }
 uv-redacted = { workspace = true }
 uv-resolver = { workspace = true }
 uv-types = { workspace = true }
+
+[dev-dependencies]
+fs-err = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -482,21 +482,33 @@ pub fn to_requirements<'req>(
     requirements
 }
 
-/// Convert back to PEP508 without the VerbatimParsedUrl
-/// We need this function because we need to convert to the introduced
-/// `VerbatimParsedUrl` back to crates.io `VerbatimUrl`, for the locking
+/// Convert uv `Requirement<VerbatimParsedUrl>` to `pep508_rs::Requirement`.
+///
+/// Carries `verbatim.given()` over because `pep508_rs::VerbatimUrl`'s
+/// `Display`/`Serialize` ignore it, so a string round-trip would drop the
+/// original spelling and bake absolute paths into `pixi.lock` (#4680).
 pub fn convert_uv_requirements_to_pep508<'req>(
     requires_dist: impl Iterator<Item = &'req uv_pep508::Requirement<uv_pypi_types::VerbatimParsedUrl>>,
 ) -> Result<Vec<pep508_rs::Requirement>, crate::ConversionError> {
-    // Convert back top PEP508 Requirement<VerbatimUrl>
-    let requirements: Result<Vec<pep508_rs::Requirement>, _> = requires_dist
+    requires_dist
         .map(|r| {
             let requirement = r.to_string();
-            pep508_rs::Requirement::from_str(&requirement).map_err(crate::Pep508Error::Pep508Error)
-        })
-        .collect();
+            let mut converted = pep508_rs::Requirement::from_str(&requirement)
+                .map_err(crate::Pep508Error::Pep508Error)?;
 
-    Ok(requirements?)
+            if let (
+                Some(uv_pep508::VersionOrUrl::Url(uv_url)),
+                Some(pep508_rs::VersionOrUrl::Url(pep_url)),
+            ) = (&r.version_or_url, &mut converted.version_or_url)
+                && let Some(given) = uv_url.verbatim.given()
+            {
+                *pep_url =
+                    pep508_rs::VerbatimUrl::from_url(pep_url.raw().clone()).with_given(given);
+            }
+
+            Ok(converted)
+        })
+        .collect()
 }
 
 /// Converts `uv_normalize::PackageName` to `pep508_rs::PackageName`
@@ -794,5 +806,34 @@ mod tests {
 
         let host_names: Vec<String> = result.iter().map(|h| h.to_string()).collect();
         assert!(host_names.contains(&"packages.example.org".to_string()));
+    }
+
+    /// #4680: relative paths must survive the uv -> pep508_rs conversion.
+    #[test]
+    fn relative_path_requirement_round_trip_keeps_given() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path();
+        fs_err::create_dir_all(project_root.join("my_subdir")).unwrap();
+
+        let uv_req: uv_pep508::Requirement<uv_pypi_types::VerbatimParsedUrl> =
+            uv_pep508::Requirement::parse("my-subdir @ ./my_subdir", project_root).unwrap();
+
+        let Some(uv_pep508::VersionOrUrl::Url(url)) = &uv_req.version_or_url else {
+            panic!("expected uv requirement to carry a Url");
+        };
+        assert_eq!(url.verbatim.given(), Some("./my_subdir"));
+
+        let converted = convert_uv_requirements_to_pep508(std::iter::once(&uv_req))
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+
+        match converted.version_or_url {
+            Some(pep508_rs::VersionOrUrl::Url(url)) => {
+                assert_eq!(url.given(), Some("./my_subdir"));
+            }
+            other => panic!("expected a VersionOrUrl::Url, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
### Description

`pep508_rs::VerbatimUrl`'s `Display` and `Serialize` impls both write the parsed (normalized) URL and ignore the `given` string. So any `pep508_rs::Requirement` that goes through a string round-trip loses its verbatim spelling. The plural `convert_uv_requirements_to_pep508` did exactly that:

```rust
let requirement = r.to_string();
pep508_rs::Requirement::from_str(&requirement)
```

For a `tool.uv.sources` path entry like `my-subdir = { path = "my_subdir" }`, this produced a `Requirement` whose `VerbatimUrl::given()` was the absolute `file://` URL of the resolved path. `rattler_lock`'s serializer (`requirement_to_string`) prefers `given()`, so the absolute path ended up baked into `pixi.lock`, breaking sharing across machines.

The sibling `to_requirements` (singular, for `uv_distribution_types::Requirement`) already handled this by carrying `verbatim.given()` over onto a fresh `pep508_rs::VerbatimUrl::with_given(...)`. This PR applies the same treatment to the plural function.

Before:
```yaml
requires_dist:
  - my-subdir @ file:///tmp/repro/my_subdir
```

After:
```yaml
requires_dist:
  - my-subdir @ my_subdir
```

Fixes #4680

### How Has This Been Tested?

- New unit test `relative_path_requirement_round_trip_keeps_given` in `pixi_uv_conversions::conversions` builds a uv `Requirement<VerbatimParsedUrl>` for `my-subdir @ ./my_subdir`, runs it through `convert_uv_requirements_to_pep508`, and asserts the resulting `VerbatimUrl::given()` is `Some("./my_subdir")`. The test fails on `main` and passes after the fix.
- Full `pixi_uv_conversions` lib (14 tests) and `pixi_core` lib (225 tests) suites pass.
- End-to-end against [gabrieldemarmiesse/pixi-bug-repro](https://github.com/gabrieldemarmiesse/pixi-bug-repro): deleted the committed `pixi.lock`, ran the patched binary, and confirmed the regenerated lockfile contains `my-subdir @ my_subdir` rather than the absolute `file:///...` URL.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.7)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.