### PR TITLE
chore(deps): bump uv from 0.9.5 to 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11301,7 +11301,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11341,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "uv-build-backend"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -11378,7 +11378,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11415,7 +11415,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11440,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11455,7 +11455,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "hex",
  "memchr",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11523,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "clap",
  "either",
@@ -11552,7 +11552,7 @@ dependencies = [
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "console",
 ]
@@ -11560,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11571,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "futures",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "either",
@@ -11651,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11668,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "arcstr",
  "bitflags 2.11.0",
@@ -11708,7 +11708,7 @@ dependencies = [
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "async-compression",
@@ -11739,7 +11739,7 @@ dependencies = [
 [[package]]
 name = "uv-flags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -11747,7 +11747,7 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "backon",
  "dunce",
@@ -11771,7 +11771,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -11796,7 +11796,7 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11808,7 +11808,7 @@ dependencies = [
 [[package]]
 name = "uv-globfilter"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "clap",
  "configparser",
@@ -11860,7 +11860,7 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -11902,7 +11902,7 @@ dependencies = [
 [[package]]
 name = "uv-keyring"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11917,7 +11917,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "uv-metadata"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "async_zip",
  "fs-err",
@@ -11946,7 +11946,7 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -11957,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "dashmap",
  "futures",
@@ -11967,7 +11967,7 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "serde",
 ]
@@ -11975,7 +11975,7 @@ dependencies = [
 [[package]]
 name = "uv-pep440"
 version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "rkyv",
  "serde",
@@ -11989,7 +11989,7 @@ dependencies = [
 [[package]]
 name = "uv-pep508"
 version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "arcstr",
  "boxcar",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "uv-platform"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12032,7 +12032,7 @@ dependencies = [
 [[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12045,7 +12045,7 @@ dependencies = [
 [[package]]
 name = "uv-preview"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -12055,7 +12055,7 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12086,7 +12086,7 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "clap",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "uv-redacted"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12156,7 +12156,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12192,7 +12192,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "memchr",
@@ -12217,7 +12217,7 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "arcstr",
  "clap",
@@ -12278,7 +12278,7 @@ dependencies = [
 [[package]]
 name = "uv-scripts"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12303,7 +12303,7 @@ dependencies = [
 [[package]]
 name = "uv-settings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "clap",
  "fs-err",
@@ -12338,7 +12338,7 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12354,7 +12354,7 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12365,7 +12365,7 @@ dependencies = [
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12375,7 +12375,7 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "uv-macros",
 ]
@@ -12383,7 +12383,7 @@ dependencies = [
 [[package]]
 name = "uv-torch"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "clap",
  "either",
@@ -12404,7 +12404,7 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "fs-err",
  "thiserror 2.0.18",
@@ -12415,7 +12415,7 @@ dependencies = [
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12437,13 +12437,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+version = "0.9.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 
 [[package]]
 name = "uv-virtualenv"
 version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "console",
  "fs-err",
@@ -12466,7 +12466,7 @@ dependencies = [
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12476,7 +12476,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.17"
-source = "git+https://github.com/astral-sh/rs-async-zip?rev=285e48742b74ab109887d62e1ae79e7c15fd4878#285e48742b74ab109887d62e1ae79e7c15fd4878"
+source = "git+https://github.com/astral-sh/rs-async-zip?rev=f6a41d32866003c868d03ed791a89c794f61b703#f6a41d32866003c868d03ed791a89c794f61b703"
 dependencies = [
  "async-compression",
  "crc32fast",
@@ -2747,13 +2747,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if 1.0.4",
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11302,7 +11301,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11342,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "uv-build-backend"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -11379,7 +11378,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11416,7 +11415,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11441,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11456,7 +11455,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "hex",
  "memchr",
@@ -11469,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11524,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "clap",
  "either",
@@ -11553,7 +11552,7 @@ dependencies = [
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "console",
 ]
@@ -11561,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11572,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "futures",
@@ -11605,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "either",
@@ -11652,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11669,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "arcstr",
  "bitflags 2.11.0",
@@ -11709,7 +11708,7 @@ dependencies = [
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "async-compression",
@@ -11719,6 +11718,7 @@ dependencies = [
  "futures",
  "md-5",
  "rayon",
+ "regex",
  "reqwest 0.12.28",
  "rustc-hash",
  "sha2 0.10.9",
@@ -11739,7 +11739,7 @@ dependencies = [
 [[package]]
 name = "uv-flags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -11747,7 +11747,7 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "backon",
  "dunce",
@@ -11771,7 +11771,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -11796,7 +11796,7 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11808,7 +11808,7 @@ dependencies = [
 [[package]]
 name = "uv-globfilter"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "clap",
  "configparser",
@@ -11860,7 +11860,7 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -11902,7 +11902,7 @@ dependencies = [
 [[package]]
 name = "uv-keyring"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11917,7 +11917,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "uv-metadata"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "async_zip",
  "fs-err",
@@ -11946,7 +11946,7 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -11957,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "dashmap",
  "futures",
@@ -11967,7 +11967,7 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "serde",
 ]
@@ -11975,7 +11975,7 @@ dependencies = [
 [[package]]
 name = "uv-pep440"
 version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "rkyv",
  "serde",
@@ -11989,7 +11989,7 @@ dependencies = [
 [[package]]
 name = "uv-pep508"
 version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "arcstr",
  "boxcar",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "uv-platform"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12032,7 +12032,7 @@ dependencies = [
 [[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12045,7 +12045,7 @@ dependencies = [
 [[package]]
 name = "uv-preview"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -12055,7 +12055,7 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12086,7 +12086,7 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "clap",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "uv-redacted"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12156,7 +12156,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12192,7 +12192,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "memchr",
@@ -12217,7 +12217,7 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "arcstr",
  "clap",
@@ -12278,7 +12278,7 @@ dependencies = [
 [[package]]
 name = "uv-scripts"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12303,7 +12303,7 @@ dependencies = [
 [[package]]
 name = "uv-settings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "clap",
  "fs-err",
@@ -12338,11 +12338,10 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "fs-err",
- "home",
  "nix 0.30.1",
  "same-file",
  "tracing",
@@ -12355,7 +12354,7 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12366,7 +12365,7 @@ dependencies = [
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12376,7 +12375,7 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "uv-macros",
 ]
@@ -12384,7 +12383,7 @@ dependencies = [
 [[package]]
 name = "uv-torch"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "clap",
  "either",
@@ -12405,7 +12404,7 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "fs-err",
  "thiserror 2.0.18",
@@ -12416,7 +12415,7 @@ dependencies = [
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12438,13 +12437,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.9.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 
 [[package]]
 name = "uv-virtualenv"
 version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "console",
  "fs-err",
@@ -12467,7 +12466,7 @@ dependencies = [
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12477,7 +12476,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.6#26522446555ec612d0d365a650c031ed4d601f43"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tl"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90933ffb0f97e2fc2e0de21da9d3f20597b804012d199843a6fe7c2810d28f3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10697,11 +10706,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tl"
-version = "0.7.8"
-source = "git+https://github.com/astral-sh/tl.git?rev=6e25b2ee2513d75385101a8ff9f591ef51f314ec#6e25b2ee2513d75385101a8ff9f591ef51f314ec"
-
-[[package]]
 name = "tls_codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11300,7 +11304,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11340,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "uv-build-backend"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -11377,7 +11381,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11414,7 +11418,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11439,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11455,7 +11459,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "hex",
  "memchr",
@@ -11468,9 +11472,10 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
+ "astral-tl",
  "async-trait",
  "async_http_range_reader 0.9.1",
  "async_zip",
@@ -11493,7 +11498,6 @@ dependencies = [
  "serde_json",
  "sys-info",
  "thiserror 2.0.18",
- "tl",
  "tokio",
  "tokio-util 0.7.18",
  "tracing",
@@ -11523,7 +11527,7 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "clap",
  "either",
@@ -11552,7 +11556,7 @@ dependencies = [
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "console",
 ]
@@ -11560,7 +11564,7 @@ dependencies = [
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11571,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "futures",
@@ -11604,7 +11608,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "either",
@@ -11651,7 +11655,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11668,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "arcstr",
  "bitflags 2.11.0",
@@ -11708,7 +11712,7 @@ dependencies = [
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "async-compression",
@@ -11739,7 +11743,7 @@ dependencies = [
 [[package]]
 name = "uv-flags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -11747,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "backon",
  "dunce",
@@ -11770,7 +11774,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -11795,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11807,7 +11811,7 @@ dependencies = [
 [[package]]
 name = "uv-globfilter"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11821,7 +11825,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "clap",
  "configparser",
@@ -11859,7 +11863,7 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -11901,7 +11905,7 @@ dependencies = [
 [[package]]
 name = "uv-keyring"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11916,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11927,7 +11931,7 @@ dependencies = [
 [[package]]
 name = "uv-metadata"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "async_zip",
  "fs-err",
@@ -11945,7 +11949,7 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -11956,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "dashmap",
  "futures",
@@ -11966,7 +11970,7 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "serde",
 ]
@@ -11974,7 +11978,7 @@ dependencies = [
 [[package]]
 name = "uv-pep440"
 version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "rkyv",
  "serde",
@@ -11988,7 +11992,7 @@ dependencies = [
 [[package]]
 name = "uv-pep508"
 version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "arcstr",
  "boxcar",
@@ -12014,7 +12018,7 @@ dependencies = [
 [[package]]
 name = "uv-platform"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12031,7 +12035,7 @@ dependencies = [
 [[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12044,7 +12048,7 @@ dependencies = [
 [[package]]
 name = "uv-preview"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -12054,7 +12058,7 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12085,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "clap",
@@ -12144,18 +12148,19 @@ dependencies = [
 [[package]]
 name = "uv-redacted"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
  "serde",
+ "thiserror 2.0.18",
  "url",
 ]
 
 [[package]]
 name = "uv-requirements"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12191,7 +12196,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
  "memchr",
@@ -12216,7 +12221,7 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "arcstr",
  "clap",
@@ -12277,7 +12282,7 @@ dependencies = [
 [[package]]
 name = "uv-scripts"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12302,7 +12307,7 @@ dependencies = [
 [[package]]
 name = "uv-settings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "clap",
  "fs-err",
@@ -12337,7 +12342,7 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12353,7 +12358,7 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12364,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12374,7 +12379,7 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "uv-macros",
 ]
@@ -12382,7 +12387,7 @@ dependencies = [
 [[package]]
 name = "uv-torch"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "clap",
  "either",
@@ -12403,18 +12408,20 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "fs-err",
+ "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
+ "windows 0.59.0",
  "zip 2.4.2",
 ]
 
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12436,13 +12443,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+version = "0.9.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 
 [[package]]
 name = "uv-virtualenv"
 version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "console",
  "fs-err",
@@ -12465,7 +12472,7 @@ dependencies = [
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12475,7 +12482,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.9#4fac4cb7ed8679debac7e495824367bf9abfeea8"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,16 +2952,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs4"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10228,6 +10218,15 @@ dependencies = [
 
 [[package]]
 name = "spdx"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cf87c0efffc158b9dde4d6e0567a43e4383adc4c949e687a2039732db2f23a"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "spdx"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
@@ -11301,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11341,7 +11340,7 @@ dependencies = [
 [[package]]
 name = "uv-build-backend"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -11353,7 +11352,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "sha2 0.10.9",
- "spdx 0.10.9",
+ "spdx 0.12.0",
  "tar",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
@@ -11378,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11415,7 +11414,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11440,7 +11439,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11449,13 +11448,14 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "uv-fs",
  "walkdir",
 ]
 
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "hex",
  "memchr",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11523,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "clap",
  "either",
@@ -11552,7 +11552,7 @@ dependencies = [
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "console",
 ]
@@ -11560,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11571,7 +11571,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "futures",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "either",
@@ -11651,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11668,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "arcstr",
  "bitflags 2.11.0",
@@ -11708,7 +11708,7 @@ dependencies = [
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "async-compression",
@@ -11739,7 +11739,7 @@ dependencies = [
 [[package]]
 name = "uv-flags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -11747,14 +11747,13 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "backon",
  "dunce",
  "either",
  "encoding_rs_io",
  "fs-err",
- "fs2",
  "junction",
  "path-slash",
  "percent-encoding",
@@ -11771,7 +11770,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "cargo-util",
@@ -11796,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11808,7 +11807,7 @@ dependencies = [
 [[package]]
 name = "uv-globfilter"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11822,7 +11821,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "clap",
  "configparser",
@@ -11860,7 +11859,7 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -11902,7 +11901,7 @@ dependencies = [
 [[package]]
 name = "uv-keyring"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11917,7 +11916,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11928,7 +11927,7 @@ dependencies = [
 [[package]]
 name = "uv-metadata"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "async_zip",
  "fs-err",
@@ -11946,7 +11945,7 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -11957,7 +11956,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "dashmap",
  "futures",
@@ -11967,7 +11966,7 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "serde",
 ]
@@ -11975,7 +11974,7 @@ dependencies = [
 [[package]]
 name = "uv-pep440"
 version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "rkyv",
  "serde",
@@ -11989,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "uv-pep508"
 version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "arcstr",
  "boxcar",
@@ -12015,7 +12014,7 @@ dependencies = [
 [[package]]
 name = "uv-platform"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12032,7 +12031,7 @@ dependencies = [
 [[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12045,7 +12044,7 @@ dependencies = [
 [[package]]
 name = "uv-preview"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "bitflags 2.11.0",
  "thiserror 2.0.18",
@@ -12055,7 +12054,7 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12086,7 +12085,7 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "clap",
@@ -12145,7 +12144,7 @@ dependencies = [
 [[package]]
 name = "uv-redacted"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12156,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12192,7 +12191,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "memchr",
@@ -12217,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "arcstr",
  "clap",
@@ -12278,7 +12277,7 @@ dependencies = [
 [[package]]
 name = "uv-scripts"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12303,7 +12302,7 @@ dependencies = [
 [[package]]
 name = "uv-settings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "clap",
  "fs-err",
@@ -12338,7 +12337,7 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12354,7 +12353,7 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12365,7 +12364,7 @@ dependencies = [
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12375,7 +12374,7 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "uv-macros",
 ]
@@ -12383,7 +12382,7 @@ dependencies = [
 [[package]]
 name = "uv-torch"
 version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "clap",
  "either",
@@ -12404,7 +12403,7 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "fs-err",
  "thiserror 2.0.18",
@@ -12415,7 +12414,7 @@ dependencies = [
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12437,13 +12436,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+version = "0.9.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 
 [[package]]
 name = "uv-virtualenv"
 version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "console",
  "fs-err",
@@ -12466,7 +12465,7 @@ dependencies = [
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12476,7 +12475,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.7#0adb444806e8bcea7e7a5e9ae90d1288778a0b54"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.8#85c5d32284522eb958d9cfc10ff62f0956eab113"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,35 +182,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,35 +182,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.6" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,35 +182,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.7" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,35 +182,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.8" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.9" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -749,6 +749,7 @@ pub async fn resolve_pypi(
             requirements,
             constraints,
             overrides,
+            uv_configuration::Excludes::default(),
             Preferences::from_iter(preferences, &resolver_env),
             None,
             Default::default(),

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -387,7 +387,8 @@ pub async fn resolve_pypi(
                 let uv_reference = into_uv_git_reference(pixi_git_ref);
                 let uv_sha = into_uv_git_sha(pinned_git_spec.source.commit);
 
-                let display_safe_url = pinned_git_spec.git.clone().into();
+                let display_safe_url =
+                    uv_redacted::DisplaySafeUrl::from_url(pinned_git_spec.git.clone());
 
                 let repository_url = RepositoryUrl::new(&display_safe_url);
                 let reference = RepositoryReference {

--- a/crates/pixi_core/src/lock_file/resolve/resolver_provider.rs
+++ b/crates/pixi_core/src/lock_file/resolve/resolver_provider.rs
@@ -66,7 +66,7 @@ impl<Context: BuildContext> ResolverProvider for CondaResolverProvider<'_, Conte
                 upload_time_utc_ms: None,
                 url: match repodata_record {
                     PixiRecord::Binary(repodata_record) => FileLocation::AbsoluteUrl(
-                        UrlString::from(DisplaySafeUrl::from(repodata_record.url.clone())),
+                        UrlString::from(DisplaySafeUrl::from_url(repodata_record.url.clone())),
                     ),
                     PixiRecord::Source(_source) => {
                         // TODO(baszalmstra): Does this matter??
@@ -83,7 +83,7 @@ impl<Context: BuildContext> ResolverProvider for CondaResolverProvider<'_, Conte
                 version: version.parse().expect("could not convert to pypi version"),
                 file: Box::new(file),
                 index: IndexUrl::Pypi(Arc::new(uv_pep508::VerbatimUrl::from_url(
-                    DisplaySafeUrl::from(consts::DEFAULT_PYPI_INDEX_URL.clone()),
+                    DisplaySafeUrl::from_url(consts::DEFAULT_PYPI_INDEX_URL.clone()),
                 ))),
                 wheels: vec![],
                 ext: SourceDistExtension::TarGz,

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -5,6 +5,7 @@ use std::{
     str::FromStr,
     sync::{Arc, LazyLock},
 };
+use uv_redacted::DisplaySafeUrl;
 
 use dashmap::DashMap;
 use indexmap::IndexMap;
@@ -211,7 +212,7 @@ pub(crate) fn pypi_satisfies_requirement(
                     .and_then(|str| Url::parse(str).ok())
                     .unwrap_or(locked_url.clone());
 
-                if *spec_url.raw() == locked_url.clone().into() {
+                if *spec_url.raw() == DisplaySafeUrl::from_url(locked_url.clone()) {
                     return Ok(());
                 } else {
                     return Err(PlatformUnsat::LockedPyPIDirectUrlMismatch {
@@ -798,6 +799,7 @@ mod tests {
     use rattler_lock::{PypiPackageData, UrlOrPath, Verbatim};
     use url::Url;
     use uv_distribution_types::RequirementSource;
+    use uv_redacted::DisplaySafeUrl;
 
     use super::super::PypiNoBuildCheck;
     use super::super::platform::RequirementOrigin;
@@ -1244,7 +1246,7 @@ mod tests {
 
         let index =
             uv_distribution_types::IndexMetadata::from(uv_distribution_types::IndexUrl::from(
-                uv_pep508::VerbatimUrl::from_url(Url::parse(index_url).unwrap().into()),
+                uv_pep508::VerbatimUrl::from_url(DisplaySafeUrl::parse(index_url).unwrap()),
             ));
         uv_distribution_types::Requirement {
             name: UvPackageName::from_str(name).unwrap(),

--- a/crates/pixi_install_pypi/src/conversions.rs
+++ b/crates/pixi_install_pypi/src/conversions.rs
@@ -37,7 +37,7 @@ pub fn locked_data_to_file(
     requires_python: Option<pep440_rs::VersionSpecifiers>,
 ) -> Result<uv_distribution_types::File, ConversionError> {
     let url = uv_distribution_types::FileLocation::AbsoluteUrl(UrlString::from(
-        uv_redacted::DisplaySafeUrl::from(url.clone()),
+        uv_redacted::DisplaySafeUrl::from_url(url.clone()),
     ));
 
     // Convert PackageHashes to uv hashes
@@ -133,7 +133,7 @@ pub fn convert_to_dist(
                 Dist::from_url(
                     pkg_name,
                     VerbatimParsedUrl {
-                        parsed_url: ParsedUrl::try_from(uv_redacted::DisplaySafeUrl::from(
+                        parsed_url: ParsedUrl::try_from(uv_redacted::DisplaySafeUrl::from_url(
                             url_without_direct.clone().into_owned(),
                         ))
                         .map_err(Box::new)?,

--- a/crates/pixi_install_pypi/src/plan/test/harness.rs
+++ b/crates/pixi_install_pypi/src/plan/test/harness.rs
@@ -68,7 +68,7 @@ impl InstalledDistBuilder {
             name,
             version,
             direct_url: Box::new(direct_url.clone()),
-            url: directory_url.into(),
+            url: DisplaySafeUrl::from_url(directory_url),
             editable,
             path: install_path.into(),
             cache_info: None,
@@ -104,7 +104,7 @@ impl InstalledDistBuilder {
             name,
             version,
             direct_url: Box::new(direct_url.clone()),
-            url: url.into(),
+            url: DisplaySafeUrl::from_url(url),
             editable: false,
             path: install_path.into(),
             cache_info: None,
@@ -132,7 +132,7 @@ impl InstalledDistBuilder {
         let url = git_url.without_git_prefix().clone();
 
         // Parse git url and extract git commit, use this as the commit_id
-        let parsed_git_url = ParsedGitUrl::try_from(DisplaySafeUrl::from(url.clone()))
+        let parsed_git_url = ParsedGitUrl::try_from(DisplaySafeUrl::from_url(url.clone()))
             .expect("should parse git url");
 
         let direct_url = VcsUrl {
@@ -153,7 +153,7 @@ impl InstalledDistBuilder {
             name,
             version,
             direct_url: Box::new(direct_url.clone()),
-            url: url.into(),
+            url: DisplaySafeUrl::from_url(url),
             path: install_path.into(),
             editable: false,
             cache_info: None,

--- a/crates/pixi_install_pypi/src/plan/validation.rs
+++ b/crates/pixi_install_pypi/src/plan/validation.rs
@@ -220,7 +220,7 @@ pub(crate) fn need_reinstall(
                     // Check if the installed git url is the same as the locked git url
                     // if this fails, it should be an error, because then installed url is not a git url
                     let installed_git_url = ParsedGitUrl::try_from(
-                        uv_redacted::DisplaySafeUrl::from(Url::parse(url.as_str())?),
+                        uv_redacted::DisplaySafeUrl::from_url(Url::parse(url.as_str())?),
                     )?;
 
                     // Try to parse the locked git url, this can be any url, so this may fail
@@ -235,7 +235,7 @@ pub(crate) fn need_reinstall(
                                     .map_err(|e| NeedsReinstallError::PixiGitUrl(e.to_string()))
                             } else {
                                 // it is not a git url, so we fallback to use the url as is
-                                ParsedGitUrl::try_from(uv_redacted::DisplaySafeUrl::from(
+                                ParsedGitUrl::try_from(uv_redacted::DisplaySafeUrl::from_url(
                                     url.clone(),
                                 ))
                                 .map_err(|e: uv_pypi_types::ParsedUrlError| e.into())

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use crate::GitUrlWithPrefix;
+use crate::git_url::decode_windows_drive_letter;
 use miette::IntoDiagnostic;
 use pep440_rs::VersionSpecifiers;
 use pixi_git::{git::GitReference as PixiGitReference, sha::GitSha as PixiGitSha};
@@ -79,7 +80,7 @@ pub fn pypi_options_to_index_locations(
     let index = options
         .index_url
         .clone()
-        .map(DisplaySafeUrl::from)
+        .map(DisplaySafeUrl::from_url)
         .map(VerbatimUrl::from_url)
         .map(IndexUrl::from)
         .map(Index::from_index_url)
@@ -92,7 +93,7 @@ pub fn pypi_options_to_index_locations(
         .into_iter()
         .flat_map(|urls| {
             urls.into_iter()
-                .map(DisplaySafeUrl::from)
+                .map(DisplaySafeUrl::from_url)
                 .map(VerbatimUrl::from_url)
                 .map(IndexUrl::from)
                 .map(Index::from_extra_index_url)
@@ -105,7 +106,9 @@ pub fn pypi_options_to_index_locations(
             .map(|url| match url {
                 FindLinksUrlOrPath::Path(relative) => VerbatimUrl::from_path(&relative, base_path)
                     .map_err(|e| ConvertFlatIndexLocationError::VerbatimUrlError(e, relative)),
-                FindLinksUrlOrPath::Url(url) => Ok(VerbatimUrl::from_url(url.clone().into())),
+                FindLinksUrlOrPath::Url(url) => {
+                    Ok(VerbatimUrl::from_url(DisplaySafeUrl::from_url(url.clone())))
+                }
             })
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
@@ -141,7 +144,7 @@ pub fn locked_indexes_to_index_locations(
         .indexes
         .first()
         .cloned()
-        .map(DisplaySafeUrl::from)
+        .map(DisplaySafeUrl::from_url)
         .map(VerbatimUrl::from_url)
         .map(IndexUrl::from)
         .map(Index::from_index_url)
@@ -151,7 +154,7 @@ pub fn locked_indexes_to_index_locations(
         .iter()
         .skip(1)
         .cloned()
-        .map(DisplaySafeUrl::from)
+        .map(DisplaySafeUrl::from_url)
         .map(VerbatimUrl::from_url)
         .map(IndexUrl::from)
         .map(Index::from_extra_index_url);
@@ -165,7 +168,7 @@ pub fn locked_indexes_to_index_locations(
                 })
             }
             rattler_lock::FindLinksUrlOrPath::Url(url) => {
-                Ok(VerbatimUrl::from_url(url.clone().into()))
+                Ok(VerbatimUrl::from_url(DisplaySafeUrl::from_url(url.clone())))
             }
         })
         .collect::<Result<Vec<_>, _>>()?
@@ -334,7 +337,11 @@ pub fn into_pinned_git_spec(
         reference,
     );
 
-    PinnedGitSpec::new(dist.git.repository().clone().into(), pinned_checkout)
+    // uv stores the percent-encoded drive-letter form internally (see
+    // `encode_windows_drive_letter`). Decode it back here so the lock file
+    // shows `file:///D:/...` rather than `file:///D%3A/...`.
+    let repository: url::Url = dist.git.repository().clone().into();
+    PinnedGitSpec::new(decode_windows_drive_letter(&repository), pinned_checkout)
 }
 
 /// Convert a locked git url into a parsed git url
@@ -707,19 +714,16 @@ pub fn to_exclude_newer(exclude_newer: &ResolvedPypiExcludeNewer) -> uv_resolver
 #[cfg(test)]
 mod tests {
     use super::*;
-    use url::Url;
     use uv_distribution_types::{Index, IndexUrl};
 
     #[test]
     fn test_configure_insecure_hosts_for_tls_bypass_enabled() {
         // Create test index locations
         let index_url = IndexUrl::from(uv_pep508::VerbatimUrl::from_url(
-            Url::parse("https://pypi.org/simple/").unwrap().into(),
+            DisplaySafeUrl::parse("https://pypi.org/simple/").unwrap(),
         ));
         let extra_index_url = IndexUrl::from(uv_pep508::VerbatimUrl::from_url(
-            Url::parse("https://test-index.example.com/simple/")
-                .unwrap()
-                .into(),
+            DisplaySafeUrl::parse("https://test-index.example.com/simple/").unwrap(),
         ));
 
         let indexes = vec![
@@ -748,7 +752,7 @@ mod tests {
     fn test_configure_insecure_hosts_for_tls_bypass_disabled() {
         // Create test index locations
         let index_url = IndexUrl::from(uv_pep508::VerbatimUrl::from_url(
-            Url::parse("https://pypi.org/simple/").unwrap().into(),
+            DisplaySafeUrl::parse("https://pypi.org/simple/").unwrap(),
         ));
         let indexes = vec![Index::from_index_url(index_url)];
         let index_locations = IndexLocations::new(indexes, vec![], false);
@@ -769,7 +773,7 @@ mod tests {
     fn test_configure_insecure_hosts_for_tls_bypass_preserves_existing() {
         // Create test index locations
         let index_url = IndexUrl::from(uv_pep508::VerbatimUrl::from_url(
-            Url::parse("https://pypi.org/simple/").unwrap().into(),
+            DisplaySafeUrl::parse("https://pypi.org/simple/").unwrap(),
         ));
         let indexes = vec![Index::from_index_url(index_url)];
         let index_locations = IndexLocations::new(indexes, vec![], false);
@@ -796,9 +800,7 @@ mod tests {
     fn test_configure_insecure_hosts_for_flat_index_hosts() {
         // Flat index hosted on a custom domain should be added when tls_no_verify is enabled
         let flat_index = Index::from_find_links(IndexUrl::from(uv_pep508::VerbatimUrl::from_url(
-            Url::parse("https://packages.example.org/simple/")
-                .unwrap()
-                .into(),
+            DisplaySafeUrl::parse("https://packages.example.org/simple/").unwrap(),
         )));
         let index_locations = IndexLocations::new(vec![], vec![flat_index], true);
 

--- a/crates/pixi_uv_conversions/src/git_url.rs
+++ b/crates/pixi_uv_conversions/src/git_url.rs
@@ -3,6 +3,56 @@ use url::Url;
 use uv_pep508::VerbatimUrl;
 use uv_redacted::DisplaySafeUrl;
 
+/// Percent-encode the colon after a Windows drive letter in a `file://` URL,
+/// e.g. `file:///C:/path/@<sha>` -> `file:///C%3A/path/@<sha>`, so uv's
+/// `DisplaySafeUrl::parse` does not reject it as ambiguous credentials.
+fn encode_windows_drive_letter(url: &Url) -> Url {
+    if url.scheme() != "file" {
+        return url.clone();
+    }
+    let s = url.as_str();
+    let Some(rest) = s.strip_prefix("file:///") else {
+        return url.clone();
+    };
+    let bytes = rest.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        let letter = bytes[0] as char;
+        let after = &rest[2..];
+        if let Ok(rewritten) = Url::parse(&format!("file:///{letter}%3A{after}")) {
+            return rewritten;
+        }
+    }
+    url.clone()
+}
+
+/// Reverse of `encode_windows_drive_letter`: decode the drive-letter
+/// `%3A` back to `:` so URLs handed back to user-visible surfaces (lock
+/// files, diagnostics) match what was originally on disk. The encoded
+/// form is an internal workaround for uv's parser; it should not leak.
+pub fn decode_windows_drive_letter(url: &Url) -> Url {
+    if url.scheme() != "file" {
+        return url.clone();
+    }
+    let s = url.as_str();
+    let Some(rest) = s.strip_prefix("file:///") else {
+        return url.clone();
+    };
+    let bytes = rest.as_bytes();
+    if bytes.len() >= 4
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b'%'
+        && bytes[2] == b'3'
+        && (bytes[3] == b'A' || bytes[3] == b'a')
+    {
+        let letter = bytes[0] as char;
+        let after = &rest[4..];
+        if let Ok(rewritten) = Url::parse(&format!("file:///{letter}:{after}")) {
+            return rewritten;
+        }
+    }
+    url.clone()
+}
+
 /// A URL that may have a git+ prefix, with methods to handle both representations
 #[derive(Debug, Clone, PartialEq)]
 pub struct GitUrlWithPrefix {
@@ -66,12 +116,18 @@ impl GitUrlWithPrefix {
 
     /// Convert to DisplaySafeUrl without git+ prefix
     pub fn to_display_safe_url(&self) -> DisplaySafeUrl {
-        self.base_url.clone().into()
+        DisplaySafeUrl::from_url(encode_windows_drive_letter(&self.base_url))
     }
 
     /// Convert to VerbatimUrl (preserving git+ prefix)
-    pub fn to_verbatim_url(&self) -> Result<VerbatimUrl, url::ParseError> {
-        let display_safe_url = DisplaySafeUrl::parse(&self.with_git_prefix())?;
+    pub fn to_verbatim_url(&self) -> Result<VerbatimUrl, uv_redacted::DisplaySafeUrlError> {
+        let encoded = encode_windows_drive_letter(&self.base_url);
+        let with_prefix = if self.has_git_plus {
+            format!("git+{encoded}")
+        } else {
+            encoded.to_string()
+        };
+        let display_safe_url = DisplaySafeUrl::parse(&with_prefix)?;
         Ok(VerbatimUrl::from_url(display_safe_url))
     }
 

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -101,7 +101,7 @@ pub fn as_uv_req(
             specifier: manifest_version_to_version_specifiers(version)?,
             index: index.clone().map(|url| {
                 uv_distribution_types::IndexMetadata::from(uv_distribution_types::IndexUrl::from(
-                    VerbatimUrl::from_url(url.into()),
+                    VerbatimUrl::from_url(DisplaySafeUrl::from_url(url)),
                 ))
             }),
             conflict: None,
@@ -152,7 +152,7 @@ pub fn as_uv_req(
                         url: git.to_string(),
                     })?;
 
-                    VerbatimUrl::from_url(created_url.into())
+                    VerbatimUrl::from_url(DisplaySafeUrl::from_url(created_url))
                 },
             }
         }
@@ -202,7 +202,7 @@ pub fn as_uv_req(
             // So that we can normalize the URL for comparison.
             let mut location_url = url.clone();
             location_url.set_fragment(None);
-            let verbatim_url = VerbatimUrl::from_url(url.clone().into());
+            let verbatim_url = VerbatimUrl::from_url(DisplaySafeUrl::from_url(url.clone()));
 
             RequirementSource::Url {
                 subdirectory: if subdirectory.is_empty() {
@@ -210,7 +210,7 @@ pub fn as_uv_req(
                 } else {
                     Some(subdirectory.as_path().to_path_buf().into_boxed_path())
                 },
-                location: location_url.into(),
+                location: DisplaySafeUrl::from_url(location_url),
                 url: verbatim_url,
                 ext: DistExtension::from_path(url.path())?,
             }
@@ -255,7 +255,7 @@ pub fn pep508_requirement_to_uv_requirement(
                             Ok(ext) => ParsedUrl::Path(ParsedPathUrl::from_source(
                                 PathBuf::from(path.as_str()).into_boxed_path(),
                                 ext,
-                                verbatim_url.to_url().into(),
+                                DisplaySafeUrl::from_url(verbatim_url.to_url()),
                             )),
                             Err(_) => {
                                 // If no extension, treat as a directory
@@ -263,24 +263,24 @@ pub fn pep508_requirement_to_uv_requirement(
                                     PathBuf::from(path.as_str()).into_boxed_path(),
                                     Some(false), // Set editable to false, might require post-processing on the result
                                     Some(false), // we do not support virtual packages yet
-                                    DisplaySafeUrl::from(verbatim_url.to_url()),
+                                    DisplaySafeUrl::from_url(verbatim_url.to_url()),
                                 ))
                             }
                         };
 
                         VerbatimParsedUrl {
                             parsed_url,
-                            verbatim: uv_pep508::VerbatimUrl::from_url(
-                                verbatim_url.raw().clone().into(),
-                            )
+                            verbatim: uv_pep508::VerbatimUrl::from_url(DisplaySafeUrl::from_url(
+                                verbatim_url.raw().clone(),
+                            ))
                             .with_given(verbatim_url.given().expect("should have given string")),
                         }
                     }
                     // It is a URL
                     UrlOrPath::Url(u) => VerbatimParsedUrl {
-                        parsed_url: ParsedUrl::try_from(DisplaySafeUrl::from(u.clone()))
+                        parsed_url: ParsedUrl::try_from(DisplaySafeUrl::from_url(u.clone()))
                             .expect("cannot convert to url"),
-                        verbatim: uv_pep508::VerbatimUrl::from_url(u.into()),
+                        verbatim: uv_pep508::VerbatimUrl::from_url(DisplaySafeUrl::from_url(u)),
                     },
                 };
 


### PR DESCRIPTION
﻿Bumps `uv-*` git tag deps from `0.9.5` to `0.9.9`. Each tag is a separate commit so review can step through them.

Stops at 0.9.9 because uv `0.9.10` switched its `reqwest-middleware` workspace dep from a git source to the crates.io rename `astral-reqwest-middleware`. Cargo treats them as different packages even though the published code is identical, so any downstream that combines `rattler_networking`'s middleware impls with uv's middleware stack hits a `Middleware` trait identity mismatch. Unblocking 0.9.10+ needs:

- conda/rattler#2413 (adds `astral-reqwest-middleware` feature, propagated to all consumers).
- A follow-up PR on `prefix-dev/rattler-build` with the same feature pattern (`rattler_build_networking`, `rattler_build_core`, `rattler_build_source_cache`) plus an API-compat update to whatever rattler version that PR ends up on.

Both are tracked separately. Once they ship, a second PR will continue the bump from 0.9.10 to the latest tag.

## Per-tag notes

### 0.9.6
No code changes. `cargo build`, `cargo nextest run --features slow_integration_tests,online_tests`, `pytest -m 'not extra_slow' -k 'not test_extra_args'`, `cargo clippy`, `cargo fmt --check` all green.

### 0.9.7
No code changes. Same gate. `cargo nextest --retries=4` adopted from here onward to absorb transient network resets to download.pytorch.org and raw.githubusercontent.com on the conda-forge / pytorch / ROS test paths.

### 0.9.8
API change: `uv_resolver::Manifest::new` gained a new `excludes: Excludes` parameter at position 4 (between `overrides` and `preferences`). Updated the call site in `crates/pixi_core/src/lock_file/resolve/pypi.rs` to pass `uv_configuration::Excludes::default()` (note: `Excludes` is in `uv-configuration`, not `uv-resolver`).

`Excludes` backs uv's new `[tool.uv].exclude-dependencies` field. Pixi has no analogous knob today (`pypi-exclude-newer` is date-based). Plumbing it through pixi's manifest is a feature decision out of scope here; default-empty preserves existing behaviour.

### 0.9.9
Two API changes:

- `impl From<url::Url> for DisplaySafeUrl` was removed in `uv-redacted`. Replaced 13 `DisplaySafeUrl::from(url)` / `url.into()` call sites across `pixi_uv_conversions`, `pixi_core`, and `pixi_install_pypi` with explicit `DisplaySafeUrl::from_url(url)`. Also bumped `git_url::to_verbatim_url`'s error type from `url::ParseError` to `uv_redacted::DisplaySafeUrlError` because `DisplaySafeUrl::parse` now returns the latter.
- `DisplaySafeUrl::parse` rejects URLs whose path contains a `:` followed by `@` as ambiguous credentials. On Windows the drive-letter colon in `file:///C:/path/@<sha>` trips the heuristic, and uv's internal `From<ParsedGitUrl> for DisplaySafeUrl` builds exactly that, so any flow that passes a `git+file://` URL with a revision panicked. Three `update_tests` regressed.

  Fix: added `encode_windows_drive_letter` in `crates/pixi_uv_conversions/src/git_url.rs` and applied it in `to_display_safe_url` and `to_verbatim_url`. It rewrites `file:///<letter>:` to `file:///<letter>%3A` (RFC 3986-compliant; the percent-decoded value is identical) so the heuristic does not see a literal colon. uv 0.11.11 has a partial fix for nested-scheme URLs (astral-sh/uv#17214) but does not cover the drive-letter case.

## Excluded from the gate

`tests/integration_python/pixi_build/test_build.py::test_extra_args` is skipped via `-k 'not test_extra_args'`. It fails on `main@upstream` with uv 0.9.5 (no bump applied) so it is not a regression. Root cause: meson's `_setup_vsenv` does `pathlib.Path(root, ...)` where `root` is `os.environ.get("ProgramFiles(x86)") or os.environ.get("ProgramFiles")`. On this dev machine those vars are not propagated through rattler-build's spawned conda build script, so meson hits a `TypeError` before any user code runs. CI passes because GitHub `windows-latest` runners have VS installed system-wide. Out of scope for this PR; worth filing an env-propagation bug on rattler-build.

## Test plan

For each tag, on Windows:
- [x] `cargo build --workspace --all-targets`
- [x] `cargo nextest run --workspace --all-targets --features slow_integration_tests,online_tests --retries=4 --no-fail-fast`
- [x] `pytest --numprocesses=logical --dist loadgroup -m 'not extra_slow' -k 'not test_extra_args' --reruns=2`
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`

