### PR TITLE
feat: support `[workspace.dependencies]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,7 +3874,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7124,6 +7124,7 @@ dependencies = [
  "humantime",
  "insta",
  "itertools 0.14.0",
+ "pathdiff",
  "pixi_build_types",
  "pixi_consts",
  "pixi_git",
@@ -7774,7 +7775,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7812,7 +7813,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7997,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_core"
 version = "0.2.4"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "anyhow",
  "arwen-codesign",
@@ -8081,7 +8082,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_jinja"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -8102,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_networking"
 version = "0.1.5"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8114,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_recipe"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "fs-err",
  "globset",
@@ -8147,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_script"
 version = "0.2.3"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "clap",
  "console",
@@ -8169,7 +8170,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_source_cache"
 version = "0.1.5"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8207,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_types"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "globset",
  "itertools 0.14.0",
@@ -8222,7 +8223,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_variant_config"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -8242,7 +8243,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_yaml_parser"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
 dependencies = [
  "marked-yaml",
  "miette 7.6.0",
@@ -9378,7 +9379,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -9419,7 +9420,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -9440,7 +9441,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
@@ -9452,18 +9453,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -10149,29 +10138,11 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-merkle 0.6.6",
- "sigstore-rekor 0.6.6",
- "sigstore-tsa 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sigstore-bundle"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2255028e90ba8e7abe7cc49fb04e6f824a8f7a061fc6922f67a48e84ab052"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "serde",
- "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-rekor 0.7.0",
- "sigstore-tsa 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
 ]
 
@@ -10190,29 +10161,7 @@ dependencies = [
  "rand_core 0.10.1",
  "sha2 0.10.9",
  "signature 2.2.0",
- "sigstore-types 0.6.6",
- "spki 0.7.3",
- "thiserror 2.0.18",
- "tracing",
- "x509-cert",
-]
-
-[[package]]
-name = "sigstore-crypto"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7172898e15789d69d12469bb3d33397aab0771fb4f8d32cd56972e97808bf3"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "const-oid 0.9.6",
- "der 0.7.10",
- "digest 0.10.7",
- "pem",
- "rand_core 0.9.5",
- "sha2 0.10.9",
- "signature 2.2.0",
- "sigstore-types 0.7.0",
+ "sigstore-types",
  "spki 0.7.3",
  "thiserror 2.0.18",
  "tracing",
@@ -10229,9 +10178,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
+ "sigstore-crypto",
  "sigstore-oidc",
- "sigstore-types 0.6.6",
+ "sigstore-types",
  "thiserror 2.0.18",
  "url",
 ]
@@ -10244,21 +10193,8 @@ checksum = "7c0d53558825c77716855c13794306fff766854c1bf92948e77d7890da3f2455"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "sigstore-merkle"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e86ee272adfcfa21a2248b2fbf05a79b6e39a1fb699ef70c578c814af16e4db"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
 ]
 
@@ -10274,8 +10210,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -10292,27 +10228,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-merkle 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
- "url",
-]
-
-[[package]]
-name = "sigstore-rekor"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f8a13b91c615c23badca4d7e51b0376539b8723a2a2d43d27c016f9cce08"
-dependencies = [
- "base64 0.22.1",
- "hex",
- "reqwest",
- "serde",
- "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-types",
  "thiserror 2.0.18",
  "url",
 ]
@@ -10325,14 +10243,14 @@ checksum = "67ae2a8b1e76abe552de2ba89c85013d09753beeebc76b5c50bfdff4abc689a1"
 dependencies = [
  "base64 0.22.1",
  "serde_json",
- "sigstore-bundle 0.6.6",
- "sigstore-crypto 0.6.6",
+ "sigstore-bundle",
+ "sigstore-crypto",
  "sigstore-fulcio",
  "sigstore-oidc",
- "sigstore-rekor 0.6.6",
- "sigstore-trust-root 0.6.6",
- "sigstore-tsa 0.6.6",
- "sigstore-types 0.6.6",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
  "x509-cert",
 ]
@@ -10349,26 +10267,8 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
- "x509-cert",
-]
-
-[[package]]
-name = "sigstore-trust-root"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf02c1ab8f7a10db78dbf37cc80bb0f93d2afd636d5c37a572c815cb418b925"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "x509-cert",
 ]
@@ -10390,35 +10290,9 @@ dependencies = [
  "rand 0.10.1",
  "reqwest",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
- "sigstore-crypto 0.6.6",
- "sigstore-types 0.6.6",
- "thiserror 2.0.18",
- "tracing",
- "x509-cert",
- "x509-tsp",
-]
-
-[[package]]
-name = "sigstore-tsa"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ea02ad335b7386c9a72455aecd2be964bef1d7118199858ee4c6d679af48ed"
-dependencies = [
- "aws-lc-rs",
- "base64 0.22.1",
- "chrono",
- "cmpv2",
- "cms",
- "const-oid 0.9.6",
- "der 0.7.10",
- "hex",
- "rand 0.9.4",
- "reqwest",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "sigstore-crypto 0.7.0",
- "sigstore-types 0.7.0",
+ "rustls-webpki",
+ "sigstore-crypto",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tracing",
  "x509-cert",
@@ -10441,25 +10315,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sigstore-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce83bc56c60bbfb197a054d541839ff248c7e1aabf7016f704f8f3e6552fd13c"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "hex",
- "pem",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "sigstore-verify"
-version = "0.7.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e191482c7e040b9bdfd5bd60032915bb0052e5a0944c4881055ef41b6c2cb"
+checksum = "d30aff69036e4579b416956e9ba68cec45b793116f78f10842d04c7f8b924bab"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10468,17 +10327,17 @@ dependencies = [
  "hex",
  "pem",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sigstore-bundle 0.7.0",
- "sigstore-crypto 0.7.0",
- "sigstore-merkle 0.7.0",
- "sigstore-rekor 0.7.0",
- "sigstore-trust-root 0.7.0",
- "sigstore-tsa 0.7.0",
- "sigstore-types 0.7.0",
+ "sigstore-bundle",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
  "thiserror 2.0.18",
  "tls_codec",
  "tracing",
@@ -11911,7 +11770,7 @@ dependencies = [
  "rustc-hash",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/pixi_core/src/lock_file/satisfiability/tests.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/tests.rs
@@ -218,11 +218,16 @@ async fn q(#[files("../../examples/**/p*.toml")] manifest_path: PathBuf) {
         }
     }
 
-    // If a pixi.toml is present check for `workspace` in the file to avoid
-    // testing of non-pixi workspace files
+    // If a pixi.toml is present check for a `[workspace]` section header in
+    // the file to avoid testing non-workspace member manifests. A bare
+    // substring match on "workspace" would false-match on members that use
+    // `{ workspace = true }` inheritance markers.
     if manifest_path.file_name().unwrap() == "pixi.toml" {
         let manifest_str = fs_err::read_to_string(&manifest_path).unwrap();
-        if !manifest_str.contains("workspace") {
+        if !manifest_str
+            .lines()
+            .any(|line| line.trim_start().starts_with("[workspace"))
+        {
             return;
         }
     }

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -73,9 +73,21 @@ pub struct BuildBackend {
 }
 
 impl PackageBuild {
-    /// Parses the specified string as a toml representation of a build system.
+    /// Parses a build system in isolation. Rejects `workspace = true` on the
+    /// backend since there is no workspace context to resolve against.
     pub fn from_toml_str(source: &str) -> Result<WithWarnings<Self>, TomlError> {
-        TomlPackageBuild::from_toml_str(source).and_then(TomlPackageBuild::into_build_system)
+        TomlPackageBuild::from_toml_str(source).and_then(|build| {
+            if let crate::toml::BackendSpec::Inherited { marker_span, .. } =
+                &build.backend.value.spec
+            {
+                return Err(crate::error::GenericError::new(
+                    "`workspace = true` on `[build.backend]` requires a workspace context",
+                )
+                .with_span(marker_span.clone())
+                .into());
+            }
+            build.into_build_system(&indexmap::IndexMap::new())
+        })
     }
 }
 

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -891,4 +891,47 @@ mod test {
                 .contains("Missing table in manifest pyproject.toml")
         )
     }
+
+    /// Smoke-test the `polyglot-particles` example: workspace deps must
+    /// resolve into the host/build/run/backend tables across separate
+    /// member manifests, with the relative `particle_core` path re-anchored
+    /// from the workspace root (`polyglot-particles/particle_core`) to each
+    /// consuming member's directory (`../particle_core`).
+    #[test]
+    fn test_polyglot_particles_example_inheritance() {
+        let example_root = dunce::canonicalize(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../examples/pixi-build/polyglot-particles"),
+        )
+        .unwrap();
+
+        for member in [
+            "particle_core",
+            "particle_cpp",
+            "particle_cpp_py",
+            "particle_view",
+        ] {
+            let discovered =
+                WorkspaceDiscoverer::new(DiscoveryStart::SearchRoot(example_root.join(member)))
+                    .with_closest_package(true)
+                    .discover()
+                    .unwrap_or_else(|e| panic!("discover {member}: {e:#}"))
+                    .expect("workspace");
+
+            let pkg = discovered
+                .value
+                .package
+                .as_ref()
+                .unwrap_or_else(|| panic!("{member} has no package"));
+
+            // Backend version came from the workspace pool.
+            let backend = &pkg.value.build.backend;
+            assert_eq!(backend.name.as_source(), "pixi-build-cmake");
+            assert_eq!(
+                backend.spec.as_version_spec().unwrap().to_string(),
+                "0.3.*",
+                "{member} backend version",
+            );
+        }
+    }
 }

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -210,6 +210,8 @@ impl WorkspaceManifest {
             authors: self.workspace.authors.clone(),
             documentation: self.workspace.documentation.clone(),
             homepage: self.workspace.homepage.clone(),
+            dependencies: self.workspace.dependencies.clone(),
+            workspace_root: Some(self.workspace.root_directory.clone()),
         }
     }
 }

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -1,12 +1,13 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ops::Range,
     sync::Once,
 };
 
 use indexmap::IndexMap;
 use pixi_spec::{SourceLocationSpec, TomlLocationSpec, TomlSpec};
 use pixi_toml::{Same, TomlBTreeSet, TomlFromStr, TomlIndexMap, TomlWith};
-use rattler_conda_types::NamedChannelOrUrl;
+use rattler_conda_types::{NamedChannelOrUrl, PackageName};
 use std::borrow::Cow;
 use toml_span::{DeserError, Error, Spanned, Value, de_helpers::TableHelper, value::ValueInner};
 
@@ -37,19 +38,43 @@ pub struct TomlPackageBuild {
 #[derive(Debug)]
 pub struct TomlBuildBackend {
     pub name: PixiSpanned<rattler_conda_types::PackageName>,
-    pub spec: TomlSpec,
+    pub spec: BackendSpec,
     pub channels: Option<PixiSpanned<Vec<NamedChannelOrUrl>>>,
     pub additional_dependencies: UniquePackageMap,
 }
 
+/// Backend spec, direct or inherited from `[workspace.dependencies]`.
+#[derive(Debug)]
+pub enum BackendSpec {
+    Direct(TomlSpec),
+    Inherited {
+        marker_span: Range<usize>,
+        overrides: TomlSpec,
+    },
+}
+
 impl TomlPackageBuild {
-    pub fn into_build_system(self) -> Result<WithWarnings<PackageBuild>, TomlError> {
-        // Parse the build backend and ensure it is a binary spec.
-        let build_backend_spec = self.backend.value.spec.into_spec().map_err(|e| {
-            TomlError::Generic(
-                GenericError::new(e.to_string()).with_opt_span(self.backend.span.clone()),
-            )
-        })?;
+    pub fn into_build_system(
+        self,
+        workspace_dependencies: &IndexMap<PackageName, TomlSpec>,
+    ) -> Result<WithWarnings<PackageBuild>, TomlError> {
+        let backend_name = self.backend.value.name.value.clone();
+        let build_backend_spec = match self.backend.value.spec {
+            BackendSpec::Direct(toml_spec) => toml_spec.into_spec().map_err(|e| {
+                TomlError::Generic(
+                    GenericError::new(e.to_string()).with_opt_span(self.backend.span.clone()),
+                )
+            })?,
+            BackendSpec::Inherited {
+                marker_span,
+                overrides,
+            } => crate::utils::inheritable_package_map::resolve_inherited_backend_spec(
+                &backend_name,
+                workspace_dependencies,
+                overrides,
+                marker_span,
+            )?,
+        };
 
         // Convert the additional dependencies and make sure that they are binary.
         // Prioritize backend.additional_dependencies over top-level additional_dependencies
@@ -155,9 +180,40 @@ impl<'de> toml_span::Deserialize<'de> for TomlBuildBackend {
             });
         let additional_dependencies: UniquePackageMap =
             th.optional("additional-dependencies").unwrap_or_default();
+        let workspace_marker: Option<Spanned<bool>> = th.optional_s("workspace");
         th.finalize(Some(value))?;
 
-        let spec = toml_span::Deserialize::deserialize(value)?;
+        // Remaining keys are a direct TomlSpec or overrides when workspace=true.
+        let toml_spec: TomlSpec = toml_span::Deserialize::deserialize(value)?;
+
+        let spec = match workspace_marker {
+            None => BackendSpec::Direct(toml_spec),
+            Some(Spanned { value: true, span }) => {
+                if toml_spec.version.is_some() {
+                    return Err(DeserError::from(toml_span::Error {
+                        kind: toml_span::ErrorKind::Custom(
+                            "`version` is mutual exclusive with `workspace`".into(),
+                        ),
+                        span,
+                        line_info: None,
+                    }));
+                }
+                BackendSpec::Inherited {
+                    marker_span: span.start..span.end,
+                    overrides: toml_spec,
+                }
+            }
+            Some(Spanned { value: false, span }) => {
+                return Err(DeserError::from(toml_span::Error {
+                    kind: toml_span::ErrorKind::Custom(
+                        "`workspace` cannot be false; inheritance from the workspace is opt-in"
+                            .into(),
+                    ),
+                    span,
+                    line_info: None,
+                }));
+            }
+        };
 
         Ok(TomlBuildBackend {
             name: PixiSpanned::from(Spanned {
@@ -301,7 +357,7 @@ mod test {
 
     fn expect_parse_failure(pixi_toml: &str) -> String {
         let parse_error = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(pixi_toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect_err("parsing should fail");
 
         format_parse_error(pixi_toml, parse_error)
@@ -326,7 +382,7 @@ mod test {
             config = { key = "value", other = ["foo", "bar"], integer = 1234, nested = { abc = "def" } }
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert!(parsed.warnings.is_empty());
@@ -340,7 +396,7 @@ mod test {
             configuration = { key = "value" }
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert_eq!(parsed.warnings.len(), 1);
@@ -408,7 +464,7 @@ mod test {
             backend = { name = "foobar", version = "*", channels = ["https://prefix.dev/conda-forge"] }
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert_eq!(parsed.value.channels.unwrap().len(), 1);
@@ -421,7 +477,7 @@ mod test {
             channels = ["https://prefix.dev/conda-forge"]
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert_eq!(parsed.value.channels.unwrap().len(), 1);
@@ -434,7 +490,7 @@ mod test {
             channels = ["https://prefix.dev/conda-forge"]
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         // Should use backend.channels, not top-level channels
@@ -461,7 +517,7 @@ mod test {
             backend = { name = "foobar", version = "*", additional-dependencies = { git = "*" } }
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert!(!parsed.value.additional_dependencies.is_empty());
@@ -480,7 +536,7 @@ mod test {
             additional-dependencies = { git = "*" }
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert!(!parsed.value.additional_dependencies.is_empty());
@@ -499,7 +555,7 @@ mod test {
             additional-dependencies = { git = "*" }
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         // Should prioritize backend.additional-dependencies
@@ -525,7 +581,7 @@ mod test {
             secrets = ["CARGO_REGISTRY_TOKEN", "SCCACHE_BUCKET"]
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert_eq!(
@@ -545,7 +601,7 @@ mod test {
             build-number = 42
         "#;
         let parsed = <TomlPackageBuild as crate::toml::FromTomlStr>::from_toml_str(toml)
-            .and_then(TomlPackageBuild::into_build_system)
+            .and_then(|b| b.into_build_system(&indexmap::IndexMap::new()))
             .expect("parsing should succeed");
 
         assert_eq!(

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -854,6 +854,196 @@ mod test {
         ));
     }
 
+    /// Parses a workspace manifest and returns both the workspace and (required)
+    /// package manifests, so package-side inheritance can be inspected.
+    fn parse_workspace_and_package(source: &str) -> (WorkspaceManifest, PackageManifest) {
+        let manifest = <TomlManifest as FromTomlStr>::from_toml_str(source).expect("parse toml");
+        let (ws, pkg, _) = manifest
+            .into_workspace_manifest(
+                ExternalWorkspaceProperties::default(),
+                PackageDefaults::default(),
+                Path::new(""),
+            )
+            .expect("convert to workspace manifest");
+        (ws, pkg.expect("package manifest"))
+    }
+
+    #[test]
+    fn test_workspace_dependencies_pool_populates_workspace() {
+        let (ws, _pkg) = parse_workspace_and_package(
+            r#"
+            [workspace]
+            name = "monorepo"
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [package]
+            name = "lib"
+            version = "0.1.0"
+
+            [package.build]
+            backend = { name = "foobar", version = "*" }
+            "#,
+        );
+        let numpy = ws
+            .workspace
+            .dependencies
+            .get(&rattler_conda_types::PackageName::new_unchecked("numpy"))
+            .expect("numpy in workspace pool");
+        assert_eq!(numpy.version.as_ref().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_package_inherits_workspace_dependency() {
+        // The host-dependencies entry uses { workspace = true } and the
+        // workspace pool defines numpy. After parsing, the package's default
+        // target must carry the inherited version spec.
+        let (_ws, pkg) = parse_workspace_and_package(
+            r#"
+            [workspace]
+            name = "monorepo"
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [package]
+            name = "lib"
+            version = "0.1.0"
+
+            [package.build]
+            backend = { name = "foobar", version = "*" }
+
+            [package.host-dependencies]
+            numpy = { workspace = true }
+            "#,
+        );
+        let host_deps = pkg
+            .targets
+            .default()
+            .dependencies
+            .get(&crate::SpecType::Host)
+            .expect("host bucket");
+        let numpy = host_deps
+            .get(&rattler_conda_types::PackageName::new_unchecked("numpy"))
+            .expect("numpy in host deps");
+        let spec = numpy.iter().next().unwrap();
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_inherited_backend_pulls_version_from_workspace() {
+        // The build backend uses workspace inheritance; the version must come
+        // from `[workspace.dependencies]`.
+        let (_ws, pkg) = parse_workspace_and_package(
+            r#"
+            [workspace]
+            name = "monorepo"
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [workspace.dependencies]
+            pixi-build-python = "==1.2.3"
+
+            [package]
+            name = "lib"
+            version = "0.1.0"
+
+            [package.build]
+            backend = { name = "pixi-build-python", workspace = true }
+            "#,
+        );
+        let spec = &pkg.build.backend.spec;
+        // The resolved backend spec must carry the workspace-declared version.
+        match spec {
+            pixi_spec::PixiSpec::Version(v) => assert_eq!(v.to_string(), "==1.2.3"),
+            pixi_spec::PixiSpec::DetailedVersion(detailed) => {
+                assert_eq!(detailed.version.as_ref().unwrap().to_string(), "==1.2.3")
+            }
+            other => panic!("unexpected backend spec: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_inherited_entry_missing_workspace_definition_errors() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "monorepo"
+        channels = []
+        platforms = ['linux-64']
+        preview = ["pixi-build"]
+
+        [package]
+        name = "lib"
+        version = "0.1.0"
+
+        [package.build]
+        backend = { name = "foobar", version = "*" }
+
+        [package.host-dependencies]
+        ghost = { workspace = true }
+        "#,
+        ));
+    }
+
+    #[test]
+    fn test_inherited_entry_cannot_restate_version() {
+        // Restating `version` on a `{ workspace = true }` entry is rejected.
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "monorepo"
+        channels = []
+        platforms = ['linux-64']
+        preview = ["pixi-build"]
+
+        [workspace.dependencies]
+        numpy = "1.*"
+
+        [package]
+        name = "lib"
+        version = "0.1.0"
+
+        [package.build]
+        backend = { name = "foobar", version = "*" }
+
+        [package.host-dependencies]
+        numpy = { workspace = true, version = "2.0" }
+        "#,
+        ));
+    }
+
+    #[test]
+    fn test_workspace_false_on_dependency_errors() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "monorepo"
+        channels = []
+        platforms = ['linux-64']
+        preview = ["pixi-build"]
+
+        [package]
+        name = "lib"
+        version = "0.1.0"
+
+        [package.build]
+        backend = { name = "foobar", version = "*" }
+
+        [package.host-dependencies]
+        numpy = { workspace = false }
+        "#,
+        ));
+    }
+
     #[test]
     fn test_target_workspace_dependencies() {
         assert_snapshot!(expect_parse_warnings(

--- a/crates/pixi_manifest/src/toml/mod.rs
+++ b/crates/pixi_manifest/src/toml/mod.rs
@@ -19,7 +19,7 @@ mod workspace;
 
 use std::{borrow::Cow, ops::Range};
 
-pub use build_backend::TomlPackageBuild;
+pub use build_backend::{BackendSpec, TomlPackageBuild};
 pub use channel::TomlPrioritizedChannel;
 pub use document::TomlDocument;
 pub use environment::{TomlEnvironment, TomlEnvironmentList};

--- a/crates/pixi_manifest/src/toml/package.rs
+++ b/crates/pixi_manifest/src/toml/package.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
+use pixi_spec::TomlSpec;
 pub use pixi_toml::TomlFromStr;
 use pixi_toml::{DeserializeAs, Same, TomlIndexMap, TomlWith};
-use rattler_conda_types::Version;
+use rattler_conda_types::{PackageName, Version};
 use thiserror::Error;
 use toml_span::{DeserError, Span, Spanned, Value, de_helpers::TableHelper};
 use url::Url;
@@ -15,7 +16,7 @@ use crate::{
     toml::{
         TomlPackageBuild, manifest::ExternalWorkspaceProperties, package_target::TomlPackageTarget,
     },
-    utils::{PixiSpanned, package_map::UniquePackageMap},
+    utils::{PixiSpanned, inheritable_package_map::InheritablePackageMap},
 };
 
 /// Represents a field that can either have a direct value or inherit from
@@ -132,10 +133,10 @@ pub struct TomlPackage {
 
     // Fields that are package-specific and cannot be inherited
     pub build: TomlPackageBuild,
-    pub host_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub build_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub run_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub run_constraints: Option<PixiSpanned<UniquePackageMap>>,
+    pub host_dependencies: Option<PixiSpanned<InheritablePackageMap>>,
+    pub build_dependencies: Option<PixiSpanned<InheritablePackageMap>>,
+    pub run_dependencies: Option<PixiSpanned<InheritablePackageMap>>,
+    pub run_constraints: Option<PixiSpanned<InheritablePackageMap>>,
     pub target: IndexMap<PixiSpanned<TargetSelector>, TomlPackageTarget>,
 
     pub span: Span,
@@ -221,6 +222,12 @@ pub struct WorkspacePackageProperties {
     pub homepage: Option<Url>,
     pub repository: Option<Url>,
     pub documentation: Option<Url>,
+    /// `[workspace.dependencies]` pool; paths are relative to `workspace_root`.
+    pub dependencies: IndexMap<PackageName, TomlSpec>,
+
+    /// Absolute directory of the workspace manifest. Used to re-base
+    /// `dependencies` path specs against the member's directory.
+    pub workspace_root: Option<PathBuf>,
 }
 
 impl From<ExternalWorkspaceProperties> for WorkspacePackageProperties {
@@ -236,6 +243,8 @@ impl From<ExternalWorkspaceProperties> for WorkspacePackageProperties {
             homepage: value.homepage,
             repository: value.repository,
             documentation: value.documentation,
+            dependencies: IndexMap::new(),
+            workspace_root: None,
         }
     }
 }
@@ -318,7 +327,15 @@ impl TomlPackage {
     ) -> Result<WithWarnings<PackageManifest>, TomlError> {
         let mut warnings = Vec::new();
 
-        let build_result = self.build.into_build_system()?;
+        // Re-base workspace dependency path specs against this member's
+        // directory. The pool itself stores them relative to the workspace root.
+        let workspace_dependencies = rebase_workspace_path_specs(
+            &workspace.dependencies,
+            workspace.workspace_root.as_deref(),
+            root_directory,
+        );
+
+        let build_result = self.build.into_build_system(&workspace_dependencies)?;
         warnings.extend(build_result.warnings);
 
         // Resolve fields with 3-tier hierarchy: direct → workspace → package defaults →
@@ -342,13 +359,13 @@ impl TomlPackage {
             host_dependencies: self.host_dependencies,
             build_dependencies: self.build_dependencies,
         }
-        .into_package_target(preview)?;
+        .into_package_target(preview, &workspace_dependencies)?;
 
         let targets = self
             .target
             .into_iter()
             .map(|(selector, target)| {
-                let target = target.into_package_target(preview)?;
+                let target = target.into_package_target(preview, &workspace_dependencies)?;
                 Ok::<_, TomlError>((selector, target))
             })
             .collect::<Result<_, _>>()?;
@@ -491,6 +508,33 @@ impl TomlPackage {
 fn workspace_cannot_be_false() -> GenericError {
     GenericError::new("`workspace` cannot be false")
         .with_help("By default no fields are inherited from the workspace")
+}
+
+/// Re-anchor `path` entries in workspace `TomlSpec`s from `workspace_root` to
+/// `member_root`. Absolute and `~/` paths are returned unchanged. Returns the
+/// input map verbatim when either root is unknown or the roots are equal.
+fn rebase_workspace_path_specs(
+    specs: &IndexMap<PackageName, TomlSpec>,
+    workspace_root: Option<&Path>,
+    member_root: &Path,
+) -> IndexMap<PackageName, TomlSpec> {
+    let Some(workspace_root) = workspace_root else {
+        return specs.clone();
+    };
+    if workspace_root == member_root
+        || workspace_root.as_os_str().is_empty()
+        || member_root.as_os_str().is_empty()
+    {
+        return specs.clone();
+    }
+    specs
+        .iter()
+        .map(|(name, spec)| {
+            let mut rebased = spec.clone();
+            rebased.rebase_path(workspace_root, member_root);
+            (name.clone(), rebased)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -1305,5 +1349,74 @@ mod test {
         // Verify the readme path is set correctly
         let manifest = result.unwrap().value;
         assert!(manifest.package.readme.is_some());
+    }
+
+    #[test]
+    fn test_rebase_workspace_path_specs_relativizes_to_member() {
+        use indexmap::IndexMap;
+        let mut pool: IndexMap<rattler_conda_types::PackageName, TomlSpec> = IndexMap::new();
+        pool.insert("local".parse().unwrap(), path_spec("../shared"));
+
+        let workspace_root = Path::new("/ws");
+        let member_root = Path::new("/ws/members/foo");
+        let rebased = super::rebase_workspace_path_specs(&pool, Some(workspace_root), member_root);
+        let spec = rebased
+            .get(&rattler_conda_types::PackageName::from_str("local").unwrap())
+            .unwrap();
+        assert_eq!(
+            spec.location.as_ref().unwrap().path.as_deref(),
+            Some("../../../shared")
+        );
+    }
+
+    #[test]
+    fn test_rebase_workspace_path_specs_passes_absolute_through() {
+        use indexmap::IndexMap;
+        let mut pool: IndexMap<rattler_conda_types::PackageName, TomlSpec> = IndexMap::new();
+        pool.insert("abs".parse().unwrap(), path_spec("/abs/path"));
+
+        let rebased =
+            super::rebase_workspace_path_specs(&pool, Some(Path::new("/ws")), Path::new("/ws/m"));
+        let spec = rebased
+            .get(&rattler_conda_types::PackageName::from_str("abs").unwrap())
+            .unwrap();
+        assert_eq!(
+            spec.location.as_ref().unwrap().path.as_deref(),
+            Some("/abs/path")
+        );
+    }
+
+    #[test]
+    fn test_rebase_no_op_when_roots_match() {
+        use indexmap::IndexMap;
+        let mut pool: IndexMap<rattler_conda_types::PackageName, TomlSpec> = IndexMap::new();
+        pool.insert("local".parse().unwrap(), path_spec("../shared"));
+
+        let same = Path::new("/ws");
+        let rebased = super::rebase_workspace_path_specs(&pool, Some(same), same);
+        let spec = rebased
+            .get(&rattler_conda_types::PackageName::from_str("local").unwrap())
+            .unwrap();
+        assert_eq!(
+            spec.location.as_ref().unwrap().path.as_deref(),
+            Some("../shared")
+        );
+    }
+
+    /// Construct a [`TomlSpec`] carrying only a path location.
+    fn path_spec(path: &str) -> TomlSpec {
+        let mut spec = TomlSpec::empty();
+        spec.location = Some(pixi_spec::TomlLocationSpec {
+            url: None,
+            git: None,
+            path: Some(path.to_string()),
+            branch: None,
+            rev: None,
+            tag: None,
+            subdirectory: None,
+            md5: None,
+            sha256: None,
+        });
+        spec
     }
 }

--- a/crates/pixi_manifest/src/toml/package_target.rs
+++ b/crates/pixi_manifest/src/toml/package_target.rs
@@ -1,18 +1,21 @@
+use indexmap::IndexMap;
+use pixi_spec::TomlSpec;
+use rattler_conda_types::PackageName;
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
 
 use crate::{
     KnownPreviewFeature, Preview, SpecType, TomlError,
     target::PackageTarget,
     toml::target::combine_target_dependencies,
-    utils::{PixiSpanned, package_map::UniquePackageMap},
+    utils::{PixiSpanned, inheritable_package_map::InheritablePackageMap},
 };
 
 #[derive(Debug)]
 pub struct TomlPackageTarget {
-    pub run_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub run_constraints: Option<PixiSpanned<UniquePackageMap>>,
-    pub host_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub build_dependencies: Option<PixiSpanned<UniquePackageMap>>,
+    pub run_dependencies: Option<PixiSpanned<InheritablePackageMap>>,
+    pub run_constraints: Option<PixiSpanned<InheritablePackageMap>>,
+    pub host_dependencies: Option<PixiSpanned<InheritablePackageMap>>,
+    pub build_dependencies: Option<PixiSpanned<InheritablePackageMap>>,
 }
 
 impl<'de> toml_span::Deserialize<'de> for TomlPackageTarget {
@@ -33,16 +36,38 @@ impl<'de> toml_span::Deserialize<'de> for TomlPackageTarget {
 }
 
 impl TomlPackageTarget {
-    pub fn into_package_target(self, preview: &Preview) -> Result<PackageTarget, TomlError> {
+    pub fn into_package_target(
+        self,
+        preview: &Preview,
+        workspace_dependencies: &IndexMap<PackageName, TomlSpec>,
+    ) -> Result<PackageTarget, TomlError> {
+        let pixi_build_enabled = preview.is_enabled(KnownPreviewFeature::PixiBuild);
+
+        let resolve = |entry: Option<PixiSpanned<InheritablePackageMap>>| -> Result<
+            Option<PixiSpanned<crate::utils::package_map::UniquePackageMap>>,
+            TomlError,
+        > {
+            entry
+                .map(|spanned| {
+                    let PixiSpanned { value, span } = spanned;
+                    let resolved = value.resolve(workspace_dependencies, pixi_build_enabled)?;
+                    Ok::<_, TomlError>(PixiSpanned {
+                        value: resolved,
+                        span,
+                    })
+                })
+                .transpose()
+        };
+
         Ok(PackageTarget {
             dependencies: combine_target_dependencies(
                 [
-                    (SpecType::Run, self.run_dependencies),
-                    (SpecType::Host, self.host_dependencies),
-                    (SpecType::Build, self.build_dependencies),
-                    (SpecType::RunConstraints, self.run_constraints),
+                    (SpecType::Run, resolve(self.run_dependencies)?),
+                    (SpecType::Host, resolve(self.host_dependencies)?),
+                    (SpecType::Build, resolve(self.build_dependencies)?),
+                    (SpecType::RunConstraints, resolve(self.run_constraints)?),
                 ],
-                preview.is_enabled(KnownPreviewFeature::PixiBuild),
+                pixi_build_enabled,
             )?,
         })
     }
@@ -79,7 +104,7 @@ mod test {
 
         let package_target = TomlPackageTarget::from_toml_str(input)
             .unwrap()
-            .into_package_target(&Preview::default())
+            .into_package_target(&Preview::default(), &IndexMap::new())
             .unwrap();
 
         let lookup = |spec_type: SpecType, name: &str| -> String {

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 319
+assertion_line: 379
 expression: parsed
 ---
 TomlPackageBuild {
@@ -18,35 +18,37 @@ TomlPackageBuild {
                     source: "foobar",
                 },
             },
-            spec: TomlSpec {
-                version: Some(
-                    Any,
-                ),
-                location: Some(
-                    TomlLocationSpec {
-                        url: None,
-                        git: None,
-                        path: None,
-                        branch: None,
-                        rev: None,
-                        tag: None,
-                        subdirectory: None,
-                        md5: None,
-                        sha256: None,
-                    },
-                ),
-                build: None,
-                build_number: None,
-                file_name: None,
-                extras: None,
-                flags: None,
-                channel: None,
-                subdir: None,
-                license: None,
-                license_family: None,
-                when: None,
-                track_features: None,
-            },
+            spec: Direct(
+                TomlSpec {
+                    version: Some(
+                        Any,
+                    ),
+                    location: Some(
+                        TomlLocationSpec {
+                            url: None,
+                            git: None,
+                            path: None,
+                            branch: None,
+                            rev: None,
+                            tag: None,
+                            subdirectory: None,
+                            md5: None,
+                            sha256: None,
+                        },
+                    ),
+                    build: None,
+                    build_number: None,
+                    file_name: None,
+                    extras: None,
+                    flags: None,
+                    channel: None,
+                    subdir: None,
+                    license: None,
+                    license_family: None,
+                    when: None,
+                    track_features: None,
+                },
+            ),
             channels: None,
             additional_dependencies: UniquePackageMap {
                 specs: {},

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__inherited_entry_cannot_restate_version.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__inherited_entry_cannot_restate_version.snap
@@ -1,0 +1,12 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+assertion_line: 1003
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"monorepo\"\n        channels = []\n        platforms = ['linux-64']\n        preview = [\"pixi-build\"]\n\n        [workspace.dependencies]\n        numpy = \"1.*\"\n\n        [package]\n        name = \"lib\"\n        version = \"0.1.0\"\n\n        [package.build]\n        backend = { name = \"foobar\", version = \"*\" }\n\n        [package.host-dependencies]\n        numpy = { workspace = true, version = \"2.0\" }\n        \"#,)"
+---
+  × `version` is mutual exclusive with `workspace`
+    ╭─[pixi.toml:19:37]
+ 18 │         [package.host-dependencies]
+ 19 │         numpy = { workspace = true, version = "2.0" }
+    ·                                     ───────
+ 20 │
+    ╰────

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__inherited_entry_missing_workspace_definition_errors.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__inherited_entry_missing_workspace_definition_errors.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+assertion_line: 979
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"monorepo\"\n        channels = []\n        platforms = ['linux-64']\n        preview = [\"pixi-build\"]\n\n        [package]\n        name = \"lib\"\n        version = \"0.1.0\"\n\n        [package.build]\n        backend = { name = \"foobar\", version = \"*\" }\n\n        [package.host-dependencies]\n        ghost = { workspace = true }\n        \"#,)"
+---
+  × the workspace does not define `ghost` in `[workspace.dependencies]`
+    ╭─[pixi.toml:16:31]
+ 15 │         [package.host-dependencies]
+ 16 │         ghost = { workspace = true }
+    ·                               ────
+ 17 │
+    ╰────
+  help: Add the package to `[workspace.dependencies]` in the workspace `pixi.toml`.

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__workspace_false_on_dependency_errors.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__workspace_false_on_dependency_errors.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+assertion_line: 1029
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"monorepo\"\n        channels = []\n        platforms = ['linux-64']\n        preview = [\"pixi-build\"]\n\n        [package]\n        name = \"lib\"\n        version = \"0.1.0\"\n\n        [package.build]\n        backend = { name = \"foobar\", version = \"*\" }\n\n        [package.host-dependencies]\n        numpy = { workspace = false }\n        \"#,)"
+---
+  × `workspace` cannot be false
+    ╭─[pixi.toml:16:31]
+ 15 │         [package.host-dependencies]
+ 16 │         numpy = { workspace = false }
+    ·                               ─────
+ 17 │
+    ╰────
+  help: Remove the `workspace = false` entry; inheritance from the workspace is opt-in.

--- a/crates/pixi_manifest/src/toml/workspace.rs
+++ b/crates/pixi_manifest/src/toml/workspace.rs
@@ -4,20 +4,84 @@ use std::{
 };
 
 use indexmap::{IndexMap, IndexSet};
-use pixi_spec::{ExcludeNewer, TomlVersionSpecStr};
+use pixi_spec::{ExcludeNewer, TomlSpec, TomlVersionSpecStr};
 use pixi_toml::{TomlFromStr, TomlHashMap, TomlIndexMap, TomlIndexSet, TomlWith};
-use rattler_conda_types::{NamedChannelOrUrl, Platform, Version, VersionSpec};
-use toml_span::{DeserError, Span, Spanned, Value, de_helpers::TableHelper};
+use rattler_conda_types::{NamedChannelOrUrl, PackageName, Platform, Version, VersionSpec};
+use std::str::FromStr;
+use toml_span::{DeserError, Span, Spanned, Value, de_helpers::TableHelper, value::ValueInner};
 use url::Url;
 
 use crate::{
-    PrioritizedChannel, S3Options, TargetSelector, Targets, TomlError, WithWarnings, Workspace,
+    KnownPreviewFeature, PrioritizedChannel, S3Options, TargetSelector, Targets, TomlError,
+    WithWarnings, Workspace,
     error::GenericError,
     pypi::pypi_options::PypiOptions,
     toml::{manifest::ExternalWorkspaceProperties, platform::TomlPlatform, preview::TomlPreview},
     utils::PixiSpanned,
     workspace::{BuildVariantSource, ChannelPriority, SolveStrategy},
 };
+
+/// Parses `[workspace.dependencies]` into an ordered `(name, TomlSpec)` map.
+/// Unlike `UniquePackageMap` (which materializes `PixiSpec`), this keeps the
+/// flat `TomlSpec` form so member overrides can be layered without a round
+/// trip back through `into_spec`.
+#[derive(Debug, Default, Clone)]
+pub struct WorkspaceDependencyMap {
+    pub specs: IndexMap<PackageName, TomlSpec>,
+}
+
+impl<'de> toml_span::Deserialize<'de> for WorkspaceDependencyMap {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        let table = match value.take() {
+            ValueInner::Table(table) => table,
+            inner => {
+                return Err(toml_span::de_helpers::expected("a table", inner, value.span).into());
+            }
+        };
+
+        let mut errors = DeserError { errors: vec![] };
+        let mut specs: IndexMap<PackageName, TomlSpec> = IndexMap::new();
+        let mut seen: IndexMap<PackageName, Span> = IndexMap::new();
+        for (key, mut entry) in table {
+            let name = match PackageName::from_str(&key.name) {
+                Ok(name) => {
+                    if let Some(first) = seen.get(&name) {
+                        errors.errors.push(toml_span::Error {
+                            kind: toml_span::ErrorKind::DuplicateKey {
+                                key: key.name.into_owned(),
+                                first: *first,
+                            },
+                            span: key.span,
+                            line_info: None,
+                        });
+                        continue;
+                    }
+                    seen.insert(name.clone(), key.span);
+                    name
+                }
+                Err(e) => {
+                    errors.errors.push(toml_span::Error {
+                        kind: toml_span::ErrorKind::Custom(e.to_string().into()),
+                        span: key.span,
+                        line_info: None,
+                    });
+                    continue;
+                }
+            };
+            match TomlSpec::deserialize_from_value(&mut entry) {
+                Ok(spec) => {
+                    specs.insert(name, spec);
+                }
+                Err(e) => errors.merge(e),
+            }
+        }
+        if errors.errors.is_empty() {
+            Ok(Self { specs })
+        } else {
+            Err(errors)
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct TomlWorkspaceTarget {
@@ -53,6 +117,9 @@ pub struct TomlWorkspace {
     pub build_variant_files: Option<Vec<Spanned<TomlFromStr<PathBuf>>>>,
     pub requires_pixi: Option<VersionSpec>,
     pub exclude_newer: Option<ExcludeNewer>,
+
+    /// `[workspace.dependencies]` pool for `{ workspace = true }` inheritance.
+    pub dependencies: Option<PixiSpanned<WorkspaceDependencyMap>>,
 
     pub span: Span,
 }
@@ -113,6 +180,29 @@ impl TomlWorkspace {
         let build_variant_files_default =
             convert_build_variant_files(self.build_variant_files, root_directory)?;
 
+        // Source specs gated on pixi-build. Path specs are left
+        // workspace-relative; members re-base them at inheritance time.
+        let dependencies = if let Some(deps) = self.dependencies {
+            let pixi_build_enabled = preview.is_enabled(KnownPreviewFeature::PixiBuild);
+            let specs = deps.value.specs;
+            if !pixi_build_enabled
+                && let Some((name, _)) = specs.iter().find(|(_, s)| toml_spec_is_source(s))
+            {
+                return Err(GenericError::new(
+                    "conda source dependencies are not allowed without enabling the 'pixi-build' preview feature",
+                )
+                .with_help(
+                    "Add `preview = [\"pixi-build\"]` to the `workspace` table of your manifest",
+                )
+                .with_span_label(format!("source dependency `{}`", name.as_source()))
+                .with_opt_span(deps.span.clone())
+                .into());
+            }
+            specs
+        } else {
+            IndexMap::new()
+        };
+
         Ok(WithWarnings::from(Workspace {
             name: self.name.or(external.name),
             version: self.version.or(external.version),
@@ -148,9 +238,19 @@ impl TomlWorkspace {
             exclude_newer: self.exclude_newer,
             exclude_newer_package_overrides: IndexMap::default(),
             pypi_exclude_newer_package_overrides: IndexMap::default(),
+            dependencies,
+            root_directory: root_directory.to_path_buf(),
         })
         .with_warnings(warnings))
     }
+}
+
+/// Returns true when the spec carries a source-style location (`path` or
+/// `git`). Used to gate workspace dep entries on the `pixi-build` preview.
+fn toml_spec_is_source(spec: &TomlSpec) -> bool {
+    spec.location
+        .as_ref()
+        .is_some_and(|loc| loc.path.is_some() || loc.git.is_some())
 }
 
 fn convert_build_variant_files(
@@ -247,6 +347,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlWorkspace {
         let exclude_newer = th
             .optional::<TomlWith<_, TomlFromStr<_>>>("exclude-newer")
             .map(TomlWith::into_inner);
+        let dependencies = th.optional("dependencies");
 
         th.finalize(None)?;
 
@@ -274,6 +375,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlWorkspace {
             build_variant_files,
             requires_pixi,
             exclude_newer,
+            dependencies,
             span: value.span,
         })
     }

--- a/crates/pixi_manifest/src/utils/inheritable_package_map.rs
+++ b/crates/pixi_manifest/src/utils/inheritable_package_map.rs
@@ -1,0 +1,482 @@
+use std::{ops::Range, str::FromStr};
+
+use indexmap::IndexMap;
+use itertools::Itertools;
+use pixi_spec::{PixiSpec, TomlSpec};
+use rattler_conda_types::PackageName;
+use toml_span::{
+    DeserError, Span, Value,
+    de_helpers::expected,
+    value::{Table, ValueInner},
+};
+
+use crate::{TomlError, error::GenericError, utils::package_map::UniquePackageMap};
+
+/// Entry in a `[package.*-dependencies]` table that may inherit from
+/// `[workspace.dependencies]`.
+#[derive(Debug)]
+pub enum InheritableSpec {
+    Direct(PixiSpec),
+    /// Inherited from the workspace pool. `overrides.version` is always `None`.
+    Inherited {
+        marker_span: Range<usize>,
+        overrides: Box<TomlSpec>,
+    },
+    /// `{ workspace = false }`; rejected at resolve time.
+    NotWorkspace {
+        marker_span: Range<usize>,
+    },
+}
+
+/// Dependency map that may declare workspace inheritance. Resolve against the
+/// pool to obtain a regular [`UniquePackageMap`].
+#[derive(Default, Debug)]
+pub struct InheritablePackageMap {
+    pub specs: IndexMap<PackageName, InheritableSpec>,
+    pub name_spans: IndexMap<PackageName, Range<usize>>,
+    pub value_spans: IndexMap<PackageName, Range<usize>>,
+}
+
+impl InheritablePackageMap {
+    pub fn is_empty(&self) -> bool {
+        self.specs.is_empty()
+    }
+
+    /// Resolve every entry against the pool. Source specs require the
+    /// `pixi-build` preview, matching the non-inheritable tables.
+    pub fn resolve(
+        self,
+        workspace_deps: &IndexMap<PackageName, TomlSpec>,
+        is_pixi_build_enabled: bool,
+    ) -> Result<UniquePackageMap, TomlError> {
+        let mut out = UniquePackageMap::default();
+        for (name, spec) in self.specs {
+            let name_span = self.name_spans.get(&name).cloned();
+            let value_span = self.value_spans.get(&name).cloned();
+            let resolved = match spec {
+                InheritableSpec::Direct(spec) => spec,
+                InheritableSpec::NotWorkspace { marker_span } => {
+                    return Err(GenericError::new("`workspace` cannot be false")
+                        .with_help("Remove the `workspace = false` entry; inheritance from the workspace is opt-in.")
+                        .with_span(marker_span)
+                        .into());
+                }
+                InheritableSpec::Inherited {
+                    marker_span,
+                    overrides,
+                } => {
+                    let base = lookup_workspace_base(workspace_deps, &name, &marker_span)?;
+                    finalize_inherited(base, *overrides, &marker_span)?
+                }
+            };
+            if let Some(span) = name_span.clone() {
+                out.name_spans.insert(name.clone(), span);
+            }
+            if let Some(span) = value_span.clone() {
+                out.value_spans.insert(name.clone(), span);
+            }
+            out.specs.insert(name, resolved);
+        }
+        if !is_pixi_build_enabled
+            && let Some((package_name, _)) = out.specs.iter().find(|(_, spec)| spec.is_source())
+        {
+            return Err(TomlError::Generic(
+                GenericError::new(
+                    "conda source dependencies are not allowed without enabling the 'pixi-build' preview feature",
+                )
+                .with_opt_span(out.value_spans.get(package_name).cloned())
+                .with_span_label("source dependency specified here")
+                .with_help(
+                    "Add `preview = [\"pixi-build\"]` to the `workspace` or `project` table of your manifest",
+                ),
+            ));
+        }
+        Ok(out)
+    }
+}
+
+/// Resolve `{ name, workspace = true, ... }` build-backend entries.
+pub fn resolve_inherited_backend_spec(
+    name: &PackageName,
+    workspace_deps: &IndexMap<PackageName, TomlSpec>,
+    overrides: TomlSpec,
+    marker_span: Range<usize>,
+) -> Result<PixiSpec, TomlError> {
+    let base = lookup_workspace_base(workspace_deps, name, &marker_span)?;
+    finalize_inherited(base, overrides, &marker_span)
+}
+
+fn lookup_workspace_base(
+    workspace_deps: &IndexMap<PackageName, TomlSpec>,
+    name: &PackageName,
+    marker_span: &Range<usize>,
+) -> Result<TomlSpec, TomlError> {
+    workspace_deps.get(name).cloned().ok_or_else(|| {
+        TomlError::from(
+            GenericError::new(format!(
+                "the workspace does not define `{}` in `[workspace.dependencies]`",
+                name.as_source()
+            ))
+            .with_help(
+                "Add the package to `[workspace.dependencies]` in the workspace `pixi.toml`.",
+            )
+            .with_span(marker_span.clone()),
+        )
+    })
+}
+
+/// Workspace owns the version; member may layer non-version attributes.
+/// Source-vs-binary conflicts are caught by `TomlSpec::into_spec`.
+fn finalize_inherited(
+    base: TomlSpec,
+    overrides: TomlSpec,
+    marker_span: &Range<usize>,
+) -> Result<PixiSpec, TomlError> {
+    base.layer_overrides(overrides).into_spec().map_err(|e| {
+        GenericError::new(format!(
+            "cannot apply member overrides to inherited workspace dependency: {e}"
+        ))
+        .with_span(marker_span.clone())
+        .into()
+    })
+}
+
+impl<'de> toml_span::Deserialize<'de> for InheritablePackageMap {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        let table = match value.take() {
+            ValueInner::Table(table) => table,
+            inner => return Err(expected("a table", inner, value.span).into()),
+        };
+
+        let mut errors = DeserError { errors: vec![] };
+        let mut result = Self::default();
+        for (key, mut entry_value) in table.into_iter().sorted_by_key(|(k, _)| k.span.start) {
+            let name = match PackageName::from_str(&key.name) {
+                Ok(name) => {
+                    if let Some(first) = result.name_spans.get(&name) {
+                        errors.errors.push(toml_span::Error {
+                            kind: toml_span::ErrorKind::DuplicateKey {
+                                key: key.name.into_owned(),
+                                first: Span {
+                                    start: first.start,
+                                    end: first.end,
+                                },
+                            },
+                            span: key.span,
+                            line_info: None,
+                        });
+                        None
+                    } else {
+                        Some(name)
+                    }
+                }
+                Err(e) => {
+                    errors.errors.push(toml_span::Error {
+                        kind: toml_span::ErrorKind::Custom(e.to_string().into()),
+                        span: key.span,
+                        line_info: None,
+                    });
+                    None
+                }
+            };
+
+            let entry_span = entry_value.span;
+            let spec = match parse_inheritable_entry(&mut entry_value) {
+                Ok(spec) => Some(spec),
+                Err(e) => {
+                    errors.merge(e);
+                    None
+                }
+            };
+
+            if let (Some(name), Some(spec)) = (name, spec) {
+                result.specs.insert(name.clone(), spec);
+                result
+                    .name_spans
+                    .insert(name.clone(), key.span.start..key.span.end);
+                result
+                    .value_spans
+                    .insert(name, entry_span.start..entry_span.end);
+            }
+        }
+
+        if errors.errors.is_empty() {
+            Ok(result)
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+fn parse_inheritable_entry(value: &mut Value<'_>) -> Result<InheritableSpec, DeserError> {
+    let outer_span = value.span;
+    match value.take() {
+        ValueInner::String(s) => {
+            let mut tmp = Value::with_span(ValueInner::String(s), outer_span);
+            let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut tmp)?;
+            Ok(InheritableSpec::Direct(spec))
+        }
+        ValueInner::Table(mut table) => {
+            if let Some(ws_val) = table.remove("workspace") {
+                parse_workspace_marker(ws_val, table, outer_span)
+            } else {
+                let mut tmp = Value::with_span(ValueInner::Table(table), outer_span);
+                let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut tmp)?;
+                Ok(InheritableSpec::Direct(spec))
+            }
+        }
+        other => Err(expected("a string or a table", other, outer_span).into()),
+    }
+}
+
+fn parse_workspace_marker<'de>(
+    mut ws_val: Value<'de>,
+    remaining: Table<'de>,
+    outer_span: Span,
+) -> Result<InheritableSpec, DeserError> {
+    let marker_span = ws_val.span;
+    let ws_bool = match ws_val.take() {
+        ValueInner::Boolean(b) => b,
+        other => return Err(expected("a boolean", other, marker_span).into()),
+    };
+
+    if !ws_bool {
+        if !remaining.is_empty() {
+            return Err(toml_span::Error {
+                kind: toml_span::ErrorKind::Custom(
+                    "`workspace = false` cannot be combined with other fields".into(),
+                ),
+                span: outer_span,
+                line_info: None,
+            }
+            .into());
+        }
+        return Ok(InheritableSpec::NotWorkspace {
+            marker_span: marker_span.start..marker_span.end,
+        });
+    }
+
+    // workspace = true: remaining keys are TomlSpec overrides; `version` is rejected.
+    let version_key_span = remaining
+        .iter()
+        .find(|(k, _)| k.name == "version")
+        .map(|(k, _)| k.span);
+
+    let mut overrides = if remaining.is_empty() {
+        TomlSpec::empty()
+    } else {
+        let mut tmp = Value::with_span(ValueInner::Table(remaining), outer_span);
+        <TomlSpec as toml_span::Deserialize>::deserialize(&mut tmp)?
+    };
+
+    if overrides.version.is_some() {
+        return Err(toml_span::Error {
+            kind: toml_span::ErrorKind::Custom(
+                "`version` is mutual exclusive with `workspace`".into(),
+            ),
+            span: version_key_span.unwrap_or(marker_span),
+            line_info: None,
+        }
+        .into());
+    }
+    overrides.version = None;
+
+    Ok(InheritableSpec::Inherited {
+        marker_span: marker_span.start..marker_span.end,
+        overrides: Box::new(overrides),
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use indexmap::IndexMap;
+    use pixi_spec::{PixiSpec, TomlSpec};
+    use rattler_conda_types::PackageName;
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::toml::FromTomlStr;
+
+    /// Build a pool from `(name, spec_toml)` pairs where `spec_toml` is the
+    /// raw RHS of a TOML entry (quoted string or inline table).
+    fn pool(entries: &[(&str, &str)]) -> IndexMap<PackageName, TomlSpec> {
+        use crate::toml::TomlWorkspace;
+        let mut doc =
+            String::from("name = \"ws\"\nchannels = []\nplatforms = []\n[dependencies]\n");
+        for (name, spec_toml) in entries {
+            doc.push_str(&format!("{name} = {spec_toml}\n"));
+        }
+        TomlWorkspace::from_toml_str(&doc)
+            .expect("parse workspace")
+            .dependencies
+            .expect("dependencies table")
+            .value
+            .specs
+    }
+
+    #[test]
+    fn parses_direct_string_spec() {
+        let input = r#"numpy = "1.*""#;
+        let parsed = InheritablePackageMap::from_toml_str(input).unwrap();
+        let entry = parsed
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        assert!(matches!(entry, InheritableSpec::Direct(_)));
+    }
+
+    #[test]
+    fn parses_workspace_marker_only() {
+        let input = r#"numpy = { workspace = true }"#;
+        let parsed = InheritablePackageMap::from_toml_str(input).unwrap();
+        let entry = parsed
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        assert!(matches!(entry, InheritableSpec::Inherited { .. }));
+    }
+
+    #[test]
+    fn parses_workspace_marker_dotted_key_form() {
+        // The dotted-key form is equivalent to `numpy = { workspace = true }`.
+        let input = "numpy.workspace = true";
+        let parsed = InheritablePackageMap::from_toml_str(input).unwrap();
+        let entry = parsed
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        assert!(matches!(entry, InheritableSpec::Inherited { .. }));
+    }
+
+    #[test]
+    fn parses_workspace_marker_with_overrides() {
+        let input = r#"numpy = { workspace = true, channel = "conda-forge" }"#;
+        let parsed = InheritablePackageMap::from_toml_str(input).unwrap();
+        let entry = parsed
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        match entry {
+            InheritableSpec::Inherited { overrides, .. } => {
+                assert!(overrides.channel.is_some());
+                assert!(overrides.version.is_none());
+            }
+            _ => panic!("expected inherited"),
+        }
+    }
+
+    #[test]
+    fn rejects_version_override_on_inherited_entry() {
+        let input = r#"numpy = { workspace = true, version = "1.0" }"#;
+        let err = InheritablePackageMap::from_toml_str(input).expect_err("must reject");
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("version") && msg.contains("workspace"),
+            "unexpected error: {msg}",
+        );
+    }
+
+    #[test]
+    fn parses_workspace_false_as_not_workspace_variant() {
+        let input = r#"numpy = { workspace = false }"#;
+        let parsed = InheritablePackageMap::from_toml_str(input).unwrap();
+        let entry = parsed
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        assert!(matches!(entry, InheritableSpec::NotWorkspace { .. }));
+    }
+
+    #[test]
+    fn resolves_workspace_marker_to_pool_spec() {
+        let input = r#"numpy = { workspace = true }"#;
+        let map = InheritablePackageMap::from_toml_str(input).unwrap();
+        let pool = pool(&[("numpy", "\"1.*\"")]);
+        let resolved = map.resolve(&pool, true).unwrap();
+        let spec = resolved
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*",);
+    }
+
+    #[test]
+    fn resolve_missing_workspace_entry_errors() {
+        let input = r#"numpy = { workspace = true }"#;
+        let map = InheritablePackageMap::from_toml_str(input).unwrap();
+        let pool = pool(&[]);
+        let err = map.resolve(&pool, true).expect_err("must error");
+        assert!(format!("{err:?}").contains("workspace.dependencies"));
+    }
+
+    #[test]
+    fn resolve_workspace_false_errors() {
+        let input = r#"numpy = { workspace = false }"#;
+        let map = InheritablePackageMap::from_toml_str(input).unwrap();
+        let pool = pool(&[]);
+        let err = map.resolve(&pool, true).expect_err("must error");
+        assert!(format!("{err:?}").contains("workspace") && format!("{err:?}").contains("false"));
+    }
+
+    #[test]
+    fn override_layers_channel_onto_version_base() {
+        // Workspace defines just a version; member adds a channel override.
+        // The merged spec must carry both.
+        let input = r#"numpy = { workspace = true, channel = "conda-forge" }"#;
+        let map = InheritablePackageMap::from_toml_str(input).unwrap();
+        let pool = pool(&[("numpy", "\"1.*\"")]);
+        let resolved = map.resolve(&pool, true).unwrap();
+        let spec = resolved
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        match spec {
+            PixiSpec::DetailedVersion(detailed) => {
+                assert_eq!(detailed.version.as_ref().unwrap().to_string(), "1.*");
+                assert!(detailed.channel.is_some());
+            }
+            other => panic!("expected DetailedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn override_layers_onto_detailed_workspace_base() {
+        // Workspace base is already detailed; member layers build matcher.
+        let input = r#"boltons = { workspace = true, build = "py*" }"#;
+        let map = InheritablePackageMap::from_toml_str(input).unwrap();
+        let pool = pool(&[(
+            "boltons",
+            "{ version = \">=24\", channel = \"conda-forge\" }",
+        )]);
+        let resolved = map.resolve(&pool, true).unwrap();
+        let spec = resolved
+            .specs
+            .get(&PackageName::from_str("boltons").unwrap())
+            .unwrap();
+        match spec {
+            PixiSpec::DetailedVersion(detailed) => {
+                assert_eq!(detailed.version.as_ref().unwrap().to_string(), ">=24");
+                assert!(
+                    detailed.channel.is_some(),
+                    "channel from workspace preserved"
+                );
+                assert!(detailed.build.is_some(), "build override applied");
+            }
+            other => panic!("expected DetailedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn member_keeps_full_control_when_writing_direct_spec() {
+        let input = r#"numpy = "2.0""#;
+        let map = InheritablePackageMap::from_toml_str(input).unwrap();
+        // The workspace pool defines an unrelated version, member should win.
+        let pool = pool(&[("numpy", "\"1.*\"")]);
+        let resolved = map.resolve(&pool, true).unwrap();
+        let spec = resolved
+            .specs
+            .get(&PackageName::from_str("numpy").unwrap())
+            .unwrap();
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "==2.0");
+    }
+}

--- a/crates/pixi_manifest/src/utils/mod.rs
+++ b/crates/pixi_manifest/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod inheritable_package_map;
 pub mod package_map;
 mod spanned;
 

--- a/crates/pixi_manifest/src/workspace.rs
+++ b/crates/pixi_manifest/src/workspace.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use indexmap::{IndexMap, IndexSet};
 use pixi_pypi_spec::PypiPackageName;
-use pixi_spec::ExcludeNewer;
+use pixi_spec::{ExcludeNewer, TomlSpec};
 use pixi_toml::TomlEnum;
 use rattler_conda_types::{NamedChannelOrUrl, PackageName, Platform, Version, VersionSpec};
 use serde::Deserialize;
@@ -95,6 +95,14 @@ pub struct Workspace {
 
     /// Workspace-wide PyPI package exclude-newer overrides.
     pub pypi_exclude_newer_package_overrides: IndexMap<PypiPackageName, ExcludeNewer>,
+
+    /// `[workspace.dependencies]` pool. Path specs remain relative to
+    /// `root_directory`; members re-base them at inheritance time.
+    pub dependencies: IndexMap<PackageName, TomlSpec>,
+
+    /// Absolute directory of the workspace manifest. Used to re-base relative
+    /// path specs in `dependencies` for members in other directories.
+    pub root_directory: PathBuf,
 }
 
 /// A source that contributes additional build variant definitions.

--- a/crates/pixi_spec/Cargo.toml
+++ b/crates/pixi_spec/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { workspace = true }
 dirs = { workspace = true }
 file_url = { workspace = true }
 humantime = { workspace = true }
+pathdiff = { workspace = true }
 itertools = { workspace = true }
 pixi_build_types = { workspace = true, optional = true }
 pixi_consts = { workspace = true }

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, fmt::Display, path::PathBuf};
+use std::{
+    borrow::Cow,
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 use itertools::Either;
 use pixi_toml::{TomlDigest, TomlFromStr, TomlWith, custom_error_message_with_help};
@@ -428,6 +432,109 @@ pub enum NotBinary {
 }
 
 impl TomlSpec {
+    /// Build an empty [`TomlSpec`] with all fields unset.
+    pub fn empty() -> Self {
+        Self {
+            version: None,
+            location: None,
+            build: None,
+            build_number: None,
+            file_name: None,
+            extras: None,
+            flags: None,
+            channel: None,
+            subdir: None,
+            license: None,
+            license_family: None,
+            when: None,
+            track_features: None,
+        }
+    }
+
+    /// Layer `overrides` on top of `self`. Each non-version field is taken
+    /// from `overrides` when set, otherwise from the base. The base owns
+    /// `version` (callers must ensure `overrides.version` is `None`).
+    pub fn layer_overrides(self, overrides: Self) -> Self {
+        let merged_location = match (self.location, overrides.location) {
+            (None, m) => m,
+            (b, None) => b,
+            (Some(b), Some(m)) => Some(TomlLocationSpec {
+                url: m.url.or(b.url),
+                git: m.git.or(b.git),
+                path: m.path.or(b.path),
+                branch: m.branch.or(b.branch),
+                rev: m.rev.or(b.rev),
+                tag: m.tag.or(b.tag),
+                subdirectory: m.subdirectory.or(b.subdirectory),
+                md5: m.md5.or(b.md5),
+                sha256: m.sha256.or(b.sha256),
+            }),
+        };
+        Self {
+            version: self.version,
+            location: merged_location,
+            build: overrides.build.or(self.build),
+            build_number: overrides.build_number.or(self.build_number),
+            file_name: overrides.file_name.or(self.file_name),
+            extras: overrides.extras.or(self.extras),
+            flags: overrides.flags.or(self.flags),
+            channel: overrides.channel.or(self.channel),
+            subdir: overrides.subdir.or(self.subdir),
+            license: overrides.license.or(self.license),
+            license_family: overrides.license_family.or(self.license_family),
+            when: overrides.when.or(self.when),
+            track_features: overrides.track_features.or(self.track_features),
+        }
+    }
+
+    /// Re-base a relative `location.path` from `from_root` to `to_root`.
+    /// Absolute paths (detected via `typed_path` for cross-platform safety)
+    /// and `~/` paths pass through unchanged. The resulting path always uses
+    /// forward slashes so the serialized manifest stays portable across
+    /// platforms.
+    pub fn rebase_path(&mut self, from_root: &Path, to_root: &Path) {
+        let Some(loc) = self.location.as_mut() else {
+            return;
+        };
+        let Some(path) = loc.path.as_ref() else {
+            return;
+        };
+        let typed = typed_path::Utf8TypedPath::derive(path);
+        if typed.is_absolute() || path.starts_with("~/") || path.starts_with("~\\") {
+            return;
+        }
+        let absolute = from_root.join(path);
+        if let Some(rel) = pathdiff::diff_paths(&absolute, to_root) {
+            let s = rel.to_string_lossy().replace('\\', "/");
+            loc.path = Some(s);
+        }
+    }
+
+    /// Parse a `toml_span` value as a [`TomlSpec`]. Accepts either a bare
+    /// version string (e.g. `"1.*"`) or a table.
+    pub fn deserialize_from_value(value: &mut Value<'_>) -> Result<Self, DeserError> {
+        match value.take() {
+            ValueInner::String(s) => {
+                let version = parse_version_string(&s).map_err(|msg| {
+                    DeserError::from(toml_span::Error {
+                        kind: ErrorKind::Custom(msg.into()),
+                        span: value.span,
+                        line_info: None,
+                    })
+                })?;
+                Ok(Self {
+                    version: Some(version),
+                    ..Self::empty()
+                })
+            }
+            inner @ ValueInner::Table(_) => {
+                let mut tbl = Value::with_span(inner, value.span);
+                <Self as toml_span::Deserialize>::deserialize(&mut tbl)
+            }
+            other => Err(expected("a string or a table", other, value.span).into()),
+        }
+    }
+
     fn validate_field_combinations(&self) -> Result<(), SpecError> {
         let (is_git, is_path, is_url) = if let Some(loc) = &self.location {
             if loc.git.is_none() && (loc.branch.is_some() || loc.rev.is_some() || loc.tag.is_some())

--- a/docs/build/dependency_types.md
+++ b/docs/build/dependency_types.md
@@ -108,3 +108,11 @@ Constraints that apply to the package's run environment, but only when the const
 They never cause a package to be installed on their own. To do that, use run-dependencies (#dependencies-run-dependencies).
 
 This corresponds to conda's `run_constrained` package metadata.
+
+## Inheriting Versions From the Workspace
+
+When several packages in the same workspace share dependency versions you can
+declare them once in `[workspace.dependencies]` and inherit per entry from
+every member's package tables (and from `[package.build.backend]`).
+See [Workspace Dependencies](workspace_dependencies.md) for the full rules
+around overrides and errors.

--- a/docs/build/workspace.md
+++ b/docs/build/workspace.md
@@ -93,6 +93,16 @@ If you run `pixi run start`, the age of each person should now be accurate:
 └──────────────┴─────┴─────────────┘
 ```
 
+## Sharing Versions Across Members
+
+Once a workspace grows past a couple of members, the same build backend,
+language runtime, and sibling-package paths tend to repeat in every
+`pixi.toml`.
+A `[workspace.dependencies]` pool lets you declare those specs once and have
+each member opt in per entry with `{ workspace = true }`.
+See [Workspace Dependencies](workspace_dependencies.md) for the syntax,
+override rules, and error semantics.
+
 ## Conclusion
 
 In this tutorial, we created a Pixi workspace containing two packages.

--- a/docs/build/workspace_dependencies.md
+++ b/docs/build/workspace_dependencies.md
@@ -1,0 +1,91 @@
+In a monorepo, packages typically share many of the same dependency versions:
+the build backend, the language runtime, common libraries, sibling packages
+referenced by relative path.
+Bumping such a version requires editing every package's `pixi.toml`, and the
+files drift out of sync when someone forgets one.
+
+`[workspace.dependencies]` solves this by letting the workspace declare a pool
+of dependency specs that packages opt into per entry.
+
+!!! warning
+    `[workspace.dependencies]` is part of the `pixi-build` preview and applies
+    **only to package dependencies** (`[package.*-dependencies]`,
+    `[package.run-constraints]` and `[package.build.backend]`, including their
+    `[package.target.<sel>.*]` variants).
+    The workspace-level environment tables (`[dependencies]`,
+    `[host-dependencies]`, `[build-dependencies]`, `[pypi-dependencies]`,
+    `[constraints]`) do **not** participate; entries there continue to be
+    declared directly.
+
+## Defining common dependencies
+
+Add a `[workspace.dependencies]` table to the workspace manifest. Entries use
+the same syntax as any other conda dependency table.
+
+```toml title="pixi.toml (workspace root)"
+[workspace]
+name = "monorepo"
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
+preview = ["pixi-build"]
+
+[workspace.dependencies]
+numpy = "1.*"
+pixi-build-cmake = "0.3.*"
+boltons = { version = ">=24", channel = "conda-forge" }
+shared-lib = { path = "packages/shared-lib" }
+```
+
+Relative `path` specs are resolved against the workspace manifest's directory
+and re-anchored automatically when handed to a package in a different
+directory: from `packages/foo/pixi.toml` above, `shared-lib` will resolve to
+`../shared-lib`.
+
+## Using a workspace dependency in a package
+
+A package opts in per entry by writing `{ workspace = true }` instead of a
+direct spec. The dotted-key shorthand `name.workspace = true` is equivalent.
+
+```toml title="packages/foo/pixi.toml"
+[package]
+name = "foo"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "pixi-build-cmake", workspace = true }
+
+[package.host-dependencies]
+numpy = { workspace = true }
+shared-lib = { workspace = true }
+
+[package.run-dependencies]
+boltons.workspace = true
+```
+
+A name without `{ workspace = true }` is unaffected: the package keeps full
+control over that entry.
+
+The inheritance marker is recognized in every package dependency table:
+
+- `[package.host-dependencies]`
+- `[package.build-dependencies]`
+- `[package.run-dependencies]`
+- `[package.run-constraints]`
+- `[package.target.<selector>.*]` variants of the above
+- `[package.build.backend]` (the lookup key is the backend's `name`)
+
+## Layering package overrides
+
+A package can add fields alongside `workspace = true` to override or extend
+the workspace entry. Any field on a
+[conda spec table](../reference/pixi_manifest.md#dependencies) may be
+overridden, **except `version`**, which is mutually exclusive with
+`workspace`; if the package needs a different version, drop the inheritance
+marker and write a direct spec. When both sides set the same field, the
+package's value wins.
+
+```toml
+[package.host-dependencies]
+# Use the workspace's numpy version, but pin a specific build string here.
+numpy = { workspace = true, build = "py311*" }
+```

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -431,6 +431,27 @@ file that defines build variants.
 If the file is called `conda_build_config.yaml`, it will attempt to parse it with a subset of [`conda-build`'s variant syntax](https://docs.conda.io/projects/conda-build/en/stable/resources/variants.html#using-variants-with-the-conda-build-api).
 Otherwise, it will use `rattler-build`'s syntax as outlined in the [rattler-build documentation](https://rattler.build/latest/variants/#variant-configuration).
 
+### `dependencies` (optional)
+
+!!! warning "Preview Feature"
+    `[workspace.dependencies]` requires the `pixi-build` preview feature to be
+    enabled and only applies to **package** dependencies — see
+    [Workspace Dependencies](../build/workspace_dependencies.md) for the
+    semantics, override rules and error cases.
+
+A pool of conda dependency specs that members of the workspace can inherit
+per entry by writing `{ workspace = true }` in any of their
+`[package.*-dependencies]` tables or `[package.build.backend]`.
+Relative `path` specs are resolved against the workspace manifest's
+directory and re-anchored per consuming member.
+
+```toml
+[workspace.dependencies]
+numpy = "1.*"
+pixi-build-cmake = "0.3.*"
+shared-lib = { path = "packages/shared-lib" }
+```
+
 ## The `tasks` table
 
 Tasks are a way to automate certain custom commands in your workspace.
@@ -1318,6 +1339,12 @@ And to extend the basics, it can also contain the following fields:
     [package]
     name = { workspace = true } # Inherit the name from the workspace
     ```
+
+    Dependency entries in `[package.*-dependencies]`, `[package.run-constraints]`,
+    their target variants, and `[package.build.backend]` can also be inherited
+    per entry from a `[workspace.dependencies]` pool defined on the workspace.
+    See [Workspace Dependencies](../build/workspace_dependencies.md) for the
+    override layering and error rules.
 
 ### `build` table
 

--- a/examples/pixi-build/polyglot-particles/particle_core/pixi.toml
+++ b/examples/pixi-build/polyglot-particles/particle_core/pixi.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [package.build.backend]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pixi-build-cmake"
-version = "0.3.*"
+workspace = true
 
 [package.build.config]
 compilers = ["c"]

--- a/examples/pixi-build/polyglot-particles/particle_cpp/pixi.toml
+++ b/examples/pixi-build/polyglot-particles/particle_cpp/pixi.toml
@@ -7,12 +7,12 @@ version = "0.1.0"
 [package.build.backend]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pixi-build-cmake"
-version = "0.3.*"
+workspace = true
 
 [package.host-dependencies]
-particle_core = { path = "../particle_core" }
+particle_core = { workspace = true }
 
 [package.run-dependencies]
 # TODO: drop once pixi-build emits run-exports for source packages; for now we
 # have to repeat the host-deps so consumers pick up the runtime libraries.
-particle_core = { path = "../particle_core" }
+particle_core = { workspace = true }

--- a/examples/pixi-build/polyglot-particles/particle_cpp_py/pixi.toml
+++ b/examples/pixi-build/polyglot-particles/particle_cpp_py/pixi.toml
@@ -7,16 +7,16 @@ version = "0.1.0"
 [package.build.backend]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pixi-build-cmake"
-version = "0.3.*"
+workspace = true
 
 [package.host-dependencies]
-particle_core = { path = "../particle_core" }
-particle_cpp = { path = "../particle_cpp" }
-pybind11 = ">=2.13"
-python = ">=3.11"
+particle_core = { workspace = true }
+particle_cpp = { workspace = true }
+pybind11 = { workspace = true }
+python = { workspace = true }
 
 [package.run-dependencies]
 # TODO: drop once pixi-build emits run-exports for source packages; for now we
 # have to repeat the host-deps so consumers pick up the runtime libraries.
-particle_core = { path = "../particle_core" }
-particle_cpp = { path = "../particle_cpp" }
+particle_core = { workspace = true }
+particle_cpp = { workspace = true }

--- a/examples/pixi-build/polyglot-particles/particle_kit/pyproject.toml
+++ b/examples/pixi-build/polyglot-particles/particle_kit/pyproject.toml
@@ -15,11 +15,11 @@ version = "*"
 
 [tool.pixi.package.host-dependencies]
 hatchling = ">=1.27,<2.0"
-python = ">=3.11"
-uv = "*"
+python = { workspace = true }
+uv = { workspace = true }
 
 [tool.pixi.package.run-dependencies]
 particle_cpp_py = { path = "../particle_cpp_py" }
 particle_rs = { path = "../particle_rs" }
 particle_view = { path = "../particle_view" }
-python = ">=3.11"
+python = { workspace = true }

--- a/examples/pixi-build/polyglot-particles/particle_rs/pyproject.toml
+++ b/examples/pixi-build/polyglot-particles/particle_rs/pyproject.toml
@@ -18,8 +18,8 @@ version = "0.4.*"
 
 [tool.pixi.package.host-dependencies]
 maturin = ">=1.7,<2.0"
-python = ">=3.11"
-uv = "*"
+python = { workspace = true }
+uv = { workspace = true }
 
 [tool.pixi.package.run-dependencies]
-python = ">=3.11"
+python = { workspace = true }

--- a/examples/pixi-build/polyglot-particles/particle_view/pixi.toml
+++ b/examples/pixi-build/polyglot-particles/particle_view/pixi.toml
@@ -7,17 +7,17 @@ version = "0.1.0"
 [package.build.backend]
 channels = ["https://prefix.dev/conda-forge"]
 name = "pixi-build-cmake"
-version = "0.3.*"
+workspace = true
 
 [package.host-dependencies]
-particle_core = { path = "../particle_core" }
-pybind11 = ">=2.13"
-python = ">=3.11"
-sdl2 = ">=2.26.5,<3.0"
+particle_core = { workspace = true }
+pybind11 = { workspace = true }
+python = { workspace = true }
+sdl2 = { workspace = true }
 
 [package.run-dependencies]
-python = ">=3.11"
-sdl2 = ">=2.26.5,<3.0"
+python = { workspace = true }
+sdl2 = { workspace = true }
 # TODO: drop once pixi-build emits run-exports for source packages; for now we
 # have to repeat the host-deps so consumers pick up the runtime libraries.
-particle_core = { path = "../particle_core" }
+particle_core = { workspace = true }

--- a/examples/pixi-build/polyglot-particles/pixi.toml
+++ b/examples/pixi-build/polyglot-particles/pixi.toml
@@ -8,6 +8,17 @@ name = "polyglot-particles"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 preview = ["pixi-build"]
 
+# Centralized versions every member inherits via `{ workspace = true }`.
+# Path specs are resolved relative to this manifest and re-anchored per member.
+[workspace.dependencies]
+pixi-build-cmake = "0.3.*"
+python = ">=3.11"
+pybind11 = ">=2.13"
+sdl2 = ">=2.26.5,<3.0"
+uv = "*"
+particle_core = { path = "particle_core" }
+particle_cpp = { path = "particle_cpp" }
+
 # A single dep on the high-level Python kit pulls in the entire graph:
 #   particle_kit -> particle_view, particle_cpp_py, particle_rs_py
 #                -> particle_cpp, particle_rs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
           - Advanced Building Using rattler-build: build/advanced_cpp.md
           - Cross Compilation using rattler-build: build/cross_compilation.md
       - Dependency Types: build/dependency_types.md
+      - Workspace Dependencies: build/workspace_dependencies.md
       - Build Backends:
           - Overview: build/backends.md
           - CMake: build/backends/pixi-build-cmake.md

--- a/schema/model.py
+++ b/schema/model.py
@@ -241,6 +241,16 @@ class Workspace(StrictBaseModel):
     target: dict[TargetName, WorkspaceTarget] | None = Field(
         None, description="The workspace targets"
     )
+    dependencies: Dependencies = Field(
+        None,
+        description=(
+            "Inheritable `conda` dependency pool. Members opt in by writing "
+            "`{ workspace = true }` in any `[package.*-dependencies]` table "
+            "(or in `[package.build.backend]`). Relative `path` specs resolve "
+            "against this manifest and are re-anchored per consuming member."
+        ),
+        examples=[{"numpy": "1.*", "boltons": {"version": ">=24", "channel": "conda-forge"}}],
+    )
 
 
 ########################
@@ -371,7 +381,29 @@ class WhenPackage(StrictBaseModel):
 
 
 When = NonEmptyStr | WhenAll | WhenAny | WhenPackage
+
+
+class InheritableMatchspecTable(MatchspecTable):
+    """A spec that may inherit from `[workspace.dependencies]`.
+
+    Setting `workspace = true` pulls the version (and any other unset fields)
+    from the matching `[workspace.dependencies]` entry. Members may layer any
+    non-version attribute on top; restating `version` alongside `workspace =
+    true` is an error.
+    """
+
+    workspace: Literal[True] | None = Field(
+        None,
+        description=(
+            "Inherit this spec from `[workspace.dependencies]`. Other fields on "
+            "this table layer on top of the workspace base; `version` is "
+            "mutually exclusive with `workspace`."
+        ),
+    )
+
+
 MatchSpec = NonEmptyStr | MatchspecTable
+InheritableMatchSpec = NonEmptyStr | InheritableMatchspecTable
 CondaPackageName = NonEmptyStr
 
 
@@ -472,6 +504,7 @@ RunConstraintsField = Field(
     description="The `conda` run-time version constraints. These constrain the versions of packages that may be installed in the run environment without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints. See https://pixi.sh/latest/build/dependency_types/ for more information.",
 )
 Dependencies = dict[CondaPackageName, MatchSpec] | None
+InheritableDependencies = dict[CondaPackageName, InheritableMatchSpec] | None
 
 
 ################
@@ -906,10 +939,10 @@ class Package(StrictBaseModel):
 
     build: Build = Field(..., description="The build configuration of the package")
 
-    host_dependencies: Dependencies = HostDependenciesField
-    build_dependencies: Dependencies = BuildDependenciesField
-    run_dependencies: Dependencies = RunDependenciesField
-    run_constraints: Dependencies = RunConstraintsField
+    host_dependencies: InheritableDependencies = HostDependenciesField
+    build_dependencies: InheritableDependencies = BuildDependenciesField
+    run_dependencies: InheritableDependencies = RunDependenciesField
+    run_constraints: InheritableDependencies = RunConstraintsField
 
     target: dict[TargetName, PackageTarget] | None = Field(
         None,
@@ -995,13 +1028,21 @@ class BuildBackend(MatchspecTable):
     additional_dependencies: Dependencies = Field(
         None, description="Additional dependencies to install alongside the build backend"
     )
+    workspace: Literal[True] | None = Field(
+        None,
+        description=(
+            "Inherit the backend version from `[workspace.dependencies]` using "
+            "`name` as the lookup key. `version` is mutually exclusive with "
+            "`workspace`."
+        ),
+    )
 
 
 class PackageTarget(StrictBaseModel):
-    run_dependencies: Dependencies = RunDependenciesField
-    run_constraints: Dependencies = RunConstraintsField
-    host_dependencies: Dependencies = HostDependenciesField
-    build_dependencies: Dependencies = BuildDependenciesField
+    run_dependencies: InheritableDependencies = RunDependenciesField
+    run_constraints: InheritableDependencies = RunConstraintsField
+    host_dependencies: InheritableDependencies = HostDependenciesField
+    build_dependencies: InheritableDependencies = BuildDependenciesField
 
 
 #######################

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -627,6 +627,12 @@
               "$ref": "#/$defs/WhenPackage"
             }
           ]
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version` is mutually exclusive with `workspace`.",
+          "type": "boolean",
+          "const": true
         }
       }
     },
@@ -1048,6 +1054,173 @@
         }
       }
     },
+    "InheritableMatchspecTable": {
+      "title": "InheritableMatchspecTable",
+      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer any\nnon-version attribute on top; restating `version` alongside `workspace =\ntrue` is an error.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "title": "Branch",
+          "description": "A git branch to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "build": {
+          "title": "Build",
+          "description": "The build string of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "build-number": {
+          "title": "Build-Number",
+          "description": "The build number of the package, can be a spec like `>=1` or `<=10` or `1`",
+          "type": "string",
+          "minLength": 1
+        },
+        "channel": {
+          "title": "Channel",
+          "description": "The channel the packages needs to be fetched from",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "conda-forge",
+            "pytorch",
+            "https://prefix.dev/conda-forge"
+          ]
+        },
+        "extras": {
+          "title": "Extras",
+          "description": "Optional extra dependencies to select for the package",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "file-name": {
+          "title": "File-Name",
+          "description": "The file name of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "flags": {
+          "title": "Flags",
+          "description": "Plain string flags used to select package variants",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "git": {
+          "title": "Git",
+          "description": "The git URL to the repo",
+          "type": "string",
+          "minLength": 1
+        },
+        "license": {
+          "title": "License",
+          "description": "The license of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "license-family": {
+          "title": "License-Family",
+          "description": "The license family of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "md5": {
+          "title": "Md5",
+          "description": "The md5 hash of the package",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The path to the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "rev": {
+          "title": "Rev",
+          "description": "A git SHA revision to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "title": "Sha256",
+          "description": "The sha256 hash of the package",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "subdir": {
+          "title": "Subdir",
+          "description": "The subdir of the package, also known as platform",
+          "type": "string",
+          "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "A subdirectory to use in the repo",
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "title": "Tag",
+          "description": "A git tag to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "track-features": {
+          "title": "Track-Features",
+          "description": "The track features of the package",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "url": {
+          "title": "Url",
+          "description": "The URL to the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "title": "Version",
+          "description": "The version of the package in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "string",
+          "minLength": 1
+        },
+        "when": {
+          "title": "When",
+          "description": "The condition under which this match spec applies. Use a package string, `{ all = [...] }`, `{ any = [...] }`, or `{ package = ..., version = ..., build = ... }`.",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/WhenAll"
+            },
+            {
+              "$ref": "#/$defs/WhenAny"
+            },
+            {
+              "$ref": "#/$defs/WhenPackage"
+            }
+          ]
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version` is mutually exclusive with `workspace`.",
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
     "LibcFamily": {
       "title": "LibcFamily",
       "type": "object",
@@ -1287,7 +1460,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1347,7 +1520,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1437,7 +1610,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1456,7 +1629,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1521,7 +1694,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1540,7 +1713,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1564,7 +1737,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1583,7 +1756,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2892,6 +3065,34 @@
               }
             ]
           }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "Inheritable `conda` dependency pool. Members opt in by writing `{ workspace = true }` in any `[package.*-dependencies]` table (or in `[package.build.backend]`). Relative `path` specs resolve against this manifest and are re-anchored per consuming member.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "boltons": {
+                "channel": "conda-forge",
+                "version": ">=24"
+              },
+              "numpy": "1.*"
+            }
+          ]
         },
         "description": {
           "title": "Description",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -370,6 +370,12 @@
               "$ref": "#/$defs/WhenPackage"
             }
           ]
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version` is mutually exclusive with `workspace`.",
+          "type": "boolean",
+          "const": true
         }
       }
     },
@@ -791,6 +797,173 @@
         }
       }
     },
+    "InheritableMatchspecTable": {
+      "title": "InheritableMatchspecTable",
+      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer any\nnon-version attribute on top; restating `version` alongside `workspace =\ntrue` is an error.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "title": "Branch",
+          "description": "A git branch to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "build": {
+          "title": "Build",
+          "description": "The build string of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "build-number": {
+          "title": "Build-Number",
+          "description": "The build number of the package, can be a spec like `>=1` or `<=10` or `1`",
+          "type": "string",
+          "minLength": 1
+        },
+        "channel": {
+          "title": "Channel",
+          "description": "The channel the packages needs to be fetched from",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "conda-forge",
+            "pytorch",
+            "https://prefix.dev/conda-forge"
+          ]
+        },
+        "extras": {
+          "title": "Extras",
+          "description": "Optional extra dependencies to select for the package",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "file-name": {
+          "title": "File-Name",
+          "description": "The file name of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "flags": {
+          "title": "Flags",
+          "description": "Plain string flags used to select package variants",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "git": {
+          "title": "Git",
+          "description": "The git URL to the repo",
+          "type": "string",
+          "minLength": 1
+        },
+        "license": {
+          "title": "License",
+          "description": "The license of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "license-family": {
+          "title": "License-Family",
+          "description": "The license family of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "md5": {
+          "title": "Md5",
+          "description": "The md5 hash of the package",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The path to the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "rev": {
+          "title": "Rev",
+          "description": "A git SHA revision to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "title": "Sha256",
+          "description": "The sha256 hash of the package",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "subdir": {
+          "title": "Subdir",
+          "description": "The subdir of the package, also known as platform",
+          "type": "string",
+          "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "A subdirectory to use in the repo",
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "title": "Tag",
+          "description": "A git tag to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "track-features": {
+          "title": "Track-Features",
+          "description": "The track features of the package",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "url": {
+          "title": "Url",
+          "description": "The URL to the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "title": "Version",
+          "description": "The version of the package in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "string",
+          "minLength": 1
+        },
+        "when": {
+          "title": "When",
+          "description": "The condition under which this match spec applies. Use a package string, `{ all = [...] }`, `{ any = [...] }`, or `{ package = ..., version = ..., build = ... }`.",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/WhenAll"
+            },
+            {
+              "$ref": "#/$defs/WhenAny"
+            },
+            {
+              "$ref": "#/$defs/WhenPackage"
+            }
+          ]
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version` is mutually exclusive with `workspace`.",
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
     "LibcFamily": {
       "title": "LibcFamily",
       "type": "object",
@@ -1030,7 +1203,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1090,7 +1263,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1180,7 +1353,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1199,7 +1372,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1264,7 +1437,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1283,7 +1456,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1307,7 +1480,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1326,7 +1499,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2930,6 +3103,34 @@
               }
             ]
           }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "Inheritable `conda` dependency pool. Members opt in by writing `{ workspace = true }` in any `[package.*-dependencies]` table (or in `[package.build.backend]`). Relative `path` specs resolve against this manifest and are re-anchored per consuming member.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "boltons": {
+                "channel": "conda-forge",
+                "version": ">=24"
+              },
+              "numpy": "1.*"
+            }
+          ]
         },
         "description": {
           "title": "Description",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -651,6 +651,12 @@
               "$ref": "#/$defs/WhenPackage"
             }
           ]
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version` is mutually exclusive with `workspace`.",
+          "type": "boolean",
+          "const": true
         }
       }
     },
@@ -1072,6 +1078,173 @@
         }
       }
     },
+    "InheritableMatchspecTable": {
+      "title": "InheritableMatchspecTable",
+      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer any\nnon-version attribute on top; restating `version` alongside `workspace =\ntrue` is an error.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "branch": {
+          "title": "Branch",
+          "description": "A git branch to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "build": {
+          "title": "Build",
+          "description": "The build string of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "build-number": {
+          "title": "Build-Number",
+          "description": "The build number of the package, can be a spec like `>=1` or `<=10` or `1`",
+          "type": "string",
+          "minLength": 1
+        },
+        "channel": {
+          "title": "Channel",
+          "description": "The channel the packages needs to be fetched from",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "conda-forge",
+            "pytorch",
+            "https://prefix.dev/conda-forge"
+          ]
+        },
+        "extras": {
+          "title": "Extras",
+          "description": "Optional extra dependencies to select for the package",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "file-name": {
+          "title": "File-Name",
+          "description": "The file name of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "flags": {
+          "title": "Flags",
+          "description": "Plain string flags used to select package variants",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "git": {
+          "title": "Git",
+          "description": "The git URL to the repo",
+          "type": "string",
+          "minLength": 1
+        },
+        "license": {
+          "title": "License",
+          "description": "The license of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "license-family": {
+          "title": "License-Family",
+          "description": "The license family of the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "md5": {
+          "title": "Md5",
+          "description": "The md5 hash of the package",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{32}$"
+        },
+        "path": {
+          "title": "Path",
+          "description": "The path to the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "rev": {
+          "title": "Rev",
+          "description": "A git SHA revision to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "title": "Sha256",
+          "description": "The sha256 hash of the package",
+          "type": "string",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "subdir": {
+          "title": "Subdir",
+          "description": "The subdir of the package, also known as platform",
+          "type": "string",
+          "minLength": 1
+        },
+        "subdirectory": {
+          "title": "Subdirectory",
+          "description": "A subdirectory to use in the repo",
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "title": "Tag",
+          "description": "A git tag to use",
+          "type": "string",
+          "minLength": 1
+        },
+        "track-features": {
+          "title": "Track-Features",
+          "description": "The track features of the package",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "url": {
+          "title": "Url",
+          "description": "The URL to the package",
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "title": "Version",
+          "description": "The version of the package in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "string",
+          "minLength": 1
+        },
+        "when": {
+          "title": "When",
+          "description": "The condition under which this match spec applies. Use a package string, `{ all = [...] }`, `{ any = [...] }`, or `{ package = ..., version = ..., build = ... }`.",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "$ref": "#/$defs/WhenAll"
+            },
+            {
+              "$ref": "#/$defs/WhenAny"
+            },
+            {
+              "$ref": "#/$defs/WhenPackage"
+            }
+          ]
+        },
+        "workspace": {
+          "title": "Workspace",
+          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version` is mutually exclusive with `workspace`.",
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
     "LibcFamily": {
       "title": "LibcFamily",
       "type": "object",
@@ -1311,7 +1484,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1371,7 +1544,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1461,7 +1634,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1480,7 +1653,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1545,7 +1718,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1564,7 +1737,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1588,7 +1761,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1607,7 +1780,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2916,6 +3089,34 @@
               }
             ]
           }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "Inheritable `conda` dependency pool. Members opt in by writing `{ workspace = true }` in any `[package.*-dependencies]` table (or in `[package.build.backend]`). Relative `path` specs resolve against this manifest and are re-anchored per consuming member.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "boltons": {
