### PR TITLE
fix(exec): make env cache key independent of command

### DIFF
--- a/crates/pixi_cli/src/exec.rs
+++ b/crates/pixi_cli/src/exec.rs
@@ -168,7 +168,6 @@ pub async fn create_exec_prefix(
     client: &ClientWithMiddleware,
     has_guessed_package: bool,
 ) -> miette::Result<Prefix> {
-    let command = args.command.first().expect("missing required command");
     let specs = specs.to_vec();
 
     let channels = args
@@ -178,13 +177,18 @@ pub async fn create_exec_prefix(
         .map(|c| c.base_url.to_string())
         .collect();
 
-    let environment_hash =
-        EnvironmentHash::new(command.clone(), specs.clone(), channels, args.platform);
+    let environment_hash = EnvironmentHash::new(specs.clone(), channels, args.platform);
+
+    let dir_prefix = exec_dir_prefix(
+        &specs,
+        args.command.first().map(String::as_str),
+        has_guessed_package,
+    );
 
     let prefix = Prefix::new(
         cache_dir
             .join(pixi_consts::consts::CACHED_ENVS_DIR)
-            .join(environment_hash.name()),
+            .join(environment_hash.name(dir_prefix.as_deref())),
     );
 
     let guard = AsyncPrefixGuard::new(prefix.root())
@@ -363,6 +367,31 @@ fn list_exec_environment(
     Ok(())
 }
 
+/// Picks the human-readable prefix for the cached env directory:
+/// the single spec's name when there is exactly one, otherwise the guessed
+/// package (when pixi guessed one), otherwise nothing.
+fn exec_dir_prefix(
+    specs: &[MatchSpec],
+    command: Option<&str>,
+    has_guessed_package: bool,
+) -> Option<String> {
+    if let [single] = specs {
+        return single
+            .name
+            .as_exact()
+            .map(|name| name.as_normalized().to_string());
+    }
+    if has_guessed_package {
+        return command.and_then(|c| {
+            guess_package_spec(c)
+                .name
+                .as_exact()
+                .map(|name| name.as_normalized().to_string())
+        });
+    }
+    None
+}
+
 /// This function is used to guess the package name from the command.
 fn guess_package_spec(command: &str) -> MatchSpec {
     // Replace any illegal character with a dash.
@@ -397,4 +426,43 @@ fn to_exec_match_specs(specs: &[MatchSpecOrPath]) -> miette::Result<Vec<MatchSpe
                 .map_err(|err| miette::miette!(err))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_conda_types::{MatchSpec, ParseStrictness};
+
+    use super::exec_dir_prefix;
+
+    fn spec(s: &str) -> MatchSpec {
+        MatchSpec::from_str(s, ParseStrictness::Lenient).unwrap()
+    }
+
+    // `pixi exec --spec foo cmd`: single spec → use the spec name.
+    #[test]
+    fn single_explicit_spec_wins() {
+        let prefix = exec_dir_prefix(&[spec("rucio-mcp")], Some("sh"), false);
+        assert_eq!(prefix.as_deref(), Some("rucio-mcp"));
+    }
+
+    // `pixi exec cmd`: no spec, package guessed from cmd → use cmd.
+    #[test]
+    fn guessed_only_uses_command() {
+        let prefix = exec_dir_prefix(&[spec("voms-proxy-init")], Some("voms-proxy-init"), true);
+        assert_eq!(prefix.as_deref(), Some("voms-proxy-init"));
+    }
+
+    // `pixi exec --with extra cmd`: guess + extra → use cmd, not "extra".
+    #[test]
+    fn with_uses_command_not_extra_spec() {
+        let prefix = exec_dir_prefix(&[spec("extra"), spec("cmd")], Some("cmd"), true);
+        assert_eq!(prefix.as_deref(), Some("cmd"));
+    }
+
+    // `pixi exec --spec a --spec b cmd`: multiple explicit specs, no guess → no prefix.
+    #[test]
+    fn multiple_explicit_specs_have_no_prefix() {
+        let prefix = exec_dir_prefix(&[spec("foo"), spec("bar")], Some("cmd"), false);
+        assert_eq!(prefix, None);
+    }
 }

--- a/crates/pixi_utils/src/cache.rs
+++ b/crates/pixi_utils/src/cache.rs
@@ -2,36 +2,111 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 
 use rattler_conda_types::{MatchSpec, Platform};
 
-/// A hash that uniquely identifies an environment.
+/// Hash identifying a cached `pixi exec` environment by its specs, channels
+/// and platform. The executed command is intentionally not part of the hash.
 #[derive(Hash)]
 pub struct EnvironmentHash {
-    pub command: String,
     pub specs: Vec<MatchSpec>,
     pub channels: Vec<String>,
     pub platform: Platform,
 }
 
 impl EnvironmentHash {
-    /// Creates a new environment hash.
-    pub fn new(
-        command: String,
-        specs: Vec<MatchSpec>,
-        channels: Vec<String>,
-        platform: Platform,
-    ) -> Self {
+    pub fn new(specs: Vec<MatchSpec>, channels: Vec<String>, platform: Platform) -> Self {
+        let mut specs = specs;
+        // Canonical order so spec ordering doesn't change the hash.
+        specs.sort_by_cached_key(MatchSpec::to_string);
         Self {
-            command,
             specs,
             channels,
             platform,
         }
     }
 
-    /// Returns the name of the environment.
-    pub fn name(&self) -> String {
+    /// Directory name for the cached environment: `{prefix}-{hash}` when a
+    /// prefix is given, otherwise just `{hash}`.
+    pub fn name(&self, prefix: Option<&str>) -> String {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         let hash = hasher.finish();
-        format!("{}-{:x}", self.command, hash)
+        match prefix {
+            Some(prefix) => format!("{prefix}-{hash:x}"),
+            None => format!("{hash:x}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_conda_types::{MatchSpec, ParseStrictness, Platform};
+
+    use super::EnvironmentHash;
+
+    fn spec(s: &str) -> MatchSpec {
+        MatchSpec::from_str(s, ParseStrictness::Lenient).unwrap()
+    }
+
+    // Regression test for https://github.com/prefix-dev/pixi/discussions/6034.
+    #[test]
+    fn name_does_not_depend_on_command() {
+        let h = EnvironmentHash::new(
+            vec![spec("rucio-mcp")],
+            vec!["conda-forge".into()],
+            Platform::Linux64,
+        );
+        let strip = |s: String| s.rsplit_once('-').unwrap().1.to_string();
+        assert_eq!(
+            strip(h.name(Some("sh"))),
+            strip(h.name(Some("voms-proxy-init"))),
+        );
+    }
+
+    #[test]
+    fn name_has_no_prefix_when_caller_passes_none() {
+        let h = EnvironmentHash::new(vec![spec("foo")], vec![], Platform::Linux64);
+        let name = h.name(None);
+        assert!(name.chars().all(|c| c.is_ascii_hexdigit()), "got {name}");
+    }
+
+    #[test]
+    fn name_uses_caller_provided_prefix() {
+        let h = EnvironmentHash::new(vec![spec("extra"), spec("cmd")], vec![], Platform::Linux64);
+        assert!(h.name(Some("cmd")).starts_with("cmd-"));
+    }
+
+    #[test]
+    fn name_ignores_spec_order() {
+        let a = EnvironmentHash::new(vec![spec("foo"), spec("bar")], vec![], Platform::Linux64);
+        let b = EnvironmentHash::new(vec![spec("bar"), spec("foo")], vec![], Platform::Linux64);
+        assert_eq!(a.name(None), b.name(None));
+    }
+
+    #[test]
+    fn name_changes_when_specs_change() {
+        let a = EnvironmentHash::new(vec![spec("foo")], vec![], Platform::Linux64);
+        let b = EnvironmentHash::new(vec![spec("bar")], vec![], Platform::Linux64);
+        assert_ne!(a.name(None), b.name(None));
+    }
+
+    #[test]
+    fn name_changes_when_platform_changes() {
+        let a = EnvironmentHash::new(vec![spec("foo")], vec![], Platform::Linux64);
+        let b = EnvironmentHash::new(vec![spec("foo")], vec![], Platform::Osx64);
+        assert_ne!(a.name(None), b.name(None));
+    }
+
+    #[test]
+    fn name_changes_when_channel_order_changes() {
+        let a = EnvironmentHash::new(
+            vec![spec("foo")],
+            vec!["conda-forge".into(), "bioconda".into()],
+            Platform::Linux64,
+        );
+        let b = EnvironmentHash::new(
+            vec![spec("foo")],
+            vec!["bioconda".into(), "conda-forge".into()],
+            Platform::Linux64,
+        );
+        assert_ne!(a.name(None), b.name(None));
     }
 }


### PR DESCRIPTION
### Description

Drops the executed command from the `pixi exec` env cache key so two invocations sharing the same specs reuse the same cached environment. Also makes spec ordering irrelevant.

Before, `pixi exec --spec rucio-mcp sh -c '...'` and `pixi exec --spec rucio-mcp voms-proxy-init` resolved to different cache dirs and couldn't share file mutations (e.g. refreshed CRLs). See discussion #6034.

The cache directory is now `{prefix}-{hash}`, where the hash covers the (sorted) specs, channels and platform. The `{prefix}-` part is only included when:

- exactly one spec is given (prefix = the spec's package name), or
- pixi guessed a package from the command (prefix = the command).

Otherwise the directory name is just `{hash}`.

Old `cached-envs-v0` entries become unused; `pixi clean cache --exec` clears them.

Fixes #{issue}

### How Has This Been Tested?

```
cargo test -p pixi_utils --lib cache::
cargo test -p pixi_cli   --lib exec::
```

Unit tests cover: command-independence (regression), spec-order-independence, single-spec prefix, guessed-command prefix, `--with` prefix, and the multi-spec hash-only case.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.7).

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
