### PR TITLE
fix: pixi shell-hook -e prod does repodata fetch

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -2,6 +2,11 @@ use fs_err as fs;
 use pixi_build_backend_passthrough::{BackendEvent, ObservableBackend, PassthroughBackend};
 use pixi_build_frontend::BackendOverride;
 use pixi_consts::consts;
+use pixi_core::{
+    InstallFilter, UpdateLockFileOptions,
+    environment::get_update_lock_file_and_prefix,
+    lock_file::{ReinstallPackages, UpdateMode},
+};
 use rattler_conda_types::{Platform, package::RunExportsJson};
 use rattler_lock::{LockFile, PackageBuildSource};
 use std::path::PathBuf;
@@ -2419,6 +2424,89 @@ my-package = {{ path = "./my-package" }}
         count_build_events(&second_build_events),
         0,
         "second install should reuse the existing build cache for an unchanged source package"
+    );
+}
+
+/// Shell activation should trust an already-installed prefix whose lock hash
+/// marker matches, even when the lock-file contains source packages. Falling
+/// through to the install path can initialize build backends and touch private
+/// channels while generating a shell hook.
+#[tokio::test]
+async fn activation_quick_validate_uses_cached_prefix_with_source_packages() {
+    setup_tracing();
+
+    let (instantiator, mut observer) =
+        ObservableBackend::instantiator(PassthroughBackend::instantiator());
+    let backend_override = BackendOverride::from_memory(instantiator);
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(
+        source_dir.join("pixi.toml"),
+        r#"
+[package]
+name = "my-package"
+version = "0.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        pixi.manifest_path(),
+        format!(
+            r#"
+[workspace]
+name = "my-package"
+channels = []
+platforms = ["{}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package" }}
+"#,
+            Platform::current()
+        ),
+    )
+    .unwrap();
+
+    pixi.install().await.unwrap();
+    assert_eq!(count_build_events(&observer.events()), 1);
+
+    let workspace = pixi.workspace().unwrap();
+    let environment = workspace.environment_from_name_or_env_var(None).unwrap();
+    let environment_file = environment
+        .dir()
+        .join(consts::CONDA_META_DIR)
+        .join(consts::ENVIRONMENT_FILE_NAME);
+    let before = fs::metadata(&environment_file).unwrap().modified().unwrap();
+
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    get_update_lock_file_and_prefix(
+        &environment,
+        None,
+        UpdateMode::QuickValidateActivation,
+        UpdateLockFileOptions::default(),
+        ReinstallPackages::default(),
+        &InstallFilter::default(),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        observer.events().is_empty(),
+        "activation quick validation should not invoke the source build backend"
+    );
+    let after = fs::metadata(&environment_file).unwrap().modified().unwrap();
+    assert_eq!(
+        before, after,
+        "activation quick validation should return from the cached-prefix path without rewriting the prefix marker"
     );
 }
 

