### PR TITLE
perf(tests): share git-source fixture, drop pixi-run-git overhead

### DIFF
--- a/tests/integration_python/pixi_build/test_specified_build_source/conftest.py
+++ b/tests/integration_python/pixi_build/test_specified_build_source/conftest.py
@@ -15,20 +15,8 @@ class LocalGitRepo:
     tag: str
 
 
-@pytest.fixture
-def local_cpp_git_repo(
-    pixi: Path,
-    build_data: Path,
-    tmp_path_factory: pytest.TempPathFactory,
-) -> LocalGitRepo:
-    """
-    Create a local git repository mirroring the minimal pixi-build-cmake workspace so tests can
-    exercise git sources without touching the network.
-    """
-
+def _build_local_cpp_git_repo(repo_path: Path, build_data: Path) -> LocalGitRepo:
     source_root = build_data.joinpath("minimal-backend-workspaces", "pixi-build-cmake")
-    repo_root = tmp_path_factory.mktemp("git-repo")
-    repo_path = repo_root.joinpath("repo")
     copytree_with_local_backend(source_root, repo_path)
 
     marker = repo_path.joinpath("src", "LOCAL_MARKER.txt")
@@ -39,7 +27,7 @@ def local_cpp_git_repo(
 
     def run_git(*args: str) -> str:
         result = subprocess.run(
-            [str(pixi), "run", "git", *args],
+            ["git", *args],
             cwd=repo_path,
             capture_output=True,
             text=True,
@@ -89,3 +77,27 @@ def local_cpp_git_repo(
         other_feature_rev=other_feature_rev,
         tag="fixture-v1",
     )
+
+
+@pytest.fixture(scope="session")
+def local_cpp_git_repo(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> LocalGitRepo:
+    """
+    Session-scoped local git repository mirroring the minimal pixi-build-cmake workspace so tests
+    can exercise git sources without touching the network. Tests that need to mutate the repo
+    should use `local_cpp_git_repo_mutable` instead.
+    """
+    build_data = Path(__file__).parents[3].joinpath("data", "pixi-build").resolve()
+    repo_path = tmp_path_factory.mktemp("git-repo").joinpath("repo")
+    return _build_local_cpp_git_repo(repo_path, build_data)
+
+
+@pytest.fixture
+def local_cpp_git_repo_mutable(
+    build_data: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> LocalGitRepo:
+    """Per-test copy for tests that push commits into the repo."""
+    repo_path = tmp_path_factory.mktemp("git-repo-mut").joinpath("repo")
+    return _build_local_cpp_git_repo(repo_path, build_data)

--- a/tests/integration_python/pixi_build/test_specified_build_source/test_git.py
+++ b/tests/integration_python/pixi_build/test_specified_build_source/test_git.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import subprocess
 import tomllib
 from collections.abc import Iterator
 from pathlib import Path
@@ -197,10 +198,10 @@ def test_git_path_build_has_absolutely_no_respect_to_lock_file(
     pixi: Path,
     build_data: Path,
     tmp_pixi_workspace: Path,
-    local_cpp_git_repo: LocalGitRepo,
+    local_cpp_git_repo_mutable: LocalGitRepo,
 ) -> None:
     prepare_cpp_git_workspace(
-        tmp_pixi_workspace, build_data, local_cpp_git_repo, branch="other-feature"
+        tmp_pixi_workspace, build_data, local_cpp_git_repo_mutable, branch="other-feature"
     )
 
     lock_path = tmp_pixi_workspace / "pixi.lock"
@@ -209,26 +210,32 @@ def test_git_path_build_has_absolutely_no_respect_to_lock_file(
     )
 
     initial_sources = extract_git_sources(lock_path)
-    assert any(local_cpp_git_repo.other_feature_rev in entry for entry in initial_sources)
+    assert any(local_cpp_git_repo_mutable.other_feature_rev in entry for entry in initial_sources)
 
-    repo_path = local_cpp_git_repo.path
+    repo_path = local_cpp_git_repo_mutable.path
     main_path = repo_path.joinpath("src", "main.cpp")
-    verify_cli_command([pixi, "run", "git", "checkout", "other-feature"], cwd=repo_path)
+    subprocess.run(["git", "checkout", "other-feature"], cwd=repo_path, check=True)
     main_path.write_text(
         main_path.read_text().replace("Build backend works", "Build backend works v2")
     )
-    verify_cli_command(
-        [pixi, "run", "git", "add", main_path.relative_to(repo_path).as_posix()],
+    subprocess.run(
+        ["git", "add", main_path.relative_to(repo_path).as_posix()],
         cwd=repo_path,
+        check=True,
     )
-    verify_cli_command(
-        [pixi, "run", "git", "commit", "-m", "Update branch for pixi build test"],
+    subprocess.run(
+        ["git", "commit", "-m", "Update branch for pixi build test"],
         cwd=repo_path,
+        check=True,
     )
-    new_branch_rev = verify_cli_command(
-        [pixi, "run", "git", "rev-parse", "HEAD"], cwd=repo_path
+    new_branch_rev = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
     ).stdout.strip()
-    assert new_branch_rev != local_cpp_git_repo.other_feature_rev
+    assert new_branch_rev != local_cpp_git_repo_mutable.other_feature_rev
 
     verify_cli_command(
         [


### PR DESCRIPTION
### Description

Speeds up `tests/integration_python/pixi_build/test_specified_build_source/test_git.py`.

- `local_cpp_git_repo` is now `scope="session"`. 7 of the 8 tests don't mutate the repo, so they can share one initialization.
- The fixture uses system `git` instead of `pixi run git`, which previously had to materialize the workspace's pixi env on every invocation just to spawn `git` from `PATH`.
- The one test that pushes commits into the repo (`test_git_path_build_has_absolutely_no_respect_to_lock_file`) now uses a separate function-scoped `local_cpp_git_repo_mutable` fixture so the shared repo stays read-only for everyone else.

### How Has This Been Tested?

CI Windows, slowest-durations entries for these tests:

| Phase | Before | After |
|---|---|---|
| setup `test_git_path_lock_branch_records_branch_metadata` | 44.26s | dropped from list |
| setup `test_git_path_build_has_absolutely_no_respect_to_lock_file` | 42.55s | dropped from list |
| setup `test_git_path_build` | 34.52s | dropped from list |
| setup `test_git_path_lock_consistent_across_platforms` | 30.54s | dropped from list |
| setup `test_git_path_lock_tag_records_tag_metadata` | 29.11s | dropped from list |
| setup `test_git_path_lock_update_preserves_git_source` | 22.86s | dropped from list |
| setup `test_git_path_lock_rev_marks_explicit_rev` | 21.62s | dropped from list |
| setup `test_git_path_lock_detects_manual_rev_change` | 21.14s | dropped from list |
| **Sum of setup** | **246.6s** | **~0s in slowest-50** |
| call `test_git_path_build` | 12.34s | 36.23s* |
| call `test_git_path_lock_branch_records_branch_metadata` | 18.47s | 16.74s |
| call `test_git_path_build_has_absolutely_no_respect_to_lock_file` | 25.12s | 15.56s |
| call `test_git_path_lock_tag_records_tag_metadata` | 19.98s | 10.52s |

*the first test's call now absorbs the one-time session-fixture cost.

Net CI Windows saving on this file: **~243s**, dominated by per-test setup elimination.

Local Windows (debug build), full file: 257.6s → 59.9s.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.7).

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
