### PR TITLE
fix: bump mimalloc to 0.1.51 to fix win-arm64 process-exit crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,9 +4699,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "2892ae4ea6fa2cb7acb0e236a6880d39523239cd9089de71d220910ccc806790"
 dependencies = [
  "cc",
 ]
@@ -4975,9 +4975,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "ebca48a43116bc25f18a61360f1be98412f50cc218f5e52c823086b999a4a21a"
 dependencies = [
  "libmimalloc-sys",
 ]

--- a/crates/pixi_allocator/Cargo.toml
+++ b/crates/pixi_allocator/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 [dependencies]
 
 [target.'cfg(all(target_os = "windows"))'.dependencies]
-mimalloc = { version = "0.1.43" }
+mimalloc = { version = "0.1.51" }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), not(target_os = "freebsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }


### PR DESCRIPTION
### Description

Any pixi command exits with `STATUS_ACCESS_VIOLATION` (`0xC0000005`, decimal `3221225477`) on win-arm64 in 0.69.0. The crash happens *after* pixi has finished its work and printed all output, in a process-exit destructor, not in pixi logic. setup-pixi surfaces it because the runner treats the non-zero exit as a failure:

```
The process 'C:\Users\runneradmin\.pixi\bin\pixi.exe' failed with exit code 3221225477
```

**Root cause.** The crash is in **mimalloc**, our global allocator on Windows (`crates/pixi_allocator/src/lib.rs`). Between 0.68.1 and 0.69.0, uv bumps transitively raised the resolved versions:

- `mimalloc`: 0.1.48 -> 0.1.50
- `libmimalloc-sys`: 0.1.44 -> 0.1.47

That bump silently flipped the bundled C library from mimalloc v2 to **mimalloc v3.3.1**. The wrapper's opt-in feature flag was renamed from `v3` to `v2` in 0.1.49, inverting the default; pixi pins no features, so we tracked whatever the new default was.

mimalloc v3.3.0 / v3.3.1 has a known win-arm64 bug ([microsoft/mimalloc#1277](https://github.com/microsoft/mimalloc/issues/1277)): the MSVC C atomic wrapper on ARM64 uses compare-exchange (a write-capable instruction) to implement loads of read-only sentinel objects, which triggers an access violation on read-only pages. The symptom in the linked issue matches byte-for-byte: `exit code: 0xc0000005, STATUS_ACCESS_VIOLATION`. uv and ruff hit the same bug ([astral-sh/uv#19192](https://github.com/astral-sh/uv/pull/19192), [astral-sh/ruff#24880](https://github.com/astral-sh/ruff/issues/24880)); they pinned to `mimalloc/v2` before v3.3.2 shipped.

**Fix.** Upstream fixed it in [microsoft/mimalloc@60a1f3b](https://github.com/microsoft/mimalloc/commit/60a1f3b), shipped in **mimalloc C v3.3.2** (verified `git compare v3.3.2...60a1f3b` shows v3.3.2 contains the commit). That vendored C version landed in `libmimalloc-sys 0.1.48` / `mimalloc 0.1.51`. This PR:

1. Bumps `libmimalloc-sys 0.1.47 -> 0.1.48` and `mimalloc 0.1.50 -> 0.1.51` in `Cargo.lock`.
2. Raises the floor in `crates/pixi_allocator/Cargo.toml` to `0.1.51` so future resolutions can't drop back to a buggy version.

No source code changes.

### How Has This Been Tested?

- [ ] CI: standard build + test matrix.
- [ ] Win-arm64: needs validation on a real Windows-on-ARM machine. Easiest repro is the setup-pixi step from the bug report (`pixi info --manifest-path ...`); should exit 0 with this branch where 0.69.0 exits 3221225477.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas