### PR TITLE
fix: propagate run-exports from host/build 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5867,6 +5867,7 @@ dependencies = [
  "pypi_mapping",
  "rattler_conda_types",
  "rattler_lock",
+ "rattler_package_streaming",
  "rattler_virtual_packages",
  "reqwest 0.12.28",
  "serde_json",

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -40,7 +40,7 @@ futures = { workspace = true }
 http = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
-insta = { workspace = true, features = ["yaml", "glob", "filters"] }
+insta = { workspace = true, features = ["yaml", "glob", "filters", "redactions"] }
 pep508_rs = { workspace = true }
 pixi_build_backend_passthrough = { workspace = true }
 pixi_build_frontend = { workspace = true }
@@ -58,6 +58,7 @@ pixi_utils = { workspace = true }
 pypi_mapping = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_lock = { workspace = true }
+rattler_package_streaming = { workspace = true }
 rattler_virtual_packages = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -2537,3 +2537,160 @@ backend.version = "0.1.0"
         ".pixi/.gitignore was not created after publish"
     );
 }
+
+/// Regression test for https://github.com/prefix-dev/pixi/issues/6147
+///
+/// When building a source package whose `[package.host-dependencies]` provide
+/// run-exports, the resulting `.conda` artifact's `info/index.json` `depends`
+/// array must list the host dependency *and* every run-export it contributes.
+///
+/// In pixi 0.68.0 the `SourceBuildKey` pipeline forwarded only the recipe's
+/// raw `output.run_dependencies` to the build backend, skipping the
+/// `extend_with_run_exports_from_build_and_host` merge step that the lockfile
+/// resolution path uses. This caused the built package's `depends` to come
+/// back empty even though the lockfile recorded the correct dependencies.
+///
+/// The test exercises the end-to-end path: it puts a mock host package with
+/// run-exports in a local channel, builds a source package that uses it as a
+/// host-dependency, and then inspects the produced `.conda` to make sure the
+/// merged `depends` (plus the license forwarded from the project model) is
+/// what landed in `info/index.json`.
+#[tokio::test]
+async fn test_build_propagates_host_run_exports_into_index_json() {
+    use rattler_conda_types::package::IndexJson;
+
+    setup_tracing();
+
+    // A host package whose run-exports pull in `runtime-lib >=1.0` and pin
+    // `host-lib` itself into the consumer's `depends`. This mirrors how
+    // real C libraries (e.g. hdf5) advertise both a pin on themselves and
+    // a runtime link via `pin_subpackage` + extra runtime deps.
+    let run_exports = RunExportsJson {
+        weak: vec![
+            "host-lib >=2.5,<3.0a0".to_string(),
+            "runtime-lib >=1.0".to_string(),
+        ],
+        ..Default::default()
+    };
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(
+        Package::build("host-lib", "2.5.0")
+            .with_subdir(Platform::current())
+            .with_materialize(true)
+            .with_run_exports(run_exports.clone())
+            .finish(),
+    );
+    package_database.add_package(
+        Package::build("runtime-lib", "1.0.0")
+            .with_subdir(Platform::current())
+            .with_materialize(true)
+            .finish(),
+    );
+    let channel = package_database.into_channel().await.unwrap();
+
+    // NOTE: we intentionally do NOT call `.with_run_exports(...)` on the
+    // PassthroughBackend instantiator here. That would make the backend
+    // pre-bake the run-exports into the `conda_outputs` response and bypass
+    // the bug being tested. With this configuration the backend returns an
+    // empty `run_dependencies` list and pixi is solely responsible for
+    // resolving run-exports from the host environment.
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(BackendOverride::from_memory(
+            PassthroughBackend::instantiator(),
+        ));
+
+    let manifest_content = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[package]
+name = "my-pkg"
+version = "0.4.2"
+license = "BSD-3-Clause"
+
+[package.build]
+backend = {{ name = "in-memory", version = "0.1.0" }}
+
+# Opt the passthrough backend into a platform-specific build so weak
+# run-exports from host-dependencies actually propagate (NoArch only
+# picks up `noarch` run-exports).
+[package.build.config]
+noarch = false
+
+[package.host-dependencies]
+host-lib = "*"
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    pixi.update_manifest(&manifest_content).unwrap();
+
+    // Publish into a target_dir so we get a stable on-disk location for the
+    // produced .conda artifact.
+    let target_dir = TempDir::new().unwrap();
+    publish::execute(publish::Args {
+        backend_override: Some(BackendOverride::from_memory(
+            PassthroughBackend::instantiator(),
+        )),
+        config_cli: Default::default(),
+        target_platform: Platform::current(),
+        build_platform: Platform::current(),
+        build_string_prefix: None,
+        build_number: None,
+        build_dir: None,
+        clean: false,
+        path: Some(pixi.manifest_path()),
+        target_channel: None,
+        target_dir: Some(target_dir.path().to_path_buf()),
+        force: false,
+        skip_existing: true,
+        generate_attestation: false,
+    })
+    .await
+    .expect("publish should succeed");
+
+    // `--target-dir` mode copies the produced `.conda` files directly into
+    // the destination directory.
+    let produced = fs::read_dir(target_dir.path())
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.extension().and_then(|s| s.to_str()) == Some("conda")
+                && path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|n| n.starts_with("my-pkg-"))
+        })
+        .expect("publish did not produce a .conda for my-pkg");
+
+    // Read the produced .conda's info/index.json and snapshot it. Subdir
+    // is redacted because it varies with the host platform the test runs
+    // on; everything else (name, version, license, depends, constrains,
+    // noarch, build string / number) must stay stable, and in particular
+    // both run-exports — the `host-lib` self-pin and the runtime link to
+    // `runtime-lib` — must show up in `depends`. Before the fix `depends`
+    // came back as `[]`.
+    let index_json: IndexJson = rattler_package_streaming::seek::read_package_file(&produced)
+        .expect("failed to read info/index.json from the produced .conda");
+
+    // Subdir is redacted because it varies with the host platform the
+    // test runs on.
+    insta::assert_yaml_snapshot!(index_json, {
+        ".subdir" => "[SUBDIR]",
+    }, @r###"
+    build: ""
+    build_number: 0
+    depends:
+      - "host-lib >=2.5,<3.0a0"
+      - runtime-lib >=1.0
+    license: BSD-3-Clause
+    name: my-pkg
+    subdir: "[SUBDIR]"
+    version: 0.4.2
+    "###);
+}

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -172,6 +172,24 @@ impl InMemoryBackend for PassthroughBackend {
                 }
                 modified_index_json.license = self.project_model.license.clone();
 
