### PR TITLE
feat: support build backend secrets

### DIFF
--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -58,6 +58,16 @@ use crate::{
 
 use fs_err::tokio as tokio_fs;
 
+/// Append project-model-declared secrets to a recipe's script secrets,
+/// skipping any names the backend has already added (e.g. sccache keys).
+fn merge_project_secrets(script_secrets: &mut Vec<String>, project_secrets: &[String]) {
+    for name in project_secrets {
+        if !script_secrets.iter().any(|existing| existing == name) {
+            script_secrets.push(name.clone());
+        }
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct IntermediateBackendConfig {
@@ -267,7 +277,7 @@ where
         variant_config.variants.append(&mut param_variants);
 
         // Construct the intermediate recipe
-        let generated_recipe = self
+        let mut generated_recipe = self
             .generate_recipe
             .generate_recipe(
                 &self.project_model,
@@ -280,6 +290,15 @@ where
                 self.cache_dir.clone(),
             )
             .await?;
+
+        // Forward user-declared passthrough secrets from the manifest into the
+        // generated recipe so rattler-build performs the host-env lookup at
+        // build time. Backends may have already populated `secrets` (e.g.
+        // sccache); we union without duplicates and preserve order.
+        merge_project_secrets(
+            &mut generated_recipe.recipe.build.script.secrets,
+            &self.project_model.secrets,
+        );
 
         // Convert the recipe to source code.
         // TODO(baszalmstra): In the future it would be great if we could just
@@ -622,6 +641,11 @@ where
                 self.cache_dir.clone(),
             )
             .await?;
+
+        merge_project_secrets(
+            &mut recipe.recipe.build.script.secrets,
+            &self.project_model.secrets,
+        );
 
         // Convert the recipe to source code.
         // TODO(baszalmstra): In the future it would be great if we could just

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -58,16 +58,6 @@ use crate::{
 
 use fs_err::tokio as tokio_fs;
 
-/// Append project-model-declared secrets to a recipe's script secrets,
-/// skipping any names the backend has already added (e.g. sccache keys).
-fn merge_project_secrets(script_secrets: &mut Vec<String>, project_secrets: &[String]) {
-    for name in project_secrets {
-        if !script_secrets.iter().any(|existing| existing == name) {
-            script_secrets.push(name.clone());
-        }
-    }
-}
-
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct IntermediateBackendConfig {
@@ -277,7 +267,7 @@ where
         variant_config.variants.append(&mut param_variants);
 
         // Construct the intermediate recipe
-        let mut generated_recipe = self
+        let generated_recipe = self
             .generate_recipe
             .generate_recipe(
                 &self.project_model,
@@ -290,15 +280,6 @@ where
                 self.cache_dir.clone(),
             )
             .await?;
-
-        // Forward user-declared passthrough secrets from the manifest into the
-        // generated recipe so rattler-build performs the host-env lookup at
-        // build time. Backends may have already populated `secrets` (e.g.
-        // sccache); we union without duplicates and preserve order.
-        merge_project_secrets(
-            &mut generated_recipe.recipe.build.script.secrets,
-            &self.project_model.secrets,
-        );
 
         // Convert the recipe to source code.
         // TODO(baszalmstra): In the future it would be great if we could just
@@ -641,11 +622,6 @@ where
                 self.cache_dir.clone(),
             )
             .await?;
-
-        merge_project_secrets(
-            &mut recipe.recipe.build.script.secrets,
-            &self.project_model.secrets,
-        );
 
         // Convert the recipe to source code.
         // TODO(baszalmstra): In the future it would be great if we could just

--- a/crates/pixi_build_backend/tests/integration/common/model.rs
+++ b/crates/pixi_build_backend/tests/integration/common/model.rs
@@ -134,6 +134,7 @@ pub(crate) fn convert_test_model_to_project_model_v1(test_model: TestProjectMode
         targets: Some(targets_v1),
         build_number: None,
         build_string_prefix: None,
+        secrets: Vec::new(),
     }
 }
 

--- a/crates/pixi_build_backend/tests/integration/common/model.rs
+++ b/crates/pixi_build_backend/tests/integration/common/model.rs
@@ -134,7 +134,7 @@ pub(crate) fn convert_test_model_to_project_model_v1(test_model: TestProjectMode
         targets: Some(targets_v1),
         build_number: None,
         build_string_prefix: None,
-        secrets: Vec::new(),
+        secrets: std::collections::BTreeSet::new(),
     }
 }
 

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -140,13 +140,15 @@ impl GenerateRecipe for CMakeGenerator {
         }
         .render();
 
-        generated_recipe.recipe.build.script = Script::from_content(build_script).with_env(
-            config
-                .env
-                .iter()
-                .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
-                .collect(),
-        );
+        generated_recipe.recipe.build.script = Script::from_content(build_script)
+            .with_env(
+                config
+                    .env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
+                    .collect(),
+            )
+            .with_secrets(model.secrets.iter().cloned().collect());
 
         Ok(generated_recipe)
     }

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -100,13 +100,15 @@ impl GenerateRecipe for MojoGenerator {
 
         let build_script = BuildScriptContext { bins, pkg }.render();
 
-        generated_recipe.recipe.build.script = Script::from_content(build_script).with_env(
-            config
-                .env
-                .iter()
-                .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
-                .collect(),
-        );
+        generated_recipe.recipe.build.script = Script::from_content(build_script)
+            .with_env(
+                config
+                    .env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
+                    .collect(),
+            )
+            .with_secrets(model.secrets.iter().cloned().collect());
 
         generated_recipe.build_input_globs = Self::globs().collect::<BTreeSet<_>>();
 

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -375,13 +375,15 @@ impl GenerateRecipe for PythonGenerator {
         generated_recipe.recipe.build.python = python;
         generated_recipe.recipe.build.noarch = noarch_kind;
 
-        generated_recipe.recipe.build.script = Script::from_content(build_script).with_env(
-            config
-                .env
-                .iter()
-                .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
-                .collect(),
-        );
+        generated_recipe.recipe.build.script = Script::from_content(build_script)
+            .with_env(
+                config
+                    .env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
+                    .collect(),
+            )
+            .with_secrets(model.secrets.iter().cloned().collect());
 
         // Add the metadata input globs from the MetadataProvider
         generated_recipe

--- a/crates/pixi_build_r/src/main.rs
+++ b/crates/pixi_build_r/src/main.rs
@@ -201,13 +201,15 @@ impl GenerateRecipe for RGenerator {
         }
         .render();
 
-        generated_recipe.recipe.build.script = Script::from_content(build_script).with_env(
-            config
-                .env
-                .iter()
-                .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
-                .collect(),
-        );
+        generated_recipe.recipe.build.script = Script::from_content(build_script)
+            .with_env(
+                config
+                    .env
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
+                    .collect(),
+            )
+            .with_secrets(model.secrets.iter().cloned().collect());
 
         // Add metadata input globs
         generated_recipe

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -215,8 +215,9 @@ impl GenerateRecipe for RosGenerator {
             }
         }
 
-        generated_recipe.recipe.build.script =
-            Script::from_content(build_script_content).with_env(script_env);
+        generated_recipe.recipe.build.script = Script::from_content(build_script_content)
+            .with_env(script_env)
+            .with_secrets(model.secrets.iter().cloned().collect());
 
         Ok(generated_recipe)
     }

--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -184,6 +184,13 @@ impl GenerateRecipe for RustGenerator {
         }
         .render();
 
+        let secrets = sccache_secrets
+            .into_iter()
+            .chain(model.secrets.iter().cloned())
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+
         generated_recipe.recipe.build.script = Script::from_content(build_script)
             .with_env(
                 config_env
@@ -191,7 +198,7 @@ impl GenerateRecipe for RustGenerator {
                     .map(|(k, v)| (k.clone(), Value::new_concrete(v.clone(), None)))
                     .collect(),
             )
-            .with_secrets(sccache_secrets);
+            .with_secrets(secrets);
 
         // Add the input globs from the Cargo metadata provider
         generated_recipe

--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -124,7 +124,7 @@ impl GenerateRecipe for RustGenerator {
             .chain(system_env_vars.clone())
             .collect();
 
-        let mut sccache_secrets = Vec::default();
+        let mut sccache_secrets: BTreeSet<String> = BTreeSet::new();
 
         // Verify if user has set any sccache environment variables
         if sccache_envs(&all_env_vars).is_some() {
@@ -185,12 +185,8 @@ impl GenerateRecipe for RustGenerator {
         }
         .render();
 
-        let secrets = sccache_secrets
-            .into_iter()
-            .chain(model.secrets.iter().cloned())
-            .collect::<std::collections::BTreeSet<_>>()
-            .into_iter()
-            .collect();
+        sccache_secrets.extend(model.secrets.iter().cloned());
+        let secrets = sccache_secrets.into_iter().collect();
 
         generated_recipe.recipe.build.script = Script::from_content(build_script)
             .with_env(

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -226,6 +226,7 @@ pub fn to_project_model_v1(
         repository: manifest.package.repository.clone(),
         documentation: manifest.package.documentation.clone(),
         targets: Some(to_targets_v1(&manifest.targets, channel_config)?),
+        secrets: manifest.build.secrets.clone(),
     };
     Ok(project)
 }

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -65,6 +65,13 @@ pub struct ProjectModel {
     /// The target of the project, this may contain
     /// platform specific configurations.
     pub targets: Option<Targets>,
+
+    /// Names of environment variables that should be exposed as secrets to
+    /// the build script. Backends forward these into the generated
+    /// `build.script.secrets` so rattler-build performs the host-env
+    /// passthrough at build time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secrets: Vec<String>,
 }
 
 impl IsDefault for ProjectModel {
@@ -550,6 +557,7 @@ impl Hash for ProjectModel {
             repository,
             documentation,
             targets,
+            secrets,
         } = self;
 
         StableHashBuilder::<H>::new()
@@ -564,6 +572,7 @@ impl Hash for ProjectModel {
             .field("name", name)
             .field("readme", readme)
             .field("repository", repository)
+            .field("secrets", secrets)
             .field("targets", targets)
             .field("version", version)
             .finish(state);
@@ -871,6 +880,7 @@ mod tests {
             repository: None,
             documentation: None,
             targets: None,
+            secrets: Vec::new(),
         };
 
         let hash1 = calculate_hash(&project_model);
@@ -930,6 +940,7 @@ mod tests {
             repository: None,
             documentation: None,
             targets: None,
+            secrets: Vec::new(),
         };
 
         let hash1 = calculate_hash(&project_model);

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -69,9 +69,10 @@ pub struct ProjectModel {
     /// Names of environment variables that should be exposed as secrets to
     /// the build script. Backends forward these into the generated
     /// `build.script.secrets` so rattler-build performs the host-env
-    /// passthrough at build time.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub secrets: Vec<String>,
+    /// passthrough at build time. Stored as a set: order is not observable
+    /// and changing it should not invalidate caches.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeSet::is_empty")]
+    pub secrets: std::collections::BTreeSet<String>,
 }
 
 impl IsDefault for ProjectModel {
@@ -880,7 +881,7 @@ mod tests {
             repository: None,
             documentation: None,
             targets: None,
-            secrets: Vec::new(),
+            secrets: std::collections::BTreeSet::new(),
         };
 
         let hash1 = calculate_hash(&project_model);
@@ -940,7 +941,7 @@ mod tests {
             repository: None,
             documentation: None,
             targets: None,
-            secrets: Vec::new(),
+            secrets: std::collections::BTreeSet::new(),
         };
 
         let hash1 = calculate_hash(&project_model);

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -38,6 +38,11 @@ pub struct PackageBuild {
 
     /// The build number configured by the user.
     pub build_number: Option<u64>,
+
+    /// Names of environment variables to expose as secrets to the build
+    /// script. Values are looked up at build time from the host environment by
+    /// the build backend; only the names live in the manifest.
+    pub secrets: Vec<String>,
 }
 
 impl PackageBuild {
@@ -52,6 +57,7 @@ impl PackageBuild {
             target_config: None,
             build_string_prefix: None,
             build_number: None,
+            secrets: Vec::new(),
         }
     }
 }

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -41,8 +41,9 @@ pub struct PackageBuild {
 
     /// Names of environment variables to expose as secrets to the build
     /// script. Values are looked up at build time from the host environment by
-    /// the build backend; only the names live in the manifest.
-    pub secrets: Vec<String>,
+    /// the build backend; only the names live in the manifest. Stored as a
+    /// set since order is not observable.
+    pub secrets: std::collections::BTreeSet<String>,
 }
 
 impl PackageBuild {
@@ -57,7 +58,7 @@ impl PackageBuild {
             target_config: None,
             build_string_prefix: None,
             build_number: None,
-            secrets: Vec::new(),
+            secrets: std::collections::BTreeSet::new(),
         }
     }
 }

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -524,7 +524,10 @@ mod test {
 
         assert_eq!(
             parsed.value.secrets,
-            vec!["CARGO_REGISTRY_TOKEN".to_string(), "SCCACHE_BUCKET".to_string()]
+            vec![
+                "CARGO_REGISTRY_TOKEN".to_string(),
+                "SCCACHE_BUCKET".to_string()
+            ]
         );
     }
 

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, sync::Once};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Once,
+};
 
 use indexmap::IndexMap;
 use pixi_spec::{SourceLocationSpec, TomlLocationSpec, TomlSpec};
@@ -28,7 +31,7 @@ pub struct TomlPackageBuild {
 
     pub build_string_prefix: Option<String>,
     pub build_number: Option<u64>,
-    pub secrets: std::collections::BTreeSet<String>,
+    pub secrets: BTreeSet<String>,
 }
 
 #[derive(Debug)]
@@ -228,10 +231,8 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
         let build_string_prefix = th.optional("build-string-prefix");
         let build_number = th.optional("build-number");
         let secrets = th
-            .optional::<Vec<String>>("secrets")
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+            .optional::<BTreeSet<String>>("secrets")
+            .unwrap_or_default();
 
         th.finalize(None)?;
 

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -28,6 +28,7 @@ pub struct TomlPackageBuild {
 
     pub build_string_prefix: Option<String>,
     pub build_number: Option<u64>,
+    pub secrets: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -106,6 +107,7 @@ impl TomlPackageBuild {
                 },
                 build_string_prefix: self.build_string_prefix,
                 build_number: self.build_number,
+                secrets: self.secrets,
             },
             warnings: self.warnings,
         })
@@ -225,6 +227,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
 
         let build_string_prefix = th.optional("build-string-prefix");
         let build_number = th.optional("build-number");
+        let secrets: Vec<String> = th.optional("secrets").unwrap_or_default();
 
         th.finalize(None)?;
 
@@ -278,6 +281,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
             warnings,
             build_string_prefix,
             build_number,
+            secrets,
         })
     }
 }
@@ -506,6 +510,34 @@ mod test {
                 .additional_dependencies
                 .contains_key(&"git".parse::<rattler_conda_types::PackageName>().unwrap())
         );
+    }
+
+    #[test]
+    fn test_secrets() {
+        let toml = r#"
+            backend = { name = "foobar", version = "*" }
+            secrets = ["CARGO_REGISTRY_TOKEN", "SCCACHE_BUCKET"]
+        "#;
+        let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
+            .and_then(TomlPackageBuild::into_build_system)
+            .expect("parsing should succeed");
+
+        assert_eq!(
+            parsed.value.secrets,
+            vec!["CARGO_REGISTRY_TOKEN".to_string(), "SCCACHE_BUCKET".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_secrets_default_empty() {
+        let toml = r#"
+            backend = { name = "foobar", version = "*" }
+        "#;
+        let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
+            .and_then(TomlPackageBuild::into_build_system)
+            .expect("parsing should succeed");
+
+        assert!(parsed.value.secrets.is_empty());
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -231,8 +231,10 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
         let build_string_prefix = th.optional("build-string-prefix");
         let build_number = th.optional("build-number");
         let secrets = th
-            .optional::<BTreeSet<String>>("secrets")
-            .unwrap_or_default();
+            .optional::<Vec<String>>("secrets")
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
 
         th.finalize(None)?;
 

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -28,7 +28,7 @@ pub struct TomlPackageBuild {
 
     pub build_string_prefix: Option<String>,
     pub build_number: Option<u64>,
-    pub secrets: Vec<String>,
+    pub secrets: std::collections::BTreeSet<String>,
 }
 
 #[derive(Debug)]
@@ -227,7 +227,11 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
 
         let build_string_prefix = th.optional("build-string-prefix");
         let build_number = th.optional("build-number");
-        let secrets: Vec<String> = th.optional("secrets").unwrap_or_default();
+        let secrets = th
+            .optional::<Vec<String>>("secrets")
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
 
         th.finalize(None)?;
 
@@ -524,23 +528,11 @@ mod test {
 
         assert_eq!(
             parsed.value.secrets,
-            vec![
-                "CARGO_REGISTRY_TOKEN".to_string(),
-                "SCCACHE_BUCKET".to_string()
-            ]
+            ["CARGO_REGISTRY_TOKEN", "SCCACHE_BUCKET"]
+                .into_iter()
+                .map(String::from)
+                .collect()
         );
-    }
-
-    #[test]
-    fn test_secrets_default_empty() {
-        let toml = r#"
-            backend = { name = "foobar", version = "*" }
-        "#;
-        let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
-            .expect("parsing should succeed");
-
-        assert!(parsed.value.secrets.is_empty());
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -5,7 +5,7 @@ use std::{
 
 use indexmap::IndexMap;
 use pixi_spec::{SourceLocationSpec, TomlLocationSpec, TomlSpec};
-use pixi_toml::{Same, TomlFromStr, TomlIndexMap, TomlWith};
+use pixi_toml::{Same, TomlBTreeSet, TomlFromStr, TomlIndexMap, TomlWith};
 use rattler_conda_types::NamedChannelOrUrl;
 use std::borrow::Cow;
 use toml_span::{DeserError, Error, Spanned, Value, de_helpers::TableHelper, value::ValueInner};
@@ -231,10 +231,9 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageBuild {
         let build_string_prefix = th.optional("build-string-prefix");
         let build_number = th.optional("build-number");
         let secrets = th
-            .optional::<Vec<String>>("secrets")
-            .unwrap_or_default()
-            .into_iter()
-            .collect();
+            .optional::<TomlBTreeSet<String>>("secrets")
+            .map(TomlBTreeSet::into_inner)
+            .unwrap_or_default();
 
         th.finalize(None)?;
 

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__additional_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__additional_keys.snap
@@ -2,7 +2,7 @@
 source: crates/pixi_manifest/src/toml/build_backend.rs
 expression: "expect_parse_failure(r#\"\n            backend = { name = \"foobar\", version = \"*\" }\n            additional = \"key\"\n        \"#)"
 ---
-  × Unexpected keys, expected only 'backend', 'channels', 'additional-dependencies', 'source', 'config', 'target', 'build-string-prefix', 'build-number'
+  × Unexpected keys, expected only 'backend', 'channels', 'additional-dependencies', 'source', 'config', 'target', 'build-string-prefix', 'build-number', 'secrets'
    ╭─[pixi.toml:3:13]
  2 │             backend = { name = "foobar", version = "*" }
  3 │             additional = "key"

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
@@ -69,5 +69,5 @@ PackageBuild {
     target_config: None,
     build_string_prefix: None,
     build_number: None,
-    secrets: [],
+    secrets: {},
 }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
@@ -69,4 +69,5 @@ PackageBuild {
     target_config: None,
     build_string_prefix: None,
     build_number: None,
+    secrets: [],
 }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
@@ -120,4 +120,5 @@ TomlPackageBuild {
     ],
     build_string_prefix: None,
     build_number: None,
+    secrets: [],
 }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
@@ -120,5 +120,5 @@ TomlPackageBuild {
     ],
     build_string_prefix: None,
     build_number: None,
-    secrets: [],
+    secrets: {},
 }

--- a/crates/pixi_stable_hash/src/lib.rs
+++ b/crates/pixi_stable_hash/src/lib.rs
@@ -151,6 +151,14 @@ impl<T> IsDefault for Vec<T> {
     }
 }
 
+impl<T> IsDefault for std::collections::BTreeSet<T> {
+    type Item = Self;
+
+    fn is_non_default(&self) -> Option<&Self::Item> {
+        if !self.is_empty() { Some(self) } else { None }
+    }
+}
+
 impl<T: IsDefault> IsDefault for Option<T> {
     type Item = T::Item;
 

--- a/crates/pixi_toml/src/btree_set.rs
+++ b/crates/pixi_toml/src/btree_set.rs
@@ -1,0 +1,80 @@
+use std::collections::BTreeSet;
+
+use toml_span::{DeserError, Value, de_helpers::expected, value::ValueInner};
+
+use crate::DeserializeAs;
+
+/// [`BTreeSet`] is not supported by `toml_span` directly so we provide our own
+/// deserializer.
+///
+/// The deserializer expects an array and deduplicates the entries.
+pub struct TomlBTreeSet<T>(BTreeSet<T>);
+
+impl<T> TomlBTreeSet<T> {
+    pub fn into_inner(self) -> BTreeSet<T> {
+        self.0
+    }
+}
+
+impl<T> From<TomlBTreeSet<T>> for BTreeSet<T> {
+    fn from(value: TomlBTreeSet<T>) -> Self {
+        value.0
+    }
+}
+
+impl<'de, T: toml_span::Deserialize<'de> + Ord> toml_span::Deserialize<'de> for TomlBTreeSet<T> {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        match value.take() {
+            ValueInner::Array(array) => {
+                let mut errors = DeserError { errors: Vec::new() };
+                let mut result = BTreeSet::new();
+                for mut value in array {
+                    match T::deserialize(&mut value) {
+                        Ok(v) => {
+                            result.insert(v);
+                        }
+                        Err(e) => {
+                            errors.merge(e);
+                        }
+                    }
+                }
+                if errors.errors.is_empty() {
+                    Ok(Self(result))
+                } else {
+                    Err(errors)
+                }
+            }
+            other => Err(DeserError::from(expected("array", other, value.span))),
+        }
+    }
+}
+
+impl<'de, T: Ord, U> DeserializeAs<'de, BTreeSet<T>> for TomlBTreeSet<U>
+where
+    U: DeserializeAs<'de, T>,
+{
+    fn deserialize_as(value: &mut Value<'de>) -> Result<BTreeSet<T>, DeserError> {
+        match value.take() {
+            ValueInner::Array(array) => {
+                let mut errors = DeserError { errors: Vec::new() };
+                let mut result = BTreeSet::new();
+                for mut value in array {
+                    match U::deserialize_as(&mut value) {
+                        Ok(v) => {
+                            result.insert(v);
+                        }
+                        Err(e) => {
+                            errors.merge(e);
+                        }
+                    }
+                }
+                if errors.errors.is_empty() {
+                    Ok(result)
+                } else {
+                    Err(errors)
+                }
+            }
+            other => Err(DeserError::from(expected("array", other, value.span))),
+        }
+    }
+}

--- a/crates/pixi_toml/src/lib.rs
+++ b/crates/pixi_toml/src/lib.rs
@@ -7,6 +7,7 @@
 //! one type into another. This makes it possible to efficiently implement
 //! deserializers for types from external crates.
 
+mod btree_set;
 mod diagnostic;
 mod digest;
 mod from_str;
@@ -19,6 +20,7 @@ mod with;
 
 use std::str::FromStr;
 
+pub use btree_set::TomlBTreeSet;
 pub use diagnostic::TomlDiagnostic;
 pub use digest::TomlDigest;
 pub use from_str::TomlFromStr;

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1330,6 +1330,7 @@ The build system is a table that can contain the following fields:
 - `config`: a table that contains the configuration options for the build backend.
 - `target`: a table that can contain target specific build configuration.
   - Each target can have its own `config` table to override or extend the base configuration for specific platforms.
+- `secrets`: a list of environment variable names whose values are exposed to the build script. The names are read from the manifest; the values are looked up in the host environment at build time and forwarded to the build backend through the recipe (`build.script.secrets`), matching rattler-build's behaviour. Useful for passing credentials such as `GH_TOKEN` or registry tokens into the build without recording them in the manifest.
 
 More documentation on the backends can be found in the [build backend documentation](../build/backends.md).
 

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1330,7 +1330,7 @@ The build system is a table that can contain the following fields:
 - `config`: a table that contains the configuration options for the build backend.
 - `target`: a table that can contain target specific build configuration.
   - Each target can have its own `config` table to override or extend the base configuration for specific platforms.
-- `secrets`: a list of environment variable names whose values are exposed to the build script. The names are read from the manifest; the values are looked up in the host environment at build time and forwarded to the build backend through the recipe (`build.script.secrets`), matching rattler-build's behaviour. Useful for passing credentials such as `GH_TOKEN` or registry tokens into the build without recording them in the manifest.
+- `secrets`: a list of environment variable names whose values are exposed to the build script. The names are read from the manifest; the values are looked up in the host environment at build time and forwarded to the build backend through the recipe (`build.script.secrets`), matching rattler-build's behavior. Useful for passing credentials such as `GH_TOKEN` or registry tokens into the build without recording them in the manifest.
 
 More documentation on the backends can be found in the [build backend documentation](../build/backends.md).
 

--- a/schema/model.py
+++ b/schema/model.py
@@ -906,6 +906,14 @@ class Build(StrictBaseModel):
     build_number: UnsignedInt | None = Field(
         None, description="The build number to record in the produced package"
     )
+    secrets: list[NonEmptyStr] | None = Field(
+        None,
+        description=(
+            "Names of environment variables to expose as secrets to the build script. "
+            "Values are read from the host environment at build time; only the names "
+            "live in the manifest. Forwarded to rattler-build's `build.script.secrets`."
+        ),
+    )
 
 
 class BuildBackend(MatchspecTable):

--- a/schema/pixi_build_api.json
+++ b/schema/pixi_build_api.json
@@ -107,8 +107,9 @@
       ]
     },
     "secrets": {
-      "description": "Names of environment variables that should be exposed as secrets to\nthe build script. Backends forward these into the generated\n`build.script.secrets` so rattler-build performs the host-env\npassthrough at build time.",
+      "description": "Names of environment variables that should be exposed as secrets to\nthe build script. Backends forward these into the generated\n`build.script.secrets` so rattler-build performs the host-env\npassthrough at build time. Stored as a set: order is not observable\nand changing it should not invalidate caches.",
       "type": "array",
+      "uniqueItems": true,
       "items": {
         "type": "string"
       }

--- a/schema/pixi_build_api.json
+++ b/schema/pixi_build_api.json
@@ -105,6 +105,13 @@
           "type": "null"
         }
       ]
+    },
+    "secrets": {
+      "description": "Names of environment variables that should be exposed as secrets to\nthe build script. Backends forward these into the generated\n`build.script.secrets` so rattler-build performs the host-env\npassthrough at build time.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "$defs": {

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -379,6 +379,15 @@
           "type": "object",
           "additionalProperties": true
         },
+        "secrets": {
+          "title": "Secrets",
+          "description": "Names of environment variables to expose as secrets to the build script. Values are read from the host environment at build time; only the names live in the manifest. Forwarded to rattler-build's `build.script.secrets`.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
         "source": {
           "$ref": "#/$defs/SourceLocation",
           "description": "The source from which to build the package",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -122,6 +122,15 @@
           "type": "object",
           "additionalProperties": true
         },
+        "secrets": {
+          "title": "Secrets",
+          "description": "Names of environment variables to expose as secrets to the build script. Values are read from the host environment at build time; only the names live in the manifest. Forwarded to rattler-build's `build.script.secrets`.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
         "source": {
           "$ref": "#/$defs/SourceLocation",
           "description": "The source from which to build the package",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -403,6 +403,15 @@
           "type": "object",
           "additionalProperties": true
         },
+        "secrets": {
+          "title": "Secrets",
+          "description": "Names of environment variables to expose as secrets to the build script. Values are read from the host environment at build time; only the names live in the manifest. Forwarded to rattler-build's `build.script.secrets`.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
         "source": {
           "$ref": "#/$defs/SourceLocation",
           "description": "The source from which to build the package",


### PR DESCRIPTION
### Description

Adds a `secrets` list to `[package.build]` so manifests can declare environment variables that should be exposed to the build script as secrets, mirroring rattler-build's `build.script.secrets`.

```toml
[package.build]
backend = { name = "pixi-build-rust", version = "*" }
secrets = ["CARGO_REGISTRY_TOKEN", "SCCACHE_BUCKET"]
```

Motivation: in the rattler-build recipe execution we restrict env access by default. This gives package authors a way to opt specific env vars through, without putting secret values in the manifest. Useful for credentials such as `GH_TOKEN`, registry tokens, sccache config, etc.

### How Has This Been Tested?

Snapshots updated and TOML parsing tests added.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.