### PR TITLE
fix: detect BeeGFS, Lustre, GPFS and CephFS as network filesystem

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -186,16 +186,28 @@ fn detect_network_filesystem(path: &Path) -> Option<bool> {
     use nix::sys::statfs::{
         AUTOFS_SUPER_MAGIC, FUSE_SUPER_MAGIC, FsType, NFS_SUPER_MAGIC, SMB_SUPER_MAGIC,
     };
-    // CIFS magic isn't re-exported by `nix`
-    // so define it inline (fs/smb/client/cifsfs.h).
+    // Magics not re-exported by `nix` are defined inline below.
+    // CIFS: fs/smb/client/cifsfs.h
     let cifs_magic = FsType(0xff53_4d42_u32 as _);
+    // BeeGFS (a.k.a. fhgfs): client_module/source/common/Common.h
+    let beegfs_magic = FsType(0x1983_0326_u32 as _);
+    // Lustre: include/uapi/linux/lustre/lustre_user.h (LL_SUPER_MAGIC)
+    let lustre_magic = FsType(0x0bd0_0bd0_u32 as _);
+    // GPFS / IBM Spectrum Scale ("GPFS" in ASCII)
+    let gpfs_magic = FsType(0x4750_4653_u32 as _);
+    // CephFS: include/linux/magic.h (CEPH_SUPER_MAGIC)
+    let ceph_magic = FsType(0x00c3_6400_u32 as _);
     let fs = statfs_nearest_existing(path)?.filesystem_type();
     Some(
         fs == NFS_SUPER_MAGIC
             || fs == SMB_SUPER_MAGIC
             || fs == cifs_magic
             || fs == FUSE_SUPER_MAGIC
-            || fs == AUTOFS_SUPER_MAGIC,
+            || fs == AUTOFS_SUPER_MAGIC
+            || fs == beegfs_magic
+            || fs == lustre_magic
+            || fs == gpfs_magic
+            || fs == ceph_magic,
     )
 }
 
@@ -556,7 +568,8 @@ fn resolve_cache_kind_dir(cache_cfg: &CacheConfig, kind: CacheKind) -> miette::R
     let mut warned = NETFS_REDIRECT_WARNED.lock().unwrap();
     if warned.insert(kind) {
         tracing::warn!(
-            "cache for {:?} at {} is on a network filesystem (NFS/SMB/FUSE), \
+            "cache for {:?} at {} is on a network/parallel filesystem \
+             (NFS/SMB/FUSE/BeeGFS/Lustre/GPFS/CephFS), \
              redirected to {} for this run. Set [cache.{}] in config.toml or \
              PIXI_CACHE_DIR to override, or [cache.netfs-redirect] = \"never\" \
              to keep the original path.",


### PR DESCRIPTION
### Description

https://github.com/prefix-dev/pixi/issues/5439 was still present in a HPC machine with BeeGFS.

```console
$ stat -f -c '%T' $HOME
fhgfs
```

```console
$ pixi install

failed to map conda packages to their PyPI equivalents. This mapping is required when using PyPI dependencies alongside conda packages.
  ├─▶ failed to fetch conda-pypi mapping from remote source
  ├─▶ File still doesn't exist
  ╰─▶ No such file or directory (os error 2)
```

This PR makes Pixi detect BeeGFS, Lustre, GPFS and CephFS as network filesystem.

### How Has This Been Tested?

Tested on HPC machine with `fhgfs` filesystem.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: GitHub Copilot

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.

C.C. @traversaro @AriannaPietrasanta
