### PR TITLE
feat: support PyPI index exclude-newer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,27 +111,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -144,15 +129,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -188,15 +164,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arborium"
@@ -308,10 +275,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "astral-pubgrub"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6cb15b4f5096a3a1b41fdc2736a1c33d87c78f34d3c1ec2b669e766edadd559"
+dependencies = [
+ "astral-version-ranges",
+ "indexmap 2.14.0",
+ "log",
+ "priority-queue",
+ "rustc-hash",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "astral-reqwest-middleware"
@@ -329,19 +349,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "astral-tokio-tar"
-version = "0.5.6"
+name = "astral-reqwest-retry"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "48c76a42c052d7a95249b90b83d44e8f1bbde7c8e08dbed50d49c58321815da3"
 dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "portable-atomic",
- "rustc-hash",
+ "anyhow",
+ "astral-reqwest-middleware",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "reqwest 0.13.2",
+ "retry-policies 0.5.1",
+ "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
- "xattr",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "astral-tl"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90933ffb0f97e2fc2e0de21da9d3f20597b804012d199843a6fe7c2810d28f3"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -358,6 +392,34 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xattr",
+]
+
+[[package]]
+name = "astral-version-ranges"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31979bc305610246d78ac01d63467a12d8454c6e3b8b22b5811d343a1198dfbb"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "astral_async_http_range_reader"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
+dependencies = [
+ "astral-reqwest-middleware",
+ "futures",
+ "http-content-range",
+ "itertools 0.14.0",
+ "memmap2 0.9.10",
+ "reqwest 0.13.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.18",
+ "tracing",
 ]
 
 [[package]]
@@ -568,26 +630,6 @@ dependencies = [
 
 [[package]]
 name = "async_http_range_reader"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b537c00269e3f943e06f5d7cabf8ccd281b800fd0c7f111dd82f77154334197"
-dependencies = [
- "bisection",
- "futures",
- "http-content-range",
- "itertools 0.13.0",
- "memmap2 0.9.10",
- "reqwest 0.12.28",
- "reqwest-middleware",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.18",
- "tracing",
-]
-
-[[package]]
-name = "async_http_range_reader"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b24fc9a58e46d228f83fb140b04c5645d19b455a61c300954711ebabfc11c0bd"
@@ -603,20 +645,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.18",
  "tracing",
-]
-
-[[package]]
-name = "async_zip"
-version = "0.0.17"
-source = "git+https://github.com/astral-sh/rs-async-zip?rev=285e48742b74ab109887d62e1ae79e7c15fd4878#285e48742b74ab109887d62e1ae79e7c15fd4878"
-dependencies = [
- "async-compression",
- "crc32fast",
- "futures-lite",
- "pin-project",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util 0.7.18",
 ]
 
 [[package]]
@@ -1270,12 +1298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bisection"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1402,12 @@ dependencies = [
  "futures-lite",
  "piper",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "boxcar"
@@ -1682,7 +1710,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -2195,6 +2223,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "cyclonedx-bom"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3132b69ba8c13808bd2fa5748ac5b9816eb4f4e1f0bff6b7f9254a5940dcdeef"
+dependencies = [
+ "base64 0.22.1",
+ "cyclonedx-bom-macros",
+ "fluent-uri",
+ "indexmap 2.14.0",
+ "once_cell",
+ "ordered-float 5.3.0",
+ "purl",
+ "regex",
+ "serde",
+ "serde_json",
+ "spdx 0.13.4",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
+ "xml-rs",
+]
+
+[[package]]
+name = "cyclonedx-bom-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50341f21df64b412b4f917e34b7aa786c092d64f3f905f478cb76950c7e980c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2420,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "der_derive"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,17 +2452,6 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2747,13 +2813,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if 1.0.4",
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2901,6 +2966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,16 +3026,6 @@ checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
  "tokio",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -4452,6 +4518,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "junction"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,16 +4733,6 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
-]
 
 [[package]]
 name = "lzma-rust2"
@@ -5247,6 +5321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5384,6 +5467,15 @@ name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -5570,6 +5662,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
 
 [[package]]
 name = "pem"
@@ -5781,7 +5883,7 @@ dependencies = [
  "uv-installer",
  "uv-normalize",
  "uv-python",
- "zip 8.6.0",
+ "zip",
 ]
 
 [[package]]
@@ -6243,7 +6345,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-requirements-txt",
  "which",
- "zip 8.6.0",
+ "zip",
 ]
 
 [[package]]
