### PR TITLE
fix: to alias on target_channel

### DIFF
--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -95,13 +95,13 @@ pub struct Args {
     ///   s3://my-bucket/my-channel
     ///   channel:///path/to/local/channel
     ///   file:///path/to/local/channel
-    #[arg(long, conflicts_with = "target_dir")]
+    #[arg(long, visible_alias = "to", conflicts_with = "target_dir")]
     pub target_channel: Option<String>,
 
     /// The target local directory to copy packages into (no channel indexing).
     ///
     /// Accepts a local filesystem path.  Mutually exclusive with `--target-channel`.
-    #[arg(long, alias = "to", conflicts_with = "target_channel")]
+    #[arg(long, conflicts_with = "target_channel")]
     pub target_dir: Option<PathBuf>,
 
     /// Force overwrite existing packages

--- a/docs/reference/cli/pixi/publish.md
+++ b/docs/reference/cli/pixi/publish.md
@@ -32,6 +32,7 @@ pixi publish [OPTIONS]
 :  The path to a directory containing a package manifest, or to a specific manifest file
 - <a id="arg---target-channel" href="#arg---target-channel">`--target-channel <TARGET_CHANNEL>`</a>
 :  The target channel URL to publish packages to
+<br>**aliases**: to
 - <a id="arg---target-dir" href="#arg---target-dir">`--target-dir <TARGET_DIR>`</a>
 :  The target local directory to copy packages into (no channel indexing)
 - <a id="arg---force" href="#arg---force">`--force`</a>


### PR DESCRIPTION
### Description

We broke `pixi publish --to xxx` in `v0.68.0` where it writes to a directory instead of the channel.

This now should reenable `--to` for the channel use.

### How Has This Been Tested?

Not tested but it's very clear 😅 

### AI Disclosure
no ai

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
