### PR TITLE
fix: align `--locked` metadata serializer with lock-write side

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -20,7 +20,7 @@ use pixi_spec::Subdirectory;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
     configure_insecure_hosts_for_tls_bypass, into_pixi_reference, pypi_options_to_build_options,
-    pypi_options_to_index_locations, to_index_strategy,
+    pypi_options_to_index_locations, to_index_strategy, to_requirements,
 };
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
 use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record};
@@ -752,22 +752,16 @@ async fn read_local_package_metadata(
         }
     };
 
-    // A round-trip failure here would be a uv bug, not "static doesn't
-    // apply", so propagate rather than swallow as `Ok(None)`.
-    let requires_dist_vec: Vec<pep508_rs::Requirement> = requires_dist
-        .requires_dist
-        .iter()
-        .map(|req| {
-            req.to_string()
-                .parse::<pep508_rs::Requirement>()
-                .map_err(|e| {
-                    PlatformUnsat::FailedToReadLocalMetadata(
-                        package_name.clone(),
-                        format!("Invalid requirement: {e}"),
-                    )
-                })
-        })
-        .collect::<Result<_, _>>()?;
+    // Match the lockfile-write serializer so both sides of
+    // `compare_metadata` agree on `[tool.uv.sources]` requirements
+    // (#6049 follow-up).
+    let requires_dist_vec: Vec<pep508_rs::Requirement> =
+        to_requirements(requires_dist.requires_dist.iter()).map_err(|e| {
+            PlatformUnsat::FailedToReadLocalMetadata(
+                package_name.clone(),
+                format!("Invalid requirement: {e}"),
+            )
+        })?;
 
     let metadata = pypi_metadata::LocalPackageMetadata {
         version,

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -838,4 +838,37 @@ mod tests {
             other => panic!("expected a VersionOrUrl::Url, got {other:?}"),
         }
     }
+
+    /// Index-bearing registry sources must serialize without uv's
+    /// `(index: <url>)` `Display` suffix; `pep508_rs` rejects it (#6049).
+    #[test]
+    fn to_requirements_strips_index_suffix_from_registry_source() {
+        use std::sync::Arc;
+        use uv_distribution_types::{
+            IndexFormat, IndexMetadata, IndexUrl, Requirement as UvRequirement, RequirementSource,
+        };
+        use uv_pep508::MarkerTree;
+
+        let uv_req = UvRequirement {
+            name: uv_normalize::PackageName::from_str("isaaclab").unwrap(),
+            extras: Box::new([]),
+            groups: Box::new([]),
+            marker: MarkerTree::TRUE,
+            source: RequirementSource::Registry {
+                specifier: uv_pep440::VersionSpecifiers::empty(),
+                index: Some(IndexMetadata {
+                    url: IndexUrl::Url(Arc::new(uv_pep508::VerbatimUrl::from_url(
+                        DisplaySafeUrl::parse("https://pypi.nvidia.com/simple/").unwrap(),
+                    ))),
+                    format: IndexFormat::Simple,
+                }),
+                conflict: None,
+            },
+            origin: None,
+        };
+        assert!(uv_req.to_string().contains("(index:"));
+
+        let converted = to_requirements(std::iter::once(&uv_req)).unwrap();
+        assert_eq!(converted[0].to_string(), "isaaclab");
+    }
 }


### PR DESCRIPTION
### Description

Follow-up to #6052. When `[tool.uv.sources]` redirects an optional-dep to a named index, uv lowering tags the registry source with `index = Some(...)` and `Requirement::Display` emits ` (index: <url>)`. The lock-write path (`pixi_uv_conversions::to_requirements`) strips that suffix; the `--locked` satisfiability path was reparsing `req.to_string()` with `pep508_rs`, which rejects it. Result: `--locked` errored on a lockfile pixi had just written.

Route the satisfiability path through the same `to_requirements` helper so both sides serialize identically.

Fixes #6049 (follow-up reported by @diegoferigo-rai on rai-opensource/exploy).

### How Has This Been Tested?

- New unit test `to_requirements_strips_index_suffix_from_registry_source` constructs a `Requirement` with `index = Some(...)`, asserts uv's `Display` includes `(index:`, and pins `to_requirements` output to plain `isaaclab`.
- `cargo test -p pixi_core --lib lock_file::satisfiability`; 150 passed, no regressions on existing `test_good_satisfiability` / `test_failing_satisfiability` cases.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (claude-opus-4-7, via Claude Code on web)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.