### PR TITLE
fix: don't misclassify missing python as pypi-only during upgrade

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -440,14 +440,7 @@ pub(super) async fn lock_pypi_packages(
 
                 read_local_package_metadata(&absolute_path, pkg.name(), &build_ctx)
                     .await
-                    .map_err(|e| {
-                        CommandDispatcherError::Failed(Box::new(
-                            PlatformUnsat::FailedToReadLocalMetadata(
-                                pkg.name().clone(),
-                                format!("failed to read metadata: {e}"),
-                            ),
-                        ))
-                    })?
+                    .map_err(|e| CommandDispatcherError::Failed(Box::new(e)))?
             } else {
                 None
             }
@@ -508,18 +501,15 @@ async fn read_local_package_metadata(
 
     let pypi_options = ctx.environment.pypi_options();
 
-    // Find the Python interpreter from locked records
+    // Missing python is a conda-side gap (e.g. `unlock_packages` stripped
+    // it pre-resolve); raise the non-pypi-only variant so the env is
+    // marked `outdated_conda`. #6093.
     let python_record = ctx
         .locked_pixi_records
         .records
         .iter()
         .find(|r| is_python_record(r))
-        .ok_or_else(|| {
-            PlatformUnsat::FailedToReadLocalMetadata(
-                package_name.clone(),
-                "No Python interpreter found in locked packages".to_string(),
-            )
-        })?;
+        .ok_or(PlatformUnsat::MissingPythonInterpreter)?;
 
     // Create marker environment for the target platform
     let marker_environment = determine_marker_environment(ctx.platform, python_record.as_ref())


### PR DESCRIPTION
### Description

`pixi upgrade` on a workspace with a local editable PyPI dep (e.g. `pkg = { path = ".", editable = true }`) failed on the second run with `No Python interpreter found in the dependencies`.

Root cause: `update_dependencies` unlocks `python` from the conda lock before re-solving. Satisfiability then calls `read_local_package_metadata` for the path source, which looks up python in `locked_pixi_records` first and on miss returned `FailedToReadLocalMetadata`. `FailedToReadLocalMetadata` marked the satisfiability as "`is_pypi_only`" variant. Because the conda dep walk runs *after* the pypi metadata read inside the `try_join!` in `verify_package_platform_satisfiability`, that pypi-only error short-circuited the join, the env was marked only `outdated_pypi`, conda was never re-solved, and the subsequent pypi resolve aborted on the missing python record.

Fix: return the existing non-pypi-only `PlatformUnsat::MissingPythonInterpreter` in that branch, and stop re-wrapping `read_local_package_metadata` errors at the call site (the wrap was discarding variant info). The conda walk now correctly schedules a re-solve, python lands back in the records, and the pypi resolve proceeds normally.

Fixes #6093

### How Has This Been Tested?

`cargo check -p pixi_core` passes. 

Manual repro from the issue:

```toml
[workspace]
channels = ["conda-forge"]
name = "hello_world"
platforms = ["linux-64"]

[dependencies]
python = ">=3.14.4,<3.15"

[pypi-dependencies]
hello_world = { path = ".", editable = true }
```

Run `pixi upgrade` twice, before this change, the second run errors, after it succeeds.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Opus 4.7)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient tests to cover my changes.