+                // Reflect the run-dependencies and run-constraints that
+                // the frontend resolved (including run-exports propagated
+                // from build / host envs) into the package's index.json
+                // so that consumers inspecting the built `.conda` see the
+                // expected `depends` / `constrains` arrays.
+                if let Some(run_dependencies) = &params.run_dependencies {
+                    modified_index_json.depends = run_dependencies
+                        .iter()
+                        .map(|dep| dep.spec.to_string())
+                        .collect();
+                }
+                if let Some(run_constraints) = &params.run_constraints {
+                    modified_index_json.constrains = run_constraints
+                        .iter()
+                        .map(|dep| dep.spec.to_string())
+                        .collect();
+                }
+
                 create_conda_package_on_the_fly(&modified_index_json, &output_path).map_err(
                     |err| {
                         Box::new(

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -70,6 +70,9 @@ pub enum SourceBuildError {
     #[diagnostic(transparent)]
     BackendBuildError(#[from] BackendSourceBuildError),
 
+    #[error("failed to amend run exports for {0} environment")]
+    RunExportsExtraction(String, #[source] Arc<RunExportExtractorError>),
+
     #[error("failed to read metadata from the output package")]
     ReadIndexJson(#[source] Arc<rattler_package_streaming::ExtractError>),
 

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -33,6 +33,7 @@ use crate::{
     InstallPixiEnvironmentExt, InstallPixiEnvironmentSpec, InstantiateBackendKey,
     ProjectModelOverrides, SourceBuildError,
     build::{Dependencies, PixiRunExports},
+    compute_data::HasGateway,
 };
 use pixi_compute_cache_dirs::CacheDirsExt;
 use pixi_compute_sources::SourceCheckoutExt;
@@ -285,17 +286,20 @@ async fn compute_inner(
     // - host deps see build records
     // - run deps (+ run_exports) see build + host records
     let source_anchor = SourceAnchor::from(SourceLocationSpec::from(manifest_source.clone()));
-    let build_pixi_records: Vec<PixiRecord> = build_records
+    let mut build_pixi_records: Vec<PixiRecord> = build_records
         .iter()
         .cloned()
         .map(|r| PixiRecord::Binary(Arc::new(r)))
         .collect();
-    let host_pixi_records: Vec<PixiRecord> = host_records
+    let mut host_pixi_records: Vec<PixiRecord> = host_records
         .iter()
         .cloned()
         .map(|r| PixiRecord::Binary(Arc::new(r)))
         .collect();
 
+    // Resolve build dependencies first; the build env can't reference
+    // pin-compatible markers against anything (it's the env being defined)
+    // so we hand `Dependencies::new` an empty compatibility map.
     let build_dependencies = output
         .build_dependencies
         .as_ref()
@@ -310,6 +314,23 @@ async fn compute_inner(
         .map_err(SourceBuildError::from)?
         .unwrap_or_default();
 
+    // Extract run-exports from the build env now so the host
+    // dependencies (and ultimately the run dependencies) can incorporate
+    // them. Without this step the backend receives the raw
+    // `run_dependencies` from the output and the resulting
+    // `info/index.json` `depends` array is missing any dependencies
+    // contributed by build / host packages' run-exports.
+    let gateway = ctx.global_data().gateway().clone();
+    let build_run_exports = build_dependencies
+        .extract_run_exports(
+            &mut build_pixi_records,
+            &output.ignore_run_exports,
+            &gateway,
+            None,
+        )
+        .await
+        .map_err(|err| SourceBuildError::RunExportsExtraction("build".into(), Arc::new(err)))?;
+
     let mut compat_map: std::collections::HashMap<rattler_conda_types::PackageName, &PixiRecord> =
         std::collections::HashMap::new();
     for r in &build_pixi_records {
@@ -322,14 +343,32 @@ async fn compute_inner(
         .map(|deps| Dependencies::new(deps, Some(source_anchor.clone()), &compat_map))
         .transpose()
         .map_err(SourceBuildError::from)?
-        .unwrap_or_default();
+        .unwrap_or_default()
+        // Apply strong build run-exports to host so the host env's
+        // run-export extraction sees them as direct dependencies.
+        .extend_with_run_exports_from_build(&build_run_exports);
+
+    let host_run_exports = host_dependencies
+        .extract_run_exports(
+            &mut host_pixi_records,
+            &output.ignore_run_exports,
+            &gateway,
+            None,
+        )
+        .await
+        .map_err(|err| SourceBuildError::RunExportsExtraction("host".into(), Arc::new(err)))?;
 
     for r in &host_pixi_records {
         compat_map.insert(r.name().clone(), r);
     }
 
     let run_dependencies = Dependencies::new(&output.run_dependencies, None, &compat_map)
-        .map_err(SourceBuildError::from)?;
+        .map_err(SourceBuildError::from)?
+        .extend_with_run_exports_from_build_and_host(
+            host_run_exports,
+            build_run_exports,
+            output.metadata.subdir,
+        );
     let run_exports = PixiRunExports::try_from_protocol(&output.run_exports, &compat_map)
         .map_err(SourceBuildError::from)?;
 


### PR DESCRIPTION
### Description

Fixes a regression introduced in v0.68.0 where `pixi build` produced `.conda` packages with an empty `"depends"` array in `info/index.json`. Run-exports from `host-dependencies` (and `build-dependencies`) were no longer being propagated into the built package's runtime dependency metadata.

The regression caused projects that rely on host dependencies like `hdf5` to ship packages missing their expected runtime requirements (e.g. `libcxx >=22`, `hdf5 >=2.1.0,<3.0a0`), breaking downstream installs.

Before:

```json
"depends": []
```

After:

```json
"depends": [
  "libcxx >=22",
  "hdf5 >=2.1.0,<3.0a0"
]
```

Fixes #6147

### How Has This Been Tested?

- Reproduced the bug locally on `osx-arm64` against the minimal example attached to #6147 (CMake backend + `hdf5` as a `host-dependency`):
  1. `pixi build` on `v0.68.1` → `info/index.json` contains `"depends": []`.
  2. `pixi build` with this fix → `info/index.json` contains the expected `hdf5` and `libcxx` entries.
- Verified the same example on `linux-64` to confirm the strong/weak run-export propagation paths are exercised on non-noarch targets.
- Added a regression test that builds a source package with a host-dependency exporting run-exports and asserts that the resulting `PackageRecord.depends` is non-empty and contains the expected specs.
- Ran `cargo test -p pixi_command_dispatcher` and the `pixi_build` integration tests.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.