@@ -6650,7 +6752,6 @@ dependencies = [
  "tracing",
  "typed-path",
  "url",
- "uv-auth",
  "uv-cache",
  "uv-cache-info",
  "uv-client",
@@ -6975,7 +7076,7 @@ dependencies = [
  "tracing",
  "url",
  "xz2",
- "zip 8.6.0",
+ "zip",
  "zstd",
 ]
 
@@ -7027,6 +7128,7 @@ dependencies = [
  "pixi_uv_conversions",
  "reqwest 0.12.28",
  "tracing",
+ "url",
  "uv-cache",
  "uv-client",
  "uv-configuration",
@@ -7068,6 +7170,7 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
+ "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-redacted",
@@ -7096,6 +7199,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes 0.8.4",
+ "cbc 0.1.2",
+ "der 0.7.10",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7112,6 +7230,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
+ "pkcs5",
+ "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -7249,22 +7369,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.11.0",
  "flate2",
- "hex",
  "procfs-core",
- "rustix 0.38.44",
+ "rustix 1.1.4",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
@@ -7339,19 +7458,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "pubgrub"
-version = "0.3.0"
-source = "git+https://github.com/astral-sh/pubgrub?rev=d8efd77673c9a90792da9da31b6c0da7ea8a324b#d8efd77673c9a90792da9da31b6c0da7ea8a324b"
-dependencies = [
- "indexmap 2.14.0",
- "log",
- "priority-queue",
- "rustc-hash",
- "thiserror 2.0.18",
- "version-ranges",
 ]
 
 [[package]]
@@ -7445,6 +7551,16 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -7888,7 +8004,7 @@ dependencies = [
  "tracing",
  "url",
  "walkdir",
- "zip 8.6.0",
+ "zip",
  "zstd",
 ]
 
@@ -8221,11 +8337,11 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090fa9f0e13494294bb02bbcf6f7356c97b4483dd80b5838436aeaafada1f58e"
 dependencies = [
- "astral-tokio-tar 0.6.0",
+ "astral-tokio-tar",
  "astral_async_zip",
  "async-compression",
  "async-spooled-tempfile",
- "async_http_range_reader 0.10.0",
+ "async_http_range_reader",
  "bzip2 0.6.1",
  "chrono",
  "fs-err",
@@ -8250,7 +8366,7 @@ dependencies = [
  "tokio-util 0.7.18",
  "tracing",
  "url",
- "zip 8.6.0",
+ "zip",
  "zstd",
 ]
 
@@ -8654,31 +8770,31 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.18.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea386ba750000b6e59f760a08bdcca9461809b95e6f8f209ce5724056802824f"
+checksum = "2f343280e2e5ce07f97f32ead07a68824cb9cea60093ad78f22664011f90ae47"
 dependencies = [
  "reqsign-aws-v4",
  "reqsign-command-execute-tokio",
  "reqsign-core",
  "reqsign-file-read-tokio",
+ "reqsign-google",
  "reqsign-http-send-reqwest",
 ]
 
 [[package]]
 name = "reqsign-aws-v4"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab367a07c335a3eaa22395a9d9b0031ac73aee5893573281b2fa27bf97dc94f2"
+checksum = "44eaca382e94505a49f1a4849658d153aebf79d9c1a58e5dd3b10361511e9f43"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "form_urlencoded",
  "http 1.4.0",
  "log",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "rust-ini",
  "serde",
@@ -8689,26 +8805,25 @@ dependencies = [
 
 [[package]]
 name = "reqsign-command-execute-tokio"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eac3cf53a53139831e3fb8ff2189d54059d2191122a31ebd1229a66e338b3d"
+checksum = "fc4e0330fd26f72c7c6c4f09ab23fdf424b2a669ffdacc562803b2b3eecc7198"
 dependencies = [
- "async-trait",
  "reqsign-core",
  "tokio",
 ]
 
 [[package]]
 name = "reqsign-core"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba66eb941c0f723269a394baf3b19a2fa697a1e593f3e902779df6c35d24e21"
+checksum = "b10302cf0a7d7e7352ba211fc92c3c5bebf1286153e49cc5aa87348078a8e102"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
+ "futures",
  "hex",
  "hmac",
  "http 1.4.0",
@@ -8722,30 +8837,48 @@ dependencies = [
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702f12a867bf8e507de907fa0f4d75b96469ace7edd33fcc1fc8a8ef58f3c8d2"
+checksum = "e2d89295b3d17abea31851cc8de55d843d89c52132c864963c38d41920613dc5"
 dependencies = [
  "anyhow",
- "async-trait",
  "reqsign-core",
  "tokio",
 ]
 
 [[package]]
-name = "reqsign-http-send-reqwest"
-version = "2.0.1"
+name = "reqsign-google"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46186bce769674f9200ad01af6f2ca42de3e819ddc002fff1edae135bfb6cd9c"
+checksum = "35cc609b49c69e76ecaceb775a03f792d1ed3e7755ab3548d4534fd801e3242e"
+dependencies = [
+ "form_urlencoded",
+ "http 1.4.0",
+ "jsonwebtoken",
+ "log",
+ "percent-encoding",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+]
+
+[[package]]
+name = "reqsign-http-send-reqwest"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46db7dfc9632310d2bdc7978c2e217187cd814842da66b3daf20a45f4e8a1e5e"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "futures-channel",
  "http 1.4.0",
  "http-body-util",
  "reqsign-core",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "wasm-bindgen-futures",
 ]
 
@@ -8794,7 +8927,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -8807,7 +8940,9 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -8818,6 +8953,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -8832,12 +8968,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util 0.7.18",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -9048,6 +9186,7 @@ dependencies = [
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -9122,6 +9261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -9279,6 +9427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9358,6 +9515,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -9534,7 +9702,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -10147,6 +10315,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10388,16 +10568,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -10701,11 +10871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tl"
-version = "0.7.8"
-source = "git+https://github.com/astral-sh/tl.git?rev=6e25b2ee2513d75385101a8ff9f591ef51f314ec#6e25b2ee2513d75385101a8ff9f591ef51f314ec"
-
-[[package]]
 name = "tls_codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10890,6 +11055,21 @@ name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -11303,11 +11483,12 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "arcstr",
+ "astral-reqwest-middleware",
  "async-trait",
  "base64 0.22.1",
  "etcetera",
@@ -11316,9 +11497,8 @@ dependencies = [
  "http 1.4.0",
  "jiff",
  "percent-encoding",
- "reqsign 0.18.1",
- "reqwest 0.12.28",
- "reqwest-middleware",
+ "reqsign 0.20.0",
+ "reqwest 0.13.2",
  "rust-netrc",
  "rustc-hash",
  "schemars 1.2.1",
@@ -11343,21 +11523,25 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
+ "astral-version-ranges",
  "base64 0.22.1",
  "csv",
  "flate2",
  "fs-err",
  "globset",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "rustc-hash",
  "schemars 1.2.1",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
- "spdx 0.10.9",
+ "spdx 0.13.4",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -11370,20 +11554,19 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-preview",
  "uv-pypi-types",
- "uv-version",
  "uv-warnings",
- "version-ranges",
  "walkdir",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "fs-err",
  "indoc",
  "itertools 0.14.0",
@@ -11395,8 +11578,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
+ "uv-auth",
  "uv-cache-key",
  "uv-configuration",
  "uv-distribution",
@@ -11405,7 +11589,6 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
- "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-static",
@@ -11417,8 +11600,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11427,6 +11610,7 @@ dependencies = [
  "same-file",
  "serde",
  "tempfile",
+ "thiserror 2.0.18",
  "tracing",
  "uv-cache-info",
  "uv-cache-key",
@@ -11442,8 +11626,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11452,13 +11636,14 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "uv-fs",
  "walkdir",
 ]
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "hex",
  "memchr",
@@ -11470,13 +11655,16 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
+ "astral-reqwest-middleware",
+ "astral-reqwest-retry",
+ "astral-tl",
+ "astral_async_http_range_reader",
+ "astral_async_zip",
  "async-trait",
- "async_http_range_reader 0.9.1",
- "async_zip",
  "bytecheck",
  "fs-err",
  "futures",
@@ -11486,17 +11674,16 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "percent-encoding",
- "reqwest 0.12.28",
- "reqwest-middleware",
- "reqwest-retry 0.7.0",
+ "reqwest 0.13.2",
  "rkyv",
  "rmp-serde",
  "rustc-hash",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
- "sys-info",
  "thiserror 2.0.18",
- "tl",
  "tokio",
  "tokio-util 0.7.18",
  "tracing",
@@ -11512,6 +11699,7 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-pep508",
+ "uv-platform",
  "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
@@ -11521,23 +11709,27 @@ dependencies = [
  "uv-torch",
  "uv-version",
  "uv-warnings",
+ "webpki-root-certs 1.0.6",
+ "x509-parser",
 ]
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "either",
  "fs-err",
  "rayon",
+ "reqwest 0.13.2",
  "rustc-hash",
  "same-file",
  "schemars 1.2.1",
  "serde",
  "serde-untagged",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "url",
  "uv-auth",
@@ -11549,21 +11741,22 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-redacted",
  "uv-static",
 ]
 
 [[package]]
 name = "uv-console"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11573,8 +11766,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "futures",
@@ -11606,17 +11799,17 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
+ "astral-reqwest-middleware",
  "either",
  "fs-err",
  "futures",
  "nanoid 0.4.0",
  "owo-colors",
- "reqwest 0.12.28",
- "reqwest-middleware",
+ "reqwest 0.13.2",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -11635,6 +11828,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-extract",
+ "uv-flags",
  "uv-fs",
  "uv-git",
  "uv-git-types",
@@ -11644,17 +11838,19 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
+ "uv-python",
  "uv-redacted",
  "uv-types",
+ "uv-warnings",
  "uv-workspace",
  "walkdir",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11670,10 +11866,11 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
+ "astral-version-ranges",
  "bitflags 2.11.0",
  "fs-err",
  "http 1.4.0",
@@ -11705,23 +11902,23 @@ dependencies = [
  "uv-redacted",
  "uv-small-str",
  "uv-warnings",
- "version-ranges",
 ]
 
 [[package]]
 name = "uv-extract"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
- "astral-tokio-tar 0.5.6",
+ "astral-tokio-tar",
+ "astral_async_zip",
  "async-compression",
- "async_zip",
  "blake2",
  "fs-err",
  "futures",
  "md-5",
  "rayon",
- "reqwest 0.12.28",
+ "regex",
+ "reqwest 0.13.2",
  "rustc-hash",
  "sha2 0.10.9",
  "tar",
@@ -11733,58 +11930,65 @@ dependencies = [
  "uv-distribution-filename",
  "uv-pypi-types",
  "uv-static",
+ "uv-warnings",
  "xz2",
- "zip 2.4.2",
+ "zip",
  "zstd",
 ]
 
 [[package]]
 name = "uv-flags"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "backon",
+ "clap",
  "dunce",
  "either",
  "encoding_rs_io",
  "fs-err",
- "fs2",
  "junction",
  "path-slash",
  "percent-encoding",
+ "reflink-copy",
+ "rustc-hash",
  "rustix 1.1.4",
  "same-file",
  "schemars 1.2.1",
  "serde",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
- "windows 0.59.0",
+ "uv-static",
+ "uv-warnings",
+ "walkdir",
+ "windows 0.61.3",
 ]
 
 [[package]]
 name = "uv-git"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
+ "astral-reqwest-middleware",
  "cargo-util",
  "dashmap",
  "fs-err",
- "reqwest 0.12.28",
- "reqwest-middleware",
+ "owo-colors",
+ "reqwest 0.13.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "url",
  "uv-auth",
  "uv-cache-key",
  "uv-fs",
@@ -11792,25 +11996,28 @@ dependencies = [
  "uv-redacted",
  "uv-static",
  "uv-version",
+ "uv-warnings",
  "which",
 ]
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "uv-cache-key",
  "uv-redacted",
+ "uv-static",
 ]
 
 [[package]]
 name = "uv-globfilter"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "globset",
  "owo-colors",
@@ -11823,27 +12030,24 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
- "clap",
  "configparser",
  "csv",
  "data-encoding",
  "fs-err",
+ "itertools 0.14.0",
  "mailparse",
  "owo-colors",
  "pathdiff",
- "reflink-copy",
  "regex",
  "rustc-hash",
  "same-file",
- "schemars 1.2.1",
  "self-replace",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "uv-distribution-filename",
@@ -11861,8 +12065,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -11903,8 +12107,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -11912,14 +12116,14 @@ dependencies = [
  "security-framework 3.7.0",
  "thiserror 2.0.18",
  "tokio",
- "windows 0.59.0",
+ "windows 0.61.3",
  "zeroize",
 ]
 
 [[package]]
 name = "uv-macros"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11929,10 +12133,10 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
- "async_zip",
+ "astral_async_zip",
  "fs-err",
  "futures",
  "thiserror 2.0.18",
@@ -11942,13 +12146,13 @@ dependencies = [
  "uv-distribution-filename",
  "uv-normalize",
  "uv-pypi-types",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -11958,8 +12162,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "dashmap",
  "futures",
@@ -11968,32 +12172,33 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.7.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
+ "astral-version-ranges",
  "rkyv",
  "serde",
  "tracing",
  "unicode-width 0.2.2",
  "unscanny",
  "uv-cache-key",
- "version-ranges",
 ]
 
 [[package]]
 name = "uv-pep508"
-version = "0.6.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
+ "astral-version-ranges",
  "boxcar",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -12003,6 +12208,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "smallvec",
+ "temp-env",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
  "url",
@@ -12011,31 +12217,33 @@ dependencies = [
  "uv-normalize",
  "uv-pep440",
  "uv-redacted",
- "version-ranges",
 ]
 
 [[package]]
 name = "uv-platform"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "goblin",
  "procfs",
  "regex",
+ "rustix 1.1.4",
  "target-lexicon",
  "thiserror 2.0.18",
  "tracing",
  "uv-fs",
  "uv-platform-tags",
  "uv-static",
+ "windows-version",
 ]
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
+ "bitflags 2.11.0",
  "memchr",
  "rkyv",
  "rustc-hash",
@@ -12046,18 +12254,19 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
- "bitflags 2.11.0",
+ "enumflags2",
+ "itertools 0.14.0",
  "thiserror 2.0.18",
  "uv-warnings",
 ]
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12072,7 +12281,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "thiserror 2.0.18",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12087,10 +12296,12 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
+ "astral-reqwest-middleware",
+ "astral-reqwest-retry",
  "clap",
  "configparser",
  "dunce",
@@ -12098,20 +12309,17 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "once_cell",
+ "junction",
  "owo-colors",
  "ref-cast",
  "regex",
- "reqwest 0.12.28",
- "reqwest-middleware",
- "reqwest-retry 0.7.0",
+ "reqwest 0.13.2",
  "rmp-serde",
  "rustc-hash",
  "same-file",
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "sys-info",
  "target-lexicon",
  "tempfile",
  "thiserror 2.0.18",
@@ -12125,6 +12333,7 @@ dependencies = [
  "uv-client",
  "uv-dirs",
  "uv-distribution-filename",
+ "uv-distribution-types",
  "uv-extract",
  "uv-fs",
  "uv-install-wheel",
@@ -12140,25 +12349,26 @@ dependencies = [
  "uv-trampoline-builder",
  "uv-warnings",
  "which",
- "windows 0.59.0",
+ "windows 0.61.3",
  "windows-registry",
 ]
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
  "serde",
+ "thiserror 2.0.18",
  "url",
 ]
 
 [[package]]
 name = "uv-requirements"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12166,7 +12376,6 @@ dependencies = [
  "fs-err",
  "futures",
  "rustc-hash",
- "serde",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -12193,13 +12402,13 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
+ "astral-reqwest-middleware",
  "fs-err",
  "memchr",
- "reqwest 0.12.28",
- "reqwest-middleware",
+ "reqwest 0.13.2",
  "rustc-hash",
  "thiserror 2.0.18",
  "tracing",
@@ -12218,11 +12427,13 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
+ "astral-pubgrub",
  "clap",
+ "cyclonedx-bom",
  "dashmap",
  "either",
  "fs-err",
@@ -12232,20 +12443,21 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "owo-colors",
+ "percent-encoding",
  "petgraph",
- "pubgrub",
  "rkyv",
  "rustc-hash",
  "same-file",
  "schemars 1.2.1",
  "serde",
+ "serde_json",
  "smallvec",
  "textwrap",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12265,6 +12477,7 @@ dependencies = [
  "uv-pep440",
  "uv-pep508",
  "uv-platform-tags",
+ "uv-preview",
  "uv-pypi-types",
  "uv-python",
  "uv-redacted",
@@ -12273,14 +12486,15 @@ dependencies = [
  "uv-static",
  "uv-torch",
  "uv-types",
+ "uv-version",
  "uv-warnings",
  "uv-workspace",
 ]
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12289,6 +12503,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
+ "tracing",
  "url",
  "uv-configuration",
  "uv-distribution-types",
@@ -12304,8 +12519,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "fs-err",
@@ -12339,25 +12554,24 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "fs-err",
- "home",
- "nix 0.30.1",
+ "nix 0.31.2",
  "same-file",
  "tracing",
  "uv-fs",
  "uv-static",
- "windows 0.59.0",
+ "windows 0.61.3",
  "windows-registry",
 ]
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12367,8 +12581,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12377,16 +12591,17 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
+ "thiserror 2.0.18",
  "uv-macros",
 ]
 
 [[package]]
 name = "uv-torch"
-version = "0.1.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "either",
@@ -12406,19 +12621,23 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
+ "anyhow",
  "fs-err",
+ "goblin",
+ "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
- "zip 2.4.2",
+ "windows 0.61.3",
+ "zip",
 ]
 
 [[package]]
 name = "uv-types"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12440,13 +12659,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.9.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.11.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "console",
  "fs-err",
@@ -12458,32 +12677,32 @@ dependencies = [
  "tracing",
  "uv-console",
  "uv-fs",
- "uv-preview",
+ "uv-platform-tags",
  "uv-pypi-types",
  "uv-python",
  "uv-shell",
  "uv-version",
- "uv-warnings",
 ]
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "owo-colors",
  "rustc-hash",
 ]
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.9.5#d5f39331a73d5042e70ab770463dff632e20c127"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "fs-err",
  "glob",
+ "ignore",
  "itertools 0.14.0",
  "owo-colors",
  "rustc-hash",
@@ -12492,7 +12711,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "uv-build-backend",
  "uv-cache-key",
