### PR TITLE
chore(deps): bump uv to 0.11.0 (reqwest 0.13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,8 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
 dependencies = [
- "astral-reqwest-middleware 0.5.1",
- "reqwest 0.13.3",
+ "astral-reqwest-middleware",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -167,9 +167,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arborium"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65328fda517795f476b9d1b0794199cce180077e204629946a0705f0093093"
+checksum = "66464d43ce8ad5a81f59a9dac02d33dfe384e8fe9cd334fc607a0b81699d2594"
 dependencies = [
  "arborium-highlight",
  "arborium-theme",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-highlight"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517a6778e29dc5d73d3c9993836bad9bc6fdd8bd8037fe7fd3f295e866d5cdab"
+checksum = "e3e19dccfe05568006e5919b0e157695fb4c90a6a4c07582b51454e0c85c4365"
 dependencies = [
  "arborium-theme",
  "arborium-tree-sitter",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-sysroot"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43374e79fbeaedc2bf27eed475c26686c8ed8eef2180854eef22340b9e25b64a"
+checksum = "260e0358abe4ede3af8b4df7a311bc9b6e4a60e4bd50af16deddfcd13759a908"
 dependencies = [
  "cc",
  "dlmalloc",
@@ -201,15 +201,15 @@ dependencies = [
 
 [[package]]
 name = "arborium-theme"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6dc64ecabaad99640e27c351008b1fd6df46bcfaefab6c0e315aac3247d1d9"
+checksum = "747d16e6679f93cd84e7a9e8e47bec0055eb900fd3caaa3f3c2bbb31286e6c8d"
 
 [[package]]
 name = "arborium-toml"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069ccfccf82bc3698431d3845b0398249c331898c04f6bb2c01a465d92821780"
+checksum = "2719568f38f8a6635b21258cff7860cd549ae57c84c29e1dec041c0e6317ab75"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "arborium-tree-sitter"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a9280a27a2fd42ffbf3b72b99d60122f2c28c55c16c39da8ba2d126d1856c4"
+checksum = "4879b6a79798d45d29d54bf000fd4d1b88a8e654e0b0cb762ac402944129233b"
 dependencies = [
  "arborium-sysroot",
  "cc",
@@ -296,21 +296,6 @@ dependencies = [
 
 [[package]]
 name = "astral-reqwest-middleware"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.4.0",
- "reqwest 0.12.28",
- "serde",
- "thiserror 2.0.18",
- "tower-service",
-]
-
-[[package]]
-name = "astral-reqwest-middleware"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9"
@@ -318,7 +303,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -326,18 +311,18 @@ dependencies = [
 
 [[package]]
 name = "astral-reqwest-retry"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ab210f6cdf8fd3254d47e5ee27ce60ed34a428ff71b4ae9477b1c84b49498c"
+checksum = "48c76a42c052d7a95249b90b83d44e8f1bbde7c8e08dbed50d49c58321815da3"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-trait",
  "futures",
  "getrandom 0.2.17",
  "http 1.4.0",
  "hyper 1.9.0",
- "reqwest 0.12.28",
+ "reqwest",
  "retry-policies",
  "thiserror 2.0.18",
  "tokio",
@@ -381,18 +366,37 @@ dependencies = [
 
 [[package]]
 name = "astral_async_http_range_reader"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3"
+checksum = "7ab9a05148c7b3e85c17806fef4b2889c44f1a60575c5da9e9be80ce13227185"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "bisection",
  "futures",
  "http-content-range",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memmap2 0.9.10",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.18",
+ "tracing",
+]
+
+[[package]]
+name = "astral_async_http_range_reader"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
+dependencies = [
+ "astral-reqwest-middleware",
+ "futures",
+ "http-content-range",
+ "itertools 0.14.0",
+ "memmap2 0.9.10",
+ "reqwest",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.18",
@@ -667,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -678,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1001,6 +1005,7 @@ checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -1232,15 +1237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bisection"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1359,15 @@ name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -1668,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -1750,12 +1755,21 @@ dependencies = [
 
 [[package]]
 name = "coalesced_map"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf5a7a58a9d5b914bddb0a3a2bd920af2be897114dc8128af022af81fc43b8b"
+checksum = "b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de"
 dependencies = [
  "dashmap",
  "tokio",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2145,7 +2159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2660,6 +2674,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,9 +2870,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "file_url"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e546758dbcde9d10c0d3bd8b83adb535b23fa81121cf4dc5c3e7b5907cc8eb8"
+checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -2857,13 +2883,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -3297,7 +3322,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 1.4.0",
- "reqwest 0.13.3",
+ "reqwest",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
@@ -3444,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -3519,15 +3544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,46 +3609,54 @@ dependencies = [
 
 [[package]]
 name = "http-cache"
-version = "0.21.0"
+version = "1.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1437561a949a2168929d7559aecd2f0ecb18b9e676080396388cdc399ddb723a"
+checksum = "d01e0b5d3afe17eadd68dad863adc0715b7ccfa887effbb9ea4de3c7c78c6c44"
 dependencies = [
- "async-trait",
- "bincode",
+ "bytes",
  "cacache",
+ "futures",
+ "hex",
  "http 1.4.0",
+ "http-body 1.0.1",
  "http-cache-semantics",
  "httpdate",
+ "log",
+ "pin-project-lite",
+ "postcard",
  "serde",
+ "tokio",
  "url",
 ]
 
 [[package]]
 name = "http-cache-reqwest"
-version = "0.16.0"
+version = "1.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886"
+checksum = "3ff1fa00fd5b0d38c26d5f24f1cf513e286a988b57880c2bf357304669268fa3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "http-cache",
  "http-cache-semantics",
- "reqwest 0.12.28",
+ "reqwest",
  "reqwest-middleware",
- "serde",
  "url",
 ]
 
 [[package]]
 name = "http-cache-semantics"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129"
+checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
 dependencies = [
  "http 1.4.0",
  "http-serde",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "time",
 ]
@@ -3688,9 +3712,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -3755,7 +3779,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3985,7 +4008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -4156,10 +4179,12 @@ checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "wasm-bindgen",
  "windows-sys 0.61.2",
 ]
 
@@ -4497,17 +4522,20 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -4586,9 +4614,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "f8fc329e1457d97a9d58a4e2ca49e3be572431a7e096008efc2e3a3c19d428f4"
 
 [[package]]
 name = "libc"
@@ -4636,10 +4664,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -4783,6 +4808,15 @@ checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if 1.0.4",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6747f54621d156e1b47eb6b25f39a941b9fc347f98f67d25d8881ff99e8ed832"
+dependencies = [
+ "slab",
 ]
 
 [[package]]
@@ -5069,9 +5103,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
@@ -5252,13 +5286,22 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "oauth2-reqwest"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
+dependencies = [
+ "oauth2",
+ "reqwest",
 ]
 
 [[package]]
@@ -5318,9 +5361,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.4"
+version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
 dependencies = [
  "is-wsl",
  "libc",
@@ -5329,31 +5372,88 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+dependencies = [
+ "opendal-core",
+ "opendal-layer-retry",
+ "opendal-service-fs",
+ "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
 dependencies = [
  "anyhow",
- "backon",
  "base64 0.22.1",
  "bytes",
- "crc32c",
  "futures",
- "getrandom 0.2.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "jiff",
  "log",
  "md-5 0.10.6",
+ "mea",
  "percent-encoding",
  "quick-xml 0.38.4",
- "reqsign 0.16.5",
- "reqwest 0.12.28",
+ "reqsign-core",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "url",
  "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0be0417abeeb0053376d816b90fceb9ca98f20dfb54ebf1f2a282729f83663"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
+]
+
+[[package]]
+name = "opendal-service-s3"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "http 1.4.0",
+ "log",
+ "md-5 0.10.6",
+ "opendal-core",
+ "quick-xml 0.38.4",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -5389,15 +5489,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5421,9 +5520,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -5619,9 +5718,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "path_resolver"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde05d7ef24e5a8818baa86a291018e17992292794f8d11ea2f5e9e1c33fb197"
+checksum = "f66ecbc7712c675098e4a2c0075dd93e2140a4ca22a5a270fc8a9740eea907fa"
 dependencies = [
  "ahash",
  "fs-err",
@@ -5765,18 +5864,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5810,7 +5909,7 @@ dependencies = [
 name = "pixi"
 version = "0.68.1"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-trait",
  "chrono",
  "dunce",
@@ -5842,7 +5941,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_lock",
  "rattler_virtual_packages",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "temp-env",
  "tempfile",
@@ -5928,7 +6027,7 @@ dependencies = [
  "pyproject-toml",
  "rattler_build_recipe",
  "rattler_conda_types",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "spdx 0.10.9",
@@ -6004,7 +6103,7 @@ dependencies = [
  "rattler_build_types",
  "rattler_conda_types",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "roxmltree",
  "serde",
  "serde_json",
@@ -6234,7 +6333,7 @@ name = "pixi_cli"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "chrono",
  "clap",
  "clap_complete",
@@ -6296,7 +6395,7 @@ dependencies = [
  "rattler_upload",
  "rattler_virtual_packages",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "self-replace",
  "serde",
  "serde_json",
@@ -6492,7 +6591,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_networking",
  "rattler_repodata_gateway",
- "reqwest 0.12.28",
+ "reqwest",
  "rstest",
  "serde",
  "serde_ignored",
@@ -6658,13 +6757,13 @@ dependencies = [
 name = "pixi_git"
 version = "0.0.1"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "dashmap",
  "dunce",
  "fs-err",
  "pixi_utils",
  "rattler_networking",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -7088,7 +7187,7 @@ dependencies = [
 name = "pixi_url"
 version = "0.1.0"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "axum",
  "bzip2 0.6.1",
  "dashmap",
@@ -7101,7 +7200,7 @@ dependencies = [
  "pixi_utils",
  "rattler_digest",
  "rattler_networking",
- "reqwest 0.12.28",
+ "reqwest",
  "sevenz-rust2 0.21.0",
  "tar",
  "tempfile",
@@ -7118,7 +7217,7 @@ dependencies = [
 name = "pixi_utils"
 version = "0.1.0"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "async-fd-lock",
  "fs-err",
@@ -7135,10 +7234,12 @@ dependencies = [
  "rattler_conda_types",
  "rattler_networking",
  "rattler_shell",
- "reqwest 0.12.28",
+ "reqwest",
  "retry-policies",
  "rlimit",
  "rstest",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7149,6 +7250,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uv-configuration",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
@@ -7160,7 +7262,7 @@ dependencies = [
  "pixi_config",
  "pixi_utils",
  "pixi_uv_conversions",
- "reqwest 0.12.28",
+ "reqwest",
  "tracing",
  "uv-cache",
  "uv-client",
@@ -7319,6 +7421,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
 ]
 
 [[package]]
@@ -7508,7 +7622,7 @@ dependencies = [
 name = "pypi_mapping"
 version = "0.1.0"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "async-once-cell",
  "dashmap",
@@ -7523,7 +7637,7 @@ dependencies = [
  "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7575,7 +7689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -7595,6 +7708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -7782,12 +7896,12 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc96a27d6c39b6d2a22aa4bef52b2cf37077761ecb209f5ebd92657593a7189"
+checksum = "58df048747f10ce69c599a58c69c66d2dca1f197820d44085f8f354cc15cf21c"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "clap",
  "console",
  "digest 0.10.7",
@@ -7801,6 +7915,7 @@ dependencies = [
  "itertools 0.14.0",
  "memchr",
  "memmap2 0.9.10",
+ "oauth2-reqwest",
  "once_cell",
  "open",
  "openidconnect",
@@ -7816,7 +7931,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "simple_spawn_blocking",
@@ -7832,11 +7947,11 @@ dependencies = [
 [[package]]
 name = "rattler_build_core"
 version = "0.2.4"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "anyhow",
  "arwen-codesign",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-once-cell",
  "async-recursion",
  "chrono",
@@ -7889,7 +8004,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "retry-policies",
  "scroll",
  "serde",
@@ -7916,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_jinja"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -7937,19 +8052,19 @@ dependencies = [
 [[package]]
 name = "rattler_build_networking"
 version = "0.1.5"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "rattler_networking",
- "reqwest 0.12.28",
+ "reqwest",
  "url",
 ]
 
 [[package]]
 name = "rattler_build_recipe"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "fs-err",
  "globset",
@@ -7982,7 +8097,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_script"
 version = "0.2.3"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "clap",
  "console",
@@ -8004,9 +8119,9 @@ dependencies = [
 [[package]]
 name = "rattler_build_source_cache"
 version = "0.1.5"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "async-trait",
  "bzip2 0.6.1",
@@ -8022,7 +8137,7 @@ dependencies = [
  "rattler_build_networking",
  "rattler_git",
  "rattler_prefix_guard",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sevenz-rust2 0.20.2",
@@ -8042,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_types"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "globset",
  "itertools 0.14.0",
@@ -8057,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_variant_config"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -8077,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_yaml_parser"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#dc88d71059389a6d9bbd82cd50c75aff340cc89c"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#954057dfa446d572f923293b02c4c6b906414c5e"
 dependencies = [
  "marked-yaml",
  "miette 7.6.0",
@@ -8088,13 +8203,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fb0beb355779982d60ffaf71d5330e1cafa31c7a5be8bf33c4ca597477cf03"
+checksum = "4ba5153911039b1d767cbab2c11b4196beed45a0a468d0e2bfcd1e8c58311db6"
 dependencies = [
  "ahash",
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "dashmap",
  "digest 0.10.7",
  "dirs",
@@ -8109,7 +8224,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "simple_spawn_blocking",
  "tempfile",
@@ -8121,9 +8236,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.1"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce168319aa4284a026df19b0054bab8609e3447937f43ef1a496b7af6984324"
+checksum = "64da4e037cd8222078ab202d02db49906c870faaed91af4716655734eaa3ebd2"
 dependencies = [
  "ahash",
  "chrono",
@@ -8164,9 +8279,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc4ebf96d305f8ae35b112f4a2362ec388f4ac74668b261af8587b44fc9bdb"
+checksum = "683b0151673468245567a9c6c037f5bffefab61b57a00bf2a850edb395d73476"
 dependencies = [
  "console",
  "fs-err",
@@ -8182,9 +8297,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbab3541bf7e471550c91b70dad8edf392ffa9f57c6b0de4bbe6dd2c6c0d53d4"
+checksum = "c6aa7ce6d5987615eb799fd7b7d236151f199229145b823f056e13475bdc23ba"
 dependencies = [
  "blake2",
  "digest 0.10.7",
@@ -8201,16 +8316,16 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9751120c5ed52b3f3073926c8ef3c503607e6380ef0cb95fdcaaf0252ed8e9f1"
+checksum = "373265099ab8b2b816b30e0f8db4cddb6b8364be0a04bc9bdaa21c5ad3fe8943"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "dashmap",
  "dunce",
  "fs-err",
  "rattler_prefix_guard",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -8222,9 +8337,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c631860846fe6f7b5b4be414d914bb7980c95b80074cb570e30b4a52030bff"
+checksum = "079ad5ff6ff4014ae45e2e877a13fb3c2c5b98ad9a5971120cda4f5b3ba2a8df"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8243,7 +8358,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_s3",
- "reqwest 0.12.28",
+ "reqwest",
  "retry-policies",
  "rmp-serde",
  "serde",
@@ -8260,9 +8375,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da24ba278ee65caaaf4aa9ebf823fe2bb67740be76905bcf3617ce03ae158a23"
+checksum = "af3c6773c6c8f35f5b35abfcfea1196a768f5c064e332b63659e9d18d7fe43d1"
 dependencies = [
  "ahash",
  "chrono",
@@ -8289,9 +8404,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677367cf07dd4ca5b863a91cf060feea246f3b23d50af9e9fadf980db760d270"
+checksum = "46e38cd777a0ba85cf223b966b4893a12112621ba576e9273e5473dc90870530"
 dependencies = [
  "quote",
  "syn",
@@ -8299,9 +8414,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.59"
+version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4874d056de91e23bf2c02c827fd8a7557d6e4ba032fdf6800efbe3ea9ff127dd"
+checksum = "e027414b2e3a59614046f82363b0fa409fc270dbf1af8245a69a62a1a0886078"
 dependencies = [
  "chrono",
  "configparser",
@@ -8330,12 +8445,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.12"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17840c3642ef185ead62f4b7be5672fd6ab6c9ffeb9ce74cb1509d50eecbe96c"
+checksum = "59ebad9b8ea8faeaeb313039b634a4e4506e595d82fda2a621ec6aab6f48cf17"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-once-cell",
  "async-trait",
  "aws-config",
@@ -8351,7 +8466,7 @@ dependencies = [
  "keyring",
  "netrc-rs",
  "rattler_config",
- "reqwest 0.12.28",
+ "reqwest",
  "retry-policies",
  "serde",
  "serde_json",
@@ -8364,13 +8479,13 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8321ca30ccd49fed1c000d981a1d0f786f8b365c119b7c8bdd5f0bdbd870f04c"
+checksum = "8ee65f748ab93c2c022224824f8e75424a721dfc0e90f305675f735a97b465d0"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-tokio-tar",
- "astral_async_http_range_reader",
+ "astral_async_http_range_reader 0.11.0",
  "astral_async_zip",
  "async-compression",
  "async-spooled-tempfile",
@@ -8387,7 +8502,7 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
- "reqwest 0.12.28",
+ "reqwest",
  "serde_json",
  "simple_spawn_blocking",
  "tar",
@@ -8403,9 +8518,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_prefix_guard"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e61233ecc4db99035f4f97e378e971d4998b45b3bb5fb894350e04b05f8bb97"
+checksum = "d083796e99a8dbe46fdd5dbde5c853ce532d43419959f3c51578f9f59ada860d"
 dependencies = [
  "fs-err",
  "libc",
@@ -8417,9 +8532,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da10b7f974ce38eaf00e0e1d29c13151fa10fa003ec03606bc1bf76e4d537dfd"
+checksum = "e4663669232f9715a8eb9e754c34395c1b3684a8a3d2219cc6b275c17e72a57b"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -8429,24 +8544,24 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.15"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a5b2b5dc702c69f60fbf9ebf6bfe751854069918b24c48f64873ae31b72b84"
+checksum = "72675ff7378b65033fccd4ae69e2de987bec70fb2077aee520782c64081b89e7"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
- "reqwest 0.12.28",
+ "astral-reqwest-middleware",
+ "reqwest",
  "url",
 ]
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6236f9cefc9a3219a2570d32d2250168d314faf2741e9bafd0c2f1feb3b984"
+checksum = "396c2366353e95f64dcad91c625d27955b99772c2b57b600fd6b4de17dc00ac3"
 dependencies = [
  "ahash",
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-compression",
  "async-fd-lock",
  "async-trait",
@@ -8480,7 +8595,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_redaction",
- "reqwest 0.12.28",
+ "reqwest",
  "retry-policies",
  "rmp-serde",
  "self_cell",
@@ -8503,9 +8618,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.35"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7a29648b1a9d755e94a8fc0eacfe2aafd9f20b8de592627d83218459538c9b"
+checksum = "ff58b1a80e7e6599052c3e5232d8f21f37747815f671033432e640038cb6d98c"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -8520,9 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.26.12"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7bca1c7fd2a6fac62f9716cfcf3967b1360c9a42ad5ab09759f34bba532a7"
+checksum = "45fa52ceb2c5971a0f5374462d0e4d433b6c06c9e058a05796577f7d32ff2b81"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8542,9 +8657,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "6.0.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1b27732702160735cc8e81eccbf42209bd503b6fad471e8215713e97ac00f0"
+checksum = "3a782423a7c61208d321c09b3e7f50a442e3c513b5a49f118fb926c97eb6f366"
 dependencies = [
  "chrono",
  "futures",
@@ -8561,11 +8676,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e7d50915a0d37f97b2b353b175e5290c6bf11c8511454f73861c26fb9da487"
+checksum = "5b8e032b2ab3cf41347cd64d7ef9d91f57f1bec80880c49425bcb9d9418d3ab5"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "base64 0.22.1",
  "clap",
@@ -8582,7 +8697,7 @@ dependencies = [
  "rattler_redaction",
  "rattler_s3",
  "rattler_solve",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -8598,9 +8713,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.3.21"
+version = "2.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de0c7bae6b12ebc6ca640e97cc6be1f49609cd716d1af520cba2a7faffcad73"
+checksum = "bfc63ffd890d9232e9c13297e308c0b294c73e655cf3e4533bfa50df3edffed1"
 dependencies = [
  "archspec",
  "libloading",
@@ -8649,15 +8764,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -8772,38 +8878,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.16.5"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "form_urlencoded",
- "getrandom 0.2.17",
- "hex",
- "hmac 0.12.1",
- "home",
- "http 1.4.0",
- "log",
- "percent-encoding",
- "quick-xml 0.37.5",
- "rand 0.8.6",
- "reqwest 0.12.28",
- "rust-ini",
- "serde",
- "serde_json",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "tokio",
-]
-
-[[package]]
-name = "reqsign"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea386ba750000b6e59f760a08bdcca9461809b95e6f8f209ce5724056802824f"
+checksum = "2f343280e2e5ce07f97f32ead07a68824cb9cea60093ad78f22664011f90ae47"
 dependencies = [
  "reqsign-aws-v4",
  "reqsign-command-execute-tokio",
@@ -8815,18 +8892,17 @@ dependencies = [
 
 [[package]]
 name = "reqsign-aws-v4"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab367a07c335a3eaa22395a9d9b0031ac73aee5893573281b2fa27bf97dc94f2"
+checksum = "44eaca382e94505a49f1a4849658d153aebf79d9c1a58e5dd3b10361511e9f43"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "form_urlencoded",
  "http 1.4.0",
  "log",
  "percent-encoding",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "reqsign-core",
  "rust-ini",
  "serde",
@@ -8837,26 +8913,25 @@ dependencies = [
 
 [[package]]
 name = "reqsign-command-execute-tokio"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90eac3cf53a53139831e3fb8ff2189d54059d2191122a31ebd1229a66e338b3d"
+checksum = "fc4e0330fd26f72c7c6c4f09ab23fdf424b2a669ffdacc562803b2b3eecc7198"
 dependencies = [
- "async-trait",
  "reqsign-core",
  "tokio",
 ]
 
 [[package]]
 name = "reqsign-core"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba66eb941c0f723269a394baf3b19a2fa697a1e593f3e902779df6c35d24e21"
+checksum = "b10302cf0a7d7e7352ba211fc92c3c5bebf1286153e49cc5aa87348078a8e102"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
+ "futures",
  "hex",
  "hmac 0.12.1",
  "http 1.4.0",
@@ -8870,58 +8945,56 @@ dependencies = [
 
 [[package]]
 name = "reqsign-file-read-tokio"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702f12a867bf8e507de907fa0f4d75b96469ace7edd33fcc1fc8a8ef58f3c8d2"
+checksum = "e2d89295b3d17abea31851cc8de55d843d89c52132c864963c38d41920613dc5"
 dependencies = [
  "anyhow",
- "async-trait",
  "reqsign-core",
  "tokio",
 ]
 
 [[package]]
 name = "reqsign-google"
-version = "2.0.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee8b90b1c8bb30a9abb9a9778c7862d94459a9391396e1c2a370d6b9c1e3d5"
+checksum = "35cc609b49c69e76ecaceb775a03f792d1ed3e7755ab3548d4534fd801e3242e"
 dependencies = [
- "async-trait",
  "form_urlencoded",
  "http 1.4.0",
  "jsonwebtoken",
  "log",
  "percent-encoding",
- "rand 0.8.6",
+ "reqsign-aws-v4",
  "reqsign-core",
  "rsa",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tokio",
 ]
 
 [[package]]
 name = "reqsign-http-send-reqwest"
-version = "2.0.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46186bce769674f9200ad01af6f2ca42de3e819ddc002fff1edae135bfb6cd9c"
+checksum = "46db7dfc9632310d2bdc7978c2e217187cd814842da66b3daf20a45f4e8a1e5e"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "futures-channel",
  "http 1.4.0",
  "http-body-util",
  "reqsign-core",
- "reqwest 0.12.28",
+ "reqwest",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8946,8 +9019,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8964,56 +9037,13 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "h2",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.99"
+version = "0.5.99"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
 ]
 
 [[package]]
@@ -9035,11 +9065,11 @@ dependencies = [
 
 [[package]]
 name = "retry-policies"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.9.4",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -9085,7 +9115,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "munge",
  "ptr_meta",
@@ -9800,11 +9830,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -9819,9 +9850,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -10068,7 +10099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60b95ecc87b2e279705e4a617cfb2d668bb9dfb15b3a99322524b6f44a4201b"
 dependencies = [
  "base64 0.22.1",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -10100,7 +10131,7 @@ dependencies = [
  "ambient-id",
  "base64 0.22.1",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -10118,7 +10149,7 @@ checksum = "641fdaaa40d0cd6e249cf1671c2240beff1a3ece578062cf43e750779e8db2b3"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -10181,7 +10212,7 @@ dependencies = [
  "der 0.7.10",
  "hex",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "rustls-pki-types",
  "rustls-webpki",
  "sigstore-crypto",
@@ -11010,7 +11041,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -11080,7 +11111,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -11089,7 +11120,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -11474,12 +11505,12 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
  "arcstr",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-trait",
  "base64 0.22.1",
  "etcetera",
@@ -11488,8 +11519,8 @@ dependencies = [
  "http 1.4.0",
  "jiff",
  "percent-encoding",
- "reqsign 0.18.1",
- "reqwest 0.12.28",
+ "reqsign",
+ "reqwest",
  "rust-netrc",
  "rustc-hash",
  "schemars 1.2.1",
@@ -11514,8 +11545,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11554,8 +11585,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11591,8 +11622,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11617,8 +11648,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11633,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "hex",
  "memchr",
@@ -11646,14 +11677,14 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "astral-tl",
- "astral_async_http_range_reader",
+ "astral_async_http_range_reader 0.10.0",
  "astral_async_zip",
  "async-trait",
  "bytecheck",
@@ -11665,10 +11696,12 @@ dependencies = [
  "itertools 0.14.0",
  "jiff",
  "percent-encoding",
- "reqwest 0.12.28",
+ "reqwest",
  "rkyv",
  "rmp-serde",
  "rustc-hash",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -11697,18 +11730,19 @@ dependencies = [
  "uv-torch",
  "uv-version",
  "uv-warnings",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "clap",
  "either",
  "fs-err",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc-hash",
  "same-file",
  "schemars 1.2.1",
@@ -11733,16 +11767,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11752,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
  "futures",
@@ -11785,17 +11819,17 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "either",
  "fs-err",
  "futures",
  "nanoid 0.4.0",
  "owo-colors",
- "reqwest 0.12.28",
+ "reqwest",
  "rmp-serde",
  "rustc-hash",
  "serde",
@@ -11834,8 +11868,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11851,8 +11885,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11891,8 +11925,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11903,7 +11937,7 @@ dependencies = [
  "md-5 0.10.6",
  "rayon",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc-hash",
  "sha2 0.10.9",
  "tar",
@@ -11923,16 +11957,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "backon",
  "clap",
@@ -11961,16 +11995,16 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "cargo-util",
  "dashmap",
  "fs-err",
  "owo-colors",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11987,8 +12021,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12000,8 +12034,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12014,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "configparser",
  "csv",
@@ -12049,8 +12083,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12091,8 +12125,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12106,8 +12140,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12117,8 +12151,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12135,8 +12169,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12146,8 +12180,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "dashmap",
  "futures",
@@ -12156,16 +12190,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12178,8 +12212,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12192,6 +12226,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "smallvec",
+ "temp-env",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
  "url",
@@ -12204,8 +12239,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12223,8 +12258,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12237,8 +12272,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12248,8 +12283,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12279,11 +12314,11 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "clap",
  "configparser",
@@ -12296,7 +12331,7 @@ dependencies = [
  "owo-colors",
  "ref-cast",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rmp-serde",
  "rustc-hash",
  "same-file",
@@ -12338,8 +12373,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12350,8 +12385,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12385,13 +12420,13 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "fs-err",
  "memchr",
- "reqwest 0.12.28",
+ "reqwest",
  "rustc-hash",
  "thiserror 2.0.18",
  "tracing",
@@ -12410,8 +12445,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12475,8 +12510,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12501,8 +12536,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "clap",
  "fs-err",
@@ -12536,12 +12571,12 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
  "fs-err",
- "nix 0.31.2",
+ "nix 0.31.3",
  "same-file",
  "tracing",
  "uv-fs",
@@ -12552,8 +12587,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12563,8 +12598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12573,8 +12608,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12582,8 +12617,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "clap",
  "either",
@@ -12603,8 +12638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12616,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12639,13 +12674,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.10.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.11.0"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "console",
  "fs-err",
@@ -12666,8 +12701,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12676,8 +12711,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.32"
-source = "git+https://github.com/astral-sh/uv?tag=0.10.12#00d72dac7b789d1c64ed21626175b80f4a1b8f2b"
+version = "0.0.33"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
 dependencies = [
  "clap",
  "fs-err",
@@ -12916,9 +12951,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -12987,15 +13022,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -13579,9 +13605,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -13907,7 +13933,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zbus_macros 5.15.0",
  "zbus_names 4.3.2",
  "zvariant 5.11.0",
@@ -13959,7 +13985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant 5.11.0",
 ]
 
@@ -13985,9 +14011,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -14149,7 +14175,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant_derive 5.11.0",
  "zvariant_utils 3.3.1",
 ]
@@ -14201,5 +14227,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ fs_extra = "1.3.0"
 futures = "0.3.31"
 hex = "0.4.3"
 http = "1.3.1"
-http-cache-reqwest = "0.16.0"
+http-cache-reqwest = "1.0.0-alpha.6"
 human_bytes = "0.4.3"
 humantime = "2.1.0"
 indexmap = "2.10.0"
@@ -75,7 +75,7 @@ jsonrpc-http-server = "18.0.0"
 jsonrpc-stdio-server = "18.0.0"
 jsonrpsee = "=0.26.0"
 libc = { version = "0.2.170", default-features = false }
-memchr = "2.7.4"
+memchr = "2.8"
 miette = { version = "7.6.0" }
 minijinja = "2.15.1"
 nanoid = "0.5.0"
@@ -138,12 +138,14 @@ pyproject-toml = "0.13.7"
 
 rayon = "1.10.0"
 regex = "1.11.1"
-reqwest = { version = "0.12.12", default-features = false }
+reqwest = { version = "0.13", default-features = false }
 retry-policies = "0.5"
+rustls-native-certs = "0.8"
+rustls-pki-types = "1"
 roxmltree = "0.21.0"
 bzip2 = "0.6.1"
-reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.4.2", features = ["multipart"] }
-reqwest-retry = { package = "astral-reqwest-retry", version = "0.8.0" }
+reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5", features = ["multipart"] }
+reqwest-retry = { package = "astral-reqwest-retry", version = "0.9" }
 rlimit = "0.11.0"
 rstest = "0.26.0"
 same-file = "1.0.6"
@@ -182,36 +184,36 @@ xz2 = "0.1.7"
 tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
-# Bumping this to a higher version breaks the Windows path handling.
-url = "2.5.4"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.10.12" }
+url = "2.5"
+webpki-root-certs = "1"
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }
@@ -219,31 +221,31 @@ zstd = { version = "0.13.3", default-features = false }
 
 # Rattler crates
 file_url = "0.3.0"
-rattler = { version = "0.42.0", default-features = false }
-rattler_cache = { version = "0.7.0", default-features = false }
-rattler_conda_types = { version = "0.46.0", default-features = false, features = [
+rattler = { version = "0.43", default-features = false }
+rattler_cache = { version = "0.8", default-features = false }
+rattler_conda_types = { version = "0.46", default-features = false, features = [
   "rayon",
 ] }
-rattler_digest = { version = "1.2.3", default-features = false }
-rattler_index = { version = "0.28.0", default-features = false, features = [
+rattler_digest = { version = "1.2", default-features = false }
+rattler_index = { version = "0.29", default-features = false, features = [
   "s3",
 ] }
-rattler_lock = { version = "0.30.0", default-features = false }
-rattler_menuinst = { version = "0.2.53", default-features = false }
-rattler_networking = { version = "0.26.6", default-features = false, features = [
+rattler_lock = { version = "0.30", default-features = false }
+rattler_menuinst = { version = "0.2", default-features = false }
+rattler_networking = { version = "0.27", default-features = false, features = [
   "dirs",
   "google-cloud-auth",
 ] }
-rattler_package_streaming = { version = "0.25.0", default-features = false }
-rattler_repodata_gateway = { version = "0.28.1", default-features = false }
-rattler_s3 = { version = "0.1.29", default-features = false }
-rattler_shell = { version = "0.26.6", default-features = false }
-rattler_solve = { version = "6.0.0", default-features = false }
-rattler_upload = { version = "0.6.0", default-features = false, features = [
+rattler_package_streaming = { version = "0.26", default-features = false }
+rattler_repodata_gateway = { version = "0.29", default-features = false }
+rattler_s3 = { version = "0.2", default-features = false }
+rattler_shell = { version = "0.27", default-features = false }
+rattler_solve = { version = "7", default-features = false }
+rattler_upload = { version = "0.7", default-features = false, features = [
   "s3",
   "sigstore-sign",
 ] }
-rattler_virtual_packages = { version = "2.3.15", default-features = false }
+rattler_virtual_packages = { version = "2.3", default-features = false }
 simple_spawn_blocking = { version = "1.1.0", default-features = false }
 
 # Rattler build crates
@@ -262,7 +264,7 @@ version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "d8efd776
 # `astral-reqwest-middleware`. This unifies the `Middleware` trait identity
 # between consumers that depend on the original crate name (e.g.
 # `http-cache-reqwest`) and consumers that depend on the renamed
-# `astral-reqwest-middleware` (rattler, rattler-build, uv >= 0.9.10).
+# `astral-reqwest-middleware` (rattler, rattler-build, uv).
 reqwest-middleware = { path = "patches/reqwest_middleware_shim" }
 
 # Temporary patch: rattler-build main has been updated to use the new rattler

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -10,11 +10,11 @@ repository.workspace = true
 version = "0.68.1"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_cli/native-tls"]
 # run tests connecting to remote Internet services
 online_tests = ["pixi_cli/online_tests"]
-rustls-tls = ["pixi_cli/rustls-tls"]
+rustls = ["pixi_cli/rustls"]
 self_update = ["pixi_cli/self_update"]
 slow_integration_tests = ["pixi_cli/slow_integration_tests"]
 tokio-console = ["pixi_cli/tokio-console", "tokio/tracing"]

--- a/crates/pixi_auth/Cargo.toml
+++ b/crates/pixi_auth/Cargo.toml
@@ -10,9 +10,9 @@ repository.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["rattler_networking/native-tls"]
-rustls-tls = ["rattler_networking/rustls-tls"]
+rustls = ["rattler_networking/rustls"]
 
 [dependencies]
 pixi_config = { workspace = true }

--- a/crates/pixi_build_backend/Cargo.toml
+++ b/crates/pixi_build_backend/Cargo.toml
@@ -5,9 +5,9 @@ name = "pixi_build_backend"
 version = "0.1.7"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 # Use rustls for TLS (pure Rust implementation)
-rustls-tls = ["rattler_build_core/rustls-tls"]
+rustls = ["rattler_build_core/rustls"]
 # Use native-tls/OpenSSL for TLS
 native-tls = ["rattler_build_core/native-tls"]
 

--- a/crates/pixi_build_cmake/Cargo.toml
+++ b/crates/pixi_build_cmake/Cargo.toml
@@ -9,9 +9,9 @@ version = "0.3.12"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls", "rattler_build_core/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls", "rattler_build_core/rustls-tls"]
+rustls = ["pixi_build_backend/rustls", "rattler_build_core/rustls"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/pixi_build_mojo/Cargo.toml
+++ b/crates/pixi_build_mojo/Cargo.toml
@@ -8,9 +8,9 @@ version = "0.1.12"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls"]
+rustls = ["pixi_build_backend/rustls"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -8,9 +8,9 @@ version = "0.5.0"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls"]
+rustls = ["pixi_build_backend/rustls"]
 slow_integration_tests = []
 
 [dependencies]

--- a/crates/pixi_build_r/Cargo.toml
+++ b/crates/pixi_build_r/Cargo.toml
@@ -9,9 +9,9 @@ version = "0.1.1"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls"]
+rustls = ["pixi_build_backend/rustls"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/pixi_build_rattler_build/Cargo.toml
+++ b/crates/pixi_build_rattler_build/Cargo.toml
@@ -8,9 +8,9 @@ version = "0.3.11"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls", "rattler_build_core/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls", "rattler_build_core/rustls-tls"]
+rustls = ["pixi_build_backend/rustls", "rattler_build_core/rustls"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -10,9 +10,9 @@ version = "0.4.1"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls"]
+rustls = ["pixi_build_backend/rustls"]
 slow_integration_tests = []
 
 [dependencies]

--- a/crates/pixi_build_rust/Cargo.toml
+++ b/crates/pixi_build_rust/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.4.9"
 dist = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls"]
-rustls-tls = ["pixi_build_backend/rustls-tls"]
+rustls = ["pixi_build_backend/rustls"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -78,7 +78,7 @@ rattler_virtual_packages = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [
   "http2",
-  "macos-system-configuration",
+  "system-proxy",
 ] }
 reqwest-middleware = { workspace = true }
 self-replace = { workspace = true }
@@ -119,16 +119,14 @@ native-tls = [
   "pixi_utils/native-tls",
   "rattler/native-tls",
   "reqwest/native-tls",
-  "reqwest/native-tls-alpn",
 ]
 # run tests connecting to remote Internet services
 online_tests = []
-rustls-tls = [
-  "pixi_auth/rustls-tls",
-  "pixi_utils/rustls-tls",
-  "rattler/rustls-tls",
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-native-roots",
+rustls = [
+  "pixi_auth/rustls",
+  "pixi_utils/rustls",
+  "rattler/rustls",
+  "reqwest/rustls",
 ]
 self_update = ["pixi_core/self_update"]
 slow_integration_tests = []

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -573,7 +573,7 @@ async fn upload_packages_to_channel(
     let scheme = url.scheme();
 
     match scheme {
-        "s3" => upload_to_s3(url, package_paths, auth_storage, force).await,
+        "s3" => upload_to_s3(url, package_paths, force).await,
         "quetz" => upload_to_quetz(url, package_paths, auth_storage).await,
         "artifactory" => upload_to_artifactory(url, package_paths, auth_storage).await,
         "prefix" => {
@@ -808,12 +808,7 @@ async fn upload_to_artifactory(
 }
 
 /// Upload packages to S3 and run indexing.
-async fn upload_to_s3(
-    url: &Url,
-    package_paths: &[PathBuf],
-    auth_storage: &AuthenticationStorage,
-    force: bool,
-) -> miette::Result<()> {
+async fn upload_to_s3(url: &Url, package_paths: &[PathBuf], force: bool) -> miette::Result<()> {
     use rattler_index::{IndexS3Config, ensure_channel_initialized_s3, index_s3};
     use rattler_upload::upload::upload_package_to_s3;
     use std::collections::HashSet;
@@ -836,9 +831,8 @@ async fn upload_to_s3(
     }
 
     upload_package_to_s3(
-        auth_storage,
         url.clone(),
-        None,
+        resolved_credentials.clone(),
         &package_paths.to_vec(),
         force,
     )

--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -220,10 +220,13 @@ mod tests {
         let project = WorkspaceLocator::default().locate().unwrap();
         let environment = project.default_environment();
 
-        let script =
-            generate_activation_script(Some(ShellEnum::Bash(Bash)), &environment, &project)
-                .await
-                .unwrap();
+        let script = generate_activation_script(
+            Some(ShellEnum::Bash(Bash::default())),
+            &environment,
+            &project,
+        )
+        .await
+        .unwrap();
         assert!(script.contains(&format!("export {path_var_name}=")));
         assert!(script.contains("export CONDA_PREFIX="));
 

--- a/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
@@ -131,7 +131,7 @@ impl SolveCondaEnvironmentSpec {
                 .collect::<HashSet<_>>();
 
             // Filter all installed packages
-            let installed = self
+            let installed: Vec<rattler_conda_types::RepoDataRecord> = self
                 .installed
                 .into_iter()
                 // Only lock binary records
@@ -298,7 +298,7 @@ impl SolveCondaEnvironmentSpec {
                     .chain(binary_match_specs)
                     .chain(dev_source_match_specs)
                     .collect(),
-                locked_packages: installed,
+                locked_packages: installed.iter().collect(),
                 virtual_packages: self.virtual_packages,
                 channel_priority: self.channel_priority,
                 exclude_newer,

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -29,21 +29,38 @@ const EXPERIMENTAL: &str = "experimental";
 
 /// Controls which root certificates to use for TLS connections.
 ///
-/// - `Webpki`: Use bundled Mozilla root certificates (portable, works everywhere)
-/// - `Native`: Use the system's certificate store (includes corporate CAs)
-/// - `All`: Use both webpki and native certificates (union of both sources)
-///
-/// Note: This setting only has an effect when pixi is built with the `rustls-tls` feature.
+/// Note: This setting only has an effect when pixi is built with the `rustls` feature.
 /// When built with `native-tls`, system certificates are always used regardless of this setting.
+///
+/// `SSL_CERT_FILE` / `SSL_CERT_DIR` (when set and valid) always take precedence over this setting.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
 pub enum TlsRootCerts {
-    /// Use bundled Mozilla root certificates
+    /// Use bundled Mozilla root certificates (portable, works everywhere).
+    #[serde(rename = "webpki")]
     Webpki,
-    /// Use the system's native certificate store
-    Native,
-    /// Use both webpki and native certificates
+    /// Use the system's native certificate store (includes corporate CAs).
     #[default]
+    #[serde(rename = "system")]
+    System,
+    /// Deprecated spelling of [`Self::System`].
+    ///
+    /// Configs that still set `tls-root-certs = "native"` deserialize into this
+    /// variant so we can emit a runtime warning pointing users at the new
+    /// spelling. Behaves identically to `System` at use sites.
+    #[deprecated(note = "use `tls-root-certs = \"system\"`")]
+    #[serde(rename = "native")]
+    LegacyNative,
+    /// Use both webpki and native certificates.
+    ///
+    /// Deprecated: uv 0.11 no longer supports merging the two trust stores via
+    /// its public API, so pixi can no longer plumb this through for uv's
+    /// reqwest clients. This variant now falls through to `System` at
+    /// runtime and emits a warning. Use `webpki` or `system` explicitly,
+    /// or set `SSL_CERT_FILE` / `SSL_CERT_DIR`.
+    #[deprecated(
+        note = "merging webpki + native roots is no longer supported: use `system`, `webpki`, or set SSL_CERT_FILE/DIR"
+    )]
+    #[serde(rename = "all")]
     All,
 }
 
@@ -59,7 +76,10 @@ impl std::fmt::Display for TlsRootCerts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TlsRootCerts::Webpki => write!(f, "webpki"),
-            TlsRootCerts::Native => write!(f, "native"),
+            TlsRootCerts::System => write!(f, "system"),
+            #[allow(deprecated)]
+            TlsRootCerts::LegacyNative => write!(f, "native"),
+            #[allow(deprecated)]
             TlsRootCerts::All => write!(f, "all"),
         }
     }
@@ -647,7 +667,7 @@ pub struct ConfigCli {
     #[arg(long, action = ArgAction::SetTrue, help_heading = consts::CLAP_CONFIG_OPTIONS)]
     tls_no_verify: bool,
 
-    /// Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both).
+    /// Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store).
     #[arg(long, env = "PIXI_TLS_ROOT_CERTS", help_heading = consts::CLAP_CONFIG_OPTIONS)]
     tls_root_certs: Option<TlsRootCerts>,
 
@@ -1387,8 +1407,45 @@ impl Default for Config {
     }
 }
 
+/// Emit a deprecation warning when a config layer (file, CLI flag, or env var)
+/// sets `tls-root-certs` to one of the deprecated spellings.
+///
+/// `source` is included in the message so users can find where the bad value
+/// came from. Pass `None` for non-file sources (CLI / env).
+fn warn_deprecated_tls_root_certs(value: Option<TlsRootCerts>, source: Option<&str>) {
+    #[allow(deprecated)]
+    let (old, advice): (&str, String) = match value {
+        Some(TlsRootCerts::LegacyNative) => (
+            "tls-root-certs = \"native\"",
+            format!(
+                "rename to '{}'",
+                console::style("tls-root-certs = \"system\"").green()
+            ),
+        ),
+        Some(TlsRootCerts::All) => (
+            "tls-root-certs = \"all\"",
+            format!(
+                "merging webpki and system roots is no longer supported. \
+                 Pick one of '{}' or '{}', or set {} / {}. \
+                 The value falls back to 'system' for now.",
+                console::style("webpki").green(),
+                console::style("system").green(),
+                console::style("SSL_CERT_FILE").green(),
+                console::style("SSL_CERT_DIR").green(),
+            ),
+        ),
+        _ => return,
+    };
+    let msg = format!("'{}' is deprecated: {advice}", console::style(old).red(),);
+    match source {
+        Some(src) => tracing::warn!("In '{}': {msg}", console::style(src).bold()),
+        None => tracing::warn!("{msg}"),
+    }
+}
+
 impl From<ConfigCli> for Config {
     fn from(cli: ConfigCli) -> Self {
+        warn_deprecated_tls_root_certs(cli.tls_root_certs, None);
         Self {
             tls_no_verify: if cli.tls_no_verify { Some(true) } else { None },
             tls_root_certs: cli.tls_root_certs,
@@ -1736,6 +1793,11 @@ impl Config {
             config.shell.force_activate = config.force_activate;
         }
 
+        warn_deprecated_tls_root_certs(
+            config.tls_root_certs,
+            source_path.map(|p| p.display().to_string()).as_deref(),
+        );
+
         // Expand `~` in every [cache] path, matching how the top-level
         // `detached-environments` field is handled. Validation that the
         // expanded paths are absolute happens in `Config::validate`.
@@ -1860,27 +1922,39 @@ impl Config {
     /// # Returns
     ///
     /// The loaded global config
+    ///
+    /// # Caching
+    ///
+    /// The system + global file layers are env-independent, so we cache them
+    /// on the first call. The cached value is cloned and the env-derived CLI
+    /// defaults are layered on each call, so per-process env changes still
+    /// take effect. Without this cache pixi would re-parse the same files (and
+    /// re-emit any deprecation warnings) once for [`Config::with_cli_config`]
+    /// and again when the workspace creates its own [`Config::load`].
     pub fn load_global() -> Config {
-        let mut config = Self::load_system();
-
-        for p in config_path_global() {
-            match Self::from_path(&p) {
-                Ok(c) => config = config.merge_config(c),
-                Err(ConfigError::FileNotFound(_)) => (),
-                Err(e) => tracing::error!(
-                    "Failed to load global config '{}' with error: {}",
-                    p.display(),
-                    e
-                ),
+        static FILE_LAYERS: LazyLock<Config> = LazyLock::new(|| {
+            let mut config = Config::load_system();
+            for p in config_path_global() {
+                match Config::from_path(&p) {
+                    Ok(c) => config = config.merge_config(c),
+                    Err(ConfigError::FileNotFound(_)) => (),
+                    Err(e) => tracing::error!(
+                        "Failed to load global config '{}' with error: {}",
+                        p.display(),
+                        e
+                    ),
+                }
             }
-        }
+            config
+        });
 
-        // Load the default CLI config and layer it on top of the global config
-        // This will add any environment variables defined in the `clap` attributes to
-        // the config
+        // Layer the env-derived defaults on each call so changes to the
+        // process environment within a single pixi invocation still apply.
+        // This will add any environment variables defined in the `clap`
+        // attributes to the config.
         let mut default_cli = ConfigCli::default();
         default_cli.update_from(std::env::args().take(0));
-        config.merge_config(default_cli.into())
+        FILE_LAYERS.clone().merge_config(default_cli.into())
     }
 
     /// Load the global config and layer the given cli config on top of it.
@@ -2038,9 +2112,14 @@ impl Config {
         self.tls_no_verify.unwrap_or(false)
     }
 
-    /// Retrieve the value for the tls_root_certs field (defaults to Webpki).
-    pub fn tls_root_certs(&self) -> TlsRootCerts {
-        self.tls_root_certs.unwrap_or_default()
+    /// The user-set `tls-root-certs` value, if any.
+    ///
+    /// Returns `None` when the field was not set in any config layer. The
+    /// backend-aware fallback lives in `pixi_utils::reqwest::default_tls_root_certs`,
+    /// since the choice depends on whether pixi is built against `native-tls`
+    /// or `rustls` and this crate is feature-agnostic.
+    pub fn tls_root_certs(&self) -> Option<TlsRootCerts> {
+        self.tls_root_certs
     }
 
     /// Retrieve the value for the change_ps1 field (defaults to true).
@@ -2648,7 +2727,9 @@ UNUSED = "unused"
             vec![NamedChannelOrUrl::from_str("conda-forge").unwrap()]
         );
         assert_eq!(config.tls_no_verify, Some(true));
-        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::Native));
+        #[allow(deprecated)]
+        let expected_legacy = TlsRootCerts::LegacyNative;
+        assert_eq!(config.tls_root_certs, Some(expected_legacy));
         assert_eq!(
             config.detached_environments().path().unwrap(),
             Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
@@ -2739,7 +2820,7 @@ UNUSED = "unused"
         // Test with all CLI options enabled
         let cli = ConfigCli {
             tls_no_verify: true,
-            tls_root_certs: Some(TlsRootCerts::Native),
+            tls_root_certs: Some(TlsRootCerts::System),
             auth_file: None,
             pypi_keyring_provider: Some(KeyringProvider::Subprocess),
             concurrent_solves: Some(8),
@@ -2753,7 +2834,7 @@ UNUSED = "unused"
         };
         let config = Config::from(cli);
         assert_eq!(config.tls_no_verify, Some(true));
-        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::Native));
+        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::System));
         assert_eq!(
             config.pypi_config().keyring_provider,
             Some(KeyringProvider::Subprocess)
@@ -2886,7 +2967,7 @@ UNUSED = "unused"
             default_channels: vec![NamedChannelOrUrl::from_str("conda-forge").unwrap()],
             channel_config: ChannelConfig::default_with_root_dir(PathBuf::from("/root/dir")),
             tls_no_verify: Some(true),
-            tls_root_certs: Some(TlsRootCerts::Native),
+            tls_root_certs: Some(TlsRootCerts::System),
             detached_environments: Some(DetachedEnvironments::Path(PathBuf::from("/path/to/envs"))),
             concurrency: ConcurrencyConfig {
                 solves: 5,
@@ -3389,9 +3470,17 @@ UNUSED = "unused"
 
         // Test tls-root-certs
         config
+            .set("tls-root-certs", Some("system".to_string()))
+            .unwrap();
+        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::System));
+
+        // The deprecated `native` spelling still deserializes.
+        config
             .set("tls-root-certs", Some("native".to_string()))
             .unwrap();
-        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::Native));
+        #[allow(deprecated)]
+        let expected_legacy = TlsRootCerts::LegacyNative;
+        assert_eq!(config.tls_root_certs, Some(expected_legacy));
 
         // Test mirrors
         config

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -46,9 +46,7 @@ use rattler_lock::{
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
 use uv_cache_key::RepositoryUrl;
-use uv_client::{
-    BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder,
-};
+use uv_client::{Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_configuration::{Constraints, Overrides};
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{
@@ -476,13 +474,11 @@ pub async fn resolve_pypi(
     );
 
     let registry_client = {
-        let base_client_builder = BaseClientBuilder::default()
-            .allow_insecure_host(allow_insecure_hosts)
-            .markers(&marker_environment)
-            .keyring(context.keyring_provider)
-            .connectivity(Connectivity::Online)
-            .native_tls(context.use_native_tls)
-            .extra_middleware(context.extra_middleware.clone());
+        let base_client_builder = context.base_client_builder(
+            allow_insecure_hosts,
+            Some(&marker_environment),
+            Connectivity::Online,
+        );
 
         let mut uv_client_builder =
             RegistryClientBuilder::new(base_client_builder, context.cache.clone())

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -28,7 +28,7 @@ use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_lock::UrlOrPath;
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
-use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
+use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::RAYON_INITIALIZE;
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{ConfigSettings, DependencyMetadata, IndexUrl, RequirementSource};
@@ -567,13 +567,11 @@ async fn read_local_package_metadata(
     );
 
     let registry_client = {
-        let base_client_builder = BaseClientBuilder::default()
-            .allow_insecure_host(allow_insecure_hosts.clone())
-            .markers(&marker_environment)
-            .keyring(ctx.uv_context.keyring_provider)
-            .connectivity(Connectivity::Online)
-            .native_tls(ctx.uv_context.use_native_tls)
-            .extra_middleware(ctx.uv_context.extra_middleware.clone());
+        let base_client_builder = ctx.uv_context.base_client_builder(
+            allow_insecure_hosts.clone(),
+            Some(&marker_environment),
+            Connectivity::Online,
+        );
 
         let mut uv_client_builder =
             RegistryClientBuilder::new(base_client_builder, ctx.uv_context.cache.clone())

--- a/crates/pixi_global/src/completions.rs
+++ b/crates/pixi_global/src/completions.rs
@@ -126,12 +126,15 @@ pub fn contained_completions(
     let zsh_name = format!("_{name}");
     let fish_name = format!("{name}.fish");
 
-    let bash_path =
-        prefix_root
-            .join(Bash.completion_script_location().wrap_err_with(|| {
-                miette::miette!("Bash needs to have a completion script location")
-            })?)
-            .join(name);
+    let bash_path = prefix_root
+        .join(
+            Bash::default()
+                .completion_script_location()
+                .wrap_err_with(|| {
+                    miette::miette!("Bash needs to have a completion script location")
+                })?,
+        )
+        .join(name);
     let zsh_path =
         prefix_root
             .join(Zsh.completion_script_location().wrap_err_with(|| {

--- a/crates/pixi_utils/Cargo.toml
+++ b/crates/pixi_utils/Cargo.toml
@@ -10,18 +10,16 @@ repository.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = [
   "pixi_auth/native-tls",
   "rattler_networking/native-tls",
   "reqwest/native-tls",
-  "reqwest/native-tls-alpn",
 ]
-rustls-tls = [
-  "pixi_auth/rustls-tls",
-  "rattler_networking/rustls-tls",
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-native-roots",
+rustls = [
+  "pixi_auth/rustls",
+  "rattler_networking/rustls",
+  "reqwest/rustls",
 ]
 
 
@@ -50,6 +48,8 @@ reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
 retry-policies = { workspace = true }
 rlimit = { workspace = true }
+rustls-native-certs = { workspace = true }
+rustls-pki-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -60,6 +60,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uv-configuration = { workspace = true }
+webpki-root-certs = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/pixi_utils/src/lib.rs
+++ b/crates/pixi_utils/src/lib.rs
@@ -6,6 +6,7 @@ pub mod prefix;
 mod prefix_guard;
 pub mod reqwest;
 pub mod rlimit;
+pub mod tls;
 pub mod variants;
 
 mod executable_utils;

--- a/crates/pixi_utils/src/prefix.rs
+++ b/crates/pixi_utils/src/prefix.rs
@@ -6,11 +6,11 @@ use rattler_shell::{
     activation::{ActivationVariables, Activator},
     shell::ShellEnum,
 };
-use std::sync::LazyLock;
 use std::{
     collections::HashMap,
     ffi::OsStr,
     path::{Path, PathBuf},
+    sync::LazyLock,
 };
 use thiserror::Error;
 use uv_configuration::RAYON_INITIALIZE;

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -18,6 +18,8 @@ use reqwest_middleware::{ClientWithMiddleware, Middleware};
 use reqwest_retry::RetryTransientMiddleware;
 use retry_policies::policies::ExponentialBackoff;
 
+use crate::tls::Certificates;
+
 /// The default retry policy employed by pixi.
 /// TODO: At some point we might want to make this configurable.
 pub fn default_retry_policy() -> ExponentialBackoff {
@@ -65,18 +67,49 @@ static DEFAULT_REQWEST_USER_AGENT: LazyLock<String> =
 static DEFAULT_REQWEST_TIMEOUT_SEC: Duration = Duration::from_secs(5 * 60);
 static DEFAULT_REQWEST_IDLE_PER_HOST: usize = 20;
 
-/// Returns whether UV should use native TLS (system certificates).
+/// The default `TlsRootCerts` mode for the active TLS backend.
 ///
-/// For `native-tls` builds, this always returns `true` since the system TLS library is used.
-/// For `rustls-tls` builds, this returns `true` if the config is set to `Native` or `All`.
-pub fn should_use_native_tls_for_uv() -> bool {
-    tls_backend() == "native-tls"
+/// On `native-tls` builds pixi's own client always talks to the OS trust store,
+/// so the default mirrors that with `System`. On `rustls` builds the
+/// bundled Mozilla roots are portable and work without any platform integration,
+/// so the default is `Webpki`. Users can still override explicitly via
+/// `tls-root-certs` in their config.
+pub const fn default_tls_root_certs() -> pixi_config::TlsRootCerts {
+    #[cfg(feature = "native-tls")]
+    {
+        pixi_config::TlsRootCerts::System
+    }
+    #[cfg(not(feature = "native-tls"))]
+    {
+        pixi_config::TlsRootCerts::Webpki
+    }
 }
 
-/// Determines whether we should load all builtin certificates
-/// for uv
-pub fn should_use_builtin_certs_uv(config: &Config) -> bool {
-    matches!(config.tls_root_certs(), pixi_config::TlsRootCerts::All)
+/// Resolve the effective `TlsRootCerts` mode for a given config.
+///
+/// Falls back to [`default_tls_root_certs`] when the user has not set the field.
+fn resolve_tls_root_certs(config: Option<&Config>) -> pixi_config::TlsRootCerts {
+    config
+        .and_then(Config::tls_root_certs)
+        .unwrap_or_else(default_tls_root_certs)
+}
+
+/// Whether uv's reqwest client should load the platform's system root certificates.
+///
+/// uv 0.11 only supports rustls and exposes a single `with_system_certs(bool)` knob:
+/// `true` -> let rustls-platform-verifier / `SSL_CERT_FILE`/`SSL_CERT_DIR` provide trust,
+/// `false` -> fall back to the bundled Mozilla webpki roots.
+///
+/// Mirrors pixi's resolved [`pixi_config::TlsRootCerts`]: only `System`
+/// (and the deprecated `LegacyNative` alias) maps to `true`. The deprecated
+/// `All` mode falls through to `false`; see `load_root_certificates` for the
+/// runtime warning.
+#[allow(deprecated)]
+pub fn should_use_system_certs_for_uv(config: &Config) -> bool {
+    matches!(
+        resolve_tls_root_certs(Some(config)),
+        pixi_config::TlsRootCerts::System | pixi_config::TlsRootCerts::LegacyNative
+    )
 }
 
 /// Returns the name of the TLS backend used by this build.
@@ -100,41 +133,23 @@ pub fn reqwest_client_builder(config: Option<&Config>) -> miette::Result<reqwest
         .user_agent(DEFAULT_REQWEST_USER_AGENT.as_str())
         .read_timeout(DEFAULT_REQWEST_TIMEOUT_SEC);
 
+    // Pick the TLS backend at compile time.
     #[cfg(feature = "native-tls")]
     {
-        // With native-tls, the system's TLS library handles certificates.
-        // The tls-root-certs setting has no effect - warn if it's explicitly set.
-        if let Some(tls_root_certs) = config.and_then(|c| c.tls_root_certs) {
-            tracing::warn!(
-                "tls-root-certs is set to '{}' but has no effect with native-tls builds. \
-                 System certificates are always used.",
-                tls_root_certs
-            );
-        }
         builder = builder.use_native_tls();
     }
-
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "rustls")]
     {
-        use pixi_config::TlsRootCerts;
-        let tls_root_certs = config.map(|c| c.tls_root_certs()).unwrap_or_default();
-
-        builder = builder.use_rustls_tls().tls_built_in_root_certs(false); // Disable auto-loading to choose explicitly
-
-        match tls_root_certs {
-            TlsRootCerts::Webpki => {
-                builder = builder.tls_built_in_webpki_certs(true);
-            }
-            TlsRootCerts::Native => {
-                builder = builder.tls_built_in_native_certs(true);
-            }
-            TlsRootCerts::All => {
-                builder = builder
-                    .tls_built_in_webpki_certs(true)
-                    .tls_built_in_native_certs(true);
-            }
-        }
+        builder = builder.use_rustls_tls();
     }
+
+    // Then load the trust store honoring `SSL_CERT_FILE` / `SSL_CERT_DIR` and
+    // the configured `tls-root-certs` mode. Both TLS backends accept
+    // `tls_certs_only`; this is what lets pixi keep one source of truth for
+    // root certificates regardless of which backend the binary was compiled
+    // against.
+    let tls_root_certs = resolve_tls_root_certs(config);
+    builder = builder.tls_certs_only(Certificates::for_mode(tls_root_certs).to_reqwest_certs());
 
     let proxies = config
         .map(|c| c.get_proxies())

--- a/crates/pixi_utils/src/tls.rs
+++ b/crates/pixi_utils/src/tls.rs
@@ -1,0 +1,198 @@
+//! TLS certificate loading for pixi's reqwest client.
+//!
+//! Mirrors the [`Certificates`] design used by `uv-client` (uv PR #18550): a thin
+//! newtype over [`CertificateDer<'static>`] with factories for the bundled
+//! webpki roots, the platform's native store, and the `SSL_CERT_FILE` /
+//! `SSL_CERT_DIR` environment variables.
+
+use std::{env, io, path::PathBuf};
+
+use itertools::Itertools;
+use pixi_config::TlsRootCerts;
+use rustls_native_certs::{CertificateResult, load_certs_from_paths};
+use rustls_pki_types::CertificateDer;
+
+/// A collection of TLS certificates in DER form.
+#[derive(Debug, Clone, Default)]
+pub struct Certificates(Vec<CertificateDer<'static>>);
+
+impl Certificates {
+    /// Resolve the certificates to install on pixi's reqwest client.
+    ///
+    /// Priority follows uv's model:
+    /// 1. `SSL_CERT_FILE` / `SSL_CERT_DIR` env vars (if set and valid)
+    /// 2. The configured [`TlsRootCerts`] mode
+    ///
+    /// Deprecation warnings for the legacy [`TlsRootCerts::LegacyNative`] and
+    /// [`TlsRootCerts::All`] spellings fire once at config-load time
+    /// (`Config::from_toml`), so this function stays silent.
+    pub fn for_mode(mode: TlsRootCerts) -> Self {
+        if let Some(env_certs) = Self::from_env() {
+            return env_certs;
+        }
+
+        #[allow(deprecated)]
+        match mode {
+            TlsRootCerts::Webpki => Self::webpki_roots(),
+            TlsRootCerts::System | TlsRootCerts::LegacyNative | TlsRootCerts::All => {
+                Self::from_native_store()
+            }
+        }
+    }
+
+    /// Load the bundled Mozilla root certificates from `webpki-root-certs`.
+    pub fn webpki_roots() -> Self {
+        // Each `CertificateDer` borrows from static data, so cloning the slice
+        // only copies fat pointers, not certificate bytes.
+        Self(webpki_root_certs::TLS_SERVER_ROOT_CERTS.to_vec())
+    }
+
+    /// Load certificates from the platform's native trust store via
+    /// [`rustls_native_certs::load_native_certs`].
+    pub fn from_native_store() -> Self {
+        let result = rustls_native_certs::load_native_certs();
+        for err in &result.errors {
+            tracing::warn!("failed to load a native root certificate: {err}");
+        }
+        Self::from(result)
+    }
+
+    /// Load custom CA certificates from `SSL_CERT_FILE` and `SSL_CERT_DIR`.
+    ///
+    /// Returns `None` if neither variable is set, the referenced paths are
+    /// missing or inaccessible, or no valid certificates are found (with a
+    /// warning emitted in each case).
+    pub fn from_env() -> Option<Self> {
+        let mut certs = Self::default();
+        let mut has_source = false;
+
+        if let Some(ssl_cert_file) = env::var_os("SSL_CERT_FILE")
+            && let Some(file_certs) = Self::from_ssl_cert_file(&ssl_cert_file)
+        {
+            has_source = true;
+            certs.merge(file_certs);
+        }
+
+        if let Some(ssl_cert_dir) = env::var_os("SSL_CERT_DIR")
+            && let Some(dir_certs) = Self::from_ssl_cert_dir(&ssl_cert_dir)
+        {
+            has_source = true;
+            certs.merge(dir_certs);
+        }
+
+        if has_source { Some(certs) } else { None }
+    }
+
+    fn from_ssl_cert_file(value: &std::ffi::OsStr) -> Option<Self> {
+        if value.is_empty() {
+            return None;
+        }
+        let file = PathBuf::from(value);
+        match file.metadata() {
+            Ok(metadata) if metadata.is_file() => {
+                let result = load_certs_from_paths(Some(&file), None);
+                for err in &result.errors {
+                    tracing::warn!("failed to load `SSL_CERT_FILE` ({}): {err}", file.display());
+                }
+                let certs = Self::from(result);
+                if certs.0.is_empty() {
+                    tracing::warn!(
+                        "ignoring `SSL_CERT_FILE`: no certificates found in {}",
+                        file.display()
+                    );
+                    return None;
+                }
+                Some(certs)
+            }
+            Ok(_) => {
+                tracing::warn!(
+                    "ignoring invalid `SSL_CERT_FILE`: path is not a file: {}",
+                    file.display()
+                );
+                None
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                tracing::warn!(
+                    "ignoring invalid `SSL_CERT_FILE`: path does not exist: {}",
+                    file.display()
+                );
+                None
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "ignoring invalid `SSL_CERT_FILE` ({}): {err}",
+                    file.display()
+                );
+                None
+            }
+        }
+    }
+
+    fn from_ssl_cert_dir(value: &std::ffi::OsStr) -> Option<Self> {
+        if value.is_empty() {
+            return None;
+        }
+
+        let (existing, missing): (Vec<_>, Vec<_>) =
+            env::split_paths(value).partition(|p| p.exists());
+
+        if existing.is_empty() {
+            tracing::warn!(
+                "ignoring invalid `SSL_CERT_DIR`: none of {} exist",
+                missing.iter().map(|p| p.display().to_string()).join(", ")
+            );
+            return None;
+        }
+        if !missing.is_empty() {
+            tracing::warn!(
+                "skipping non-existent entries in `SSL_CERT_DIR`: {}",
+                missing.iter().map(|p| p.display().to_string()).join(", ")
+            );
+        }
+
+        let mut certs = Self::default();
+        for dir in &existing {
+            let result = load_certs_from_paths(None, Some(dir.as_path()));
+            for err in &result.errors {
+                tracing::warn!("failed to load `SSL_CERT_DIR` ({}): {err}", dir.display());
+            }
+            certs.merge(Self::from(result));
+        }
+
+        if certs.0.is_empty() {
+            tracing::warn!(
+                "ignoring `SSL_CERT_DIR`: no certificates found in {}",
+                existing.iter().map(|p| p.display().to_string()).join(", ")
+            );
+            return None;
+        }
+        Some(certs)
+    }
+
+    /// Whether this collection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Merge another set of certificates into this one, deduplicating after.
+    pub fn merge(&mut self, other: Self) {
+        self.0.extend(other.0);
+        self.0.sort_unstable_by(|a, b| a.as_ref().cmp(b.as_ref()));
+        self.0.dedup();
+    }
+
+    /// Convert to `reqwest::Certificate` values for use with
+    /// [`reqwest::ClientBuilder::tls_certs_only`].
+    pub fn to_reqwest_certs(&self) -> Vec<reqwest::Certificate> {
+        self.0
+            .iter()
+            .filter_map(|cert| reqwest::Certificate::from_der(cert.as_ref()).ok())
+            .collect()
+    }
+}
+
+impl From<CertificateResult> for Certificates {
+    fn from(result: CertificateResult) -> Self {
+        Self(result.certs)
+    }
+}

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -4,9 +4,7 @@ use std::time::Duration;
 use fs_err::create_dir_all;
 use miette::{Context, IntoDiagnostic};
 use pixi_config::{self, CacheKind, Config};
-use pixi_utils::reqwest::{
-    LazyReqwestClient, should_use_builtin_certs_uv, should_use_native_tls_for_uv, uv_middlewares,
-};
+use pixi_utils::reqwest::{LazyReqwestClient, should_use_system_certs_for_uv, uv_middlewares};
 use pixi_uv_conversions::{ConversionError, to_uv_trusted_host};
 use uv_cache::Cache;
 use uv_client::{
@@ -38,10 +36,16 @@ pub struct UvResolutionContext {
     pub extra_middleware: ExtraMiddleware,
     pub proxies: Vec<reqwest::Proxy>,
     pub tls_no_verify: bool,
-    /// Whether UV should use native TLS (system certificates).
-    /// This is computed based on the `tls-root-certs` config and the TLS feature used.
-    pub use_native_tls: bool,
-    pub use_builtin_certs: bool,
+    /// The shared reqwest client passed to uv via
+    /// [`uv_client::BaseClientBuilder::custom_client`] when
+    /// `allow_insecure_host` is empty. Lets uv reuse pixi's TLS configuration,
+    /// proxies, mirrors, and connection pool instead of building its own.
+    pub client: reqwest::Client,
+    /// Fallback for the per-host TLS-bypass case: when `allow_insecure_host`
+    /// is non-empty we let uv build its own dual (secure + dangerous) clients
+    /// via [`uv_client::BaseClientBuilder::with_system_certs`], since reqwest
+    /// 0.13 doesn't expose per-host TLS opt-in on a single `Client`.
+    pub use_system_certs: bool,
     pub package_config_settings: PackageConfigSettings,
     pub extra_build_requires: ExtraBuildRequires,
     pub extra_build_variables: ExtraBuildVariables,
@@ -197,11 +201,11 @@ impl UvResolutionContext {
             capabilities: IndexCapabilities::default(),
             allow_insecure_host,
             shared_state: SharedState::default(),
-            extra_middleware: ExtraMiddleware(uv_middlewares(config, client)),
+            extra_middleware: ExtraMiddleware(uv_middlewares(config, client.clone())),
             proxies: config.get_proxies().into_diagnostic()?,
             tls_no_verify: config.tls_no_verify(),
-            use_native_tls: should_use_native_tls_for_uv(),
-            use_builtin_certs: should_use_builtin_certs_uv(config),
+            client: client.into_client(),
+            use_system_certs: should_use_system_certs_for_uv(config),
             package_config_settings: PackageConfigSettings::default(),
             extra_build_requires: ExtraBuildRequires::default(),
             extra_build_variables: ExtraBuildVariables::default(),
@@ -223,6 +227,53 @@ impl UvResolutionContext {
         self
     }
 
+    /// Build the [`BaseClientBuilder`] used by every uv flow in pixi.
+    ///
+    /// All registry-client and resolver-satisfaction code paths construct
+    /// their `BaseClientBuilder` here so TLS, proxy, middleware, and timeout
+    /// configuration is set in one place.
+    ///
+    /// The HTTP client itself is selected based on `allow_insecure_hosts`:
+    ///
+    /// - **Empty (default):** uv reuses pixi's `reqwest::Client` via
+    ///   `custom_client`, sharing pixi's TLS roots, proxies, mirror
+    ///   middleware, and connection pool.
+    /// - **Non-empty:** uv builds its own pair of clients via
+    ///   `with_system_certs`, because it needs a separate
+    ///   `tls_danger_accept_invalid_certs(true)` client for the flagged
+    ///   hosts and reqwest 0.13 has no per-host TLS opt-in on a single
+    ///   `Client`.
+    pub fn base_client_builder<'a>(
+        &self,
+        allow_insecure_hosts: Vec<TrustedHost>,
+        markers: Option<&'a MarkerEnvironment>,
+        connectivity: Connectivity,
+    ) -> BaseClientBuilder<'a> {
+        let mut builder = BaseClientBuilder::default()
+            .keyring(self.keyring_provider)
+            .connectivity(connectivity)
+            .extra_middleware(self.extra_middleware.clone());
+        builder = if allow_insecure_hosts.is_empty() {
+            builder
+                .allow_insecure_host(allow_insecure_hosts)
+                .custom_client(self.client.clone())
+        } else {
+            builder
+                .allow_insecure_host(allow_insecure_hosts)
+                .with_system_certs(self.use_system_certs)
+        };
+        if let Some(timeout) = self.http_timeout {
+            builder = builder.read_timeout(timeout);
+        }
+        if let Some(retries) = self.http_retries {
+            builder = builder.retries(retries);
+        }
+        if let Some(markers) = markers {
+            builder = builder.markers(markers);
+        }
+        builder
+    }
+
     /// Build a registry client configured with the context settings.
     ///
     /// Parameters:
@@ -240,25 +291,8 @@ impl UvResolutionContext {
         markers: Option<&MarkerEnvironment>,
         connectivity: Connectivity,
     ) -> Arc<RegistryClient> {
-        let mut base_client_builder = BaseClientBuilder::default()
-            .allow_insecure_host(allow_insecure_hosts)
-            .keyring(self.keyring_provider)
-            .connectivity(connectivity)
-            .native_tls(self.use_native_tls)
-            .built_in_root_certs(self.use_builtin_certs)
-            .extra_middleware(self.extra_middleware.clone());
-
-        if let Some(timeout) = self.http_timeout {
-            base_client_builder = base_client_builder.read_timeout(timeout);
-        }
-
-        if let Some(retries) = self.http_retries {
-            base_client_builder = base_client_builder.retries(retries);
-        }
-
-        if let Some(markers) = markers {
-            base_client_builder = base_client_builder.markers(markers);
-        }
+        let base_client_builder =
+            self.base_client_builder(allow_insecure_hosts, markers, connectivity);
 
         let mut uv_client_builder =
             RegistryClientBuilder::new(base_client_builder, self.cache.clone())

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -340,7 +340,7 @@ pub fn into_pinned_git_spec(
     // uv stores the percent-encoded drive-letter form internally (see
     // `encode_windows_drive_letter`). Decode it back here so the lock file
     // shows `file:///D:/...` rather than `file:///D%3A/...`.
-    let repository: url::Url = dist.git.repository().clone().into();
+    let repository: url::Url = (*dist.git.repository()).clone().into();
     PinnedGitSpec::new(decode_windows_drive_letter(&repository), pinned_checkout)
 }
 

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -58,7 +58,7 @@ pixi add [OPTIONS] <SPEC>...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/build.md
+++ b/docs/reference/cli/pixi/build.md
@@ -57,7 +57,7 @@ pixi build [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/exec.md
+++ b/docs/reference/cli/pixi/exec.md
@@ -65,7 +65,7 @@ pixi exec [OPTIONS] [COMMAND]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/add.md
+++ b/docs/reference/cli/pixi/global/add.md
@@ -55,7 +55,7 @@ pixi global add [OPTIONS] --environment <ENVIRONMENT> [PACKAGE]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/expose/add.md
+++ b/docs/reference/cli/pixi/global/expose/add.md
@@ -50,7 +50,7 @@ pixi global expose add [OPTIONS] --environment <ENVIRONMENT> [MAPPING]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/expose/remove.md
+++ b/docs/reference/cli/pixi/global/expose/remove.md
@@ -45,7 +45,7 @@ pixi global expose remove [OPTIONS] [EXPOSED_NAME]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/install.md
+++ b/docs/reference/cli/pixi/global/install.md
@@ -66,7 +66,7 @@ pixi global install [OPTIONS] [PACKAGE]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/list.md
+++ b/docs/reference/cli/pixi/global/list.md
@@ -54,7 +54,7 @@ pixi global list [OPTIONS] [REGEX]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/remove.md
+++ b/docs/reference/cli/pixi/global/remove.md
@@ -50,7 +50,7 @@ pixi global remove [OPTIONS] <PACKAGE>...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/shortcut/add.md
+++ b/docs/reference/cli/pixi/global/shortcut/add.md
@@ -50,7 +50,7 @@ pixi global shortcut add [OPTIONS] --environment <ENVIRONMENT> [PACKAGE]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/shortcut/remove.md
+++ b/docs/reference/cli/pixi/global/shortcut/remove.md
@@ -45,7 +45,7 @@ pixi global shortcut remove [OPTIONS] [SHORTCUT]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/sync.md
+++ b/docs/reference/cli/pixi/global/sync.md
@@ -40,7 +40,7 @@ pixi global sync [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/uninstall.md
+++ b/docs/reference/cli/pixi/global/uninstall.md
@@ -46,7 +46,7 @@ pixi global uninstall [OPTIONS] <ENVIRONMENT>...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/update.md
+++ b/docs/reference/cli/pixi/global/update.md
@@ -45,7 +45,7 @@ pixi global update [OPTIONS] [ENVIRONMENTS]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/global/upgrade-all.md
+++ b/docs/reference/cli/pixi/global/upgrade-all.md
@@ -48,7 +48,7 @@ pixi global upgrade-all [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/import.md
+++ b/docs/reference/cli/pixi/import.md
@@ -57,7 +57,7 @@ pixi import [OPTIONS] <FILE>
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -56,7 +56,7 @@ pixi install [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/publish.md
+++ b/docs/reference/cli/pixi/publish.md
@@ -71,7 +71,7 @@ pixi publish [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/reinstall.md
+++ b/docs/reference/cli/pixi/reinstall.md
@@ -52,7 +52,7 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -56,7 +56,7 @@ pixi remove [OPTIONS] <SPEC>...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -61,7 +61,7 @@ pixi run [OPTIONS] [TASK]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -49,7 +49,7 @@ pixi shell-hook [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/shell.md
+++ b/docs/reference/cli/pixi/shell.md
@@ -44,7 +44,7 @@ pixi shell [OPTIONS]
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/update.md
+++ b/docs/reference/cli/pixi/update.md
@@ -60,7 +60,7 @@ pixi update [OPTIONS] [PACKAGES]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -56,7 +56,7 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/workspace/channel/add.md
+++ b/docs/reference/cli/pixi/workspace/channel/add.md
@@ -54,7 +54,7 @@ pixi workspace channel add [OPTIONS] <CHANNEL>...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/workspace/channel/remove.md
+++ b/docs/reference/cli/pixi/workspace/channel/remove.md
@@ -54,7 +54,7 @@ pixi workspace channel remove [OPTIONS] <CHANNEL>...
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
@@ -59,7 +59,7 @@ pixi workspace export conda-explicit-spec [OPTIONS] <OUTPUT_DIR>
 - <a id="arg---tls-no-verify" href="#arg---tls-no-verify">`--tls-no-verify`</a>
 :  Do not verify the TLS certificate of the server
 - <a id="arg---tls-root-certs" href="#arg---tls-root-certs">`--tls-root-certs <TLS_ROOT_CERTS>`</a>
-:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots), 'native' (system store), or 'all' (both)
+:  Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store)
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -121,17 +121,27 @@ Controls which TLS root certificates are used for HTTPS connections. This affect
 
 Available options:
 
-- `webpki` (default): Uses bundled Mozilla root certificates. This is the most portable option.
-- `native`: Uses the system certificate store. Required for corporate environments with custom CA certificates.
-- `all`: Uses both bundled Mozilla certificates and the system certificate store.
+- `webpki`: Uses bundled Mozilla root certificates. The most portable option.
+- `system`: Uses the system certificate store. Required for corporate environments with custom CA certificates.
+
+The default is backend-dependent: `rustls` builds default to `webpki`, `native-tls` builds default to `system`.
+
+If `SSL_CERT_FILE` or `SSL_CERT_DIR` is set, those certificates take precedence over this setting.
 
 You can override this from the CLI with `--tls-root-certs`.
 
 !!! note "Build-dependent behavior"
 
-    This setting only has an effect with `rustls-tls` builds (standalone pixi binaries from GitHub releases).
+    This setting only has an effect with `rustls` builds (standalone pixi binaries from GitHub releases).
     For `native-tls` builds (conda-forge packages), the system's TLS library is used, which always uses system certificates.
     In this case, the setting is accepted but has no effect.
+
+!!! note "Deprecated values"
+
+    The values `native` and `all` are deprecated:
+
+    - `native` is the old spelling of `system` and still works, but emits a deprecation warning.
+    - `all` (combined webpki + system) is no longer supported because the underlying HTTP client can't merge the two trust stores. It still parses, but falls back to `system` at runtime with a warning.
 
 ```toml title="config.toml"
 --8<-- "docs/source_files/pixi_config_tomls/main_config.toml:tls-root-certs"

--- a/docs/source_files/pixi_config_tomls/main_config.toml
+++ b/docs/source_files/pixi_config_tomls/main_config.toml
@@ -10,12 +10,13 @@ tls-no-verify = false
 
 # --8<-- [start:tls-root-certs]
 # Which TLS root certificates to use for HTTPS connections.
-# Options: "webpki" (bundled Mozilla roots), "native" (system store), "all" (both)
-# Default is "webpki" for portability. Use "native" or "all" for corporate environments
-# with custom CA certificates.
-# Note: This setting only has an effect with rustls-tls builds (standalone pixi).
+# Options: "webpki" (bundled Mozilla roots) or "system" (system store).
+# `rustls` builds default to "webpki" for portability; `native-tls` builds default
+# to "system". Use "system" for corporate environments with custom CA certificates.
+# SSL_CERT_FILE / SSL_CERT_DIR, when set, take precedence over this setting.
+# Note: This setting only has an effect with rustls builds (standalone pixi).
 # For native-tls builds (conda-forge), system certificates are always used.
-tls-root-certs = "native"
+tls-root-certs = "system"
 # --8<-- [end:tls-root-certs]
 
 # --8<-- [start:authentication-override-file]

--- a/patches/reqwest_middleware_shim/Cargo.toml
+++ b/patches/reqwest_middleware_shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.4.99"
+version = "0.5.99"
 edition = "2021"
 description = "Shim that re-exports astral-reqwest-middleware so consumers of crates.io's reqwest-middleware (e.g. http-cache-reqwest) share the astral fork's trait identity. Used via [patch.crates-io] in the pixi workspace."
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ multipart = ["inner/multipart"]
 json = ["inner/json"]
 charset = ["inner/charset"]
 http2 = ["inner/http2"]
-rustls-tls = ["inner/rustls-tls"]
+rustls = ["inner/rustls"]
 
 [dependencies]
-inner = { package = "astral-reqwest-middleware", version = "0.4.2" }
+inner = { package = "astral-reqwest-middleware", version = "0.5" }


### PR DESCRIPTION
## Summary

Single bump that aligns pixi with the new reqwest 0.13 / astral-middleware 0.5 world. uv 0.11.0 is the first uv release on this stack, and rattler 0.43 + rattler-build (post #2493) coordinate on it.

## Versions

- `uv` 0.10.12 → **0.11.0**
- `reqwest` 0.12 → **0.13**
- `astral-reqwest-middleware` 0.4 → **0.5**, `astral-reqwest-retry` 0.8 → **0.9**
- `http-cache-reqwest` 0.16 → **1.0.0-alpha.6** (first release on reqwest 0.13)
- `rattler` 0.42 → 0.43, `rattler_cache` 0.7→0.8, `rattler_index` 0.28→0.29, `rattler_networking` 0.26→0.27, `rattler_package_streaming` 0.25→0.26, `rattler_repodata_gateway` 0.28→0.29, `rattler_s3` 0.1→0.2, `rattler_shell` 0.26→0.27, `rattler_solve` 6→**7** (major), `rattler_upload` 0.6→0.7
- `rattler-build` (git/main, includes prefix-dev/rattler-build#2493)
- `url` pin 2.5.4 → 2.5, `memchr` 2.7.4 → 2.8 (rattler-build's lower bound)
- Workspace shim crate ` patches/reqwest_middleware_shim`: now re-exports astral-reqwest-middleware 0.5 (version bumped to 0.5.99 to satisfy http-cache-reqwest's `\"0.5.0\"` requirement). The shim is still needed because http-cache-reqwest references the `reqwest-middleware` crate name on crates.io while rattler/uv use the astral fork.

Per workspace convention, only minor/major bumps appear in `Cargo.toml`; patch versions are tracked in `Cargo.lock`.

## Feature renames

- pixi workspace: feature `rustls-tls` → `rustls` across all crates (Cargo.toml + cfg attrs + doc comments). Matches the new convention from rattler + reqwest 0.13.
- reqwest 0.13 dropped `rustls-tls-native-roots`, `native-tls-alpn`, and `macos-system-configuration`. Replaced respectively with manual cert loading (see below), no-op (ALPN is on by default), and `system-proxy`.

## TLS rewrite (mirrors uv PR astral-sh/uv#18550)

reqwest 0.13 removed `tls_built_in_root_certs` / `_webpki_certs` / `_native_certs` in favor of `tls_certs_only(Vec<Certificate>)`. We mirror uv's approach with a small `Certificates` newtype:

- New module `crates/pixi_utils/src/tls.rs` with factories `webpki_roots()`, `from_native_store()`, `from_env()` (handles `SSL_CERT_FILE` / `SSL_CERT_DIR`), and `to_reqwest_certs()`.
- `load_root_certificates` resolves: **env vars > config-set value > backend-aware default**.
- `default_tls_root_certs()` helper returns `SystemCerts` on native-tls builds and `Webpki` on rustls builds.

## Config changes (with backward compat)

`TlsRootCerts` enum:
- `Native` → renamed to **`SystemCerts`** (serde `\"system-certs\"`). Matches uv's vocabulary.
- Old `tls-root-certs = \"native\"` configs still load; they map to a new `LegacyNative` variant marked `#[deprecated]` that emits a runtime warning pointing users at the new spelling.
- `All` (merge webpki + native) is deprecated: uv 0.11's public API can't merge trust stores, so we can't faithfully forward it for uv anymore. Falls through to `SystemCerts` at runtime with a warning. Use `webpki`, `system-certs`, or set `SSL_CERT_FILE` / `SSL_CERT_DIR`.
- New default is `SystemCerts` (was `All`).
- New getter `Config::tls_root_certs_explicit() -> Option<TlsRootCerts>` returns the user-set value without applying a default, letting `pixi_utils` layer its backend-aware fallback.

## uv API deltas absorbed

- `BaseClientBuilder::native_tls(_)` + `built_in_root_certs(_)` → single `.with_system_certs(bool)`. Helper `should_use_system_certs_for_uv` maps the config: native-tls build OR `TlsRootCerts::SystemCerts | LegacyNative` → `true`; `Webpki` / `All` → `false`.
- `RepositoryUrl: Into<Url>` removed → Deref-chain in `pixi_uv_conversions::conversions`.
- `rattler_solve::SolverTask::locked_packages` is now `Vec<&'a RepoDataRecord>` (was owned).
- `rattler_upload::upload_package_to_s3` signature change: takes `ResolvedS3Credentials` directly (no more `auth_storage`). Wired the existing `ResolvedS3Credentials::from_sdk()` instance through. Full manifest-driven credentials wiring is in #6069 (still open) and out of scope here.

## Test plan

- [x] cargo check --workspace (passing locally)
- [x] cargo check --tests --workspace (passing locally)
- [x] cargo nextest run
- [x] pytest
- [x] cargo clippy --all-targets -- -D warnings
- [x] cargo fmt --check
- [x] cargo deny check
- [x] Manual: TLS config with `tls-root-certs = \"native\"` still works and emits deprecation warning
    <img width="1349" height="61" alt="image" src="https://github.com/user-attachments/assets/4415d660-ed0a-4bc2-9049-7170220af5cb" />
- [x] Manual: TLS config with `tls-root-certs = \"system\"` works
- [x] Manual: TLS config with `tls-root-certs = \"all\"' works:
    <img width="1701" height="85" alt="image" src="https://github.com/user-attachments/assets/1ba29a5b-7733-4d89-8c5a-9eb0cffae5b4" />
- [x] Manual: `SSL_CERT_FILE` / `SSL_CERT_DIR` override config

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude