### PR TITLE
fix: invalidate build-backend metadata cache when backend spec changes

### DIFF
--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -755,8 +755,7 @@ impl BuildBackendMetadataInner {
                 .target_configuration
                 .as_ref(),
         );
-        let backend_spec_hash =
-            BackendSpecHash::from(&checkouts.discovered_backend.backend_spec);
+        let backend_spec_hash = BackendSpecHash::from(&checkouts.discovered_backend.backend_spec);
 
         if skip_cache {
             let BackendSpec::JsonRpc(spec) = &checkouts.discovered_backend.backend_spec;

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -25,7 +25,7 @@ use crate::cache::{
 };
 use crate::compute_data::{HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter};
 use crate::injected_config::{BackendOverrideKey, EnabledProtocolsKey};
-use crate::input_hash::{ConfigurationHash, ProjectModelHash};
+use crate::input_hash::{BackendSpecHash, ConfigurationHash, ProjectModelHash};
 use crate::{
     BackendHandle, BuildEnvironment, EnvironmentRef, InstantiateBackendError,
     InstantiateBackendKey, ProjectModelOverrides, SourceCheckout, SourceCheckoutError,
@@ -271,6 +271,7 @@ impl BuildBackendMetadataInner {
         build_source_checkout: &SourceCheckout,
         project_model_hash: Option<ProjectModelHash>,
         configuration_hash: ConfigurationHash,
+        backend_spec_hash: BackendSpecHash,
         requested_variants: &BTreeMap<String, Vec<VariantValue>>,
     ) -> Result<
         Result<
@@ -295,6 +296,16 @@ impl BuildBackendMetadataInner {
         if cache_entry.configuration_hash != configuration_hash {
             tracing::info!(
                 "found cached outputs with different build configuration, invalidating cache."
+            );
+            return Ok(Err(Some(cache_entry)));
+        }
+
+        // Check the backend spec. Entries written before this field existed
+        // have `None`; treat them as stale so they get repopulated with a
+        // recorded spec hash.
+        if cache_entry.backend_spec_hash != Some(backend_spec_hash) {
+            tracing::info!(
+                "found cached outputs with different backend specification, invalidating cache."
             );
             return Ok(Err(Some(cache_entry)));
         }
@@ -605,6 +616,7 @@ enum CacheProbe {
         stale: Option<CacheEntry<BuildBackendMetadataCache>>,
         project_model_hash: Option<ProjectModelHash>,
         configuration_hash: ConfigurationHash,
+        backend_spec_hash: BackendSpecHash,
         skip_cache: bool,
     },
 }
@@ -743,6 +755,8 @@ impl BuildBackendMetadataInner {
                 .target_configuration
                 .as_ref(),
         );
+        let backend_spec_hash =
+            BackendSpecHash::from(&checkouts.discovered_backend.backend_spec);
 
         if skip_cache {
             let BackendSpec::JsonRpc(spec) = &checkouts.discovered_backend.backend_spec;
@@ -752,6 +766,7 @@ impl BuildBackendMetadataInner {
                 stale: None,
                 project_model_hash,
                 configuration_hash,
+                backend_spec_hash,
                 skip_cache,
             });
         }
@@ -761,6 +776,7 @@ impl BuildBackendMetadataInner {
             &checkouts.build_source_checkout,
             project_model_hash,
             configuration_hash,
+            backend_spec_hash,
             &self.variant_configuration,
         )
         .await?
@@ -779,6 +795,7 @@ impl BuildBackendMetadataInner {
                 stale,
                 project_model_hash,
                 configuration_hash,
+                backend_spec_hash,
                 skip_cache,
             }),
         }