@@ -12724,6 +12943,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -13217,6 +13449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13513,16 +13754,16 @@ dependencies = [
 
 [[package]]
 name = "wmi"
-version = "0.16.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9189bc72f0e4d814d812216ec06636ce3ea5597ff5f1ff9f9f0e5ec781c027"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
 dependencies = [
  "futures",
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.59.0",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -13555,6 +13796,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "x509-tsp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13584,6 +13842,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmlparser"
@@ -13875,38 +14139,20 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
-dependencies = [
- "arbitrary",
- "bzip2 0.5.2",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "flate2",
- "indexmap 2.14.0",
- "lzma-rs",
- "memchr",
- "thiserror 2.0.18",
- "xz2",
- "zopfli",
- "zstd",
-]
-
-[[package]]
-name = "zip"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
+ "bzip2 0.6.1",
  "crc32fast",
  "flate2",
  "indexmap 2.14.0",
+ "lzma-rust2",
  "memchr",
  "time",
  "typed-path",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,35 +182,35 @@ tracing-test = "0.2"
 typed-path = "0.12.0"
 # Bumping this to a higher version breaks the Windows path handling.
 url = "2.5.4"
-uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.9.5" }
+uv-auth = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }

--- a/crates/pixi/tests/integration_rust/pypi_tests.rs
+++ b/crates/pixi/tests/integration_rust/pypi_tests.rs
@@ -861,6 +861,112 @@ async fn test_pinning_index() {
 }
 
 #[tokio::test]
+async fn test_exclude_newer_pypi_index_override() {
+    setup_tracing();
+
+    let platform = Platform::current();
+
+    let mut package_db = MockRepoData::default();
+    package_db.add_package(
+        Package::build("python", "3.12.0")
+            .with_subdir(platform)
+            .with_timestamp("2010-12-02T02:07:43Z".parse().unwrap())
+            .finish(),
+    );
+    let channel = package_db.into_channel().await.unwrap();
+
+    let default_idx = PyPIDatabase::new().into_simple_index().unwrap();
+
+    let internal_idx = PyPIDatabase::new()
+        .with(
+            PyPIPackage::new("foo", "2.0.0")
+                .with_timestamp("2020-12-02T07:00:00Z".parse().unwrap()),
+        )
+        .into_simple_index()
+        .unwrap();
+
+    let baseline = PixiControl::from_manifest(&format!(
+        r#"
+        [workspace]
+        name = "pypi-exclude-newer-index-baseline"
+        platforms = ["{platform}"]
+        channels = ["{channel_url}"]
+        exclude-newer = "2015-12-02T02:07:43Z"
+        conda-pypi-map = {{}}
+
+        [dependencies]
+        python = "==3.12.0"
+
+        [pypi-dependencies]
+        foo = "*"
+
+        [pypi-options]
+        index-url = "{default_idx_url}"
+        extra-index-urls = ["{internal_idx_url}"]
+        "#,
+        platform = platform,
+        channel_url = channel.url(),
+        default_idx_url = default_idx.index_url(),
+        internal_idx_url = internal_idx.index_url(),
+    ))
+    .unwrap();
+
+    let err = baseline
+        .update_lock_file()
+        .await
+        .expect_err("global cutoff should reject the internal-index candidate");
+    let rendered = format!("{err:?}");
+    assert!(
+        rendered.contains("no versions of foo"),
+        "expected PyPI solve to fail once the internal-index candidate is filtered by exclude-newer, got:\n{rendered}"
+    );
+
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+        [workspace]
+        name = "pypi-exclude-newer-index"
+        platforms = ["{platform}"]
+        channels = ["{channel_url}"]
+        exclude-newer = "2015-12-02T02:07:43Z"
+        conda-pypi-map = {{}}
+
+        [dependencies]
+        python = "==3.12.0"
+
+        [pypi-dependencies]
+        foo = "*"
+
+        [pypi-options]
+        index-url = "{default_idx_url}"
+        extra-index-urls = [
+            {{ url = "{internal_idx_url}", exclude-newer = "0d" }},
+        ]
+        "#,
+        platform = platform,
+        channel_url = channel.url(),
+        default_idx_url = default_idx.index_url(),
+        internal_idx_url = internal_idx.index_url(),
+    ))
+    .unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+    assert_eq!(
+        lock_file.get_pypi_package_version("default", platform, "foo"),
+        Some("2.0.0".into())
+    );
+    assert_eq!(
+        lock_file
+            .get_pypi_package_url("default", platform, "foo")
+            .unwrap()
+            .as_path()
+            .unwrap(),
+        Utf8TypedPath::from(&*internal_idx.index_path().as_os_str().to_string_lossy())
+            .join("foo")
+            .join("foo-2.0.0-py3-none-any.whl")
+    );
+}
+
+#[tokio::test]
 async fn test_exclude_newer_per_package_pypi_index_override() {
     setup_tracing();
 

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -10,7 +10,6 @@ use pixi_uv_conversions::convert_uv_requirements_to_pep508;
 use rattler_conda_types::Platform;
 
 use tracing::warn;
-use uv_client::BaseClientBuilder;
 use uv_requirements_txt::RequirementsTxt;
 
 use miette::{Diagnostic, IntoDiagnostic, Result};
@@ -198,13 +197,9 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
             (conda_deps, pypi_deps)
         }
         ProcessedInput::PypiTxt => {
-            let reqs_txt = RequirementsTxt::parse(
-                &input_file,
-                workspace.workspace().root(),
-                &BaseClientBuilder::default(),
-            )
-            .await
-            .into_diagnostic()?;
+            let reqs_txt = RequirementsTxt::parse(&input_file, workspace.workspace().root())
+                .await
+                .into_diagnostic()?;
             let pypi_deps = convert_uv_requirements_txt_to_pep508(reqs_txt)?;
 
             (vec![], pypi_deps)

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -37,7 +37,7 @@ use uv_build_frontend::SourceBuild;
 use uv_cache::Cache;
 use uv_client::RegistryClient;
 use uv_configuration::{
-    BuildKind, BuildOptions, BuildOutput, Concurrency, Constraints, IndexStrategy, SourceStrategy,
+    BuildKind, BuildOptions, BuildOutput, Concurrency, Constraints, IndexStrategy, NoSources,
 };
 use uv_dispatch::{BuildDispatch, BuildDispatchError, SharedState};
 use uv_distribution_filename::DistFilename;
@@ -70,7 +70,7 @@ pub struct UvBuildDispatchParams<'a> {
     shared_state: SharedState,
     link_mode: uv_install_wheel::LinkMode,
     exclude_newer: Option<ExcludeNewer>,
-    sources: SourceStrategy,
+    sources: NoSources,
     concurrency: Concurrency,
     preview: uv_preview::Preview,
     workspace_cache: WorkspaceCache,
@@ -105,7 +105,7 @@ impl<'a> UvBuildDispatchParams<'a> {
             link_mode: LinkMode::default(),
             constraints: Constraints::default(),
             exclude_newer: None,
-            sources: SourceStrategy::default(),
+            sources: NoSources::default(),
             concurrency: Concurrency::default(),
             preview: uv_preview::Preview::default(),
             workspace_cache: WorkspaceCache::default(),
@@ -125,7 +125,7 @@ impl<'a> UvBuildDispatchParams<'a> {
     }
 
     /// Set the source strategy for the build dispatch
-    pub fn with_source_strategy(mut self, sources: SourceStrategy) -> Self {
+    pub fn with_source_strategy(mut self, sources: NoSources) -> Self {
         self.sources = sources;
         self
     }
@@ -424,9 +424,9 @@ impl<'a> LazyBuildDispatch<'a> {
                     self.params.build_options,
                     self.params.hasher,
                     self.params.exclude_newer.clone().unwrap_or_default(),
-                    self.params.sources,
+                    self.params.sources.clone(),
                     self.params.workspace_cache.clone(),
-                    self.params.concurrency,
+                    self.params.concurrency.clone(),
                     self.params.preview,
                 )
                 .with_build_extra_env_vars(env_vars);
@@ -478,8 +478,8 @@ impl BuildContext for LazyBuildDispatch<'_> {
         self.params.config_settings
     }
 
-    fn sources(&self) -> uv_configuration::SourceStrategy {
-        self.params.sources
+    fn sources(&self) -> &NoSources {
+        &self.params.sources
     }
 
     fn locations(&self) -> &uv_distribution_types::IndexLocations {
@@ -518,7 +518,7 @@ impl BuildContext for LazyBuildDispatch<'_> {
         install_path: &'a Path,
         version_id: Option<&'a str>,
         dist: Option<&'a SourceDist>,
-        sources: SourceStrategy,
+        sources: &'a NoSources,
         build_kind: BuildKind,
         build_output: BuildOutput,
         build_stack: BuildStack,
@@ -545,12 +545,20 @@ impl BuildContext for LazyBuildDispatch<'_> {
         source: &'a Path,
         subdirectory: Option<&'a Path>,
         output_dir: &'a Path,
+        sources: NoSources,
         build_kind: BuildKind,
         version_id: Option<&'a str>,
     ) -> Result<Option<DistFilename>, impl IsBuildBackendError> {
         let dispatch = self.get_or_try_init().await?;
         dispatch
-            .direct_build(source, subdirectory, output_dir, build_kind, version_id)
+            .direct_build(
+                source,
+                subdirectory,
+                output_dir,
+                sources,
+                build_kind,
+                version_id,
+            )
             .await
             .map_err(LazyBuildDispatchError::from)
     }

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -46,10 +46,8 @@ use rattler_lock::{
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
 use uv_cache_key::RepositoryUrl;
-use uv_client::{
-    BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder,
-};
-use uv_configuration::{Constraints, Overrides};
+use uv_client::{Connectivity, FlatIndexClient, RegistryClient};
+use uv_configuration::{Constraints, Excludes, Overrides};
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{
     BuiltDist, ConfigSettings, DependencyMetadata, Diagnostic, Dist, FileLocation, HashPolicy,
@@ -474,26 +472,13 @@ pub async fn resolve_pypi(
         &index_locations,
     );
 
-    let registry_client = {
-        let base_client_builder = BaseClientBuilder::default()
-            .allow_insecure_host(allow_insecure_hosts)
-            .markers(&marker_environment)
-            .keyring(context.keyring_provider)
-            .connectivity(Connectivity::Online)
-            .native_tls(context.use_native_tls)
-            .extra_middleware(context.extra_middleware.clone());
-
-        let mut uv_client_builder =
-            RegistryClientBuilder::new(base_client_builder, context.cache.clone())
-                .index_locations(index_locations.clone())
-                .index_strategy(index_strategy);
-
-        for p in &context.proxies {
-            uv_client_builder = uv_client_builder.proxy(p.clone())
-        }
-
-        Arc::new(uv_client_builder.build())
-    };
+    let registry_client = context.build_registry_client(
+        allow_insecure_hosts,
+        &index_locations,
+        index_strategy,
+        Some(&marker_environment),
+        Connectivity::Online,
+    )?;
     let dependency_overrides =
         pypi_options.dependency_overrides.as_ref().map(|overrides|->Result<Vec<_>, _> {
             overrides
@@ -580,8 +565,8 @@ pub async fn resolve_pypi(
     // mostly with build isolation. In that case we want to use fresh
     // non-tampered requests.
     .with_shared_state(context.shared_state.fork())
-    .with_source_strategy(context.source_strategy)
-    .with_concurrency(context.concurrency)
+    .with_source_strategy(context.source_strategy.clone())
+    .with_concurrency(context.concurrency.clone())
     .with_link_mode(link_mode);
 
     // Use cached build dispatch dependencies
@@ -724,16 +709,17 @@ pub async fn resolve_pypi(
 
     let resolution_future = panic::AssertUnwindSafe(async {
         let lookahead_index = InMemoryIndex::default();
-        let lookaheads = LookaheadResolver::new(
+        let mut hasher = context.hash_strategy.clone();
+        let (lookaheads, updated_hasher) = LookaheadResolver::new(
             &requirements,
             &constraints,
             &overrides,
-            &context.hash_strategy,
+            &hasher,
             &lookahead_index,
             DistributionDatabase::new(
                 &registry_client,
                 &lazy_build_dispatch,
-                context.concurrency.downloads,
+                context.concurrency.downloads_semaphore.clone(),
             ),
         )
         .with_reporter(UvReporter::new_arc(
@@ -743,12 +729,14 @@ pub async fn resolve_pypi(
         .await
         .into_diagnostic()
         .map_err(|e| SolveError::LookAhead(e.into()))?;
+        hasher = updated_hasher;
 
         // Move manifest and provider setup inside catch_unwind
         let manifest = Manifest::new(
             requirements,
             constraints,
             overrides,
+            Excludes::default(),
             Preferences::from_iter(preferences, &resolver_env),
             None,
             Default::default(),
@@ -761,14 +749,15 @@ pub async fn resolve_pypi(
             DistributionDatabase::new(
                 &registry_client,
                 &lazy_build_dispatch,
-                context.concurrency.downloads,
+                context.concurrency.downloads_semaphore.clone(),
             ),
             &flat_index,
             Some(&provider_tags),
             &requires_python,
             AllowedYanks::from_manifest(&manifest, &resolver_env, options.dependency_mode),
-            &context.hash_strategy,
+            &hasher,
             options.exclude_newer.clone(),
+            &index_locations,
             &build_options,
             &context.capabilities,
         );
@@ -831,7 +820,7 @@ pub async fn resolve_pypi(
             &registry_client,
             resolution,
             &context.capabilities,
-            context.concurrency.downloads,
+            context.concurrency.downloads_semaphore.clone(),
             project_root,
             &original_git_references,
         )
@@ -995,7 +984,7 @@ async fn lock_pypi_packages(
     registry_client: &Arc<RegistryClient>,
     resolution: Resolution,
     index_capabilities: &IndexCapabilities,
-    concurrent_downloads: usize,
+    concurrent_downloads: Arc<tokio::sync::Semaphore>,
     abs_project_root: &Path,
     original_git_references: &HashMap<uv_normalize::PackageName, pixi_spec::GitReference>,
 ) -> miette::Result<LockedPypiRecords> {

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -27,7 +27,7 @@ use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_lock::UrlOrPath;
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
-use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
+use uv_client::{Connectivity, FlatIndexClient};
 use uv_configuration::RAYON_INITIALIZE;
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{ConfigSettings, DependencyMetadata, IndexUrl, RequirementSource};
@@ -565,26 +565,21 @@ async fn read_local_package_metadata(
         &index_locations,
     );
 
-    let registry_client = {
-        let base_client_builder = BaseClientBuilder::default()
-            .allow_insecure_host(allow_insecure_hosts.clone())
-            .markers(&marker_environment)
-            .keyring(ctx.uv_context.keyring_provider)
-            .connectivity(Connectivity::Online)
-            .native_tls(ctx.uv_context.use_native_tls)
-            .extra_middleware(ctx.uv_context.extra_middleware.clone());
-
-        let mut uv_client_builder =
-            RegistryClientBuilder::new(base_client_builder, ctx.uv_context.cache.clone())
-                .index_locations(index_locations.clone())
-                .index_strategy(index_strategy);
-
-        for p in &ctx.uv_context.proxies {
-            uv_client_builder = uv_client_builder.proxy(p.clone())
-        }
-
-        Arc::new(uv_client_builder.build())
-    };
+    let registry_client = ctx
+        .uv_context
+        .build_registry_client(
+            allow_insecure_hosts,
+            &index_locations,
+            index_strategy,
+            Some(&marker_environment),
+            Connectivity::Online,
+        )
+        .map_err(|e| {
+            PlatformUnsat::FailedToReadLocalMetadata(
+                package_name.clone(),
+                format!("Failed to build uv registry client: {e}"),
+            )
+        })?;
 
     // Get tags for this platform (needed for FlatIndex)
     let system_requirements = ctx.environment.system_requirements();
@@ -638,8 +633,8 @@ async fn read_local_package_metadata(
     .with_index_strategy(index_strategy)
     .with_workspace_cache(ctx.uv_context.workspace_cache.clone())
     .with_shared_state(ctx.uv_context.shared_state.fork())
-    .with_source_strategy(ctx.uv_context.source_strategy)
-    .with_concurrency(ctx.uv_context.concurrency);
+    .with_source_strategy(ctx.uv_context.source_strategy.clone())
+    .with_concurrency(ctx.uv_context.concurrency.clone());
 
     // Get or create conda prefix updater for the environment
     // Use best_platform() because we can only install/run Python on the host platform
@@ -699,7 +694,7 @@ async fn read_local_package_metadata(
     let database = DistributionDatabase::new(
         &registry_client,
         &lazy_build_dispatch,
-        ctx.uv_context.concurrency.downloads,
+        ctx.uv_context.concurrency.downloads_semaphore.clone(),
     );
 
     // Missing or unparsable pyproject -> trust the lock.
@@ -708,7 +703,7 @@ async fn read_local_package_metadata(
         tracing::debug!(package = %package_name, "no readable pyproject.toml");
         return Ok(None);
     };
-    let Ok(pyproject_toml) = PyProjectToml::from_toml(&contents) else {
+    let Ok(pyproject_toml) = PyProjectToml::from_toml(&contents, pyproject_path.display()) else {
         tracing::debug!(package = %package_name, "pyproject.toml could not be parsed");
         return Ok(None);
     };

--- a/crates/pixi_install_pypi/Cargo.toml
+++ b/crates/pixi_install_pypi/Cargo.toml
@@ -41,7 +41,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 typed-path = { workspace = true }
 url = { workspace = true }
-uv-auth = { workspace = true }
 uv-cache = { workspace = true }
 uv-cache-info = { workspace = true }
 uv-client = { workspace = true }

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -35,7 +35,6 @@ use rattler_conda_types::Platform;
 use rattler_lock::{PypiDistributionData, PypiIndexes, PypiPackageData, UrlOrPath};
 use rayon::prelude::*;
 use utils::elapsed;
-use uv_auth::store_credentials_from_url;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClient};
 use uv_configuration::{BuildOptions, Constraints, IndexStrategy};
 use uv_dispatch::BuildDispatch;
@@ -531,7 +530,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             index_strategy,
             None,
             Connectivity::Online,
-        );
+        )?;
 
         // Resolve the flat indexes from `--find-links`.
         let flat_index_client = FlatIndexClient::new(
@@ -904,13 +903,20 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         let distribution_database = DistributionDatabase::new(
             setup.registry_client.as_ref(),
             &build_dispatch,
-            self.context_config.uv_context.concurrency.downloads,
+            self.context_config
+                .uv_context
+                .concurrency
+                .downloads_semaphore
+                .clone(),
         );
 
         // Before hitting the network let's make sure the credentials are available to
         // uv
         for url in setup.index_locations.indexes().map(|index| index.url()) {
-            let success = store_credentials_from_url(url.url());
+            let success = setup
+                .registry_client
+                .credentials_cache()
+                .store_credentials_from_url(url.url());
             tracing::debug!("Stored credentials for {}: {}", url, success);
         }
 
@@ -974,9 +980,9 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             &setup.build_options,
             &self.context_config.uv_context.hash_strategy,
             setup.exclude_newer.clone(),
-            self.context_config.uv_context.source_strategy,
+            self.context_config.uv_context.source_strategy.clone(),
             self.context_config.uv_context.workspace_cache.clone(),
-            self.context_config.uv_context.concurrency,
+            self.context_config.uv_context.concurrency.clone(),
             self.context_config.uv_context.preview,
         )
         // Important: this passes any CONDA activation to the uv build process

--- a/crates/pixi_manifest/src/pypi/pypi_options.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_options.rs
@@ -1,10 +1,11 @@
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use pep508_rs::PackageName;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
-use serde::{Serialize, Serializer, ser::SerializeSeq};
+use pixi_spec::ExcludeNewer;
+use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct};
 use thiserror::Error;
 use url::Url;
 
@@ -82,6 +83,82 @@ pub enum FindLinksUrlOrPath {
     Url(Url),
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum PypiIndexExcludeNewer {
+    /// Disable the workspace-level PyPI exclude-newer cutoff for this index.
+    Disabled,
+    /// Override the workspace-level PyPI exclude-newer cutoff for this index.
+    Enabled(ExcludeNewer),
+}
+
+impl fmt::Display for PypiIndexExcludeNewer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "false"),
+            Self::Enabled(exclude_newer) => exclude_newer.fmt(f),
+        }
+    }
+}
+
+impl Serialize for PypiIndexExcludeNewer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Disabled => serializer.serialize_bool(false),
+            Self::Enabled(exclude_newer) => exclude_newer.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PypiIndex {
+    pub url: Url,
+    pub exclude_newer: Option<PypiIndexExcludeNewer>,
+}
+
+impl PypiIndex {
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            exclude_newer: None,
+        }
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+}
+
+impl From<Url> for PypiIndex {
+    fn from(url: Url) -> Self {
+        Self::new(url)
+    }
+}
+
+impl fmt::Display for PypiIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.url.fmt(f)
+    }
+}
+
+impl Serialize for PypiIndex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let Some(exclude_newer) = self.exclude_newer else {
+            return self.url.serialize(serializer);
+        };
+
+        let mut state = serializer.serialize_struct("PypiIndex", 2)?;
+        state.serialize_field("url", &self.url)?;
+        state.serialize_field("exclude-newer", &exclude_newer)?;
+        state.end()
+    }
+}
+
 /// Don't build sdist for all or certain packages
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
@@ -154,9 +231,9 @@ impl NoBinary {
 #[serde(rename_all = "kebab-case")]
 pub struct PypiOptions {
     /// The index URL to use as the primary pypi index
-    pub index_url: Option<Url>,
+    pub index_url: Option<PypiIndex>,
     /// Any extra indexes to use, that will be searched after the primary index
-    pub extra_index_urls: Option<Vec<Url>>,
+    pub extra_index_urls: Option<Vec<PypiIndex>>,
     /// Flat indexes also called `--find-links` in pip
     /// These are flat listings of distributions
     pub find_links: Option<Vec<FindLinksUrlOrPath>>,
@@ -196,8 +273,9 @@ impl PypiOptions {
         skip_wheel_filename_check: Option<bool>,
     ) -> Self {
         Self {
-            index_url: index,
-            extra_index_urls: extra_indexes,
+            index_url: index.map(Into::into),
+            extra_index_urls: extra_indexes
+                .map(|extra_indexes| extra_indexes.into_iter().map(Into::into).collect()),
             find_links: flat_indexes,
             no_build_isolation,
             index_strategy,
@@ -224,10 +302,10 @@ impl PypiOptions {
                 FindLinksUrlOrPath::Url(url) => Some(url),
             });
 
-        let extra_indexes = self.extra_index_urls.iter().flatten();
+        let extra_indexes = self.extra_index_urls.iter().flatten().map(PypiIndex::url);
         find_links
             .chain(extra_indexes)
-            .chain(std::iter::once(self.index_url.as_ref()).flatten())
+            .chain(std::iter::once(self.index_url.as_ref().map(PypiIndex::url)).flatten())
     }
 
     /// Merges two `PypiOptions` together, according to the following rules
@@ -323,10 +401,17 @@ impl From<PypiOptions> for rattler_lock::PypiIndexes {
     fn from(value: PypiOptions) -> Self {
         let primary_index = value
             .index_url
+            .map(|index| index.url)
             .unwrap_or(pixi_consts::consts::DEFAULT_PYPI_INDEX_URL.clone());
         Self {
             indexes: std::iter::once(primary_index)
-                .chain(value.extra_index_urls.into_iter().flatten())
+                .chain(
+                    value
+                        .extra_index_urls
+                        .into_iter()
+                        .flatten()
+                        .map(|index| index.url),
+                )
                 .collect(),
             find_links: value
                 .find_links
@@ -493,8 +578,10 @@ mod tests {
     fn test_merge_pypi_options() {
         // Create the first set of options
         let opts = PypiOptions {
-            index_url: Some(Url::parse("https://example.com/pypi").unwrap()),
-            extra_index_urls: Some(vec![Url::parse("https://example.com/extra").unwrap()]),
+            index_url: Some(Url::parse("https://example.com/pypi").unwrap().into()),
+            extra_index_urls: Some(vec![
+                Url::parse("https://example.com/extra").unwrap().into(),
+            ]),
             find_links: Some(vec![
                 FindLinksUrlOrPath::Path("/path/to/flat/index".into()),
                 FindLinksUrlOrPath::Url(Url::parse("https://flat.index").unwrap()),
@@ -529,7 +616,9 @@ mod tests {
         // Create the second set of options
         let opts2 = PypiOptions {
             index_url: None,
-            extra_index_urls: Some(vec![Url::parse("https://example.com/extra2").unwrap()]),
+            extra_index_urls: Some(vec![
+                Url::parse("https://example.com/extra2").unwrap().into(),
+            ]),
             find_links: Some(vec![
                 FindLinksUrlOrPath::Path("/path/to/flat/index2".into()),
                 FindLinksUrlOrPath::Url(Url::parse("https://flat.index2").unwrap()),
@@ -645,7 +734,7 @@ mod tests {
     fn test_error_on_multiple_primary_indexes() {
         // Create the first set of options
         let opts = PypiOptions {
-            index_url: Some(Url::parse("https://example.com/pypi").unwrap()),
+            index_url: Some(Url::parse("https://example.com/pypi").unwrap().into()),
             extra_index_urls: None,
             find_links: None,
             no_build_isolation: NoBuildIsolation::default(),
@@ -659,7 +748,7 @@ mod tests {
 
         // Create the second set of options
         let opts2 = PypiOptions {
-            index_url: Some(Url::parse("https://example.com/pypi2").unwrap()),
+            index_url: Some(Url::parse("https://example.com/pypi2").unwrap().into()),
             extra_index_urls: None,
             find_links: None,
             no_build_isolation: NoBuildIsolation::default(),

--- a/crates/pixi_manifest/src/toml/pypi_options.rs
+++ b/crates/pixi_manifest/src/toml/pypi_options.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, str::FromStr};
 
 use indexmap::IndexSet;
-use pixi_toml::{TomlEnum, TomlFromStr, TomlIndexMap, TomlWith};
+use pixi_toml::{TomlEnum, TomlFromStr, TomlIndexMap};
 use toml_span::{
     DeserError, ErrorKind, Value,
     de_helpers::{TableHelper, expected},
@@ -10,7 +10,8 @@ use toml_span::{
 use url::Url;
 
 use crate::pypi::pypi_options::{
-    FindLinksUrlOrPath, NoBinary, NoBuild, NoBuildIsolation, PrereleaseMode, PypiOptions,
+    FindLinksUrlOrPath, NoBinary, NoBuild, NoBuildIsolation, PrereleaseMode, PypiIndex,
+    PypiIndexExcludeNewer, PypiOptions,
 };
 
 /// A helper struct to deserialize a [`pep508_rs::PackageName`] from a TOML
@@ -107,16 +108,49 @@ impl<'de> toml_span::Deserialize<'de> for NoBinary {
     }
 }
 
+impl<'de> toml_span::Deserialize<'de> for PypiIndexExcludeNewer {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        if value.as_bool().is_some() {
+            if bool::deserialize(value)? {
+                return Err(toml_span::Error {
+                    kind: ErrorKind::Custom("expected false to disable exclude-newer".into()),
+                    span: value.span,
+                    line_info: None,
+                }
+                .into());
+            }
+
+            return Ok(Self::Disabled);
+        }
+
+        TomlFromStr::deserialize(value)
+            .map(|exclude_newer| Self::Enabled(exclude_newer.into_inner()))
+    }
+}
+
+impl<'de> toml_span::Deserialize<'de> for PypiIndex {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        if value.as_str().is_some() {
+            return Ok(Self::new(
+                TomlFromStr::deserialize(value).map(TomlFromStr::into_inner)?,
+            ));
+        }
+
+        let mut th = TableHelper::new(value)?;
+        let url = th.required::<TomlFromStr<_>>("url")?.into_inner();
+        let exclude_newer = th.optional("exclude-newer");
+        th.finalize(None)?;
+
+        Ok(Self { url, exclude_newer })
+    }
+}
+
 impl<'de> toml_span::Deserialize<'de> for PypiOptions {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = TableHelper::new(value)?;
 
-        let index_url = th
-            .optional::<TomlFromStr<_>>("index-url")
-            .map(TomlFromStr::into_inner);
-        let extra_index_urls = th
-            .optional::<TomlWith<_, Vec<TomlFromStr<_>>>>("extra-index-urls")
-            .map(|x| x.into_inner());
+        let index_url = th.optional("index-url");
+        let extra_index_urls = th.optional::<Vec<PypiIndex>>("extra-index-urls");
         let find_links = th.optional("find-links");
         let no_build_isolation = th.optional("no-build-isolation").unwrap_or_default();
         let index_strategy = th
@@ -282,8 +316,10 @@ mod test {
         assert_eq!(
             deserialized_options,
             PypiOptions {
-                index_url: Some(Url::parse("https://example.com/pypi").unwrap()),
-                extra_index_urls: Some(vec![Url::parse("https://example.com/extra").unwrap()]),
+                index_url: Some(Url::parse("https://example.com/pypi").unwrap().into()),
+                extra_index_urls: Some(vec![
+                    Url::parse("https://example.com/extra").unwrap().into()
+                ]),
                 find_links: Some(vec![
                     FindLinksUrlOrPath::Path("/path/to/flat/index".into()),
                     FindLinksUrlOrPath::Url(Url::parse("https://flat.index").unwrap())
@@ -305,6 +341,37 @@ mod test {
                 no_binary: Default::default(),
                 skip_wheel_filename_check: None,
             },
+        );
+    }
+
+    #[test]
+    fn test_deserialize_pypi_index_exclude_newer() {
+        let toml_str = r#"
+        index-url = { url = "https://example.com/pypi", exclude-newer = "7d" }
+        extra-index-urls = [
+            { url = "https://example.com/internal", exclude-newer = false },
+            "https://example.com/extra",
+        ]
+        "#;
+
+        let deserialized_options: PypiOptions = PypiOptions::from_toml_str(toml_str).unwrap();
+
+        assert_eq!(
+            deserialized_options.index_url,
+            Some(PypiIndex {
+                url: Url::parse("https://example.com/pypi").unwrap(),
+                exclude_newer: Some(PypiIndexExcludeNewer::Enabled("7d".parse().unwrap())),
+            })
+        );
+        assert_eq!(
+            deserialized_options.extra_index_urls,
+            Some(vec![
+                PypiIndex {
+                    url: Url::parse("https://example.com/internal").unwrap(),
+                    exclude_newer: Some(PypiIndexExcludeNewer::Disabled),
+                },
+                Url::parse("https://example.com/extra").unwrap().into(),
+            ])
         );
     }
 

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -79,6 +79,14 @@ pub fn should_use_builtin_certs_uv(config: &Config) -> bool {
     matches!(config.tls_root_certs(), pixi_config::TlsRootCerts::All)
 }
 
+/// Returns whether uv should use the system certificate store.
+pub fn should_use_system_certs_uv(config: &Config) -> bool {
+    matches!(
+        config.tls_root_certs(),
+        pixi_config::TlsRootCerts::Native | pixi_config::TlsRootCerts::All
+    )
+}
+
 /// Returns the name of the TLS backend used by this build.
 ///
 /// This is determined at compile time based on the enabled features.

--- a/crates/pixi_uv_context/Cargo.toml
+++ b/crates/pixi_uv_context/Cargo.toml
@@ -16,6 +16,7 @@ pixi_utils = { workspace = true, default-features = false }
 pixi_uv_conversions = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 uv-cache = { workspace = true }
 uv-client = { workspace = true }
 uv-configuration = { workspace = true }

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -4,15 +4,13 @@ use std::time::Duration;
 use fs_err::create_dir_all;
 use miette::{Context, IntoDiagnostic};
 use pixi_config::{self, CacheKind, Config};
-use pixi_utils::reqwest::{
-    LazyReqwestClient, should_use_builtin_certs_uv, should_use_native_tls_for_uv, uv_middlewares,
-};
+use pixi_utils::reqwest::{LazyReqwestClient, should_use_system_certs_uv};
 use pixi_uv_conversions::{ConversionError, to_uv_trusted_host};
 use uv_cache::Cache;
 use uv_client::{
     BaseClientBuilder, Connectivity, ExtraMiddleware, RegistryClient, RegistryClientBuilder,
 };
-use uv_configuration::{Concurrency, IndexStrategy, SourceStrategy, TrustedHost};
+use uv_configuration::{Concurrency, IndexStrategy, NoSources, ProxyUrl, TrustedHost};
 use uv_dispatch::SharedState;
 use uv_distribution_types::{
     ExtraBuildRequires, ExtraBuildVariables, IndexCapabilities, IndexLocations,
@@ -31,17 +29,17 @@ pub struct UvResolutionContext {
     pub hash_strategy: HashStrategy,
     pub keyring_provider: uv_configuration::KeyringProviderType,
     pub concurrency: Concurrency,
-    pub source_strategy: SourceStrategy,
+    pub source_strategy: NoSources,
     pub capabilities: IndexCapabilities,
     pub allow_insecure_host: Vec<TrustedHost>,
     pub shared_state: SharedState,
     pub extra_middleware: ExtraMiddleware,
-    pub proxies: Vec<reqwest::Proxy>,
     pub tls_no_verify: bool,
-    /// Whether UV should use native TLS (system certificates).
-    /// This is computed based on the `tls-root-certs` config and the TLS feature used.
-    pub use_native_tls: bool,
-    pub use_builtin_certs: bool,
+    /// Whether uv should use the system certificate store.
+    pub use_system_certs: bool,
+    pub http_proxy: Option<ProxyUrl>,
+    pub https_proxy: Option<ProxyUrl>,
+    pub no_proxy: Option<Vec<String>>,
     pub package_config_settings: PackageConfigSettings,
     pub extra_build_requires: ExtraBuildRequires,
     pub extra_build_variables: ExtraBuildVariables,
@@ -144,15 +142,69 @@ fn build_concurrency(config: &Config) -> Concurrency {
     let builds = read_usize_env("UV_CONCURRENT_BUILDS").unwrap_or(defaults.builds);
     let installs = read_usize_env("UV_CONCURRENT_INSTALLS").unwrap_or(defaults.installs);
 
-    Concurrency {
-        downloads,
-        builds,
-        installs,
+    Concurrency::new(downloads, builds, installs)
+}
+
+fn proxy_from_env_enabled() -> bool {
+    [
+        "https_proxy",
+        "HTTPS_PROXY",
+        "http_proxy",
+        "all_proxy",
+        "ALL_PROXY",
+    ]
+    .iter()
+    .any(|key| std::env::var(key).is_ok_and(|value| !value.is_empty()))
+}
+
+fn parse_proxy_url(url: &url::Url) -> miette::Result<ProxyUrl> {
+    url.as_str()
+        .parse()
+        .into_diagnostic()
+        .with_context(|| format!("failed to parse proxy URL '{}'", url))
+}
+
+fn build_uv_proxy_config(
+    config: &Config,
+) -> miette::Result<(Option<ProxyUrl>, Option<ProxyUrl>, Option<Vec<String>>)> {
+    if (config.proxy_config.https.is_none() && config.proxy_config.http.is_none())
+        || proxy_from_env_enabled()
+    {
+        return Ok((None, None, None));
     }
+
+    let no_proxy = (!config.proxy_config.non_proxy_hosts.is_empty())
+        .then(|| config.proxy_config.non_proxy_hosts.clone());
+
+    if config.proxy_config.https == config.proxy_config.http {
+        let proxy = parse_proxy_url(
+            config
+                .proxy_config
+                .https
+                .as_ref()
+                .expect("matching proxies must contain a URL"),
+        )?;
+        return Ok((Some(proxy.clone()), Some(proxy), no_proxy));
+    }
+
+    let http_proxy = config
+        .proxy_config
+        .http
+        .as_ref()
+        .map(parse_proxy_url)
+        .transpose()?;
+    let https_proxy = config
+        .proxy_config
+        .https
+        .as_ref()
+        .map(parse_proxy_url)
+        .transpose()?;
+
+    Ok((http_proxy, https_proxy, no_proxy))
 }
 
 impl UvResolutionContext {
-    pub fn from_config(config: &Config, client: LazyReqwestClient) -> miette::Result<Self> {
+    pub fn from_config(config: &Config, _client: LazyReqwestClient) -> miette::Result<Self> {
         let uv_cache = config.cache_dir_for(CacheKind::PypiWheels)?;
         if !uv_cache.exists() {
             create_dir_all(&uv_cache)
@@ -190,6 +242,7 @@ impl UvResolutionContext {
         let http_timeout = read_http_timeout_from_env();
         let http_retries = read_http_retries_from_env();
         let concurrency = build_concurrency(config);
+        let (http_proxy, https_proxy, no_proxy) = build_uv_proxy_config(config)?;
 
         Ok(Self {
             cache,
@@ -197,15 +250,18 @@ impl UvResolutionContext {
             hash_strategy: HashStrategy::None,
             keyring_provider,
             concurrency,
-            source_strategy: SourceStrategy::Enabled,
+            source_strategy: NoSources::None,
             capabilities: IndexCapabilities::default(),
             allow_insecure_host,
             shared_state: SharedState::default(),
-            extra_middleware: ExtraMiddleware(uv_middlewares(config, client)),
-            proxies: config.get_proxies().into_diagnostic()?,
+            // Pixi's reqwest middleware stack currently targets reqwest 0.12,
+            // while uv 0.11 uses reqwest 0.13 internally.
+            extra_middleware: ExtraMiddleware(Vec::new()),
             tls_no_verify: config.tls_no_verify(),
-            use_native_tls: should_use_native_tls_for_uv(),
-            use_builtin_certs: should_use_builtin_certs_uv(config),
+            use_system_certs: should_use_system_certs_uv(config),
+            http_proxy,
+            https_proxy,
+            no_proxy,
             package_config_settings: PackageConfigSettings::default(),
             extra_build_requires: ExtraBuildRequires::default(),
             extra_build_variables: ExtraBuildVariables::default(),
@@ -243,17 +299,19 @@ impl UvResolutionContext {
         index_strategy: IndexStrategy,
         markers: Option<&MarkerEnvironment>,
         connectivity: Connectivity,
-    ) -> Arc<RegistryClient> {
+    ) -> miette::Result<Arc<RegistryClient>> {
         let mut base_client_builder = BaseClientBuilder::default()
             .allow_insecure_host(allow_insecure_hosts)
             .keyring(self.keyring_provider)
             .connectivity(connectivity)
-            .native_tls(self.use_native_tls)
-            .built_in_root_certs(self.use_builtin_certs)
+            .with_system_certs(self.use_system_certs)
+            .http_proxy(self.http_proxy.clone())
+            .https_proxy(self.https_proxy.clone())
+            .no_proxy(self.no_proxy.clone())
             .extra_middleware(self.extra_middleware.clone());
 
         if let Some(timeout) = self.http_timeout {
-            base_client_builder = base_client_builder.timeout(timeout);
+            base_client_builder = base_client_builder.read_timeout(timeout);
         }
 
         if let Some(retries) = self.http_retries {
@@ -264,16 +322,15 @@ impl UvResolutionContext {
             base_client_builder = base_client_builder.markers(markers);
         }
 
-        let mut uv_client_builder =
-            RegistryClientBuilder::new(base_client_builder, self.cache.clone())
-                .index_locations(index_locations.clone())
-                .index_strategy(index_strategy);
+        let uv_client_builder = RegistryClientBuilder::new(base_client_builder, self.cache.clone())
+            .index_locations(index_locations.clone())
+            .index_strategy(index_strategy);
 
-        for p in &self.proxies {
-            uv_client_builder = uv_client_builder.proxy(p.clone());
-        }
-
-        Arc::new(uv_client_builder.build())
+        uv_client_builder
+            .build()
+            .map(Arc::new)
+            .into_diagnostic()
+            .context("failed to build uv registry client")
     }
 }
 

--- a/crates/pixi_uv_conversions/Cargo.toml
+++ b/crates/pixi_uv_conversions/Cargo.toml
@@ -34,6 +34,7 @@ uv-git-types = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pep440 = { workspace = true }
 uv-pep508 = { workspace = true, features = ["non-pep508-extensions"] }
+uv-preview = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-redacted = { workspace = true }

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -1,4 +1,5 @@
 use std::{
+    ops::Deref,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -11,7 +12,7 @@ use pixi_manifest::pypi::{
     ResolvedPypiExcludeNewer,
     pypi_options::{
         FindLinksUrlOrPath, IndexStrategy, NoBinary, NoBuild, NoBuildIsolation, PrereleaseMode,
-        PypiOptions,
+        PypiIndex, PypiIndexExcludeNewer, PypiOptions,
     },
 };
 use pixi_record::{LockedGitUrl, PinnedGitCheckout, PinnedGitSpec};
@@ -24,6 +25,7 @@ use uv_normalize::{InvalidNameError, PackageName};
 use uv_pep508::{VerbatimUrl, VerbatimUrlError};
 use uv_python::PythonEnvironment;
 use uv_redacted::DisplaySafeUrl;
+use uv_resolver::{ExcludeNewerOverride, ExcludeNewerValue};
 
 use crate::{ConversionError, VersionError};
 
@@ -79,10 +81,7 @@ pub fn pypi_options_to_index_locations(
     let index = options
         .index_url
         .clone()
-        .map(DisplaySafeUrl::from)
-        .map(VerbatimUrl::from_url)
-        .map(IndexUrl::from)
-        .map(Index::from_index_url)
+        .map(|index| pypi_index_to_uv_index(index, Index::from_index_url))
         .into_iter();
 
     // Convert to list of extra indexes
@@ -92,10 +91,7 @@ pub fn pypi_options_to_index_locations(
         .into_iter()
         .flat_map(|urls| {
             urls.into_iter()
-                .map(DisplaySafeUrl::from)
-                .map(VerbatimUrl::from_url)
-                .map(IndexUrl::from)
-                .map(Index::from_extra_index_url)
+                .map(|index| pypi_index_to_uv_index(index, Index::from_extra_index_url))
         });
 
     let flat_indexes = if let Some(flat_indexes) = options.find_links.clone() {
@@ -122,6 +118,35 @@ pub fn pypi_options_to_index_locations(
     let no_index = indexes.is_empty() && !flat_indexes.is_empty();
 
     Ok(IndexLocations::new(indexes, flat_indexes, no_index))
+}
+
+fn pypi_index_to_uv_index(index: PypiIndex, build_index: impl FnOnce(IndexUrl) -> Index) -> Index {
+    let PypiIndex { url, exclude_newer } = index;
+    let mut index = build_index(IndexUrl::from(VerbatimUrl::from_url(DisplaySafeUrl::from(
+        url,
+    ))));
+
+    if let Some(exclude_newer) = exclude_newer {
+        enable_uv_index_exclude_newer_preview();
+        index.exclude_newer = Some(to_uv_exclude_newer_override(exclude_newer));
+    }
+
+    index
+}
+
+fn enable_uv_index_exclude_newer_preview() {
+    let _ = uv_preview::init(uv_preview::Preview::new(&[
+        uv_preview::PreviewFeature::IndexExcludeNewer,
+    ]));
+}
+
+fn to_uv_exclude_newer_override(exclude_newer: PypiIndexExcludeNewer) -> ExcludeNewerOverride {
+    match exclude_newer {
+        PypiIndexExcludeNewer::Disabled => ExcludeNewerOverride::Disabled,
+        PypiIndexExcludeNewer::Enabled(exclude_newer) => {
+            ExcludeNewerOverride::Enabled(Box::new(to_exclude_newer_value(exclude_newer.cutoff())))
+        }
+    }
 }
 
 /// Convert locked indexes to IndexLocations
@@ -334,7 +359,7 @@ pub fn into_pinned_git_spec(
         reference,
     );
 
-    PinnedGitSpec::new(dist.git.repository().clone().into(), pinned_checkout)
+    PinnedGitSpec::new(dist.git.repository().deref().clone(), pinned_checkout)
 }
 
 /// Convert a locked git url into a parsed git url
@@ -365,6 +390,7 @@ pub fn to_parsed_git_url(
             },
             into_uv_git_reference(git_source.reference.into()),
             Some(into_uv_git_sha(git_source.commit)),
+            uv_git_types::GitLfs::default(),
         )
         .into_diagnostic()?,
         if git_source.subdirectory.is_empty() {
@@ -668,19 +694,20 @@ pub fn configure_insecure_hosts_for_tls_bypass(
     allow_insecure_hosts
 }
 
-fn to_exclude_newer_timestamp(
-    exclude_newer: chrono::DateTime<chrono::Utc>,
-) -> uv_resolver::ExcludeNewerTimestamp {
+fn to_exclude_newer_timestamp(exclude_newer: chrono::DateTime<chrono::Utc>) -> jiff::Timestamp {
     let seconds_since_epoch = exclude_newer.timestamp();
     let nanoseconds = exclude_newer.timestamp_subsec_nanos();
-    let timestamp = jiff::Timestamp::new(seconds_since_epoch, nanoseconds as _).unwrap_or(
+    jiff::Timestamp::new(seconds_since_epoch, nanoseconds as _).unwrap_or(
         if seconds_since_epoch < 0 {
             jiff::Timestamp::MIN
         } else {
             jiff::Timestamp::MAX
         },
-    );
-    timestamp.into()
+    )
+}
+
+fn to_exclude_newer_value(exclude_newer: chrono::DateTime<chrono::Utc>) -> ExcludeNewerValue {
+    ExcludeNewerValue::new(to_exclude_newer_timestamp(exclude_newer), None)
 }
 
 /// Converts a resolved PyPI exclude-newer configuration to `uv_resolver::ExcludeNewer`.
@@ -692,14 +719,14 @@ pub fn to_exclude_newer(exclude_newer: &ResolvedPypiExcludeNewer) -> uv_resolver
             (
                 PackageName::from_str(package.as_ref())
                     .expect("pep508 package name should be valid uv package name"),
-                to_exclude_newer_timestamp(*cutoff),
+                to_exclude_newer_value(*cutoff),
             )
         })
         .map(uv_resolver::ExcludeNewerPackageEntry::from)
         .collect();
 
     uv_resolver::ExcludeNewer::new(
-        exclude_newer.cutoff.map(to_exclude_newer_timestamp),
+        exclude_newer.cutoff.map(to_exclude_newer_value),
         package_cutoffs,
     )
 }

--- a/crates/pixi_uv_conversions/src/git_url.rs
+++ b/crates/pixi_uv_conversions/src/git_url.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use url::Url;
 use uv_pep508::VerbatimUrl;
-use uv_redacted::DisplaySafeUrl;
+use uv_redacted::{DisplaySafeUrl, DisplaySafeUrlError};
 
 /// A URL that may have a git+ prefix, with methods to handle both representations
 #[derive(Debug, Clone, PartialEq)]
@@ -70,7 +70,7 @@ impl GitUrlWithPrefix {
     }
 
     /// Convert to VerbatimUrl (preserving git+ prefix)
-    pub fn to_verbatim_url(&self) -> Result<VerbatimUrl, url::ParseError> {
+    pub fn to_verbatim_url(&self) -> Result<VerbatimUrl, DisplaySafeUrlError> {
         let display_safe_url = DisplaySafeUrl::parse(&self.with_git_prefix())?;
         Ok(VerbatimUrl::from_url(display_safe_url))
     }

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -132,6 +132,7 @@ pub fn as_uv_req(
                         .and_then(|s| s.map(uv_git_types::GitOid::from_str))
                         .transpose()
                         .expect("could not parse sha"),
+                    uv_git_types::GitLfs::default(),
                 )?,
                 subdirectory: if subdirectory.is_empty() {
                     None

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -261,8 +261,11 @@ fn create_tags(
         implementation_name,
         // TODO: This might not be entirely correct..
         python_version,
-        true,
-        gil_disabled,
+        uv_platform_tags::TagsOptions {
+            manylinux_compatible: true,
+            gil_disabled,
+            ..uv_platform_tags::TagsOptions::default()
+        },
     )
     .map_err(PyPITagError::FailedToDetermineWheelTags)
 }

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -312,6 +312,9 @@ For conda packages, the workspace-level cutoff can be overridden per package in 
 For PyPI packages, the workspace-level cutoff can be overridden per package in the
 [`[pypi-exclude-newer]`](#exclude-newer-optional) table.
 
+For PyPI indexes, the workspace-level cutoff can be overridden per index in
+[`[pypi-options]`](#the-pypi-options-table).
+
 This is especially useful when a package is pinned to a separate `channel` or `index` and needs a
 different cutoff than the rest of the workspace.
 
@@ -530,9 +533,18 @@ An example:
 ```toml
 [pypi-options]
 index-url = "https://pypi.org/simple"
-extra-index-urls = ["https://example.com/simple"]
+extra-index-urls = [
+  { url = "https://internal.example/simple", exclude-newer = "0d" },
+  "https://example.com/simple",
+]
 find-links = [{path = './links'}]
 ```
+
+`index-url` and entries in `extra-index-urls` can be either a URL string or a table with:
+
+- `url`: the PyPI index URL.
+- `exclude-newer`: an index-specific cutoff. Use a timestamp, date, relative duration, or `false`
+  to disable the workspace cutoff for packages resolved from that index.
 
 There are some [examples](https://github.com/prefix-dev/pixi/tree/main/examples/pypi-custom-registry) in the Pixi repository, that make use of this feature.
 

--- a/docs/switching_from/uv.md
+++ b/docs/switching_from/uv.md
@@ -352,6 +352,32 @@ And a PyPI package uses the same pattern, but with PyPI-specific tables:
     tqdm = "2025-02-01"
     ```
 
+Pixi can also override `exclude-newer` for a whole PyPI index:
+
+=== "pixi.toml"
+
+    ```toml
+    [workspace]
+    exclude-newer = "7d"
+
+    [pypi-options]
+    extra-index-urls = [
+      { url = "https://internal.example/simple", exclude-newer = "0d" },
+    ]
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.pixi.workspace]
+    exclude-newer = "7d"
+
+    [tool.pixi.pypi-options]
+    extra-index-urls = [
+      { url = "https://internal.example/simple", exclude-newer = "0d" },
+    ]
+    ```
+
 Unlike uv, Pixi can also override `exclude-newer` on a per-channel level:
 
 === "pixi.toml"

--- a/schema/model.py
+++ b/schema/model.py
@@ -716,18 +716,38 @@ class S3Options(StrictBaseModel):
     )
 
 
+class PyPIIndex(StrictBaseModel):
+    """A PyPI index URL with optional index-specific settings"""
+
+    url: NonEmptyStr = Field(
+        description="PyPI registry URL for this index",
+        examples=["https://pypi.org/simple"],
+    )
+    exclude_newer: ExcludeNewer | Literal[False] | None = Field(
+        None,
+        description="Override the workspace-level `exclude-newer` cutoff for this PyPI index, or set to false to disable it for this index",
+        examples=["0d", "2025-01-01", False],
+    )
+
+
 class PyPIOptions(StrictBaseModel):
     """Options that determine the behavior of PyPI package resolution and installation"""
 
-    index_url: NonEmptyStr | None = Field(
+    index_url: NonEmptyStr | PyPIIndex | None = Field(
         None,
         description="PyPI registry that should be used as the primary index",
-        examples=["https://pypi.org/simple"],
+        examples=[
+            "https://pypi.org/simple",
+            {"url": "https://pypi.org/simple", "exclude-newer": "0d"},
+        ],
     )
-    extra_index_urls: list[NonEmptyStr] | None = Field(
+    extra_index_urls: list[NonEmptyStr | PyPIIndex] | None = Field(
         None,
         description="Additional PyPI registries that should be used as extra indexes",
-        examples=[["https://pypi.org/simple"]],
+        examples=[
+            ["https://pypi.org/simple"],
+            [{"url": "https://internal.example/simple", "exclude-newer": False}],
+        ],
     )
     find_links: list[FindLinksPath | FindLinksURL] | None = Field(
         None,

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -1597,6 +1597,45 @@
         }
       }
     },
+    "PyPIIndex": {
+      "title": "PyPIIndex",
+      "description": "A PyPI index URL with optional index-specific settings",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exclude-newer": {
+          "title": "Exclude-Newer",
+          "description": "Override the workspace-level `exclude-newer` cutoff for this PyPI index, or set to false to disable it for this index",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})|\\d{4}-\\d{2}-\\d{2}|(\\d+\\s*[A-Za-z]+\\s*)+)$"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ],
+          "examples": [
+            "0d",
+            "2025-01-01",
+            false
+          ]
+        },
+        "url": {
+          "title": "Url",
+          "description": "PyPI registry URL for this index",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "https://pypi.org/simple"
+          ]
+        }
+      }
+    },
     "PyPIOptions": {
       "title": "PyPIOptions",
       "description": "Options that determine the behavior of PyPI package resolution and installation",
@@ -1647,12 +1686,25 @@
           "description": "Additional PyPI registries that should be used as extra indexes",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIIndex"
+              }
+            ]
           },
           "examples": [
             [
               "https://pypi.org/simple"
+            ],
+            [
+              {
+                "exclude-newer": false,
+                "url": "https://internal.example/simple"
+              }
             ]
           ]
         },
@@ -1702,10 +1754,21 @@
         "index-url": {
           "title": "Index-Url",
           "description": "PyPI registry that should be used as the primary index",
-          "type": "string",
-          "minLength": 1,
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/PyPIIndex"
+            }
+          ],
           "examples": [
-            "https://pypi.org/simple"
+            "https://pypi.org/simple",
+            {
+              "exclude-newer": "0d",
+              "url": "https://pypi.org/simple"
+            }
           ]
         },
         "no-binary": {

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1340,6 +1340,45 @@
         }
       }
     },
+    "PyPIIndex": {
+      "title": "PyPIIndex",
+      "description": "A PyPI index URL with optional index-specific settings",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exclude-newer": {
+          "title": "Exclude-Newer",
+          "description": "Override the workspace-level `exclude-newer` cutoff for this PyPI index, or set to false to disable it for this index",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})|\\d{4}-\\d{2}-\\d{2}|(\\d+\\s*[A-Za-z]+\\s*)+)$"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ],
+          "examples": [
+            "0d",
+            "2025-01-01",
+            false
+          ]
+        },
+        "url": {
+          "title": "Url",
+          "description": "PyPI registry URL for this index",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "https://pypi.org/simple"
+          ]
+        }
+      }
+    },
     "PyPIOptions": {
       "title": "PyPIOptions",
       "description": "Options that determine the behavior of PyPI package resolution and installation",
@@ -1390,12 +1429,25 @@
           "description": "Additional PyPI registries that should be used as extra indexes",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIIndex"
+              }
+            ]
           },
           "examples": [
             [
               "https://pypi.org/simple"
+            ],
+            [
+              {
+                "exclude-newer": false,
+                "url": "https://internal.example/simple"
+              }
             ]
           ]
         },
@@ -1445,10 +1497,21 @@
         "index-url": {
           "title": "Index-Url",
           "description": "PyPI registry that should be used as the primary index",
-          "type": "string",
-          "minLength": 1,
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/PyPIIndex"
+            }
+          ],
           "examples": [
-            "https://pypi.org/simple"
+            "https://pypi.org/simple",
+            {
+              "exclude-newer": "0d",
+              "url": "https://pypi.org/simple"
+            }
           ]
         },
         "no-binary": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1621,6 +1621,45 @@
         }
       }
     },
+    "PyPIIndex": {
+      "title": "PyPIIndex",
+      "description": "A PyPI index URL with optional index-specific settings",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exclude-newer": {
+          "title": "Exclude-Newer",
+          "description": "Override the workspace-level `exclude-newer` cutoff for this PyPI index, or set to false to disable it for this index",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})|\\d{4}-\\d{2}-\\d{2}|(\\d+\\s*[A-Za-z]+\\s*)+)$"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ],
+          "examples": [
+            "0d",
+            "2025-01-01",
+            false
+          ]
+        },
+        "url": {
+          "title": "Url",
+          "description": "PyPI registry URL for this index",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "https://pypi.org/simple"
+          ]
+        }
+      }
+    },
     "PyPIOptions": {
       "title": "PyPIOptions",
       "description": "Options that determine the behavior of PyPI package resolution and installation",
@@ -1671,12 +1710,25 @@
           "description": "Additional PyPI registries that should be used as extra indexes",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIIndex"
+              }
+            ]
           },
           "examples": [
             [
               "https://pypi.org/simple"
+            ],
+            [
+              {
+                "exclude-newer": false,
+                "url": "https://internal.example/simple"
+              }
             ]
           ]
         },
@@ -1726,10 +1778,21 @@
         "index-url": {
           "title": "Index-Url",
           "description": "PyPI registry that should be used as the primary index",
-          "type": "string",
-          "minLength": 1,
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/PyPIIndex"
+            }
+          ],
           "examples": [
-            "https://pypi.org/simple"
+            "https://pypi.org/simple",
+            {
+              "exclude-newer": "0d",
+              "url": "https://pypi.org/simple"
+            }
           ]
         },
         "no-binary": {


### PR DESCRIPTION
## Summary
- upgrade uv dependencies to 0.11.5, the first uv tag with per-index `exclude-newer` support
- allow `[pypi-options] index-url` and `extra-index-urls` entries to be either URL strings or `{ url, exclude-newer }` tables
- pass index-specific cutoffs through to uv, update docs/schema, and add an integration test covering a PyPI extra index override

Closes #5775

## Notes
- uv 0.11 moved its registry client internals to reqwest 0.13. Pixi proxy config is mapped to uv's proxy API, but Pixi's existing reqwest 0.12 middleware stack cannot be attached directly to uv's client.

## Tests
- `cargo check -p pixi --features pixi_utils/rustls-tls`
- `cargo test -p pixi_manifest -p pixi_utils -p pixi_spec --features pixi_utils/rustls-tls,pixi_spec/rattler_lock test_deserialize_pypi_index_exclude_newer`
- `cargo test -p pixi --test integration_rust test_exclude_newer_pypi_index_override --features pixi_utils/rustls-tls`
- `pixi run -e schema test-schema`
- `pixi run ruff check schema/model.py`
- `git diff --check`