### PR TITLE
chore(deps): bump uv to 0.10.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11703,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "hex",
  "memchr",
@@ -11732,8 +11732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11787,8 +11787,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "clap",
  "either",
@@ -11817,16 +11817,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11836,8 +11836,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "futures",
@@ -11869,8 +11869,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11917,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -12005,16 +12005,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "backon",
  "dunce",
@@ -12038,8 +12038,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12065,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12078,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12092,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "clap",
  "configparser",
@@ -12131,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12173,8 +12173,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12188,8 +12188,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12199,8 +12199,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12217,8 +12217,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12228,8 +12228,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "dashmap",
  "futures",
@@ -12238,16 +12238,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12260,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12286,8 +12286,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12303,8 +12303,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12316,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12358,8 +12358,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12416,8 +12416,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12428,8 +12428,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12464,8 +12464,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12489,8 +12489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12554,8 +12554,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12579,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "clap",
  "fs-err",
@@ -12614,8 +12614,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12630,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12641,8 +12641,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12651,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12660,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "clap",
  "either",
@@ -12681,8 +12681,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12694,8 +12694,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12717,13 +12717,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.9.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "console",
  "fs-err",
@@ -12746,8 +12746,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12756,8 +12756,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
+version = "0.0.19"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11500,8 +11500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11540,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11581,8 +11581,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11618,8 +11618,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11644,8 +11644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11660,8 +11660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "hex",
  "memchr",
@@ -11673,8 +11673,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11728,8 +11728,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "clap",
  "either",
@@ -11759,16 +11759,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11778,8 +11778,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "futures",
@@ -11811,8 +11811,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11859,8 +11859,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11876,8 +11876,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11916,8 +11916,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11948,16 +11948,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "backon",
  "clap",
@@ -11986,8 +11986,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12012,8 +12012,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12025,8 +12025,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12039,8 +12039,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "configparser",
  "csv",
@@ -12074,8 +12074,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12116,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12131,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12142,8 +12142,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12160,8 +12160,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12171,8 +12171,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "dashmap",
  "futures",
