### PR TITLE
feat: centralize default compiler variants and add CUDA support

### DIFF
--- a/crates/pixi_build_backend/src/compilers.rs
+++ b/crates/pixi_build_backend/src/compilers.rs
@@ -1,9 +1,14 @@
 //! We could expose the `default_compiler` function from the `rattler-build`
 //! crate
 
-use std::{collections::HashSet, fmt::Display, ops::Deref};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Display,
+    ops::Deref,
+};
 
 use itertools::Itertools;
+use rattler_build_jinja::Variable;
 use rattler_build_recipe::stage0::{
     ConditionalList, Item, JinjaTemplate, SerializableMatchSpec, Value,
 };
@@ -34,6 +39,11 @@ pub fn default_compiler(platform: &Platform, language: &str) -> String {
     match language {
         // Platform agnostic compilers
         "fortran" => "gfortran",
+        // CUDA: matches conda-forge's global pinning since CUDA 12 (the legacy
+        // `nvcc` package was CUDA 11 and earlier). CUDA is only supported on
+        // Linux/Windows, but we return the same name on macOS to keep this
+        // function platform-agnostic for `cuda`.
+        "cuda" => "cuda-nvcc",
         // Platform specific compilers
         "c" | "cxx" => {
             if platform.is_windows() {
@@ -65,6 +75,38 @@ pub fn default_compiler(platform: &Platform, language: &str) -> String {
         _ => language,
     }
     .to_string()
+}
+
+/// Returns the default compiler variants that backends should seed for the
+/// given host platform.
+///
+/// These mirror conda-forge's global pinning so that recipes which use
+/// `${{ compiler(...) }}` resolve to sensible packages out of the box:
+///
+/// * On Windows, `c_compiler` and `cxx_compiler` default to `vs2022`
+///   (rattler-build's built-in default is `vs2017`, which is too old for most
+///   CI runners, and conda-forge moved off `vs2019` in 2024).
+/// * On Linux and Windows, `cuda_compiler` defaults to `cuda-nvcc`, matching
+///   the `cuda_compiler: cuda-nvcc  # [linux or win]` line in conda-forge's
+///   pinning. CUDA is not supported on macOS.
+pub fn default_compiler_variants(
+    host_platform: Platform,
+) -> BTreeMap<NormalizedKey, Vec<Variable>> {
+    let mut variants = BTreeMap::new();
+
+    if host_platform.is_windows() {
+        variants.insert(NormalizedKey::from("c_compiler"), vec!["vs2022".into()]);
+        variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2022".into()]);
+    }
+
+    if host_platform.is_linux() || host_platform.is_windows() {
+        variants.insert(
+            NormalizedKey::from("cuda_compiler"),
+            vec!["cuda-nvcc".into()],
+        );
+    }
+
+    variants
 }
 
 /// Create a jinja template item for a matchspec.
@@ -178,5 +220,48 @@ mod tests {
     fn test_compiler_requirements_python() {
         let result = compiler_requirement(&Language::Other("python"));
         assert_yaml_snapshot!(result);
+    }
+
+    #[test]
+    fn test_default_compiler_cuda() {
+        assert_eq!(default_compiler(&Platform::Linux64, "cuda"), "cuda-nvcc");
+        assert_eq!(default_compiler(&Platform::Win64, "cuda"), "cuda-nvcc");
+        // CUDA is unsupported on macOS but `default_compiler` is platform
+        // agnostic for cuda so it still returns the conda-forge package name.
+        assert_eq!(default_compiler(&Platform::Osx64, "cuda"), "cuda-nvcc");
+    }
+
+    #[test]
+    fn test_default_compiler_variants_linux() {
+        let variants = default_compiler_variants(Platform::Linux64);
+        assert_eq!(
+            variants.get(&NormalizedKey::from("cuda_compiler")),
+            Some(&vec!["cuda-nvcc".into()])
+        );
+        assert!(!variants.contains_key(&NormalizedKey::from("c_compiler")));
+        assert!(!variants.contains_key(&NormalizedKey::from("cxx_compiler")));
+    }
+
+    #[test]
+    fn test_default_compiler_variants_windows() {
+        let variants = default_compiler_variants(Platform::Win64);
+        assert_eq!(
+            variants.get(&NormalizedKey::from("c_compiler")),
+            Some(&vec!["vs2022".into()])
+        );
+        assert_eq!(
+            variants.get(&NormalizedKey::from("cxx_compiler")),
+            Some(&vec!["vs2022".into()])
+        );
+        assert_eq!(
+            variants.get(&NormalizedKey::from("cuda_compiler")),
+            Some(&vec!["cuda-nvcc".into()])
+        );
+    }
+
+    #[test]
+    fn test_default_compiler_variants_macos() {
+        let variants = default_compiler_variants(Platform::Osx64);
+        assert!(variants.is_empty());
     }
 }

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -6,6 +6,7 @@ use build_script::{BuildPlatform, BuildScriptContext};
 use config::CMakeBackendConfig;
 use miette::IntoDiagnostic;
 use pixi_build_backend::{
+    compilers::default_compiler_variants,
     generated_recipe::{DefaultMetadataProvider, GenerateRecipe, GeneratedRecipe, PythonParams},
     intermediate_backend::IntermediateBackendInstantiator,
     tools::BackendIdentifier,
@@ -176,18 +177,7 @@ impl GenerateRecipe for CMakeGenerator {
         &self,
         host_platform: Platform,
     ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
-        let mut variants = BTreeMap::new();
-
-        if host_platform.is_windows() {
-            // Default to the Visual Studio 2022 compiler on Windows
-            // Not 2019 due to Conda-forge switching and the mainstream support dropping in 2024.
-            // rattler-build will default to vs2017 which for most github runners is too
-            // old.
-            variants.insert(NormalizedKey::from("c_compiler"), vec!["vs2022".into()]);
-            variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2022".into()]);
-        }
-
-        Ok(variants)
+        Ok(default_compiler_variants(host_platform))
     }
 }
 
@@ -459,6 +449,53 @@ mod tests {
             Some(&VariantValue::from("vs2022")),
             "On windows the default cxx_compiler variant should be vs2022"
         );
+    }
+
+    #[tokio::test]
+    async fn test_default_cuda_compiler() {
+        let project_model = project_fixture!({
+            "name": "foobar",
+            "version": "0.1.0",
+        });
+
+        for platform in [Platform::Linux64, Platform::Win64] {
+            let factory = IntermediateBackendInstantiator::<CMakeGenerator>::new(
+                BackendIdentifier::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
+                LoggingOutputHandler::default(),
+                Arc::default(),
+            )
+            .initialize(InitializeParams {
+                workspace_directory: None,
+                source_directory: None,
+                manifest_path: PathBuf::from("pixi.toml"),
+                project_model: Some(project_model.clone()),
+                configuration: Some(serde_json::json!({ "compilers": ["cuda"] })),
+                target_configuration: None,
+                cache_directory: None,
+            })
+            .await
+            .unwrap();
+
+            let current_dir = std::env::current_dir().unwrap();
+            let outputs = factory
+                .0
+                .conda_outputs(CondaOutputsParams {
+                    channels: vec![],
+                    host_platform: platform,
+                    build_platform: platform,
+                    variant_configuration: None,
+                    variant_files: None,
+                    work_directory: current_dir,
+                })
+                .await
+                .unwrap();
+
+            assert_eq!(
+                outputs.outputs[0].metadata.variant.get("cuda_compiler"),
+                Some(&VariantValue::from("cuda-nvcc")),
+                "On {platform} the default cuda_compiler variant should be cuda-nvcc",
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -6,6 +6,7 @@ use config::{MojoBackendConfig, clean_project_name};
 use miette::{Error, IntoDiagnostic};
 use pixi_build_backend::generated_recipe::DefaultMetadataProvider;
 use pixi_build_backend::{
+    compilers::default_compiler_variants,
     generated_recipe::{GenerateRecipe, GeneratedRecipe, PythonParams},
     intermediate_backend::IntermediateBackendInstantiator,
     tools::BackendIdentifier,
@@ -128,18 +129,7 @@ impl GenerateRecipe for MojoGenerator {
         &self,
         host_platform: Platform,
     ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
-        let mut variants = BTreeMap::new();
-
-        if host_platform.is_windows() {
-            // Default to the Visual Studio 2022 compiler on Windows
-            // Not 2019 due to Conda-forge switching and the mainstream support dropping in 2024.
-            // rattler-build will default to vs2017 which for most github runners is too
-            // old.
-            variants.insert(NormalizedKey::from("c_compiler"), vec!["vs2022".into()]);
-            variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2022".into()]);
-        }
-
-        Ok(variants)
+        Ok(default_compiler_variants(host_platform))
     }
 }
 

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -10,6 +10,7 @@ use miette::IntoDiagnostic;
 use pixi_build_backend::variants::NormalizedKey;
 use pixi_build_backend::{
     Variable,
+    compilers::default_compiler_variants,
     generated_recipe::{GenerateRecipe, GeneratedRecipe, PythonParams},
     intermediate_backend::IntermediateBackendInstantiator,
     tools::BackendIdentifier,
@@ -449,18 +450,7 @@ impl GenerateRecipe for PythonGenerator {
         &self,
         host_platform: Platform,
     ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
-        let mut variants = BTreeMap::new();
-
-        if host_platform.is_windows() {
-            // Default to the Visual Studio 2022 compiler on Windows
-            // Not 2019 due to Conda-forge switching and the mainstream support dropping in 2024.
-            // rattler-build will default to vs2017 which for most github runners is too
-            // old.
-            variants.insert(NormalizedKey::from("c_compiler"), vec!["vs2022".into()]);
-            variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2022".into()]);
-        }
-
-        Ok(variants)
+        Ok(default_compiler_variants(host_platform))
     }
 }
 

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use config::RosBackendConfig;
 use fs_err as fs;
 use miette::IntoDiagnostic;
+use pixi_build_backend::compilers::default_compiler_variants;
 use pixi_build_backend::generated_recipe::{GenerateRecipe, GeneratedRecipe, PythonParams};
 use pixi_build_backend::intermediate_backend::IntermediateBackendInstantiator;
 use pixi_build_backend::tools::BackendIdentifier;
@@ -268,12 +269,7 @@ impl GenerateRecipe for RosGenerator {
         &self,
         host_platform: Platform,
     ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
-        let mut variants = BTreeMap::new();
-        if host_platform.is_windows() {
-            variants.insert(NormalizedKey::from("c_compiler"), vec!["vs2022".into()]);
-            variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2022".into()]);
-        }
-        Ok(variants)
+        Ok(default_compiler_variants(host_platform))
     }
 }
 

--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -10,6 +10,7 @@ use pixi_build_backend::variants::NormalizedKey;
 use pixi_build_backend::{
     Variable,
     cache::{sccache_envs, sccache_tools},
+    compilers::default_compiler_variants,
     generated_recipe::{GenerateRecipe, GeneratedRecipe, PythonParams},
     intermediate_backend::IntermediateBackendInstantiator,
     tools::BackendIdentifier,
@@ -226,18 +227,7 @@ impl GenerateRecipe for RustGenerator {
         &self,
         host_platform: Platform,
     ) -> miette::Result<BTreeMap<NormalizedKey, Vec<Variable>>> {
-        let mut variants = BTreeMap::new();
-
-        if host_platform.is_windows() {
-            // Default to the Visual Studio 2022 compiler on Windows
-            // Not 2019 due to Conda-forge switching and the mainstream support dropping in 2024.
-            // rattler-build will default to vs2017 which for most github runners is too
-            // old.
-            variants.insert(NormalizedKey::from("c_compiler"), vec!["vs2022".into()]);
-            variants.insert(NormalizedKey::from("cxx_compiler"), vec!["vs2022".into()]);
-        }
-
-        Ok(variants)
+        Ok(default_compiler_variants(host_platform))
     }
 }
 


### PR DESCRIPTION
### Description

This PR refactors compiler variant handling across all build backends by:

1. **Adding CUDA compiler support**: Introduces `"cuda" => "cuda-nvcc"` to the `default_compiler()` function, matching conda-forge's global pinning for CUDA 12+. While CUDA is only supported on Linux/Windows, the function remains platform-agnostic to simplify usage.

2. **Centralizing compiler variants logic**: Extracts the duplicated Windows compiler variant logic (VS2022 defaults) from all five backends (CMake, Mojo, Python, Rust, ROS) into a new `default_compiler_variants()` function in `pixi_build_backend::compilers`. This function now also handles CUDA compiler variants on Linux and Windows.

3. **Reducing code duplication**: All backends now call the centralized `default_compiler_variants()` function instead of maintaining their own variant logic, making future compiler changes easier to maintain.

### Changes Made

- **`crates/pixi_build_backend/src/compilers.rs`**:
  - Added `BTreeMap` import and `rattler_build_jinja::Variable` import
  - Added `"cuda" => "cuda-nvcc"` case to `default_compiler()`
  - Added new `default_compiler_variants()` function that returns platform-specific compiler variants
  - Added comprehensive unit tests for CUDA compiler and variant behavior across platforms

- **`crates/pixi_build_cmake/src/main.rs`**:
  - Replaced inline variant logic with call to `default_compiler_variants()`
  - Added integration test `test_default_cuda_compiler()` to verify CUDA variant is set correctly on Linux and Windows

- **`crates/pixi_build_mojo/src/main.rs`**:
  - Replaced inline variant logic with call to `default_compiler_variants()`

- **`crates/pixi_build_python/src/main.rs`**:
  - Replaced inline variant logic with call to `default_compiler_variants()`

- **`crates/pixi_build_rust/src/main.rs`**:
  - Replaced inline variant logic with call to `default_compiler_variants()`

- **`crates/pixi_build_ros/src/main.rs`**:
  - Replaced inline variant logic with call to `default_compiler_variants()`

### How Has This Been Tested?

- Added unit tests in `pixi_build_backend/src/compilers.rs`:
  - `test_default_compiler_cuda()`: Verifies CUDA compiler returns "cuda-nvcc" across all platforms
  - `test_default_compiler_variants_linux()`: Verifies Linux gets CUDA compiler variant only
  - `test_default_compiler_variants_windows()`: Verifies Windows gets VS2022 and CUDA variants
  - `test_default_compiler_variants_macos()`: Verifies macOS gets no default variants

- Added integration test in `pixi_build_cmake/src/main.rs`:
  - `test_default_cuda_compiler()`: Verifies CUDA variant is properly set in generated recipes on Linux and Windows

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes

https://claude.ai/code/session_01Ra4vMcwvDXuz1pe4gvE6Gz