### PR TITLE
feat(clean): report size of removed files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6172,6 +6172,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "futures",
+ "human_bytes",
  "indexmap 2.14.0",
  "indicatif",
  "insta",

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -33,6 +33,7 @@ fancy_display = { workspace = true }
 flate2 = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+human_bytes = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 indicatif = { workspace = true }
 is_executable = { workspace = true }

--- a/crates/pixi_cli/src/clean.rs
+++ b/crates/pixi_cli/src/clean.rs
@@ -12,6 +12,7 @@ use crate::cli_config::WorkspaceConfig;
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use fs_err::tokio as tokio_fs;
+use human_bytes::human_bytes;
 use indicatif::ProgressBar;
 use miette::IntoDiagnostic;
 use pixi_progress::{global_multi_progress, long_running_progress_style};
@@ -123,16 +124,17 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         })
         .transpose()?;
 
+    let mut total_removed: u64 = 0;
     if let Some(explicit_env) = explicit_environment {
         if args.activation_cache {
-            remove_file(explicit_env.activation_cache_file_path(), true).await?;
+            total_removed += remove_file(explicit_env.activation_cache_file_path(), true).await?;
             tracing::info!(
                 "Only removing activation cache for explicit environment '{}'",
                 explicit_env.name().fancy_display()
             );
         } else {
-            remove_folder_with_progress(explicit_env.dir(), true).await?;
-            remove_file(explicit_env.activation_cache_file_path(), false).await?;
+            total_removed += remove_folder_with_progress(explicit_env.dir(), true).await?;
+            total_removed += remove_file(explicit_env.activation_cache_file_path(), false).await?;
             tracing::info!(
                 "Skipping removal of task cache and solve group environments for explicit environment '{}'",
                 explicit_env.name().fancy_display()
@@ -142,24 +144,29 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         // Remove all pixi related work from the workspace. Always clean both
         // the default .pixi location and the effective (possibly detached) location
         // so leftover artifacts are removed regardless of config changes.
-        remove_folder_with_progress(workspace.default_environments_dir(), false).await?;
-        remove_folder_with_progress(workspace.default_solve_group_environments_dir(), false)
-            .await?;
-        remove_folder_with_progress(workspace.environments_dir(), false).await?;
-        remove_folder_with_progress(workspace.solve_group_environments_dir(), false).await?;
-        remove_folder_with_progress(workspace.task_cache_folder(), false).await?;
-        remove_folder_with_progress(workspace.activation_env_cache_folder(), false).await?;
+        total_removed +=
+            remove_folder_with_progress(workspace.default_environments_dir(), false).await?;
+        total_removed +=
+            remove_folder_with_progress(workspace.default_solve_group_environments_dir(), false)
+                .await?;
+        total_removed += remove_folder_with_progress(workspace.environments_dir(), false).await?;
+        total_removed +=
+            remove_folder_with_progress(workspace.solve_group_environments_dir(), false).await?;
+        total_removed += remove_folder_with_progress(workspace.task_cache_folder(), false).await?;
+        total_removed +=
+            remove_folder_with_progress(workspace.activation_env_cache_folder(), false).await?;
         for dir in workspace_build_cache_dirs(&workspace) {
-            remove_folder_with_progress(dir, false).await?;
+            total_removed += remove_folder_with_progress(dir, false).await?;
         }
         prune_workspace_registry().await?;
     } else {
         if args.activation_cache {
-            remove_folder_with_progress(workspace.activation_env_cache_folder(), true).await?;
+            total_removed +=
+                remove_folder_with_progress(workspace.activation_env_cache_folder(), true).await?;
         }
         if args.build {
             for dir in workspace_build_cache_dirs(&workspace) {
-                remove_folder_with_progress(dir, false).await?;
+                total_removed += remove_folder_with_progress(dir, false).await?;
             }
             eprintln!(
                 "{}When issues persist, you can remove all build related global cache with: {}",
@@ -171,6 +178,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             prune_workspace_registry().await?;
         }
     }
+    print_total_removed(total_removed);
     Ok(())
 }
 
@@ -245,9 +253,11 @@ async fn clean_cache(args: CacheArgs) -> miette::Result<()> {
         return Ok(());
     }
 
+    let mut total_removed: u64 = 0;
     for dir in dirs {
-        remove_folder_with_progress(dir, true).await?;
+        total_removed += remove_folder_with_progress(dir, true).await?;
     }
+    print_total_removed(total_removed);
     Ok(())
 }
 
@@ -269,7 +279,7 @@ async fn prune_workspace_registry() -> miette::Result<()> {
 async fn remove_folder_with_progress(
     folder: PathBuf,
     warning_non_existent: bool,
-) -> miette::Result<()> {
+) -> miette::Result<u64> {
     if !folder.exists() {
         if warning_non_existent {
             eprintln!(
@@ -278,7 +288,7 @@ async fn remove_folder_with_progress(
                 folder
             );
         }
-        return Ok(());
+        return Ok(0);
     }
     let pb = global_multi_progress().add(ProgressBar::new_spinner());
     pb.enable_steady_tick(Duration::from_millis(100));
@@ -289,13 +299,22 @@ async fn remove_folder_with_progress(
         folder.clone().display()
     ));
 
+    let size = {
+        let folder = folder.clone();
+        tokio::task::spawn_blocking(move || dir_size(&folder).unwrap_or(0))
+            .await
+            .unwrap_or(0)
+    };
+
     match tokio_fs::remove_dir_all(&folder).await {
         Ok(()) => {
             pb.finish_with_message(format!(
-                "{} {}",
+                "{} {} ({})",
                 console::style("Removed").green(),
-                folder.display()
+                folder.display(),
+                human_bytes(size as f64)
             ));
+            Ok(size)
         }
         Err(e) => {
             pb.finish_with_message(format!(
@@ -304,9 +323,44 @@ async fn remove_folder_with_progress(
                 folder.display(),
                 e
             ));
+            Ok(0)
         }
     }
-    Ok(())
+}
+
+/// Recursively computes the total size in bytes of all files within `path`.
+/// Symlinks are not followed; their own metadata length is counted.
+fn dir_size(path: &std::path::Path) -> std::io::Result<u64> {
+    let meta = match fs_err::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(0),
+    };
+    if meta.file_type().is_symlink() {
+        return Ok(meta.len());
+    }
+    if !meta.is_dir() {
+        return Ok(meta.len());
+    }
+    let mut total = 0u64;
+    let entries = match fs_err::read_dir(path) {
+        Ok(e) => e,
+        Err(_) => return Ok(0),
+    };
+    for entry in entries.flatten() {
+        total = total.saturating_add(dir_size(&entry.path()).unwrap_or(0));
+    }
+    Ok(total)
+}
+
+fn print_total_removed(total: u64) {
+    if total == 0 {
+        return;
+    }
+    eprintln!(
+        "{} {}",
+        console::style("Removed").green().bold(),
+        human_bytes(total as f64)
+    );
 }
 
 /// Build-related per-workspace cache directories. Aggregated here so
@@ -338,7 +392,7 @@ fn workspace_build_cache_dirs(workspace: &Workspace) -> Vec<PathBuf> {
     ]
 }
 
-async fn remove_file(file: PathBuf, warning_non_existent: bool) -> miette::Result<()> {
+async fn remove_file(file: PathBuf, warning_non_existent: bool) -> miette::Result<u64> {
     if !file.exists() {
         if warning_non_existent {
             eprintln!(
@@ -346,15 +400,23 @@ async fn remove_file(file: PathBuf, warning_non_existent: bool) -> miette::Resul
                 console::style(format!("File {:?} was not found.", file)).yellow()
             );
         }
-        return Ok(());
+        return Ok(0);
     }
+
+    let size = fs_err::metadata(&file).map(|m| m.len()).unwrap_or(0);
 
     // Ignore errors
     let result = tokio_fs::remove_file(&file).await;
     if let Err(e) = result {
         tracing::info!("Failed to remove file {:?}: {}", file, e);
+        Ok(0)
     } else {
-        eprintln!("{} {}", console::style("removed").green(), file.display());
+        eprintln!(
+            "{} {} ({})",
+            console::style("removed").green(),
+            file.display(),
+            human_bytes(size as f64)
+        );
+        Ok(size)
     }
-    Ok(())
 }

--- a/crates/pixi_cli/src/clean.rs
+++ b/crates/pixi_cli/src/clean.rs
@@ -16,6 +16,7 @@ use human_bytes::human_bytes;
 use indicatif::ProgressBar;
 use miette::IntoDiagnostic;
 use pixi_progress::{global_multi_progress, long_running_progress_style};
+use std::path::Path;
 use std::str::FromStr;
 
 /// Command to clean the parts of your system which are touched by pixi.
@@ -299,15 +300,15 @@ async fn remove_folder_with_progress(
         folder.clone().display()
     ));
 
-    let size = {
+    let removed = {
         let folder = folder.clone();
-        tokio::task::spawn_blocking(move || dir_size(&folder).unwrap_or(0))
+        tokio::task::spawn_blocking(move || remove_dir_recording_size(&folder))
             .await
-            .unwrap_or(0)
+            .unwrap_or(Ok(0))
     };
 
-    match tokio_fs::remove_dir_all(&folder).await {
-        Ok(()) => {
+    match removed {
+        Ok(size) => {
             pb.finish_with_message(format!(
                 "{} {} ({})",
                 console::style("Removed").green(),
@@ -316,40 +317,54 @@ async fn remove_folder_with_progress(
             ));
             Ok(size)
         }
-        Err(e) => {
+        Err((size, e)) => {
             pb.finish_with_message(format!(
                 "{} {} ({})",
                 console::style("Failed to remove").red(),
                 folder.display(),
                 e
             ));
-            Ok(0)
+            Ok(size)
         }
     }
 }
 
-/// Recursively computes the total size in bytes of all files within `path`.
-/// Symlinks are not followed; their own metadata length is counted.
-fn dir_size(path: &std::path::Path) -> std::io::Result<u64> {
+/// Recursively delete `path`, summing the size of every file/symlink that was
+/// successfully removed. On error, returns the partial total alongside the
+/// first I/O error encountered.
+fn remove_dir_recording_size(path: &Path) -> Result<u64, (u64, std::io::Error)> {
     let meta = match fs_err::symlink_metadata(path) {
         Ok(m) => m,
-        Err(_) => return Ok(0),
+        Err(e) => return Err((0, e)),
     };
-    if meta.file_type().is_symlink() {
-        return Ok(meta.len());
+
+    if meta.is_dir() && !meta.file_type().is_symlink() {
+        let mut total = 0u64;
+        let entries = match fs_err::read_dir(path) {
+            Ok(e) => e,
+            Err(e) => return Err((0, e)),
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => return Err((total, e)),
+            };
+            match remove_dir_recording_size(&entry.path()) {
+                Ok(size) => total = total.saturating_add(size),
+                Err((size, e)) => return Err((total.saturating_add(size), e)),
+            }
+        }
+        if let Err(e) = fs_err::remove_dir(path) {
+            return Err((total, e));
+        }
+        Ok(total)
+    } else {
+        let size = meta.len();
+        if let Err(e) = fs_err::remove_file(path) {
+            return Err((0, e));
+        }
+        Ok(size)
     }
-    if !meta.is_dir() {
-        return Ok(meta.len());
-    }
-    let mut total = 0u64;
-    let entries = match fs_err::read_dir(path) {
-        Ok(e) => e,
-        Err(_) => return Ok(0),
-    };
-    for entry in entries.flatten() {
-        total = total.saturating_add(dir_size(&entry.path()).unwrap_or(0));
-    }
-    Ok(total)
 }
 
 fn print_total_removed(total: u64) {


### PR DESCRIPTION
### Description

`pixi clean` is now a tiny bit more rewarding: it tells you how much disk space you just liberated. Because "removed your environments" hits different when followed by "(4.2 GiB)".

The recursive deletion now sums file sizes as it goes. Each folder gets its own `Removed <path> (<size>)` line and the run ends with a bold `Removed <total>` summary.

Works for `pixi clean`, `pixi clean --environment`, `pixi clean cache`, and friends.

### How Has This Been Tested?

- `cargo check -p pixi_cli`
- `cargo clippy -p pixi_cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Manual: ran `pixi clean` and `pixi clean cache` on a real workspace,
  watched the spinner spin and the bytes add up.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas