### PR TITLE
fix: v0.68.0 `pixi-aarch64-pc-windows-msvc.zip` contains an x86_64 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,9 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Azure login (OIDC)
-        if: runner.os == 'Windows'
+        # Skip in dry-run: the Azure federated identity is configured to trust
+        # only release tags / main, so login fails on feature branches.
+        if: runner.os == 'Windows' && needs.plan.outputs.publishing == 'true'
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -225,7 +227,7 @@ jobs:
           }
           Get-ChildItem target/distrib -Filter "*.msi" | Copy-Item -Destination $signDir
       - name: Sign Windows binaries
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && needs.plan.outputs.publishing == 'true'
         uses: azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # v1.2.0
         with:
           endpoint: ${{ vars.AZURE_SIGNING_ENDPOINT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,10 +213,15 @@ jobs:
         run: |
           $signDir = Join-Path $env:RUNNER_TEMP "to-sign"
           New-Item -ItemType Directory -Path $signDir -Force
+          # Stage each archive's exe in its own subfolder so binaries with the
+          # same name (e.g. pixi.exe for both x86_64 and aarch64 windows zips)
+          # do not overwrite each other in the signing directory.
           foreach ($zip in (Get-ChildItem target/distrib -Filter "*.zip")) {
             $extractDir = Join-Path $env:RUNNER_TEMP $zip.BaseName
             Expand-Archive -Path $zip.FullName -DestinationPath $extractDir -Force
-            Get-ChildItem $extractDir -Filter "*.exe" -Recurse | Copy-Item -Destination $signDir
+            $zipSignDir = Join-Path $signDir $zip.BaseName
+            New-Item -ItemType Directory -Path $zipSignDir -Force
+            Get-ChildItem $extractDir -Filter "*.exe" -Recurse | Copy-Item -Destination $zipSignDir
           }
           Get-ChildItem target/distrib -Filter "*.msi" | Copy-Item -Destination $signDir
       - name: Sign Windows binaries
@@ -228,6 +233,7 @@ jobs:
           certificate-profile-name: ${{ vars.AZURE_CERTIFICATE_PROFILE_NAME }}
           files-folder: ${{ runner.temp }}/to-sign
           files-folder-filter: exe,msi
+          files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
@@ -238,16 +244,18 @@ jobs:
           $signDir = Join-Path $env:RUNNER_TEMP "to-sign"
           foreach ($zip in (Get-ChildItem target/distrib -Filter "*.zip")) {
             $extractDir = Join-Path $env:RUNNER_TEMP $zip.BaseName
-            # Overwrite extracted exe with signed version
+            $zipSignDir = Join-Path $signDir $zip.BaseName
+            # Overwrite extracted exe with signed version from this zip's subfolder
             Get-ChildItem $extractDir -Filter "*.exe" -Recurse | ForEach-Object {
-              $signed = Join-Path $signDir $_.Name
+              $signed = Join-Path $zipSignDir $_.Name
               if (Test-Path $signed) { Copy-Item $signed $_.FullName -Force }
             }
             # Recreate zip
             Remove-Item $zip.FullName
             Compress-Archive -Path (Join-Path $extractDir "*") -DestinationPath $zip.FullName
           }
-          # Overwrite MSI with signed version
+          # Overwrite MSI with signed version (MSI filenames are unique per target,
+          # so they stay at the root of the signing directory)
           Get-ChildItem $signDir -Filter "*.msi" | ForEach-Object {
             $orig = Get-ChildItem target/distrib -Filter $_.Name
             if ($orig) { Copy-Item $_.FullName $orig.FullName -Force }


### PR DESCRIPTION
### Description

Fixes #6059: v0.68.0 `pixi-aarch64-pc-windows-msvc.zip` contains an x86_64 binary.

Both Windows targets share a runner in `dist-workspace.toml`, so cargo-dist groups them into one matrix job with two zips in `target/distrib/`. The Windows signing block copies every `pixi.exe` into a flat `to-sign/` dir — the second overwrites the first, and the surviving binary is repackaged into both zips.

Fix: stage exes into per-zip subfolders of `to-sign/` and set `files-folder-recurse: true` on the signing action.

### How Has This Been Tested?

- [x] Needs to run **Actions → Release → Run workflow** on this branch with `tag: dry-run` (host/announce skip, nothing is published), then verify the two Windows zips contain binaries of the expected architecture (`file` / `dumpbin /headers`). Requires upstream secrets, so can't run from a fork. (See https://github.com/prefix-dev/pixi/actions/runs/25662387593)

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas