### PR TITLE
fix: trust path-based pypi overrides for transitive registry specs

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -144,6 +144,23 @@ pub(crate) fn pypi_satisfies_requirement(
         RequirementSource::Registry {
             specifier, index, ..
         } => {
+            // A transitive pep508 requirement (from a wheel's `requires_dist`)
+            // pointing to a name that is locked as a local path / editable
+            // install has been intentionally overridden by the user. The
+            // local package's version may be dynamic (e.g. hatch-vcs,
+            // setuptools-scm) and not statically determinable — in which
+            // case `lock_pypi_packages` falls back to `MIN_VERSION`
+            // ("0a0.dev0") and the specifier check would otherwise fail on
+            // every check, marking the environment perpetually outdated
+            // (issue #6167). Trust the path-based override here; the
+            // path/editable consistency is verified elsewhere via the
+            // dedicated path/editable matching arms.
+            if origin == RequirementOrigin::RequiresDist
+                && matches!(&**locked_data.location(), UrlOrPath::Path(_))
+            {
+                return Ok(());
+            }
+
             let version_string = locked_record.locked_version.to_string();
             if !specifier.contains(
                 &uv_pep440::Version::from_str(&version_string).expect("could not parse version"),
@@ -1231,6 +1248,50 @@ mod tests {
             &[],
         )
         .expect("transitive requirement with no pep508 index must satisfy a custom-index lock");
+    }
+
+    /// Regression test for issue #6167: a path-based (e.g. editable) package
+    /// with a dynamic version that cannot be statically determined gets locked
+    /// with `MIN_VERSION` ("0a0.dev0") as a fallback. When another wheel
+    /// declares it as a `requires_dist` constraint with a normal version
+    /// specifier (creating a circular reference), the transitive specifier
+    /// check used to fail every time, marking the environment as perpetually
+    /// outdated. Path-based overrides must satisfy transitive registry-style
+    /// constraints.
+    #[test]
+    fn test_pypi_path_override_satisfies_transitive_registry_spec() {
+        // Locked path-based source package with no determinable version —
+        // simulates an editable install whose version is dynamic (e.g.
+        // hatch-vcs) and could not be extracted statically.
+        let data = make_source_package_with(
+            "synth",
+            Verbatim::new(UrlOrPath::Path(".".into())),
+            vec![],
+            None,
+        );
+        let locked_data =
+            UnresolvedPypiRecord::from(data).lock(pep440_rs::MIN_VERSION.clone());
+
+        // Transitive requirement from another wheel's `requires_dist`:
+        // pep508 with a registry-style specifier.
+        let spec = pep508_requirement_to_uv_requirement(
+            pep508_rs::Requirement::from_str("synth>=1.6.0").unwrap(),
+        )
+        .unwrap();
+
+        let project_root = PathBuf::from_str("/").unwrap();
+
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            &project_root,
+            RequirementOrigin::RequiresDist,
+            &[],
+        )
+        .expect(
+            "a path-locked package must satisfy a transitive registry constraint \
+             even when its locked version is the MIN_VERSION fallback",
+        );
     }
 
     /// Helper to build a `uv_distribution_types::Requirement` with an explicit index.

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -1269,8 +1269,7 @@ mod tests {
             vec![],
             None,
         );
-        let locked_data =
-            UnresolvedPypiRecord::from(data).lock(pep440_rs::MIN_VERSION.clone());
+        let locked_data = UnresolvedPypiRecord::from(data).lock(pep440_rs::MIN_VERSION.clone());
 
         // Transitive requirement from another wheel's `requires_dist`:
         // pep508 with a registry-style specifier.


### PR DESCRIPTION
### Description

When a wheel's `requires_dist` references a name that the lockfile resolves to a local path / editable package, `pypi_satisfies_requirement` applied a version-specifier check against the locked version. Path packages with dynamic versioning (`hatch-vcs`, `setuptools-scm`, ...) cannot be extracted statically, so `lock_pypi_packages` falls back to `pep440_rs::MIN_VERSION` (`0a0.dev0`), which never satisfies a normal constraint like `>=1.6.0`. The environment is then reported outdated on every run, even immediately after `pixi lock`, producing the infinite "lockfile out of date" loop described in the issue (a circular `synth` <-> `qdev-quant` dependency where `synth` is the editable
package being developed).

This change skips the specifier (and index) check when the requirement is transitive (`RequirementOrigin::RequiresDist`) and the locked record is a path-based override. Path / editable consistency continues to be verified through the dedicated path/editable matching arms in the same function, so this only narrows the registry-style version check that cannot meaningfully apply to a locally overridden package.

Fixes #6167

### How Has This Been Tested?

- Added a unit-test regression: `test_pypi_path_override_satisfies_transitive_registry_spec`
  in `crates/pixi_core/src/lock_file/satisfiability/pypi.rs`. It locks a
  source package with `pep440_rs::MIN_VERSION` (simulating the dynamic
  version fallback) and asserts that a transitive
  `synth>=1.6.0` `RequiresDist` requirement now satisfies it.
- Ran `cargo test -p pixi_core --lib lock_file::satisfiability::pypi` —
  31 passed, 0 failed.
- The original `Manifest`-origin behaviour is unchanged (existing
  index/version-mismatch tests still pass), so direct manifest
  constraints are not affected.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPyzVPfQigyiDzfD5E7gVu)_