### PR TITLE
feat: add `--package-format` to `pixi publish` for tar.bz2 output

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -647,6 +647,7 @@ async fn test_publish_fails_before_build_or_upload_when_one_variant_is_unsatisfi
         generate_attestation: false,
         variant: Vec::new(),
         variant_config: Vec::new(),
+        package_format: None,
     })
     .await
     .expect_err("publish should fail when one variant cannot be resolved");
@@ -2469,6 +2470,7 @@ async fn test_publish_without_target_builds_but_does_not_upload() {
         generate_attestation: false,
         variant: Vec::new(),
         variant_config: Vec::new(),
+        package_format: None,
     })
     .await
     .expect("publish without target should succeed");
@@ -2535,6 +2537,7 @@ backend.version = "0.1.0"
         generate_attestation: false,
         variant: Vec::new(),
         variant_config: Vec::new(),
+        package_format: None,
     })
     .await;
 
@@ -2657,6 +2660,7 @@ host-lib = "*"
         generate_attestation: false,
         variant: Vec::new(),
         variant_config: Vec::new(),
+        package_format: None,
     })
     .await
     .expect("publish should succeed");

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -791,8 +791,14 @@ where
                 timestamp: chrono::Utc::now(),
                 subpackages: BTreeMap::new(),
                 packaging_settings: PackagingSettings::from_args(
-                    CondaArchiveType::Conda,
-                    CompressionLevel::default(),
+                    params
+                        .package_format
+                        .map(|pf| pf.archive_type)
+                        .unwrap_or(CondaArchiveType::Conda),
+                    params
+                        .package_format
+                        .map(|pf| CompressionLevel::from(pf.compression_level))
+                        .unwrap_or_default(),
                 ),
                 store_recipe: false,
                 force_colors: true,

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -111,6 +111,7 @@ async fn test_conda_build_v1() {
         work_directory: build_dir.clone(),
         output_directory: None,
         editable: None,
+        package_format: None,
     };
 
     let some_config = json!({

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -437,8 +437,14 @@ impl Protocol for RattlerBuildBackend {
                 timestamp: chrono::Utc::now(),
                 subpackages: BTreeMap::new(),
                 packaging_settings: PackagingSettings::from_args(
-                    CondaArchiveType::Conda,
-                    CompressionLevel::default(),
+                    params
+                        .package_format
+                        .map(|pf| pf.archive_type)
+                        .unwrap_or(CondaArchiveType::Conda),
+                    params
+                        .package_format
+                        .map(|pf| CompressionLevel::from(pf.compression_level))
+                        .unwrap_or_default(),
                 ),
                 store_recipe: false,
                 force_colors: true,

--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -12,6 +12,7 @@ use std::{
 
 use rattler_conda_types::{
     ChannelUrl, MatchSpec, PackageName, Platform, RepoDataRecord, VersionWithSource,
+    compression_level::CompressionLevel, package::CondaArchiveType,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, DisplayFromStr, serde_as};
@@ -63,6 +64,85 @@ pub struct CondaBuildV1Params {
     /// Whether we want to install the package as editable
     // TODO: remove this parameter as soon as we have profiles
     pub editable: Option<bool>,
+
+    /// Archive format and compression level. `None` lets the backend pick.
+    #[serde(default)]
+    pub package_format: Option<CondaPackageFormat>,
+}
+
+/// Archive format paired with its compression level.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct CondaPackageFormat {
+    pub archive_type: CondaArchiveType,
+    #[serde(default)]
+    pub compression_level: CondaCompressionLevel,
+}
+
+impl CondaPackageFormat {
+    /// `.conda` at the cheapest compression. Used for intermediate
+    /// artifacts that get unpacked immediately.
+    pub const fn fast() -> Self {
+        CondaPackageFormat {
+            archive_type: CondaArchiveType::Conda,
+            compression_level: CondaCompressionLevel::Named(NamedCompressionLevel::Lowest),
+        }
+    }
+}
+
+/// Wire-level mirror of `rattler_conda_types::compression_level::
+/// CompressionLevel` with serde and `Hash`.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(untagged)]
+pub enum CondaCompressionLevel {
+    Named(NamedCompressionLevel),
+    /// Numeric level; range depends on the archive type.
+    Numeric(i32),
+}
+
+impl Default for CondaCompressionLevel {
+    fn default() -> Self {
+        CondaCompressionLevel::Named(NamedCompressionLevel::Default)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NamedCompressionLevel {
+    Lowest,
+    #[default]
+    Default,
+    Highest,
+}
+
+impl From<CondaCompressionLevel> for CompressionLevel {
+    fn from(value: CondaCompressionLevel) -> Self {
+        match value {
+            CondaCompressionLevel::Named(NamedCompressionLevel::Lowest) => CompressionLevel::Lowest,
+            CondaCompressionLevel::Named(NamedCompressionLevel::Default) => {
+                CompressionLevel::Default
+            }
+            CondaCompressionLevel::Named(NamedCompressionLevel::Highest) => {
+                CompressionLevel::Highest
+            }
+            CondaCompressionLevel::Numeric(level) => CompressionLevel::Numeric(level),
+        }
+    }
+}
+
+impl From<CompressionLevel> for CondaCompressionLevel {
+    fn from(value: CompressionLevel) -> Self {
+        match value {
+            CompressionLevel::Lowest => CondaCompressionLevel::Named(NamedCompressionLevel::Lowest),
+            CompressionLevel::Default => {
+                CondaCompressionLevel::Named(NamedCompressionLevel::Default)
+            }
+            CompressionLevel::Highest => {
+                CondaCompressionLevel::Named(NamedCompressionLevel::Highest)
+            }
+            CompressionLevel::Numeric(level) => CondaCompressionLevel::Numeric(level),
+        }
+    }
 }
 
 #[serde_as]

--- a/crates/pixi_cli/src/build.rs
+++ b/crates/pixi_cli/src/build.rs
@@ -106,6 +106,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         generate_attestation: false,
         variant: Vec::new(),
         variant_config: Vec::new(),
+        package_format: None,
     })
     .await
 }

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -19,10 +19,10 @@ use pixi_auth::get_auth_store;
 use pixi_build_frontend::BackendOverride;
 use pixi_command_dispatcher::{
     BackendMetadataDir, BuildBackendMetadataSpec, BuildEnvironment, BuildProfile, CacheDirs,
-    ComputeResultExt, EnvironmentRef, EnvironmentSpec, EphemeralEnv,
+    ComputeResultExt, CondaPackageFormat, EnvironmentRef, EnvironmentSpec, EphemeralEnv,
     keys::{ResolveSourcePackageKey, ResolveSourcePackageSpec, SourceBuildKey, SourceBuildSpec},
 };
-use pixi_config::ConfigCli;
+use pixi_config::{ConfigCli, PackageFormatAndCompression};
 use pixi_core::{
     Workspace, WorkspaceLocator, environment::sanity_check_workspace, workspace::DiscoveryStart,
 };
@@ -138,6 +138,12 @@ pub struct Args {
     /// `build-variants-files`.
     #[arg(long = "variant-config", short = 'm', value_name = "FILE")]
     pub variant_config: Vec<PathBuf>,
+
+    /// Archive format and optional compression level, e.g. `conda`,
+    /// `tar-bz2`, `conda:max`, `conda:15`, `tar-bz2:9`. Numeric ranges
+    /// match rattler-build: -7..=22 for `.conda`, 1..=9 for `.tar.bz2`.
+    #[arg(long)]
+    pub package_format: Option<PackageFormatAndCompression>,
 }
 
 /// Parse a `KEY=VAL[,VAL...]` variant override.
@@ -747,6 +753,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             variant_files: Some(variant_files.clone()),
             build_string_prefix: args.build_string_prefix.clone(),
             build_number: args.build_number,
+            package_format: args.package_format.as_ref().map(|f| CondaPackageFormat {
+                archive_type: f.archive_type,
+                compression_level: f.compression_level.into(),
+            }),
         };
         let built = command_dispatcher
             .engine()
@@ -1300,7 +1310,10 @@ async fn upload_to_local_filesystem_channel(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+    use rattler_conda_types::{compression_level::CompressionLevel, package::CondaArchiveType};
 
     #[test]
     fn parse_variant_accepts_single_and_comma_list() {
@@ -1312,6 +1325,38 @@ mod tests {
             parse_variant("cuda-version=12.8,13.0").unwrap(),
             ("cuda-version".into(), vec!["12.8".into(), "13.0".into()]),
         );
+    }
+
+    #[test]
+    fn parses_bare_package_format() {
+        let parsed = PackageFormatAndCompression::from_str("conda").unwrap();
+        assert_eq!(parsed.archive_type, CondaArchiveType::Conda);
+        assert_eq!(parsed.compression_level, CompressionLevel::Default);
+    }
+
+    #[test]
+    fn parses_named_compression_level() {
+        let parsed = PackageFormatAndCompression::from_str("conda:max").unwrap();
+        assert_eq!(parsed.archive_type, CondaArchiveType::Conda);
+        assert_eq!(parsed.compression_level, CompressionLevel::Highest);
+    }
+
+    #[test]
+    fn parses_numeric_compression_level() {
+        let parsed = PackageFormatAndCompression::from_str("tar-bz2:5").unwrap();
+        assert_eq!(parsed.archive_type, CondaArchiveType::TarBz2);
+        assert_eq!(parsed.compression_level, CompressionLevel::Numeric(5));
+    }
+
+    #[test]
+    fn rejects_unknown_format() {
+        assert!(PackageFormatAndCompression::from_str("zip").is_err());
+    }
+
+    #[test]
+    fn rejects_out_of_range_numeric_level() {
+        assert!(PackageFormatAndCompression::from_str("tar-bz2:42").is_err());
+        assert!(PackageFormatAndCompression::from_str("conda:99").is_err());
     }
 
     #[test]

--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -21,7 +21,7 @@ use pixi_build_types::{
     procedures::conda_build_v1::{
         CondaBuildV1Dependency, CondaBuildV1DependencyRunExportSource,
         CondaBuildV1DependencySource, CondaBuildV1Output, CondaBuildV1Params, CondaBuildV1Prefix,
-        CondaBuildV1PrefixPackage, CondaBuildV1RunExports,
+        CondaBuildV1PrefixPackage, CondaBuildV1RunExports, CondaPackageFormat,
     },
 };
 use pixi_glob::GlobSet;
@@ -103,6 +103,9 @@ pub struct BackendSourceBuildV1Method {
 
     /// Whether to build the package in editable mode.
     pub editable: bool,
+
+    /// Archive format and compression level. `None` lets the backend pick.
+    pub package_format: Option<CondaPackageFormat>,
 }
 
 #[derive(Debug, Serialize)]
@@ -284,6 +287,7 @@ impl BackendSourceBuildSpec {
                     work_directory: work_directory.clone(),
                     output_directory: params.output_directory,
                     editable: Some(params.editable),
+                    package_format: params.package_format,
                 },
                 move |line| {
                     let _err = futures::executor::block_on(log_sink.send(line));

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -73,6 +73,7 @@ impl std::fmt::Display for ArtifactCacheKey {
 ///
 /// The caller provides source-dep sha256s split into build / host buckets
 /// to preserve the same bucket separation applied to binary deps.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_artifact_cache_key(
     record: &UnresolvedSourceRecord,
     build_platform: Platform,
@@ -81,6 +82,7 @@ pub fn compute_artifact_cache_key(
     build_source_dep_sha256s: &[Sha256Hash],
     host_source_dep_sha256s: &[Sha256Hash],
     project_model_overrides: &crate::ProjectModelOverrides,
+    package_format: Option<pixi_build_types::procedures::conda_build_v1::CondaPackageFormat>,
 ) -> ArtifactCacheKey {
     let mut hasher = Xxh3::new();
     record.name().as_normalized().hash(&mut hasher);
@@ -91,6 +93,8 @@ pub fn compute_artifact_cache_key(
     host_platform.hash(&mut hasher);
     backend_identifier.hash(&mut hasher);
     project_model_overrides.hash(&mut hasher);
+    // Distinguish artifacts by output format.
+    package_format.hash(&mut hasher);
 
     // Bucket-tagged streams: the same (url, sha256) behaves differently
     // when installed into the build prefix vs. the host prefix because
@@ -841,6 +845,7 @@ mod cache_key_tests {
             extra_build_sha,
             &[],
             &Default::default(),
+            None,
         )
         .to_string()
     }
@@ -909,6 +914,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         )
         .to_string();
         let k2 = compute_artifact_cache_key(
@@ -919,6 +925,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         )
         .to_string();
         assert_ne!(k1, k2);
@@ -935,6 +942,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         )
         .to_string();
         let k2 = compute_artifact_cache_key(
@@ -945,6 +953,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         )
         .to_string();
         assert_ne!(k1, k2);
@@ -1025,6 +1034,7 @@ mod cache_key_tests {
             &[],
             &[sha(0xaa)],
             &Default::default(),
+            None,
         )
         .to_string();
         let k2 = compute_artifact_cache_key(
@@ -1035,6 +1045,7 @@ mod cache_key_tests {
             &[],
             &[sha(0xbb)],
             &Default::default(),
+            None,
         )
         .to_string();
         assert_ne!(k1, k2);
@@ -1055,6 +1066,7 @@ mod cache_key_tests {
             &[sha(0xaa)],
             &[],
             &Default::default(),
+            None,
         )
         .to_string();
         let host_only = compute_artifact_cache_key(
@@ -1065,6 +1077,7 @@ mod cache_key_tests {
             &[],
             &[sha(0xaa)],
             &Default::default(),
+            None,
         )
         .to_string();
         assert_ne!(build_only, host_only);
@@ -1127,6 +1140,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         );
         let osx_arm = compute_artifact_cache_key(
             &r,
@@ -1136,6 +1150,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         );
         assert_ne!(linux, osx_arm);
     }
@@ -1151,6 +1166,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         );
         let prefixed = compute_artifact_cache_key(
             &r,
@@ -1163,6 +1179,7 @@ mod cache_key_tests {
                 build_string_prefix: Some("foobar".to_string()),
                 build_number: None,
             },
+            None,
         );
         assert_ne!(bare, prefixed);
     }
@@ -1178,6 +1195,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
         );
         let numbered = compute_artifact_cache_key(
             &r,
@@ -1190,7 +1208,73 @@ mod cache_key_tests {
                 build_string_prefix: None,
                 build_number: Some(42),
             },
+            None,
         );
         assert_ne!(bare, numbered);
