### PR TITLE
fix: use gnu target for riscv64 in install.sh

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -47,7 +47,12 @@ __wrap__() {
 
     case "${ARCH-}" in
     arm64 | aarch64) ARCH="aarch64" ;;
-    riscv64) ARCH="riscv64gc" ;;
+    riscv64)
+        ARCH="riscv64gc"
+        if [ "${PLATFORM-}" = "unknown-linux-musl" ]; then
+            PLATFORM="unknown-linux-gnu"
+        fi
+        ;;
     esac
 
     BINARY="pixi-${ARCH}-${PLATFORM}"

--- a/install/install.sh
+++ b/install/install.sh
@@ -39,7 +39,11 @@ __wrap__() {
     if [ "${PLATFORM-}" = "Darwin" ]; then
         PLATFORM="apple-darwin"
     elif [ "${PLATFORM-}" = "Linux" ]; then
-        PLATFORM="unknown-linux-musl"
+        if [ "${ARCH-}" = "riscv64" ]; then
+            PLATFORM="unknown-linux-gnu"
+        else
+            PLATFORM="unknown-linux-musl"
+        fi
     elif [ "$(uname -o)" = "Msys" ]; then
         IS_MSYS=true
         PLATFORM="pc-windows-msvc"
@@ -47,12 +51,7 @@ __wrap__() {
 
     case "${ARCH-}" in
     arm64 | aarch64) ARCH="aarch64" ;;
-    riscv64)
-        ARCH="riscv64gc"
-        if [ "${PLATFORM-}" = "unknown-linux-musl" ]; then
-            PLATFORM="unknown-linux-gnu"
-        fi
-        ;;
+    riscv64) ARCH="riscv64gc" ;;
     esac
 
     BINARY="pixi-${ARCH}-${PLATFORM}"


### PR DESCRIPTION
### Description

The `install.sh` script unconditionally sets `PLATFORM="unknown-linux-musl"` for all Linux architectures. However, the riscv64gc pixi build is only published as `pixi-riscv64gc-unknown-linux-gnu.tar.gz` — there is no musl variant. This causes a 404 when running the installer on RISC-V Linux systems.

This fix overrides the platform to `unknown-linux-gnu` specifically in the riscv64 case, since that's the only available target.

Fixes #6135

### How Has This Been Tested?

Verified the release assets — confirmed that only `pixi-riscv64gc-unknown-linux-gnu.tar.gz` exists (no musl variant). The logic is straightforward: the platform override only triggers when `ARCH` is riscv64 and `PLATFORM` is `unknown-linux-musl`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code