### PR TITLE
fix: serialize  PEP 508 deps as filesystem paths

### DIFF
--- a/crates/pixi_pypi_spec/src/lib.rs
+++ b/crates/pixi_pypi_spec/src/lib.rs
@@ -624,13 +624,49 @@ mod tests {
         assert_eq!(
             as_pypi_req,
             PixiPypiSpec::new(PixiPypiSource::Path {
-                path: pixi_spec::Verbatim::new_with_given(
-                    PathBuf::from("/path/to/boltons"),
-                    "/path/to/boltons".to_string(),
-                ),
+                path: pixi_spec::Verbatim::new(PathBuf::from("/path/to/boltons")),
                 editable: None,
             })
         );
+    }
+
+    #[test]
+    fn test_pep508_file_url_serializes_as_path() {
+        // Regression: a `file://` URL in a PEP 508 requirement must round-trip
+        // through the manifest as a filesystem path, NOT as `path = "file://..."`.
+        // The latter is unloadable because, on reload, the string is treated as
+        // a relative PathBuf and joined with the project root.
+        // See prefix-dev/pixi#6071.
+        #[cfg(target_os = "windows")]
+        let pypi: pep508_rs::Requirement = "boltons @ file:///C:/path/to/boltons".parse().unwrap();
+        #[cfg(not(target_os = "windows"))]
+        let pypi: pep508_rs::Requirement = "boltons @ file:///path/to/boltons".parse().unwrap();
+
+        let as_pypi_req: PixiPypiSpec = pypi.try_into().unwrap();
+        let serialized = as_pypi_req.to_string();
+        assert!(
+            !serialized.contains("file://"),
+            "serialized PixiPypiSpec must not contain `file://`, got: {serialized}",
+        );
+    }
+
+    #[test]
+    fn test_pep508_relative_path_preserves_given() {
+        // Counterpart to `test_pep508_file_url_serializes_as_path`: when the
+        // user writes a *bare relative path* (pep508_rs's non-PEP-508 extension),
+        // we must keep their original spelling as `given` so the lockfile and
+        // manifest stay portable. Only the `file://` URL form should be discarded.
+        let working_dir = std::env::temp_dir();
+        let pypi: pep508_rs::Requirement =
+            pep508_rs::Requirement::parse("mine @ ./mine", &working_dir).unwrap();
+
+        let as_pypi_req: PixiPypiSpec = pypi.try_into().unwrap();
+        match as_pypi_req.source() {
+            PixiPypiSource::Path { path, .. } => {
+                assert_eq!(path.given(), Some("./mine"));
+            }
+            other => panic!("expected Path source, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -85,14 +85,21 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             req.marker,
                         )
                     } else if url.scheme().eq_ignore_ascii_case("file") {
-                        // Convert the file url to a path.
+                        // Convert the file URL to a filesystem path. Preserve `u.given()`
+                        // only when it is already in path form (e.g. `./mine`, `/abs/p`):
+                        // the destination `path = "..."` field expects a filesystem path,
+                        // so a `file://...` `given` would round-trip into an unloadable
+                        // manifest. See prefix-dev/pixi#6071.
                         let file = url.to_file_path().map_err(|_| {
                             Pep508ToPyPiRequirementError::PathUrlIntoPath(url.clone())
                         })?;
-                        let path = if let Some(g) = u.given() {
-                            Verbatim::new_with_given(file, g.to_string())
-                        } else {
-                            Verbatim::new(file)
+                        let path = match u.given() {
+                            Some(g)
+                                if !g.get(..5).is_some_and(|p| p.eq_ignore_ascii_case("file:")) =>
+                            {
+                                Verbatim::new_with_given(file, g.to_string())
+                            }
+                            _ => Verbatim::new(file),
                         };
                         PixiPypiSpec::with_extras_and_markers(
                             PixiPypiSource::Path {

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -94,9 +94,7 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             Pep508ToPyPiRequirementError::PathUrlIntoPath(url.clone())
                         })?;
                         let path = match u.given() {
-                            Some(g)
-                                if !g.get(..5).is_some_and(|p| p.eq_ignore_ascii_case("file:")) =>
-                            {
+                            Some(g) if !g.starts_with("file:") => {
                                 Verbatim::new_with_given(file, g.to_string())
                             }
                             _ => Verbatim::new(file),


### PR DESCRIPTION
### Description

Pixi 0.68.0 introduced a regression where `pixi add --pypi 'name @ file:///abs/path'` writes the full `file://...` URL into the `path = "..."` field of `pixi.toml`. The resulting manifest cannot be solved by pixi: on reload, the URL string is treated as a relative `PathBuf` and joined with the project root.

From what I understand #5607 changed `crates/pixi_pypi_spec/src/pep508.rs` to wrap the parsed file path in a `Verbatim`, storing the user's original `file://...` string as `given`. The manifest serializer prefers `given` over the inner `PathBuf`, so the URL ended up under a field that expects a filesystem path.

`rattler_lock::Verbatim`'s `PartialEq` only compares `inner`, ignoring `given`. The existing `test_from_args` assertion was a no-op for this class of bug because `Verbatim::new_with_given(path, url)` and `Verbatim::new(path)` compare equal.

Dropping the URL form of `given` for `file://` URLs seems to restore the pre-#5607 behavior of storing a bare `PathBuf`, whose `Display` correctly produces a filesystem path on serialization.

```toml
# Before (0.68.0) — unloadable
subpkg = { path = "file:///tmp/.../sibling/subpkg" }

# After — matches 0.67.x
subpkg = { path = "/tmp/.../sibling/subpkg" }
```

Fixes #6071 

### How Has This Been Tested?

- fixed the existing `test_from_args`
- new `test_pep508_file_url_serializes_as_path` to make sure there is no `file://` URL into the `path = "..."` field
- `cargo test -p pixi_pypi_spec --features 'pixi_spec/rattler_lock'`
- `pixi run lint`

### AI Disclosure
- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.
Tools: Claude (Opus 4.7)

### Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added sufficient tests to cover my changes.