+    }
+
+    #[test]
+    fn archive_type_matters() {
+        use pixi_build_types::procedures::conda_build_v1::CondaPackageFormat;
+        use rattler_conda_types::package::CondaArchiveType;
+        let r = record("foo");
+        let conda = compute_artifact_cache_key(
+            &r,
+            Platform::Linux64,
+            Platform::Linux64,
+            "b",
+            &[],
+            &[],
+            &Default::default(),
+            Some(CondaPackageFormat {
+                archive_type: CondaArchiveType::Conda,
+                compression_level: Default::default(),
+            }),
+        );
+        let tar_bz2 = compute_artifact_cache_key(
+            &r,
+            Platform::Linux64,
+            Platform::Linux64,
+            "b",
+            &[],
+            &[],
+            &Default::default(),
+            Some(CondaPackageFormat {
+                archive_type: CondaArchiveType::TarBz2,
+                compression_level: Default::default(),
+            }),
+        );
+        assert_ne!(conda, tar_bz2);
+    }
+
+    #[test]
+    fn compression_level_matters() {
+        use pixi_build_types::procedures::conda_build_v1::{
+            CondaCompressionLevel, CondaPackageFormat, NamedCompressionLevel,
+        };
+        use rattler_conda_types::package::CondaArchiveType;
+        let pf = |level: CondaCompressionLevel| CondaPackageFormat {
+            archive_type: CondaArchiveType::Conda,
+            compression_level: level,
+        };
+        let r = record("foo");
+        let key = |level: CondaCompressionLevel| {
+            compute_artifact_cache_key(
+                &r,
+                Platform::Linux64,
+                Platform::Linux64,
+                "b",
+                &[],
+                &[],
+                &Default::default(),
+                Some(pf(level)),
+            )
+        };
+        let default_level = key(CondaCompressionLevel::Named(NamedCompressionLevel::Default));
+        let max_level = key(CondaCompressionLevel::Named(NamedCompressionLevel::Highest));
+        let numeric_level = key(CondaCompressionLevel::Numeric(5));
+        assert_ne!(default_level, max_level);
+        assert_ne!(default_level, numeric_level);
+        assert_ne!(max_level, numeric_level);
     }
 }

