### PR TITLE
fix: reuse locked git commit for source deps without rev

### DIFF
--- a/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
@@ -313,6 +313,11 @@ impl CommandDispatcher {
         &self.data.package_cache
     }
 
+    /// Returns the git resolver used by the command dispatcher.
+    pub fn git_resolver(&self) -> &GitResolver {
+        &self.data.git_resolver
+    }
+
     /// Returns the platform and virtual packages used for tool environments.
     pub fn tool_platform(&self) -> (Platform, &[GenericVirtualPackage]) {
         (self.data.tool_platform.0, &self.data.tool_platform.1)

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -279,6 +279,13 @@ impl Workspace {
         }
         let command_dispatcher = builder.finish();
 
+        // Seed the dispatcher's git resolver with every locked git source.
+        // Without this, a dep like `git = "https://…"` (no `rev`) resolves
+        // its `DefaultBranch` reference against the remote on every command
+        // because the locked SHA never reaches the git checkout layer's
+        // fast-path. See https://github.com/prefix-dev/pixi/issues/6091.
+        seed_git_resolver_from_lock_file(&lock_file, command_dispatcher.git_resolver());
+
         // Get the package cache from the dispatcher.
         let package_cache = command_dispatcher.package_cache().clone();
 
@@ -3128,6 +3135,52 @@ fn is_editable_from_manifest(
         .unwrap_or(false)
 }
 
+/// Populates `resolver` with one entry per locked git source in `lock_file`,
+/// mapping `(repository_url, requested_reference)` to its resolved commit SHA.
+///
+/// The `GitResolver` already deduplicates fetches within a process: a hit on
+/// its precise-commit map short-circuits a remote fetch in
+/// [`pixi_git::source::GitSource::fetch`]. Without this seed step, a git dep
+/// declared as `{ git = "..." }` (no `rev`) maps to
+/// `GitReference::DefaultBranch`, the resolver has no precise commit on a
+/// fresh process, and every `pixi run` re-resolves `HEAD` from the remote —
+/// even though the lock file already records the commit. Seeding from the
+/// lock file at the start of the update flow lets the fast-path engage.
+fn seed_git_resolver_from_lock_file(
+    lock_file: &LockFile,
+    resolver: &pixi_git::resolver::GitResolver,
+) {
+    use pixi_git::{resolver::RepositoryReference, url::RepositoryUrl};
+    use pixi_record::LockedGitUrl;
+    use rattler_lock::UrlOrPath;
+
+    for package in lock_file.packages() {
+        let Some(source) = package.as_source_conda() else {
+            continue;
+        };
+        let UrlOrPath::Url(url) = &source.location else {
+            continue;
+        };
+        if !LockedGitUrl::is_locked_git_url(url) {
+            continue;
+        }
+        let pinned = match LockedGitUrl::new(url.clone()).to_pinned_git_spec() {
+            Ok(pinned) => pinned,
+            Err(err) => {
+                tracing::debug!(
+                    "skipping git resolver seed for malformed locked url {url}: {err:?}"
+                );
+                continue;
+            }
+        };
+        let repo_ref = RepositoryReference {
+            url: RepositoryUrl::new(&pinned.git),
+            reference: pinned.source.reference.into(),
+        };
+        resolver.insert(repo_ref, pinned.source.commit);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3204,5 +3257,94 @@ mod tests {
             !is_editable_from_manifest(&deps, &pep508_name),
             "Higher-priority feature's explicit editable=false should take precedence"
         );
+    }
+
+    /// `seed_git_resolver_from_lock_file` must populate the resolver with one
+    /// entry per locked git source, including a default-branch source whose
+    /// requested ref does not carry the SHA. Without this seed the
+    /// `pin_and_checkout` path for such a dep cannot reach the fetch
+    /// fast-path and re-resolves HEAD on every run.
+    #[test]
+    fn test_seed_git_resolver_seeds_default_branch_source() {
+        use pixi_git::{
+            GitUrl, git::GitReference as PixiGitReference, resolver::GitResolver, sha::GitSha,
+        };
+        use pixi_record::{PinnedGitCheckout, PinnedGitSpec};
+        use pixi_spec::{GitReference as SpecGitReference, Subdirectory};
+        use rattler_conda_types::{PackageName, PackageRecord, Version};
+        use rattler_lock::{
+            CondaPackageData, CondaSourceData, PlatformData, PlatformName, SourceMetadata,
+            UrlOrPath,
+        };
+        use std::collections::BTreeMap;
+        use url::Url;
+
+        let repo_url = Url::parse("https://example.com/owner/repo").unwrap();
+        let sha_str = "1234567890abcdef1234567890abcdef12345678";
+        let sha = GitSha::from_str(sha_str).unwrap();
+
+        let pinned = PinnedGitSpec {
+            git: repo_url.clone(),
+            source: PinnedGitCheckout {
+                commit: sha,
+                subdirectory: Subdirectory::default(),
+                reference: SpecGitReference::DefaultBranch,
+            },
+        };
+        let locked_url: Url = pinned.into_locked_git_url().into();
+
+        let record = PackageRecord::new(
+            PackageName::new_unchecked("my-pkg"),
+            Version::from_str("0.1.0").unwrap(),
+            "py_0".into(),
+        );
+
+        let source = CondaSourceData {
+            location: UrlOrPath::Url(locked_url),
+            package_build_source: None,
+            variants: BTreeMap::new(),
+            identifier_hash: None,
+            sources: BTreeMap::new(),
+            source_data: rattler_lock::SourceData::default(),
+            metadata: SourceMetadata::Full(Box::new(record)),
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![PlatformData {
+                name: PlatformName::try_from("linux-64").unwrap(),
+                subdir: Platform::Linux64,
+                virtual_packages: Vec::new(),
+            }])
+            .unwrap()
+            .with_conda_package(
+                "default",
+                "linux-64",
+                CondaPackageData::Source(Box::new(source)),
+            )
+            .unwrap()
+            .finish();
+
+        let resolver = GitResolver::default();
+        seed_git_resolver_from_lock_file(&lock_file, &resolver);
+
+        // An unpinned spec built like `pin_and_checkout_git` does (no `rev`)
+        // should now resolve to the locked SHA via the resolver cache.
+        let unpinned = GitUrl::from_reference(repo_url.clone(), PixiGitReference::DefaultBranch);
+        let precise = resolver
+            .precise(unpinned)
+            .expect("resolver should now know the precise commit for the default branch");
+        assert_eq!(
+            precise.precise().map(|s| s.to_string()),
+            Some(sha_str.to_string()),
+        );
+
+        // Sanity: an empty lockfile produces no entries.
+        let resolver = GitResolver::default();
+        seed_git_resolver_from_lock_file(&LockFile::default(), &resolver);
+        let unrelated = GitUrl::from_reference(
+            Url::parse("https://example.com/other/repo").unwrap(),
+            PixiGitReference::DefaultBranch,
+        );
+        assert!(resolver.precise(unrelated).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes #6091.

A conda source dep declared as `{ git = "https://..." }` (no `rev`) re-fetched the remote's default branch on every command. The fix is a 5-line helper that seeds the dispatcher's `GitResolver` with the locked commits, so the existing no-fetch fast path engages.

## Why this was happening

The "skip fetch" fast path in `pixi_git::source::GitSource::fetch` only fires when `GitUrl.precise` is `Some(sha)`:

```rust
match (self.git.precise, remote.db_at(&db_path).ok()) {
    (Some(rev), Some(db)) if db.contains(rev.into()) => /* no fetch */,
    _ => /* fetch */,
}
```

- With `rev = "<40-char sha>"`: parsed into `GitReference::FullCommit`; `GitUrl::from_reference` auto-fills `precise` via `reference.as_sha()`. Fast path hits.
- Without `rev`: parsed into `GitReference::DefaultBranch`; `as_sha()` returns `None`; `precise` stays unset. Fast path skipped — even though the lock file *does* store the resolved sha.

`GitResolver` already keeps an in-process `(url, ref) → sha` cache that `fetch()` consults before going to the network. It just wasn't seeded from the lock file.

## What this change does

`seed_git_resolver_from_lock_file` walks every conda source package in the lock file, parses any `git+...#<sha>` URL via `LockedGitUrl::to_pinned_git_spec`, and inserts `(repository_url, requested_reference) → sha` into the dispatcher's `GitResolver`. It's called once, right after the dispatcher is built in `Workspace::update_lock_file`.

After seeding, `pin_and_checkout` for `{ git = "url" }` (no `rev`):

1. builds `GitUrl::from_reference(url, DefaultBranch)` — precise unset
2. `GitResolver::fetch` looks up `RepositoryReference { url, DefaultBranch }`, finds the seeded sha, calls `url.with_precise(sha)`
3. `GitSource::fetch` sees `precise = Some(sha)`, finds the commit in the local db, returns without touching the network

## Scope / safety

`pixi update` and `pixi add` build their own dispatcher off an *unlocked* lock file (`unlock_packages` / `UpdateContext::builder`), so seeding does not pin stale refs there — those flows continue to re-resolve mutable refs as expected. The seed only affects `update_lock_file`, which is the entry point for `pixi run`, `pixi install`, `pixi shell`, etc.

If the user changes a manifest spec (e.g. adds a `branch = "..."` or changes the URL), `PinnedGitCheckout::matches_source_spec` correctly returns false and a re-lock fires; the seeded entry for the old `(url, ref)` pair is harmless because the new pair isn't in the map.

## Test plan

- [x] Added `test_seed_git_resolver_seeds_default_branch_source` covering the default-branch case end-to-end (build a lock file with a git source pin, seed an empty `GitResolver`, assert `resolver.precise(...)` returns the locked sha).
- [x] `cargo check --workspace --tests`
- [x] `cargo clippy -p pixi_core -p pixi_command_dispatcher --tests --lib`
- [ ] Manual: in a workspace with `kelvin = { git = "https://github.com/bgreni/Kelvin" }` confirm that `pixi run <task>` no longer fetches after the first install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)