### PR TITLE
fix: conda package build for windows and osx

### DIFF
--- a/.github/workflows/backends-release.yml
+++ b/.github/workflows/backends-release.yml
@@ -2,6 +2,11 @@ name: "Backends - Conda Packages"
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build packages but skip the upload step"
+        type: boolean
+        default: true
   push:
     branches:
       - main
@@ -26,7 +31,7 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'release:backends')}}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'release:backends') }}
     timeout-minutes: 80
     permissions:
       id-token: write
@@ -104,7 +109,7 @@ jobs:
           Start-Sleep -Seconds 2
 
   build-linux:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'release:backends')}}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'release:backends') }}
     timeout-minutes: 80
     permissions:
       id-token: write
@@ -168,7 +173,7 @@ jobs:
   upload:
     needs: [build, build-linux]
     runs-on: ubuntu-latest
-    if: github.repository == 'prefix-dev/pixi'
+    if: ${{ github.repository == 'prefix-dev/pixi' && !inputs.dry_run }}
     permissions:
       id-token: write
       contents: read

--- a/pixi-build-backends/recipe/all-backends/recipe.yaml
+++ b/pixi-build-backends/recipe/all-backends/recipe.yaml
@@ -35,6 +35,8 @@ outputs:
         - ninja
         - cargo-bundle-licenses
         - cargo-auditable
+        - if: osx
+          then: ld64
       host:
         - pkg-config
         - libzlib

--- a/pixi-build-backends/recipe/all-backends/recipe.yaml
+++ b/pixi-build-backends/recipe/all-backends/recipe.yaml
@@ -47,11 +47,6 @@ outputs:
           AWS_LC_SYS_CMAKE_BUILDER: "1"
           CARGO_PROFILE_RELEASE_STRIP: symbols
         content:
-          - if: osx and x86_64
-            then:
-              # use the default linker for osx-64 as we are hitting a bug with the conda-forge linker
-              # https://github.com/rust-lang/rust/issues/140686
-              - unset CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER
           - if: unix
             then:
               - export RUSTC_WRAPPER=sccache

--- a/pixi-build-backends/recipe/all-backends/recipe.yaml
+++ b/pixi-build-backends/recipe/all-backends/recipe.yaml
@@ -28,6 +28,7 @@ outputs:
     requirements:
       build:
         - ${{ compiler("rust") }}
+        - ${{ compiler("c") }}
         - ${{ stdlib("c") }}
         # for building aws-lc-sys
         - cmake

--- a/pixi-build-backends/recipe/all-backends/recipe.yaml
+++ b/pixi-build-backends/recipe/all-backends/recipe.yaml
@@ -29,6 +29,9 @@ outputs:
       build:
         - ${{ compiler("rust") }}
         - ${{ stdlib("c") }}
+        # for building aws-lc-sys
+        - cmake
+        - ninja
         - cargo-bundle-licenses
         - cargo-auditable
       host:

--- a/pixi.toml
+++ b/pixi.toml
@@ -95,7 +95,8 @@ rm -rf output/bld/ && \
   --channel https://prefix.dev/conda-forge \
   --variant-config pixi-build-backends/recipe/variants.yaml \
   --recipe pixi-build-backends/recipe/all-backends/recipe.yaml \
-  --target-platform {{ target_platform }}
+  --target-platform {{ target_platform }} \
+  --env-isolation=none
 """
 description = "Build a backend packages"
 


### PR DESCRIPTION
### Description

We didn't have cmake / compilers in the conda build env. Also unsetting the linker now broke macos 64.


### How Has This Been Tested?

CI here: https://github.com/prefix-dev/pixi/actions/runs/26215804170

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
