### PR TITLE
fix: bump rust version for backends

### DIFF
--- a/pixi-build-backends/recipe/variants.yaml
+++ b/pixi-build-backends/recipe/variants.yaml
@@ -49,4 +49,4 @@ python_min:
 
 # Pin the compiler used
 rust_compiler_version:
-  - 1.90.0
+  - 1.94.0


### PR DESCRIPTION
### Description

Bump the rust version for the build backends. They were still on 1.90.0 while the rest of the repo was on 1.94.0. 

### How Has This Been Tested?

CI

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code