### PR TITLE
fix: pixi-build-mojo source directory builds

### DIFF
--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -1,17 +1,8 @@
-{%- set is_cmd_exe = build_platform == "windows" -%}
-{%- macro env(key) -%}
-{%- if is_cmd_exe %}{{ "%" ~ key ~ "%" }}{% else %}{{ "$" ~key }}{% endif -%}
-{% endmacro -%}
-
 {# - Set up common variables -#}
-{%- set library_prefix =  "%LIBRARY_PREFIX%" if build_platform == "windows" else "$PREFIX" -%}
+{%- set library_prefix = "$PREFIX" -%}
 
 mojo --version
-{% if is_cmd_exe -%}
-cd /d "{{ source_dir }}"
-{% else -%}
 cd "{{ source_dir }}"
-{% endif %}
 
 {#- Build any binaries -#}
 {% if bins %}

--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -7,7 +7,11 @@
 {%- set library_prefix =  "%LIBRARY_PREFIX%" if build_platform == "windows" else "$PREFIX" -%}
 
 mojo --version
-
+{% if is_cmd_exe -%}
+cd /d "{{ source_dir }}"
+{% else -%}
+cd "{{ source_dir }}"
+{% endif %}
 
 {#- Build any binaries -#}
 {% if bins %}

--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -2,7 +2,6 @@
 {%- set library_prefix = "$PREFIX" -%}
 
 mojo --version
-cd "{{ source_dir }}"
 
 {#- Build any binaries -#}
 {% if bins %}

--- a/crates/pixi_build_mojo/src/build_script.rs
+++ b/crates/pixi_build_mojo/src/build_script.rs
@@ -4,12 +4,20 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct BuildScriptContext {
+    pub build_platform: BuildPlatform,
     /// The directory where the source code is located, the manifest root.
     pub source_dir: String,
     /// Any executable artifacts to create.
     pub bins: Option<Vec<MojoBinConfig>>,
     /// Any packages to create.
     pub pkg: Option<MojoPkgConfig>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BuildPlatform {
+    Windows,
+    Unix,
 }
 
 impl BuildScriptContext {

--- a/crates/pixi_build_mojo/src/build_script.rs
+++ b/crates/pixi_build_mojo/src/build_script.rs
@@ -4,20 +4,12 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct BuildScriptContext {
-    pub build_platform: BuildPlatform,
     /// The directory where the source code is located, the manifest root.
     pub source_dir: String,
     /// Any executable artifacts to create.
     pub bins: Option<Vec<MojoBinConfig>>,
     /// Any packages to create.
     pub pkg: Option<MojoPkgConfig>,
-}
-
-#[derive(Copy, Clone, Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum BuildPlatform {
-    Windows,
-    Unix,
 }
 
 impl BuildScriptContext {

--- a/crates/pixi_build_mojo/src/build_script.rs
+++ b/crates/pixi_build_mojo/src/build_script.rs
@@ -4,8 +4,6 @@ use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub struct BuildScriptContext {
-    /// The directory where the source code is located, the manifest root.
-    pub source_dir: String,
     /// Any executable artifacts to create.
     pub bins: Option<Vec<MojoBinConfig>>,
     /// Any packages to create.

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -1,7 +1,7 @@
 mod build_script;
 mod config;
 
-use build_script::BuildScriptContext;
+use build_script::{BuildPlatform, BuildScriptContext};
 use config::{MojoBackendConfig, clean_project_name};
 use miette::{Error, IntoDiagnostic};
 use pixi_build_backend::generated_recipe::DefaultMetadataProvider;
@@ -98,6 +98,11 @@ impl GenerateRecipe for MojoGenerator {
         );
 
         let build_script = BuildScriptContext {
+            build_platform: if Platform::current().is_windows() {
+                BuildPlatform::Windows
+            } else {
+                BuildPlatform::Unix
+            },
             source_dir: manifest_root.display().to_string(),
             bins,
             pkg,

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -1,7 +1,7 @@
 mod build_script;
 mod config;
 
-use build_script::{BuildPlatform, BuildScriptContext};
+use build_script::BuildScriptContext;
 use config::{MojoBackendConfig, clean_project_name};
 use miette::{Error, IntoDiagnostic};
 use pixi_build_backend::generated_recipe::DefaultMetadataProvider;
@@ -98,11 +98,6 @@ impl GenerateRecipe for MojoGenerator {
         );
 
         let build_script = BuildScriptContext {
-            build_platform: if Platform::current().is_windows() {
-                BuildPlatform::Windows
-            } else {
-                BuildPlatform::Unix
-            },
             source_dir: manifest_root.display().to_string(),
             bins,
             pkg,
@@ -350,11 +345,7 @@ mod tests {
             .unwrap()
             .as_concrete()
             .unwrap();
-        let cd = if Platform::current().is_windows() {
-            format!("cd /d \"{}\"", source_dir.display())
-        } else {
-            format!("cd \"{}\"", source_dir.display())
-        };
+        let cd = format!("cd \"{}\"", source_dir.display());
 
         let cd_pos = script
             .find(&cd)

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -72,7 +72,8 @@ impl GenerateRecipe for MojoGenerator {
         );
 
         // Auto-derive bins and pkg fields/configs if needed
-        let (bins, pkg) = config.auto_derive(&manifest_root, &cleaned_project_name)?;
+        let (mut bins, mut pkg) = config.auto_derive(&manifest_root, &cleaned_project_name)?;
+        Self::make_paths_absolute(&manifest_root, &mut bins, &mut pkg)?;
 
         // Add compiler
         let requirements = &mut generated_recipe.recipe.requirements;
@@ -97,12 +98,7 @@ impl GenerateRecipe for MojoGenerator {
             variants,
         );
 
-        let build_script = BuildScriptContext {
-            source_dir: manifest_root.display().to_string(),
-            bins,
-            pkg,
-        }
-        .render();
+        let build_script = BuildScriptContext { bins, pkg }.render();
 
         generated_recipe.recipe.build.script = Script::from_content(build_script).with_env(
             config
@@ -148,6 +144,41 @@ impl GenerateRecipe for MojoGenerator {
 }
 
 impl MojoGenerator {
+    fn make_paths_absolute(
+        manifest_root: &Path,
+        bins: &mut Option<Vec<config::MojoBinConfig>>,
+        pkg: &mut Option<config::MojoPkgConfig>,
+    ) -> miette::Result<()> {
+        if let Some(bins) = bins {
+            for bin in bins {
+                if let Some(path) = &mut bin.path {
+                    *path = Self::absolute_path(manifest_root, path)?;
+                }
+            }
+        }
+        if let Some(pkg) = pkg
+            && let Some(path) = &mut pkg.path
+        {
+            *path = Self::absolute_path(manifest_root, path)?;
+        }
+        Ok(())
+    }
+
+    fn absolute_path(manifest_root: &Path, path: &str) -> miette::Result<String> {
+        let path = Path::new(path);
+        if path.is_absolute() {
+            return Ok(path.display().to_string());
+        }
+        let manifest_root = if manifest_root.is_absolute() {
+            manifest_root.to_path_buf()
+        } else {
+            std::env::current_dir()
+                .into_diagnostic()?
+                .join(manifest_root)
+        };
+        Ok(manifest_root.join(path).display().to_string())
+    }
+
     fn globs() -> impl Iterator<Item = String> {
         [
             // Source files
@@ -249,6 +280,7 @@ mod tests {
 
         insta::assert_yaml_snapshot!(generated_recipe.recipe, {
         ".source[0].path" => "[ ... path ... ]",
+        ".build.script" => "[ ... script ... ]",
         });
     }
 
@@ -298,11 +330,12 @@ mod tests {
 
         insta::assert_yaml_snapshot!(generated_recipe.recipe, {
         ".source[0].path" => "[ ... path ... ]",
+        ".build.script" => "[ ... script ... ]",
         });
     }
 
     #[tokio::test]
-    async fn test_relative_paths_are_resolved_from_source_dir() {
+    async fn test_relative_paths_are_made_absolute() {
         let project_model = project_fixture!({
             "name": "foobar",
             "version": "0.1.0",
@@ -345,18 +378,22 @@ mod tests {
             .unwrap()
             .as_concrete()
             .unwrap();
-        let cd = format!("cd \"{}\"", source_dir.display());
+        let bin_path = source_dir.join("src/main.mojo").display().to_string();
+        let pkg_path = source_dir.join("src/foobar").display().to_string();
 
-        let cd_pos = script
-            .find(&cd)
-            .unwrap_or_else(|| panic!("script did not cd into source dir:\n{script}"));
-        let build_pos = script.find("mojo build").unwrap();
-        let package_pos = script.find("mojo package").unwrap();
-
-        assert!(cd_pos < build_pos, "script changes dir after mojo build");
         assert!(
-            cd_pos < package_pos,
-            "script changes dir after mojo package"
+            !script
+                .lines()
+                .any(|line| line.trim_start().starts_with("cd ")),
+            "script should not change directory:\n{script}"
+        );
+        assert!(
+            script.contains(&format!("\"{bin_path}\"")),
+            "script should use absolute bin path:\n{script}"
+        );
+        assert!(
+            script.contains(&format!("\"{pkg_path}\"")),
+            "script should use absolute pkg path:\n{script}"
         );
     }
 

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -307,6 +307,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_relative_paths_are_resolved_from_source_dir() {
+        let project_model = project_fixture!({
+            "name": "foobar",
+            "version": "0.1.0",
+        });
+        let temp = tempfile::TempDir::new().unwrap();
+        let source_dir = temp.path().to_path_buf();
+
+        let generated_recipe = MojoGenerator::default()
+            .generate_recipe(
+                &project_model,
+                &MojoBackendConfig {
+                    bins: Some(vec![MojoBinConfig {
+                        name: Some(String::from("example")),
+                        path: Some(String::from("src/main.mojo")),
+                        extra_args: None,
+                    }]),
+                    pkg: Some(MojoPkgConfig {
+                        name: Some(String::from("lib")),
+                        path: Some(String::from("src/foobar")),
+                        extra_args: None,
+                    }),
+                    ..Default::default()
+                },
+                source_dir.clone(),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+            )
+            .await
+            .expect("Failed to generate recipe");
+
+        let content = generated_recipe.recipe.build.script.content.unwrap();
+        let script = content
+            .iter()
+            .next()
+            .unwrap()
+            .as_value()
+            .unwrap()
+            .as_concrete()
+            .unwrap();
+        let cd = if Platform::current().is_windows() {
+            format!("cd /d \"{}\"", source_dir.display())
+        } else {
+            format!("cd \"{}\"", source_dir.display())
+        };
+
+        let cd_pos = script
+            .find(&cd)
+            .unwrap_or_else(|| panic!("script did not cd into source dir:\n{script}"));
+        let build_pos = script.find("mojo build").unwrap();
+        let package_pos = script.find("mojo package").unwrap();
+
+        assert!(cd_pos < build_pos, "script changes dir after mojo build");
+        assert!(
+            cd_pos < package_pos,
+            "script changes dir after mojo package"
+        );
+    }
+
+    #[tokio::test]
     async fn test_compiler_is_in_build_requirements() {
         let project_model = project_fixture!({
             "name": "foobar",

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
@@ -7,9 +7,7 @@ package:
   name: foobar
   version: 0.1.0
 build:
-  script:
-    content:
-      - "mojo --version\ncd \".\"\n\nmojo build -I . \"./main.mojo\" -o $PREFIX/bin/example"
+  script: "[ ... script ... ]"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
@@ -9,7 +9,7 @@ package:
 build:
   script:
     content:
-      - "mojo --version\ncd \".\"\n\n\nmojo build -I . \"./main.mojo\" -o $PREFIX/bin/example"
+      - "mojo --version\ncd \".\"\n\nmojo build -I . \"./main.mojo\" -o $PREFIX/bin/example"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_bin_is_set.snap
@@ -9,7 +9,7 @@ package:
 build:
   script:
     content:
-      - "mojo --version\n\nmojo build -I . \"./main.mojo\" -o $PREFIX/bin/example"
+      - "mojo --version\ncd \".\"\n\n\nmojo build -I . \"./main.mojo\" -o $PREFIX/bin/example"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
@@ -9,7 +9,7 @@ package:
 build:
   script:
     content:
-      - "mojo --version\ncd \".\"\n\n\nmojo build -i . \"./main.mojo\" -o $PREFIX/bin/example\n\n\nmojo package -i . \"mylib\" -o $PREFIX/lib/mojo/lib.mojopkg"
+      - "mojo --version\ncd \".\"\n\nmojo build -i . \"./main.mojo\" -o $PREFIX/bin/example\n\n\nmojo package -i . \"mylib\" -o $PREFIX/lib/mojo/lib.mojopkg"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
@@ -7,9 +7,7 @@ package:
   name: foobar
   version: 0.1.0
 build:
-  script:
-    content:
-      - "mojo --version\ncd \".\"\n\nmojo build -i . \"./main.mojo\" -o $PREFIX/bin/example\n\n\nmojo package -i . \"mylib\" -o $PREFIX/lib/mojo/lib.mojopkg"
+  script: "[ ... script ... ]"
   python:
     entry_points: []
     skip_pyc_compilation: []

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__mojo_pkg_is_set.snap
@@ -9,7 +9,7 @@ package:
 build:
   script:
     content:
-      - "mojo --version\n\nmojo build -i . \"./main.mojo\" -o $PREFIX/bin/example\n\n\nmojo package -i . \"mylib\" -o $PREFIX/lib/mojo/lib.mojopkg"
+      - "mojo --version\ncd \".\"\n\n\nmojo build -i . \"./main.mojo\" -o $PREFIX/bin/example\n\n\nmojo package -i . \"mylib\" -o $PREFIX/lib/mojo/lib.mojopkg"
   python:
     entry_points: []
     skip_pyc_compilation: []


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
Run generated Mojo build scripts from the manifest source directory so relative package and binary paths resolve against the project checkout.

If a user specified a `package.build.config.pkg` we weren't switching the specified dir to actually do the mojo package command. This fixes the same issues with bins.


<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue} - None

### How Has This Been Tested?

`cargo test -p pixi-build-mojo --bin pixi-build-mojo -j 1`

And an e2e test against the failing project:

```
PIXI_BUILD_BACKEND_OVERRIDE="pixi-build-mojo=/Users/me/dev/pixi/target/debug/pixi-build-mojo" pixi build
```

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: pi+GPT5.5

<!-- Add your prompt here, this helps us understand your results.-->
```plaintext
>   I am the pixi-build-mojo backend auther, but it's been a while. Everything look slike it should work there, why would mojo give that error? are we failing ot copy the src path into the workdir maybe?
> Yes add a test that fails, fix it and run tests, also build and test against the failing project
```


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
