### PR TITLE
chore(publish): Remove unused arguments from pixi publish

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -633,7 +633,6 @@ async fn test_publish_fails_before_build_or_upload_when_one_variant_is_unsatisfi
     let err = publish::execute(publish::Args {
         backend_override: Some(BackendOverride::from_memory(instantiator)),
         config_cli: Default::default(),
-        lock_and_install_config: Default::default(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_dir: None,
@@ -2452,7 +2451,6 @@ async fn test_publish_without_target_builds_but_does_not_upload() {
     publish::execute(publish::Args {
         backend_override: Some(BackendOverride::from_memory(instantiator)),
         config_cli: Default::default(),
-        lock_and_install_config: Default::default(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_dir: None,
@@ -2515,7 +2513,6 @@ backend.version = "0.1.0"
     let _ = publish::execute(publish::Args {
         backend_override: None,
         config_cli: Default::default(),
-        lock_and_install_config: Default::default(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_dir: None,

--- a/crates/pixi_cli/src/build.rs
+++ b/crates/pixi_cli/src/build.rs
@@ -92,7 +92,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     publish::execute(publish::Args {
         config_cli: args.config_cli,
         backend_override: args.backend_override,
-        lock_and_install_config: args.lock_and_install_config,
         target_platform: args.target_platform,
         build_platform: args.build_platform,
         build_dir: args.build_dir,

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -35,8 +35,6 @@ use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_networking::AuthenticationStorage;
 use rattler_package_streaming::seek::read_package_file;
 
-use crate::cli_config::LockAndInstallConfig;
-
 /// Build a conda package and publish it to a channel.
 ///
 /// This is a convenience command that combines `pixi build` and `pixi upload`.
@@ -58,9 +56,6 @@ pub struct Args {
     /// Backend override for testing purposes.
     #[clap(skip)]
     pub backend_override: Option<BackendOverride>,
-
-    #[clap(flatten)]
-    pub lock_and_install_config: LockAndInstallConfig,
 
     /// The target platform to build for (defaults to the current platform)
     #[clap(long, short, default_value_t = Platform::current())]

--- a/docs/reference/cli/pixi/publish.md
+++ b/docs/reference/cli/pixi/publish.md
@@ -71,19 +71,6 @@ pixi publish [OPTIONS]
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)
 
-## Update Options
-- <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
-:  Don't modify the environment, only modify the lock-file
-<br>**env**: `PIXI_NO_INSTALL`
-- <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
-:  Install the environment as defined in the lockfile, doesn't update lockfile if it isn't up-to-date with the manifest file
-<br>**env**: `PIXI_FROZEN`
-- <a id="arg---locked" href="#arg---locked">`--locked`</a>
-:  Check if lockfile is up-to-date before installing the environment, aborts when lockfile isn't up-to-date with the manifest file
-<br>**env**: `PIXI_LOCKED`
-- <a id="arg---as-is" href="#arg---as-is">`--as-is`</a>
-:  Shorthand for the combination of --no-install and --frozen
-
 ## Description
 Build a conda package and publish it to a channel.
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1467,8 +1467,6 @@ dependencies:
                     "publish",
                     "--path",
                     manifest_path,
-                    "--frozen",
-                    "--no-install",
                     "--target-channel",
                     "https://prefix.dev/test-channel",
                 ],


### PR DESCRIPTION
### Description

Remove unused --locked, --frozen, --no-install and --as-is command line arguments. They were not used anywhere.

### How Has This Been Tested?

By running the existing tests

### AI Disclosure

No AI was harmed in this PR

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
