### PR TITLE
feat: add oauth default login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,12 +232,12 @@ dependencies = [
 
 [[package]]
 name = "archspec"
-version = "0.2.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33"
+checksum = "9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7"
 dependencies = [
  "cfg-if 1.0.4",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "libc",
  "serde",
  "serde_json",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1756,7 +1756,8 @@ dependencies = [
 [[package]]
 name = "coalesced_map"
 version = "0.1.3"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2269,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if 1.0.4",
  "crossbeam-utils",
@@ -2521,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "dlmalloc"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5b01c17f85ee988d832c40e549a64bd89ab2c9f8d8a613bdf5122ae507e294"
+checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
@@ -2870,7 +2871,8 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "file_url"
 version = "0.3.1"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4138,6 +4140,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -4603,9 +4614,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fc329e1457d97a9d58a4e2ca49e3be572431a7e096008efc2e3a3c19d428f4"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -5209,9 +5220,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -5478,9 +5489,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if 1.0.4",
@@ -5509,9 +5520,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -5708,7 +5719,8 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.9"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66ecbc7712c675098e4a2c0075dd93e2140a4ca22a5a270fc8a9740eea907fa"
 dependencies = [
  "ahash",
  "fs-err",
@@ -7885,7 +7897,8 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.43.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58df048747f10ce69c599a58c69c66d2dca1f197820d44085f8f354cc15cf21c"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -8191,7 +8204,8 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.8.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba5153911039b1d767cbab2c11b4196beed45a0a468d0e2bfcd1e8c58311db6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8223,7 +8237,8 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.46.2"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64da4e037cd8222078ab202d02db49906c870faaed91af4716655734eaa3ebd2"
 dependencies = [
  "ahash",
  "chrono",
@@ -8265,7 +8280,8 @@ dependencies = [
 [[package]]
 name = "rattler_config"
 version = "0.3.13"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b0151673468245567a9c6c037f5bffefab61b57a00bf2a850edb395d73476"
 dependencies = [
  "console",
  "fs-err",
@@ -8282,7 +8298,8 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.2.5"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6aa7ce6d5987615eb799fd7b7d236151f199229145b823f056e13475bdc23ba"
 dependencies = [
  "blake2",
  "digest 0.10.7",
@@ -8290,7 +8307,6 @@ dependencies = [
  "hex",
  "md-5 0.10.6",
  "serde",
- "serde-untagged",
  "serde_bytes",
  "serde_with",
  "sha2 0.10.9",
@@ -8301,7 +8317,8 @@ dependencies = [
 [[package]]
 name = "rattler_git"
 version = "0.1.3"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373265099ab8b2b816b30e0f8db4cddb6b8364be0a04bc9bdaa21c5ad3fe8943"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -8321,7 +8338,8 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.29.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079ad5ff6ff4014ae45e2e877a13fb3c2c5b98ad9a5971120cda4f5b3ba2a8df"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8336,7 +8354,6 @@ dependencies = [
  "indicatif",
  "opendal",
  "rattler_conda_types",
- "rattler_config",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -8359,7 +8376,8 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.30.1"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3c6773c6c8f35f5b35abfcfea1196a768f5c064e332b63659e9d18d7fe43d1"
 dependencies = [
  "ahash",
  "chrono",
@@ -8387,7 +8405,8 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.14"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e38cd777a0ba85cf223b966b4893a12112621ba576e9273e5473dc90870530"
 dependencies = [
  "quote",
  "syn",
@@ -8396,7 +8415,8 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.60"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e027414b2e3a59614046f82363b0fa409fc270dbf1af8245a69a62a1a0886078"
 dependencies = [
  "chrono",
  "configparser",
@@ -8426,9 +8446,9 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.27.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ebad9b8ea8faeaeb313039b634a4e4506e595d82fda2a621ec6aab6f48cf17"
 dependencies = [
- "ambient-id",
  "anyhow",
  "astral-reqwest-middleware",
  "async-once-cell",
@@ -8460,7 +8480,8 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.26.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee65f748ab93c2c022224824f8e75424a721dfc0e90f305675f735a97b465d0"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -8498,7 +8519,8 @@ dependencies = [
 [[package]]
 name = "rattler_prefix_guard"
 version = "0.1.1"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d083796e99a8dbe46fdd5dbde5c853ce532d43419959f3c51578f9f59ada860d"
 dependencies = [
  "fs-err",
  "libc",
@@ -8511,7 +8533,8 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.11"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4663669232f9715a8eb9e754c34395c1b3684a8a3d2219cc6b275c17e72a57b"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -8522,7 +8545,8 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.2.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72675ff7378b65033fccd4ae69e2de987bec70fb2077aee520782c64081b89e7"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -8532,7 +8556,8 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.29.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396c2366353e95f64dcad91c625d27955b99772c2b57b600fd6b4de17dc00ac3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8594,7 +8619,8 @@ dependencies = [
 [[package]]
 name = "rattler_s3"
 version = "0.2.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff58b1a80e7e6599052c3e5232d8f21f37747815f671033432e640038cb6d98c"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -8610,7 +8636,8 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.27.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45fa52ceb2c5971a0f5374462d0e4d433b6c06c9e058a05796577f7d32ff2b81"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8631,7 +8658,8 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "7.0.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a782423a7c61208d321c09b3e7f50a442e3c513b5a49f118fb926c97eb6f366"
 dependencies = [
  "chrono",
  "futures",
@@ -8649,7 +8677,8 @@ dependencies = [
 [[package]]
 name = "rattler_upload"
 version = "0.7.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8e032b2ab3cf41347cd64d7ef9d91f57f1bec80880c49425bcb9d9418d3ab5"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8685,7 +8714,8 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.3.22"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc63ffd890d9232e9c13297e308c0b294c73e655cf3e4533bfa50df3edffed1"
 dependencies = [
  "archspec",
  "libloading",
@@ -10315,7 +10345,8 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
 dependencies = [
  "tokio",
 ]
@@ -10563,9 +10594,9 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a79feaa49de4a6c8191bdbd5fb3eada50671e9367d874d1c12e3d36db131414"
+checksum = "88826d6169418c98e8bc52a43f79d50907dfa3e87ba5161930d42c6f980b35ee"
 dependencies = [
  "junction",
  "libc",
@@ -10650,9 +10681,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -11159,9 +11190,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,12 +232,12 @@ dependencies = [
 
 [[package]]
 name = "archspec"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7"
+checksum = "3ea6ba19ec651dfd93c3d00cf86048feca2eeab57e8e7cc218e053fe5d08fb33"
 dependencies = [
  "cfg-if 1.0.4",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "libc",
  "serde",
  "serde_json",
@@ -1756,8 +1756,7 @@ dependencies = [
 [[package]]
 name = "coalesced_map"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fe09392885c9af28aed39c6ddd06e41b43dbe98a850ccf0abe3f88d7cc75de"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2871,8 +2870,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "file_url"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d8c8b9119e366c1b4103d3ca9b5e09cc5684ae14f1265d1472d0a7fbc61747"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4134,15 +4132,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -5719,8 +5708,7 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ecbc7712c675098e4a2c0075dd93e2140a4ca22a5a270fc8a9740eea907fa"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "ahash",
  "fs-err",
@@ -7897,8 +7885,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58df048747f10ce69c599a58c69c66d2dca1f197820d44085f8f354cc15cf21c"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -8204,8 +8191,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba5153911039b1d767cbab2c11b4196beed45a0a468d0e2bfcd1e8c58311db6"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8237,8 +8223,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64da4e037cd8222078ab202d02db49906c870faaed91af4716655734eaa3ebd2"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "ahash",
  "chrono",
@@ -8280,8 +8265,7 @@ dependencies = [
 [[package]]
 name = "rattler_config"
 version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b0151673468245567a9c6c037f5bffefab61b57a00bf2a850edb395d73476"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "console",
  "fs-err",
@@ -8298,8 +8282,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6aa7ce6d5987615eb799fd7b7d236151f199229145b823f056e13475bdc23ba"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "blake2",
  "digest 0.10.7",
@@ -8307,6 +8290,7 @@ dependencies = [
  "hex",
  "md-5 0.10.6",
  "serde",
+ "serde-untagged",
  "serde_bytes",
  "serde_with",
  "sha2 0.10.9",
@@ -8317,8 +8301,7 @@ dependencies = [
 [[package]]
 name = "rattler_git"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373265099ab8b2b816b30e0f8db4cddb6b8364be0a04bc9bdaa21c5ad3fe8943"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -8338,8 +8321,7 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "079ad5ff6ff4014ae45e2e877a13fb3c2c5b98ad9a5971120cda4f5b3ba2a8df"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8354,6 +8336,7 @@ dependencies = [
  "indicatif",
  "opendal",
  "rattler_conda_types",
+ "rattler_config",
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
@@ -8376,8 +8359,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3c6773c6c8f35f5b35abfcfea1196a768f5c064e332b63659e9d18d7fe43d1"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "ahash",
  "chrono",
@@ -8405,8 +8387,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e38cd777a0ba85cf223b966b4893a12112621ba576e9273e5473dc90870530"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "quote",
  "syn",
@@ -8415,8 +8396,7 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e027414b2e3a59614046f82363b0fa409fc270dbf1af8245a69a62a1a0886078"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "chrono",
  "configparser",
@@ -8446,9 +8426,9 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ebad9b8ea8faeaeb313039b634a4e4506e595d82fda2a621ec6aab6f48cf17"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
+ "ambient-id",
  "anyhow",
  "astral-reqwest-middleware",
  "async-once-cell",
@@ -8480,8 +8460,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee65f748ab93c2c022224824f8e75424a721dfc0e90f305675f735a97b465d0"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -8519,8 +8498,7 @@ dependencies = [
 [[package]]
 name = "rattler_prefix_guard"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d083796e99a8dbe46fdd5dbde5c853ce532d43419959f3c51578f9f59ada860d"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "fs-err",
  "libc",
@@ -8533,8 +8511,7 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4663669232f9715a8eb9e754c34395c1b3684a8a3d2219cc6b275c17e72a57b"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -8545,8 +8522,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72675ff7378b65033fccd4ae69e2de987bec70fb2077aee520782c64081b89e7"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -8556,8 +8532,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396c2366353e95f64dcad91c625d27955b99772c2b57b600fd6b4de17dc00ac3"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8619,8 +8594,7 @@ dependencies = [
 [[package]]
 name = "rattler_s3"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff58b1a80e7e6599052c3e5232d8f21f37747815f671033432e640038cb6d98c"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -8636,8 +8610,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fa52ceb2c5971a0f5374462d0e4d433b6c06c9e058a05796577f7d32ff2b81"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8658,8 +8631,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a782423a7c61208d321c09b3e7f50a442e3c513b5a49f118fb926c97eb6f366"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "chrono",
  "futures",
@@ -8677,8 +8649,7 @@ dependencies = [
 [[package]]
 name = "rattler_upload"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8e032b2ab3cf41347cd64d7ef9d91f57f1bec80880c49425bcb9d9418d3ab5"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8714,8 +8685,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "2.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc63ffd890d9232e9c13297e308c0b294c73e655cf3e4533bfa50df3edffed1"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "archspec",
  "libloading",
@@ -10345,8 +10315,7 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0b0b683828aa9d4f5c0e59b0c856a12c30a65b5f1ca4292664734d76fa9c2"
+source = "git+https://github.com/conda/rattler?rev=6f2d1a601ee168457de82a1882ff3624a957c2b7#6f2d1a601ee168457de82a1882ff3624a957c2b7"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,38 +282,6 @@ rattler_build_types = { git = "https://github.com/prefix-dev/rattler-build", bra
 rattler_build_variant_config = { git = "https://github.com/prefix-dev/rattler-build", branch = "main" }
 rattler_build_yaml_parser = { git = "https://github.com/prefix-dev/rattler-build", branch = "main" }
 
-# Pull in conda/rattler#2402 (`feat: add oauth default login`) ahead of a
-# crates.io release. PR is merged on rattler main; pinned to a known-good SHA
-# so unrelated rattler changes don't sneak in between cargo updates. To bump:
-# `gh api repos/conda/rattler/commits/main --jq .sha` and update `rev` below.
-# Every rattler workspace crate pixi consumes is patched so the transitive
-# graph builds from one source (avoids duplicate `rattler_conda_types` etc.).
-coalesced_map = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-file_url = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-path_resolver = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_cache = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_conda_types = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_config = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_digest = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_git = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_index = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_lock = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_macros = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_menuinst = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_networking = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_package_streaming = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_prefix_guard = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_pty = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_redaction = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_repodata_gateway = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_s3 = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_shell = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_solve = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_upload = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-rattler_virtual_packages = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-simple_spawn_blocking = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
-
 [patch."https://github.com/prefix-dev/rattler-build"]
 #rattler-build = { path = "/var/home/tobias/src/rattler-build" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,18 +136,20 @@ pypi_mapping = { path = "crates/pypi_mapping" }
 pypi_modifiers = { path = "crates/pypi_modifiers" }
 pyproject-toml = "0.13.7"
 
+bzip2 = "0.6.1"
 rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.13", default-features = false }
+reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5", features = [
+  "multipart",
+] }
+reqwest-retry = { package = "astral-reqwest-retry", version = "0.9" }
 retry-policies = "0.5"
+rlimit = "0.11.0"
+roxmltree = "0.21.0"
+rstest = "0.26.0"
 rustls-native-certs = "0.8"
 rustls-pki-types = "1"
-roxmltree = "0.21.0"
-bzip2 = "0.6.1"
-reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5", features = ["multipart"] }
-reqwest-retry = { package = "astral-reqwest-retry", version = "0.9" }
-rlimit = "0.11.0"
-rstest = "0.26.0"
 same-file = "1.0.6"
 schemars = "1.1.0"
 self-replace = "1.5.0"
@@ -185,7 +187,6 @@ tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"
 typed-path = "0.12.0"
 url = "2.5"
-webpki-root-certs = "1"
 uv-build-frontend = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
 uv-cache = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
 uv-cache-info = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
@@ -214,6 +215,7 @@ uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" 
 uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
 uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
 uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.0" }
+webpki-root-certs = "1"
 which = "8.0.0"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }
@@ -279,6 +281,38 @@ rattler_build_source_cache = { git = "https://github.com/prefix-dev/rattler-buil
 rattler_build_types = { git = "https://github.com/prefix-dev/rattler-build", branch = "main" }
 rattler_build_variant_config = { git = "https://github.com/prefix-dev/rattler-build", branch = "main" }
 rattler_build_yaml_parser = { git = "https://github.com/prefix-dev/rattler-build", branch = "main" }
+
+# Pull in conda/rattler#2402 (`feat: add oauth default login`) ahead of a
+# crates.io release. PR is merged on rattler main; pinned to a known-good SHA
+# so unrelated rattler changes don't sneak in between cargo updates. To bump:
+# `gh api repos/conda/rattler/commits/main --jq .sha` and update `rev` below.
+# Every rattler workspace crate pixi consumes is patched so the transitive
+# graph builds from one source (avoids duplicate `rattler_conda_types` etc.).
+coalesced_map = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+file_url = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+path_resolver = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_cache = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_conda_types = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_config = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_digest = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_git = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_index = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_lock = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_macros = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_menuinst = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_networking = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_package_streaming = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_prefix_guard = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_pty = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_redaction = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_repodata_gateway = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_s3 = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_shell = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_solve = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_upload = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+rattler_virtual_packages = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
+simple_spawn_blocking = { git = "https://github.com/conda/rattler", rev = "6f2d1a601ee168457de82a1882ff3624a957c2b7" }
 
 [patch."https://github.com/prefix-dev/rattler-build"]
 #rattler-build = { path = "/var/home/tobias/src/rattler-build" }

--- a/docs/deployment/authentication.md
+++ b/docs/deployment/authentication.md
@@ -1,40 +1,116 @@
-You can authenticate Pixi with a server like prefix.dev, a private quetz instance or anaconda.org.
-Different servers use different authentication methods.
-In this documentation page, we detail how you can authenticate against the different servers and where the authentication information is stored.
-
+You can authenticate Pixi with a server like prefix.dev, a private quetz instance, anaconda.org, or any S3-compatible bucket. Different servers use different authentication methods. This page covers how to authenticate against each, and where the authentication information is stored.
 ```shell
 Usage: pixi auth login [OPTIONS] <HOST>
 
 Arguments:
-  <HOST>  The host to authenticate with (e.g. repo.prefix.dev)
+  <HOST>  The host to authenticate with (e.g. prefix.dev)
 
 Options:
-      --token <TOKEN>                                The token to use (for authentication with prefix.dev)
-      --username <USERNAME>                          The username to use (for basic HTTP authentication)
-      --password <PASSWORD>                          The password to use (for basic HTTP authentication)
-      --conda-token <CONDA_TOKEN>                    The token to use on anaconda.org / quetz authentication
+      --user-agent <USER_AGENT>  User-Agent header used for requests
+
+Token / Basic Authentication:
+      --token <TOKEN>              The token to use (for authentication with prefix.dev)
+      --username <USERNAME>        The username to use (for basic HTTP authentication)
+      --password <PASSWORD>        The password to use (for basic HTTP authentication)
+      --conda-token <CONDA_TOKEN>  The token to use on anaconda.org / quetz authentication
+
+S3 Authentication:
       --s3-access-key-id <S3_ACCESS_KEY_ID>          The S3 access key ID
       --s3-secret-access-key <S3_SECRET_ACCESS_KEY>  The S3 secret access key
       --s3-session-token <S3_SESSION_TOKEN>          The S3 session token
-  -v, --verbose...                                   Increase logging verbosity
-  -q, --quiet...                                     Decrease logging verbosity
-      --color <COLOR>                                Whether the log needs to be colored [env: PIXI_COLOR=] [default: auto] [possible values: always, never, auto]
-      --no-progress                                  Hide all progress bars, always turned on if stderr is not a terminal [env: PIXI_NO_PROGRESS=]
-  -h, --help                                         Print help
+
+OAuth/OIDC Authentication:
+      --oauth                                      Use OAuth/OIDC authentication
+      --oauth-issuer-url <OAUTH_ISSUER_URL>        OIDC issuer URL (defaults to <https://{host>})
+      --oauth-client-id <OAUTH_CLIENT_ID>          OAuth client ID (defaults to "rattler")
+      --oauth-client-secret <OAUTH_CLIENT_SECRET>  OAuth client secret (for confidential clients)
+      --oauth-flow <OAUTH_FLOW>                    OAuth flow: auto (default), auth-code, device-code [possible values: auto, auth-code,
+                                                   device-code]
+      --oauth-scope <OAUTH_SCOPES>                 Additional OAuth scopes to request (repeatable)
+      --oauth-redirect-uri <OAUTH_REDIRECT_URI>    OAuth redirect URI (defaults to a random localhost port). Set this when the OAuth client on
+                                                   the `IdP` side is registered with a specific redirect URI such as
+                                                   `http://127.0.0.1:8000/auth/oidc`
+
+Global Options:
+  -h, --help           Display help information
+  -v, --verbose...     Increase logging verbosity (-v for warnings, -vv for info, -vvv for debug, -vvvv for trace)
+  -q, --quiet...       Decrease logging verbosity (quiet mode)
+      --color <COLOR>  Whether the log needs to be colored [env: PIXI_COLOR=] [default: auto] [possible values: always, never, auto]
+      --no-progress    Hide all progress bars, always turned on if stderr is not a terminal [env: PIXI_NO_PROGRESS=]
 ```
 
-The different options are "token", "conda-token" and "username + password".
+## OAuth/OIDC authentication
 
-The token variant implements a standard "Bearer Token" authentication as is used on the prefix.dev platform.
-A Bearer Token is sent with every request as an additional header of the form `Authentication: Bearer <TOKEN>`.
+The simplest way to authenticate against prefix.dev is:
 
-The conda-token option is used on anaconda.org and can be used with a quetz server. With this option, the token is sent as part of the URL following this scheme: `conda.anaconda.org/t/<TOKEN>/conda-forge/linux-64/...`.
+```shell
+pixi auth login prefix.dev
+```
 
-The last option, username & password, are used for "Basic HTTP Authentication". This is the equivalent of adding `http://user:password@myserver.com/...`. This authentication method can be configured quite easily with a reverse NGinx or Apache server and is thus commonly used in self-hosted systems.
+A browser tab opens, you log in to prefix.dev, and Pixi stores the credentials in your system keychain. Every later `pixi install`, `pixi upload`, or `pixi publish` reuses them automatically, and Pixi refreshes the token in the background before it expires.
+
+!!!info "What this login allows"
+    Pixi requests the rights to access your profile, read from channels, and upload your packages. This covers the basics commands like `pixi install`, `pixi upload` or `pixi publish` to work out of the box.
+
+
+### Choosing an OAuth flow
+
+`pixi auth login` defaults to `--oauth-flow auto`, which picks at runtime:
+
+- **Authorization Code with PKCE** when you're on a desktop machine with a working browser. Pixi opens a browser tab, you sign in on prefix.dev, and a local callback page completes the exchange.
+- **Device Code** when Pixi can't open a browser for you. Pixi prints a short user code and a URL; you open the URL on any device, paste the code, and Pixi receives the authentication. This is the common case for SSH sessions, headless servers, container shells, and similar environments without a browser.
+
+You can force a specific flow if `auto` picks wrong for your environment:
+
+```shell
+pixi auth login prefix.dev --oauth-flow device-code
+```
+
+### Other OIDC providers
+
+For self-hosted OIDC providers (or any host where Pixi doesn't ship built-in defaults), pass the configuration explicitly:
+
+```shell
+pixi auth login my.private.host \
+    --oauth \
+    --oauth-issuer-url https://idp.example.com \
+    --oauth-client-id my-cli-client \
+    --oauth-scope openid --oauth-scope channel:read
+```
+
+
+## Token authentication
+
+If you prefer to manage tokens yourself (e.g. in CI, where browser login isn't an option), you can use a standard "Bearer Token" authentication
+
+```shell
+pixi auth login prefix.dev --token pfx_jj8WDzvnuTHEGdAhwRZMC1Ag8gSto8
+```
+
+Bearer tokens are sent with every request as an `Authorization: Bearer <TOKEN>` header.
+
+
+## anaconda.org / quetz
+
+```shell
+pixi auth login anaconda.org --conda-token xy-72b914cc-c105-4ec7-a969-ab21d23480ed
+```
+
+The conda-token is embedded in the URL path: `conda.anaconda.org/t/<TOKEN>/conda-forge/linux-64/...`. Quetz servers accept the same scheme.
+
+## Basic HTTP authentication
+
+```shell
+pixi auth login myserver.com --username user --password password
+```
+
+This is the equivalent of `http://user:password@myserver.com/...` and is the typical choice for self-hosted channels behind an NGINX/Apache reverse proxy with HTTP basic auth.
 
 ## Examples
 
-Login to prefix.dev:
+Below are the existing per-method examples, kept for quick reference.
+
+Login to prefix.dev with a manual token:
 
 ```shell
 pixi auth login prefix.dev --token pfx_jj8WDzvnuTHEGdAhwRZMC1Ag8gSto8
@@ -65,7 +141,6 @@ pixi auth login s3://my-bucket --s3-access-key-id <access-key-id> --s3-secret-ac
 
 ## Where does Pixi store the authentication information?
 
-The storage location for the authentication information is system-dependent. By default, Pixi tries to use the keychain to store this sensitive information securely on your machine.
 
 On Windows, the credentials are stored in the "credentials manager". Searching for `rattler` (the underlying library Pixi uses) you should find any credentials stored by Pixi (or other rattler-based programs).
 

--- a/docs/reference/cli/pixi/auth/login_extender
+++ b/docs/reference/cli/pixi/auth/login_extender
@@ -2,6 +2,29 @@
 
 ## Examples
 
+OAuth against prefix.dev
+
+```shell
+pixi auth login prefix.dev
+```
+
+OAuth against a self-hosted OIDC provider:
+
+```shell
+pixi auth login my.private.host \
+    --oauth \
+    --oauth-issuer-url https://idp.example.com \
+    --oauth-client-id my-cli-client
+```
+
+OAuth on a headless machine (no usable browser — uses the device-code flow):
+
+```shell
+pixi auth login prefix.dev --oauth-flow device-code
+```
+
+Manual tokens, basic auth, and S3 credentials:
+
 ```shell
 pixi auth login repo.prefix.dev --token pfx_JQEV-m_2bdz-D8NSyRSaAndHANx0qHjq7f2iD
 pixi auth login anaconda.org --conda-token ABCDEFGHIJKLMNOP


### PR DESCRIPTION
### Description

Adding `oauth` as a default login method. This means that users can type instead of this
```shell
pixi auth login https://prefix.dev --oauth-client-id rattler --oauth-scope profile --oauth-scope offline_access --oauth-scope channel:read
```

just

```shell
pixi auth login prefix.dev
```


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude



### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
