### PR TITLE
fix(test): use `--target-dir` for integration test

### DIFF
--- a/tests/integration_python/test_build.py
+++ b/tests/integration_python/test_build.py
@@ -31,9 +31,16 @@ def test_workspace_variants_separate_work_directories(
     # Copy to workspace
     shutil.copytree(workspace_variants_project, tmp_pixi_workspace, dirs_exist_ok=True)
 
-    # TODO: Needs to publish to a local directory instead to be fully compatible with pixi build
+    # Build all variants and copy them into the workspace directory (no channel indexing).
     verify_cli_command(
-        [pixi, "publish", "--path", tmp_pixi_workspace, f"channel://{tmp_pixi_workspace}"],
+        [
+            pixi,
+            "publish",
+            "--path",
+            tmp_pixi_workspace,
+            "--target-dir",
+            str(tmp_pixi_workspace),
+        ],
     )
 
     # Check that the package's bld root exists.


### PR DESCRIPTION
### Description

This PR fixes the failing integration test on main. The test was migrated from `pixi build --output-dir` to `pixi publish ... channel://<path>` after `pixi build` was merged into `pixi publish`, but the URL was passed as a positional argument that clap rejects, and `channel://` is not a supported scheme. Switch the test to `pixi publish --target-dir <dir>`, which copies the built artifacts into the directory without creating a channel structure, the original intent of the test.

### How Has This Been Tested?

CI