### PR TITLE
chore(deps): bump rattler-build crates to latest main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,7 +3874,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7773,7 +7773,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7811,7 +7811,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7996,7 +7996,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_core"
 version = "0.2.4"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "anyhow",
  "arwen-codesign",
@@ -8080,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_jinja"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -8101,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_networking"
 version = "0.1.5"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8113,7 +8113,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_recipe"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "fs-err",
  "globset",
@@ -8146,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_script"
 version = "0.2.3"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "clap",
  "console",
@@ -8168,7 +8168,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_source_cache"
 version = "0.1.5"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8206,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_types"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "globset",
  "itertools 0.14.0",
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_variant_config"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -8241,7 +8241,7 @@ dependencies = [
 [[package]]
 name = "rattler_build_yaml_parser"
 version = "0.1.6"
-source = "git+https://github.com/prefix-dev/rattler-build?branch=main#22f5d08c576e7453a7393835a63b29f202b111c7"
+source = "git+https://github.com/prefix-dev/rattler-build?branch=main#51c5fff930512422781c99d8217a11524690a3a4"
 dependencies = [
  "marked-yaml",
  "miette 7.6.0",
@@ -9377,7 +9377,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -9418,7 +9418,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -9439,7 +9439,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
@@ -9451,6 +9451,18 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -10136,11 +10148,29 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sigstore-crypto",
- "sigstore-merkle",
- "sigstore-rekor",
- "sigstore-tsa",
- "sigstore-types",
+ "sigstore-crypto 0.6.6",
+ "sigstore-merkle 0.6.6",
+ "sigstore-rekor 0.6.6",
+ "sigstore-tsa 0.6.6",
+ "sigstore-types 0.6.6",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-bundle"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2255028e90ba8e7abe7cc49fb04e6f824a8f7a061fc6922f67a48e84ab052"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "serde",
+ "serde_json",
+ "sigstore-crypto 0.7.0",
+ "sigstore-merkle 0.7.0",
+ "sigstore-rekor 0.7.0",
+ "sigstore-tsa 0.7.0",
+ "sigstore-types 0.7.0",
  "thiserror 2.0.18",
 ]
 
@@ -10159,7 +10189,29 @@ dependencies = [
  "rand_core 0.10.1",
  "sha2 0.10.9",
  "signature 2.2.0",
- "sigstore-types",
+ "sigstore-types 0.6.6",
+ "spki 0.7.3",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-crypto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7172898e15789d69d12469bb3d33397aab0771fb4f8d32cd56972e97808bf3"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "pem",
+ "rand_core 0.9.5",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "sigstore-types 0.7.0",
  "spki 0.7.3",
  "thiserror 2.0.18",
  "tracing",
@@ -10176,9 +10228,9 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sigstore-crypto",
+ "sigstore-crypto 0.6.6",
  "sigstore-oidc",
- "sigstore-types",
+ "sigstore-types 0.6.6",
  "thiserror 2.0.18",
  "url",
 ]
@@ -10191,8 +10243,21 @@ checksum = "7c0d53558825c77716855c13794306fff766854c1bf92948e77d7890da3f2455"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "sigstore-crypto",
- "sigstore-types",
+ "sigstore-crypto 0.6.6",
+ "sigstore-types 0.6.6",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-merkle"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e86ee272adfcfa21a2248b2fbf05a79b6e39a1fb699ef70c578c814af16e4db"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "sigstore-crypto 0.7.0",
+ "sigstore-types 0.7.0",
  "thiserror 2.0.18",
 ]
 
@@ -10208,8 +10273,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sigstore-crypto",
- "sigstore-types",
+ "sigstore-crypto 0.6.6",
+ "sigstore-types 0.6.6",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -10226,9 +10291,27 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sigstore-crypto",
- "sigstore-merkle",
- "sigstore-types",
+ "sigstore-crypto 0.6.6",
+ "sigstore-merkle 0.6.6",
+ "sigstore-types 0.6.6",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "sigstore-rekor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2448f8a13b91c615c23badca4d7e51b0376539b8723a2a2d43d27c016f9cce08"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sigstore-crypto 0.7.0",
+ "sigstore-merkle 0.7.0",
+ "sigstore-types 0.7.0",
  "thiserror 2.0.18",
  "url",
 ]
