### PR TITLE
feat: support `build-string-prefix` and `build-number` in `[package-build]`

### DIFF
--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -214,8 +214,8 @@ pub fn to_project_model_v1(
 ) -> Result<pbt::ProjectModel, SpecConversionError> {
     let project = pbt::ProjectModel {
         name: manifest.package.name.clone(),
-        build_string_prefix: None,
-        build_number: None,
+        build_string_prefix: manifest.build.build_string_prefix.clone(),
+        build_number: manifest.build.build_number,
         version: manifest.package.version.clone(),
         description: manifest.package.description.clone(),
         authors: manifest.package.authors.clone(),

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -32,6 +32,12 @@ pub struct PackageBuild {
 
     /// Target-specific configuration for different platforms
     pub target_config: Option<IndexMap<TargetSelector, serde_value::Value>>,
+
+    /// An optional prefix to prepend to the auto-generated build string.
+    pub build_string_prefix: Option<String>,
+
+    /// The build number configured by the user.
+    pub build_number: Option<u64>,
 }
 
 impl PackageBuild {
@@ -44,6 +50,8 @@ impl PackageBuild {
             source: None,
             config: None,
             target_config: None,
+            build_string_prefix: None,
+            build_number: None,
         }
     }
 }

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -25,6 +25,9 @@ pub struct TomlPackageBuild {
     pub configuration: Option<serde_value::Value>,
     pub target: IndexMap<PixiSpanned<TargetSelector>, TomlPackageBuildTarget>,
     pub warnings: Vec<crate::Warning>,
+
+    pub build_string_prefix: Option<String>,
+    pub build_number: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -101,6 +104,8 @@ impl TomlPackageBuild {
                 } else {
                     Some(target_config)
                 },
+                build_string_prefix: self.build_string_prefix,
+                build_number: self.build_number,
             },
             warnings: self.warnings,
         })
@@ -218,6 +223,9 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
             .map(TomlWith::into_inner)
             .unwrap_or_default();
 
+        let build_string_prefix = th.optional("build-string-prefix");
+        let build_number = th.optional("build-number");
+
         th.finalize(None)?;
 
         // Issue a warning if both legacy channels and backend.channels are present
@@ -268,6 +276,8 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
             configuration,
             target,
             warnings,
+            build_string_prefix,
+            build_number,
         })
     }
 }
@@ -496,5 +506,23 @@ mod test {
                 .additional_dependencies
                 .contains_key(&"git".parse::<rattler_conda_types::PackageName>().unwrap())
         );
+    }
+
+    #[test]
+    fn test_build_string_prefix_and_build_number() {
+        let toml = r#"
+            backend = { name = "foobar", version = "*" }
+            build-string-prefix = "myprefix"
+            build-number = 42
+        "#;
+        let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
+            .and_then(TomlPackageBuild::into_build_system)
+            .expect("parsing should succeed");
+
+        assert_eq!(
+            parsed.value.build_string_prefix.as_deref(),
+            Some("myprefix")
+        );
+        assert_eq!(parsed.value.build_number, Some(42));
     }
 }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__additional_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__additional_keys.snap
@@ -1,9 +1,8 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
 expression: "expect_parse_failure(r#\"\n            backend = { name = \"foobar\", version = \"*\" }\n            additional = \"key\"\n        \"#)"
-snapshot_kind: text
 ---
-  × Unexpected keys, expected only 'backend', 'channels', 'additional-dependencies', 'source', 'config', 'target'
+  × Unexpected keys, expected only 'backend', 'channels', 'additional-dependencies', 'source', 'config', 'target', 'build-string-prefix', 'build-number'
    ╭─[pixi.toml:3:13]
  2 │             backend = { name = "foobar", version = "*" }
  3 │             additional = "key"

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 313
 expression: parsed.value
 ---
 PackageBuild {
@@ -68,4 +67,6 @@ PackageBuild {
         ),
     ),
     target_config: None,
+    build_string_prefix: None,
+    build_number: None,
 }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 299
 expression: parsed
 ---
 TomlPackageBuild {
@@ -119,4 +118,6 @@ TomlPackageBuild {
             },
         ),
     ],
+    build_string_prefix: None,
+    build_number: None,
 }

--- a/schema/model.py
+++ b/schema/model.py
@@ -900,6 +900,12 @@ class Build(StrictBaseModel):
             },
         ],
     )
+    build_string_prefix: NonEmptyStr | None = Field(
+        None, description="An optional prefix to prepend to the auto-generated build string"
+    )
+    build_number: UnsignedInt | None = Field(
+        None, description="The build number to record in the produced package"
+    )
 
 
 class BuildBackend(MatchspecTable):

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -340,6 +340,18 @@
           "$ref": "#/$defs/BuildBackend",
           "description": "The build backend to instantiate"
         },
+        "build-number": {
+          "title": "Build-Number",
+          "description": "The build number to record in the produced package",
+          "type": "integer",
+          "minimum": 0
+        },
+        "build-string-prefix": {
+          "title": "Build-String-Prefix",
+          "description": "An optional prefix to prepend to the auto-generated build string",
+          "type": "string",
+          "minLength": 1
+        },
         "channels": {
           "title": "Channels",
           "description": "The `conda` channels that are used to fetch the build backend from",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -83,6 +83,18 @@
           "$ref": "#/$defs/BuildBackend",
           "description": "The build backend to instantiate"
         },
+        "build-number": {
+          "title": "Build-Number",
+          "description": "The build number to record in the produced package",
+          "type": "integer",
+          "minimum": 0
+        },
+        "build-string-prefix": {
+          "title": "Build-String-Prefix",
+          "description": "An optional prefix to prepend to the auto-generated build string",
+          "type": "string",
+          "minLength": 1
+        },
         "channels": {
           "title": "Channels",
           "description": "The `conda` channels that are used to fetch the build backend from",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -364,6 +364,18 @@
           "$ref": "#/$defs/BuildBackend",
           "description": "The build backend to instantiate"
         },
+        "build-number": {
+          "title": "Build-Number",
+          "description": "The build number to record in the produced package",
+          "type": "integer",
+          "minimum": 0
+        },
+        "build-string-prefix": {
+          "title": "Build-String-Prefix",
+          "description": "An optional prefix to prepend to the auto-generated build string",
+          "type": "string",
+          "minLength": 1
+        },
         "channels": {
           "title": "Channels",
           "description": "The `conda` channels that are used to fetch the build backend from",


### PR DESCRIPTION
### Description

Add `build-string-prefix` and `build-number` keys to the package build section so the user can override the auto-generated build string and build number from the manifest. The values are wired through `PackageBuild` into the `pbt::ProjectModel` consumed by build backends, exposed in the JSON schema, and covered by a parse test.

Fixes: #3160 

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude


### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
