### PR TITLE
feat(list): add a flag to only list local packages

### DIFF
--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -200,6 +200,7 @@ impl<I: Interface> WorkspaceContext<I> {
         platform: Option<Platform>,
         environment: Option<String>,
         explicit: bool,
+        local: bool,
         no_install: bool,
         lock_file_usage: LockFileUsage,
     ) -> miette::Result<Vec<Package>> {
@@ -209,6 +210,7 @@ impl<I: Interface> WorkspaceContext<I> {
             platform,
             environment,
             explicit,
+            local,
             no_install,
             lock_file_usage,
         )

--- a/crates/pixi_api/src/workspace/list/mod.rs
+++ b/crates/pixi_api/src/workspace/list/mod.rs
@@ -26,6 +26,7 @@ pub async fn list(
     platform: Option<Platform>,
     environment: Option<String>,
     explicit: bool,
+    local: bool,
     no_install: bool,
     lock_file_usage: LockFileUsage,
 ) -> miette::Result<Vec<Package>> {
@@ -150,6 +151,14 @@ pub async fn list(
         packages_to_output = packages_to_output
             .into_iter()
             .filter(|p| p.is_explicit)
+            .collect::<Vec<_>>();
+    }
+
+    // Only return local packages if needed
+    if local {
+        packages_to_output = packages_to_output
+            .into_iter()
+            .filter(|p| p.size_bytes.is_none())
             .collect::<Vec<_>>();
     }
 

--- a/crates/pixi_cli/src/list.rs
+++ b/crates/pixi_cli/src/list.rs
@@ -168,6 +168,10 @@ pub struct Args {
     #[arg(long, alias = "json-pretty")]
     pub json: bool,
 
+    /// Whether to output only local packages
+    #[arg(long)]
+    pub local: bool,
+
     /// Sorting strategy
     #[arg(long, default_value = "name", value_enum, conflicts_with = "json")]
     pub sort_by: SortBy,
@@ -211,6 +215,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             args.platform,
             args.environment,
             args.explicit,
+            args.local,
             args.no_install_config.no_install,
             lock_file_usage,
         )
@@ -230,8 +235,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     if packages_to_output.is_empty() && !args.json {
+        let local_message = if args.local { "local " } else { "" };
         miette::bail!(
-            "No packages found in '{}' environment for '{}' platform.",
+            "No {}packages found in '{}' environment for '{}' platform.",
+            local_message,
             environment.name().fancy_display(),
             consts::ENVIRONMENT_STYLE.apply_to(platform),
         );

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -22,6 +22,8 @@ pixi list [OPTIONS] [REGEX]
 :  The platform to list packages for. Defaults to the current platform
 - <a id="arg---json" href="#arg---json">`--json`</a>
 :  Whether to output in json format
+- <a id="arg---local" href="#arg---local">`--local`</a>
+:  Whether to output only local packages
 - <a id="arg---sort-by" href="#arg---sort-by">`--sort-by <SORT_BY>`</a>
 :  Sorting strategy
 <br>**default**: `name`


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

Provide a way to list only packages that are part of a Pixi workspace. 

```console
$ pixi list
Name                               Version          Build                          Size  Kind   Source
_libgcc_mutex                      0.1              conda_forge                2.50 KiB  conda  https://prefix.dev/conda-forge
...
zstd                               1.5.7            hb78ec9c_6               587.28 KiB  conda  https://prefix.dev/conda-forge

$ pixi list --local
Error:   × No local packages found in 'default' environment for 'linux-64' platform.

$ pixi list -w my-pixi-workspace
Name               Version    Build                        Size  Kind   Source
_openmp_mutex      4.5        20_gnu                  28.27 KiB  conda  https://conda.anaconda.org/conda-forge
bzip2              1.0.8      hda65f42_9             254.08 KiB  conda  https://conda.anaconda.org/conda-forge
ca-certificates    2026.4.22  hbd8a1cb_0             127.97 KiB  conda  https://conda.anaconda.org/conda-forge
ld_impl_linux-64   2.45.1     default_hbd61a6d_102   710.94 KiB  conda  https://conda.anaconda.org/conda-forge
libexpat           2.8.0      hecca717_0              75.43 KiB  conda  https://conda.anaconda.org/conda-forge
libffi             3.5.2      h3435931_0              57.22 KiB  conda  https://conda.anaconda.org/conda-forge
libgcc             15.2.0     he0feb66_18           1017.37 KiB  conda  https://conda.anaconda.org/conda-forge
libgomp            15.2.0     he0feb66_18            589.12 KiB  conda  https://conda.anaconda.org/conda-forge
liblzma            5.8.3      hb03c661_0             110.82 KiB  conda  https://conda.anaconda.org/conda-forge
libmpdec           4.0.0      hb03c661_1              90.23 KiB  conda  https://conda.anaconda.org/conda-forge
libsqlite          3.53.1     h0c1763c_0             932.58 KiB  conda  https://conda.anaconda.org/conda-forge
libstdcxx          15.2.0     h934c35e_18              5.58 MiB  conda  https://conda.anaconda.org/conda-forge
libuuid            2.42       h5347b49_0              39.35 KiB  conda  https://conda.anaconda.org/conda-forge
libzlib            1.3.2      h25fd6f3_2              62.14 KiB  conda  https://conda.anaconda.org/conda-forge
my_cpp_package     0.1.0      hb0f4dca_0                         conda  packages/my_cpp_package
my_python_package  0.1.0      pyh4616a5c_0                       conda  packages/my_python_package
ncurses            6.6        hdb14827_0             897.42 KiB  conda  https://conda.anaconda.org/conda-forge
numpy              2.4.4                              53.90 MiB  pypi   https://pypi.org/simple
openssl            3.6.2      h35e630c_0               3.02 MiB  conda  https://conda.anaconda.org/conda-forge
python             3.14.4     habeac84_100_cp314      35.01 MiB  conda  https://conda.anaconda.org/conda-forge
python_abi         3.14       8_cp314                  6.83 KiB  conda  https://conda.anaconda.org/conda-forge
readline           8.3        h853b02a_0             336.99 KiB  conda  https://conda.anaconda.org/conda-forge
tk                 8.6.13     noxft_h366c992_103       3.15 MiB  conda  https://conda.anaconda.org/conda-forge
tzdata             2025c      hc9c84f9_1             116.34 KiB  conda  https://conda.anaconda.org/conda-forge
zstd               1.5.7      hb78ec9c_6             587.28 KiB  conda  https://conda.anaconda.org/conda-forge

$ pixi list -w my-pixi-workspace --local
Name               Version  Build         Size  Kind   Source
my_cpp_package     0.1.0    hb0f4dca_0          conda  packages/my_cpp_package
my_python_package  0.1.0    pyh4616a5c_0        conda  packages/my_python_package

$ pixi list -w empty_workspace
Error:   × No packages found in 'default' environment for 'linux-64' platform.

$ pixi list -w empty_workspace --local 
Error:   × No local packages found in 'default' environment for 'linux-64' platform.
```

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

Ran `pixi run lint` and `pixi run test`
Used the built `pixi` binary to test the behavior on different workspaces (as visible above)

### Checklist:
<!--- Remove the non relevant items. --->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation