### PR TITLE
chore(deps): bump uv to 0.11.15

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,6 +23,16 @@ DENO_EXECUTABLE_NAME = "pixi"
 # A little hack to make the CARGO_WORKSPACE_DIR available in tests.
 # See: https://github.com/rust-lang/cargo/issues/3946#issuecomment-973132993
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
+# Match uv's runtime stack budget for every thread libtest spawns. uv's
+# binary sets 4 MB on main2, the tokio runtime, and rayon via
+# `uv_configuration::min_stack_size()`; its async state machines
+# (especially the `process_request → setup_build → resolve` recursion
+# in the 0.11.15 async-zip / async-tar paths) outgrow the 2 MB libtest
+# default. Pixi's integration tests call into uv inside a
+# `#[tokio::test]`, so libtest's per-test thread needs the same 4 MB
+# headroom. `crates/pixi/src/main.rs` already reads this variable for
+# the production `main2` thread.
+RUST_MIN_STACK = "4194304"
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -362,26 +362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31979bc305610246d78ac01d63467a12d8454c6e3b8b22b5811d343a1198dfbb"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "astral_async_http_range_reader"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9a05148c7b3e85c17806fef4b2889c44f1a60575c5da9e9be80ce13227185"
-dependencies = [
- "astral-reqwest-middleware",
- "bisection",
- "futures",
- "http-content-range",
- "itertools 0.14.0",
- "memmap2 0.9.10",
- "reqwest",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util 0.7.18",
- "tracing",
 ]
 
 [[package]]
@@ -1235,12 +1215,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bisection"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
 
 [[package]]
 name = "bit-set"
@@ -2494,7 +2468,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2528,7 +2502,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2784,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3827,7 +3801,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4185,7 +4159,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4545,7 +4519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4571,7 +4545,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4995,7 +4969,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5166,7 +5140,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7724,7 +7698,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7762,9 +7736,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8485,7 +8459,7 @@ checksum = "8ee65f748ab93c2c022224824f8e75424a721dfc0e90f305675f735a97b465d0"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
- "astral_async_http_range_reader 0.11.0",
+ "astral_async_http_range_reader",
  "astral_async_zip",
  "async-compression",
  "async-spooled-tempfile",
@@ -9289,7 +9263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9369,7 +9343,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10398,7 +10372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10716,7 +10690,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10726,7 +10700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11363,7 +11337,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11505,8 +11479,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11545,8 +11519,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11585,8 +11559,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11622,8 +11596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11648,8 +11622,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11664,8 +11638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "hex",
  "memchr",
@@ -11677,14 +11651,14 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "astral-tl",
- "astral_async_http_range_reader 0.10.0",
+ "astral_async_http_range_reader",
  "astral_async_zip",
  "async-trait",
  "bytecheck",
@@ -11735,8 +11709,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "clap",
  "either",