--- a/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
@@ -12,6 +12,7 @@ use rattler_conda_types::{PackageName, RepoDataRecord};
 
 use crate::BuildProfile;
 use crate::CommandDispatcherError;
+use crate::CondaPackageFormat;
 use crate::cache::markers::{SourceBuildArtifactsDir, SourceBuildWorkspacesDir};
 use crate::compute_data::{
     HasAllowExecuteLinkScripts, HasAllowLinkOptions, HasPackageCache, HasPixiInstallReporter,
@@ -171,6 +172,9 @@ async fn install_inner(
                 // forwards user-supplied values here.
                 build_string_prefix: None,
                 build_number: None,
+                // Source packages built during `pixi install` are unpacked
+                // immediately, so use the cheapest compression.
+                package_format: Some(CondaPackageFormat::fast()),
             };
             sub_ctx
                 .compute(&SourceBuildKey::new(build_spec))

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -9,7 +9,10 @@ use std::{collections::BTreeMap, hash::Hash, path::PathBuf, sync::Arc};
 
 use derive_more::Display;
 use futures::{SinkExt, channel::mpsc::unbounded};
-use pixi_build_types::procedures::conda_outputs::{CondaOutput, CondaOutputsParams};
+use pixi_build_types::procedures::{
+    conda_build_v1::CondaPackageFormat,
+    conda_outputs::{CondaOutput, CondaOutputsParams},
+};
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_record::{PixiRecord, UnresolvedPixiRecord, UnresolvedSourceRecord, VariantValue};
 use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceLocationSpec};
