### PR TITLE
fix: avoid editable-flag conflict with transitive tool.uv.sources

### DIFF
--- a/crates/pixi/tests/integration_rust/solve_group_tests.rs
+++ b/crates/pixi/tests/integration_rust/solve_group_tests.rs
@@ -1071,6 +1071,100 @@ version = "0.1.0"
     );
 }
 
+/// Regression test for #6121: `core` declared editable both as a direct
+/// pixi pypi-dependency and via the transitive `[tool.uv.sources]` of
+/// `middle` must not produce a "conflicting URLs" error.
+#[tokio::test]
+async fn test_transitive_uv_sources_editable_consistency() {
+    setup_tracing();
+
+    // Create a fake channel with Python
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("python", "3.10.0").finish());
+
+    let channel_dir = TempDir::new().unwrap();
+    package_database
+        .write_repodata(channel_dir.path())
+        .await
+        .unwrap();
+
+    let channel = Url::from_file_path(channel_dir.path()).unwrap();
+    let platform = Platform::current();
+
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+    [project]
+    name = "test-transitive-editable"
+    channels = ["{channel}"]
+    platforms = ["{platform}"]
+    conda-pypi-map = {{}} # disable mapping
+
+    [dependencies]
+    python = "*"
+
+    [pypi-dependencies]
+    core   = {{ path = "./core",   editable = true }}
+    middle = {{ path = "./middle", editable = true }}
+    "#
+    ))
+    .unwrap();
+
+    let project_path = pixi.workspace_path();
+
+    let core_dir = project_path.join("core");
+    fs_err::create_dir_all(&core_dir).unwrap();
+    fs_err::write(
+        core_dir.join("pyproject.toml"),
+        r#"
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "core"
+version = "0.1.0"
+"#,
+    )
+    .unwrap();
+    let core_src = core_dir.join("core");
+    fs_err::create_dir_all(&core_src).unwrap();
+    fs_err::write(core_src.join("__init__.py"), "").unwrap();
+
+    let middle_dir = project_path.join("middle");
+    fs_err::create_dir_all(&middle_dir).unwrap();
+    fs_err::write(
+        middle_dir.join("pyproject.toml"),
+        r#"
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "middle"
+version = "0.1.0"
+dependencies = ["core"]
+
+[tool.uv.sources]
+core = { path = "../core", editable = true }
+"#,
+    )
+    .unwrap();
+    let middle_src = middle_dir.join("middle");
+    fs_err::create_dir_all(&middle_src).unwrap();
+    fs_err::write(middle_src.join("__init__.py"), "").unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        lock_file.contains_pypi_package("default", platform, "core"),
+        "default environment should contain core"
+    );
+    assert!(
+        lock_file.contains_pypi_package("default", platform, "middle"),
+        "default environment should contain middle"
+    );
+}
+
 #[tokio::test]
 async fn test_missing_mapping_file_error_includes_path() {
     setup_tracing();

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -172,12 +172,11 @@ pub fn as_uv_req(
             if canonicalized.is_dir() {
                 RequirementSource::Directory {
                     install_path: canonicalized.into_boxed_path(),
-                    // Always set editable to false during resolution.
-                    // Editability doesn't affect resolution and is looked up from the
-                    // manifest at install time. This allows different environments in a
-                    // solve-group to have different editability settings without causing
-                    // "conflicting URLs" errors from the uv resolver.
-                    editable: Some(false),
+                    // Editability is applied at install time from the manifest
+                    // (`is_editable_from_manifest`). Leaving it unspecified
+                    // avoids uv "conflicting URLs" errors across solve-group
+                    // environments and transitive `[tool.uv.sources]` (#6121).
+                    editable: None,
                     url: verbatim,
                     // TODO: we could see if we ever need this
                     // AFAICS it would be useful for constraining dependencies


### PR DESCRIPTION
### Description

`pixi lock` failed with `Requirements contain conflicting URLs ... (editable)` when a path dependency declared in `[tool.pixi.pypi-dependencies]` was *also* referenced by a transitive `[tool.uv.sources]` entry. pixi was rewriting its own declaration to `editable = false` while uv preserved the transitive's `editable = true`, and uv's URL conflict check rejected the mismatch.

Send `editable: None` to uv at resolution time instead of a fixed boolean. uv treats `None` as "no opinion" and accepts unification with any transitive `editable` value. Editability is still applied at install time from the manifest (`is_editable_from_manifest`), so behaviour is unchanged.

Fixes #6121

### How Has This Been Tested?

- New regression test `test_transitive_uv_sources_editable_consistency` reproduces the issue's exact structure (app → core + middle, both editable; middle's `[tool.uv.sources]` re-declares core editable). Confirmed to fail on `main` with the reported error and pass with the fix.
- Existing `test_solve_group_per_environment_editability` (mixed `editable = true`/`false` across solve-group envs) still passes, the constant-editable invariant is preserved.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.