### PR TITLE
fix: drop bare self-references in expand_self_extras

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
@@ -154,8 +154,13 @@ pub fn expand_self_extras(
                 path.remove(&extra);
             }
             Frame::Expand(req) => {
-                if req.name != *package_name || req.extras.is_empty() {
+                if req.name != *package_name {
                     result.push(req);
+                    continue;
+                }
+                // Bare self-reference (no extras) is a no-op — build
+                // backends drop these so the lockfile never contains them.
+                if req.extras.is_empty() {
                     continue;
                 }
                 // `foo[a, b]` and `foo[a]` + `foo[b]` produce the same
@@ -528,6 +533,29 @@ dev  = ["foo[test]"]
         insta::assert_snapshot!(render(&expanded), @r"
         trio ; python_full_version >= '3.10' and extra == 'all'
         trio ; python_full_version >= '3.10' and extra == 'async'
+        ");
+    }
+
+    /// Regression test for <https://github.com/prefix-dev/pixi/issues/6136>
+    /// A bare self-reference like `itables ; extra == "test-base"` should
+    /// be dropped during expansion (build backends drop these too).
+    #[test]
+    fn expand_self_extras_drops_bare_self_reference() {
+        let input = vec![
+            req("pytest ; extra == 'test-base'"),
+            req("itables ; extra == 'test-base'"),
+            req("itables[test-base] ; extra == 'dev'"),
+            req("watchfiles ; extra == 'dev'"),
+        ];
+        let expanded = expand_self_extras(&input, &pkg_name("itables"));
+        // The bare `itables ; extra == 'test-base'` must NOT appear.
+        // `itables ; extra == 'dev'` must NOT appear either (expanded
+        // from `itables[test-base] ; extra == 'dev'` hitting the bare ref).
+        // `pytest ; extra == 'test-base'` is a real top-level entry.
+        insta::assert_snapshot!(render(&expanded), @r"
+        pytest ; extra == 'dev'
+        pytest ; extra == 'test-base'
+        watchfiles ; extra == 'dev'
         ");
     }
 }


### PR DESCRIPTION
### Description

When an optional-dependency group includes the package itself without extras (e.g. `test-base = ["itables", "pytest"]`), `expand_self_extras` was keeping the bare self-reference in the expanded output. Build backends drop these (a package can't meaningfully depend on itself without extras), so the lockfile never contains them, causing a permanent metadata mismatch.

This made `pixi install --locked` always fail with "lock-file not up-to-date" and `pixi lock` always report an update even though the lockfile was byte-identical.

The fix splits the condition at line 157 so bare self-references are skipped rather than pushed to the result.

Fixes #6136

### How Has This Been Tested?

- Added `expand_self_extras_drops_bare_self_reference` unit test that reproduces the exact pattern from itables' pyproject.toml
- All 14 existing `pypi_metadata` tests continue to pass
- Manually verified against the [itables repo at the reported commit](https://github.com/mwouts/itables/commit/0144cce8787a504cee2cccf8c9f6f3a903ecd930):
  - `pixi lock` now reports "Lock-file was already up-to-date"
  - `pixi install --locked` now succeeds

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.