### PR TITLE
fix: improve conda-pypi mapping error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,6 +234,7 @@ rattler_index = { version = "0.29", default-features = false, features = [
 ] }
 rattler_lock = { version = "0.30", default-features = false }
 rattler_menuinst = { version = "0.2", default-features = false }
+rattler_redaction = { version = "0.2", default-features = false, features = ["reqwest-middleware"] }
 rattler_networking = { version = "0.27", default-features = false, features = [
   "dirs",
   "google-cloud-auth",

--- a/crates/pypi_mapping/Cargo.toml
+++ b/crates/pypi_mapping/Cargo.toml
@@ -23,6 +23,7 @@ pixi_config = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true }
 rattler_networking = { workspace = true }
+rattler_redaction = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }

--- a/crates/pypi_mapping/src/lib.rs
+++ b/crates/pypi_mapping/src/lib.rs
@@ -368,14 +368,21 @@ impl MappingClient {
     /// Adds cache path context to a MappingError, and reclassifies middleware
     /// errors (which originate from the HTTP cache layer) as cache corruption.
     fn with_cache_path_context(&self, err: MappingError) -> MappingError {
+        use rattler_redaction::Redact;
         let cache_path = self.cache_path.display().to_string();
         match err {
             MappingError::IoError { source, .. } => MappingError::IoError { source, cache_path },
             MappingError::Reqwest { source, url } => {
                 if source.is_middleware() {
-                    MappingError::Cache { source, cache_path }
+                    MappingError::Cache {
+                        source: source.redact(),
+                        cache_path,
+                    }
                 } else {
-                    MappingError::Reqwest { source, url }
+                    MappingError::Reqwest {
+                        source: source.redact(),
+                        url,
+                    }
                 }
             }
             other => other,

--- a/crates/pypi_mapping/src/lib.rs
+++ b/crates/pypi_mapping/src/lib.rs
@@ -155,22 +155,29 @@ impl MappingClientBuilder {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, miette::Diagnostic)]
 pub enum MappingError {
-    #[error("failed to access conda-pypi mapping cache at '{path}'")]
+    #[error("failed to access conda-pypi mapping cache at '{cache_path}'")]
+    #[diagnostic(help("try clearing the cache with: rm -rf {cache_path}"))]
     IoError {
         #[source]
         source: std::io::Error,
-        path: PathBuf,
+        cache_path: String,
     },
-    #[error("failed to fetch conda-pypi mapping from remote source")]
-    Reqwest(#[source] reqwest_middleware::Error),
-}
-
-impl From<reqwest_middleware::Error> for MappingError {
-    fn from(err: reqwest_middleware::Error) -> Self {
-        MappingError::Reqwest(err)
-    }
+    #[error("failed to fetch conda-pypi mapping from '{url}'")]
+    Reqwest {
+        #[source]
+        source: reqwest_middleware::Error,
+        url: String,
+    },
+    #[error(
+        "conda-pypi mapping cache error (cache path: {cache_path}). Try clearing it with: rm -rf {cache_path}"
+    )]
+    Cache {
+        #[source]
+        source: reqwest_middleware::Error,
+        cache_path: String,
+    },
 }
 
 impl MappingClient {
@@ -358,13 +365,19 @@ impl MappingClient {
         Ok(purls)
     }
 
-    /// Adds cache path context to a MappingError if it's an IO error.
+    /// Adds cache path context to a MappingError, and reclassifies middleware
+    /// errors (which originate from the HTTP cache layer) as cache corruption.
     fn with_cache_path_context(&self, err: MappingError) -> MappingError {
+        let cache_path = self.cache_path.display().to_string();
         match err {
-            MappingError::IoError { source, path: _ } => MappingError::IoError {
-                source,
-                path: self.cache_path.clone(),
-            },
+            MappingError::IoError { source, .. } => MappingError::IoError { source, cache_path },
+            MappingError::Reqwest { source, url } => {
+                if source.is_middleware() {
+                    MappingError::Cache { source, cache_path }
+                } else {
+                    MappingError::Reqwest { source, url }
+                }
+            }
             other => other,
         }
     }

--- a/crates/pypi_mapping/src/prefix/compressed_mapping_client.rs
+++ b/crates/pypi_mapping/src/prefix/compressed_mapping_client.rs
@@ -98,6 +98,7 @@ impl CompressedMappingClient {
                     ),
                     None => None,
                 };
+                tracing::debug!(url = %compressed_mapping_url, "fetching compressed conda-pypi mapping");
                 let response = inner
                     .client
                     .client()
@@ -127,7 +128,13 @@ impl DerivePurls for CompressedMappingClient {
         }
 
         // Get the mapping from the server
-        let mapping = self.get_mapping(cache_metrics).await?;
+        let mapping =
+            self.get_mapping(cache_metrics)
+                .await
+                .map_err(|source| MappingError::Reqwest {
+                    source,
+                    url: COMPRESSED_MAPPING.to_string(),
+                })?;
 
         // Determine the mapping for the record
         let Some(potential_pypi_name) = mapping.get(record.package_record.name.as_normalized())

--- a/crates/pypi_mapping/src/prefix/hash_mapping_client.rs
+++ b/crates/pypi_mapping/src/prefix/hash_mapping_client.rs
@@ -41,14 +41,14 @@ impl From<reqwest::Error> for HashMappingClientError {
     }
 }
 
