### PR TITLE
chore: bump backend versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "fs-err",

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-python"
-version = "0.4.9"
+version = "0.5.0"
 
 [package.metadata.dist]
 dist = false


### PR DESCRIPTION
### Description
bump the `pixi-build-python` backend with a minor release as we change the use of `pip` by default to `uv` which breaks lockfiles