@@ -11767,16 +11741,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11786,8 +11760,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "futures",
@@ -11819,8 +11793,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11858,6 +11832,7 @@ dependencies = [
  "uv-pep508",
  "uv-platform-tags",
  "uv-pypi-types",
+ "uv-python",
  "uv-redacted",
  "uv-types",
  "uv-warnings",
@@ -11868,8 +11843,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11885,8 +11860,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11925,8 +11900,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11957,16 +11932,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "backon",
  "clap",
@@ -11995,8 +11970,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12021,8 +11996,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12034,8 +12009,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12048,8 +12023,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "configparser",
  "csv",
@@ -12083,8 +12058,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12125,8 +12100,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12140,8 +12115,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12151,8 +12126,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12169,8 +12144,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12180,8 +12155,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "dashmap",
  "futures",
@@ -12190,16 +12165,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12212,8 +12187,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12239,8 +12214,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12258,8 +12233,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12272,8 +12247,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12283,8 +12258,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12314,8 +12289,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12373,8 +12348,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12385,8 +12360,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12420,8 +12395,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12445,8 +12420,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12468,6 +12443,7 @@ dependencies = [
  "same-file",
  "schemars 1.2.1",
  "serde",
+ "serde_json",
  "smallvec",
  "textwrap",
  "thiserror 2.0.18",
@@ -12510,8 +12486,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12536,8 +12512,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "clap",
  "fs-err",
@@ -12571,8 +12547,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12587,8 +12563,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12598,8 +12574,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12608,8 +12584,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12617,8 +12593,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "clap",
  "either",
@@ -12638,10 +12614,12 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
+ "anyhow",
  "fs-err",
+ "goblin",
  "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
@@ -12651,8 +12629,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12674,13 +12652,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.2"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.11.3"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "console",
  "fs-err",
@@ -12701,8 +12679,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12711,8 +12689,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.35"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
+version = "0.0.36"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
 dependencies = [
  "clap",
  "fs-err",
@@ -13058,7 +13036,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4577,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4603,7 +4603,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5027,7 +5027,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5054,15 +5054,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -5198,7 +5189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6477,7 +6468,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "miette 7.6.0",
- "nanoid 0.5.0",
+ "nanoid",
  "once_cell",
  "ordermap",
  "parking_lot 0.12.5",
@@ -7765,7 +7756,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7803,9 +7794,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9339,7 +9330,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9419,7 +9410,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10448,7 +10439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10766,7 +10757,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10776,7 +10767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11413,7 +11404,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11555,8 +11546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11595,8 +11586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11628,6 +11619,7 @@ dependencies = [
  "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
+ "uv-version",
  "uv-warnings",
  "walkdir",
  "zip",
@@ -11635,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11672,11 +11664,10 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "fs-err",
- "nanoid 0.4.0",
  "rmp-serde",
  "rustc-hash",
  "same-file",
@@ -11688,6 +11679,7 @@ dependencies = [
  "uv-cache-key",
  "uv-dirs",
  "uv-distribution-types",
+ "uv-fastid",
  "uv-fs",
  "uv-normalize",
  "uv-pypi-types",
@@ -11698,8 +11690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11714,8 +11706,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "hex",
  "memchr",
@@ -11727,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11787,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "clap",
  "either",
@@ -11819,16 +11811,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11838,8 +11830,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "futures",
@@ -11872,15 +11864,14 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
  "either",
  "fs-err",
  "futures",
- "nanoid 0.4.0",
  "owo-colors",
  "reqwest",
  "rmp-serde",
@@ -11901,6 +11892,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-extract",
+ "uv-fastid",
  "uv-flags",
  "uv-fs",
  "uv-git",
@@ -11923,8 +11915,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11940,8 +11932,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11980,8 +11972,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12009,17 +12001,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-fastid"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+dependencies = [
+ "fastrand",
+ "rand 0.9.4",
+ "serde",
+]
+
+[[package]]
 name = "uv-flags"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "backon",
  "clap",
@@ -12042,14 +12044,15 @@ dependencies = [
  "tracing",
  "uv-static",
  "uv-warnings",
+ "uv-windows",
  "walkdir",
  "windows 0.61.3",
 ]
 
 [[package]]
 name = "uv-git"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12074,8 +12077,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12088,8 +12091,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12102,8 +12105,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "configparser",
  "csv",
@@ -12137,8 +12140,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12179,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12194,8 +12197,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12205,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12223,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12234,8 +12237,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "dashmap",
  "futures",
@@ -12244,16 +12247,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12266,8 +12269,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12293,8 +12296,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12312,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12326,8 +12329,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12337,8 +12340,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12368,8 +12371,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12381,7 +12384,6 @@ dependencies = [
  "futures",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "junction",
  "owo-colors",
  "ref-cast",
  "regex",
@@ -12427,8 +12429,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12439,8 +12441,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12474,8 +12476,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12499,8 +12501,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12565,8 +12567,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12591,8 +12593,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "clap",
  "fs-err",
@@ -12628,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12644,8 +12646,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12655,8 +12657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12665,8 +12667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12674,8 +12676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "clap",
  "either",
@@ -12695,8 +12697,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12710,8 +12712,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12733,13 +12735,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.8"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.11.9"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "console",
  "fs-err",
@@ -12760,8 +12762,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12769,9 +12771,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-windows"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+dependencies = [
+ "arrayvec",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "uv-workspace"
-version = "0.0.41"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
+version = "0.0.42"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
 dependencies = [
  "clap",
  "fs-err",
@@ -13117,7 +13128,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2468,7 +2468,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2502,7 +2502,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2758,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3801,7 +3801,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4159,7 +4159,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4519,7 +4519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4545,7 +4545,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4969,7 +4969,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5140,7 +5140,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7698,7 +7698,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7736,9 +7736,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9263,7 +9263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9343,7 +9343,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10372,7 +10372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10690,7 +10690,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10700,7 +10700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11337,7 +11337,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11479,8 +11479,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11519,8 +11519,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11559,8 +11559,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11596,8 +11596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11622,8 +11622,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11638,8 +11638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "hex",
  "memchr",
@@ -11651,8 +11651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11709,8 +11709,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "clap",
  "either",
@@ -11741,16 +11741,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11760,8 +11760,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "futures",
@@ -11793,8 +11793,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11843,8 +11843,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11860,8 +11860,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11900,8 +11900,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11932,16 +11932,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "backon",
  "clap",
@@ -11970,8 +11970,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11996,21 +11996,22 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "uv-cache-key",
  "uv-redacted",
  "uv-static",
 ]
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12023,8 +12024,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "configparser",
  "csv",
@@ -12058,8 +12059,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12100,8 +12101,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12115,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12126,8 +12127,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12144,8 +12145,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12155,8 +12156,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "dashmap",
  "futures",
@@ -12165,16 +12166,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12187,8 +12188,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12214,8 +12215,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12233,8 +12234,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12247,8 +12248,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12258,8 +12259,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12289,8 +12290,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12348,8 +12349,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12360,8 +12361,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12395,8 +12396,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12420,8 +12421,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12486,8 +12487,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12512,8 +12513,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "clap",
  "fs-err",
@@ -12547,8 +12548,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12563,8 +12564,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12574,8 +12575,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12584,8 +12585,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12593,8 +12594,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "clap",
  "either",
@@ -12614,8 +12615,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12629,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12652,13 +12653,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.3"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.11.4"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "console",
  "fs-err",
@@ -12679,8 +12680,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12689,8 +12690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.36"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.3#45da18ac317f9abdf9313066907511b5aebc476b"
+version = "0.0.37"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
 dependencies = [
  "clap",
  "fs-err",
@@ -13036,7 +13037,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4577,7 +4577,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "junction"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4603,7 +4613,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5027,7 +5037,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5189,7 +5199,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7756,7 +7766,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7794,9 +7804,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9330,7 +9340,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9410,7 +9420,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10439,7 +10449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10639,7 +10649,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88826d6169418c98e8bc52a43f79d50907dfa3e87ba5161930d42c6f980b35ee"
 dependencies = [
- "junction",
+ "junction 1.4.2",
  "libc",
  "sys_traits_macros",
  "windows-sys 0.59.0",
@@ -10757,7 +10767,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10767,7 +10777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11404,7 +11414,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11546,8 +11556,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11586,8 +11596,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11627,8 +11637,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11664,8 +11674,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "fs-err",
  "rmp-serde",
@@ -11690,8 +11700,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11706,8 +11716,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "hex",
  "memchr",
@@ -11719,8 +11729,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11779,8 +11789,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "clap",
  "either",
@@ -11811,16 +11821,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11830,8 +11840,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "futures",
@@ -11864,8 +11874,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11915,8 +11925,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11932,8 +11942,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11972,8 +11982,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12002,8 +12012,8 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -12012,16 +12022,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "backon",
  "clap",
@@ -12029,7 +12039,7 @@ dependencies = [
  "either",
  "encoding_rs_io",
  "fs-err",
- "junction",
+ "junction 2.0.0",
  "path-slash",
  "percent-encoding",
  "reflink-copy",
@@ -12051,8 +12061,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12077,8 +12087,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "percent-encoding",
  "serde",
@@ -12092,8 +12102,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12106,8 +12116,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "configparser",
  "csv",
@@ -12141,8 +12151,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12183,8 +12193,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12198,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12209,8 +12219,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12227,8 +12237,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12238,8 +12248,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "dashmap",
  "futures",
@@ -12248,16 +12258,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12270,8 +12280,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12297,8 +12307,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12316,8 +12326,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12330,8 +12340,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12341,8 +12351,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12372,8 +12382,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12430,8 +12440,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12442,8 +12452,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12477,8 +12487,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12502,8 +12512,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12568,8 +12578,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12594,8 +12604,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "clap",
  "fs-err",
@@ -12631,8 +12641,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12647,8 +12657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12658,8 +12668,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12668,8 +12678,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12677,8 +12687,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "clap",
  "either",
@@ -12698,8 +12708,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12713,8 +12723,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12736,13 +12746,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.13"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.11.14"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "console",
  "fs-err",
@@ -12763,8 +12773,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12773,8 +12783,8 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "arrayvec",
  "windows 0.61.3",
@@ -12782,8 +12792,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.46"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
+version = "0.0.47"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
 dependencies = [
  "clap",
  "fs-err",
@@ -13129,7 +13139,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,7 +2494,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2528,7 +2528,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2784,7 +2784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3827,7 +3827,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4185,7 +4185,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4545,7 +4545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4571,7 +4571,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5166,7 +5166,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5281,7 +5281,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -7571,7 +7571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7724,7 +7724,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7762,9 +7762,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9289,7 +9289,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9369,7 +9369,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10716,7 +10716,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10726,7 +10726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11505,8 +11505,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11545,8 +11545,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11585,8 +11585,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11622,8 +11622,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11648,8 +11648,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11664,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "hex",
  "memchr",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11735,8 +11735,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "clap",
  "either",
@@ -11767,16 +11767,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11786,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "futures",
@@ -11819,8 +11819,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11868,8 +11868,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11885,8 +11885,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11925,8 +11925,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11957,16 +11957,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "backon",
  "clap",
@@ -11995,8 +11995,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12021,8 +12021,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12034,8 +12034,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12048,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "configparser",
  "csv",
@@ -12083,8 +12083,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12125,8 +12125,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12140,8 +12140,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12151,8 +12151,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12169,8 +12169,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12180,8 +12180,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "dashmap",
  "futures",
@@ -12190,16 +12190,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12212,8 +12212,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12239,8 +12239,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12258,8 +12258,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12272,8 +12272,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12283,8 +12283,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12314,8 +12314,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12373,8 +12373,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12385,8 +12385,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12420,8 +12420,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12445,8 +12445,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12510,8 +12510,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12536,8 +12536,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "clap",
  "fs-err",
@@ -12571,8 +12571,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12587,8 +12587,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12598,8 +12598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12608,8 +12608,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12617,8 +12617,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "clap",
  "either",
@@ -12638,8 +12638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12651,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12674,13 +12674,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.0"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.11.1"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "console",
  "fs-err",
@@ -12701,8 +12701,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12711,8 +12711,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.33"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.0#1f31f0e9fbcfcf95aed89b44a376596e14b40e06"
+version = "0.0.34"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
 dependencies = [
  "clap",
  "fs-err",
@@ -13058,7 +13058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3854,7 +3854,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4212,7 +4212,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4572,7 +4572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4598,7 +4598,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5022,7 +5022,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5193,7 +5193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7760,7 +7760,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7798,9 +7798,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9334,7 +9334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9414,7 +9414,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10443,7 +10443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10761,7 +10761,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10771,7 +10771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11408,7 +11408,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11550,8 +11550,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11590,8 +11590,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11630,8 +11630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11667,8 +11667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11693,8 +11693,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11709,8 +11709,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "hex",
  "memchr",
@@ -11722,8 +11722,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11782,8 +11782,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "clap",
  "either",
@@ -11814,16 +11814,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11833,8 +11833,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "futures",
@@ -11866,8 +11866,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11899,6 +11899,7 @@ dependencies = [
  "uv-fs",
  "uv-git",
  "uv-git-types",
+ "uv-install-wheel",
  "uv-metadata",
  "uv-normalize",
  "uv-pep440",
@@ -11916,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11933,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11973,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12005,16 +12006,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "backon",
  "clap",
@@ -12043,8 +12044,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12069,8 +12070,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12083,8 +12084,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12097,8 +12098,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "configparser",
  "csv",
@@ -12132,8 +12133,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12174,8 +12175,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12189,8 +12190,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12200,8 +12201,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12218,8 +12219,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12229,8 +12230,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "dashmap",
  "futures",
@@ -12239,16 +12240,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12261,8 +12262,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12288,8 +12289,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12307,8 +12308,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12321,8 +12322,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12332,8 +12333,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12363,8 +12364,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12422,8 +12423,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12434,8 +12435,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12469,8 +12470,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12494,8 +12495,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12560,8 +12561,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12586,8 +12587,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "clap",
  "fs-err",
@@ -12621,8 +12622,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12637,8 +12638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12648,8 +12649,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12658,8 +12659,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12667,8 +12668,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "clap",
  "either",
@@ -12688,8 +12689,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12703,8 +12704,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12726,13 +12727,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.5"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.11.6"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "console",
  "fs-err",
@@ -12753,8 +12754,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12763,8 +12764,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.38"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
+version = "0.0.39"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
 dependencies = [
  "clap",
  "fs-err",
@@ -13110,7 +13111,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4577,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4603,7 +4603,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5027,7 +5027,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5189,7 +5189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7756,7 +7756,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7794,9 +7794,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9330,7 +9330,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9410,7 +9410,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10439,7 +10439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10757,7 +10757,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10767,7 +10767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11404,7 +11404,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11546,8 +11546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11586,8 +11586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11627,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11664,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "fs-err",
  "rmp-serde",
@@ -11690,8 +11690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11706,8 +11706,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "hex",
  "memchr",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11779,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "clap",
  "either",
@@ -11811,16 +11811,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11830,8 +11830,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "futures",
@@ -11864,8 +11864,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11915,8 +11915,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11932,8 +11932,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11972,8 +11972,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12002,8 +12002,8 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -12012,16 +12012,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "backon",
  "clap",
@@ -12051,8 +12051,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12077,8 +12077,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "percent-encoding",
  "serde",
@@ -12092,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12106,8 +12106,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "configparser",
  "csv",
@@ -12141,8 +12141,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12183,8 +12183,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12198,8 +12198,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12209,8 +12209,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12227,8 +12227,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12238,8 +12238,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "dashmap",
  "futures",
@@ -12248,16 +12248,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12270,8 +12270,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12297,8 +12297,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12316,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12330,8 +12330,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12341,8 +12341,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12372,8 +12372,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12430,8 +12430,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12442,8 +12442,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12477,8 +12477,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12502,8 +12502,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12568,8 +12568,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12594,8 +12594,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "clap",
  "fs-err",
@@ -12631,8 +12631,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12647,8 +12647,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12658,8 +12658,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12668,8 +12668,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12677,8 +12677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "clap",
  "either",
@@ -12698,8 +12698,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12713,8 +12713,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12736,13 +12736,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.12"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.11.13"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "console",
  "fs-err",
@@ -12763,8 +12763,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12773,8 +12773,8 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "arrayvec",
  "windows 0.61.3",
@@ -12782,8 +12782,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.45"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
+version = "0.0.46"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.13#4512a39319dbd9ad96e0b0a22223eb263dbf5d16"
 dependencies = [
  "clap",
  "fs-err",
@@ -13129,7 +13129,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3854,7 +3854,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4212,7 +4212,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4572,7 +4572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4598,7 +4598,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5022,7 +5022,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5193,7 +5193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7760,7 +7760,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7798,9 +7798,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9334,7 +9334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9414,7 +9414,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10443,7 +10443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10761,7 +10761,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10771,7 +10771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11408,7 +11408,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11550,8 +11550,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11590,8 +11590,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11630,8 +11630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11667,8 +11667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11693,8 +11693,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11709,8 +11709,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "hex",
  "memchr",
@@ -11722,8 +11722,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11782,8 +11782,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "clap",
  "either",
@@ -11814,16 +11814,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11833,8 +11833,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "futures",
@@ -11866,8 +11866,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11917,8 +11917,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11934,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11974,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12006,16 +12006,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "backon",
  "clap",
@@ -12044,8 +12044,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12070,8 +12070,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12084,8 +12084,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12098,8 +12098,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "configparser",
  "csv",
@@ -12133,8 +12133,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12175,8 +12175,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12190,8 +12190,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12201,8 +12201,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12219,8 +12219,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12230,8 +12230,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "dashmap",
  "futures",
@@ -12240,16 +12240,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12262,8 +12262,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12289,8 +12289,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12308,8 +12308,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12322,8 +12322,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12333,8 +12333,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12364,8 +12364,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12423,8 +12423,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12435,8 +12435,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12470,8 +12470,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12495,8 +12495,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12561,8 +12561,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12587,8 +12587,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "clap",
  "fs-err",
@@ -12609,6 +12609,7 @@ dependencies = [
  "uv-macros",
  "uv-normalize",
  "uv-options-metadata",
+ "uv-pep440",
  "uv-pep508",
  "uv-pypi-types",
  "uv-python",
@@ -12616,14 +12617,15 @@ dependencies = [
  "uv-resolver",
  "uv-static",
  "uv-torch",
+ "uv-version",
  "uv-warnings",
  "uv-workspace",
 ]
 
 [[package]]
 name = "uv-shell"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12638,8 +12640,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12649,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12659,8 +12661,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12668,8 +12670,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "clap",
  "either",
@@ -12689,8 +12691,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12704,8 +12706,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12727,13 +12729,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.6"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.11.7"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "console",
  "fs-err",
@@ -12754,8 +12756,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12764,8 +12766,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.39"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.6#65950801cc3c609b65be34938bb407ab6e30a9fe"
+version = "0.0.40"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
 dependencies = [
  "clap",
  "fs-err",
@@ -13111,7 +13113,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2494,7 +2494,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2528,7 +2528,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2784,7 +2784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3827,7 +3827,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4185,7 +4185,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4545,7 +4545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4571,7 +4571,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4995,7 +4995,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5166,7 +5166,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7724,7 +7724,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7762,9 +7762,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9289,7 +9289,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9369,7 +9369,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10398,7 +10398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10716,7 +10716,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10726,7 +10726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11363,7 +11363,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11505,8 +11505,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11545,8 +11545,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11585,8 +11585,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11622,8 +11622,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11648,8 +11648,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11664,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "hex",
  "memchr",
@@ -11677,8 +11677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11735,8 +11735,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "clap",
  "either",
@@ -11767,16 +11767,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11786,8 +11786,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "futures",
@@ -11819,8 +11819,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11868,8 +11868,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11885,8 +11885,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11925,8 +11925,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11957,16 +11957,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "backon",
  "clap",
@@ -11995,8 +11995,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12021,8 +12021,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12034,8 +12034,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12048,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "configparser",
  "csv",
@@ -12083,8 +12083,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12125,8 +12125,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12140,8 +12140,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12151,8 +12151,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12169,8 +12169,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12180,8 +12180,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "dashmap",
  "futures",
@@ -12190,16 +12190,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12212,8 +12212,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12239,8 +12239,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12258,8 +12258,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12272,8 +12272,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12283,8 +12283,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12314,8 +12314,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12373,8 +12373,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12385,8 +12385,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12420,8 +12420,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12445,8 +12445,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12510,8 +12510,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12536,8 +12536,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "clap",
  "fs-err",
@@ -12571,8 +12571,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12587,8 +12587,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12598,8 +12598,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12608,8 +12608,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12617,8 +12617,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "clap",
  "either",
@@ -12638,8 +12638,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12651,8 +12651,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12674,13 +12674,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.1"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.11.2"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "console",
  "fs-err",
@@ -12701,8 +12701,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12711,8 +12711,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.34"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.1#a6042f67fcfa4d2196029b127f6cdb5a9b8c0864"
+version = "0.0.35"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.2#02036a8ba599677fa4c5e2f24dad1c516735fbad"
 dependencies = [
  "clap",
  "fs-err",
@@ -13058,7 +13058,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4577,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4603,7 +4603,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5027,7 +5027,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5189,7 +5189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7756,7 +7756,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7794,9 +7794,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9330,7 +9330,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9410,7 +9410,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10439,7 +10439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10757,7 +10757,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10767,7 +10767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11404,7 +11404,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11546,8 +11546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11586,8 +11586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11627,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11664,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "fs-err",
  "rmp-serde",
@@ -11690,8 +11690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11706,8 +11706,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "hex",
  "memchr",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11779,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "clap",
  "either",
@@ -11811,16 +11811,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11830,8 +11830,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "futures",
@@ -11864,8 +11864,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11915,8 +11915,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11932,8 +11932,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11972,8 +11972,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12002,8 +12002,8 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -12012,16 +12012,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "backon",
  "clap",
@@ -12051,8 +12051,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12077,8 +12077,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12091,8 +12091,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12105,8 +12105,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "configparser",
  "csv",
@@ -12140,8 +12140,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12182,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12197,8 +12197,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12208,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12226,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12237,8 +12237,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "dashmap",
  "futures",
@@ -12247,16 +12247,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12269,8 +12269,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12296,8 +12296,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12315,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12329,8 +12329,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12340,8 +12340,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12371,8 +12371,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12429,8 +12429,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12441,8 +12441,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12476,8 +12476,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12501,8 +12501,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12567,8 +12567,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12593,8 +12593,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "clap",
  "fs-err",
@@ -12630,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12646,8 +12646,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12657,8 +12657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12667,8 +12667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12676,8 +12676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "clap",
  "either",
@@ -12697,8 +12697,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12712,8 +12712,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12735,13 +12735,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.10"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.11.11"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "console",
  "fs-err",
@@ -12762,8 +12762,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12772,8 +12772,8 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "arrayvec",
  "windows 0.61.3",
@@ -12781,8 +12781,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.43"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
+version = "0.0.44"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
 dependencies = [
  "clap",
  "fs-err",
@@ -13128,7 +13128,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4577,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4603,7 +4603,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5027,7 +5027,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5189,7 +5189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7756,7 +7756,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7794,9 +7794,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9330,7 +9330,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9410,7 +9410,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10439,7 +10439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10757,7 +10757,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10767,7 +10767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11404,7 +11404,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11546,8 +11546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11586,8 +11586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11627,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11664,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "fs-err",
  "rmp-serde",
@@ -11690,8 +11690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11706,8 +11706,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "hex",
  "memchr",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11779,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "clap",
  "either",
@@ -11811,16 +11811,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11830,8 +11830,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "futures",
@@ -11864,8 +11864,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11915,8 +11915,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11932,8 +11932,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11972,8 +11972,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12002,8 +12002,8 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -12012,16 +12012,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "backon",
  "clap",
@@ -12051,8 +12051,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12077,8 +12077,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12091,8 +12091,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12105,8 +12105,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "configparser",
  "csv",
@@ -12140,8 +12140,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12182,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12197,8 +12197,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12208,8 +12208,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12226,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12237,8 +12237,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "dashmap",
  "futures",
@@ -12247,16 +12247,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12269,8 +12269,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12296,8 +12296,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12315,8 +12315,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12329,8 +12329,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12340,8 +12340,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12371,8 +12371,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12429,8 +12429,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12441,8 +12441,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12476,8 +12476,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12501,8 +12501,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12567,8 +12567,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12593,8 +12593,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "clap",
  "fs-err",
@@ -12630,8 +12630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12646,8 +12646,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12657,8 +12657,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12667,8 +12667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12676,8 +12676,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "clap",
  "either",
@@ -12697,8 +12697,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12712,8 +12712,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12735,13 +12735,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.9"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.11.10"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "console",
  "fs-err",
@@ -12762,8 +12762,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12772,8 +12772,8 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "arrayvec",
  "windows 0.61.3",
@@ -12781,8 +12781,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.42"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.9#7829a03b6c6226de50296fecbe9277022c375b7c"
+version = "0.0.43"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.10#add376fd92974b284cad95076d3ee4286ac60e52"
 dependencies = [
  "clap",
  "fs-err",
@@ -13128,7 +13128,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4577,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4603,7 +4603,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5027,7 +5027,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5189,7 +5189,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7756,7 +7756,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7794,9 +7794,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9330,7 +9330,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9410,7 +9410,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10439,7 +10439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10757,7 +10757,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10767,7 +10767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11404,7 +11404,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11546,8 +11546,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11586,8 +11586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11627,8 +11627,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11664,8 +11664,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "fs-err",
  "rmp-serde",
@@ -11690,8 +11690,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11706,8 +11706,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "hex",
  "memchr",
@@ -11719,8 +11719,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11779,8 +11779,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "clap",
  "either",
@@ -11811,16 +11811,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11830,8 +11830,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "futures",
@@ -11864,8 +11864,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11915,8 +11915,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11932,8 +11932,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11972,8 +11972,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -12002,8 +12002,8 @@ dependencies = [
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -12012,16 +12012,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "backon",
  "clap",
@@ -12051,8 +12051,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12077,9 +12077,10 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
+ "percent-encoding",
  "serde",
  "thiserror 2.0.18",
  "tracing",
@@ -12091,8 +12092,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12105,8 +12106,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "configparser",
  "csv",
@@ -12140,8 +12141,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12182,8 +12183,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12197,8 +12198,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12208,8 +12209,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12226,8 +12227,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12237,8 +12238,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "dashmap",
  "futures",
@@ -12247,16 +12248,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12269,8 +12270,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12296,8 +12297,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12315,8 +12316,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12329,8 +12330,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12340,8 +12341,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12371,8 +12372,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12429,8 +12430,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12441,8 +12442,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12476,8 +12477,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12501,8 +12502,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12567,8 +12568,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12593,8 +12594,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "clap",
  "fs-err",
@@ -12630,8 +12631,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12646,8 +12647,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12657,8 +12658,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12667,8 +12668,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12676,8 +12677,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "clap",
  "either",
@@ -12697,8 +12698,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12712,8 +12713,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12735,13 +12736,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.11"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.11.12"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "console",
  "fs-err",
@@ -12762,8 +12763,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12772,8 +12773,8 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "arrayvec",
  "windows 0.61.3",
@@ -12781,8 +12782,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.44"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.11#ed7b060013cdf641a39a59cbf631a857e0e827e1"
+version = "0.0.45"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.12#63c5f57d36c03835b9840149c76f20c5bdb982a7"
 dependencies = [
  "clap",
  "fs-err",
@@ -13128,7 +13129,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -272,6 +272,45 @@ dependencies = [
  "scroll",
  "sha2 0.10.9",
  "tempfile",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2371,6 +2410,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "der_derive"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2502,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2758,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3801,7 +3854,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4159,7 +4212,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4519,7 +4572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4545,7 +4598,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4969,7 +5022,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5140,7 +5193,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5319,6 +5372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -7698,7 +7760,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7736,9 +7798,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9241,6 +9303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9263,7 +9334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9343,7 +9414,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10372,7 +10443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10690,7 +10761,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10700,7 +10771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11337,7 +11408,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11479,8 +11550,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11519,8 +11590,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11559,8 +11630,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11596,8 +11667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11622,8 +11693,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11638,8 +11709,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "hex",
  "memchr",
@@ -11651,8 +11722,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11676,6 +11747,7 @@ dependencies = [
  "rustc-hash",
  "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -11705,12 +11777,13 @@ dependencies = [
  "uv-version",
  "uv-warnings",
  "webpki-root-certs 1.0.7",
+ "x509-parser",
 ]
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "either",
@@ -11741,16 +11814,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11760,8 +11833,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "futures",
@@ -11793,8 +11866,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11843,8 +11916,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11860,8 +11933,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11900,8 +11973,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11932,16 +12005,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "backon",
  "clap",
@@ -11970,8 +12043,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11996,8 +12069,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12010,8 +12083,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12024,8 +12097,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "configparser",
  "csv",
@@ -12059,8 +12132,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12101,8 +12174,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12116,8 +12189,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12127,8 +12200,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12145,8 +12218,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12156,8 +12229,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "dashmap",
  "futures",
@@ -12166,16 +12239,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12188,8 +12261,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12215,8 +12288,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12234,8 +12307,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12248,8 +12321,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12259,8 +12332,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
@@ -12290,8 +12363,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12349,8 +12422,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12361,8 +12434,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12396,8 +12469,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12421,8 +12494,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12487,8 +12560,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12513,8 +12586,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "fs-err",
@@ -12548,8 +12621,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12564,8 +12637,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12575,8 +12648,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12585,8 +12658,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12594,8 +12667,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "either",
@@ -12615,8 +12688,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12630,8 +12703,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12653,13 +12726,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.4"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.11.5"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "console",
  "fs-err",
@@ -12680,8 +12753,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12690,8 +12763,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.37"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.4#3523c23490c252706262de1cb7ea8dac34db60f3"
+version = "0.0.38"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.5#95eaa68c8df627eb915bc355831fd7d169d91fe3"
 dependencies = [
  "clap",
  "fs-err",
@@ -13037,7 +13110,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13735,6 +13808,23 @@ dependencies = [
  "signature 2.2.0",
  "spki 0.7.3",
  "tls_codec",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -433,6 +433,21 @@ dependencies = [
  "futures-lite",
  "pin-project",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-util 0.7.18",
+]
+
+[[package]]
+name = "astral_async_zip"
+version = "0.0.18-rc4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d523231a4339307c7699aa5d9492fe6873906afefc9d7853b5e7ffbfee3c7f1"
+dependencies = [
+ "async-compression",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
 ]
@@ -2521,7 +2536,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2555,7 +2570,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2811,7 +2826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3859,7 +3874,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4217,7 +4232,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4577,7 +4592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4587,7 +4602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4613,7 +4628,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5037,7 +5052,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5199,7 +5214,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7766,7 +7781,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7804,9 +7819,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8528,7 +8543,7 @@ dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
  "astral_async_http_range_reader",
- "astral_async_zip",
+ "astral_async_zip 0.0.17",
  "async-compression",
  "async-spooled-tempfile",
  "bzip2 0.6.1",
@@ -8925,6 +8940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f343280e2e5ce07f97f32ead07a68824cb9cea60093ad78f22664011f90ae47"
 dependencies = [
  "reqsign-aws-v4",
+ "reqsign-azure-storage",
  "reqsign-command-execute-tokio",
  "reqsign-core",
  "reqsign-file-read-tokio",
@@ -8950,6 +8966,28 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha1 0.10.6",
+]
+
+[[package]]
+name = "reqsign-azure-storage"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a321980405d596bd34aaf95c4722a3de4128a67fd19e74a81a83aa3fdf082e6"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "http 1.4.0",
+ "jsonwebtoken",
+ "log",
+ "pem",
+ "percent-encoding",
+ "reqsign-core",
+ "rsa",
+ "serde",
+ "serde_json",
  "sha1 0.10.6",
 ]
 
@@ -9278,16 +9316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-netrc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e98097f62769f92dbf95fb51f71c0a68ec18a4ee2e70e0d3e4f47ac005d63e9"
-dependencies = [
- "shellexpand",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9340,7 +9368,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9420,7 +9448,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10449,7 +10477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10767,7 +10795,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10777,7 +10805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11070,7 +11098,6 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "foldhash 0.2.0",
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
@@ -11086,6 +11113,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
+ "foldhash 0.2.0",
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
@@ -11140,28 +11168,16 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
+ "toml_writer",
  "winnow 1.0.3",
 ]
 
@@ -11414,7 +11430,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11556,8 +11572,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11572,19 +11588,19 @@ dependencies = [
  "percent-encoding",
  "reqsign",
  "reqwest",
- "rust-netrc",
  "rustc-hash",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
  "uv-fs",
  "uv-keyring",
+ "uv-netrc",
  "uv-once-map",
  "uv-preview",
  "uv-redacted",
@@ -11596,14 +11612,17 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
+ "astral-tokio-tar",
  "astral-version-ranges",
+ "astral_async_zip 0.0.18-rc4",
  "base64 0.22.1",
  "csv",
  "flate2",
  "fs-err",
+ "futures-lite",
  "globset",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -11613,10 +11632,10 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "spdx 0.13.4",
- "tar",
  "tempfile",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uv-distribution-filename",
  "uv-fs",
@@ -11629,16 +11648,16 @@ dependencies = [
  "uv-platform-tags",
  "uv-preview",
  "uv-pypi-types",
+ "uv-toml",
  "uv-version",
  "uv-warnings",
  "walkdir",
- "zip",
 ]
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11652,7 +11671,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "uv-auth",
  "uv-cache-key",
@@ -11674,8 +11693,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "fs-err",
  "rmp-serde",
@@ -11700,15 +11719,15 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "fs-err",
  "globwalk",
  "schemars 1.2.1",
  "serde",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uv-fs",
  "walkdir",
@@ -11716,8 +11735,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "hex",
  "memchr",
@@ -11729,15 +11748,15 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "astral-tl",
  "astral_async_http_range_reader",
- "astral_async_zip",
+ "astral_async_zip 0.0.18-rc4",
  "async-trait",
  "bytecheck",
  "fs-err",
@@ -11789,8 +11808,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "clap",
  "either",
@@ -11821,16 +11840,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11840,8 +11859,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "futures",
@@ -11874,8 +11893,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11891,7 +11910,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "uv-auth",
@@ -11920,13 +11939,12 @@ dependencies = [
  "uv-warnings",
  "uv-workspace",
  "walkdir",
- "zip",
 ]
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11942,8 +11960,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11982,13 +12000,14 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "astral-tokio-tar",
- "astral_async_zip",
+ "astral_async_zip 0.0.18-rc4",
  "async-compression",
  "blake2",
+ "flate2",
  "fs-err",
  "futures",
  "md-5 0.10.6",
@@ -12007,13 +12026,12 @@ dependencies = [
  "uv-static",
  "uv-warnings",
  "xz2",
- "zip",
 ]
 
 [[package]]
 name = "uv-fastid"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "fastrand",
  "rand 0.9.4",
@@ -12022,16 +12040,16 @@ dependencies = [
 
 [[package]]
 name = "uv-flags"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "backon",
  "clap",
@@ -12047,6 +12065,7 @@ dependencies = [
  "rustix 1.1.4",
  "same-file",
  "schemars 1.2.1",
+ "self-replace",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
@@ -12061,8 +12080,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12074,6 +12093,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
  "uv-auth",
  "uv-cache-key",
  "uv-fs",
@@ -12087,8 +12107,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "percent-encoding",
  "serde",
@@ -12102,8 +12122,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12116,8 +12136,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "configparser",
  "csv",
@@ -12151,8 +12171,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12193,8 +12213,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12208,8 +12228,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12219,10 +12239,10 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
- "astral_async_zip",
+ "astral_async_zip 0.0.18-rc4",
  "fs-err",
  "futures",
  "thiserror 2.0.18",
@@ -12232,13 +12252,21 @@ dependencies = [
  "uv-distribution-filename",
  "uv-normalize",
  "uv-pypi-types",
- "zip",
+]
+
+[[package]]
+name = "uv-netrc"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
+dependencies = [
+ "shellexpand",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12248,8 +12276,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "dashmap",
  "futures",
@@ -12258,16 +12286,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12280,8 +12308,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12307,8 +12335,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12326,8 +12354,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12340,8 +12368,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12351,8 +12379,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -12367,7 +12395,7 @@ dependencies = [
  "serde",
  "serde-untagged",
  "thiserror 2.0.18",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12382,8 +12410,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12440,8 +12468,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12452,8 +12480,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12462,7 +12490,7 @@ dependencies = [
  "futures",
  "rustc-hash",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12487,8 +12515,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12512,8 +12540,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12541,8 +12569,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-key",
@@ -12578,8 +12606,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12587,7 +12615,7 @@ dependencies = [
  "regex",
  "serde",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "uv-configuration",
@@ -12604,15 +12632,15 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "clap",
  "fs-err",
  "serde",
  "textwrap",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "url",
  "uv-cache-info",
@@ -12641,8 +12669,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12657,8 +12685,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12668,8 +12696,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12678,17 +12706,26 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
 ]
 
 [[package]]
+name = "uv-toml"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
+dependencies = [
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+]
+
+[[package]]
 name = "uv-torch"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "clap",
  "either",
@@ -12703,28 +12740,29 @@ dependencies = [
  "uv-pep440",
  "uv-platform-tags",
  "uv-static",
- "wmi",
+ "windows 0.61.3",
 ]
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
+ "astral_async_zip 0.0.18-rc4",
  "fs-err",
+ "futures-lite",
  "goblin",
  "tempfile",
  "thiserror 2.0.18",
  "uv-fs",
  "windows 0.61.3",
- "zip",
 ]
 
 [[package]]
 name = "uv-types"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12746,20 +12784,19 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.14"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.11.15"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "console",
  "fs-err",
  "itertools 0.14.0",
  "owo-colors",
  "pathdiff",
- "self-replace",
  "thiserror 2.0.18",
  "tracing",
  "uv-console",
@@ -12773,8 +12810,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12783,8 +12820,8 @@ dependencies = [
 
 [[package]]
 name = "uv-windows"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "arrayvec",
  "windows 0.61.3",
@@ -12792,8 +12829,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.47"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.14#3fdfdc7d4a63c9f283eb751823b7628b13116684"
+version = "0.0.48"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.15#3cffe97c2e48c9e49422c738da3af95919dd0bf5"
 dependencies = [
  "clap",
  "fs-err",
@@ -12806,8 +12843,8 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "tracing",
  "uv-build-backend",
  "uv-cache-key",
@@ -13139,7 +13176,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13797,20 +13834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wmi"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
-dependencies = [
- "futures",
- "log",
- "serde",
- "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14187,16 +14210,13 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "bzip2 0.6.1",
  "crc32fast",
  "flate2",
  "indexmap 2.14.0",
- "lzma-rust2",
  "memchr",
  "time",
  "typed-path",
  "zopfli",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2521,7 +2521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2811,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3499,6 +3499,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3854,7 +3859,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4212,7 +4217,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4572,7 +4577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4598,7 +4603,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5022,7 +5027,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5193,7 +5198,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7760,7 +7765,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7798,9 +7803,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9334,7 +9339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9414,7 +9419,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10443,7 +10448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10761,7 +10766,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10771,7 +10776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11408,7 +11413,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11550,8 +11555,8 @@ dependencies = [
 
 [[package]]
 name = "uv-auth"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -11590,8 +11595,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-backend"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -11630,8 +11635,8 @@ dependencies = [
 
 [[package]]
 name = "uv-build-frontend"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anstream",
  "fs-err",
@@ -11667,8 +11672,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "fs-err",
  "nanoid 0.4.0",
@@ -11693,8 +11698,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-info"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "fs-err",
  "globwalk",
@@ -11709,8 +11714,8 @@ dependencies = [
 
 [[package]]
 name = "uv-cache-key"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "hex",
  "memchr",
@@ -11722,8 +11727,8 @@ dependencies = [
 
 [[package]]
 name = "uv-client"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11782,8 +11787,8 @@ dependencies = [
 
 [[package]]
 name = "uv-configuration"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "clap",
  "either",
@@ -11814,16 +11819,16 @@ dependencies = [
 
 [[package]]
 name = "uv-console"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "uv-dirs"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "etcetera",
  "fs-err",
@@ -11833,8 +11838,8 @@ dependencies = [
 
 [[package]]
 name = "uv-dispatch"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "futures",
@@ -11858,6 +11863,7 @@ dependencies = [
  "uv-preview",
  "uv-pypi-types",
  "uv-python",
+ "uv-requirements",
  "uv-resolver",
  "uv-types",
  "uv-version",
@@ -11866,8 +11872,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -11917,8 +11923,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-filename"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "memchr",
  "rkyv",
@@ -11934,8 +11940,8 @@ dependencies = [
 
 [[package]]
 name = "uv-distribution-types"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -11974,8 +11980,8 @@ dependencies = [
 
 [[package]]
 name = "uv-extract"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -11989,7 +11995,6 @@ dependencies = [
  "reqwest",
  "rustc-hash",
  "sha2 0.10.9",
- "tar",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.18",
@@ -12001,21 +12006,20 @@ dependencies = [
  "uv-warnings",
  "xz2",
  "zip",
- "zstd",
 ]
 
 [[package]]
 name = "uv-flags"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "uv-fs"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "backon",
  "clap",
@@ -12044,8 +12048,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12070,8 +12074,8 @@ dependencies = [
 
 [[package]]
 name = "uv-git-types"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12084,8 +12088,8 @@ dependencies = [
 
 [[package]]
 name = "uv-globfilter"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "globset",
  "owo-colors",
@@ -12098,8 +12102,8 @@ dependencies = [
 
 [[package]]
 name = "uv-install-wheel"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "configparser",
  "csv",
@@ -12133,8 +12137,8 @@ dependencies = [
 
 [[package]]
 name = "uv-installer"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -12175,8 +12179,8 @@ dependencies = [
 
 [[package]]
 name = "uv-keyring"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12190,8 +12194,8 @@ dependencies = [
 
 [[package]]
 name = "uv-macros"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12201,8 +12205,8 @@ dependencies = [
 
 [[package]]
 name = "uv-metadata"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -12219,8 +12223,8 @@ dependencies = [
 
 [[package]]
 name = "uv-normalize"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "rkyv",
  "schemars 1.2.1",
@@ -12230,8 +12234,8 @@ dependencies = [
 
 [[package]]
 name = "uv-once-map"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "dashmap",
  "futures",
@@ -12240,16 +12244,16 @@ dependencies = [
 
 [[package]]
 name = "uv-options-metadata"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "uv-pep440"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "astral-version-ranges",
  "rkyv",
@@ -12262,8 +12266,8 @@ dependencies = [
 
 [[package]]
 name = "uv-pep508"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -12289,8 +12293,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "fs-err",
  "goblin",
@@ -12308,8 +12312,8 @@ dependencies = [
 
 [[package]]
 name = "uv-platform-tags"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "bitflags 2.11.1",
  "memchr",
@@ -12322,8 +12326,8 @@ dependencies = [
 
 [[package]]
 name = "uv-preview"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "enumflags2",
  "itertools 0.14.0",
@@ -12333,10 +12337,10 @@ dependencies = [
 
 [[package]]
 name = "uv-pypi-types"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "jiff",
@@ -12364,8 +12368,8 @@ dependencies = [
 
 [[package]]
 name = "uv-python"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -12423,8 +12427,8 @@ dependencies = [
 
 [[package]]
 name = "uv-redacted"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "ref-cast",
  "schemars 1.2.1",
@@ -12435,8 +12439,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "configparser",
@@ -12470,8 +12474,8 @@ dependencies = [
 
 [[package]]
 name = "uv-requirements-txt"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "astral-reqwest-middleware",
  "fs-err",
@@ -12495,8 +12499,8 @@ dependencies = [
 
 [[package]]
 name = "uv-resolver"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -12506,7 +12510,7 @@ dependencies = [
  "either",
  "fs-err",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "jiff",
@@ -12561,8 +12565,8 @@ dependencies = [
 
 [[package]]
 name = "uv-scripts"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "fs-err",
  "indoc",
@@ -12587,8 +12591,8 @@ dependencies = [
 
 [[package]]
 name = "uv-settings"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "clap",
  "fs-err",
@@ -12624,8 +12628,8 @@ dependencies = [
 
 [[package]]
 name = "uv-shell"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12640,8 +12644,8 @@ dependencies = [
 
 [[package]]
 name = "uv-small-str"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -12651,8 +12655,8 @@ dependencies = [
 
 [[package]]
 name = "uv-state"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "fs-err",
  "tempfile",
@@ -12661,8 +12665,8 @@ dependencies = [
 
 [[package]]
 name = "uv-static"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "thiserror 2.0.18",
  "uv-macros",
@@ -12670,8 +12674,8 @@ dependencies = [
 
 [[package]]
 name = "uv-torch"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "clap",
  "either",
@@ -12691,8 +12695,8 @@ dependencies = [
 
 [[package]]
 name = "uv-trampoline-builder"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -12706,8 +12710,8 @@ dependencies = [
 
 [[package]]
 name = "uv-types"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -12729,13 +12733,13 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.11.7"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.11.8"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 
 [[package]]
 name = "uv-virtualenv"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "console",
  "fs-err",
@@ -12756,8 +12760,8 @@ dependencies = [
 
 [[package]]
 name = "uv-warnings"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "anstream",
  "owo-colors",
@@ -12766,8 +12770,8 @@ dependencies = [
 
 [[package]]
 name = "uv-workspace"
-version = "0.0.40"
-source = "git+https://github.com/astral-sh/uv?tag=0.11.7#9d177269e110f40d578804e1b3d4ca3183a4ef6c"
+version = "0.0.41"
+source = "git+https://github.com/astral-sh/uv?tag=0.11.8#0e961dd9a2bb6f73493d9e8398b725ad2d3b3837"
 dependencies = [
  "clap",
  "fs-err",
@@ -13113,7 +13117,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.3" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.7" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.12" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.13" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.10" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.11" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.2" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.1" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.6" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.8" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.9" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.14" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,34 +187,34 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
-uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.4" }
+uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-cache-key = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-client = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-configuration = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-dispatch = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-distribution = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-distribution-filename = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-distribution-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-flags = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-git = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-git-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-install-wheel = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-installer = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-normalize = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-pep440 = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-pep508 = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-platform-tags = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-preview = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-pypi-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-python = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-redacted = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-requirements = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
+uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.5" }
 webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -3,7 +3,6 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::LazyLock,
 };
 
 use dunce::canonicalize;
@@ -29,7 +28,7 @@ use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
 use tempfile::{TempDir, tempdir};
 use tokio::{fs, task::JoinSet};
 use url::Url;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 use uv_normalize::PackageName;
 use uv_python::PythonEnvironment;
 
@@ -1428,7 +1427,7 @@ async fn test_multiple_prefix_update() {
 
     // Normally in pixi, the RAYON_INITIALIZE is lazily initialized by the reporter
     // associated with the command dispatcher.
-    LazyLock::force(&RAYON_INITIALIZE);
+    initialize_rayon_once();
 
     let channels = group
         .channel_urls(&group.workspace().channel_config())

--- a/crates/pixi/tests/integration_rust/snapshots/integration_rust__add_tests__add_pypi_git-2.snap
+++ b/crates/pixi/tests/integration_rust/snapshots/integration_rust__add_tests__add_pypi_git-2.snap
@@ -2,4 +2,4 @@
 source: crates/pixi/tests/integration_rust/add_tests.rs
 expression: boltons.location
 ---
-git+https://github.com/mahmoud/boltons.git#[FULL_COMMIT]
+git+https://github.com/mahmoud/boltons#[FULL_COMMIT]

--- a/crates/pixi_cli/src/exec.rs
+++ b/crates/pixi_cli/src/exec.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, collections::HashMap, path::Path, str::FromStr, sync::LazyLock};
+use std::{collections::BTreeSet, collections::HashMap, path::Path, str::FromStr};
 
 use clap::{Parser, ValueHint};
 use itertools::Itertools;
@@ -16,7 +16,7 @@ use rattler_conda_types::{GenericVirtualPackage, MatchSpec, PackageName, Platfor
 use rattler_solve::{SolverImpl, SolverTask, resolvo::Solver};
 use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
 use reqwest_middleware::ClientWithMiddleware;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 
 use crate::{cli_config::ChannelsConfig, match_spec_or_path::MatchSpecOrPath};
 
@@ -295,7 +295,7 @@ pub async fn create_exec_prefix(
 
     // Force the initialization of the rayon thread pool to avoid implicit creation
     // by the Installer.
-    LazyLock::force(&RAYON_INITIALIZE);
+    initialize_rayon_once();
 
     // Install the environment
     Installer::new()

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -43,13 +43,13 @@ use uv_dispatch::{BuildDispatch, BuildDispatchError, SharedState};
 use uv_distribution_filename::DistFilename;
 use uv_distribution_types::{
     CachedDist, ConfigSettings, DependencyMetadata, ExtraBuildRequires, IndexLocations,
-    IsBuildBackendError, PackageConfigSettings, Resolution, SourceDist,
+    IsBuildBackendError, PackageConfigSettings, SourceDist,
 };
 use uv_distribution_types::{ExtraBuildVariables, Requirement};
 use uv_install_wheel::LinkMode;
 use uv_python::{Interpreter, InterpreterError, PythonEnvironment};
 use uv_resolver::{ExcludeNewer, FlatIndex};
-use uv_types::{BuildArena, BuildContext, BuildStack, HashStrategy};
+use uv_types::{BuildArena, BuildContext, BuildStack, HashStrategy, ResolvedRequirements};
 use uv_workspace::WorkspaceCache;
 
 /// This structure holds all the parameters needed to create a `BuildContext` uv implementation.
@@ -491,7 +491,7 @@ impl BuildContext for LazyBuildDispatch<'_> {
         &'a self,
         requirements: &'a [Requirement],
         build_stack: &'a BuildStack,
-    ) -> Result<Resolution, impl IsBuildBackendError> {
+    ) -> Result<ResolvedRequirements, impl IsBuildBackendError> {
         let dispatch = self.get_or_try_init().await?;
         dispatch
             .resolve(requirements, build_stack)
@@ -501,7 +501,7 @@ impl BuildContext for LazyBuildDispatch<'_> {
 
     async fn install<'a>(
         &'a self,
-        resolution: &'a Resolution,
+        resolution: &'a ResolvedRequirements,
         venv: &'a PythonEnvironment,
         build_stack: &'a BuildStack,
     ) -> Result<Vec<CachedDist>, impl IsBuildBackendError> {

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -425,6 +425,7 @@ impl<'a> LazyBuildDispatch<'a> {
                     self.params.hasher,
                     self.params.exclude_newer.clone().unwrap_or_default(),
                     self.params.sources.clone(),
+                    uv_types::SourceTreeEditablePolicy::default(),
                     self.params.workspace_cache.clone(),
                     self.params.concurrency.clone(),
                     self.params.preview,

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -492,9 +492,12 @@ impl BuildContext for LazyBuildDispatch<'_> {
         requirements: &'a [Requirement],
         build_stack: &'a BuildStack,
     ) -> Result<ResolvedRequirements, impl IsBuildBackendError> {
+        // Box the inner uv future. uv re-enters this trait recursively when an
+        // sdist needs its build backend resolved (`process_request → setup_build
+        // → resolve → install → process_request`), so flattening the
+        // state machine here keeps the cumulative stack frame bounded.
         let dispatch = self.get_or_try_init().await?;
-        dispatch
-            .resolve(requirements, build_stack)
+        Box::pin(dispatch.resolve(requirements, build_stack))
             .await
             .map_err(LazyBuildDispatchError::Uv)
     }
@@ -506,8 +509,7 @@ impl BuildContext for LazyBuildDispatch<'_> {
         build_stack: &'a BuildStack,
     ) -> Result<Vec<CachedDist>, impl IsBuildBackendError> {
         let dispatch = self.get_or_try_init().await?;
-        dispatch
-            .install(resolution, venv, build_stack)
+        Box::pin(dispatch.install(resolution, venv, build_stack))
             .await
             .map_err(LazyBuildDispatchError::Uv)
     }
@@ -525,20 +527,19 @@ impl BuildContext for LazyBuildDispatch<'_> {
         build_stack: BuildStack,
     ) -> Result<Self::SourceDistBuilder, impl IsBuildBackendError> {
         let dispatch = self.get_or_try_init().await?;
-        dispatch
-            .setup_build(
-                source,
-                subdirectory,
-                install_path,
-                version_id,
-                dist,
-                sources,
-                build_kind,
-                build_output,
-                build_stack,
-            )
-            .await
-            .map_err(LazyBuildDispatchError::from)
+        Box::pin(dispatch.setup_build(
+            source,
+            subdirectory,
+            install_path,
+            version_id,
+            dist,
+            sources,
+            build_kind,
+            build_output,
+            build_stack,
+        ))
+        .await
+        .map_err(LazyBuildDispatchError::from)
     }
 
     async fn direct_build<'a>(
@@ -551,17 +552,16 @@ impl BuildContext for LazyBuildDispatch<'_> {
         version_id: Option<&'a str>,
     ) -> Result<Option<DistFilename>, impl IsBuildBackendError> {
         let dispatch = self.get_or_try_init().await?;
-        dispatch
-            .direct_build(
-                source,
-                subdirectory,
-                output_dir,
-                sources,
-                build_kind,
-                version_id,
-            )
-            .await
-            .map_err(LazyBuildDispatchError::from)
+        Box::pin(dispatch.direct_build(
+            source,
+            subdirectory,
+            output_dir,
+            sources,
+            build_kind,
+            version_id,
+        ))
+        .await
+        .map_err(LazyBuildDispatchError::from)
     }
 
     /// Workspace discovery caching.

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -489,7 +489,7 @@ pub async fn resolve_pypi(
             uv_client_builder = uv_client_builder.proxy(p.clone())
         }
 
-        Arc::new(uv_client_builder.build())
+        Arc::new(uv_client_builder.build().into_diagnostic()?)
     };
     let dependency_overrides =
         pypi_options.dependency_overrides.as_ref().map(|overrides|->Result<Vec<_>, _> {
@@ -771,6 +771,7 @@ pub async fn resolve_pypi(
             AllowedYanks::from_manifest(&manifest, &resolver_env, options.dependency_mode),
             &hash_strategy,
             options.exclude_newer.clone(),
+            &index_locations,
             &build_options,
             &context.capabilities,
         );

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -721,7 +721,11 @@ pub async fn resolve_pypi(
 
     let resolution_future = panic::AssertUnwindSafe(async {
         let lookahead_index = InMemoryIndex::default();
-        let lookaheads = LookaheadResolver::new(
+        // uv 0.11.4 changed `LookaheadResolver::resolve` to return both the
+        // lookaheads and a hash strategy refined by what it discovered along
+        // the way. We adopt the refined strategy for the downstream resolver
+        // matching uv's own `pip` flow.
+        let (lookaheads, hash_strategy) = LookaheadResolver::new(
             &requirements,
             &constraints,
             &overrides,
@@ -765,7 +769,7 @@ pub async fn resolve_pypi(
             Some(&provider_tags),
             &requires_python,
             AllowedYanks::from_manifest(&manifest, &resolver_env, options.dependency_mode),
-            &context.hash_strategy,
+            &hash_strategy,
             options.exclude_newer.clone(),
             &build_options,
             &context.capabilities,
@@ -783,7 +787,7 @@ pub async fn resolve_pypi(
         let resolver = Resolver::new_custom_io(
             manifest,
             options,
-            &context.hash_strategy,
+            &hash_strategy,
             resolver_env,
             &marker_environment,
             Some(tags),

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -725,22 +725,24 @@ pub async fn resolve_pypi(
         // lookaheads and a hash strategy refined by what it discovered along
         // the way. We adopt the refined strategy for the downstream resolver
         // matching uv's own `pip` flow.
-        let (lookaheads, hash_strategy) = LookaheadResolver::new(
-            &requirements,
-            &constraints,
-            &overrides,
-            &context.hash_strategy,
-            &lookahead_index,
-            DistributionDatabase::new(
-                &registry_client,
-                &lazy_build_dispatch,
-                context.concurrency.downloads_semaphore.clone(),
-            ),
+        let (lookaheads, hash_strategy) = Box::pin(
+            LookaheadResolver::new(
+                &requirements,
+                &constraints,
+                &overrides,
+                &context.hash_strategy,
+                &lookahead_index,
+                DistributionDatabase::new(
+                    &registry_client,
+                    &lazy_build_dispatch,
+                    context.concurrency.downloads_semaphore.clone(),
+                ),
+            )
+            .with_reporter(UvReporter::new_arc(
+                UvReporterOptions::new().with_existing(pb.clone()),
+            ))
+            .resolve(&resolver_env),
         )
-        .with_reporter(UvReporter::new_arc(
-            UvReporterOptions::new().with_existing(pb.clone()),
-        ))
-        .resolve(&resolver_env)
         .await
         .into_diagnostic()
         .map_err(|e| SolveError::LookAhead(e.into()))?;
@@ -813,8 +815,7 @@ pub async fn resolve_pypi(
             UvReporterOptions::new().with_existing(pb.clone()),
         ));
 
-        let resolution = resolver
-            .resolve()
+        let resolution = Box::pin(resolver.resolve())
             .await
             .map_err(|e| create_solve_error(e, &conda_python_packages))?;
 
@@ -1154,13 +1155,12 @@ async fn lock_pypi_packages(
                         })
                         .transpose()?;
 
-                    let metadata_response = database
-                        .get_or_build_wheel_metadata(
-                            &Dist::Source(source.clone()),
-                            HashPolicy::None,
-                        )
-                        .await
-                        .into_diagnostic()?;
+                    let metadata_response = Box::pin(database.get_or_build_wheel_metadata(
+                        &Dist::Source(source.clone()),
+                        HashPolicy::None,
+                    ))
+                    .await
+                    .into_diagnostic()?;
                     let metadata = metadata_response.metadata;
 
                     // Use the precise url if we got it back

--- a/crates/pixi_core/src/lock_file/resolve/resolver_provider.rs
+++ b/crates/pixi_core/src/lock_file/resolve/resolver_provider.rs
@@ -156,9 +156,13 @@ impl<Context: BuildContext> ResolverProvider for CondaResolverProvider<'_, Conte
             .left_future();
         }
 
-        // Otherwise just call the default implementation
+        // Otherwise just call the default implementation. Box the fallback
+        // future so the recursive uv build path (which can re-enter the
+        // resolver to fetch build dependencies) heaps its state machine
+        // instead of inlining it into the parent's stack frame.
         self.fallback
             .get_or_build_wheel_metadata(dist)
+            .boxed_local()
             .right_future()
     }
 

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -718,7 +718,7 @@ async fn read_local_package_metadata(
 
     // `dynamic` is set when *any* `[project.dynamic]` field is listed,
     // not just dependencies, so we accept the deps regardless.
-    let requires_dist = match database.requires_dist(directory, &pyproject_toml).await {
+    let requires_dist = match Box::pin(database.requires_dist(directory, &pyproject_toml)).await {
         Ok(Some(rd)) => {
             tracing::debug!(
                 package = %package_name,

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     str::FromStr,
-    sync::{Arc, LazyLock},
+    sync::Arc,
 };
 use uv_redacted::DisplaySafeUrl;
 
@@ -29,7 +29,7 @@ use rattler_lock::UrlOrPath;
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{ConfigSettings, DependencyMetadata, IndexUrl, RequirementSource};
 use uv_git_types::GitReference;
@@ -645,7 +645,7 @@ async fn read_local_package_metadata(
 
             // Force the initialization of the rayon thread pool to avoid implicit creation
             // by the uv.
-            LazyLock::force(&RAYON_INITIALIZE);
+            initialize_rayon_once();
 
             CondaPrefixUpdater::builder(
                 group,

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -572,7 +572,11 @@ async fn read_local_package_metadata(
             uv_client_builder = uv_client_builder.proxy(p.clone())
         }
 
-        Arc::new(uv_client_builder.build())
+        Arc::new(
+            uv_client_builder
+                .build()
+                .expect("failed to build uv registry client"),
+        )
     };
 
     // Get tags for this platform (needed for FlatIndex)

--- a/crates/pixi_core/src/lock_file/satisfiability/tests.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/tests.rs
@@ -72,7 +72,7 @@ async fn verify_lockfile_satisfiability(
     // that might trigger implicit rayon initialization (e.g. uv's
     // DistributionDatabase). Without this, concurrent tests can race
     // and trigger a GlobalPoolAlreadyInitialized panic.
-    std::sync::LazyLock::force(&uv_configuration::RAYON_INITIALIZE);
+    uv_configuration::initialize_rayon_once();
 
     let mut individual_verified_envs = HashMap::new();
 

--- a/crates/pixi_core/src/rayon_primer.rs
+++ b/crates/pixi_core/src/rayon_primer.rs
@@ -2,10 +2,7 @@
 //! would race for it. Registered by default; UI reporters override the
 //! slot and carry their own priming.
 
-use std::sync::{
-    LazyLock,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use pixi_build_discovery::JsonRpcBackendSpec;
 use pixi_command_dispatcher::{
@@ -13,7 +10,7 @@ use pixi_command_dispatcher::{
     PixiSolveEnvironmentSpec, PixiSolveReporter,
 };
 use pixi_compute_reporters::OperationId;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 
 #[derive(Default)]
 pub struct RayonPrimer {
@@ -26,7 +23,7 @@ impl RayonPrimer {
     }
 
     fn prime() {
-        LazyLock::force(&RAYON_INITIALIZE);
+        initialize_rayon_once();
     }
 }
 

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -530,7 +530,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             index_strategy,
             None,
             Connectivity::Online,
-        );
+        )?;
 
         // Resolve the flat indexes from `--find-links`.
         let flat_index_client = FlatIndexClient::new(

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -1015,6 +1015,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             &self.context_config.uv_context.hash_strategy,
             setup.exclude_newer.clone(),
             self.context_config.uv_context.no_sources.clone(),
+            uv_types::SourceTreeEditablePolicy::default(),
             self.context_config.uv_context.workspace_cache.clone(),
             self.context_config.uv_context.concurrency.clone(),
             self.context_config.uv_context.preview,

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -151,7 +151,14 @@ pub enum ContinuePyPIPrefixUpdate<'a> {
 
 /// Remove site-packages installed for an outdated interpreter so the next run
 /// starts from a clean slate.
-async fn uninstall_outdated_site_packages(site_packages: &Path) -> miette::Result<()> {
+///
+/// `layout` describes the old interpreter's install scheme — uv needs it to
+/// resolve and validate the paths recorded in each wheel's `RECORD`. The
+/// caller builds it from the old [`PythonInfo`] plus the env prefix.
+async fn uninstall_outdated_site_packages(
+    layout: &uv_install_wheel::Layout,
+    site_packages: &Path,
+) -> miette::Result<()> {
     let mut dist_dirs = Vec::new();
     for entry in fs_err::read_dir(site_packages).into_diagnostic()? {
         let entry = entry.into_diagnostic()?;
@@ -195,12 +202,34 @@ async fn uninstall_outdated_site_packages(site_packages: &Path) -> miette::Resul
         .collect::<Vec<_>>();
 
     for dist_info in installed {
-        uv_installer::uninstall(&dist_info)
+        uv_installer::uninstall(&dist_info, layout)
             .await
             .expect("uninstallation of old site-packages failed");
     }
 
     Ok(())
+}
+
+/// Build a [`uv_install_wheel::Layout`] from a conda-side [`PythonInfo`] plus
+/// the env prefix root. Used to drive uv's uninstall flow for an interpreter
+/// that's about to be replaced (we cannot ask the interpreter itself).
+fn layout_from_python_info(
+    prefix: &Prefix,
+    info: &rattler::install::PythonInfo,
+) -> uv_install_wheel::Layout {
+    let root = prefix.root();
+    uv_install_wheel::Layout {
+        sys_executable: root.join(&info.path),
+        python_version: (info.short_version.0 as u8, info.short_version.1 as u8),
+        os_name: std::env::consts::OS.to_string(),
+        scheme: uv_pypi_types::Scheme {
+            purelib: root.join(&info.site_packages_path),
+            platlib: root.join(&info.site_packages_path),
+            scripts: root.join(&info.bin_dir),
+            data: root.to_path_buf(),
+            include: root.join("include"),
+        },
+    }
 }
 
 /// React on interpreter changes before running the PyPI updater. This may
@@ -214,7 +243,8 @@ pub async fn on_python_interpreter_change<'a>(
         PythonStatus::Removed { old } => {
             let site_packages_path = prefix.root().join(&old.site_packages_path);
             if site_packages_path.exists() {
-                uninstall_outdated_site_packages(&site_packages_path).await?;
+                let layout = layout_from_python_info(prefix, old);
+                uninstall_outdated_site_packages(&layout, &site_packages_path).await?;
             }
             Ok(ContinuePyPIPrefixUpdate::Skip)
         }
@@ -222,7 +252,8 @@ pub async fn on_python_interpreter_change<'a>(
             if old.site_packages_path != new.site_packages_path {
                 let site_packages_path = prefix.root().join(&old.site_packages_path);
                 if site_packages_path.exists() {
-                    uninstall_outdated_site_packages(&site_packages_path).await?;
+                    let layout = layout_from_python_info(prefix, old);
+                    uninstall_outdated_site_packages(&layout, &site_packages_path).await?;
                 }
             }
             Ok(ContinuePyPIPrefixUpdate::Continue(new))
@@ -231,7 +262,8 @@ pub async fn on_python_interpreter_change<'a>(
             if pypi_records.is_empty() {
                 let site_packages_path = prefix.root().join(&info.site_packages_path);
                 if site_packages_path.exists() {
-                    uninstall_outdated_site_packages(&site_packages_path).await?;
+                    let layout = layout_from_python_info(prefix, info);
+                    uninstall_outdated_site_packages(&layout, &site_packages_path).await?;
                 }
                 return Ok(ContinuePyPIPrefixUpdate::Skip);
             }
@@ -729,7 +761,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         self.remove_duplicate_metadata(duplicates)
             .into_diagnostic()
             .wrap_err("while removing duplicate metadata")?;
-        self.remove_packages(extraneous, reinstalls).await?;
+        self.remove_packages(setup, extraneous, reinstalls).await?;
 
         // Install regular PyPI packages (with build isolation) as a batch
         let regular_dists = if regular_dists.is_empty() {
@@ -1008,6 +1040,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
     /// reinstallation (reinstalls)
     async fn remove_packages(
         &self,
+        setup: &UvInstallerConfig,
         extraneous: &[InstalledDist],
         reinstalls: &[(InstalledDist, NeedReinstall)],
     ) -> miette::Result<()> {
@@ -1015,8 +1048,9 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             return Ok(());
         }
         let start = std::time::Instant::now();
+        let layout = setup.venv.interpreter().layout();
         for dist_info in extraneous.iter().chain(reinstalls.iter().map(|(d, _)| d)) {
-            let summary = match uv_installer::uninstall(dist_info).await {
+            let summary = match uv_installer::uninstall(dist_info, &layout).await {
                 Ok(sum) => sum,
                 // Get error types from uv_installer
                 Err(UninstallError::Uninstall(e))

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -1191,13 +1191,15 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
 
         let start = std::time::Instant::now();
 
-        uv_installer::Installer::new(&setup.venv, uv_preview::Preview::default())
-            .with_link_mode(self.build_config.link_mode.unwrap_or_default())
-            .with_installer_name(Some(consts::PIXI_UV_INSTALLER.to_string()))
-            .with_reporter(UvReporter::new_arc(options))
-            .install(all_dists.clone())
-            .await
-            .expect("should be able to install all distributions");
+        Box::pin(
+            uv_installer::Installer::new(&setup.venv, uv_preview::Preview::default())
+                .with_link_mode(self.build_config.link_mode.unwrap_or_default())
+                .with_installer_name(Some(consts::PIXI_UV_INSTALLER.to_string()))
+                .with_reporter(UvReporter::new_arc(options))
+                .install(all_dists.clone()),
+        )
+        .await
+        .expect("should be able to install all distributions");
 
         let s = if all_dists.len() == 1 { "" } else { "s" };
         tracing::info!(

--- a/crates/pixi_reporters/src/lib.rs
+++ b/crates/pixi_reporters/src/lib.rs
@@ -6,10 +6,7 @@ mod repodata_reporter;
 mod sync_reporter;
 pub mod uv_reporter;
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, LazyLock},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use git::GitCheckoutProgress;
 use indicatif::{MultiProgress, ProgressBar};
@@ -23,7 +20,7 @@ use pixi_compute_reporters::{OperationId, OperationRegistry};
 pub use release_notes::format_release_notes;
 use repodata_reporter::RepodataReporter;
 use sync_reporter::SyncReporter;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 // Re-export the uv_reporter types for external use
 pub use uv_reporter::{UvReporter, UvReporterOptions};
 
@@ -169,7 +166,7 @@ impl pixi_command_dispatcher::PixiSolveReporter for TopLevelProgress {
             // Dependencies on conda packages trigger package-cache
             // validation via rayon; ensure it's initialized through the
             // uv path before the validation work starts.
-            LazyLock::force(&RAYON_INITIALIZE);
+            initialize_rayon_once();
         }
 
         let id = self.alloc();

--- a/crates/pixi_reporters/src/sync_reporter.rs
+++ b/crates/pixi_reporters/src/sync_reporter.rs
@@ -10,10 +10,9 @@ use pixi_compute_reporters::{OperationId, OperationRegistry};
 use pixi_progress::ProgressBarPlacement;
 use rattler::install::Transaction;
 use rattler_conda_types::{PrefixRecord, RepoDataRecord};
-use std::sync::LazyLock;
 use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 use tokio::sync::mpsc::UnboundedReceiver;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 
 #[derive(Clone)]
 pub struct SyncReporter {
@@ -60,7 +59,7 @@ impl SyncReporter {
 
         // Installing a pixi environment uses rayon. We only want to initialize the
         // rayon thread pool when we absolutely need it.
-        LazyLock::force(&RAYON_INITIALIZE);
+        initialize_rayon_once();
 
         InstallReporter {
             id: TransactionId::new(id),

--- a/crates/pixi_task/src/file_hashes.rs
+++ b/crates/pixi_task/src/file_hashes.rs
@@ -10,7 +10,6 @@
 use itertools::Itertools;
 use pixi_glob::{GlobSet, GlobSetError};
 use rayon::prelude::*;
-use std::sync::LazyLock;
 use std::{
     clone::Clone,
     collections::HashMap,
@@ -23,7 +22,7 @@ use std::{
 };
 use thiserror::Error;
 use tokio::task::JoinError;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, Error)]
@@ -106,7 +105,7 @@ impl FileHashes {
 
         // Force the initialization of the rayon thread pool to avoid implicit creation
         // by the Installer.
-        LazyLock::force(&RAYON_INITIALIZE);
+        initialize_rayon_once();
 
         // Process entries in parallel using rayon
         entries.into_par_iter().for_each(|entry| {

--- a/crates/pixi_utils/src/prefix.rs
+++ b/crates/pixi_utils/src/prefix.rs
@@ -10,10 +10,9 @@ use std::{
     collections::HashMap,
     ffi::OsStr,
     path::{Path, PathBuf},
-    sync::LazyLock,
 };
 use thiserror::Error;
-use uv_configuration::RAYON_INITIALIZE;
+use uv_configuration::initialize_rayon_once;
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum PrefixError {
@@ -65,7 +64,7 @@ impl Prefix {
     /// [`PrefixRecord`]s found in there.
     pub fn find_installed_packages(&self) -> Result<Vec<PrefixRecord>, PrefixError> {
         // Initialize rayon explicitly to avoid implicit initialization.
-        LazyLock::force(&RAYON_INITIALIZE);
+        initialize_rayon_once();
 
         PrefixRecord::collect_from_prefix(&self.root)
             .map_err(|err| PrefixError::PrefixRecordCollectionError(err, self.root.clone()))

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -290,7 +290,7 @@ impl UvResolutionContext {
         index_strategy: IndexStrategy,
         markers: Option<&MarkerEnvironment>,
         connectivity: Connectivity,
-    ) -> Arc<RegistryClient> {
+    ) -> miette::Result<Arc<RegistryClient>> {
         let base_client_builder =
             self.base_client_builder(allow_insecure_hosts, markers, connectivity);
 
@@ -303,7 +303,7 @@ impl UvResolutionContext {
             uv_client_builder = uv_client_builder.proxy(p.clone());
         }
 
-        Arc::new(uv_client_builder.build())
+        Ok(Arc::new(uv_client_builder.build().into_diagnostic()?))
     }
 }
 

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -191,6 +191,14 @@ impl UvResolutionContext {
         let http_retries = read_http_retries_from_env();
         let concurrency = build_concurrency(config);
 
+        let preview = Preview::default();
+        // uv crates read a global `PREVIEW` static (`uv_preview::get` /
+        // `uv_preview::is_enabled`) from feature-flag-gated code paths, and
+        // panic if it has not been initialized. Pixi never opts in to any
+        // preview features but must still register the value so those reads
+        // don't crash while, for instance, building a local source dist.
+        let _ = uv_preview::set(preview);
+
         Ok(Self {
             cache,
             in_flight: InFlight::default(),
@@ -209,7 +217,7 @@ impl UvResolutionContext {
             package_config_settings: PackageConfigSettings::default(),
             extra_build_requires: ExtraBuildRequires::default(),
             extra_build_variables: ExtraBuildVariables::default(),
-            preview: Preview::default(),
+            preview,
             workspace_cache: WorkspaceCache::default(),
             http_timeout,
             http_retries,

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -340,7 +340,7 @@ pub fn into_pinned_git_spec(
     // uv stores the percent-encoded drive-letter form internally (see
     // `encode_windows_drive_letter`). Decode it back here so the lock file
     // shows `file:///D:/...` rather than `file:///D%3A/...`.
-    let repository: url::Url = (*dist.git.repository()).clone().into();
+    let repository: url::Url = (**dist.git.repository()).clone();
     PinnedGitSpec::new(decode_windows_drive_letter(&repository), pinned_checkout)
 }
 

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -261,9 +261,11 @@ fn create_tags(
         implementation_name,
         // TODO: This might not be entirely correct..
         python_version,
-        true,
-        gil_disabled,
-        false,
+        uv_platform_tags::TagsOptions {
+            manylinux_compatible: true,
+            gil_disabled,
+            ..Default::default()
+        },
     )
     .map_err(PyPITagError::FailedToDetermineWheelTags)
 }

--- a/tests/data/satisfiability/v6-editable-no-rewrite/pixi.lock
+++ b/tests/data/satisfiability/v6-editable-no-rewrite/pixi.lock
@@ -32,7 +32,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: git+https://github.com/python-trio/sniffio.git#ae020e13b98d276a6558ffc25e82509fd4c288f0
+      - pypi: git+https://github.com/python-trio/sniffio#ae020e13b98d276a6558ffc25e82509fd4c288f0
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -285,7 +285,7 @@ packages:
   purls: []
   size: 345073
   timestamp: 1765813471974
-- pypi: git+https://github.com/python-trio/sniffio.git#ae020e13b98d276a6558ffc25e82509fd4c288f0
+- pypi: git+https://github.com/python-trio/sniffio#ae020e13b98d276a6558ffc25e82509fd4c288f0
   name: sniffio
   version: 1.3.1
   requires_python: '>=3.7'
@@ -315,7 +315,7 @@ packages:
   version: 0.1.0
   sha256: 0813783311097dc11aad19f784dd9dee3992f3a7b4247f940337ebb498d9ea12
   requires_dist:
-  - sniffio @ git+https://github.com/python-trio/sniffio.git@v1.3.1
+  - sniffio @ git+https://github.com/python-trio/sniffio@v1.3.1
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -866,7 +866,7 @@ def test_adding_git_deps(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
     # we want to make sure that the lock file contains the branch information
-    assert "pypi: git+https://github.com/mahmoud/boltons.git?branch=master" in lock_file.read_text()
+    assert "pypi: git+https://github.com/mahmoud/boltons?branch=master" in lock_file.read_text()
     # and that the manifest contains the branch information
     manifest = tomllib.loads(manifest_path.read_text())
     assert manifest["pypi-dependencies"]["boltons"]["branch"] == "master"
@@ -888,7 +888,7 @@ def test_adding_git_deps(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
     # we want to make sure that the lock file contains the tag information
-    assert "pypi: git+https://github.com/mahmoud/boltons.git?tag=25.0.0" in lock_file.read_text()
+    assert "pypi: git+https://github.com/mahmoud/boltons?tag=25.0.0" in lock_file.read_text()
     # and that the manifest contains the tag information
     manifest = tomllib.loads(manifest_path.read_text())
     assert manifest["pypi-dependencies"]["boltons"]["tag"] == "25.0.0"
@@ -910,7 +910,7 @@ def test_adding_git_deps(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
     # we want to make sure that the lock file contains the rev information
-    assert "pypi: git+https://github.com/mahmoud/boltons.git?rev=d70669a" in lock_file.read_text()
+    assert "pypi: git+https://github.com/mahmoud/boltons?rev=d70669a" in lock_file.read_text()
     # and that the manifest contains the rev information
     manifest = tomllib.loads(manifest_path.read_text())
     assert manifest["pypi-dependencies"]["boltons"]["rev"] == "d70669a"


### PR DESCRIPTION
## Summary

Iterative patch-version bump of uv on top of #6127 (0.11.0). Each commit lands one patch version with its required API adapters so a regression can be bisected to a specific uv tag. Lands 0.11.1 through 0.11.15, plus the fixes that make 0.11.15 viable.

## Versions

- 0.11.1 (no API changes)
- 0.11.2 (no API changes)
- 0.11.3: `Tags::from_env` collapsed three booleans into a `TagsOptions` struct.
- 0.11.4: `LookaheadResolver::resolve` now returns `(Vec<RequestedRequirements>, HashStrategy)`. `RepositoryUrl: Deref<Target=Url>` (was `DisplaySafeUrl`) so the conversion chain shifts.
- 0.11.5: `RegistryClientBuilder::build` is now fallible. `DefaultResolverProvider::new` takes `&IndexLocations`.
- 0.11.6: `uv_installer::uninstall` now takes `&Layout`. Added `layout_from_python_info` helper for the `on_python_interpreter_change` cleanup path which only has a `PythonInfo`.
- 0.11.7: `RAYON_INITIALIZE` static replaced by `initialize_rayon_once()` function (call sites updated across pixi_reporters, pixi_core, pixi_cli, pixi_task, pixi_utils, and the integration tests). `BuildDispatch::new` gained a `SourceTreeEditablePolicy` argument; pixi passes the default for now.
- 0.11.8: `uv_distribution_types::Resolution` renamed to `uv_types::ResolvedRequirements`; updated the import and the `BuildContext::{resolve,install}` impl signatures in `build_dispatch.rs`.
- 0.11.9 through 0.11.13: no API changes (Cargo.lock churn only).
- 0.11.14: uv canonicalises git URLs by stripping the `.git` suffix. Test fixtures rebaselined to the new canonical form: the `add_pypi_git-2` insta snapshot, the `v6-editable-no-rewrite` satisfiability lockfile (yohane's `requires_dist` entry and both sniffio `pypi:` location entries), and the three `test_adding_git_deps` python assertions (branch/tag/rev) in `tests/integration_python/test_main_cli.py`.
- 0.11.15: security release plus async-zip / async-tar rewrite of the build path. No API breaks, but the deeper async chains motivated the three follow-up commits below.

## Follow-up fixes

- `fix(pypi): initialize uv's global preview state to avoid panic during source build`. uv crates read a global `PREVIEW` static via `uv_preview::get` / `is_enabled` from feature-flag-gated code paths and panic if it has not been initialized. Pixi already builds a per-context `Preview` value but never registered it. Now `UvResolutionContext::from_config` calls `uv_preview::set(Preview::default())` so every entry point that touches uv (CLI, library, integration tests) initialises the global before any uv code reads it. `set` is idempotent against the OnceLock until `finalize` (which pixi never calls).
- `perf(pypi): box uv futures at recursive seams to flatten the resolver state machine`. uv re-enters pixi's `BuildContext` impl recursively when an sdist's build backend needs its own deps resolved (`process_request → setup_build → resolve → install → process_request`); each `.await` inlines uv's deep state machine into the parent's future and 0.11.15's bigger frames pushed past the test thread's 2 MB stack. Mirror uv's own technique (16 `Box::pin(commands::*)` sites in `crates/uv/src/lib.rs`) at our boundary: `Box::pin` the uv future returned from each `LazyBuildDispatch` trait method, the `LookaheadResolver::resolve` and `Resolver::resolve` calls in `resolve_pypi`, `DistributionDatabase::get_or_build_wheel_metadata` in the metadata fixup path, `DistributionDatabase::requires_dist` in satisfiability, `Installer::install` in `pixi_install_pypi`, and the `DefaultResolverProvider` fallback in `CondaResolverProvider::get_or_build_wheel_metadata`.
- `ci: raise test thread stack size to 4 MB via RUST_MIN_STACK`. uv's binary sets 4 MB on `main2`, the tokio runtime, and rayon via `uv_configuration::min_stack_size()`; uv's own test suite gets away without an explicit stack bump because it shells out to the compiled binary as a subprocess (`uv_snapshot!` runs uv's real `main()`). Pixi's integration tests are in-process: `pixi.add(...).await` runs inside a `#[tokio::test]` runtime on libtest's per-test thread, which inherits the default 2 MB stack and never sees pixi's tuned `main2` config. Add `RUST_MIN_STACK = "4194304"` to `.cargo/config.toml [env]` so every test process (CI and local) inherits the same 4 MB headroom uv ships at runtime. `crates/pixi/src/main.rs` already reads this variable for the `main2` thread, so this also keeps the production binary's stack in sync.

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude
