### PR TITLE
fix: evaluate PyPI extras when walking lockfile dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6204,6 +6204,7 @@ dependencies = [
  "pixi_task",
  "pixi_utils",
  "pixi_uv_conversions",
+ "pypi_modifiers",
  "rattler",
  "rattler_conda_types",
  "rattler_index",

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -62,6 +62,7 @@ pixi_spec = { workspace = true }
 pixi_task = { workspace = true }
 pixi_utils = { workspace = true, default-features = false }
 pixi_uv_conversions = { workspace = true }
+pypi_modifiers = { workspace = true }
 rattler = { workspace = true, features = ["cli-tools", "indicatif"] }
 rattler_conda_types = { workspace = true }
 rattler_index = { workspace = true }
@@ -105,7 +106,7 @@ which = { workspace = true }
 zip = { workspace = true, features = ["deflate", "time"] }
 
 [dev-dependencies]
-insta = { workspace = true, features = ["filters"] }
+insta = { workspace = true, features = ["filters", "glob"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true, default-features = false }

--- a/crates/pixi_cli/src/global/tree.rs
+++ b/crates/pixi_cli/src/global/tree.rs
@@ -1,5 +1,5 @@
 use crate::shared::tree::{
-    Package, PackageSource, build_reverse_dependency_map, print_dependency_tree,
+    Dependency, Package, PackageSource, build_reverse_dependency_map, print_dependency_tree,
     print_inverted_dependency_tree,
 };
 use ahash::HashSet;
@@ -85,6 +85,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     })
                     .filter(|dep_name| !dep_name.starts_with("__")) // Filter virtual packages
                     .unique() // A package may be listed with multiple constraints
+                    .map(|name| Dependency {
+                        name,
+                        via_extras: Vec::new(),
+                    })
                     .collect(),
                 needed_by: Vec::new(),
                 source: PackageSource::Conda, // Global environments can only manage Conda packages

--- a/crates/pixi_cli/src/shared/tree.rs
+++ b/crates/pixi_cli/src/shared/tree.rs
@@ -5,7 +5,7 @@ use console::Color;
 use miette::{Context, IntoDiagnostic};
 use regex::Regex;
 use std::collections::HashMap;
-use std::io::{StdoutLock, Write};
+use std::io::Write;
 
 /// Defines the source of a package. Global packages can only have Conda dependencies.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -14,12 +14,22 @@ pub enum PackageSource {
     Pypi,
 }
 
+/// An edge from a package to one of its dependencies, optionally tagged with
+/// the parent extras that activated it.
+#[derive(Debug, Clone)]
+pub struct Dependency {
+    pub name: String,
+    /// Names of the parent's extras whose marker made this edge active. Empty
+    /// for base (non-extra-gated) dependencies.
+    pub via_extras: Vec<String>,
+}
+
 /// Represents a view of a Package with only the fields required for the tree visualization.
 #[derive(Debug, Clone)]
 pub struct Package {
     pub name: String,
     pub version: String,
-    pub dependencies: Vec<String>,
+    pub dependencies: Vec<Dependency>,
     pub needed_by: Vec<String>,
     pub source: PackageSource,
 }
@@ -55,7 +65,7 @@ static UTF8_SYMBOLS: Symbols = Symbols {
 ///
 /// Returns `Ok(())` if the tree was printed successfully, or an error if the regex was invalid or no matches were found
 pub fn print_dependency_tree(
-    handle: &mut StdoutLock,
+    handle: &mut impl Write,
     dep_map: &HashMap<String, Package>,
     direct_deps: &HashSet<String>,
     regex: &Option<String>,
@@ -89,6 +99,8 @@ pub fn print_dependency_tree(
 
     let mut visited_pkgs = HashSet::new();
     let direct_dep_count = filtered_deps.len();
+    let mut filtered_deps: Vec<String> = filtered_deps.into_iter().collect();
+    filtered_deps.sort();
 
     for (index, pkg_name) in filtered_deps.iter().enumerate() {
         if !visited_pkgs.insert(pkg_name.clone()) {
@@ -111,6 +123,7 @@ pub fn print_dependency_tree(
                 pkg,
                 direct_deps.contains(&pkg.name),
                 false,
+                &[],
             )?;
 
             let prefix = if last {
@@ -169,7 +182,7 @@ pub fn print_dependency_tree(
 ///
 /// This function can return an error if writing to the output stream fails.
 fn print_dependency_node(
-    handle: &mut StdoutLock,
+    handle: &mut impl Write,
     package: &Package,
     prefix: String,
     dep_map: &HashMap<String, Package>,
@@ -177,7 +190,7 @@ fn print_dependency_node(
     direct_deps: &HashSet<String>,
 ) -> miette::Result<()> {
     let dep_count = package.dependencies.len();
-    for (index, dep_name) in package.dependencies.iter().enumerate() {
+    for (index, edge) in package.dependencies.iter().enumerate() {
         let last = index == dep_count - 1;
         let symbol = if last {
             UTF8_SYMBOLS.ell
@@ -185,7 +198,7 @@ fn print_dependency_node(
             UTF8_SYMBOLS.tee
         };
 
-        if let Some(dep) = dep_map.get(dep_name) {
+        if let Some(dep) = dep_map.get(&edge.name) {
             let visited = !visited_pkgs.insert(dep.name.clone());
 
             print_package(
@@ -194,6 +207,7 @@ fn print_dependency_node(
                 dep,
                 direct_deps.contains(&dep.name),
                 visited,
+                &edge.via_extras,
             )?;
 
             if visited {
@@ -207,13 +221,13 @@ fn print_dependency_node(
             };
             print_dependency_node(handle, dep, new_prefix, dep_map, visited_pkgs, direct_deps)?;
         } else {
-            let visited = !visited_pkgs.insert(dep_name.clone());
+            let visited = !visited_pkgs.insert(edge.name.clone());
 
             print_package(
                 handle,
                 &format!("{prefix}{symbol} "),
                 &Package {
-                    name: dep_name.to_owned(),
+                    name: edge.name.clone(),
                     version: String::from(""),
                     dependencies: Vec::new(),
                     needed_by: Vec::new(),
@@ -221,6 +235,7 @@ fn print_dependency_node(
                 },
                 false,
                 visited,
+                &edge.via_extras,
             )?;
         }
     }
@@ -240,15 +255,21 @@ fn print_dependency_node(
 /// # Errors
 /// This function can return an error if writing to the output stream fails.
 pub fn print_package(
-    handle: &mut StdoutLock,
+    handle: &mut impl Write,
     prefix: &str,
     package: &Package,
     direct: bool,
     visited: bool,
+    via_extras: &[String],
 ) -> miette::Result<()> {
+    let extras_label = if via_extras.is_empty() {
+        String::new()
+    } else {
+        format!("(extra: {})", via_extras.join(", "))
+    };
     writeln!(
         handle,
-        "{}{} {} {}",
+        "{}{} {} {}{}",
         prefix,
         if direct {
             console::style(&package.name).fg(Color::Green).bold()
@@ -259,7 +280,8 @@ pub fn print_package(
             PackageSource::Conda => console::style(&package.version).fg(Color::Yellow),
             PackageSource::Pypi => console::style(&package.version).fg(Color::Blue),
         },
-        if visited { "(*)" } else { "" }
+        console::style(extras_label).fg(Color::Cyan),
+        if visited { " (*)" } else { "" }
     )
     .map_err(|e| {
         if e.kind() == std::io::ErrorKind::BrokenPipe {
@@ -287,7 +309,7 @@ pub fn print_package(
 ///
 /// Returns `Ok(())` if the tree was printed successfully, or an error if the regex was invalid or no matches were found
 pub fn print_inverted_dependency_tree(
-    handle: &mut StdoutLock,
+    handle: &mut impl Write,
     inverted_dep_map: &HashMap<String, Package>,
     direct_deps: &HashSet<String>,
     regex: &Option<String>,
@@ -315,7 +337,14 @@ pub fn print_inverted_dependency_tree(
     for pkg_name in root_pkg_names {
         if let Some(pkg) = inverted_dep_map.get(pkg_name) {
             let visited = !visited_pkgs.insert(pkg_name.clone());
-            print_package(handle, "\n", pkg, direct_deps.contains(&pkg.name), visited)?;
+            print_package(
+                handle,
+                "\n",
+                pkg,
+                direct_deps.contains(&pkg.name),
+                visited,
+                &[],
+            )?;
 
             if !visited {
                 print_inverted_node(
@@ -357,7 +386,7 @@ pub fn print_inverted_dependency_tree(
 ///
 /// This function can return an error if writing to the output stream fails.
 fn print_inverted_node(
-    handle: &mut StdoutLock,
+    handle: &mut impl Write,
     package: &Package,
     prefix: String,
     inverted_dep_map: &HashMap<String, Package>,
@@ -381,6 +410,7 @@ fn print_inverted_node(
                 needed_pkg,
                 direct_deps.contains(&needed_pkg.name),
                 visited,
+                &[],
             )?;
 
             if !visited {
@@ -423,8 +453,8 @@ pub fn build_reverse_dependency_map(
     let mut inverted_deps = dep_map.clone();
 
     for pkg in dep_map.values() {
-        for dep in pkg.dependencies.iter() {
-            if let Some(idep) = inverted_deps.get_mut(dep) {
+        for edge in pkg.dependencies.iter() {
+            if let Some(idep) = inverted_deps.get_mut(&edge.name) {
                 idep.needed_by.push(pkg.name.clone());
             }
         }

--- a/crates/pixi_cli/src/snapshots/pixi_cli__tree__tests__pypi_extras_tree_snapshots@editable-with-extras__pixi.toml.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__tree__tests__pypi_extras_tree_snapshots@editable-with-extras__pixi.toml.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_cli/src/tree.rs
+assertion_line: 469
+expression: "render_pypi_tree(manifest, Platform::Linux64)"
+input_file: examples/editable-with-extras/pixi.toml
+---
+└── package_with_extras <unknown> 
+    ├── boltons 24.0.0 
+    ├── rich 13.7.1 (extra: color)
+    │   ├── markdown_it_py 3.0.0 
+    │   │   └── mdurl 0.1.2 
+    │   └── pygments 2.18.0 
+    └── click 8.1.7 (extra: cli)

--- a/crates/pixi_cli/src/snapshots/pixi_cli__tree__tests__pypi_extras_tree_snapshots@pypi__pixi.toml.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__tree__tests__pypi_extras_tree_snapshots@pypi__pixi.toml.snap
@@ -1,0 +1,128 @@
+---
+source: crates/pixi_cli/src/tree.rs
+assertion_line: 469
+expression: "render_pypi_tree(manifest, Platform::Linux64)"
+input_file: examples/pypi/pixi.toml
+---
+├── black 24.8.0 
+│   ├── click 8.1.7 
+│   ├── mypy_extensions 1.0.0 
+│   ├── packaging 24.1 
+│   ├── pathspec 0.12.1 
+│   ├── platformdirs 4.2.2 
+│   ├── ipython 8.26.0 (extra: jupyter)
+│   │   ├── decorator 5.1.1 
+│   │   ├── jedi 0.19.1 
+│   │   │   └── parso 0.8.4 
+│   │   ├── matplotlib_inline 0.1.7 
+│   │   │   └── traitlets 5.14.3 
+│   │   ├── prompt_toolkit 3.0.47 
+│   │   │   └── wcwidth 0.2.13 
+│   │   ├── pygments 2.18.0 
+│   │   ├── stack_data 0.6.3 
+│   │   │   ├── executing 2.0.1 
+│   │   │   ├── asttokens 2.4.1 
+│   │   │   │   └── six 1.16.0 
+│   │   │   └── pure_eval 0.2.3 
+│   │   ├── traitlets 5.14.3  (*)
+│   │   ├── typing_extensions 4.12.2 
+│   │   └── pexpect 4.9.0 
+│   │       └── ptyprocess 0.7.0 
+│   └── tokenize_rt 6.0.0 (extra: jupyter)
+├── env_test_package 0.0.3 
+├── flask 3.0.3 
+│   ├── werkzeug 3.0.4 
+│   │   └── markupsafe 2.1.5 
+│   ├── jinja2 3.1.4 
+│   │   └── markupsafe 2.1.5  (*)
+│   ├── itsdangerous 2.2.0 
+│   ├── click 8.1.7  (*)
+│   └── blinker 1.8.2 
+├── plot_antenna 1.8 
+│   ├── matplotlib 3.9.2 
+│   │   ├── contourpy 1.3.0 
+│   │   │   └── numpy  
+│   │   ├── cycler 0.12.1 
+│   │   ├── fonttools 4.53.1 
+│   │   ├── kiwisolver 1.4.5 
+│   │   ├── numpy   (*)
+│   │   ├── packaging 24.1  (*)
+│   │   ├── pillow 10.4.0 
+│   │   ├── pyparsing 3.1.4 
+│   │   └── python_dateutil 2.9.0.post0 
+│   │       └── six 1.16.0  (*)
+│   ├── numpy   (*)
+│   ├── pandas 2.2.2 
+│   │   ├── numpy   (*)
+│   │   ├── python_dateutil 2.9.0.post0  (*)
+│   │   ├── pytz 2024.1 
+│   │   └── tzdata 2024.1 
+│   └── plotly 5.23.0 
+│       ├── tenacity 9.0.0 
+│       └── packaging 24.1  (*)
+├── pyboy 1.6.6 
+│   ├── numpy   (*)
+│   ├── pysdl2 0.9.16 
+│   └── pysdl2_dll 2.30.2 
+├── pycosat 0.6.6 
+├── pyliblzfse 0.4.1 
+├── pytest_timeout 2.4.0 
+│   └── pytest 9.0.3 
+│       ├── iniconfig 2.3.0 
+│       ├── packaging 24.1  (*)
+│       ├── pluggy 1.6.0 
+│       └── pygments 2.18.0  (*)
+└── tensorflow 2.14.0 
+    ├── absl_py 2.1.0 
+    ├── astunparse 1.6.3 
+    │   ├── wheel 0.44.0 
+    │   └── six 1.16.0  (*)
+    ├── flatbuffers 24.3.25 
+    ├── gast 0.6.0 
+    ├── google_pasta 0.2.0 
+    │   └── six 1.16.0  (*)
+    ├── h5py 3.11.0 
+    │   └── numpy   (*)
+    ├── libclang 18.1.1 
+    ├── ml_dtypes 0.2.0 
+    │   └── numpy   (*)
+    ├── numpy   (*)
+    ├── opt_einsum 3.3.0 
+    │   └── numpy   (*)
+    ├── packaging 24.1  (*)
+    ├── protobuf 4.25.4 
+    ├── setuptools 74.0.0 
+    ├── six 1.16.0  (*)
+    ├── termcolor 2.4.0 
+    ├── typing_extensions 4.12.2  (*)
+    ├── wrapt 1.14.1 
+    ├── tensorflow_io_gcs_filesystem 0.37.1 
+    ├── grpcio 1.66.1 
+    ├── tensorboard 2.14.1 
+    │   ├── absl_py 2.1.0  (*)
+    │   ├── grpcio 1.66.1  (*)
+    │   ├── google_auth 2.34.0 
+    │   │   ├── cachetools 5.5.0 
+    │   │   ├── pyasn1_modules 0.4.0 
+    │   │   │   └── pyasn1 0.6.0 
+    │   │   └── rsa 4.9 
+    │   │       └── pyasn1 0.6.0  (*)
+    │   ├── google_auth_oauthlib 1.0.0 
+    │   │   ├── google_auth 2.34.0  (*)
+    │   │   └── requests_oauthlib 2.0.0 
+    │   │       ├── oauthlib 3.2.2 
+    │   │       └── requests 2.32.3 
+    │   │           ├── charset_normalizer 3.3.2 
+    │   │           ├── idna 3.8 
+    │   │           ├── urllib3 2.2.2 
+    │   │           └── certifi 2024.7.4 
+    │   ├── markdown 3.7 
+    │   ├── numpy   (*)
+    │   ├── protobuf 4.25.4  (*)
+    │   ├── requests 2.32.3  (*)
+    │   ├── setuptools 74.0.0  (*)
+    │   ├── six 1.16.0  (*)
+    │   ├── tensorboard_data_server 0.7.2 
+    │   └── werkzeug 3.0.4  (*)
+    ├── tensorflow_estimator 2.14.0 
+    └── keras 2.14.0

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -1,19 +1,21 @@
 use crate::cli_config::{LockFileUpdateConfig, NoInstallConfig, WorkspaceConfig};
 use crate::shared::tree::{
-    Package, PackageSource, build_reverse_dependency_map, print_dependency_tree,
+    Dependency, Package, PackageSource, build_reverse_dependency_map, print_dependency_tree,
     print_inverted_dependency_tree,
 };
 use ahash::HashSet;
 use clap::Parser;
 use console::Color;
 use fancy_display::FancyDisplay;
-use itertools::Itertools;
 use miette::WrapErr;
+use pep508_rs::{ExtraName, MarkerEnvironment, Requirement};
 use pixi_core::workspace::Environment;
 use pixi_core::{WorkspaceLocator, lock_file::UpdateLockFileOptions};
 use pixi_manifest::FeaturesExt;
-use rattler_conda_types::Platform;
-use rattler_lock::LockedPackage;
+use pixi_uv_conversions::to_marker_environment;
+use pypi_modifiers::pypi_marker_env::determine_marker_environment;
+use rattler_conda_types::{PackageName, Platform};
+use rattler_lock::{LockedPackage, PypiPackageData};
 use std::collections::HashMap;
 
 /// Show a tree of workspace dependencies
@@ -57,13 +59,6 @@ pub struct Args {
     pub invert: bool,
 }
 
-/// Simplified package information extracted from the lock file
-pub struct PackageInfo {
-    name: String,
-    dependencies: Vec<String>,
-    source: PackageSource,
-}
-
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
         .with_search_start(args.workspace_config.workspace_locator_start())
@@ -97,8 +92,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         })
         .unwrap_or_default();
 
-    let dep_map = generate_dependency_map(&locked_deps);
-
+    let dep_map = DependencyMapBuilder::new(&environment, platform, &locked_deps).build();
     let direct_deps = direct_dependencies(&environment, &platform, &dep_map);
 
     if !environment.is_default() {
@@ -122,87 +116,256 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     Ok(())
 }
 
-/// Helper function to extract package information from a package reference obtained from a lock file.
-pub(crate) fn extract_package_info(
-    package: &'_ rattler_lock::LockedPackage,
-) -> Option<PackageInfo> {
-    if let Some(conda_package) = package.as_conda() {
-        let name = conda_package.name().as_normalized().to_string();
+/// Per-package activated PyPI extras, propagated transitively from the
+/// manifest direct deps through `requires_dist` to a fixed point.
+pub(crate) struct PypiExtrasResolver {
+    marker_env: Option<MarkerEnvironment>,
+    activated: HashMap<String, Vec<ExtraName>>,
+}
 
-        let dependencies: Vec<String> = conda_package
-            .depends()
+impl PypiExtrasResolver {
+    pub fn new(
+        environment: &Environment<'_>,
+        platform: Platform,
+        locked_deps: &[&LockedPackage],
+    ) -> Self {
+        let marker_env = Self::build_marker_env(locked_deps, platform);
+        let activated = Self::propagate(environment, platform, locked_deps, marker_env.as_ref());
+        Self {
+            marker_env,
+            activated,
+        }
+    }
+
+    pub fn extras_for(&self, name: &str) -> &[ExtraName] {
+        self.activated
+            .get(name)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Falls back to `marker.is_true()` when no Python is locked.
+    pub fn is_active(&self, req: &Requirement, parent_extras: &[ExtraName]) -> bool {
+        match &self.marker_env {
+            Some(env) => req.evaluate_markers(env, parent_extras),
+            None => req.marker.is_true(),
+        }
+    }
+
+    /// Parent extras whose presence is required for `req`'s marker to pass.
+    /// Empty for base dependencies.
+    pub fn activating_extras<'a>(
+        &'a self,
+        req: &'a Requirement,
+        parent_extras: &'a [ExtraName],
+    ) -> impl Iterator<Item = &'a ExtraName> + 'a {
+        let gating_env = self
+            .marker_env
+            .as_ref()
+            .filter(|env| !req.marker.is_true() && !req.evaluate_markers(env, &[]));
+        parent_extras.iter().filter(move |e| {
+            gating_env.is_some_and(|env| req.evaluate_markers(env, std::slice::from_ref(*e)))
+        })
+    }
+
+    fn build_marker_env(
+        locked_deps: &[&LockedPackage],
+        platform: Platform,
+    ) -> Option<MarkerEnvironment> {
+        let python_record = locked_deps
             .iter()
-            .map(|d| {
-                d.split_once(' ')
-                    .map_or_else(|| d.to_string(), |(dep_name, _)| dep_name.to_string())
-            })
+            .filter_map(|p| p.as_conda())
+            .find(|c| c.name().as_normalized() == "python")
+            .and_then(|c| c.record())?;
+        let uv_env = determine_marker_environment(platform, python_record).ok()?;
+        to_marker_environment(&uv_env).ok()
+    }
+
+    fn propagate(
+        environment: &Environment<'_>,
+        platform: Platform,
+        locked_deps: &[&LockedPackage],
+        marker_env: Option<&MarkerEnvironment>,
+    ) -> HashMap<String, Vec<ExtraName>> {
+        let pypi_by_name: HashMap<String, &PypiPackageData> = locked_deps
+            .iter()
+            .filter_map(|p| p.as_pypi())
+            .map(|p| (p.name().as_dist_info_name().into_owned(), p))
             .collect();
 
-        Some(PackageInfo {
-            name,
-            dependencies,
-            source: PackageSource::Conda,
-        })
-    } else if let Some(pypi_package_data) = package.as_pypi() {
-        let name = pypi_package_data.name().as_dist_info_name().into_owned();
-        let dependencies = pypi_package_data
-            .requires_dist()
-            .iter()
-            .filter_map(|p| {
-                if p.marker.is_true() {
-                    Some(p.name.as_dist_info_name().into_owned())
-                } else {
-                    tracing::info!(
-                        "Skipping {} specified by {} due to marker {:?}",
-                        p.name,
-                        name,
-                        p.marker
-                    );
-                    None
+        // Pre-populate so the propagation loop can use `get_mut(&str)` and
+        // skip allocating an owned key per requirement.
+        let mut activated: HashMap<String, Vec<ExtraName>> = pypi_by_name
+            .keys()
+            .map(|name| (name.clone(), Vec::new()))
+            .collect();
+
+        for (name, specs) in environment.pypi_dependencies(Some(platform)) {
+            let key = name.as_normalized().as_dist_info_name();
+            if let Some(entry) = activated.get_mut(key.as_ref()) {
+                for spec in specs {
+                    for e in spec.extras() {
+                        if !entry.contains(e) {
+                            entry.push(e.clone());
+                        }
+                    }
                 }
-            })
-            .collect();
+            }
+        }
 
-        Some(PackageInfo {
-            name,
-            dependencies,
-            source: PackageSource::Pypi,
-        })
-    } else {
-        None
+        loop {
+            let mut changed = false;
+            for (name, pkg) in &pypi_by_name {
+                let extras_snapshot: Vec<ExtraName> =
+                    activated.get(name).cloned().unwrap_or_default();
+                for req in pkg.requires_dist() {
+                    let active = match marker_env {
+                        Some(env) => req.evaluate_markers(env, &extras_snapshot),
+                        None => req.marker.is_true(),
+                    };
+                    if !active {
+                        continue;
+                    }
+                    let target = req.name.as_dist_info_name();
+                    let Some(entry) = activated.get_mut(target.as_ref()) else {
+                        continue;
+                    };
+                    for e in &req.extras {
+                        if !entry.contains(e) {
+                            entry.push(e.clone());
+                            changed = true;
+                        }
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+
+        activated
     }
 }
 
-/// Generate a map of dependencies from a list of locked packages.
-pub fn generate_dependency_map(locked_deps: &[&'_ LockedPackage]) -> HashMap<String, Package> {
-    let mut package_dependencies_map = HashMap::new();
+/// Turns a list of locked packages into the dependency map consumed by the
+/// renderer. Uses [`PypiExtrasResolver`] to evaluate PyPI markers with the
+/// correct activated-extras context.
+pub(crate) struct DependencyMapBuilder<'a> {
+    locked_deps: &'a [&'a LockedPackage],
+    resolver: PypiExtrasResolver,
+}
 
-    for &package in locked_deps {
-        if let Some(package_info) = extract_package_info(package) {
-            package_dependencies_map.insert(
-                package_info.name.clone(),
+impl<'a> DependencyMapBuilder<'a> {
+    pub fn new(
+        environment: &Environment<'_>,
+        platform: Platform,
+        locked_deps: &'a [&'a LockedPackage],
+    ) -> Self {
+        Self {
+            locked_deps,
+            resolver: PypiExtrasResolver::new(environment, platform, locked_deps),
+        }
+    }
+
+    pub fn build(self) -> HashMap<String, Package> {
+        let mut out = HashMap::new();
+        for &package in self.locked_deps {
+            let Some((name, source, edges)) = self.package_view(package) else {
+                continue;
+            };
+            let version = match package {
+                LockedPackage::Conda(c) => c
+                    .record()
+                    .map(|r| r.version.to_string())
+                    .unwrap_or_default(),
+                LockedPackage::Pypi(p) => p.version_string(),
+            };
+            let dependencies =
+                Self::merge_edges(edges.into_iter().filter(|e| !e.name.starts_with("__")));
+            out.insert(
+                name.clone(),
                 Package {
-                    name: package_info.name,
-                    version: match package {
-                        LockedPackage::Conda(conda_data) => conda_data
-                            .record()
-                            .map(|r| r.version.to_string())
-                            .unwrap_or_default(),
-                        LockedPackage::Pypi(pypi_data) => pypi_data.version_string(),
-                    },
-                    dependencies: package_info
-                        .dependencies
-                        .into_iter()
-                        .filter(|pkg| !pkg.starts_with("__"))
-                        .unique()
-                        .collect(),
+                    name,
+                    version,
+                    dependencies,
                     needed_by: Vec::new(),
-                    source: package_info.source,
+                    source,
                 },
             );
         }
+        out
     }
-    package_dependencies_map
+
+    fn package_view(
+        &self,
+        package: &LockedPackage,
+    ) -> Option<(String, PackageSource, Vec<Dependency>)> {
+        if let Some(conda) = package.as_conda() {
+            let name = conda.name().as_normalized().to_string();
+            let edges: Vec<Dependency> = conda
+                .depends()
+                .iter()
+                .map(|d| Dependency {
+                    name: PackageName::from_matchspec_str_unchecked(d)
+                        .as_normalized()
+                        .to_string(),
+                    via_extras: Vec::new(),
+                })
+                .collect();
+            Some((name, PackageSource::Conda, edges))
+        } else if let Some(pypi) = package.as_pypi() {
+            let name = pypi.name().as_dist_info_name().into_owned();
+            let parent_extras = self.resolver.extras_for(&name);
+            let edges = pypi
+                .requires_dist()
+                .iter()
+                .filter_map(|req| {
+                    if !self.resolver.is_active(req, parent_extras) {
+                        tracing::info!(
+                            "Skipping {} specified by {} due to marker {:?}",
+                            req.name,
+                            name,
+                            req.marker
+                        );
+                        return None;
+                    }
+                    Some(Dependency {
+                        name: req.name.as_dist_info_name().into_owned(),
+                        via_extras: self
+                            .resolver
+                            .activating_extras(req, parent_extras)
+                            .map(ToString::to_string)
+                            .collect(),
+                    })
+                })
+                .collect();
+            Some((name, PackageSource::Pypi, edges))
+        } else {
+            None
+        }
+    }
+
+    /// Dedup by name, preserving `requires_dist` order. Base edges win over
+    /// extra-gated duplicates; extras are unioned otherwise.
+    fn merge_edges<I: IntoIterator<Item = Dependency>>(edges: I) -> Vec<Dependency> {
+        let mut by_name: indexmap::IndexMap<String, Dependency> = indexmap::IndexMap::new();
+        for edge in edges {
+            if let Some(existing) = by_name.get_mut(&edge.name) {
+                if existing.via_extras.is_empty() || edge.via_extras.is_empty() {
+                    existing.via_extras.clear();
+                    continue;
+                }
+                for e in edge.via_extras {
+                    if !existing.via_extras.contains(&e) {
+                        existing.via_extras.push(e);
+                    }
+                }
+            } else {
+                by_name.insert(edge.name.clone(), edge);
+            }
+        }
+        by_name.into_values().collect()
+    }
 }
 
 /// Extract the direct Conda and PyPI dependencies from the environment
@@ -238,4 +401,52 @@ pub fn direct_dependencies(
             .map(|(name, _)| name.as_normalized().as_dist_info_name().into_owned()),
     );
     project_dependency_names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pixi_core::Workspace;
+    use rattler_lock::LockFile;
+
+    /// Render the PyPI subset of an example workspace through the production
+    /// printer into a buffer for snapshot comparison.
+    fn render_pypi_tree(manifest: &std::path::Path, platform: Platform) -> String {
+        console::set_colors_enabled(false);
+
+        let workspace = Workspace::from_path(manifest).unwrap();
+        let environment = workspace.default_environment();
+        let lock_file = LockFile::from_path(&workspace.lock_file_path()).unwrap();
+        let pkgs: Vec<&LockedPackage> = lock_file
+            .environment(environment.name().as_str())
+            .and_then(|env| {
+                let p = lock_file.platform(&platform.to_string())?;
+                env.packages(p).map(Vec::from_iter)
+            })
+            .unwrap_or_default();
+
+        let dep_map: HashMap<String, Package> =
+            DependencyMapBuilder::new(&environment, platform, &pkgs)
+                .build()
+                .into_iter()
+                .filter(|(_, p)| p.source == PackageSource::Pypi)
+                .collect();
+        let mut direct_deps = direct_dependencies(&environment, &platform, &dep_map);
+        direct_deps.retain(|n| dep_map.contains_key(n));
+
+        let mut buf: Vec<u8> = Vec::new();
+        print_dependency_tree(&mut buf, &dep_map, &direct_deps, &None).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn pypi_extras_tree_snapshots() {
+        insta::glob!(
+            concat!(env!("CARGO_WORKSPACE_DIR"), "/examples"),
+            "{editable-with-extras,pypi}/pixi.toml",
+            |manifest| {
+                insta::assert_snapshot!(render_pypi_tree(manifest, Platform::Linux64));
+            }
+        );
+    }
 }


### PR DESCRIPTION
### Description

`pixi tree` was dropping every PyPI dependency gated by `extra == 'X'` because it filtered `requires_dist` with `marker.is_true()` and no extras context. For e.g. `crc-bonfire[cli]` this hid `ocviapy`, `truststore`, `click`, and the rest of the `cli` subtree.

This PR builds a PEP 508 marker environment from the locked Python and propagates activated extras transitively from the manifest direct deps through `requires_dist`. Each edge is then annotated with the parent extras that activated it, matching `uv tree`'s `(extra: <name>)` style. Top-level deps are sorted so output is deterministic. Falls back to the previous `is_true()` filter when no Python is locked.

Conda matchspec extras (`foo[extras=[bar]]`) are out of scope, left for a follow-up!

Fixes #6054

### How Has This Been Tested?

`insta::glob!` snapshot tests over `examples/{editable-with-extras,pypi}` drive the production printer against the checked-in lockfiles (no solve, no network) and verify activator annotations on both `package_with_extras[cli,color]` and `black[jupyter]`. Manual repro of #6054 confirms the missing `cli` subtree now shows up correctly tagged.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.