### PR TITLE
perf: install build and host environments concurrently

### DIFF
--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -258,25 +258,35 @@ async fn compute_inner(
     let output = fetch_matching_output(&backend, &spec, &work_directory).await?;
 
     // install_prefix recurses into source entries via SourceBuildKey,
-    // so build_records / host_records are all binaries on disk.
+    // so build_records / host_records are all binaries on disk. Build
+    // and host packages come pre-resolved on the input record (v7+
+    // lockfile), so the two installs are independent and can run
+    // concurrently.
     let directories = Directories::new(&work_directory, spec.build_environment.host_platform);
-    let (build_records, _build_install_result) = install_prefix(
-        ctx,
-        &spec,
-        InstallTarget::Build,
-        directories.build_prefix.clone(),
-        spec.record.build_packages.clone(),
-    )
-    .await?;
-
-    let (host_records, _host_install_result) = install_prefix(
-        ctx,
-        &spec,
-        InstallTarget::Host,
-        directories.host_prefix.clone(),
-        spec.record.host_packages.clone(),
-    )
-    .await?;
+    let ((build_records, _build_install_result), (host_records, _host_install_result)) = ctx
+        .try_compute2(
+            async |ctx| {
+                install_prefix(
+                    ctx,
+                    &spec,
+                    InstallTarget::Build,
+                    directories.build_prefix.clone(),
+                    spec.record.build_packages.clone(),
+                )
+                .await
+            },
+            async |ctx| {
+                install_prefix(
+                    ctx,
+                    &spec,
+                    InstallTarget::Host,
+                    directories.host_prefix.clone(),
+                    spec.record.host_packages.clone(),
+                )
+                .await
+            },
+        )
+        .await?;
 
     // Resolve `pin_compatible` markers against the build/host records we
     // just produced. Visibility ordering:


### PR DESCRIPTION
### Description

With lockfile-v7, `build_packages` and `host_packages` are pre-resolved on the source record, so the two `install_prefix` calls in `SourceBuildKey` are independent. Run them concurrently via `ctx.try_compute2(...)` instead of sequentially to cut source-build wall time.

### How Has This Been Tested?

- `cargo check -p pixi_command_dispatcher --tests` passes.
- Existing source-build coverage exercises the same code path; no behavior change is expected, only ordering.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code