### PR TITLE
test: deflake test_signal_forwarding by waiting for handler installation

### DIFF
--- a/tests/data/run_signals/test.py
+++ b/tests/data/run_signals/test.py
@@ -9,6 +9,10 @@ output_file = Path("output.txt")
 if output_file.exists():
     output_file.unlink()
 
+ready_file = Path("ready.txt")
+if ready_file.exists():
+    ready_file.unlink()
+
 
 def signal_handler(signum, frame):
     output_file.write_text(f"Signal handler called with signal {signum}\n")
@@ -19,6 +23,11 @@ def signal_handler(signum, frame):
 
 
 signal.signal(signal.SIGINT, signal_handler)
+
+# Signal to the test driver that the SIGINT handler is now installed. Without
+# this, the driver might deliver SIGINT before this line is reached, in which
+# case the default handler kills Python with exit code 130.
+ready_file.write_text("ready\n")
 
 while True:
     print("Running...\n")

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -1694,7 +1694,21 @@ def test_signal_forwarding(pixi: Path, tmp_pixi_workspace: Path) -> None:
         [pixi, "run", "--manifest-path", manifest, "start"], cwd=tmp_data_path
     )
 
-    time.sleep(1)  # wait for the process to start
+    # Wait for the child to install its SIGINT handler. Sleeping a fixed
+    # interval here is flaky on slower runners (notably macOS-aarch64): if the
+    # signal arrives before Python registers the handler, the default action
+    # kills the process with exit code 130 (128 + SIGINT).
+    ready_file = tmp_data_path.joinpath("ready.txt")
+    deadline = time.monotonic() + 30
+    while not ready_file.exists():
+        if process.poll() is not None:
+            raise AssertionError(
+                f"pixi exited before the task became ready (code {process.returncode})"
+            )
+        if time.monotonic() > deadline:
+            process.kill()
+            raise AssertionError("Timed out waiting for the task to install its SIGINT handler")
+        time.sleep(0.1)
 
     # send a SIGINT to the process
     process.send_signal(signal.SIGINT)


### PR DESCRIPTION
### Description

`test_signal_forwarding` is flaky on macos-aarch64. The test slept a fixed 1s after launching `pixi run start` and then sent SIGINT. On slower runners pixi can still be spawning the python child, or python can still be importing modules, so the signal arrives before `signal.signal(SIGINT, ...)` runs. The default handler then kills python with exit code 130 instead of the expected 12.

Fix: have `test.py` write a `ready.txt` marker right after installing the handler, and have the test poll for that marker (with a 30s budget and a process-still-alive check) before sending SIGINT.

### How Has This Been Tested?

Reasoned about the failure from the exit code (130 = 128 + SIGINT(2)) and the order of operations between `Popen` and the handler being registered. Not reproduced locally since the failure is timing-dependent and runner-specific; the change removes the timing dependency entirely.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.