### PR TITLE
docs: remove pixi build from FAQ

### DIFF
--- a/docs/misc/FAQ.md
+++ b/docs/misc/FAQ.md
@@ -25,10 +25,3 @@ We think the name sparks curiosity and fun, if you don't agree, I'm sorry, but y
     ```powershell
     New-Alias -Name not_pixi -Value pixi
     ```
-
-## Where is `pixi build`
-
-**TL;DR**: It's coming we promise!
-
-`pixi build` is going to be the subcommand that can generate a conda package out of a Pixi workspace.
-This requires a solid build tool which we're creating with [`rattler-build`](https://github.com/prefix-dev/rattler-build) which will be used as a library in pixi.


### PR DESCRIPTION
### Description

It seems the `pixi build` section has been forgotten as `pixi build` is available for a long time. If anything "Where is pixi-build" should now be revived as "merged into Pixi-publish" but I'm not sure it's worth an entry, so just deleting seems the better option.