@@ -78,6 +81,11 @@ pub struct SourceBuildSpec {
     /// User-supplied build number forwarded to the backend's project
     /// model. Overrides any value declared in the manifest.
     pub build_number: Option<u64>,
+
+    /// Archive format and compression level. `None` lets the backend pick.
+    /// Folds into the artifact cache key but not the workspace key, so
+    /// different formats share build state but get distinct artifacts.
+    pub package_format: Option<CondaPackageFormat>,
 }
 
 /// Built artifact plus its sha256 and a
@@ -186,6 +194,7 @@ async fn compute_inner(
         &build_source_dep_sha256s,
         &host_source_dep_sha256s,
         &project_model_overrides,
+        spec.package_format,
     );
 
     // On artifact cache hit, return without invoking the backend.
@@ -236,6 +245,8 @@ async fn compute_inner(
 
     // Workspace dir is the backend's build root; state persists across
     // runs that share the same (source, deps, variants, backend).
+    // `package_format` is intentionally not included: differently-encoded
+    // outputs of the same build can share the same workdir.
     let workspace_key = compute_workspace_key(
         &spec.record,
         spec.build_environment.build_platform,
@@ -404,6 +415,7 @@ async fn compute_inner(
                 },
                 variant: output.metadata.variant.clone(),
                 output_directory: None,
+                package_format: spec.package_format,
             }),
             backend,
             name: output.metadata.name.clone(),
@@ -507,6 +519,9 @@ async fn build_source_deps(
                 // dependency closure builds against consistent values.
                 build_string_prefix: spec.build_string_prefix.clone(),
                 build_number: spec.build_number,
+                // Nested source deps are unpacked into the parent's
+                // prefix immediately; use the cheapest compression.
+                package_format: Some(CondaPackageFormat::fast()),
             };
             let result = sub_ctx.compute(&SourceBuildKey::new(nested_spec)).await?;
             Ok(result.artifact_sha256)

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -117,6 +117,9 @@ pub use instantiate_backend_key::{
 };
 pub use instantiate_tool_env::{InstantiateToolEnvironmentError, InstantiateToolEnvironmentSpec};
 pub use keys::SourceMetadata;
+pub use pixi_build_types::procedures::conda_build_v1::{
+    CondaCompressionLevel, CondaPackageFormat, NamedCompressionLevel,
+};
 pub use pixi_compute_cache_dirs::{
     CacheBase, CacheDirKey, CacheDirsExt, CacheDirsKey, CacheLocation,
 };

--- a/docs/reference/cli/pixi/publish.md
+++ b/docs/reference/cli/pixi/publish.md
@@ -49,6 +49,8 @@ pixi publish [OPTIONS]
 - <a id="arg---variant-config" href="#arg---variant-config">`--variant-config (-m) <FILE>`</a>
 :  Path to an additional variant configuration YAML file
 <br>May be provided more than once.
+- <a id="arg---package-format" href="#arg---package-format">`--package-format <PACKAGE_FORMAT>`</a>
+:  Archive format and optional compression level, e.g. `conda`, `tar-bz2`, `conda:max`, `conda:15`, `tar-bz2:9`. Numeric ranges match rattler-build: -7..=22 for `.conda`, 1..=9 for `.tar.bz2`
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>


### PR DESCRIPTION
### Description

Adds `--package-format` to `pixi publish` accepting rattler-build-style strings (`conda`, `tar-bz2`, `conda:max`, `conda:15`, `tar-bz2:9`). Format selection and compression level are pushed to the `conda/build_v1` protocol so the backend emits the requested archive directly (bundled as a single `CondaPackageFormat` newtype on the wire and in the source-build cache key). 

Source packages built as transitive dependencies during `pixi install`/`pixi publish` use a `fast()` preset (`.conda` + lowest compression) since they are unpacked immediately and never leave the local cache.

Im not entirely sure what to do with the protocol. Older backends won't read this new field and simply ignore it. Is that OK?

Fixes #6137

### How Has This Been Tested?

Unit tests in `crates/pixi_cli/src/publish.rs` cover parsing (`conda`, `conda:max`, `tar-bz2:5`, unknown formats, out-of-range numeric levels). `cargo check --workspace` passes after the rebase onto current main.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.