### PR TITLE
fix: allow unsetting unknown config keys

### DIFF
--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -319,9 +319,9 @@ fn alter_config(
         }
         AlterMode::Set => config.set(key, value)?,
         AlterMode::Unset => {
-            config.set(key, None)?;
-
-            if !config.get_keys().contains(&key) {
+            if config.get_keys().contains(&key) {
+                config.set(key, None)?;
+            } else {
                 if let Ok(contents) = fs_err::read_to_string(&to)
                     && let Some(contents) = pixi_config::remove_key_from_toml(&contents, key)?
                 {

--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -317,7 +317,23 @@ fn alter_config(
                 }
             }
         }
-        AlterMode::Set | AlterMode::Unset => config.set(key, value)?,
+        AlterMode::Set => config.set(key, value)?,
+        AlterMode::Unset => {
+            config.set(key, None)?;
+
+            if !config.get_keys().contains(&key) {
+                if let Ok(contents) = fs_err::read_to_string(&to)
+                    && let Some(contents) = pixi_config::remove_key_from_toml(&contents, key)?
+                {
+                    fs_err::write(&to, contents)
+                        .into_diagnostic()
+                        .wrap_err(format!("failed to write config to '{}'", to.display()))?;
+                }
+
+                eprintln!("鉁?Updated config at {}", to.display());
+                return Ok(());
+            }
+        }
     }
 
     config.save(&to)?;

--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -330,7 +330,7 @@ fn alter_config(
                         .wrap_err(format!("failed to write config to '{}'", to.display()))?;
                 }
 
-                eprintln!("鉁?Updated config at {}", to.display());
+                eprintln!("✅ Updated config at {}", to.display());
                 return Ok(());
             }
         }

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -2132,13 +2132,18 @@ impl Config {
     ///
     /// It is required to call `save()` to persist the changes.
     pub fn set(&mut self, key: &str, value: Option<String>) -> miette::Result<()> {
-        let show_supported_keys =
-            || format!("Supported keys:\n\t{}", self.get_keys().join(",\n\t"));
-        let err = miette::miette!(
-            "Unknown key: {}\n{}",
-            console::style(key).red(),
-            show_supported_keys()
-        );
+        let supported_keys = format!("Supported keys:\n\t{}", self.get_keys().join(",\n\t"));
+        let unknown_key = || {
+            if value.is_none() {
+                Ok(())
+            } else {
+                Err(miette::miette!(
+                    "Unknown key: {}\n{}",
+                    console::style(key).red(),
+                    supported_keys
+                ))
+            }
+        };
 
         match key {
             "default-channels" => {
@@ -2210,7 +2215,7 @@ impl Config {
                         .unwrap_or_default();
                     return Ok(());
                 } else if !key.starts_with("repodata-config.") {
-                    return Err(err);
+                    return unknown_key();
                 }
 
                 let subkey = key.strip_prefix("repodata-config.").unwrap();
@@ -2227,7 +2232,7 @@ impl Config {
                         self.repodata_config.default.disable_sharded =
                             value.map(|v| v.parse()).transpose().into_diagnostic()?;
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
             }
             key if key.starts_with("pypi-config") => {
@@ -2239,7 +2244,7 @@ impl Config {
                     }
                     return Ok(());
                 } else if !key.starts_with("pypi-config.") {
-                    return Err(err);
+                    return unknown_key();
                 }
 
                 let subkey = key.strip_prefix("pypi-config.").unwrap();
@@ -2273,7 +2278,7 @@ impl Config {
                             .into_diagnostic()?
                             .unwrap_or_default();
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
             }
             key if key.starts_with("s3-options") => {
@@ -2286,7 +2291,7 @@ impl Config {
                     return Ok(());
                 }
                 let Some(subkey) = key.strip_prefix("s3-options.") else {
-                    return Err(err);
+                    return unknown_key();
                 };
                 if let Some((bucket, rest)) = subkey.split_once('.') {
                     if let Some(bucket_config) = self.s3_options.get_mut(bucket) {
@@ -2323,7 +2328,7 @@ impl Config {
                                     ));
                                 }
                             }
-                            _ => return Err(err),
+                            _ => return unknown_key(),
                         }
                     }
                 } else {
@@ -2342,7 +2347,7 @@ impl Config {
                     }
                     return Ok(());
                 } else if !key.starts_with(format!("{EXPERIMENTAL}.").as_str()) {
-                    return Err(err);
+                    return unknown_key();
                 }
 
                 let subkey = key
@@ -2353,7 +2358,7 @@ impl Config {
                         self.experimental.use_environment_activation_cache =
                             value.map(|v| v.parse()).transpose().into_diagnostic()?;
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
             }
             key if key.starts_with("concurrency") => {
@@ -2365,7 +2370,7 @@ impl Config {
                     }
                     return Ok(());
                 } else if !key.starts_with("concurrency.") {
-                    return Err(err);
+                    return unknown_key();
                 }
                 let subkey = key.strip_prefix("concurrency.").unwrap();
                 match subkey {
@@ -2383,7 +2388,7 @@ impl Config {
                             return Err(miette!("'downloads' requires a number value"));
                         }
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
             }
             key if key.starts_with("shell") => {
@@ -2395,7 +2400,7 @@ impl Config {
                     }
                     return Ok(());
                 } else if !key.starts_with("shell.") {
-                    return Err(err);
+                    return unknown_key();
                 }
                 let subkey = key.strip_prefix("shell.").unwrap();
                 match subkey {
@@ -2411,7 +2416,7 @@ impl Config {
                         self.shell.change_ps1 =
                             value.map(|v| v.parse()).transpose().into_diagnostic()?;
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
             }
             key if key.starts_with("run-post-link-scripts") => {
@@ -2444,7 +2449,7 @@ impl Config {
                     }
                     return Ok(());
                 } else if !key.starts_with("proxy-config.") {
-                    return Err(err);
+                    return unknown_key();
                 }
 
                 let subkey = key.strip_prefix("proxy-config.").unwrap();
@@ -2468,7 +2473,7 @@ impl Config {
                             .into_diagnostic()?
                             .unwrap_or_default();
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
             }
             key if key.starts_with("cache") => {
@@ -2482,7 +2487,7 @@ impl Config {
                     self.cache.validate()?;
                     return Ok(());
                 } else if !key.starts_with("cache.") {
-                    return Err(err);
+                    return unknown_key();
                 }
                 let subkey = key.strip_prefix("cache.").unwrap();
                 match subkey {
@@ -2505,12 +2510,12 @@ impl Config {
                             .into_diagnostic()?
                             .unwrap_or_default();
                     }
-                    _ => return Err(err),
+                    _ => return unknown_key(),
                 }
                 self.cache.expand_paths()?;
                 self.cache.validate()?;
             }
-            _ => return Err(err),
+            _ => return unknown_key(),
         }
 
         Ok(())
@@ -3404,7 +3409,11 @@ UNUSED = "unused"
             .unwrap();
         assert_eq!(config.pinning_strategy, Some(PinningStrategy::Semver));
 
-        config.set("unknown-key", None).unwrap_err();
+        config
+            .set("unknown-key", Some("value".to_string()))
+            .unwrap_err();
+        config.set("unknown-key", None).unwrap();
+        config.set("repodata-config.disable-jlap", None).unwrap();
     }
 
     #[rstest]

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -2581,6 +2581,30 @@ impl Config {
     }
 }
 
