### PR TITLE
fix: normalize extras order in lockfile metadata comparison

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi_metadata.rs
@@ -114,8 +114,8 @@ pub fn compare_metadata(
 /// This ensures that semantically equivalent requirements compare equal,
 /// regardless of formatting differences (e.g., whitespace, order of extras).
 fn normalize_requirement(req: &Requirement) -> String {
-    // Use the canonical string representation
-    // The pep508_rs library already normalizes package names and versions
+    let mut req = req.clone();
+    req.extras.sort();
     req.to_string()
 }
 
@@ -534,6 +534,34 @@ dev  = ["foo[test]"]
         trio ; python_full_version >= '3.10' and extra == 'all'
         trio ; python_full_version >= '3.10' and extra == 'async'
         ");
+    }
+
+    /// Regression test for <https://github.com/prefix-dev/pixi/issues/6155>
+    /// A dependency with multiple extras like `qdev-utils[db,databricks]`
+    /// should compare equal to `qdev-utils[databricks,db]` — the order of
+    /// extras is not semantically meaningful.
+    #[test]
+    fn compare_extras_order_does_not_cause_mismatch() {
+        let locked = lock_for_test(make_wheel_package_with(
+            "synth",
+            "1.0.0",
+            rattler_lock::UrlOrPath::Url(url::Url::parse("file:///test").unwrap()).into(),
+            None,
+            None,
+            vec![req("qdev-utils[databricks,db]")],
+            None,
+        ));
+
+        let current = LocalPackageMetadata {
+            version: Some(Version::from_str("1.0.0").unwrap()),
+            requires_dist: vec![req("qdev-utils[db,databricks]")],
+            requires_python: None,
+        };
+
+        assert!(
+            compare_metadata(&locked, &pkg_name("synth"), &current).is_none(),
+            "extras in different order must not trigger a metadata mismatch"
+        );
     }
 
     /// Regression test for <https://github.com/prefix-dev/pixi/issues/6136>


### PR DESCRIPTION
### Description

Dependencies with multiple extras like `qdev-utils[db,databricks]` are semantically equivalent regardless of extras order. The lockfile may store them as `qdev-utils[databricks,db]`, causing `pixi install --locked` to always report the lockfile as outdated with a confusing message:

```
dependencies changed - added: [qdev-utils], removed: [qdev-utils]
```

This sorts extras before converting to string in `normalize_requirement` so that order differences no longer produce false mismatches.

Fixes #6155

### How Has This Been Tested?

Added a unit test `compare_extras_order_does_not_cause_mismatch` that reproduces the exact scenario: locked side has `qdev-utils[databricks,db]`, current side has `qdev-utils[db,databricks]`. The test fails without the fix and passes with it.

All existing `pypi_metadata` tests continue to pass (15/15).

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Claude Opus 4.6)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.