### PR TITLE
feat: `pixi add` skips already-present packages without version spec

### DIFF
--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -708,6 +708,47 @@ async fn pinning_dependency() {
 }
 
 #[tokio::test]
+async fn add_existing_dependency_without_version_is_noop() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("foobar", "1").finish());
+    package_database.add_package(Package::build("foobar", "2").finish());
+    let local_channel = package_database.into_channel().await.unwrap();
+
+    let pixi = PixiControl::new().unwrap();
+    pixi.init().with_channel(local_channel.url()).await.unwrap();
+
+    // Add with an explicit version
+    pixi.add("foobar==1").await.unwrap();
+
+    let get_spec = |pixi: &PixiControl| -> String {
+        pixi.workspace()
+            .unwrap()
+            .workspace
+            .value
+            .default_feature()
+            .dependencies(SpecType::Run, None)
+            .unwrap_or_default()
+            .get_single("foobar")
+            .unwrap()
+            .unwrap()
+            .clone()
+            .to_toml_value()
+            .to_string()
+    };
+    assert_eq!(get_spec(&pixi), r#""==1""#);
+
+    // Re-add without a version — should be a noop, spec should remain ==1
+    pixi.add("foobar").await.unwrap();
+    assert_eq!(get_spec(&pixi), r#""==1""#);
+
+    // Re-add with an explicit version — should overwrite
+    pixi.add("foobar==2").await.unwrap();
+    assert_eq!(get_spec(&pixi), r#""==2""#);
+}
+
+#[tokio::test]
 async fn add_dependency_pinning_strategy() {
     setup_tracing();
 

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -635,19 +635,21 @@ async fn minimal_lockfile_update_pypi() {
         pep508_rs::Requirement::from_str("click==7.1.2").unwrap()
     ));
 
-    // Widening the click version to allow for the latest version
+    // Re-adding click without a version is a noop since it's already present.
+    // Only uvicorn gets updated.
     pixi.add_multiple(vec!["uvicorn==0.29.0", "click"])
         .set_type(pixi_core::DependencyType::PypiDependency)
         .with_install(true)
         .await
         .unwrap();
 
-    // `click` should not be updated to a higher version.
+    // `click` should remain at its original pinned version since the re-add
+    // without a version was skipped.
     let lock = pixi.lock_file().await.unwrap();
     assert!(lock.contains_pep508_requirement(
         consts::DEFAULT_ENVIRONMENT_NAME,
         Platform::current(),
-        pep508_rs::Requirement::from_str("click>7.1.2").unwrap()
+        pep508_rs::Requirement::from_str("click==7.1.2").unwrap()
     ));
 }
 

--- a/crates/pixi/tests/integration_rust/upgrade_tests.rs
+++ b/crates/pixi/tests/integration_rust/upgrade_tests.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 use insta::assert_snapshot;
 use pixi_cli::upgrade::{Args, parse_specs_for_platform};
 use pixi_core::Workspace;
+use pixi_manifest::DependencyOverwriteBehavior;
 use rattler_conda_types::Platform;
 use tempfile::TempDir;
 use url::Url;
@@ -77,6 +78,7 @@ async fn pypi_dependency_index_preserved_on_upgrade() {
             &[],
             true,
             args.dry_run,
+            DependencyOverwriteBehavior::Overwrite,
         )
         .await
         .unwrap();

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -288,7 +288,7 @@ impl<I: Interface> WorkspaceContext<I> {
         spec_type: SpecType,
         dep_options: DependencyOptions,
         git_options: GitOptions,
-    ) -> miette::Result<Option<UpdateDeps>> {
+    ) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
         Box::pin(crate::workspace::add::add_conda_dep(
             self.workspace_mut()?,
             specs,
@@ -304,7 +304,7 @@ impl<I: Interface> WorkspaceContext<I> {
         pypi_deps: PypiDeps,
         editable: bool,
         options: DependencyOptions,
-    ) -> miette::Result<Option<UpdateDeps>> {
+    ) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
         Box::pin(crate::workspace::add::add_pypi_dep(
             self.workspace_mut()?,
             pypi_deps,

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -4,7 +4,7 @@ use pixi_core::{
     environment::sanity_check_workspace,
     workspace::{PypiDeps, UpdateDeps, WorkspaceMut},
 };
-use pixi_manifest::{FeatureName, KnownPreviewFeature, SpecType};
+use pixi_manifest::{DependencyOverwriteBehavior, FeatureName, KnownPreviewFeature, SpecType};
 use pixi_spec::{GitSpec, SourceLocationSpec, Subdirectory};
 use rattler_conda_types::{MatchSpec, PackageName};
 
@@ -18,7 +18,7 @@ pub async fn add_conda_dep(
     spec_type: SpecType,
     dep_options: DependencyOptions,
     git_options: GitOptions,
-) -> miette::Result<Option<UpdateDeps>> {
+) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
     sanity_check_workspace(workspace.workspace()).await?;
 
     // Add the platform if it is not already present
@@ -80,7 +80,7 @@ pub async fn add_conda_dep(
     // TODO: add dry_run logic to add
     let dry_run = false;
 
-    let update_deps = match Box::pin(workspace.update_dependencies(
+    let (update_deps, skipped) = match Box::pin(workspace.update_dependencies(
         match_specs,
         IndexMap::default(),
         source_specs,
@@ -90,13 +90,14 @@ pub async fn add_conda_dep(
         &dep_options.platforms,
         false,
         dry_run,
+        DependencyOverwriteBehavior::OverwriteIfExplicit,
     ))
     .await
     {
-        Ok(update_deps) => {
+        Ok(result) => {
             // Write the updated manifest
             workspace.save().await.into_diagnostic()?;
-            update_deps
+            result
         }
         Err(e) => {
             workspace.revert().await.into_diagnostic()?;
@@ -104,7 +105,7 @@ pub async fn add_conda_dep(
         }
     };
 
-    Ok(update_deps)
+    Ok((update_deps, skipped))
 }
 
 pub async fn add_pypi_dep(
@@ -112,7 +113,7 @@ pub async fn add_pypi_dep(
     pypi_deps: PypiDeps,
     editable: bool,
     options: DependencyOptions,
-) -> miette::Result<Option<UpdateDeps>> {
+) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
     sanity_check_workspace(workspace.workspace()).await?;
 
     // Add the platform if it is not already present
@@ -123,7 +124,7 @@ pub async fn add_pypi_dep(
     // TODO: add dry_run logic to add
     let dry_run = false;
 
-    let update_deps = match Box::pin(workspace.update_dependencies(
+    let (update_deps, skipped) = match Box::pin(workspace.update_dependencies(
         IndexMap::default(),
         pypi_deps,
         IndexMap::default(),
@@ -133,13 +134,14 @@ pub async fn add_pypi_dep(
         &options.platforms,
         editable,
         dry_run,
+        DependencyOverwriteBehavior::OverwriteIfExplicit,
     ))
     .await
     {
-        Ok(update_deps) => {
+        Ok(result) => {
             // Write the updated manifest
             workspace.save().await.into_diagnostic()?;
-            update_deps
+            result
         }
         Err(e) => {
             workspace.revert().await.into_diagnostic()?;
@@ -147,5 +149,5 @@ pub async fn add_pypi_dep(
         }
     };
 
-    Ok(update_deps)
+    Ok((update_deps, skipped))
 }

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -136,7 +136,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
 
-    let update_deps = match args.dependency_config.dependency_type() {
+    let (update_deps, skipped) = match args.dependency_config.dependency_type() {
         DependencyType::CondaDependency(spec_type) => {
             let git_options = GitOptions {
                 git: args.dependency_config.git.clone(),
@@ -182,10 +182,22 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
     };
 
+    for package in &skipped {
+        eprintln!(
+            "{}{} is already a dependency",
+            console::style(console::Emoji("✔ ", "")).green(),
+            console::style(package).bold(),
+        );
+        eprintln!(
+            "  Run {} to get the newest compatible version",
+            console::style(format!("pixi upgrade {package}")).bold(),
+        );
+    }
+
     if let Some(update_deps) = update_deps {
-        // Notify the user we succeeded
+        // Notify the user we succeeded, excluding packages that were skipped
         args.dependency_config
-            .display_success("Added", update_deps.implicit_constraints);
+            .display_success("Added", update_deps.implicit_constraints, &skipped);
     }
 
     Ok(())

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -200,8 +200,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             console::style(package).bold(),
         );
         eprintln!(
-            "  Run {} to get the newest compatible version",
-            console::style(format!("pixi upgrade {package}")).bold(),
+            "  Run `{}` to get the newest compatible version",
+            console::style(format!("pixi upgrade {package}"))
+                .green()
+                .bold(),
         );
     }
 

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use clap::Parser;
 use pixi_api::{
     WorkspaceContext,
@@ -136,51 +138,60 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
 
-    let (update_deps, skipped) = match args.dependency_config.dependency_type() {
-        DependencyType::CondaDependency(spec_type) => {
-            let git_options = GitOptions {
-                git: args.dependency_config.git.clone(),
-                reference: args
-                    .dependency_config
-                    .rev
-                    .clone()
-                    .unwrap_or_default()
-                    .into(),
-                subdir: args.dependency_config.subdir.clone(),
-            };
+    let (update_deps, skipped, parsed_names): (_, Vec<String>, Vec<String>) =
+        match args.dependency_config.dependency_type() {
+            DependencyType::CondaDependency(spec_type) => {
+                let git_options = GitOptions {
+                    git: args.dependency_config.git.clone(),
+                    reference: args
+                        .dependency_config
+                        .rev
+                        .clone()
+                        .unwrap_or_default()
+                        .into(),
+                    subdir: args.dependency_config.subdir.clone(),
+                };
 
-            workspace_ctx
-                .add_conda_deps(
-                    args.dependency_config.specs()?,
-                    spec_type,
-                    (&args).try_into()?,
-                    git_options,
-                )
-                .await?
-        }
-        DependencyType::PypiDependency => {
-            let pypi_deps = match args
-                .dependency_config
-                .vcs_pep508_requirements(&workspace)
-                .transpose()?
-            {
-                Some(vcs_reqs) => vcs_reqs
-                    .into_iter()
-                    .map(|(name, req)| (name, (req, None, None)))
-                    .collect(),
-                None => args
+                let specs = args.dependency_config.specs()?;
+                let names: Vec<String> = specs
+                    .keys()
+                    .map(|n| n.as_normalized().to_string())
+                    .collect();
+                let result = workspace_ctx
+                    .add_conda_deps(specs, spec_type, (&args).try_into()?, git_options)
+                    .await?;
+                (result.0, result.1, names)
+            }
+            DependencyType::PypiDependency => {
+                let pypi_deps: pixi_core::workspace::PypiDeps = match args
                     .dependency_config
-                    .pypi_deps(&workspace)?
-                    .into_iter()
-                    .map(|(name, req)| (name, (req, None, None)))
-                    .collect(),
-            };
+                    .vcs_pep508_requirements(&workspace)
+                    .transpose()?
+                {
+                    Some(vcs_reqs) => vcs_reqs
+                        .into_iter()
+                        .map(|(name, req)| (name, (req, None, None)))
+                        .collect(),
+                    None => args
+                        .dependency_config
+                        .pypi_deps(&workspace)?
+                        .into_iter()
+                        .map(|(name, req)| (name, (req, None, None)))
+                        .collect(),
+                };
 
-            workspace_ctx
-                .add_pypi_deps(pypi_deps, args.editable, (&args).try_into()?)
-                .await?
-        }
-    };
+                let names: Vec<String> = pypi_deps
+                    .keys()
+                    .map(|n| n.as_normalized().to_string())
+                    .collect();
+                let result = workspace_ctx
+                    .add_pypi_deps(pypi_deps, args.editable, (&args).try_into()?)
+                    .await?;
+                (result.0, result.1, names)
+            }
+        };
+
+    let skipped_set: HashSet<&str> = skipped.iter().map(|s| s.as_str()).collect();
 
     for package in &skipped {
         eprintln!(
@@ -195,9 +206,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     if let Some(update_deps) = update_deps {
-        // Notify the user we succeeded, excluding packages that were skipped
-        args.dependency_config
-            .display_success("Added", update_deps.implicit_constraints, &skipped);
+        let added_specs: Vec<String> = args
+            .dependency_config
+            .specs
+            .iter()
+            .zip(parsed_names.iter())
+            .filter(|(_, name)| !skipped_set.contains(name.as_str()))
+            .map(|(raw, _)| raw.clone())
+            .collect();
+        let display_config = DependencyConfig {
+            specs: added_specs,
+            ..args.dependency_config
+        };
+        display_config.display_success("Added", update_deps.implicit_constraints);
     }
 
     Ok(())

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -333,8 +333,17 @@ impl DependencyConfig {
         &self,
         operation: &str,
         implicit_constraints: HashMap<String, String>,
+        skipped: &[String],
     ) {
         for package in self.specs.clone() {
+            if skipped.iter().any(|s| {
+                package == s.as_str()
+                    || package.strip_prefix(s.as_str()).is_some_and(|rest| {
+                        rest.starts_with(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
+                    })
+            }) {
+                continue;
+            }
             eprintln!(
                 "{}{operation} {}{}",
                 console::style(console::Emoji("✔ ", "")).green(),

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -333,22 +333,13 @@ impl DependencyConfig {
         &self,
         operation: &str,
         implicit_constraints: HashMap<String, String>,
-        skipped: &[String],
     ) {
-        for package in self.specs.clone() {
-            if skipped.iter().any(|s| {
-                package == s.as_str()
-                    || package.strip_prefix(s.as_str()).is_some_and(|rest| {
-                        rest.starts_with(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
-                    })
-            }) {
-                continue;
-            }
+        for package in &self.specs {
             eprintln!(
                 "{}{operation} {}{}",
                 console::style(console::Emoji("✔ ", "")).green(),
                 console::style(&package).bold(),
-                if let Some(constraint) = implicit_constraints.get(&package) {
+                if let Some(constraint) = implicit_constraints.get(package.as_str()) {
                     format!(" {}", console::style(constraint).dim())
                 } else {
                     "".to_string()

--- a/crates/pixi_cli/src/remove.rs
+++ b/crates/pixi_cli/src/remove.rs
@@ -82,7 +82,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     args.dependency_config
-        .display_success("Removed", Default::default(), &[]);
+        .display_success("Removed", Default::default());
 
     Ok(())
 }

--- a/crates/pixi_cli/src/remove.rs
+++ b/crates/pixi_cli/src/remove.rs
@@ -82,7 +82,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     args.dependency_config
-        .display_success("Removed", Default::default());
+        .display_success("Removed", Default::default(), &[]);
 
     Ok(())
 }

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -13,6 +13,7 @@ use pixi_core::{
     workspace::{MatchSpecs, PypiDeps, WorkspaceMut},
 };
 use pixi_diff::{LockFileDiff, LockFileJsonDiff};
+use pixi_manifest::DependencyOverwriteBehavior;
 use pixi_manifest::{FeatureName, SpecType};
 use pixi_pypi_spec::PixiPypiSource;
 use pixi_spec::PixiSpec;
@@ -157,7 +158,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         } = specs;
 
         if (!default_match_specs.is_empty() || !default_pypi_deps.is_empty())
-            && let Some(update) = workspace
+            && let (Some(update), _) = workspace
                 .update_dependencies(
                     default_match_specs,
                     default_pypi_deps,
@@ -168,6 +169,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     &[],
                     false,
                     args.dry_run,
+                    DependencyOverwriteBehavior::Overwrite,
                 )
                 .await?
         {
@@ -185,7 +187,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 continue;
             }
 
-            if let Some(update) = workspace
+            if let (Some(update), _) = workspace
                 .update_dependencies(
                     platform_match_specs,
                     platform_pypi_deps,
@@ -196,6 +198,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     &[platform],
                     false,
                     args.dry_run,
+                    DependencyOverwriteBehavior::Overwrite,
                 )
                 .await?
             {

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -250,11 +250,13 @@ impl WorkspaceMut {
         platforms: &[Platform],
         editable: bool,
         dry_run: bool,
-    ) -> Result<Option<UpdateDeps>, miette::Error> {
+        overwrite_behavior: DependencyOverwriteBehavior,
+    ) -> Result<(Option<UpdateDeps>, Vec<String>), miette::Error> {
         let mut conda_specs_to_add_constraints_for = IndexMap::new();
         let mut pypi_specs_to_add_constraints_for = IndexMap::new();
         let mut conda_packages = HashSet::new();
         let mut pypi_packages = HashSet::new();
+        let mut skipped_packages = Vec::new();
         let channel_config = self.workspace().channel_config();
         for (name, (spec, spec_type)) in match_specs {
             let (_, nameless_spec) = spec.into_nameless();
@@ -267,7 +269,7 @@ impl WorkspaceMut {
                 spec_type,
                 platforms,
                 feature_name,
-                DependencyOverwriteBehavior::Overwrite,
+                overwrite_behavior,
             )?;
             if added {
                 if nameless_spec.version.is_none() {
@@ -275,6 +277,8 @@ impl WorkspaceMut {
                         .insert(name.clone(), (spec_type, nameless_spec));
                 }
                 conda_packages.insert(name);
+            } else {
+                skipped_packages.push(name.as_normalized().to_string());
             }
         }
 
@@ -287,7 +291,7 @@ impl WorkspaceMut {
                 spec_type,
                 platforms,
                 feature_name,
-                DependencyOverwriteBehavior::Overwrite,
+                overwrite_behavior,
             )?;
         }
 
@@ -297,7 +301,7 @@ impl WorkspaceMut {
                 platforms,
                 feature_name,
                 Some(editable),
-                DependencyOverwriteBehavior::Overwrite,
+                overwrite_behavior,
                 location,
             )?;
             if added {
@@ -306,6 +310,8 @@ impl WorkspaceMut {
                         .insert(name.clone(), (spec, pixi_spec, location));
                 }
                 pypi_packages.insert(name.as_normalized().clone());
+            } else {
+                skipped_packages.push(name.as_normalized().to_string());
             }
         }
 
@@ -317,7 +323,7 @@ impl WorkspaceMut {
         }
 
         if *lock_file_update_config != LockFileUsage::Update {
-            return Ok(None);
+            return Ok((None, skipped_packages));
         }
 
         let original_lock_file = self
@@ -472,10 +478,13 @@ impl WorkspaceMut {
         let lock_file_diff =
             LockFileDiff::from_lock_files(&original_lock_file, &updated_lock_file.into_lock_file());
 
-        Ok(Some(UpdateDeps {
-            implicit_constraints,
-            lock_file_diff,
-        }))
+        Ok((
+            Some(UpdateDeps {
+                implicit_constraints,
+                lock_file_diff,
+            }),
+            skipped_packages,
+        ))
     }
 
     // Take some conda and PyPI deps as Vecs of MatchSpecs and Requirements, and add them


### PR DESCRIPTION
### Description

When a package is already a dependency and `pixi add <pkg>` is called without a version constraint, the command now skips the package instead of upgrading it. This prevents accidental version bumps and makes the behavior consistent with cargo's approach.

Users are informed with a clear message and directed to use `pixi upgrade` for intentional version updates:

```
$ pixi add crane
✔ crane is already a dependency
  Run pixi upgrade crane to get the newest compatible version
```

Explicitly versioned adds like `pixi add crane==2.0` still overwrite the existing spec as before.

Fixes #3936

### How Has This Been Tested?

- New integration test `add_existing_dependency_without_version_is_noop` validates:
  - Adding with explicit version works (`pixi add foobar==1`)
  - Re-adding without version is a noop (spec stays `==1`)
  - Re-adding with explicit version overwrites (`pixi add foobar==2`)
- All existing add and upgrade integration tests pass

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.