@@ -12181,16 +12181,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12229,8 +12229,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12246,8 +12246,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12260,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12271,8 +12271,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12302,8 +12302,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12340,6 +12340,7 @@ dependencies = [
  "uv-client",
  "uv-dirs",
  "uv-distribution-filename",
+ "uv-distribution-types",
  "uv-extract",
  "uv-fs",
  "uv-install-wheel",
@@ -12361,8 +12362,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12373,8 +12374,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12409,8 +12410,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12434,8 +12435,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12499,8 +12500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12524,8 +12525,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "clap",
  "fs-err",
@@ -12559,8 +12560,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12575,8 +12576,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12586,8 +12587,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12596,8 +12597,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12605,8 +12606,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "clap",
  "either",
@@ -12626,8 +12627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12639,8 +12640,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12662,13 +12663,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.10.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "console",
  "fs-err",
@@ -12689,8 +12690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12699,8 +12700,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
+version = "0.0.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11534,8 +11534,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11574,8 +11574,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11615,8 +11615,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11652,8 +11652,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11678,8 +11678,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11694,8 +11694,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "hex",
  "memchr",
@@ -11707,8 +11707,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11762,8 +11762,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "clap",
  "either",
@@ -11793,16 +11793,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11812,8 +11812,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "futures",
@@ -11845,8 +11845,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11893,8 +11893,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11910,8 +11910,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11950,8 +11950,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11982,16 +11982,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "backon",
  "dunce",
@@ -12015,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12041,8 +12041,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12054,8 +12054,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12068,8 +12068,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "clap",
  "configparser",
@@ -12107,8 +12107,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12149,8 +12149,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12164,8 +12164,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12175,8 +12175,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12193,8 +12193,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12204,8 +12204,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "dashmap",
  "futures",
@@ -12214,16 +12214,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12236,8 +12236,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12262,8 +12262,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12279,8 +12279,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12293,8 +12293,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12304,8 +12304,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12335,8 +12335,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12394,8 +12394,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12406,8 +12406,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12442,8 +12442,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12467,8 +12467,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12532,8 +12532,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12557,8 +12557,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "clap",
  "fs-err",
@@ -12592,8 +12592,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12608,8 +12608,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12619,8 +12619,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12629,8 +12629,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12638,8 +12638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "clap",
  "either",
@@ -12659,8 +12659,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12672,8 +12672,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12695,13 +12695,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.10.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "console",
  "fs-err",
@@ -12722,8 +12722,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12732,8 +12732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
+version = "0.0.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,27 +359,6 @@ dependencies = [
 
 [[package]]
 name = "astral-reqwest-retry"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7549bd00f62f73f2e7e76f3f77ccdabb31873f4f02f758ed88ad739d522867"
-dependencies = [
- "anyhow",
- "astral-reqwest-middleware 0.4.2",
- "async-trait",
- "futures",
- "getrandom 0.2.17",
- "http 1.4.0",
- "hyper 1.9.0",
- "reqwest 0.12.28",
- "retry-policies 0.4.0",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
-]
-
-[[package]]
-name = "astral-reqwest-retry"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ab210f6cdf8fd3254d47e5ee27ce60ed34a428ff71b4ae9477b1c84b49498c"
@@ -392,7 +371,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "reqwest 0.12.28",
- "retry-policies 0.5.1",
+ "retry-policies",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7206,7 +7185,7 @@ name = "pixi_utils"
 version = "0.1.0"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.8.0",
+ "astral-reqwest-retry",
  "async-fd-lock",
  "fs-err",
  "indicatif",
@@ -7223,7 +7202,7 @@ dependencies = [
  "rattler_networking",
  "rattler_shell",
  "reqwest 0.12.28",
- "retry-policies 0.5.1",
+ "retry-policies",
  "rlimit",
  "rstest",
  "serde",
@@ -7580,7 +7559,7 @@ name = "pypi_mapping"
 version = "0.1.0"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.8.0",
+ "astral-reqwest-retry",
  "async-once-cell",
  "dashmap",
  "fs-err",
@@ -7961,7 +7940,7 @@ dependencies = [
  "reflink-copy",
  "regex",
  "reqwest 0.12.28",
- "retry-policies 0.5.1",
+ "retry-policies",
  "scroll",
  "serde",
  "serde-untagged",
@@ -8011,7 +7990,7 @@ version = "0.1.5"
 source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.8.0",
+ "astral-reqwest-retry",
  "rattler_networking",
  "reqwest 0.12.28",
  "url",
@@ -8078,7 +8057,7 @@ version = "0.1.5"
 source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.8.0",
+ "astral-reqwest-retry",
  "async-trait",
  "bzip2 0.6.1",
  "chrono",
@@ -8315,7 +8294,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_s3",
  "reqwest 0.12.28",
- "retry-policies 0.5.1",
+ "retry-policies",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -8423,7 +8402,7 @@ dependencies = [
  "netrc-rs",
  "rattler_config",
  "reqwest 0.12.28",
- "retry-policies 0.5.1",
+ "retry-policies",
  "serde",
  "serde_json",
  "tempfile",
@@ -8552,7 +8531,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "reqwest 0.12.28",
- "retry-policies 0.5.1",
+ "retry-policies",
  "rmp-serde",
  "self_cell",
  "serde",
@@ -8637,7 +8616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95e7d50915a0d37f97b2b353b175e5290c6bf11c8511454f73861c26fb9da487"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.8.0",
+ "astral-reqwest-retry",
  "base64 0.22.1",
  "clap",
  "fs-err",
@@ -9081,15 +9060,6 @@ dependencies = [
  "itertools 0.14.0",
  "petgraph",
  "tracing",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
-dependencies = [
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -11478,8 +11448,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11518,8 +11488,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11555,8 +11525,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11593,8 +11563,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11619,8 +11589,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11635,8 +11605,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "hex",
  "memchr",
@@ -11648,12 +11618,12 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.7.0",
+ "astral-reqwest-retry",
  "astral-tl",
  "astral_async_http_range_reader",
  "astral_async_zip",
@@ -11703,8 +11673,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "clap",
  "either",
@@ -11732,16 +11702,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11751,8 +11721,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "futures",
@@ -11784,8 +11754,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11832,8 +11802,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11849,8 +11819,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11889,8 +11859,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11920,16 +11890,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "backon",
  "dunce",
@@ -11953,8 +11923,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11980,8 +11950,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11993,8 +11963,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12007,8 +11977,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "clap",
  "configparser",
@@ -12045,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12087,8 +12057,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12102,8 +12072,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12113,8 +12083,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12131,8 +12101,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12142,8 +12112,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "dashmap",
  "futures",
@@ -12152,16 +12122,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12174,8 +12144,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12200,8 +12170,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12217,8 +12187,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12230,8 +12200,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12240,8 +12210,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12271,12 +12241,12 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
- "astral-reqwest-retry 0.7.0",
+ "astral-reqwest-retry",
  "clap",
  "configparser",
  "dunce",
@@ -12329,8 +12299,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12341,8 +12311,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12377,8 +12347,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12402,8 +12372,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12467,8 +12437,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12492,8 +12462,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "clap",
  "fs-err",
@@ -12527,8 +12497,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12543,8 +12513,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12554,8 +12524,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12564,16 +12534,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "clap",
  "either",
@@ -12593,8 +12563,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12606,8 +12576,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12629,13 +12599,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.18"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.9.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "console",
  "fs-err",
@@ -12657,8 +12627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12667,8 +12637,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
+version = "0.0.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10411,15 +10411,6 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cf87c0efffc158b9dde4d6e0567a43e4383adc4c949e687a2039732db2f23a"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "spdx"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8da593e30beb790fc9424502eb898320b44e5eb30367dbda1c1edde8e2f32d7"
@@ -11487,8 +11478,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11527,8 +11518,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11541,7 +11532,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "sha2 0.10.9",
- "spdx 0.12.0",
+ "spdx 0.13.4",
  "tar",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
@@ -11564,8 +11555,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11602,8 +11593,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11612,6 +11603,7 @@ dependencies = [
  "same-file",
  "serde",
  "tempfile",
+ "thiserror 2.0.18",
  "tracing",
  "uv-cache-info",
  "uv-cache-key",
@@ -11627,8 +11619,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11643,8 +11635,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "hex",
  "memchr",
@@ -11656,8 +11648,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11711,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "clap",
  "either",
@@ -11740,16 +11732,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11759,8 +11751,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "futures",
@@ -11792,8 +11784,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11840,8 +11832,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11849,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11889,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11920,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "backon",
  "dunce",
@@ -11961,8 +11953,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11988,8 +11980,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12001,8 +11993,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12015,8 +12007,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "clap",
  "configparser",
@@ -12053,8 +12045,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12095,8 +12087,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12110,8 +12102,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12121,8 +12113,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12139,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12150,8 +12142,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "dashmap",
  "futures",
@@ -12160,16 +12152,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12182,8 +12174,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12208,8 +12200,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12225,8 +12217,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12238,8 +12230,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12248,8 +12240,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12279,8 +12271,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12337,8 +12329,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12349,8 +12341,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12385,8 +12377,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12410,8 +12402,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12475,8 +12467,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12500,8 +12492,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "clap",
  "fs-err",
@@ -12535,8 +12527,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12551,8 +12543,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12562,8 +12554,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12572,16 +12564,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "clap",
  "either",
@@ -12601,8 +12593,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12614,8 +12606,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12637,13 +12629,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.9.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "console",
  "fs-err",
@@ -12665,8 +12657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12675,8 +12667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
+version = "0.0.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.18#0cee76417ff30d1e9329ca9b7bf3d03f4f1f33b2"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11046,6 +11046,21 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
@@ -11447,8 +11462,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11487,8 +11502,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11503,6 +11518,7 @@ dependencies = [
  "sha2 0.10.9",
  "spdx 0.13.4",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -11524,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11539,7 +11555,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "uv-auth",
  "uv-cache-key",
@@ -11562,8 +11578,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11588,8 +11604,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11604,8 +11620,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "hex",
  "memchr",
@@ -11617,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11672,13 +11688,14 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "clap",
  "either",
  "fs-err",
  "rayon",
+ "reqwest 0.12.28",
  "rustc-hash",
  "same-file",
  "schemars 1.2.1",
@@ -11701,16 +11718,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11720,8 +11737,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "futures",
@@ -11753,8 +11770,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11801,8 +11818,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11818,8 +11835,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11858,8 +11875,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11889,16 +11906,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "backon",
  "dunce",
@@ -11922,8 +11939,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11949,8 +11966,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11962,8 +11979,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11976,8 +11993,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "clap",
  "configparser",
@@ -12014,8 +12031,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12056,8 +12073,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12071,8 +12088,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12082,8 +12099,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12100,8 +12117,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12111,8 +12128,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "dashmap",
  "futures",
@@ -12121,16 +12138,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12143,8 +12160,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12169,8 +12186,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12186,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12199,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12209,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12225,7 +12242,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "thiserror 2.0.18",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12240,8 +12257,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12298,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12310,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12346,8 +12363,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12371,8 +12388,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12400,7 +12417,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12436,8 +12453,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12461,8 +12478,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "clap",
  "fs-err",
@@ -12496,8 +12513,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12512,8 +12529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12523,8 +12540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12533,16 +12550,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "clap",
  "either",
@@ -12562,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12575,8 +12592,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12598,13 +12615,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.9.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "console",
  "fs-err",
@@ -12626,8 +12643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12636,8 +12653,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
+version = "0.0.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
 dependencies = [
  "clap",
  "fs-err",
@@ -12650,7 +12667,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "uv-build-backend",
  "uv-cache-key",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11703,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "hex",
  "memchr",
@@ -11732,8 +11732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11787,8 +11787,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "clap",
  "either",
@@ -11817,16 +11817,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11836,8 +11836,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "futures",
@@ -11869,8 +11869,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11917,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -12005,16 +12005,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "backon",
  "dunce",
@@ -12033,13 +12033,13 @@ dependencies = [
  "tokio",
  "tracing",
  "uv-static",
- "windows 0.59.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
 name = "uv-git"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12065,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12078,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12092,14 +12092,15 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "clap",
  "configparser",
  "csv",
  "data-encoding",
  "fs-err",
+ "itertools 0.14.0",
  "mailparse",
  "owo-colors",
  "pathdiff",
@@ -12130,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12172,8 +12173,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12181,14 +12182,14 @@ dependencies = [
  "security-framework 3.7.0",
  "thiserror 2.0.18",
  "tokio",
- "windows 0.59.0",
+ "windows 0.61.3",
  "zeroize",
 ]
 
 [[package]]
 name = "uv-macros"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12198,8 +12199,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12216,8 +12217,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12227,8 +12228,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "dashmap",
  "futures",
@@ -12237,16 +12238,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12259,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12285,8 +12286,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12302,8 +12303,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12315,18 +12316,19 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
- "bitflags 2.11.1",
+ "enumflags2",
+ "itertools 0.14.0",
  "thiserror 2.0.18",
  "uv-warnings",
 ]
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12356,8 +12358,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12408,14 +12410,14 @@ dependencies = [
  "uv-trampoline-builder",
  "uv-warnings",
  "which",
- "windows 0.59.0",
+ "windows 0.61.3",
  "windows-registry 0.5.3",
 ]
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12426,8 +12428,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12462,8 +12464,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12487,8 +12489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12552,8 +12554,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12577,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "clap",
  "fs-err",
@@ -12612,8 +12614,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12622,14 +12624,14 @@ dependencies = [
  "tracing",
  "uv-fs",
  "uv-static",
- "windows 0.59.0",
+ "windows 0.61.3",
  "windows-registry 0.5.3",
 ]
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12639,8 +12641,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12649,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12658,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "clap",
  "either",
@@ -12679,21 +12681,21 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "fs-err",
  "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
- "windows 0.59.0",
+ "windows 0.61.3",
  "zip 2.4.2",
 ]
 
 [[package]]
 name = "uv-types"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12715,13 +12717,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.9.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "console",
  "fs-err",
@@ -12743,8 +12745,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12753,8 +12755,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
+version = "0.0.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
 dependencies = [
  "clap",
  "fs-err",
@@ -13128,16 +13130,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
-dependencies = [
- "windows-core 0.59.0",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -13181,24 +13173,11 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
-dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -13211,7 +13190,7 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
@@ -13238,17 +13217,6 @@ dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
  "windows-threading 0.2.1",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -13343,15 +13311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11500,8 +11500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11540,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11581,8 +11581,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11618,8 +11618,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11644,8 +11644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11660,8 +11660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "hex",
  "memchr",
@@ -11673,8 +11673,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11728,8 +11728,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "clap",
  "either",
@@ -11742,6 +11742,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "url",
  "uv-auth",
@@ -11759,16 +11760,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11778,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "futures",
@@ -11811,8 +11812,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11859,8 +11860,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11876,8 +11877,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11916,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11948,16 +11949,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "backon",
  "clap",
@@ -11986,8 +11987,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12012,8 +12013,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12025,8 +12026,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12039,8 +12040,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "configparser",
  "csv",
@@ -12074,8 +12075,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12116,8 +12117,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12131,8 +12132,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12142,8 +12143,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12160,8 +12161,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12171,8 +12172,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "dashmap",
  "futures",
@@ -12181,16 +12182,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12203,8 +12204,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12229,8 +12230,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12246,8 +12247,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12260,8 +12261,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12271,8 +12272,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12302,8 +12303,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12362,8 +12363,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12374,8 +12375,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12410,8 +12411,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12435,8 +12436,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12500,8 +12501,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12525,8 +12526,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "clap",
  "fs-err",
@@ -12560,8 +12561,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12576,8 +12577,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12587,8 +12588,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12597,8 +12598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12606,8 +12607,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "clap",
  "either",
@@ -12627,8 +12628,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12640,8 +12641,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12663,13 +12664,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.10.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "console",
  "fs-err",
@@ -12690,8 +12691,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12700,8 +12701,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.26"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.6#a91bcf2683c425344991d43692acbc7618eb0f7b"
+version = "0.0.27"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6873,7 +6873,6 @@ dependencies = [
  "tracing",
  "typed-path",
  "url",
- "uv-auth",
  "uv-cache",
  "uv-cache-info",
  "uv-client",
@@ -11488,8 +11487,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11528,8 +11527,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11565,8 +11564,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11582,6 +11581,7 @@ dependencies = [
  "tokio",
  "toml_edit 0.23.10+spec-1.0.0",
  "tracing",
+ "uv-auth",
  "uv-cache-key",
  "uv-configuration",
  "uv-distribution",
@@ -11602,8 +11602,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11627,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11643,8 +11643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "hex",
  "memchr",
@@ -11656,8 +11656,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11711,8 +11711,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "clap",
  "either",
@@ -11740,16 +11740,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11759,8 +11759,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "futures",
@@ -11792,8 +11792,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11840,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11857,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11928,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "backon",
  "dunce",
@@ -11952,15 +11952,17 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uv-static",
  "windows 0.59.0",
 ]
 
 [[package]]
 name = "uv-git"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11986,8 +11988,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11999,8 +12001,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12013,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "clap",
  "configparser",
@@ -12051,8 +12053,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12093,8 +12095,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12108,8 +12110,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12119,8 +12121,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12137,8 +12139,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12148,8 +12150,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "dashmap",
  "futures",
@@ -12158,16 +12160,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12180,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12206,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12223,8 +12225,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12236,8 +12238,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12246,8 +12248,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12277,8 +12279,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12335,8 +12337,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12347,8 +12349,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12383,8 +12385,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12408,8 +12410,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12473,8 +12475,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12498,8 +12500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "clap",
  "fs-err",
@@ -12533,8 +12535,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12549,8 +12551,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12560,8 +12562,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12570,16 +12572,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "clap",
  "either",
@@ -12599,8 +12601,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12612,8 +12614,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12635,13 +12637,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.15"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.9.16"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "console",
  "fs-err",
@@ -12663,8 +12665,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12673,8 +12675,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
+version = "0.0.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4587,6 +4587,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "junction"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5713,6 +5728,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "pem"
@@ -7297,6 +7322,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes 0.8.4",
+ "cbc 0.1.2",
+ "der 0.7.10",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7313,6 +7353,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -8858,6 +8900,7 @@ dependencies = [
  "reqsign-command-execute-tokio",
  "reqsign-core",
  "reqsign-file-read-tokio",
+ "reqsign-google",
  "reqsign-http-send-reqwest",
 ]
 
@@ -8926,6 +8969,26 @@ dependencies = [
  "async-trait",
  "reqsign-core",
  "tokio",
+]
+
+[[package]]
+name = "reqsign-google"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acee8b90b1c8bb30a9abb9a9778c7862d94459a9391396e1c2a370d6b9c1e3d5"
+dependencies = [
+ "async-trait",
+ "form_urlencoded",
+ "http 1.4.0",
+ "jsonwebtoken",
+ "log",
+ "percent-encoding",
+ "rand 0.8.6",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -9187,6 +9250,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -9418,6 +9482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9497,6 +9570,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10293,6 +10377,18 @@ checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
 dependencies = [
  "console",
  "similar 3.1.0",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -11462,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11502,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11511,10 +11607,12 @@ dependencies = [
  "flate2",
  "fs-err",
  "globset",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "rustc-hash",
  "schemars 1.2.1",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "spdx 0.13.4",
  "tar",
@@ -11531,6 +11629,7 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-preview",
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
@@ -11540,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11578,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11604,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11620,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "hex",
  "memchr",
@@ -11633,8 +11732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11688,8 +11787,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "clap",
  "either",
@@ -11718,16 +11817,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11737,8 +11836,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "futures",
@@ -11770,8 +11869,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11818,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11835,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11875,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11906,16 +12005,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "backon",
  "dunce",
@@ -11939,8 +12038,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11966,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11979,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11993,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "clap",
  "configparser",
@@ -12031,8 +12130,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12073,8 +12172,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12088,8 +12187,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12099,8 +12198,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12117,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12128,8 +12227,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "dashmap",
  "futures",
@@ -12138,16 +12237,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12160,8 +12259,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12186,8 +12285,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12203,8 +12302,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12216,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12226,8 +12325,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12257,8 +12356,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12315,8 +12414,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12327,8 +12426,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12363,8 +12462,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12388,8 +12487,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12453,8 +12552,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12478,8 +12577,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "clap",
  "fs-err",
@@ -12513,8 +12612,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12529,8 +12628,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12540,8 +12639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12550,16 +12649,17 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
+ "thiserror 2.0.18",
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "clap",
  "either",
@@ -12579,8 +12679,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12592,8 +12692,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12615,13 +12715,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.25"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.9.26"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "console",
  "fs-err",
@@ -12643,8 +12743,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12653,8 +12753,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
+version = "0.0.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.26#ee4f0036283a350681a618176484df6bcde27507"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11489,8 +11489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11529,8 +11529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11566,8 +11566,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11603,8 +11603,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11628,8 +11628,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11644,8 +11644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "hex",
  "memchr",
@@ -11657,8 +11657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11712,8 +11712,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "clap",
  "either",
@@ -11741,16 +11741,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11760,8 +11760,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "futures",
@@ -11793,8 +11793,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11840,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11857,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11928,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "backon",
  "dunce",
@@ -11959,8 +11959,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11984,8 +11984,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11996,8 +11996,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12010,8 +12010,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "clap",
  "configparser",
@@ -12048,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12090,8 +12090,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12105,8 +12105,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12116,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12134,8 +12134,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12145,8 +12145,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "dashmap",
  "futures",
@@ -12155,16 +12155,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12177,8 +12177,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12220,8 +12220,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12233,8 +12233,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12243,8 +12243,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12274,8 +12274,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12332,8 +12332,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12344,8 +12344,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12380,8 +12380,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12405,8 +12405,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12470,8 +12470,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12495,8 +12495,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "clap",
  "fs-err",
@@ -12530,8 +12530,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12546,8 +12546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12557,8 +12557,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12567,16 +12567,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "clap",
  "either",
@@ -12596,8 +12596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12609,8 +12609,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12632,13 +12632,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.9.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "console",
  "fs-err",
@@ -12660,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12670,8 +12670,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
+version = "0.0.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11490,8 +11490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11530,8 +11530,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11570,8 +11570,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11607,8 +11607,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11633,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11649,8 +11649,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "hex",
  "memchr",
@@ -11662,8 +11662,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11717,8 +11717,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "clap",
  "either",
@@ -11749,16 +11749,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11768,8 +11768,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "futures",
@@ -11801,8 +11801,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11849,8 +11849,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11866,8 +11866,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11906,8 +11906,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11938,16 +11938,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "backon",
  "clap",
@@ -11976,8 +11976,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12002,8 +12002,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12015,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12029,8 +12029,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "configparser",
  "csv",
@@ -12064,8 +12064,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12106,8 +12106,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12121,8 +12121,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12132,8 +12132,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12150,8 +12150,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12161,8 +12161,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "dashmap",
  "futures",
@@ -12171,16 +12171,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12193,8 +12193,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12219,8 +12219,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12233,13 +12233,13 @@ dependencies = [
  "uv-fs",
  "uv-platform-tags",
  "uv-static",
- "windows-registry 0.5.3",
+ "windows-version",
 ]
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12252,8 +12252,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12263,8 +12263,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12294,8 +12294,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12353,8 +12353,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12365,8 +12365,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12400,8 +12400,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12425,8 +12425,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12490,8 +12490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12516,8 +12516,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "clap",
  "fs-err",
@@ -12551,8 +12551,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12567,8 +12567,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12578,8 +12578,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12588,8 +12588,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12597,8 +12597,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "clap",
  "either",
@@ -12618,8 +12618,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12631,8 +12631,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12654,13 +12654,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.10.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "console",
  "fs-err",
@@ -12681,8 +12681,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12691,8 +12691,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.29"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
+version = "0.0.30"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
 dependencies = [
  "clap",
  "fs-err",
@@ -13390,6 +13390,15 @@ name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
  "windows-link 0.2.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11490,8 +11490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11530,8 +11530,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11570,8 +11570,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11607,8 +11607,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11633,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11649,8 +11649,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "hex",
  "memchr",
@@ -11662,8 +11662,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11717,8 +11717,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "clap",
  "either",
@@ -11749,16 +11749,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11768,8 +11768,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "futures",
@@ -11801,8 +11801,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11842,6 +11842,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-redacted",
  "uv-types",
+ "uv-warnings",
  "uv-workspace",
  "walkdir",
  "zip",
@@ -11849,8 +11850,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11866,8 +11867,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11906,8 +11907,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11938,16 +11939,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "backon",
  "clap",
@@ -11976,8 +11977,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12002,8 +12003,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12015,8 +12016,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12029,8 +12030,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "configparser",
  "csv",
@@ -12064,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12106,8 +12107,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12121,8 +12122,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12132,8 +12133,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12150,8 +12151,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12161,8 +12162,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "dashmap",
  "futures",
@@ -12171,16 +12172,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12193,8 +12194,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12219,8 +12220,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12238,8 +12239,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12252,8 +12253,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12263,8 +12264,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12294,8 +12295,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12353,8 +12354,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12365,8 +12366,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12400,8 +12401,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12425,8 +12426,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12490,8 +12491,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12516,8 +12517,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "clap",
  "fs-err",
@@ -12551,12 +12552,12 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "fs-err",
- "nix 0.30.1",
+ "nix 0.31.2",
  "same-file",
  "tracing",
  "uv-fs",
@@ -12567,8 +12568,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12578,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12588,8 +12589,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12597,8 +12598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "clap",
  "either",
@@ -12618,8 +12619,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12631,8 +12632,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12654,13 +12655,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.10.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "console",
  "fs-err",
@@ -12681,8 +12682,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12691,8 +12692,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.10#8c730aaad652bf0c4bda1f94ce6506ecf0b68fbd"
+version = "0.0.31"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
 dependencies = [
  "clap",
  "fs-err",
@@ -13706,16 +13707,16 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.16.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9189bc72f0e4d814d812216ec06636ce3ea5597ff5f1ff9f9f0e5ec781c027"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "futures",
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11448,8 +11448,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11488,8 +11488,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11525,8 +11525,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11563,8 +11563,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11589,8 +11589,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11605,8 +11605,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "hex",
  "memchr",
@@ -11618,8 +11618,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11673,8 +11673,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "clap",
  "either",
@@ -11702,16 +11702,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11721,8 +11721,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "futures",
@@ -11754,8 +11754,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11802,8 +11802,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11819,8 +11819,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11859,8 +11859,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11890,16 +11890,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "backon",
  "dunce",
@@ -11923,8 +11923,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11950,8 +11950,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11963,8 +11963,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11977,8 +11977,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "clap",
  "configparser",
@@ -12015,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12057,8 +12057,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12072,8 +12072,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12083,8 +12083,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12101,8 +12101,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12112,8 +12112,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "dashmap",
  "futures",
@@ -12122,16 +12122,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12144,8 +12144,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12170,8 +12170,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12187,8 +12187,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12200,8 +12200,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12210,8 +12210,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12241,8 +12241,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12299,8 +12299,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12311,8 +12311,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12347,8 +12347,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12372,8 +12372,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12437,8 +12437,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12462,8 +12462,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "clap",
  "fs-err",
@@ -12497,8 +12497,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12513,8 +12513,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12524,8 +12524,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12534,16 +12534,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "clap",
  "either",
@@ -12563,8 +12563,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12576,8 +12576,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12599,13 +12599,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.9.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "console",
  "fs-err",
@@ -12627,8 +12627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12637,8 +12637,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.20#765a967236ffd71e6f82e794adf4165fedc2541f"
+version = "0.0.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,22 +7450,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.11.1",
  "flate2",
- "hex",
  "procfs-core",
- "rustix 0.38.44",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags 2.11.1",
  "hex",
@@ -11448,8 +11447,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11488,8 +11487,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11525,8 +11524,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11563,8 +11562,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11589,8 +11588,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11605,8 +11604,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "hex",
  "memchr",
@@ -11618,8 +11617,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11673,8 +11672,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "clap",
  "either",
@@ -11702,16 +11701,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11721,8 +11720,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "futures",
@@ -11754,8 +11753,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11802,8 +11801,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11819,8 +11818,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11859,8 +11858,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11890,16 +11889,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "backon",
  "dunce",
@@ -11923,8 +11922,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11950,8 +11949,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11963,8 +11962,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11977,8 +11976,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "clap",
  "configparser",
@@ -12015,8 +12014,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12057,8 +12056,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12072,8 +12071,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12083,8 +12082,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12101,8 +12100,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12112,8 +12111,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "dashmap",
  "futures",
@@ -12122,16 +12121,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12144,8 +12143,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12170,8 +12169,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12187,8 +12186,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12200,8 +12199,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12210,8 +12209,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12241,8 +12240,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12299,8 +12298,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12311,8 +12310,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12347,8 +12346,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12372,8 +12371,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12437,8 +12436,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12462,8 +12461,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "clap",
  "fs-err",
@@ -12497,8 +12496,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12513,8 +12512,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12524,8 +12523,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12534,16 +12533,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "clap",
  "either",
@@ -12563,8 +12562,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12576,8 +12575,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12599,13 +12598,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.9.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "console",
  "fs-err",
@@ -12627,8 +12626,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12637,8 +12636,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.21#0dc9556adb488469ee807e360768ed6b5a6d0488"
+version = "0.0.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.22#82a6a66b811b172a7506015587b7206742eae1a8"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11500,8 +11500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11540,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11573,7 +11573,6 @@ dependencies = [
  "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
- "uv-version",
  "uv-warnings",
  "walkdir",
  "zip",
@@ -11581,8 +11580,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11618,8 +11617,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11644,8 +11643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11660,8 +11659,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "hex",
  "memchr",
@@ -11673,8 +11672,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11728,8 +11727,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "clap",
  "either",
@@ -11760,16 +11759,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11779,8 +11778,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "futures",
@@ -11812,8 +11811,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11860,8 +11859,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11877,8 +11876,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11917,8 +11916,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11949,16 +11948,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "backon",
  "clap",
@@ -11987,8 +11986,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12013,8 +12012,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12026,8 +12025,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12040,8 +12039,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "configparser",
  "csv",
@@ -12075,8 +12074,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12117,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12132,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12143,8 +12142,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12161,8 +12160,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12172,8 +12171,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "dashmap",
  "futures",
@@ -12182,16 +12181,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12204,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12230,8 +12229,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12247,8 +12246,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12261,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12272,8 +12271,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12303,8 +12302,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12363,8 +12362,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12375,8 +12374,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12384,7 +12383,6 @@ dependencies = [
  "fs-err",
  "futures",
  "rustc-hash",
- "serde",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -12411,8 +12409,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12436,8 +12434,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12501,8 +12499,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12526,8 +12524,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "clap",
  "fs-err",
@@ -12561,8 +12559,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12577,8 +12575,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12588,8 +12586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12598,8 +12596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12607,8 +12605,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "clap",
  "either",
@@ -12628,8 +12626,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12641,8 +12639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12664,13 +12662,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.10.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "console",
  "fs-err",
@@ -12691,8 +12689,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12701,8 +12699,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.7#08ab1a344774ac4e9ff44e8b06134e8bcf01ae0e"
+version = "0.0.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,27 +111,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -144,15 +129,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -1699,7 +1675,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -4750,16 +4726,6 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
-dependencies = [
- "crc",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "lzma-rust2"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
@@ -5908,7 +5874,7 @@ dependencies = [
  "uv-installer",
  "uv-normalize",
  "uv-python",
- "zip 8.6.0",
+ "zip",
 ]
 
 [[package]]
@@ -6369,7 +6335,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-requirements-txt",
  "which",
- "zip 8.6.0",
+ "zip",
 ]
 
 [[package]]
@@ -7160,7 +7126,7 @@ dependencies = [
  "tracing",
  "url",
  "xz2",
- "zip 8.6.0",
+ "zip",
  "zstd",
 ]
 
@@ -8067,7 +8033,7 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
- "lzma-rust2 0.16.2",
+ "lzma-rust2",
  "md-5 0.10.6",
  "rattler_build_networking",
  "rattler_git",
@@ -8085,7 +8051,7 @@ dependencies = [
  "tracing",
  "url",
  "walkdir",
- "zip 8.6.0",
+ "zip",
  "zstd",
 ]
 
@@ -8447,7 +8413,7 @@ dependencies = [
  "tokio-util 0.7.18",
  "tracing",
  "url",
- "zip 8.6.0",
+ "zip",
  "zstd",
 ]
 
@@ -9904,7 +9870,7 @@ dependencies = [
  "crc32fast",
  "getrandom 0.4.2",
  "js-sys",
- "lzma-rust2 0.16.2",
+ "lzma-rust2",
  "ppmd-rust",
  "sha2 0.10.9",
  "wasm-bindgen",
@@ -9922,7 +9888,7 @@ dependencies = [
  "crc32fast",
  "getrandom 0.4.2",
  "js-sys",
- "lzma-rust2 0.16.2",
+ "lzma-rust2",
  "ppmd-rust",
  "sha2 0.11.0",
  "wasm-bindgen",
@@ -11534,8 +11500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11574,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11610,15 +11576,15 @@ dependencies = [
  "uv-version",
  "uv-warnings",
  "walkdir",
- "zip 7.1.0",
+ "zip",
 ]
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "fs-err",
  "indoc",
  "itertools 0.14.0",
@@ -11652,8 +11618,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11678,8 +11644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11694,8 +11660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "hex",
  "memchr",
@@ -11707,8 +11673,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11762,8 +11728,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "clap",
  "either",
@@ -11793,16 +11759,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11812,8 +11778,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "futures",
@@ -11845,8 +11811,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11888,13 +11854,13 @@ dependencies = [
  "uv-types",
  "uv-workspace",
  "walkdir",
- "zip 7.1.0",
+ "zip",
 ]
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11910,8 +11876,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11950,8 +11916,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11976,24 +11942,25 @@ dependencies = [
  "uv-static",
  "uv-warnings",
  "xz2",
- "zip 7.1.0",
+ "zip",
  "zstd",
 ]
 
 [[package]]
 name = "uv-flags"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "backon",
+ "clap",
  "dunce",
  "either",
  "encoding_rs_io",
@@ -12001,6 +11968,8 @@ dependencies = [
  "junction",
  "path-slash",
  "percent-encoding",
+ "reflink-copy",
+ "rustc-hash",
  "rustix 1.1.4",
  "same-file",
  "schemars 1.2.1",
@@ -12010,13 +11979,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uv-static",
+ "uv-warnings",
+ "walkdir",
  "windows 0.61.3",
 ]
 
 [[package]]
 name = "uv-git"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12041,8 +12012,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12054,8 +12025,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12068,10 +12039,9 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
- "clap",
  "configparser",
  "csv",
  "data-encoding",
@@ -12080,16 +12050,13 @@ dependencies = [
  "mailparse",
  "owo-colors",
  "pathdiff",
- "reflink-copy",
  "regex",
  "rustc-hash",
  "same-file",
- "schemars 1.2.1",
  "self-replace",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "uv-distribution-filename",
@@ -12107,8 +12074,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12149,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12164,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12175,8 +12142,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12188,13 +12155,13 @@ dependencies = [
  "uv-distribution-filename",
  "uv-normalize",
  "uv-pypi-types",
- "zip 7.1.0",
+ "zip",
 ]
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12204,8 +12171,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "dashmap",
  "futures",
@@ -12214,16 +12181,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12236,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12262,8 +12229,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12279,8 +12246,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12293,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12304,8 +12271,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12335,8 +12302,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12394,8 +12361,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12406,8 +12373,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12442,8 +12409,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12467,8 +12434,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12532,8 +12499,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12557,8 +12524,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "clap",
  "fs-err",
@@ -12592,8 +12559,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12608,8 +12575,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12619,8 +12586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12629,8 +12596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12638,8 +12605,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "clap",
  "either",
@@ -12659,21 +12626,21 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "fs-err",
  "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
  "windows 0.61.3",
- "zip 7.1.0",
+ "zip",
 ]
 
 [[package]]
 name = "uv-types"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12695,13 +12662,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.10.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "console",
  "fs-err",
@@ -12722,18 +12689,18 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "owo-colors",
  "rustc-hash",
 ]
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.4#079e3fd059c3d073151a6ac3b39eb129d66b517d"
+version = "0.0.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.5#5fa874f031b8de1bc6154066fd55f9f646a4d204"
 dependencies = [
  "clap",
  "fs-err",
@@ -14106,33 +14073,20 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.1.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9013f1222db8a6d680f13a7ccdc60a781199cd09c2fa4eff58e728bb181757fc"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "bzip2 0.6.1",
  "crc32fast",
  "flate2",
  "indexmap 2.14.0",
- "lzma-rust2 0.15.7",
- "memchr",
- "zopfli",
- "zstd",
-]
-
-[[package]]
-name = "zip"
-version = "8.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
-dependencies = [
- "crc32fast",
- "flate2",
- "indexmap 2.14.0",
+ "lzma-rust2",
  "memchr",
  "time",
  "typed-path",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,22 +356,6 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "portable-atomic",
- "rustc-hash",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
-name = "astral-tokio-tar"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
@@ -8385,7 +8369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8321ca30ccd49fed1c000d981a1d0f786f8b365c119b7c8bdd5f0bdbd870f04c"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
- "astral-tokio-tar 0.6.1",
+ "astral-tokio-tar",
  "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
@@ -11490,8 +11474,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11530,8 +11514,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11570,8 +11554,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11607,8 +11591,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11633,8 +11617,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11649,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "hex",
  "memchr",
@@ -11662,8 +11646,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11717,8 +11701,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "clap",
  "either",
@@ -11749,16 +11733,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11768,8 +11752,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "futures",
@@ -11801,8 +11785,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11850,8 +11834,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11867,8 +11851,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11907,10 +11891,10 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
- "astral-tokio-tar 0.5.6",
+ "astral-tokio-tar",
  "astral_async_zip",
  "async-compression",
  "blake2",
@@ -11939,16 +11923,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "backon",
  "clap",
@@ -11977,8 +11961,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12003,8 +11987,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12016,8 +12000,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12030,8 +12014,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "configparser",
  "csv",
@@ -12065,8 +12049,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12107,8 +12091,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12122,8 +12106,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12133,8 +12117,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12151,8 +12135,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12162,8 +12146,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "dashmap",
  "futures",
@@ -12172,16 +12156,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12194,8 +12178,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12220,8 +12204,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12239,8 +12223,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12253,8 +12237,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12264,8 +12248,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12295,8 +12279,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12354,8 +12338,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12366,8 +12350,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12401,8 +12385,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12426,8 +12410,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12491,8 +12475,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12517,8 +12501,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "clap",
  "fs-err",
@@ -12552,8 +12536,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12568,8 +12552,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12579,8 +12563,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12589,8 +12573,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12598,8 +12582,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "clap",
  "either",
@@ -12619,8 +12603,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12632,8 +12616,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12655,13 +12639,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.10.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "console",
  "fs-err",
@@ -12682,8 +12666,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12692,8 +12676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.31"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.11#006b56b12dac36c41e2486a6a0a1726e3abebe86"
+version = "0.0.32"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11703,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "hex",
  "memchr",
@@ -11732,8 +11732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11787,8 +11787,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "clap",
  "either",
@@ -11817,16 +11817,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11836,8 +11836,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "futures",
@@ -11869,8 +11869,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11917,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -12005,16 +12005,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "backon",
  "dunce",
@@ -12038,8 +12038,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12065,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12078,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12092,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "clap",
  "configparser",
@@ -12131,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12173,8 +12173,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12188,8 +12188,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12199,8 +12199,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12217,8 +12217,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12228,8 +12228,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "dashmap",
  "futures",
@@ -12238,16 +12238,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12260,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12286,8 +12286,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12303,8 +12303,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12316,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12358,8 +12358,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12416,8 +12416,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12428,8 +12428,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12464,8 +12464,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12489,8 +12489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12554,8 +12554,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12579,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "clap",
  "fs-err",
@@ -12614,8 +12614,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12630,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12641,8 +12641,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12651,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12660,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "clap",
  "either",
@@ -12681,8 +12681,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12694,8 +12694,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12717,13 +12717,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.9.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "console",
  "fs-err",
@@ -12746,8 +12746,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12756,8 +12756,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
+version = "0.0.18"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.29#1f1321d8420e2c97c3bdfac80cc2fd7fee92e209"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11665,7 +11665,6 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
- "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-static",
@@ -11677,8 +11676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11703,8 +11702,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11719,8 +11718,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "hex",
  "memchr",
@@ -11732,8 +11731,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11787,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "clap",
  "either",
@@ -11817,16 +11816,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11836,8 +11835,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "futures",
@@ -11869,8 +11868,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11917,8 +11916,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11933,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11973,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -12005,16 +12004,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "backon",
  "dunce",
@@ -12038,8 +12037,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12065,8 +12064,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12078,8 +12077,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12092,8 +12091,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "clap",
  "configparser",
@@ -12131,8 +12130,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12173,8 +12172,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12188,8 +12187,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12199,8 +12198,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12217,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12228,8 +12227,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "dashmap",
  "futures",
@@ -12238,16 +12237,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12260,8 +12259,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12286,8 +12285,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12303,9 +12302,10 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
+ "bitflags 2.11.1",
  "memchr",
  "rkyv",
  "rustc-hash",
@@ -12316,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12358,8 +12358,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12371,6 +12371,7 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "itertools 0.14.0",
+ "junction",
  "owo-colors",
  "ref-cast",
  "regex",
@@ -12416,8 +12417,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12428,8 +12429,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12464,8 +12465,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12489,8 +12490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12554,8 +12555,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12579,8 +12580,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "clap",
  "fs-err",
@@ -12614,8 +12615,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12630,8 +12631,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12641,8 +12642,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12651,8 +12652,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12660,8 +12661,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "clap",
  "either",
@@ -12681,8 +12682,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12694,8 +12695,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12717,13 +12718,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.30"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.10.0"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "console",
  "fs-err",
@@ -12736,18 +12737,16 @@ dependencies = [
  "uv-console",
  "uv-fs",
  "uv-platform-tags",
- "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-shell",
  "uv-version",
- "uv-warnings",
 ]
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12756,8 +12755,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.19"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.30#ea4560831e503c6ce34d18739476a71ac6e9a9de"
+version = "0.0.20"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11462,8 +11462,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11502,8 +11502,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11540,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11578,8 +11578,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11604,8 +11604,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11620,8 +11620,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "hex",
  "memchr",
@@ -11633,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11688,8 +11688,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "clap",
  "either",
@@ -11718,16 +11718,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11737,8 +11737,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "futures",
@@ -11770,8 +11770,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11818,8 +11818,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11835,8 +11835,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11875,8 +11875,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11906,16 +11906,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "backon",
  "dunce",
@@ -11939,8 +11939,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11966,8 +11966,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11979,8 +11979,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11993,8 +11993,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "clap",
  "configparser",
@@ -12031,8 +12031,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12073,8 +12073,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12088,8 +12088,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12099,8 +12099,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12117,8 +12117,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12128,8 +12128,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "dashmap",
  "futures",
@@ -12138,16 +12138,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12160,8 +12160,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12186,8 +12186,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12216,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12226,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12257,8 +12257,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12315,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12363,8 +12363,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12388,8 +12388,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12453,8 +12453,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12478,8 +12478,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "clap",
  "fs-err",
@@ -12513,8 +12513,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12529,8 +12529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12540,8 +12540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12550,16 +12550,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "clap",
  "either",
@@ -12579,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12592,8 +12592,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12615,13 +12615,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.24"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.9.25"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "console",
  "fs-err",
@@ -12643,8 +12643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12653,8 +12653,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
+version = "0.0.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.25#38fcac0f3668986727aa7ba6290e8cb94c1dbe5f"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11462,8 +11462,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11502,8 +11502,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11540,8 +11540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11578,8 +11578,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11604,8 +11604,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11620,8 +11620,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "hex",
  "memchr",
@@ -11633,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11688,8 +11688,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "clap",
  "either",
@@ -11718,16 +11718,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11737,8 +11737,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "futures",
@@ -11770,8 +11770,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11818,8 +11818,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11835,8 +11835,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11875,8 +11875,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11906,16 +11906,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "backon",
  "dunce",
@@ -11939,8 +11939,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11966,8 +11966,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11979,8 +11979,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11993,8 +11993,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "clap",
  "configparser",
@@ -12031,8 +12031,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12073,8 +12073,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12088,8 +12088,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12099,8 +12099,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12117,8 +12117,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12128,8 +12128,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "dashmap",
  "futures",
@@ -12138,16 +12138,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12160,8 +12160,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12186,8 +12186,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12216,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12226,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12257,8 +12257,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12315,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12363,8 +12363,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12388,8 +12388,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12453,8 +12453,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12478,8 +12478,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "clap",
  "fs-err",
@@ -12513,8 +12513,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12529,8 +12529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12540,8 +12540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12550,16 +12550,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "clap",
  "either",
@@ -12579,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12592,8 +12592,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12615,13 +12615,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.23"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.9.24"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "console",
  "fs-err",
@@ -12643,8 +12643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12653,8 +12653,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.23#00f07541a1572a9a68bba665cc72a4aa29b70c02"
+version = "0.0.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.24#0fda1525ebe299786a732b8f9560b10f28f6ad2d"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11489,8 +11489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11529,8 +11529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11566,8 +11566,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11603,8 +11603,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11628,8 +11628,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11644,8 +11644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "hex",
  "memchr",
@@ -11657,8 +11657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11712,8 +11712,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "clap",
  "either",
@@ -11741,16 +11741,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11760,8 +11760,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "futures",
@@ -11793,8 +11793,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11840,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11857,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11928,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "backon",
  "dunce",
@@ -11959,8 +11959,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11984,8 +11984,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11996,8 +11996,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12010,8 +12010,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "clap",
  "configparser",
@@ -12048,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12090,8 +12090,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12105,8 +12105,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12116,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12134,8 +12134,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12145,8 +12145,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "dashmap",
  "futures",
@@ -12155,16 +12155,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12177,8 +12177,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12220,8 +12220,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12233,8 +12233,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12243,8 +12243,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12274,8 +12274,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12332,8 +12332,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12344,8 +12344,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12380,8 +12380,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12405,8 +12405,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12470,8 +12470,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12495,8 +12495,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "clap",
  "fs-err",
@@ -12530,8 +12530,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12546,8 +12546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12557,8 +12557,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12567,16 +12567,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "clap",
  "either",
@@ -12596,8 +12596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12609,8 +12609,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12632,13 +12632,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.9.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "console",
  "fs-err",
@@ -12660,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12670,8 +12670,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
+version = "0.0.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.13#7ca92dcf66545963588d1d44dbefb658ce8c11a2"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11703,8 +11703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "hex",
  "memchr",
@@ -11732,8 +11732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11787,8 +11787,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "clap",
  "either",
@@ -11817,16 +11817,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11836,8 +11836,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "futures",
@@ -11869,8 +11869,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11917,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -12005,16 +12005,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "backon",
  "dunce",
@@ -12038,8 +12038,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12065,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12078,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12092,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "clap",
  "configparser",
@@ -12131,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12173,8 +12173,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12188,8 +12188,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12199,8 +12199,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12217,8 +12217,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12228,8 +12228,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "dashmap",
  "futures",
@@ -12238,16 +12238,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12260,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12286,8 +12286,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12303,8 +12303,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12316,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12358,8 +12358,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12416,8 +12416,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12428,8 +12428,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12464,8 +12464,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12489,8 +12489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12554,8 +12554,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12579,8 +12579,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "clap",
  "fs-err",
@@ -12614,8 +12614,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12630,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12641,8 +12641,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12651,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12660,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "clap",
  "either",
@@ -12681,8 +12681,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12694,8 +12694,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12717,13 +12717,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.27"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.9.28"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "console",
  "fs-err",
@@ -12735,6 +12735,7 @@ dependencies = [
  "tracing",
  "uv-console",
  "uv-fs",
+ "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
  "uv-python",
@@ -12745,8 +12746,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12755,8 +12756,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.27#b5797b2ab4200e719f9d9095de8e062fff7eb51a"
+version = "0.0.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.28#0e1351e4006c3c03bbb60a9ec3ef5ded010c4a8c"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,15 +190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arborium"
 version = "2.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,8 +670,8 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -692,7 +683,7 @@ dependencies = [
  "http 1.4.0",
  "p256 0.13.2",
  "rand 0.8.6",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "time",
  "tokio",
@@ -747,7 +738,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -767,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.119.0"
+version = "1.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -777,8 +768,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.6",
- "aws-smithy-json 0.61.9",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -787,14 +779,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
- "http-body 0.4.6",
+ "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tracing",
  "url",
 ]
@@ -808,8 +800,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -832,8 +824,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -856,8 +848,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -880,8 +872,8 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
- "aws-smithy-json 0.62.5",
+ "aws-smithy-http",
+ "aws-smithy-json",
  "aws-smithy-observability",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -904,7 +896,7 @@ checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -937,21 +929,22 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.12"
+version = "0.64.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
 dependencies = [
- "aws-smithy-http 0.62.6",
+ "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 0.2.12",
- "http-body 0.4.6",
- "md-5",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5 0.11.0",
  "pin-project-lite",
- "sha1",
- "sha2 0.10.9",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tracing",
 ]
 
@@ -968,32 +961,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
-dependencies = [
- "aws-smithy-eventstream",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "bytes",
- "bytes-utils",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http 1.4.0",
- "http-body 0.4.6",
- "percent-encoding",
- "pin-project-lite",
- "pin-utils",
- "tracing",
-]
-
-[[package]]
-name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1035,15 +1007,6 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
-dependencies = [
- "aws-smithy-types",
-]
-
-[[package]]
-name = "aws-smithy-json"
 version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
@@ -1077,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.63.6",
+ "aws-smithy-http",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1551,7 +1514,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "ssri",
  "tempfile",
@@ -2033,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -2048,15 +2011,14 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
  "digest 0.10.7",
- "rand 0.9.4",
- "regex",
  "rustversion",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2479,17 +2441,6 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3517,8 +3468,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4666,7 +4615,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4786,11 +4735,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4800,13 +4749,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "lzma-rs"
-version = "0.3.0"
+name = "lzma-rust2"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
- "byteorder",
  "crc",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4874,6 +4823,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if 1.0.4",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if 1.0.4",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5435,7 +5394,7 @@ dependencies = [
  "http-body 1.0.1",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign 0.16.5",
@@ -8064,7 +8023,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
- "sha1",
+ "sha1 0.10.6",
  "spdx 0.13.4",
  "thiserror 2.0.18",
  "url",
@@ -8108,8 +8067,8 @@ dependencies = [
  "futures",
  "hex",
  "indicatif",
- "lzma-rust2",
- "md-5",
+ "lzma-rust2 0.16.2",
+ "md-5 0.10.6",
  "rattler_build_networking",
  "rattler_git",
  "rattler_prefix_guard",
@@ -8281,7 +8240,7 @@ dependencies = [
  "digest 0.10.7",
  "generic-array",
  "hex",
- "md-5",
+ "md-5 0.10.6",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -8885,7 +8844,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tokio",
 ]
@@ -8923,7 +8882,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -8954,7 +8913,7 @@ dependencies = [
  "jiff",
  "log",
  "percent-encoding",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
@@ -9945,7 +9904,7 @@ dependencies = [
  "crc32fast",
  "getrandom 0.4.2",
  "js-sys",
- "lzma-rust2",
+ "lzma-rust2 0.16.2",
  "ppmd-rust",
  "sha2 0.10.9",
  "wasm-bindgen",
@@ -9963,7 +9922,7 @@ dependencies = [
  "crc32fast",
  "getrandom 0.4.2",
  "js-sys",
- "lzma-rust2",
+ "lzma-rust2 0.16.2",
  "ppmd-rust",
  "sha2 0.11.0",
  "wasm-bindgen",
@@ -9989,6 +9948,17 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -10462,7 +10432,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -10488,6 +10458,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -11558,8 +11534,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11574,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11634,13 +11610,13 @@ dependencies = [
  "uv-version",
  "uv-warnings",
  "walkdir",
- "zip 2.4.2",
+ "zip 7.1.0",
 ]
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11676,8 +11652,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11702,8 +11678,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11718,8 +11694,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "hex",
  "memchr",
@@ -11731,8 +11707,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11786,8 +11762,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "clap",
  "either",
@@ -11817,16 +11793,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11836,8 +11812,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "futures",
@@ -11869,8 +11845,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11912,13 +11888,13 @@ dependencies = [
  "uv-types",
  "uv-workspace",
  "walkdir",
- "zip 2.4.2",
+ "zip 7.1.0",
 ]
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11910,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11950,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11983,7 +11959,7 @@ dependencies = [
  "blake2",
  "fs-err",
  "futures",
- "md-5",
+ "md-5 0.10.6",
  "rayon",
  "regex",
  "reqwest 0.12.28",
@@ -12000,22 +11976,22 @@ dependencies = [
  "uv-static",
  "uv-warnings",
  "xz2",
- "zip 2.4.2",
+ "zip 7.1.0",
  "zstd",
 ]
 
 [[package]]
 name = "uv-flags"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "backon",
  "dunce",
@@ -12039,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12065,8 +12041,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12078,8 +12054,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12092,8 +12068,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "clap",
  "configparser",
@@ -12131,8 +12107,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12173,8 +12149,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12188,8 +12164,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12199,8 +12175,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12212,13 +12188,13 @@ dependencies = [
  "uv-distribution-filename",
  "uv-normalize",
  "uv-pypi-types",
- "zip 2.4.2",
+ "zip 7.1.0",
 ]
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12228,8 +12204,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "dashmap",
  "futures",
@@ -12238,16 +12214,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12260,8 +12236,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12286,8 +12262,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12303,8 +12279,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12317,8 +12293,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12328,8 +12304,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12359,8 +12335,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12418,8 +12394,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12430,8 +12406,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12466,8 +12442,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12491,8 +12467,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12556,8 +12532,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12581,8 +12557,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "clap",
  "fs-err",
@@ -12616,8 +12592,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12632,8 +12608,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12643,8 +12619,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12653,8 +12629,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12662,8 +12638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "clap",
  "either",
@@ -12683,21 +12659,21 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "fs-err",
  "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
  "windows 0.61.3",
- "zip 2.4.2",
+ "zip 7.1.0",
 ]
 
 [[package]]
 name = "uv-types"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12719,13 +12695,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.10.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "console",
  "fs-err",
@@ -12746,8 +12722,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12756,8 +12732,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.22"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
+version = "0.0.23"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.3#c75a0c625cbed187d64bbb6c406afd94f3d5da49"
 dependencies = [
  "clap",
  "fs-err",
@@ -13797,7 +13773,7 @@ checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
  "der 0.7.10",
- "sha1",
+ "sha1 0.10.6",
  "signature 2.2.0",
  "spki 0.7.3",
  "tls_codec",
@@ -13943,7 +13919,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "static_assertions",
  "tracing",
  "uds_windows",
@@ -14130,21 +14106,16 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "9013f1222db8a6d680f13a7ccdc60a781199cd09c2fa4eff58e728bb181757fc"
 dependencies = [
- "arbitrary",
- "bzip2 0.5.2",
+ "bzip2 0.6.1",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap 2.14.0",
- "lzma-rs",
+ "lzma-rust2 0.15.7",
  "memchr",
- "thiserror 2.0.18",
- "xz2",
  "zopfli",
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6401,7 +6401,6 @@ dependencies = [
  "tracing-subscriber",
  "typed-path",
  "url",
- "uv-client",
  "uv-configuration",
  "uv-pep508",
  "uv-pypi-types",
@@ -11489,8 +11488,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11529,8 +11528,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11566,8 +11565,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11603,8 +11602,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11628,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11644,8 +11643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "hex",
  "memchr",
@@ -11657,8 +11656,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11712,8 +11711,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "clap",
  "either",
@@ -11741,16 +11740,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11760,8 +11759,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "futures",
@@ -11793,8 +11792,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11822,6 +11821,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-extract",
+ "uv-flags",
  "uv-fs",
  "uv-git",
  "uv-git-types",
@@ -11840,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11857,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11928,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "backon",
  "dunce",
@@ -11959,14 +11959,15 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
  "cargo-util",
  "dashmap",
  "fs-err",
+ "owo-colors",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
@@ -11979,25 +11980,27 @@ dependencies = [
  "uv-redacted",
  "uv-static",
  "uv-version",
+ "uv-warnings",
  "which",
 ]
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
  "url",
  "uv-redacted",
+ "uv-static",
 ]
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12010,8 +12013,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "clap",
  "configparser",
@@ -12048,8 +12051,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12090,8 +12093,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12105,8 +12108,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12116,8 +12119,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12134,8 +12137,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12145,8 +12148,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "dashmap",
  "futures",
@@ -12155,16 +12158,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12177,8 +12180,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12203,8 +12206,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12220,8 +12223,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12233,8 +12236,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12243,8 +12246,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12274,8 +12277,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12332,8 +12335,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12344,8 +12347,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12380,8 +12383,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12405,8 +12408,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12470,8 +12473,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12495,8 +12498,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "clap",
  "fs-err",
@@ -12530,8 +12533,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12546,8 +12549,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12557,8 +12560,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12567,16 +12570,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "clap",
  "either",
@@ -12596,8 +12599,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12609,8 +12612,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12632,13 +12635,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.9.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "console",
  "fs-err",
@@ -12660,8 +12663,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12670,8 +12673,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.14#05814f9cd5beb251402fd6f15be97d4f9bda8531"
+version = "0.0.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.15#5eafae3327a131cbd6fd83c3c3f6b0f906aa9db2"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11676,8 +11676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11702,8 +11702,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11718,8 +11718,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "hex",
  "memchr",
@@ -11731,8 +11731,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11786,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "clap",
  "either",
@@ -11816,16 +11816,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11835,8 +11835,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "futures",
@@ -11868,8 +11868,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11916,8 +11916,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11933,8 +11933,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11973,8 +11973,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -12004,16 +12004,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "backon",
  "dunce",
@@ -12037,8 +12037,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12064,8 +12064,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12077,8 +12077,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12091,8 +12091,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "clap",
  "configparser",
@@ -12130,8 +12130,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12172,8 +12172,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12187,8 +12187,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12198,8 +12198,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12216,8 +12216,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12227,8 +12227,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "dashmap",
  "futures",
@@ -12237,16 +12237,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12259,8 +12259,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12285,8 +12285,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12302,8 +12302,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12316,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12327,8 +12327,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12358,8 +12358,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12417,8 +12417,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12429,8 +12429,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12465,8 +12465,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12490,8 +12490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12555,8 +12555,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12580,8 +12580,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "clap",
  "fs-err",
@@ -12615,8 +12615,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12631,8 +12631,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12642,8 +12642,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12652,8 +12652,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12661,8 +12661,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "clap",
  "either",
@@ -12682,8 +12682,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12695,8 +12695,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12718,13 +12718,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.10.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "console",
  "fs-err",
@@ -12745,8 +12745,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12755,12 +12755,13 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.20"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.0#0ba432459aa4e84d793fd8cfc98d13cf619316bb"
+version = "0.0.21"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
 dependencies = [
  "clap",
  "fs-err",
  "glob",
+ "ignore",
  "itertools 0.14.0",
  "owo-colors",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11489,8 +11489,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11529,8 +11529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11566,8 +11566,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11603,8 +11603,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11628,8 +11628,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11644,8 +11644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "hex",
  "memchr",
@@ -11657,8 +11657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11712,8 +11712,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "clap",
  "either",
@@ -11741,16 +11741,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11760,8 +11760,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "futures",
@@ -11793,8 +11793,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11840,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11857,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11928,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "backon",
  "dunce",
@@ -11959,8 +11959,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11984,8 +11984,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11996,8 +11996,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12010,8 +12010,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "clap",
  "configparser",
@@ -12048,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12090,8 +12090,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12105,8 +12105,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12116,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12134,8 +12134,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12145,8 +12145,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "dashmap",
  "futures",
@@ -12155,16 +12155,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12177,8 +12177,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12220,8 +12220,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12233,8 +12233,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12243,8 +12243,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12274,8 +12274,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12332,8 +12332,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12344,8 +12344,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12380,8 +12380,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12405,8 +12405,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12470,8 +12470,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12495,8 +12495,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "clap",
  "fs-err",
@@ -12530,8 +12530,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12546,8 +12546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12557,8 +12557,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12567,16 +12567,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "clap",
  "either",
@@ -12596,8 +12596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12609,8 +12609,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12632,13 +12632,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.9.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "console",
  "fs-err",
@@ -12660,8 +12660,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12670,8 +12670,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.12#0fb12333630cee7c383c35b00ad268780b905732"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,8 +11558,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11598,8 +11598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11639,8 +11639,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11676,8 +11676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11702,8 +11702,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11718,8 +11718,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "hex",
  "memchr",
@@ -11731,8 +11731,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11786,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "clap",
  "either",
@@ -11811,21 +11811,22 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-redacted",
  "uv-static",
 ]
 
 [[package]]
 name = "uv-console"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11835,8 +11836,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "futures",
@@ -11868,8 +11869,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11916,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11933,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11973,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11997,6 +11998,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-pypi-types",
  "uv-static",
+ "uv-warnings",
  "xz2",
  "zip 2.4.2",
  "zstd",
@@ -12004,16 +12006,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "backon",
  "dunce",
@@ -12037,8 +12039,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12050,7 +12052,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "url",
  "uv-auth",
  "uv-cache-key",
  "uv-fs",
@@ -12064,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12077,8 +12078,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12091,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "clap",
  "configparser",
@@ -12130,8 +12131,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12172,8 +12173,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12187,8 +12188,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12198,8 +12199,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12216,8 +12217,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12227,8 +12228,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "dashmap",
  "futures",
@@ -12237,16 +12238,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12259,8 +12260,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12285,8 +12286,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12302,8 +12303,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12316,8 +12317,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12327,8 +12328,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12358,8 +12359,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12417,8 +12418,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12429,8 +12430,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12465,8 +12466,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12490,8 +12491,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12555,8 +12556,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12580,8 +12581,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "clap",
  "fs-err",
@@ -12615,8 +12616,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12631,8 +12632,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12642,8 +12643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12652,8 +12653,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12661,8 +12662,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "clap",
  "either",
@@ -12682,8 +12683,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12695,8 +12696,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12718,13 +12719,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.10.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "console",
  "fs-err",
@@ -12745,8 +12746,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12755,8 +12756,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.21"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.1#b1b14d39aef8e307ec5cf1d7243819fd5a2cc544"
+version = "0.0.22"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.2#a788db7e5d33392b523bd6d45929da2c99da9477"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,6 +2285,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyclonedx-bom"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3132b69ba8c13808bd2fa5748ac5b9816eb4f4e1f0bff6b7f9254a5940dcdeef"
+dependencies = [
+ "base64 0.22.1",
+ "cyclonedx-bom-macros",
+ "fluent-uri",
+ "indexmap 2.14.0",
+ "once_cell",
+ "ordered-float 5.3.0",
+ "purl",
+ "regex",
+ "serde",
+ "serde_json",
+ "spdx 0.13.4",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
+ "xml-rs",
+]
+
+[[package]]
+name = "cyclonedx-bom-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50341f21df64b412b4f917e34b7aa786c092d64f3f905f478cb76950c7e980c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3023,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -5487,6 +5539,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -9645,7 +9706,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -11429,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "uv-auth"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11468,8 +11529,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11506,7 +11567,7 @@ dependencies = [
 [[package]]
 name = "uv-build-frontend"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11543,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "uv-cache"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11568,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-info"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11584,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "uv-cache-key"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "hex",
  "memchr",
@@ -11597,7 +11658,7 @@ dependencies = [
 [[package]]
 name = "uv-client"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11652,7 +11713,7 @@ dependencies = [
 [[package]]
 name = "uv-configuration"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "clap",
  "either",
@@ -11681,7 +11742,7 @@ dependencies = [
 [[package]]
 name = "uv-console"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "console",
 ]
@@ -11689,7 +11750,7 @@ dependencies = [
 [[package]]
 name = "uv-dirs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11700,7 +11761,7 @@ dependencies = [
 [[package]]
 name = "uv-dispatch"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "futures",
@@ -11733,7 +11794,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11780,7 +11841,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-filename"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11797,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "uv-distribution-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11837,7 +11898,7 @@ dependencies = [
 [[package]]
 name = "uv-extract"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11868,7 +11929,7 @@ dependencies = [
 [[package]]
 name = "uv-flags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -11876,7 +11937,7 @@ dependencies = [
 [[package]]
 name = "uv-fs"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "backon",
  "dunce",
@@ -11899,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "uv-git"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11924,7 +11985,7 @@ dependencies = [
 [[package]]
 name = "uv-git-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -11935,8 +11996,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11950,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "uv-install-wheel"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "clap",
  "configparser",
@@ -11988,7 +12049,7 @@ dependencies = [
 [[package]]
 name = "uv-installer"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12030,7 +12091,7 @@ dependencies = [
 [[package]]
 name = "uv-keyring"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12045,7 +12106,7 @@ dependencies = [
 [[package]]
 name = "uv-macros"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12055,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12074,7 +12135,7 @@ dependencies = [
 [[package]]
 name = "uv-normalize"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12085,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "uv-once-map"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "dashmap",
  "futures",
@@ -12095,15 +12156,15 @@ dependencies = [
 [[package]]
 name = "uv-options-metadata"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12116,8 +12177,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12143,7 +12204,7 @@ dependencies = [
 [[package]]
 name = "uv-platform"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12160,7 +12221,7 @@ dependencies = [
 [[package]]
 name = "uv-platform-tags"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12173,7 +12234,7 @@ dependencies = [
 [[package]]
 name = "uv-preview"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12183,7 +12244,7 @@ dependencies = [
 [[package]]
 name = "uv-pypi-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12214,7 +12275,7 @@ dependencies = [
 [[package]]
 name = "uv-python"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12272,7 +12333,7 @@ dependencies = [
 [[package]]
 name = "uv-redacted"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12283,8 +12344,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12320,7 +12381,7 @@ dependencies = [
 [[package]]
 name = "uv-requirements-txt"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12345,11 +12406,12 @@ dependencies = [
 [[package]]
 name = "uv-resolver"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
  "clap",
+ "cyclonedx-bom",
  "dashmap",
  "either",
  "fs-err",
@@ -12359,6 +12421,7 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "owo-colors",
+ "percent-encoding",
  "petgraph",
  "rkyv",
  "rustc-hash",
@@ -12391,6 +12454,7 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-redacted",
@@ -12399,6 +12463,7 @@ dependencies = [
  "uv-static",
  "uv-torch",
  "uv-types",
+ "uv-version",
  "uv-warnings",
  "uv-workspace",
 ]
@@ -12406,7 +12471,7 @@ dependencies = [
 [[package]]
 name = "uv-scripts"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12431,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "uv-settings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "clap",
  "fs-err",
@@ -12466,7 +12531,7 @@ dependencies = [
 [[package]]
 name = "uv-shell"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12482,7 +12547,7 @@ dependencies = [
 [[package]]
 name = "uv-small-str"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12493,7 +12558,7 @@ dependencies = [
 [[package]]
 name = "uv-state"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12503,15 +12568,15 @@ dependencies = [
 [[package]]
 name = "uv-static"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "clap",
  "either",
@@ -12532,7 +12597,7 @@ dependencies = [
 [[package]]
 name = "uv-trampoline-builder"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12545,7 +12610,7 @@ dependencies = [
 [[package]]
 name = "uv-types"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12567,13 +12632,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.9.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "console",
  "fs-err",
@@ -12596,7 +12661,7 @@ dependencies = [
 [[package]]
 name = "uv-warnings"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12606,7 +12671,7 @@ dependencies = [
 [[package]]
 name = "uv-workspace"
 version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.10#44f5a14f401d5fc946acb82e111686cc6a9a7a1b"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.11#8d8aabb88490672c156fc688e7823140681497d0"
 dependencies = [
  "clap",
  "fs-err",
@@ -13724,6 +13789,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11487,8 +11487,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11527,8 +11527,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11564,8 +11564,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anstream 0.6.21",
  "fs-err",
@@ -11602,8 +11602,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11627,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11643,8 +11643,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "hex",
  "memchr",
@@ -11656,8 +11656,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11711,8 +11711,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "clap",
  "either",
@@ -11740,16 +11740,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11759,8 +11759,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "futures",
@@ -11792,8 +11792,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11840,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11857,8 +11857,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11897,8 +11897,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11928,16 +11928,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "backon",
  "dunce",
@@ -11961,8 +11961,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11988,8 +11988,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12001,8 +12001,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12015,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "clap",
  "configparser",
@@ -12053,8 +12053,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12095,8 +12095,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12110,8 +12110,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12121,8 +12121,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12139,8 +12139,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12150,8 +12150,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "dashmap",
  "futures",
@@ -12160,16 +12160,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12182,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12208,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12225,8 +12225,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "memchr",
  "rkyv",
@@ -12238,8 +12238,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.18",
@@ -12248,8 +12248,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12279,8 +12279,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12337,8 +12337,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12349,8 +12349,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12385,8 +12385,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12410,8 +12410,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12475,8 +12475,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12500,8 +12500,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "clap",
  "fs-err",
@@ -12535,8 +12535,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12551,8 +12551,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12562,8 +12562,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12572,16 +12572,16 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "clap",
  "either",
@@ -12601,8 +12601,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12614,8 +12614,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12637,13 +12637,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.16"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.9.17"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "console",
  "fs-err",
@@ -12665,8 +12665,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "anstream 0.6.21",
  "owo-colors",
@@ -12675,8 +12675,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.16#a63e5b62e39c7f581831daaaa2df4a21ae27a017"
+version = "0.0.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.9.17#2b5d65e61d829bc81ce116388f849174d56a84ca"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10578,16 +10578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "sys_traits"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11500,8 +11490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11540,8 +11530,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11580,8 +11570,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11617,8 +11607,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11643,8 +11633,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11659,8 +11649,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "hex",
  "memchr",
@@ -11672,8 +11662,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11697,7 +11687,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sys-info",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
@@ -11714,6 +11703,7 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
+ "uv-platform",
  "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
@@ -11727,8 +11717,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "clap",
  "either",
@@ -11759,16 +11749,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11778,8 +11768,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "futures",
@@ -11811,8 +11801,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -11859,8 +11849,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11876,8 +11866,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11916,8 +11906,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "astral-tokio-tar 0.5.6",
  "astral_async_zip",
@@ -11948,16 +11938,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "backon",
  "clap",
@@ -11986,8 +11976,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12012,8 +12002,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12025,8 +12015,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12039,8 +12029,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "configparser",
  "csv",
@@ -12074,8 +12064,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12116,8 +12106,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12131,8 +12121,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12142,8 +12132,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12160,8 +12150,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12171,8 +12161,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "dashmap",
  "futures",
@@ -12181,16 +12171,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12203,8 +12193,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12229,25 +12219,27 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "fs-err",
  "goblin",
  "procfs",
  "regex",
+ "rustix 1.1.4",
  "target-lexicon",
  "thiserror 2.0.18",
  "tracing",
  "uv-fs",
  "uv-platform-tags",
  "uv-static",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12260,8 +12252,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12271,8 +12263,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12302,8 +12294,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware 0.4.2",
@@ -12326,7 +12318,6 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sys-info",
  "target-lexicon",
  "tempfile",
  "thiserror 2.0.18",
@@ -12362,8 +12353,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12374,8 +12365,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12409,8 +12400,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "astral-reqwest-middleware 0.4.2",
  "fs-err",
@@ -12434,8 +12425,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12499,8 +12490,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12509,6 +12500,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
+ "tracing",
  "url",
  "uv-configuration",
  "uv-distribution-types",
@@ -12524,8 +12516,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "clap",
  "fs-err",
@@ -12559,8 +12551,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12575,8 +12567,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12586,8 +12578,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12596,8 +12588,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12605,8 +12597,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "clap",
  "either",
@@ -12626,8 +12618,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12639,8 +12631,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12662,13 +12654,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.10.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "console",
  "fs-err",
@@ -12689,8 +12681,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12699,8 +12691,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.28"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.8#c021be36ab26353cf8732aa77f4e34d6e1752393"
+version = "0.0.29"
+source = "git+https://github.com/astral-sh/uv?tag=0.10.9#f675560f322a6ee6490643a2fce3cb520966c402"
 dependencies = [
  "clap",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,35 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.24" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.28" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.29" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,35 +184,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.15" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.3" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.22" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.23" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,35 +184,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.14" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,35 +184,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.6" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.16" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,35 +184,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.10" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.11" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,35 +184,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.12" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.13" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.25" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.20" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.21" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.17" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.18" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.30" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.0" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.1" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.2" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.4" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.5" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.9" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.26" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.27" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.10" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.11" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,34 +184,34 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.7" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.8" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -98,7 +98,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 typed-path = { workspace = true }
 url = { workspace = true }
-uv-client = { workspace = true }
 uv-configuration = { workspace = true }
 uv-pep508 = { workspace = true }
 uv-pypi-types = { workspace = true }

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -10,7 +10,6 @@ use pixi_uv_conversions::convert_uv_requirements_to_pep508;
 use rattler_conda_types::Platform;
 
 use tracing::warn;
-use uv_client::BaseClientBuilder;
 use uv_requirements_txt::RequirementsTxt;
 
 use miette::{Diagnostic, IntoDiagnostic, Result};
@@ -198,13 +197,9 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
             (conda_deps, pypi_deps)
         }
         ProcessedInput::PypiTxt => {
-            let reqs_txt = RequirementsTxt::parse(
-                &input_file,
-                workspace.workspace().root(),
-                &BaseClientBuilder::default(),
-            )
-            .await
-            .into_diagnostic()?;
+            let reqs_txt = RequirementsTxt::parse(&input_file, workspace.workspace().root())
+                .await
+                .into_diagnostic()?;
             let pypi_deps = convert_uv_requirements_txt_to_pep508(reqs_txt)?;
 
             (vec![], pypi_deps)

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -545,12 +545,20 @@ impl BuildContext for LazyBuildDispatch<'_> {
         source: &'a Path,
         subdirectory: Option<&'a Path>,
         output_dir: &'a Path,
+        sources: uv_configuration::SourceStrategy,
         build_kind: BuildKind,
         version_id: Option<&'a str>,
     ) -> Result<Option<DistFilename>, impl IsBuildBackendError> {
         let dispatch = self.get_or_try_init().await?;
         dispatch
-            .direct_build(source, subdirectory, output_dir, build_kind, version_id)
+            .direct_build(
+                source,
+                subdirectory,
+                output_dir,
+                sources,
+                build_kind,
+                version_id,
+            )
             .await
             .map_err(LazyBuildDispatchError::from)
     }

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -426,7 +426,7 @@ impl<'a> LazyBuildDispatch<'a> {
                     self.params.exclude_newer.clone().unwrap_or_default(),
                     self.params.sources.clone(),
                     self.params.workspace_cache.clone(),
-                    self.params.concurrency,
+                    self.params.concurrency.clone(),
                     self.params.preview,
                 )
                 .with_build_extra_env_vars(env_vars);

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -37,7 +37,7 @@ use uv_build_frontend::SourceBuild;
 use uv_cache::Cache;
 use uv_client::RegistryClient;
 use uv_configuration::{
-    BuildKind, BuildOptions, BuildOutput, Concurrency, Constraints, IndexStrategy, SourceStrategy,
+    BuildKind, BuildOptions, BuildOutput, Concurrency, Constraints, IndexStrategy, NoSources,
 };
 use uv_dispatch::{BuildDispatch, BuildDispatchError, SharedState};
 use uv_distribution_filename::DistFilename;
@@ -70,7 +70,7 @@ pub struct UvBuildDispatchParams<'a> {
     shared_state: SharedState,
     link_mode: uv_install_wheel::LinkMode,
     exclude_newer: Option<ExcludeNewer>,
-    sources: SourceStrategy,
+    sources: NoSources,
     concurrency: Concurrency,
     preview: uv_preview::Preview,
     workspace_cache: WorkspaceCache,
@@ -105,7 +105,7 @@ impl<'a> UvBuildDispatchParams<'a> {
             link_mode: LinkMode::default(),
             constraints: Constraints::default(),
             exclude_newer: None,
-            sources: SourceStrategy::default(),
+            sources: NoSources::default(),
             concurrency: Concurrency::default(),
             preview: uv_preview::Preview::default(),
             workspace_cache: WorkspaceCache::default(),
@@ -125,7 +125,7 @@ impl<'a> UvBuildDispatchParams<'a> {
     }
 
     /// Set the source strategy for the build dispatch
-    pub fn with_source_strategy(mut self, sources: SourceStrategy) -> Self {
+    pub fn with_no_sources(mut self, sources: NoSources) -> Self {
         self.sources = sources;
         self
     }
@@ -424,7 +424,7 @@ impl<'a> LazyBuildDispatch<'a> {
                     self.params.build_options,
                     self.params.hasher,
                     self.params.exclude_newer.clone().unwrap_or_default(),
-                    self.params.sources,
+                    self.params.sources.clone(),
                     self.params.workspace_cache.clone(),
                     self.params.concurrency,
                     self.params.preview,
@@ -478,8 +478,8 @@ impl BuildContext for LazyBuildDispatch<'_> {
         self.params.config_settings
     }
 
-    fn sources(&self) -> uv_configuration::SourceStrategy {
-        self.params.sources
+    fn sources(&self) -> &uv_configuration::NoSources {
+        &self.params.sources
     }
 
     fn locations(&self) -> &uv_distribution_types::IndexLocations {
@@ -518,7 +518,7 @@ impl BuildContext for LazyBuildDispatch<'_> {
         install_path: &'a Path,
         version_id: Option<&'a str>,
         dist: Option<&'a SourceDist>,
-        sources: SourceStrategy,
+        sources: &'a NoSources,
         build_kind: BuildKind,
         build_output: BuildOutput,
         build_stack: BuildStack,
@@ -545,7 +545,7 @@ impl BuildContext for LazyBuildDispatch<'_> {
         source: &'a Path,
         subdirectory: Option<&'a Path>,
         output_dir: &'a Path,
-        sources: uv_configuration::SourceStrategy,
+        sources: uv_configuration::NoSources,
         build_kind: BuildKind,
         version_id: Option<&'a str>,
     ) -> Result<Option<DistFilename>, impl IsBuildBackendError> {

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -582,7 +582,7 @@ pub async fn resolve_pypi(
     // non-tampered requests.
     .with_shared_state(context.shared_state.fork())
     .with_no_sources(context.no_sources.clone())
-    .with_concurrency(context.concurrency)
+    .with_concurrency(context.concurrency.clone())
     .with_link_mode(link_mode);
 
     // Use cached build dispatch dependencies
@@ -734,7 +734,7 @@ pub async fn resolve_pypi(
             DistributionDatabase::new(
                 &registry_client,
                 &lazy_build_dispatch,
-                context.concurrency.downloads,
+                context.concurrency.downloads_semaphore.clone(),
             ),
         )
         .with_reporter(UvReporter::new_arc(
@@ -763,7 +763,7 @@ pub async fn resolve_pypi(
             DistributionDatabase::new(
                 &registry_client,
                 &lazy_build_dispatch,
-                context.concurrency.downloads,
+                context.concurrency.downloads_semaphore.clone(),
             ),
             &flat_index,
             Some(&provider_tags),
@@ -833,7 +833,7 @@ pub async fn resolve_pypi(
             &registry_client,
             resolution,
             &context.capabilities,
-            context.concurrency.downloads,
+            context.concurrency.downloads_semaphore.clone(),
             project_root,
             &original_git_references,
         )
@@ -997,13 +997,13 @@ async fn lock_pypi_packages(
     registry_client: &Arc<RegistryClient>,
     resolution: Resolution,
     index_capabilities: &IndexCapabilities,
-    concurrent_downloads: usize,
+    downloads_semaphore: Arc<tokio::sync::Semaphore>,
     abs_project_root: &Path,
     original_git_references: &HashMap<uv_normalize::PackageName, pixi_spec::GitReference>,
 ) -> miette::Result<LockedPypiRecords> {
     let mut locked_packages = Vec::with_capacity(resolution.len());
     let database =
-        DistributionDatabase::new(registry_client, pixi_build_dispatch, concurrent_downloads);
+        DistributionDatabase::new(registry_client, pixi_build_dispatch, downloads_semaphore);
     for dist in resolution.distributions() {
         // If this refers to a conda package we can skip it
         if conda_python_packages.contains_key(dist.name()) {

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -581,7 +581,7 @@ pub async fn resolve_pypi(
     // mostly with build isolation. In that case we want to use fresh
     // non-tampered requests.
     .with_shared_state(context.shared_state.fork())
-    .with_source_strategy(context.source_strategy)
+    .with_no_sources(context.no_sources.clone())
     .with_concurrency(context.concurrency)
     .with_link_mode(link_mode);
 

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -640,7 +640,7 @@ async fn read_local_package_metadata(
     .with_workspace_cache(ctx.uv_context.workspace_cache.clone())
     .with_shared_state(ctx.uv_context.shared_state.fork())
     .with_no_sources(ctx.uv_context.no_sources.clone())
-    .with_concurrency(ctx.uv_context.concurrency);
+    .with_concurrency(ctx.uv_context.concurrency.clone());
 
     // Get or create conda prefix updater for the environment
     // Use best_platform() because we can only install/run Python on the host platform
@@ -700,7 +700,7 @@ async fn read_local_package_metadata(
     let database = DistributionDatabase::new(
         &registry_client,
         &lazy_build_dispatch,
-        ctx.uv_context.concurrency.downloads,
+        ctx.uv_context.concurrency.downloads_semaphore.clone(),
     );
 
     // Missing or unparsable pyproject -> trust the lock.

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -709,7 +709,7 @@ async fn read_local_package_metadata(
         tracing::debug!(package = %package_name, "no readable pyproject.toml");
         return Ok(None);
     };
-    let Ok(pyproject_toml) = PyProjectToml::from_toml(&contents) else {
+    let Ok(pyproject_toml) = PyProjectToml::from_toml(&contents, pyproject_path.display()) else {
         tracing::debug!(package = %package_name, "pyproject.toml could not be parsed");
         return Ok(None);
     };

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -639,7 +639,7 @@ async fn read_local_package_metadata(
     .with_index_strategy(index_strategy)
     .with_workspace_cache(ctx.uv_context.workspace_cache.clone())
     .with_shared_state(ctx.uv_context.shared_state.fork())
-    .with_source_strategy(ctx.uv_context.source_strategy)
+    .with_no_sources(ctx.uv_context.no_sources.clone())
     .with_concurrency(ctx.uv_context.concurrency);
 
     // Get or create conda prefix updater for the environment

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
@@ -250,7 +250,7 @@ dependencies = ["numpy"]
 test = ["pytest"]
 dev  = ["foo[test]"]
 "#;
-        let pyproject = uv_pypi_types::PyProjectToml::from_toml(toml).unwrap();
+        let pyproject = uv_pypi_types::PyProjectToml::from_toml(toml, "").unwrap();
         let requires_dist = uv_pypi_types::RequiresDist::from_pyproject_toml(pyproject).unwrap();
         let rendered: Vec<String> = requires_dist
             .requires_dist

--- a/crates/pixi_install_pypi/Cargo.toml
+++ b/crates/pixi_install_pypi/Cargo.toml
@@ -41,7 +41,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 typed-path = { workspace = true }
 url = { workspace = true }
-uv-auth = { workspace = true }
 uv-cache = { workspace = true }
 uv-cache-info = { workspace = true }
 uv-client = { workspace = true }

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -35,7 +35,6 @@ use rattler_conda_types::Platform;
 use rattler_lock::{PypiDistributionData, PypiIndexes, PypiPackageData, UrlOrPath};
 use rayon::prelude::*;
 use utils::elapsed;
-use uv_auth::store_credentials_from_url;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClient};
 use uv_configuration::{BuildOptions, Constraints, IndexStrategy};
 use uv_dispatch::BuildDispatch;
@@ -908,9 +907,14 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         );
 
         // Before hitting the network let's make sure the credentials are available to
-        // uv
+        // uv. As of uv 0.9.16, the global credentials cache moved to a per-client
+        // `CredentialsCache` reachable via the `BaseClient` underneath
+        // `RegistryClient`'s `CachedClient`.
+        let base_client = setup.registry_client.cached_client().uncached();
         for url in setup.index_locations.indexes().map(|index| index.url()) {
-            let success = store_credentials_from_url(url.url());
+            let success = base_client
+                .credentials_cache()
+                .store_credentials_from_url(url.url());
             tracing::debug!("Stored credentials for {}: {}", url, success);
         }
 

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -903,7 +903,11 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         let distribution_database = DistributionDatabase::new(
             setup.registry_client.as_ref(),
             &build_dispatch,
-            self.context_config.uv_context.concurrency.downloads,
+            self.context_config
+                .uv_context
+                .concurrency
+                .downloads_semaphore
+                .clone(),
         );
 
         // Before hitting the network let's make sure the credentials are available to
@@ -980,7 +984,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             setup.exclude_newer.clone(),
             self.context_config.uv_context.no_sources.clone(),
             self.context_config.uv_context.workspace_cache.clone(),
-            self.context_config.uv_context.concurrency,
+            self.context_config.uv_context.concurrency.clone(),
             self.context_config.uv_context.preview,
         )
         // Important: this passes any CONDA activation to the uv build process

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -978,7 +978,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             &setup.build_options,
             &self.context_config.uv_context.hash_strategy,
             setup.exclude_newer.clone(),
-            self.context_config.uv_context.source_strategy,
+            self.context_config.uv_context.no_sources.clone(),
             self.context_config.uv_context.workspace_cache.clone(),
             self.context_config.uv_context.concurrency,
             self.context_config.uv_context.preview,

--- a/crates/pixi_install_pypi/src/plan/test/harness.rs
+++ b/crates/pixi_install_pypi/src/plan/test/harness.rs
@@ -146,6 +146,7 @@ impl InstalledDistBuilder {
                     .reference()
                     .as_str()
                     .map(ToString::to_string),
+                git_lfs: None,
             },
         };
 

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -253,7 +253,7 @@ impl UvResolutionContext {
             .extra_middleware(self.extra_middleware.clone());
 
         if let Some(timeout) = self.http_timeout {
-            base_client_builder = base_client_builder.timeout(timeout);
+            base_client_builder = base_client_builder.read_timeout(timeout);
         }
 
         if let Some(retries) = self.http_retries {

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -12,7 +12,7 @@ use uv_cache::Cache;
 use uv_client::{
     BaseClientBuilder, Connectivity, ExtraMiddleware, RegistryClient, RegistryClientBuilder,
 };
-use uv_configuration::{Concurrency, IndexStrategy, SourceStrategy, TrustedHost};
+use uv_configuration::{Concurrency, IndexStrategy, NoSources, TrustedHost};
 use uv_dispatch::SharedState;
 use uv_distribution_types::{
     ExtraBuildRequires, ExtraBuildVariables, IndexCapabilities, IndexLocations,
@@ -31,7 +31,7 @@ pub struct UvResolutionContext {
     pub hash_strategy: HashStrategy,
     pub keyring_provider: uv_configuration::KeyringProviderType,
     pub concurrency: Concurrency,
-    pub source_strategy: SourceStrategy,
+    pub no_sources: NoSources,
     pub capabilities: IndexCapabilities,
     pub allow_insecure_host: Vec<TrustedHost>,
     pub shared_state: SharedState,
@@ -197,7 +197,7 @@ impl UvResolutionContext {
             hash_strategy: HashStrategy::None,
             keyring_provider,
             concurrency,
-            source_strategy: SourceStrategy::Enabled,
+            no_sources: NoSources::None,
             capabilities: IndexCapabilities::default(),
             allow_insecure_host,
             shared_state: SharedState::default(),

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -144,11 +144,7 @@ fn build_concurrency(config: &Config) -> Concurrency {
     let builds = read_usize_env("UV_CONCURRENT_BUILDS").unwrap_or(defaults.builds);
     let installs = read_usize_env("UV_CONCURRENT_INSTALLS").unwrap_or(defaults.installs);
 
-    Concurrency {
-        downloads,
-        builds,
-        installs,
-    }
+    Concurrency::new(downloads, builds, installs)
 }
 
 impl UvResolutionContext {

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -372,6 +372,7 @@ pub fn to_parsed_git_url(
             },
             into_uv_git_reference(git_source.reference.into()),
             Some(into_uv_git_sha(git_source.commit)),
+            uv_git_types::GitLfs::Disabled,
         )
         .into_diagnostic()?,
         if git_source.subdirectory.is_empty() {

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -678,7 +678,7 @@ pub fn configure_insecure_hosts_for_tls_bypass(
 
 fn to_exclude_newer_timestamp(
     exclude_newer: chrono::DateTime<chrono::Utc>,
-) -> uv_resolver::ExcludeNewerTimestamp {
+) -> uv_resolver::ExcludeNewerValue {
     let seconds_since_epoch = exclude_newer.timestamp();
     let nanoseconds = exclude_newer.timestamp_subsec_nanos();
     let timestamp = jiff::Timestamp::new(seconds_since_epoch, nanoseconds as _).unwrap_or(

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -132,6 +132,7 @@ pub fn as_uv_req(
                         .and_then(|s| s.map(uv_git_types::GitOid::from_str))
                         .transpose()
                         .expect("could not parse sha"),
+                    uv_git_types::GitLfs::Disabled,
                 )?,
                 subdirectory: if subdirectory.is_empty() {
                     None
@@ -371,7 +372,8 @@ mod tests {
             git: uv_git_types::GitUrl::from_fields(
                 DisplaySafeUrl::parse("ssh://git@github.com/user/test.git").unwrap(),
                 uv_git_types::GitReference::BranchOrTagOrCommit("d099af3b1028b00c232d8eda28a997984ae5848b".to_string()),
-                Some(uv_git_types::GitOid::from_str("d099af3b1028b00c232d8eda28a997984ae5848b").unwrap())).unwrap(),
+                Some(uv_git_types::GitOid::from_str("d099af3b1028b00c232d8eda28a997984ae5848b").unwrap()),
+                uv_git_types::GitLfs::Disabled).unwrap(),
             subdirectory: Default::default(),
             url: VerbatimUrl::from_url(DisplaySafeUrl::parse("git+ssh://git@github.com/user/test.git@d099af3b1028b00c232d8eda28a997984ae5848b").unwrap()),
         };
@@ -403,6 +405,7 @@ mod tests {
                     uv_git_types::GitOid::from_str("d099af3b1028b00c232d8eda28a997984ae5848b")
                         .unwrap(),
                 ),
+                uv_git_types::GitLfs::Disabled,
             )
             .unwrap(),
             subdirectory: Default::default(),

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -263,6 +263,7 @@ fn create_tags(
         python_version,
         true,
         gil_disabled,
+        false,
     )
     .map_err(PyPITagError::FailedToDetermineWheelTags)
 }

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,10 @@ allow = [
   "CC0-1.0",
   "ISC",
   "MIT",
+  # MIT-0 ("MIT No Attribution") - same as MIT minus the attribution clause,
+  # so strictly more permissive. OSI-approved. Pulled in transitively via
+  # `borrow-or-share` (uv -> cyclonedx-bom -> fluent-uri -> borrow-or-share).
+  "MIT-0",
   "MPL-2.0",
   "Unicode-3.0",
   "Zlib",


### PR DESCRIPTION
Stacked on #6037 + #6050. Continues the uv bump loop with one commit per upstream tag from `0.9.11` through `0.10.12`. Stops at 0.10.12 because uv `0.11.0` ships `astral-reqwest-middleware = "0.5.1"` and `reqwest = "0.13.x"`, which trip the `Middleware` trait identity vs. rattler/rattler-build's `0.4.2` + `reqwest 0.12.x`. Same wall the 0.9.10 PR coordinated around at the previous version line. Unblocking 0.11.0+ requires another coordinated cross-repo bump.

Each commit is pushed individually so CI runs per tag. Title will track the latest tag in this PR; the diff will collapse once #6037 and #6050 land.

## API-compat notes per tag

The full per-tag log (with file paths and rationale) is in the working notes. Highlights:

- **0.9.15** — `uv_git_types::GitUrl::from_fields` gained a 4th `lfs: GitLfs` parameter; `VcsInfo` gained `git_lfs: Option<bool>`; `RequirementsTxt::parse` lost its `&BaseClientBuilder` arg.
- **0.9.16** — `Tags::from_env` gained a 7th `is_cross: bool` parameter; `uv_auth::store_credentials_from_url` moved to a method on `BaseClient::credentials_cache()`; `BuildContext::direct_build` gained a `sources: SourceStrategy` arg.
- **0.9.17** — `uv_resolver::ExcludeNewerTimestamp` renamed to `ExcludeNewerValue`.
- **0.9.18-0.9.30** — no code changes; flaky ROS network tests forced cranking nextest `--retries` to 8.
- **0.9.26** — `uv_configuration::SourceStrategy` removed; replaced by `NoSources` with inverted semantics. Trait sigs in `uv_types::BuildContext` flipped (`fn sources(&self) -> &NoSources`, `fn setup_build(... sources: &'a NoSources, ...)`, `fn direct_build(... sources: NoSources, ...)`). Renamed `UvResolutionContext::source_strategy` → `no_sources`, `with_source_strategy` → `with_no_sources`. `NoSources` is not `Copy`, so a few cross-call moves became `.clone()`s (cheap, just `Arc`s underneath).
- **0.10.0** — `BaseClientBuilder::timeout` renamed to `read_timeout`. Most other 0.10.0 breakage already absorbed in the 0.9 patch line.
- **0.10.7** — `Concurrency` gained `downloads_semaphore`/`builds_semaphore` (`Arc<Semaphore>`); `DistributionDatabase::new`'s 3rd arg flipped from `usize` to `Arc<Semaphore>`. `Concurrency` no longer `Copy`. Updated 4 call sites + threaded `lock_pypi_packages`'s parameter.
- **0.10.9** — `PyProjectToml::from_toml` gained a `_source: impl Display` arg.

## Excluded from the gate

`tests/integration_python/pixi_build/test_build.py::test_extra_args` is still skipped via `-k 'not test_extra_args'`. Same pre-existing meson `_setup_vsenv` issue documented on #6037 / #6050.

## Test plan

For each commit, locally on Windows:

- [x] `cargo build --workspace --all-targets`
- [x] `cargo nextest run --workspace --all-targets --features slow_integration_tests,online_tests --retries=8 --no-fail-fast` — 1776 passed for every tag.
- [x] `cargo clippy --all-targets --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`

CI gates per-commit are pending; this PR is being pushed one commit at a time so that each tag lands in the CI history individually.