+/// Remove a dotted key from the given TOML document while preserving the rest
+/// of the document.
+pub fn remove_key_from_toml(toml: &str, key: &str) -> miette::Result<Option<String>> {
+    let mut document = toml_edit::DocumentMut::from_str(toml).into_diagnostic()?;
+    let path = key.split('.').collect::<Vec<_>>();
+
+    if remove_key_from_table(document.as_table_mut(), &path) {
+        Ok(Some(document.to_string()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn remove_key_from_table(table: &mut toml_edit::Table, path: &[&str]) -> bool {
+    match path {
+        [] => false,
+        [key] => table.remove(key).is_some(),
+        [head, rest @ ..] => table
+            .get_mut(head)
+            .and_then(toml_edit::Item::as_table_mut)
+            .is_some_and(|table| remove_key_from_table(table, rest)),
+    }
+}
+
 /// Returns the path to the system-level pixi config file.
 pub fn config_path_system() -> PathBuf {
     // TODO: the base_path for Windows is currently hardcoded, it should be
@@ -3417,35 +3441,26 @@ UNUSED = "unused"
     }
 
     #[test]
-    fn test_unset_unknown_key_rewrites_config_without_stale_key() {
-        let nonce = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let config_path = std::env::temp_dir().join(format!(
-            "pixi-config-unset-unknown-{}-{nonce}.toml",
-            std::process::id()
-        ));
+    fn test_unset_unknown_key_removes_only_requested_toml_key() {
+        let toml = r#"[repodata-config]
+disable-jlap = true
+kept-unknown = "keep"
+also-kept = 42
+disable-bzip2 = true
+"#;
 
-        fs_err::write(
-            &config_path,
-            r#"
-            [repodata-config]
-            disable-jlap = true
-            disable-bzip2 = true
-        "#,
-        )
-        .unwrap();
-
-        let mut config = Config::from_path(&config_path).unwrap();
+        let (mut config, _) = Config::from_toml(toml, None).unwrap();
         config.set("repodata-config.disable-jlap", None).unwrap();
-        config.save(&config_path).unwrap();
+        let saved = remove_key_from_toml(toml, "repodata-config.disable-jlap")
+            .unwrap()
+            .unwrap();
 
-        let saved = fs_err::read_to_string(&config_path).unwrap();
-        fs_err::remove_file(&config_path).unwrap();
-
-        assert!(!saved.contains("disable-jlap"));
-        assert!(saved.contains("disable-bzip2"));
+        insta::assert_snapshot!(saved, @r#"
+[repodata-config]
+kept-unknown = "keep"
+also-kept = 42
+disable-bzip2 = true
+"#);
     }
 
     #[rstest]

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -3416,6 +3416,38 @@ UNUSED = "unused"
         config.set("repodata-config.disable-jlap", None).unwrap();
     }
 
+    #[test]
+    fn test_unset_unknown_key_rewrites_config_without_stale_key() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let config_path = std::env::temp_dir().join(format!(
+            "pixi-config-unset-unknown-{}-{nonce}.toml",
+            std::process::id()
+        ));
+
+        fs_err::write(
+            &config_path,
+            r#"
+            [repodata-config]
+            disable-jlap = true
+            disable-bzip2 = true
+        "#,
+        )
+        .unwrap();
+
+        let mut config = Config::from_path(&config_path).unwrap();
+        config.set("repodata-config.disable-jlap", None).unwrap();
+        config.save(&config_path).unwrap();
+
+        let saved = fs_err::read_to_string(&config_path).unwrap();
+        fs_err::remove_file(&config_path).unwrap();
+
+        assert!(!saved.contains("disable-jlap"));
+        assert!(saved.contains("disable-bzip2"));
+    }
+
     #[rstest]
     #[case("pinning-strategy", None, None)]
     #[case("pinning-strategy", Some("semver".to_string()), Some(PinningStrategy::Semver))]


### PR DESCRIPTION
### Description

Fixes #5672.

`pixi config unset` returned an unknown-key error when the requested key was no longer part of the config schema. That made it hard to clean up stale config values such as the removed `repodata-config.disable-jlap` entry.

This keeps setting unknown keys strict, but allows unset operations (`value == None`) to continue for unknown or deprecated keys. For unsupported/stale keys that exist in the target TOML file, the CLI now removes only the requested dotted key from the TOML document instead of serializing the typed config and dropping every unknown field.

Before, trying to remove a stale key such as `repodata-config.disable-jlap` failed before saving. After this change, the unset operation is accepted and the file is rewritten without that stale key while preserving unrelated unknown keys and supported entries such as `repodata-config.disable-bzip2`.

### How Has This Been Tested?

- `cargo fmt --check -p pixi_config -p pixi_cli`
- `cargo test -p pixi_config test_unset_unknown_key_removes_only_requested_toml_key`
- `cargo test -p pixi_config`
- `cargo check -p pixi_cli`
- `git diff --check`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI Codex

Prompt: Fix the `pixi config unset` stale-key cleanup issue and address maintainer feedback by proving the stale key is removed without removing other unknown keys from the saved config file.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.