@@ -10241,14 +10324,14 @@ checksum = "67ae2a8b1e76abe552de2ba89c85013d09753beeebc76b5c50bfdff4abc689a1"
 dependencies = [
  "base64 0.22.1",
  "serde_json",
- "sigstore-bundle",
- "sigstore-crypto",
+ "sigstore-bundle 0.6.6",
+ "sigstore-crypto 0.6.6",
  "sigstore-fulcio",
  "sigstore-oidc",
- "sigstore-rekor",
- "sigstore-trust-root",
- "sigstore-tsa",
- "sigstore-types",
+ "sigstore-rekor 0.6.6",
+ "sigstore-trust-root 0.6.6",
+ "sigstore-tsa 0.6.6",
+ "sigstore-types 0.6.6",
  "thiserror 2.0.18",
  "x509-cert",
 ]
@@ -10265,8 +10348,26 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "sigstore-crypto",
- "sigstore-types",
+ "sigstore-crypto 0.6.6",
+ "sigstore-types 0.6.6",
+ "thiserror 2.0.18",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-trust-root"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf02c1ab8f7a10db78dbf37cc80bb0f93d2afd636d5c37a572c815cb418b925"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sigstore-crypto 0.7.0",
+ "sigstore-types 0.7.0",
  "thiserror 2.0.18",
  "x509-cert",
 ]
@@ -10288,9 +10389,35 @@ dependencies = [
  "rand 0.10.1",
  "reqwest",
  "rustls-pki-types",
- "rustls-webpki",
- "sigstore-crypto",
- "sigstore-types",
+ "rustls-webpki 0.103.13",
+ "sigstore-crypto 0.6.6",
+ "sigstore-types 0.6.6",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+ "x509-tsp",
+]
+
+[[package]]
+name = "sigstore-tsa"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ea02ad335b7386c9a72455aecd2be964bef1d7118199858ee4c6d679af48ed"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "chrono",
+ "cmpv2",
+ "cms",
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "hex",
+ "rand 0.9.4",
+ "reqwest",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "sigstore-crypto 0.7.0",
+ "sigstore-types 0.7.0",
  "thiserror 2.0.18",
  "tracing",
  "x509-cert",
@@ -10313,10 +10440,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sigstore-verify"
-version = "0.6.6"
+name = "sigstore-types"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30aff69036e4579b416956e9ba68cec45b793116f78f10842d04c7f8b924bab"
+checksum = "ce83bc56c60bbfb197a054d541839ff248c7e1aabf7016f704f8f3e6552fd13c"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "pem",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-verify"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e191482c7e040b9bdfd5bd60032915bb0052e5a0944c4881055ef41b6c2cb"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -10325,17 +10467,17 @@ dependencies = [
  "hex",
  "pem",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.8",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "sigstore-bundle",
- "sigstore-crypto",
- "sigstore-merkle",
- "sigstore-rekor",
- "sigstore-trust-root",
- "sigstore-tsa",
- "sigstore-types",
+ "sigstore-bundle 0.7.0",
+ "sigstore-crypto 0.7.0",
+ "sigstore-merkle 0.7.0",
+ "sigstore-rekor 0.7.0",
+ "sigstore-trust-root 0.7.0",
+ "sigstore-tsa 0.7.0",
+ "sigstore-types 0.7.0",
  "thiserror 2.0.18",
  "tls_codec",
  "tracing",
@@ -11768,7 +11910,7 @@ dependencies = [
  "rustc-hash",
  "rustls-native-certs",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,13 +251,13 @@ rattler_virtual_packages = { version = "2.4", default-features = false }
 simple_spawn_blocking = { version = "1.1.0", default-features = false }
 
 # Rattler build crates
-rattler_build_core = { version = "0.2.1", default-features = false, features = [
+rattler_build_core = { version = "0.2.4", default-features = false, features = [
   "s3",
 ] }
-rattler_build_jinja = { version = "0.1.3" }
-rattler_build_recipe = { version = "0.1.3" }
-rattler_build_types = { version = "0.1.3" }
-rattler_build_variant_config = { version = "0.1.3" }
+rattler_build_jinja = { version = "0.1.6" }
+rattler_build_recipe = { version = "0.1.6" }
+rattler_build_types = { version = "0.1.6" }
+rattler_build_variant_config = { version = "0.1.6" }
 
 [patch.crates-io]
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "d8efd77673c9a90792da9da31b6c0da7ea8a324b" }


### PR DESCRIPTION
Update workspace versions for rattler_build_* crates to match the latest release versions on rattler-build main, and refresh Cargo.lock to pick up the latest commit from the main branch patches.