-impl From<HashMappingClientError> for MappingError {
-    fn from(value: HashMappingClientError) -> Self {
-        match value {
+impl HashMappingClientError {
+    fn into_mapping_error(self, url: String) -> MappingError {
+        match self {
             HashMappingClientError::Io(err) => MappingError::IoError {
                 source: err,
-                path: std::path::PathBuf::new(),
+                cache_path: String::new(),
             },
-            HashMappingClientError::Reqwest(err) => MappingError::Reqwest(err),
+            HashMappingClientError::Reqwest(err) => MappingError::Reqwest { source: err, url },
         }
     }
 }
@@ -246,7 +246,7 @@ async fn try_fetch_mapping(
     let hash_str = format!("{sha256:x}");
     let url = format!("{STORAGE_URL}/{HASH_DIR}/{hash_str}");
 
-    // Fetch the mapping from the server
+    tracing::debug!(url = %url, "fetching hash-based conda-pypi mapping");
     let response = client.client().get(&url).send().await?;
 
     cache_metrics.record_request_response(&response);
@@ -274,7 +274,13 @@ impl DerivePurls for HashMappingClient {
         };
 
         // Fetch the mapping from the server, or return None if it doesn't exist
-        let Some(mapped_package) = self.get_mapping(sha256, cache_metrics).await? else {
+        let hash_str = format!("{sha256:x}");
+        let url = format!("{STORAGE_URL}/{HASH_DIR}/{hash_str}");
+        let Some(mapped_package) = self
+            .get_mapping(sha256, cache_metrics)
+            .await
+            .map_err(|e| e.into_mapping_error(url))?
+        else {
             return Ok(None);
         };
 


### PR DESCRIPTION
### Description

When the conda-pypi mapping cache is corrupt or inaccessible (e.g. after an `http-cache-reqwest` version upgrade that changes the serialization format from bincode to postcard), the error was misleadingly reported as a network failure:

```
failed to fetch conda-pypi mapping from remote source
io error: unexpected end of file
```

This sends users on a wild goose chase investigating their network/proxy when the fix is simply clearing the local cache.

This PR:
- Distinguishes cache-layer errors (from `http-cache` middleware) from actual network errors using `reqwest_middleware::Error::is_middleware()`
- For cache errors: shows the cache path and suggests `rm -rf` to clear it
- For network errors: includes the URL that failed so users can diagnose connectivity
- Adds `pypi_mapping` to the CLI tracing filter so its debug logs are visible with `-vv`

**Before:**
```
× failed to map conda packages to their PyPI equivalents. ...
├─▶ failed to fetch conda-pypi mapping from remote source
╰─▶ io error: unexpected end of file
```

**After (cache error):**
```
× failed to map conda packages to their PyPI equivalents. ...
├─▶ conda-pypi mapping cache error (cache path: ~/Library/Caches/rattler/cache/conda-pypi-mapping).
│   Try clearing it with: rm -rf ~/Library/Caches/rattler/cache/conda-pypi-mapping
╰─▶ Cache error: building directory .../content-v2/sha256/ef/c8 failed
```

**After (network error):**
```
× failed to map conda packages to their PyPI equivalents. ...
├─▶ failed to fetch conda-pypi mapping from 'https://conda-mapping.prefix.dev/hash-v0/...'
╰─▶ error sending request ...
```

### How Has This Been Tested?

- Verified cache error path by removing read permissions on the cache content directory
- Verified network error path retains the URL
- `cargo check -p pixi_cli` passes

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code