@@ -794,23 +811,31 @@ impl BuildBackendMetadataInner {
     ) -> Result<BuildBackendMetadata, BuildBackendMetadataError> {
         let checkouts = self.resolve_checkouts(ctx).await?;
 
-        let (cache_key, stale, project_model_hash, configuration_hash, skip_cache) =
-            match self.probe_cache(ctx, &checkouts).await? {
-                CacheProbe::Hit(metadata) => return Ok(metadata),
-                CacheProbe::Miss {
-                    cache_key,
-                    stale,
-                    project_model_hash,
-                    configuration_hash,
-                    skip_cache,
-                } => (
-                    cache_key,
-                    stale,
-                    project_model_hash,
-                    configuration_hash,
-                    skip_cache,
-                ),
-            };
+        let (
+            cache_key,
+            stale,
+            project_model_hash,
+            configuration_hash,
+            backend_spec_hash,
+            skip_cache,
+        ) = match self.probe_cache(ctx, &checkouts).await? {
+            CacheProbe::Hit(metadata) => return Ok(metadata),
+            CacheProbe::Miss {
+                cache_key,
+                stale,
+                project_model_hash,
+                configuration_hash,
+                backend_spec_hash,
+                skip_cache,
+            } => (
+                cache_key,
+                stale,
+                project_model_hash,
+                configuration_hash,
+                backend_spec_hash,
+                skip_cache,
+            ),
+        };
 
         // Instantiate the backend. `DiscoveredBackendKey` dedups inside
         // the key, so the re-discovery is free.
@@ -897,6 +922,7 @@ impl BuildBackendMetadataInner {
             source: canonical_source,
             project_model_hash,
             configuration_hash,
+            backend_spec_hash: Some(backend_spec_hash),
             timestamp: raw.timestamp,
         };
 

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -13,7 +13,7 @@ use super::common::{
     VersionedCacheEntry, WriteResult as CommonWriteResult,
 };
 use crate::build::CanonicalSourceCodeLocation;
-use crate::input_hash::{ConfigurationHash, ProjectModelHash};
+use crate::input_hash::{BackendSpecHash, ConfigurationHash, ProjectModelHash};
 use rattler_conda_types::PackageName;
 
 use crate::BuildEnvironment;
@@ -160,6 +160,13 @@ pub struct BuildBackendMetadataCacheEntry {
     /// cache even if the project model hasn't changed.
     #[serde(default)]
     pub configuration_hash: ConfigurationHash,
+
+    /// The hash of the backend specification (name + version constraints +
+    /// channels). The backend spec is not part of the `ProjectModel`, so
+    /// without this field, changes like bumping a backend version constraint
+    /// in the manifest would not invalidate the cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_spec_hash: Option<BackendSpecHash>,
 
     /// The pinned location of the source code. Although the specification of
     /// where to find the source is part of the `project_model_hash`, the

--- a/crates/pixi_command_dispatcher/src/input_hash.rs
+++ b/crates/pixi_command_dispatcher/src/input_hash.rs
@@ -1,4 +1,5 @@
 use ordermap::OrderMap;
+use pixi_build_discovery::BackendSpec;
 use pixi_build_types::{ProjectModel, TargetSelector};
 use pixi_stable_hash::{StableHashBuilder, json::StableJson, map::StableMap};
 use serde::{Deserialize, Serialize};
@@ -11,6 +12,25 @@ pub struct ProjectModelHash(u64);
 
 impl From<&'_ ProjectModel> for ProjectModelHash {
     fn from(value: &'_ ProjectModel) -> Self {
+        let mut hasher = Xxh3::new();
+        value.hash(&mut hasher);
+        Self(hasher.finish())
+    }
+}
+
+/// A hash of the backend specification (backend name, version constraints,
+/// channels, etc.) used to instantiate the build backend.
+///
+/// The resolved backend version is not known at cache-probe time (it would
+/// require running the conda solver), so we hash the unresolved spec instead.
+/// Changes to the spec in the manifest will invalidate the cache; changes to
+/// the resolved version that originate purely from channel drift will not.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct BackendSpecHash(u64);
+
+impl From<&'_ BackendSpec> for BackendSpecHash {
+    fn from(value: &'_ BackendSpec) -> Self {
         let mut hasher = Xxh3::new();
         value.hash(&mut hasher);
         Self(hasher.finish())


### PR DESCRIPTION
### Description

The build-backend metadata cache did not include the backend specification (name, version constraint, channels) in either its key or its freshness checks. Because the backend spec is not part of `ProjectModel`, and the manifest is generally not in the input globs reported by the backend, editing only the backend version in the manifest (e.g. `*` to `0.4.*` to `0.5.*`) silently reused stale metadata.

This adds a `BackendSpecHash` of the unresolved `BackendSpec`, computed in `probe_cache` and stored on `BuildBackendMetadataCacheEntry`. It is checked alongside `project_model_hash` and `configuration_hash` in `verify_cache_freshness`. Pre-existing entries (without the field) are treated as stale and repopulated once.

The resolved backend version is intentionally not tracked: doing so would require running the conda solver before every cache probe, which is too expensive. As a consequence, channel-drift within a constraint range (same spec, newer published version) is still not caught. Only spec changes in the manifest are.

### How Has This Been Tested?

Manually: editing the backend version constraint in `pixi.toml` now invalidates the cache and triggers a fresh `conda/outputs` call, where previously the cached entry was reused.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code