### PR TITLE
fix: include `precise` in CheckoutGit dedup key

### DIFF
--- a/crates/pixi_command_dispatcher/tests/integration/snapshots/integration__simple_test.snap
+++ b/crates/pixi_command_dispatcher/tests/integration/snapshots/integration__simple_test.snap
@@ -6,12 +6,13 @@ Pixi solve (test@[PLATFORM])
 ├── Git Checkout (file://[LOCAL_GIT_REPO]#[GIT_HASH])
 ├── Source metadata (foobar-desktop @ git+file://[LOCAL_GIT_REPO]?subdirectory=recipe&rev=[GIT_REF]#[GIT_HASH])
 │   ├── Build backend metadata (git+file://[LOCAL_GIT_REPO]?subdirectory=recipe&rev=[GIT_REF]#[GIT_HASH])
+│   │   ├── Git Checkout (file://[LOCAL_GIT_REPO]#[GIT_HASH])
 │   │   └── Instantiate backend (pixi-build-rattler-build)
-│   │       └── Conda solve #5
+│   │       └── Conda solve #6
 │   └── Source record (foobar-desktop @ git+file://[LOCAL_GIT_REPO]?subdirectory=recipe&rev=[GIT_REF]#[GIT_HASH])
 ├── Source metadata (foobar @ git+file://[LOCAL_GIT_REPO]?subdirectory=recipe&rev=[GIT_REF]#[GIT_HASH])
 │   └── Source record (foobar @ git+file://[LOCAL_GIT_REPO]?subdirectory=recipe&rev=[GIT_REF]#[GIT_HASH])
-└── Conda solve #9
+└── Conda solve #10
 Pixi install (test-env)
 ├── Backend source build (foobar-desktop)
 └── Backend source build (foobar)

--- a/crates/pixi_compute_sources/src/git.rs
+++ b/crates/pixi_compute_sources/src/git.rs
@@ -95,16 +95,19 @@ impl LifecycleKind for GitReporterLifecycle {
     }
 }
 
-/// Dedup key for a git checkout. Keyed on [`RepositoryReference`]
-/// (normalized URL + reference, no `precise`) so callers that differ
-/// only in whether they pre-resolved the commit still dedup.
+/// Dedup key for a git checkout. Keyed on the full [`GitUrl`]: URL,
+/// reference, AND `precise` commit, so a caller asking for a specific
+/// commit doesn't collide with one asking only for the branch.
+/// Stripping `precise` from the key let `checkout_pinned_source(A)`
+/// silently return the branch's HEAD instead of commit `A`
+/// (prefix-dev/pixi#6073).
 #[derive(Clone, Debug, Display, Hash, PartialEq, Eq)]
-#[display("{}@{}", _0.url.as_url(), _0.reference)]
-pub struct CheckoutGit(RepositoryReference);
+#[display("{}@{}", _0.repository(), _0.reference())]
+pub struct CheckoutGit(GitUrl);
 
 impl CheckoutGit {
     pub fn new(git_url: &GitUrl) -> Self {
-        Self(RepositoryReference::from(git_url))
+        Self(git_url.clone())
     }
 }
 
@@ -119,8 +122,9 @@ impl Key for CheckoutGit {
         let semaphore = data.git_checkout_semaphore().cloned();
         let reporter = data.git_checkout_reporter().cloned();
 
+        let reporter_env = RepositoryReference::from(&self.0);
         let lifecycle =
-            ReporterLifecycle::<GitReporterLifecycle>::queued(reporter.as_deref(), &self.0);
+            ReporterLifecycle::<GitReporterLifecycle>::queued(reporter.as_deref(), &reporter_env);
 
         let _permit = match semaphore.as_ref() {
             Some(s) => Some(
@@ -132,14 +136,12 @@ impl Key for CheckoutGit {
         };
         let _lifecycle = lifecycle.start();
 
-        // `from_reference` auto-fills `precise` from a full-commit
-        // reference, so the resolver skips ref-resolution when it can.
-        let git_url =
-            GitUrl::from_reference(self.0.url.clone().into_url(), self.0.reference.clone());
-
+        // Pass the original `GitUrl` straight through so the resolver
+        // honours `precise` when set (pinned checkout) and advances to
+        // the branch HEAD when not (fresh resolve).
         Arc::new(
             resolver
-                .fetch(git_url, client, cache_dir.into_std_path_buf(), None)
+                .fetch(self.0.clone(), client, cache_dir.into_std_path_buf(), None)
                 .await,
         )
     }


### PR DESCRIPTION
### Description

The `CheckoutGit` dedup key dropped `precise` and `compute` rebuilt the `GitUrl` from the reference alone, so `resolver.fetch` always re-resolved to the branch HEAD. Two callers with different pinned commits on the same branch collided on one cache slot, and `checkout_pinned_source(commit_A)` could return a `SourceCheckout` whose `path` pointed at commit B's checkout while `pinned` reported commit A.

Effect on #6073: the build backend read the latest source manifest (with the new `setuptools = "<82.0.0"`) while the lock-file still carried commit A's solved `host_packages` (`setuptools 82.0.1`), producing the silent `setuptools <82.0.0 | 82.0.1` mismatch in the build env.

Fix: key `CheckoutGit` on the full `GitUrl` and pass it through unchanged so the resolver honours `precise` when set.

Fixes #6073

### How Has This Been Tested?

Reproducer matching the issue (caiman-like path dep depending on fastplotlib-like git dep):

1. `pixi install` against fastplotlib-like @ commit A (no constraint), which locks commit A and resolves `setuptools 82.0.1` in the host env. Consistent.
2. Push commit B tightening `setuptools = "<82.0.0"`; `pixi install` (no `update`), and the lock-file stays on commit A, no rebuild, no mismatch table. Before this fix, step 2 produced `setuptools <82.0.0 | 82.0.1`.
3. `pixi update fastplotlib-like` + `pixi install`, the lock-file advances to commit B and the host env resolves `setuptools 81.0.0`. Constraint honoured.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas