### PR TITLE
feat: skip compression for editable (dev) builds in pixi-build-backend

### DIFF
--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -792,7 +792,13 @@ where
                 subpackages: BTreeMap::new(),
                 packaging_settings: PackagingSettings::from_args(
                     CondaArchiveType::Conda,
-                    CompressionLevel::default(),
+                    // Development (editable) builds skip compression to favor build speed
+                    // over artifact size, since these packages are not meant for distribution.
+                    if params.editable.unwrap_or_default() {
+                        CompressionLevel::Lowest
+                    } else {
+                        CompressionLevel::default()
+                    },
                 ),
                 store_recipe: false,
                 force_colors: true,

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -438,7 +438,13 @@ impl Protocol for RattlerBuildBackend {
                 subpackages: BTreeMap::new(),
                 packaging_settings: PackagingSettings::from_args(
                     CondaArchiveType::Conda,
-                    CompressionLevel::default(),
+                    // Development (editable) builds skip compression to favor build speed
+                    // over artifact size, since these packages are not meant for distribution.
+                    if params.editable.unwrap_or_default() {
+                        CompressionLevel::Lowest
+                    } else {
+                        CompressionLevel::default()
+                    },
                 ),
                 store_recipe: false,
                 force_colors: true,


### PR DESCRIPTION
### Description

Use the lowest compression level when building a package in editable/development mode via a pixi-build-backend. Dev artifacts are short-lived and never distributed, so trading compression ratio for build speed is worthwhile.

When `CondaBuildV1Params.editable` is true, `PackagingSettings` is built with `CompressionLevel::Lowest` (zstd level -7) instead of the default (zstd level 15). Release builds are unchanged.

### How Has This Been Tested?

`cargo check -p pixi_build_backend -p pixi-build-rattler-build` passes. Not covered by automated tests.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added sufficient tests to cover my changes.