--- a/crates/pixi_cli/src/shell.rs
+++ b/crates/pixi_cli/src/shell.rs
@@ -336,7 +336,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let (lock_file_data, prefix) = get_update_lock_file_and_prefix(
         &environment,
         Some(pixi_reporters::TopLevelProgress::from_global()),
-        UpdateMode::QuickValidate,
+        UpdateMode::QuickValidateActivation,
         UpdateLockFileOptions {
             lock_file_usage: args.lock_and_install_config.lock_file_usage()?,
             no_install: args.lock_and_install_config.no_install(),

--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -168,7 +168,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let (lock_file_data, _prefix) = get_update_lock_file_and_prefix(
         &environment,
         Some(pixi_reporters::TopLevelProgress::from_global()),
-        UpdateMode::QuickValidate,
+        UpdateMode::QuickValidateActivation,
         UpdateLockFileOptions {
             lock_file_usage: args.lock_and_install_config.lock_file_usage()?,
             no_install: args.lock_and_install_config.no_install(),

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -593,8 +593,19 @@ pub enum UpdateMode {
     /// Validate if the prefix is up-to-date.
     /// Using a fast and simple validation method.
     /// Used for skipping the update if the prefix is already up-to-date, in
-    /// activating commands. Like `pixi shell` or `pixi run`.
+    /// commands that should still refresh source packages before execution,
+    /// like `pixi run`.
     QuickValidate,
+    /// Validate if the prefix is up-to-date for shell activation.
+    ///
+    /// This trusts the prefix marker when the lock-file hash matches, even when
+    /// the lock-file contains source packages. Shell activation should not
+    /// rebuild source packages or touch the network when an already-installed
+    /// prefix matches the lock-file; commands that execute tasks should use
+    /// [`Self::QuickValidate`] so source packages can still refresh.
+    ///
+    /// Used by `pixi shell` and `pixi shell-hook`.
+    QuickValidateActivation,
     /// Force a prefix install without running the short validation.
     /// Used for updating the prefix when the lock-file likely out of date.
     /// Like `pixi install` or `pixi update`.
@@ -696,8 +707,11 @@ impl<'p> LockFileDerivedData<'p> {
         // Check if the prefix is already up-to-date by validating the hash with the
         // environment file
         let hash = self.locked_environment_hash(environment)?;
-        if update_mode == UpdateMode::QuickValidate
-            && let Some(prefix) = self.cached_prefix(environment, &hash)
+        if matches!(
+            update_mode,
+            UpdateMode::QuickValidate | UpdateMode::QuickValidateActivation
+        ) && let Some(prefix) =
+            self.cached_prefix(environment, &hash, update_mode == UpdateMode::QuickValidate)
         {
             return prefix;
         }
@@ -751,6 +765,7 @@ impl<'p> LockFileDerivedData<'p> {
         &self,
         environment: &Environment<'p>,
         hash: &LockedEnvironmentHash,
+        source_packages_invalidate_cache: bool,
     ) -> Option<Result<Prefix, Report>> {
         let Ok(Some(environment_file)) = read_environment_file(&environment.dir()) else {
             tracing::debug!(
@@ -761,42 +776,56 @@ impl<'p> LockFileDerivedData<'p> {
         };
 
         if environment_file.environment_lock_file_hash == *hash {
-            // If we contain source packages from conda or PyPI we update the prefix by
-            // default
-            let contains_conda_source_pkgs = self.lock_file.environments().any(|(_, env)| {
-                self.lock_file
-                    .platform(&Platform::current().to_string())
-                    .and_then(|p| env.conda_packages(p))
-                    .is_some_and(|mut packages| {
-                        packages.any(|package| package.as_source().is_some())
-                    })
-            });
+            // If we contain source packages from conda or PyPI we update the
+            // prefix by default. Activation-only callers can opt out: they only
+            // need an already-installed prefix matching the lock-file marker and
+            // must not rebuild source packages as a side effect of shell setup.
+            let platform = environment.best_platform();
+            let contains_conda_source_pkgs = self
+                .lock_file
+                .environment(environment.name().as_str())
+                .is_some_and(|env| {
+                    self.lock_file
+                        .platform(&platform.to_string())
+                        .and_then(|p| env.conda_packages(p))
+                        .is_some_and(|mut packages| {
+                            packages.any(|package| package.as_source().is_some())
+                        })
+                });
 
             // Check if we have source packages from PyPI
             // that is a directory, this is basically the only kind of source dependency
             // that you'll modify on a general basis.
             let contains_pypi_source_pkgs = environment
-                .pypi_dependencies(Some(Platform::current()))
+                .pypi_dependencies(Some(platform))
                 .iter()
                 .any(|(_, req)| {
                     req.iter()
                         .any(|dep| dep.as_path().map(|p| p.is_dir()).unwrap_or_default())
                 });
-            if contains_conda_source_pkgs || contains_pypi_source_pkgs {
+            if source_packages_invalidate_cache
+                && (contains_conda_source_pkgs || contains_pypi_source_pkgs)
+            {
                 tracing::debug!(
                     "Lock file contains source packages: ignore lock file hash and update the prefix"
                 );
             } else {
-                tracing::info!(
-                    "Environment '{}' is up-to-date with lock file hash",
-                    environment.name().fancy_display()
-                );
+                if contains_conda_source_pkgs || contains_pypi_source_pkgs {
+                    tracing::debug!(
+                        "Environment '{}' is up-to-date with lock file hash; using cached prefix for activation despite source packages",
+                        environment.name().fancy_display()
+                    );
+                } else {
+                    tracing::info!(
+                        "Environment '{}' is up-to-date with lock file hash",
+                        environment.name().fancy_display()
+                    );
+                }
                 return Some(Ok(Prefix::new(environment.dir())));
             }
         }
         None
     }
-
     /// Returns the up-to-date prefix for the given environment.
     async fn update_prefix(
         &self,


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #6139

### How Has This Been Tested?

unit tests

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: codex

<!-- Add your prompt here, this helps us understand your results.
```plaintext
https://github.com/prefix-dev/pixi/issues/6139#issue-4467463629
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
