### PR TITLE
chore(deps): bump clap to 4.6.1 and clap_complete to 4.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
 dependencies = [
  "clap",
 ]
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ barrier_cell = { path = "crates/barrier_cell" }
 base64 = "0.22.1"
 cargo_toml = "0.22.3"
 chrono = "0.4.40"
-clap = { version = "4.5.31", default-features = false }
+clap = { version = "4.6.1", default-features = false }
 clap-verbosity-flag = "3.0.2"
-clap_complete = "4.5.46"
-clap_complete_nushell = "4.5.5"
+clap_complete = "4.6.3"
+clap_complete_nushell = "4.6.0"
 cmp_any = "0.8.1"
 comfy-table = "7.2.1"
 console = "0.16.1"

--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -94,8 +94,15 @@ fn replace_bash_completion(script: &str) -> Cow<'_, str> {
     // Replace the '-' with '__' since that's what clap's generator does as well for Bash Shell completion.
     let bin_name: &str = pixi_utils::executable_name();
     let clap_name = bin_name.replace("-", "__");
-    let pattern = format!(r#"(?s){}__run\).*?opts="(.*?)".*?(if.*?fi)"#, clap_name);
-    let replacement = r#"CLAP_NAME__run)
+    // clap_complete >=4.6.2 separates each segment of the bin name from each
+    // subcommand with an explicit `__subcmd__` marker, so the function for the
+    // `run` subcommand of `pixi` is `pixi__subcmd__run`.
+    let func_prefix = clap_name.replace("__", "__subcmd__");
+    let pattern = format!(
+        r#"(?s){}__subcmd__run\).*?opts="(.*?)".*?(if.*?fi)"#,
+        &func_prefix
+    );
+    let replacement = r#"FUNC_PREFIX__subcmd__run)
             opts="$1"
             if [[ $${cur} == -* ]] ; then
                COMPREPLY=( $$(compgen -W "$${opts}" -- "$${cur}") )
@@ -112,7 +119,7 @@ fn replace_bash_completion(script: &str) -> Cow<'_, str> {
         script,
         replacement
             .replace("BIN_NAME", bin_name)
-            .replace("CLAP_NAME", &clap_name),
+            .replace("FUNC_PREFIX", &func_prefix),
     )
 }
 


### PR DESCRIPTION
### Description

Bumps `clap` 4.5 → 4.6.1, `clap_complete` 4.5 → 4.6.3, `clap_complete_nushell` 4.5 → 4.6.0.

clap_complete 4.6.2 changed the bash function naming scheme: it now inserts an explicit `__subcmd__` separator between each segment of the bin name and each subcommand, so what used to be `pixi__run` is now `pixi__subcmd__run`. The hand-rolled regex in `replace_bash_completion` no longer matched, silently dropping the custom task-name completion handler for `pixi run`. Updated the regex and its replacement to use the new naming and expanded `__` in the bin name to `__subcmd__` so hyphenated names (the cargo test binary) still match.

Supersedes the lockfile-only Renovate update in #5930. This was blocking the automerging update PRs.

### How Has This Been Tested?

- `cargo test -p pixi_cli --lib completion::tests` (7 passed, including `test_bash_completion_working_regex` which was failing on the Renovate PR)
- `cargo check --workspace --all-features`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas