### PR TITLE
fix: normalize self-ref extras on both sides of compare (#6049)

### DIFF
--- a/crates/pixi/tests/integration_rust/pypi_tests.rs
+++ b/crates/pixi/tests/integration_rust/pypi_tests.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use pep508_rs::Requirement;
+use pixi_core::{UpdateLockFileOptions, environment::LockFileUsage};
 use rattler_conda_types::Platform;
 use tempfile::tempdir;
 use typed_path::Utf8TypedPath;
@@ -2027,6 +2028,78 @@ test-static-pkg = {{ path = ".", editable = true }}
         }
         _ => panic!("expected a pypi package"),
     }
+}
+
+/// Reproducer for https://github.com/prefix-dev/pixi/issues/6049: a
+/// `pixi install --locked` immediately after `pixi install` must not
+/// reject the freshly-written lock over self-referential extras.
+#[tokio::test]
+#[cfg_attr(
+    any(not(feature = "online_tests"), not(feature = "slow_integration_tests")),
+    ignore
+)]
+async fn self_referential_extras_lockfile_roundtrip() {
+    setup_tracing();
+
+    let platform = Platform::current();
+
+    let pyproject = format!(
+        r#"
+[project]
+name = "foo"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest"]
+dev = ["foo[test]"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["src"]
+targets.wheel.packages = ["src/foo"]
+targets.sdist.packages = ["src/foo"]
+
+[tool.pixi.workspace]
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["{platform}"]
+
+[tool.pixi.dependencies]
+python = "~=3.12.0"
+
+[tool.pixi.pypi-dependencies]
+foo = {{ path = ".", editable = true }}
+
+[tool.pixi.environments]
+dev = {{ features = ["dev"] }}
+"#,
+    );
+
+    let pixi = PixiControl::from_pyproject_manifest(&pyproject).unwrap();
+
+    let src_dir = pixi.workspace_path().join("src").join("foo");
+    fs_err::create_dir_all(&src_dir).unwrap();
+    fs_err::write(src_dir.join("__init__.py"), "__version__ = '0.1.0'\n").unwrap();
+
+    // Resolve and write the lockfile, then re-check it under
+    // `LockFileUsage::Locked` (the `--locked` satisfiability path,
+    // skipping the conda-prefix install).
+    pixi.update_lock_file().await.unwrap();
+    pixi.workspace()
+        .unwrap()
+        .update_lock_file(
+            None,
+            UpdateLockFileOptions {
+                lock_file_usage: LockFileUsage::Locked,
+                ..UpdateLockFileOptions::default()
+            },
+        )
+        .await
+        .expect("`--locked` satisfiability check must accept the lockfile that was just written");
 }
 
 /// Find all sdist cache directories under uv-cache/sdists-v*/path/

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -945,8 +945,11 @@ async fn verify_package_platform_satisfiability(
                         };
                         if let Some(current_metadata) =
                             ctx.static_metadata_cache.get(&absolute_path)
-                            && let Some(mismatch) =
-                                pypi_metadata::compare_metadata(record, &current_metadata)
+                            && let Some(mismatch) = pypi_metadata::compare_metadata(
+                                record,
+                                pkg.name(),
+                                &current_metadata,
+                            )
                         {
                             let local_mismatch = match mismatch {
                                 pypi_metadata::MetadataMismatch::RequiresDist(diff) => {

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use dashmap::DashMap;
-use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
 use pep440_rs::VersionSpecifiers;
 use pixi_command_dispatcher::{CommandDispatcher, CommandDispatcherError};
@@ -763,16 +762,9 @@ async fn read_local_package_metadata(
         })
         .collect::<Result<_, _>>()?;
 
-    // Match the wheel METADATA shape used at lock time.
-    let empty_optional_deps = IndexMap::new();
-    let optional_deps = project
-        .and_then(|p| p.optional_dependencies.as_ref())
-        .unwrap_or(&empty_optional_deps);
-    let expanded =
-        pypi_metadata::expand_self_extras(requires_dist_vec, package_name, optional_deps);
     let metadata = pypi_metadata::LocalPackageMetadata {
         version,
-        requires_dist: expanded,
+        requires_dist: requires_dist_vec,
         requires_python,
     };
 

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
@@ -3,14 +3,13 @@
 //! This module provides functionality to:
 //! 1. Read metadata from local pyproject.toml files
 //! 2. Compare locked metadata against current source tree metadata
-use std::collections::{BTreeSet, HashMap, HashSet};
-use std::str::FromStr;
+use std::collections::{BTreeSet, HashSet};
 
-use indexmap::IndexMap;
 use pep440_rs::{Version, VersionSpecifiers};
-use pep508_rs::{PackageName, Requirement};
+use pep508_rs::{
+    ExtraName, ExtraOperator, MarkerExpression, MarkerValueExtra, PackageName, Requirement,
+};
 use pixi_install_pypi::LockedPypiRecord;
-use uv_normalize::ExtraName;
 
 /// Metadata extracted from a local package source tree.
 #[derive(Debug, Clone)]
@@ -18,7 +17,9 @@ pub struct LocalPackageMetadata {
     /// The version of the package, if statically known.
     /// `None` for packages with dynamic versions.
     pub version: Option<Version>,
-    /// The package dependencies.
+    /// The package dependencies as parsed from pyproject.toml,
+    /// including optional-dependency entries with their
+    /// `; extra == "X"` markers.
     pub requires_dist: Vec<Requirement>,
     /// The Python version requirement.
     pub requires_python: Option<VersionSpecifiers>,
@@ -50,37 +51,30 @@ pub struct RequiresDistDiff {
 /// Compare locked metadata against current metadata from the source tree.
 ///
 /// Returns `None` if the metadata matches, or `Some(MetadataMismatch)` describing
-/// what changed.
+/// what changed. Both sides are first normalized via `expand_self_extras`
+/// so self-refs like `foo[test]; extra == "dev"` compare equal to the
+/// build-backend-expanded `pytest; extra == "dev"`.
 pub fn compare_metadata(
     locked_record: &LockedPypiRecord,
+    package_name: &PackageName,
     current: &LocalPackageMetadata,
 ) -> Option<MetadataMismatch> {
-    let locked = &locked_record.data;
+    let locked_expanded = expand_self_extras(locked_record.data.requires_dist(), package_name);
+    let current_expanded = expand_self_extras(&current.requires_dist, package_name);
 
     // Compare requires_dist (as normalized sets)
-    let locked_deps: BTreeSet<String> = locked
-        .requires_dist()
-        .iter()
-        .map(normalize_requirement)
-        .collect();
-
-    let current_deps: BTreeSet<String> = current
-        .requires_dist
-        .iter()
-        .map(normalize_requirement)
-        .collect();
+    let locked_deps: BTreeSet<String> = locked_expanded.iter().map(normalize_requirement).collect();
+    let current_deps: BTreeSet<String> =
+        current_expanded.iter().map(normalize_requirement).collect();
 
     if locked_deps != current_deps {
-        // Calculate the diff
-        let added: Vec<Requirement> = current
-            .requires_dist
+        let added: Vec<Requirement> = current_expanded
             .iter()
             .filter(|r| !locked_deps.contains(&normalize_requirement(r)))
             .cloned()
             .collect();
 
-        let removed: Vec<Requirement> = locked
-            .requires_dist()
+        let removed: Vec<Requirement> = locked_expanded
             .iter()
             .filter(|r| !current_deps.contains(&normalize_requirement(r)))
             .cloned()
@@ -104,9 +98,10 @@ pub fn compare_metadata(
     }
 
     // Compare requires_python
-    if locked.requires_python() != current.requires_python.as_ref() {
+    let locked_requires_python = locked_record.data.requires_python();
+    if locked_requires_python != current.requires_python.as_ref() {
         return Some(MetadataMismatch::RequiresPython {
-            locked: locked.requires_python().cloned(),
+            locked: locked_requires_python.cloned(),
             current: current.requires_python.clone(),
         });
     }
@@ -124,60 +119,86 @@ fn normalize_requirement(req: &Requirement) -> String {
     req.to_string()
 }
 
-/// Replace each `pkg[group]` self-reference with the raw entries of
-/// `optional_dependencies[group]`, carrying the outer marker. Matches
-/// what build backends bake into wheel METADATA; UV's static parse
-/// leaves the self-references intact. Cycles in the optional-deps
-/// graph are broken on the path that closes them.
+/// Replace each `pkg[group]` self-ref with the entries gated by
+/// `extra == "<group>"` from the same list, carrying the outer marker.
+/// Mirrors the shape that build backends emit into wheel METADATA.
+/// Cycles in the optional-deps graph terminate on the closing edge.
+///
+/// Implemented with an explicit work stack rather than recursion so a
+/// pathologically deep optional-deps graph can't blow the call stack.
 pub fn expand_self_extras(
-    requires_dist: Vec<Requirement>,
+    requires_dist: &[Requirement],
     package_name: &PackageName,
-    optional_dependencies: &IndexMap<ExtraName, Vec<String>>,
 ) -> Vec<Requirement> {
-    let parsed: HashMap<&str, Vec<Requirement>> = optional_dependencies
-        .iter()
-        .map(|(extra, raws)| {
-            let reqs = raws
-                .iter()
-                .filter_map(|s| Requirement::from_str(s).ok())
-                .collect::<Vec<_>>();
-            (extra.as_ref(), reqs)
-        })
-        .collect();
+    enum Frame {
+        /// Try to expand this requirement, or push it to the result if
+        /// it isn't a self-reference.
+        Expand(Requirement),
+        /// Pop an extra off the active path once its expansion subtree
+        /// has finished processing.
+        Cleanup(ExtraName),
+    }
 
     let mut result: Vec<Requirement> = Vec::new();
-    let mut path: HashSet<&str> = HashSet::new();
-    for req in &requires_dist {
-        expand_into(req, package_name, &parsed, &mut path, &mut result);
+    let mut path: HashSet<ExtraName> = HashSet::new();
+    // Reversed so the first input is processed first.
+    let mut stack: Vec<Frame> = requires_dist
+        .iter()
+        .rev()
+        .map(|r| Frame::Expand(r.clone()))
+        .collect();
+
+    while let Some(frame) = stack.pop() {
+        match frame {
+            Frame::Cleanup(extra) => {
+                path.remove(&extra);
+            }
+            Frame::Expand(req) => {
+                if req.name != *package_name || req.extras.is_empty() {
+                    result.push(req);
+                    continue;
+                }
+                // `foo[a, b]` and `foo[a]` + `foo[b]` produce the same
+                // expansion. Splitting keeps the active path scoped to
+                // one extra at a time, matching the recursive version.
+                if req.extras.len() > 1 {
+                    for extra in req.extras.iter().rev() {
+                        let mut split = req.clone();
+                        split.extras = vec![extra.clone()];
+                        stack.push(Frame::Expand(split));
+                    }
+                    continue;
+                }
+                let requested_extra = req.extras[0].clone();
+                if !path.insert(requested_extra.clone()) {
+                    continue;
+                }
+                // Cleanup is pushed first so it pops last, after every
+                // child expansion for this extra is done.
+                stack.push(Frame::Cleanup(requested_extra.clone()));
+                let mut children: Vec<Frame> = Vec::new();
+                for child in requires_dist {
+                    let Some(MarkerExpression::Extra {
+                        operator: ExtraOperator::Equal,
+                        name: MarkerValueExtra::Extra(child_extra),
+                    }) = child.marker.top_level_extra()
+                    else {
+                        continue;
+                    };
+                    if child_extra != requested_extra {
+                        continue;
+                    }
+                    let mut expanded = child.clone();
+                    expanded.marker = child.marker.clone().simplify_extras(&[child_extra]);
+                    expanded.marker.and(req.marker.clone());
+                    children.push(Frame::Expand(expanded));
+                }
+                children.reverse();
+                stack.extend(children);
+            }
+        }
     }
     result
-}
-
-fn expand_into<'a>(
-    req: &Requirement,
-    package_name: &PackageName,
-    parsed: &'a HashMap<&'a str, Vec<Requirement>>,
-    path: &mut HashSet<&'a str>,
-    result: &mut Vec<Requirement>,
-) {
-    if req.name != *package_name || req.extras.is_empty() {
-        result.push(req.clone());
-        return;
-    }
-    for extra in &req.extras {
-        let Some((&key, group_reqs)) = parsed.get_key_value(extra.as_ref()) else {
-            continue;
-        };
-        if !path.insert(key) {
-            continue;
-        }
-        for child in group_reqs {
-            let mut expanded = child.clone();
-            expanded.marker.and(req.marker.clone());
-            expand_into(&expanded, package_name, parsed, path, result);
-        }
-        path.remove(key);
-    }
 }
 
 #[cfg(test)]
@@ -195,6 +216,54 @@ mod tests {
             .cloned()
             .unwrap_or_else(|| Version::from_str("42.23").unwrap());
         UnresolvedPypiRecord::from(data).lock(version)
+    }
+
+    fn pkg_name(s: &str) -> PackageName {
+        PackageName::from_str(s).unwrap()
+    }
+
+    fn req(s: &str) -> Requirement {
+        Requirement::from_str(s).unwrap()
+    }
+
+    fn render(reqs: &[Requirement]) -> String {
+        let mut lines: Vec<String> = reqs.iter().map(|r| r.to_string()).collect();
+        lines.sort();
+        lines.join("\n")
+    }
+
+    /// Locks in the assumption `compare_metadata` relies on: uv's
+    /// static parse of pyproject.toml flattens both `[project.dependencies]`
+    /// and `[project.optional-dependencies]` into a single
+    /// `requires_dist`, attaching `; extra == "X"` markers to the
+    /// optional entries. Without that, `expand_self_extras` would have
+    /// nothing to expand `foo[X]` against on the static-parse side.
+    #[test]
+    fn uv_static_parse_flattens_optional_dependencies_with_extra_markers() {
+        let toml = r#"
+[project]
+name = "foo"
+version = "0.1.0"
+dependencies = ["numpy"]
+
+[project.optional-dependencies]
+test = ["pytest"]
+dev  = ["foo[test]"]
+"#;
+        let pyproject = uv_pypi_types::PyProjectToml::from_toml(toml).unwrap();
+        let requires_dist = uv_pypi_types::RequiresDist::from_pyproject_toml(pyproject).unwrap();
+        let rendered: Vec<String> = requires_dist
+            .requires_dist
+            .iter()
+            .map(|r| r.to_string())
+            .collect();
+        let mut sorted = rendered.clone();
+        sorted.sort();
+        insta::assert_snapshot!(sorted.join("\n"), @r"
+        foo[test] ; extra == 'dev'
+        numpy
+        pytest ; extra == 'test'
+        ");
     }
 
     #[test]
@@ -228,7 +297,7 @@ mod tests {
             requires_python: Some(VersionSpecifiers::from_str(">=3.8").unwrap()),
         };
 
-        assert!(compare_metadata(&locked, &current).is_none());
+        assert!(compare_metadata(&locked, &pkg_name("test-package"), &current).is_none());
     }
 
     #[test]
@@ -252,48 +321,125 @@ mod tests {
             requires_python: None,
         };
 
-        let mismatch = compare_metadata(&locked, &current);
+        let mismatch = compare_metadata(&locked, &pkg_name("test-package"), &current);
         assert!(matches!(mismatch, Some(MetadataMismatch::RequiresDist(_))));
     }
 
-    fn pkg_name(s: &str) -> PackageName {
-        PackageName::from_str(s).unwrap()
+    /// Issue #6049: both lock and current hold `foo[test]; extra ==
+    /// 'dev'` verbatim from uv's static parse; they must compare equal
+    /// after expansion.
+    #[test]
+    fn compare_self_referential_extras_unexpanded_lock_matches() {
+        let locked = lock_for_test(make_wheel_package_with(
+            "foo",
+            "0.1.0",
+            rattler_lock::UrlOrPath::Url(url::Url::parse("file:///test").unwrap()).into(),
+            None,
+            None,
+            vec![
+                req("pytest ; extra == 'test'"),
+                req("foo[test] ; extra == 'dev'"),
+            ],
+            None,
+        ));
+
+        let current = LocalPackageMetadata {
+            version: Some(Version::from_str("0.1.0").unwrap()),
+            requires_dist: vec![
+                req("pytest ; extra == 'test'"),
+                req("foo[test] ; extra == 'dev'"),
+            ],
+            requires_python: None,
+        };
+
+        assert!(
+            compare_metadata(&locked, &pkg_name("foo"), &current).is_none(),
+            "self-refs in lock and pyproject must compare equal after expansion"
+        );
     }
 
-    fn extra(s: &str) -> ExtraName {
-        ExtraName::from_str(s).unwrap()
+    /// Companion case: lock came from build-backend wheel METADATA
+    /// (already expanded), current came from static parse (still a
+    /// self-ref). Expanding the current side must match.
+    #[test]
+    fn compare_expanded_lock_matches_self_ref_pyproject() {
+        let locked = lock_for_test(make_wheel_package_with(
+            "foo",
+            "0.1.0",
+            rattler_lock::UrlOrPath::Url(url::Url::parse("file:///test").unwrap()).into(),
+            None,
+            None,
+            vec![
+                req("pytest ; extra == 'test'"),
+                req("pytest ; extra == 'dev'"),
+            ],
+            None,
+        ));
+
+        let current = LocalPackageMetadata {
+            version: Some(Version::from_str("0.1.0").unwrap()),
+            requires_dist: vec![
+                req("pytest ; extra == 'test'"),
+                req("foo[test] ; extra == 'dev'"),
+            ],
+            requires_python: None,
+        };
+
+        assert!(
+            compare_metadata(&locked, &pkg_name("foo"), &current).is_none(),
+            "build-backend-expanded lock must match self-ref pyproject after expansion"
+        );
     }
 
-    fn req(s: &str) -> Requirement {
-        Requirement::from_str(s).unwrap()
-    }
+    /// Editing an extra's contents without re-locking still surfaces
+    /// as a diff: each side expands against its own list.
+    #[test]
+    fn compare_detects_stale_optional_deps() {
+        let locked = lock_for_test(make_wheel_package_with(
+            "foo",
+            "0.1.0",
+            rattler_lock::UrlOrPath::Url(url::Url::parse("file:///test").unwrap()).into(),
+            None,
+            None,
+            vec![
+                req("pytest ; extra == 'test'"),
+                req("foo[test] ; extra == 'dev'"),
+            ],
+            None,
+        ));
 
-    fn render(reqs: &[Requirement]) -> String {
-        let mut lines: Vec<String> = reqs.iter().map(|r| r.to_string()).collect();
-        lines.sort();
-        lines.join("\n")
+        let current = LocalPackageMetadata {
+            version: Some(Version::from_str("0.1.0").unwrap()),
+            requires_dist: vec![
+                req("pytest-mock ; extra == 'test'"),
+                req("foo[test] ; extra == 'dev'"),
+            ],
+            requires_python: None,
+        };
+
+        let mismatch = compare_metadata(&locked, &pkg_name("foo"), &current);
+        let Some(MetadataMismatch::RequiresDist(diff)) = mismatch else {
+            panic!("expected RequiresDist mismatch, got {mismatch:?}");
+        };
+        insta::assert_snapshot!(format!(
+            "added:\n{}\n\nremoved:\n{}",
+            render(&diff.added),
+            render(&diff.removed)
+        ), @r"
+        added:
+        pytest-mock ; extra == 'dev'
+        pytest-mock ; extra == 'test'
+
+        removed:
+        pytest ; extra == 'dev'
+        pytest ; extra == 'test'
+        ");
     }
 
     #[test]
     fn expand_self_extras_replaces_ribasim_style_self_refs() {
         // Mirrors Deltares/Ribasim: `delwaq` references `ribasim[netcdf]`
         // and `all` composes the other groups.
-        let mut optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
-        optional.insert(extra("tests"), vec!["pytest".into()]);
-        optional.insert(extra("netcdf"), vec!["xugrid".into()]);
-        optional.insert(
-            extra("delwaq"),
-            vec!["jinja2".into(), "networkx".into(), "ribasim[netcdf]".into()],
-        );
-        optional.insert(
-            extra("all"),
-            vec![
-                "ribasim[tests]".into(),
-                "ribasim[netcdf]".into(),
-                "ribasim[delwaq]".into(),
-            ],
-        );
-
         let static_parsed = vec![
             req("pandas"),
             req("pytest ; extra == 'tests'"),
@@ -306,7 +452,7 @@ mod tests {
             req("ribasim[delwaq] ; extra == 'all'"),
         ];
 
-        let expanded = expand_self_extras(static_parsed, &pkg_name("ribasim"), &optional);
+        let expanded = expand_self_extras(&static_parsed, &pkg_name("ribasim"));
         insta::assert_snapshot!(render(&expanded), @r"
         jinja2 ; extra == 'all'
         jinja2 ; extra == 'delwaq'
@@ -324,9 +470,8 @@ mod tests {
 
     #[test]
     fn expand_self_extras_preserves_non_self_references() {
-        let optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
         let input = vec![req("requests"), req("other[gpu] ; extra == 'all'")];
-        let expanded = expand_self_extras(input, &pkg_name("mypkg"), &optional);
+        let expanded = expand_self_extras(&input, &pkg_name("mypkg"));
         insta::assert_snapshot!(render(&expanded), @r"
         other[gpu] ; extra == 'all'
         requests
@@ -335,24 +480,54 @@ mod tests {
 
     #[test]
     fn expand_self_extras_drops_unknown_extras_silently() {
-        // A self-reference to an extra that doesn't exist (typo, stale
-        // metadata) is dropped.
-        let optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
+        // Self-ref to an extra with no matching entries is dropped.
         let input = vec![req("pandas"), req("mypkg[missing] ; extra == 'all'")];
-        let expanded = expand_self_extras(input, &pkg_name("mypkg"), &optional);
+        let expanded = expand_self_extras(&input, &pkg_name("mypkg"));
         insta::assert_snapshot!(render(&expanded), @"pandas");
     }
 
     #[test]
-    fn expand_self_extras_breaks_cycles() {
-        // a -> b -> a; expansion must terminate. The non-cyclic dep
-        // `actual` is still emitted with the outer marker.
-        let mut optional: IndexMap<ExtraName, Vec<String>> = IndexMap::new();
-        optional.insert(extra("a"), vec!["actual".into(), "mypkg[b]".into()]);
-        optional.insert(extra("b"), vec!["mypkg[a]".into()]);
+    fn expand_self_extras_breaks_direct_self_loop() {
+        // The entry under extra `a` references `foo[a]` itself.
+        // Without the path tracker this would recurse forever; with it,
+        // `expand_into` skips the second insert of `a` and terminates.
+        let input = vec![req("foo[a] ; extra == 'a'")];
+        let expanded = expand_self_extras(&input, &pkg_name("foo"));
+        assert!(
+            expanded.is_empty(),
+            "direct self-loop must terminate and emit nothing; got {expanded:?}"
+        );
+    }
 
-        let input = vec![req("mypkg[a] ; extra == 'X'")];
-        let expanded = expand_self_extras(input, &pkg_name("mypkg"), &optional);
-        insta::assert_snapshot!(render(&expanded), @"actual ; extra == 'x'");
+    #[test]
+    fn expand_self_extras_breaks_cycles() {
+        // a -> b -> a must terminate; non-cyclic deps still emit.
+        let input = vec![
+            req("actual ; extra == 'a'"),
+            req("mypkg[b] ; extra == 'a'"),
+            req("mypkg[a] ; extra == 'b'"),
+            req("mypkg[a] ; extra == 'X'"),
+        ];
+        let expanded = expand_self_extras(&input, &pkg_name("mypkg"));
+        insta::assert_snapshot!(render(&expanded), @r"
+        actual ; extra == 'a'
+        actual ; extra == 'a'
+        actual ; extra == 'b'
+        actual ; extra == 'x'
+        ");
+    }
+
+    #[test]
+    fn expand_self_extras_preserves_non_extra_marker_constraints() {
+        // The child's non-extra marker constraints survive expansion.
+        let input = vec![
+            req("trio ; python_version >= '3.10' and extra == 'async'"),
+            req("foo[async] ; extra == 'all'"),
+        ];
+        let expanded = expand_self_extras(&input, &pkg_name("foo"));
+        insta::assert_snapshot!(render(&expanded), @r"
+        trio ; python_full_version >= '3.10' and extra == 'all'
+        trio ; python_full_version >= '3.10' and extra == 'async'
+        ");
     }
 }


### PR DESCRIPTION
### Description

`pixi install --locked` immediately rejected a freshly-written lockfile when `pyproject.toml` contained a self-referential extra such as `dev = ["foo[test]"]`. The lockfile-write path stored `foo[test]; extra == 'dev'` verbatim, while the satisfiability path expanded it to `pytest; extra == 'dev'`, producing a phantom "added: [pytest], removed: [foo]" diff.

This PR makes `compare_metadata` normalize both sides through `expand_self_extras` before diffing. Each side scans only its own `requires_dist` (uv's static parse already flattens `[project.optional-dependencies]` into it with `; extra == "X"` markers), so no parallel optional-deps map is needed and edits to a group still surface as a real diff. Self-extras expansion runs on an explicit work stack, not recursion, so deep optional-deps graphs can't stack-overflow.

Fixes #6049

### How Has This Been Tested?

- Unit tests in `pypi_metadata.rs`:
  - Issue reproducer at the unit level (lock with `foo[test]; extra == 'dev'`, current static parse, asserts no mismatch).
  - Companion case where the lock came from build-backend wheel METADATA (already expanded).
  - Stale `[project.optional-dependencies]` still surfaces as a diff.
  - Direct self-loop and `a -> b -> a` cycle terminate.
  - `python_version` + `extra` markers preserved through expansion.
  - A test that calls `uv_pypi_types::RequiresDist::from_pyproject_toml` directly to pin the assumption that uv flattens optional-deps with `; extra == "X"` markers — if uv ever changes that, the snapshot catches it.
- Integration test `self_referential_extras_lockfile_roundtrip` in `pypi_tests.rs`: builds the issue's exact `pyproject.toml`, runs `update_lock_file()` then re-runs with `LockFileUsage::Locked` to exercise the `--locked` satisfiability path without spinning up a conda prefix or building a wheel.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.