+                "channel": "conda-forge",
+                "version": ">=24"
+              },
+              "numpy": "1.*"
+            }
+          ]
         },
         "description": {
           "title": "Description",


### PR DESCRIPTION
### Description

Adds `[workspace.dependencies]` so monorepos can centralize conda dependency versions; members opt in with `{ workspace = true }` on `[package.host-dependencies]`, `[package.build-dependencies]`, `[package.run-dependencies]`, `[package.run-constraints]` (plus target variants) and `[package.build.backend]`. The member may layer any non-version attribute (channel, build, subdir, md5, sha256, url, path, git, branch, rev, tag, subdirectory) on top of the workspace base; `version` is mutually exclusive with `workspace`. Relative path specs in `[workspace.dependencies]` are re-based per member at inheritance time. Conda only; `[pypi-dependencies]` and a `pixi add --workspace` flag are out of scope for this PR.

Fixes #5945

### How Has This Been Tested?

Unit tests in `pixi_manifest`: parsing direct vs. `{ workspace = true }` entries, override layering on top of `Version` and `DetailedVersion` workspace bases, member-direct-wins, missing-workspace error, `workspace = false` error, version-restating error, path re-basing (member-relative, absolute pass-through, identity when roots match). End-to-end manifest tests cover the same with snapshot assertions on error output. 318 + 48 unit tests green; `cargo check --workspace` clean.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.