### PR TITLE
refactor: consolidate source specs into unified SourceSpec variant

### DIFF
--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -105,7 +105,7 @@ impl GlobalSpecs {
                     .transpose()?
                     .unwrap_or_default(),
             };
-            Some(PixiSpec::Git(git_spec))
+            Some(PixiSpec::from(git_spec))
         } else if let Some(path) = &self.path {
             let absolute_path = dunce::canonicalize(path.as_str())
                 .map_err(|_| GlobalSpecsConversionError::AbsolutizePath(path.to_string()))?;
@@ -159,7 +159,7 @@ impl GlobalSpecs {
                         manifest_root.to_string_lossy().to_string(),
                     )
                 })?;
-            Some(PixiSpec::Path(pixi_spec::PathSpec {
+            Some(PixiSpec::from(pixi_spec::PathSpec {
                 path: Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
                     .to_typed_path_buf(),
             }))
@@ -274,10 +274,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(global_specs.len(), 1);
-        assert!(matches!(
-            &global_specs.first().unwrap().spec,
-            &PixiSpec::Git(..)
-        ))
+        assert!(global_specs.first().unwrap().spec.as_git().is_some())
     }
 
     #[tokio::test]
@@ -315,7 +312,7 @@ mod tests {
                 assert_eq!(global_specs.len(), 1);
                 let installed_spec = &global_specs[0];
 
-                let PixiSpec::Path(path_spec) = &installed_spec.spec else {
+                let Some(path_spec) = installed_spec.spec.as_path() else {
                     panic!("expected path spec");
                 };
 

--- a/crates/pixi_command_dispatcher/src/reporter.rs
+++ b/crates/pixi_command_dispatcher/src/reporter.rs
@@ -172,8 +172,7 @@ pub(crate) fn has_direct_conda_dependency(
     dependencies: &pixi_spec_containers::DependencyMap<rattler_conda_types::PackageName, PixiSpec>,
 ) -> bool {
     dependencies.iter_specs().any(|(_, spec)| match spec {
-        PixiSpec::Url(url) => url.is_binary(),
-        PixiSpec::Path(path) => path.is_binary(),
+        PixiSpec::Source(source) => source.is_binary(),
         _ => false,
     })
 }

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -13,7 +13,7 @@ use pixi_manifest::FeaturesExt;
 use pixi_progress::await_in_progress;
 use pixi_pypi_spec::PixiPypiSource;
 pub use pixi_python_status::PythonStatus;
-use pixi_spec::{GitSpec, PixiSpec};
+use pixi_spec::GitSpec;
 use pixi_utils::{prefix::Prefix, rlimit::try_increase_rlimit_to_sensible};
 use rattler_conda_types::Platform;
 use rattler_lock::{LockFile, LockedPackage};
@@ -401,7 +401,7 @@ pub fn extract_git_requirements_from_workspace(project: &Workspace) -> Vec<GitSp
             let pypi_dependencies = env.pypi_dependencies(Some(platform));
             for (_, dep_spec) in dependencies {
                 for spec in dep_spec {
-                    if let PixiSpec::Git(spec) = spec {
+                    if let Some(spec) = spec.as_git() {
                         requirements.push(spec.clone());
                     }
                 }
@@ -438,8 +438,8 @@ pub async fn store_credentials_from_project(project: &Workspace) -> miette::Resu
             let dependencies = env.combined_dependencies(Some(platform));
             for (_, dep_spec) in dependencies {
                 for spec in dep_spec {
-                    if let PixiSpec::Git(spec) = spec {
-                        store_credentials_from_url(&spec.git);
+                    if let Some(git_spec) = spec.as_git() {
+                        store_credentials_from_url(&git_spec.git);
                     }
                 }
             }

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -33,6 +33,7 @@ use rattler_conda_types::{
     NamelessMatchSpec, PackageName, ParseChannelError, StringMatcher, VersionSpec,
 };
 pub use rattler_lock::Verbatim;
+use serde_with::{serde_as, skip_serializing_none};
 pub use source_anchor::SourceAnchor;
 pub use subdirectory::{Subdirectory, SubdirectoryError};
 use thiserror::Error;
@@ -83,20 +84,14 @@ pub enum PixiSpec {
     /// be retrieved from a channel.
     DetailedVersion(Box<DetailedSpec>),
 
-    /// The spec is represented as an archive that can be downloaded from the
-    /// specified URL. The package should be retrieved from the URL and can
-    /// either represent a source or binary package depending on the archive
-    /// type.
-    Url(UrlSpec),
-
-    /// The spec is represented as a git repository. The package represents a
-    /// source distribution of some kind.
-    Git(GitSpec),
-
-    /// The spec is represented as a local path. The package should be retrieved
-    /// from the local filesystem. The package can be either a source or binary
-    /// package.
-    Path(PathSpec),
+    /// The spec is represented by a source location (path, git repository,
+    /// or URL archive), optionally combined with match-spec metadata such as
+    /// `version`, `build`, `flags`, `when`, etc.
+    ///
+    /// A path or URL location may resolve to either a source or binary
+    /// package depending on its file extension; see
+    /// [`Self::into_source_or_binary`].
+    Source(Box<SourceSpec>),
 }
 
 impl Default for PixiSpec {
@@ -110,9 +105,7 @@ impl Display for PixiSpec {
         match self {
             PixiSpec::Version(version) => write!(f, "{version}"),
             PixiSpec::DetailedVersion(detailed) => write!(f, "{detailed}"),
-            PixiSpec::Url(url) => write!(f, "{url}"),
-            PixiSpec::Git(git) => write!(f, "{git}"),
-            PixiSpec::Path(path) => write!(f, "{path}"),
+            PixiSpec::Source(source) => write!(f, "{source}"),
         }
     }
 }
@@ -135,14 +128,14 @@ impl PixiSpec {
         channel_config: &ChannelConfig,
     ) -> Self {
         if let Some(url) = spec.url {
-            Self::Url(UrlSpec {
-                url,
-                md5: spec.md5,
-                sha256: spec.sha256,
-                // A nameless matchspec always describes a binary spec which cannot have a
-                // subdirectory
-                subdirectory: Subdirectory::default(),
-            })
+            Self::Source(Box::new(SourceSpec::from(SourceLocationSpec::Url(
+                UrlSourceSpec {
+                    url,
+                    md5: spec.md5,
+                    sha256: spec.sha256,
+                    subdirectory: Subdirectory::default(),
+                },
+            ))))
         } else if spec.build.is_none()
             && spec.build_number.is_none()
             && spec.file_name.is_none()
@@ -209,26 +202,35 @@ impl PixiSpec {
         }
     }
 
-    /// Returns a [`UrlSpec`] if this instance is a detailed version spec.
-    pub fn as_url(&self) -> Option<&UrlSpec> {
+    /// Returns the inner [`SourceSpec`] if this instance carries a source
+    /// location.
+    pub fn as_source(&self) -> Option<&SourceSpec> {
         match self {
-            Self::Url(v) => Some(v),
+            Self::Source(v) => Some(v),
             _ => None,
         }
     }
 
-    /// Returns a [`GitSpec`] if this instance is a git spec.
+    /// Returns a [`UrlSourceSpec`] if this instance carries a URL location.
+    pub fn as_url(&self) -> Option<&UrlSourceSpec> {
+        match self {
+            Self::Source(v) => v.location.as_url(),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`GitSpec`] if this instance carries a git location.
     pub fn as_git(&self) -> Option<&GitSpec> {
         match self {
-            Self::Git(v) => Some(v),
+            Self::Source(v) => v.location.as_git(),
             _ => None,
         }
     }
 
-    /// Returns a [`PathSpec`] if this instance is a path spec.
-    pub fn as_path(&self) -> Option<&PathSpec> {
+    /// Returns a [`PathSourceSpec`] if this instance carries a path location.
+    pub fn as_path(&self) -> Option<&PathSourceSpec> {
         match self {
-            Self::Path(v) => Some(v),
+            Self::Source(v) => v.location.as_path(),
             _ => None,
         }
     }
@@ -254,10 +256,22 @@ impl PixiSpec {
         }
     }
 
-    /// Converts this instance into a [`UrlSpec`] if possible.
-    pub fn into_url(self) -> Option<UrlSpec> {
+    /// Converts this instance into a [`SourceSpec`] if it carries a source
+    /// location.
+    pub fn into_source(self) -> Option<SourceSpec> {
         match self {
-            Self::Url(v) => Some(v),
+            Self::Source(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Converts this instance into a [`UrlSourceSpec`] if possible.
+    pub fn into_url(self) -> Option<UrlSourceSpec> {
+        match self {
+            Self::Source(v) => match v.location {
+                SourceLocationSpec::Url(url) => Some(url),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -265,15 +279,21 @@ impl PixiSpec {
     /// Converts this instance into a [`GitSpec`] if possible.
     pub fn into_git(self) -> Option<GitSpec> {
         match self {
-            Self::Git(v) => Some(v),
+            Self::Source(v) => match v.location {
+                SourceLocationSpec::Git(git) => Some(git),
+                _ => None,
+            },
             _ => None,
         }
     }
 
-    /// Converts this instance into a [`PathSpec`] if possible.
-    pub fn into_path(self) -> Option<PathSpec> {
+    /// Converts this instance into a [`PathSourceSpec`] if possible.
+    pub fn into_path(self) -> Option<PathSourceSpec> {
         match self {
-            Self::Path(v) => Some(v),
+            Self::Source(v) => match v.location {
+                SourceLocationSpec::Path(path) => Some(path),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -293,9 +313,12 @@ impl PixiSpec {
             PixiSpec::DetailedVersion(spec) => {
                 Some(spec.try_into_nameless_match_spec(channel_config)?)
             }
-            PixiSpec::Url(url) => url.try_into_nameless_match_spec().ok(),
-            PixiSpec::Git(_) => None,
-            PixiSpec::Path(path) => path.try_into_nameless_match_spec(&channel_config.root_dir)?,
+            PixiSpec::Source(source) => match source.location.clone() {
+                SourceLocationSpec::Url(url) => UrlSpec::from(url).try_into_nameless_match_spec().ok(),
+                SourceLocationSpec::Git(_) => None,
+                SourceLocationSpec::Path(path) => PathSpec::from(path)
+                    .try_into_nameless_match_spec(&channel_config.root_dir)?,
+            },
         };
 
         Ok(spec)
@@ -308,15 +331,28 @@ impl PixiSpec {
             PixiSpec::DetailedVersion(detailed) => {
                 Either::Right(BinarySpec::DetailedVersion(detailed))
             }
-            PixiSpec::Url(url) => url
-                .into_source_or_binary()
-                .map_left(|url| SourceLocationSpec::Url(url).into())
-                .map_right(BinarySpec::Url),
-            PixiSpec::Git(git) => Either::Left(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .into_source_or_binary()
-                .map_left(|path| SourceLocationSpec::Path(path).into())
-                .map_right(BinarySpec::Path),
+            PixiSpec::Source(source) => {
+                let source = *source;
+                match &source.location {
+                    SourceLocationSpec::Url(url) => {
+                        let url_spec = UrlSpec::from(url.clone());
+                        match url_spec.into_source_or_binary() {
+                            Either::Left(_) => Either::Left(source),
+                            Either::Right(binary) => Either::Right(BinarySpec::Url(binary)),
+                        }
+                    }
+                    SourceLocationSpec::Git(_) => Either::Left(source),
+                    SourceLocationSpec::Path(path) => {
+                        let path_spec = PathSpec {
+                            path: path.path.clone(),
+                        };
+                        match path_spec.into_source_or_binary() {
+                            Either::Left(_) => Either::Left(source),
+                            Either::Right(binary) => Either::Right(BinarySpec::Path(binary)),
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -325,15 +361,26 @@ impl PixiSpec {
     #[allow(clippy::result_large_err)]
     pub fn try_into_source_spec(self) -> Result<SourceSpec, Self> {
         match self {
-            PixiSpec::Url(url) => url
-                .try_into_source_url()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
-            PixiSpec::Git(git) => Ok(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .try_into_source_path()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
+            PixiSpec::Source(source) => {
+                let source = *source;
+                let is_source = match &source.location {
+                    SourceLocationSpec::Url(url) => {
+                        !UrlSpec::from(url.clone()).is_binary()
+                    }
+                    SourceLocationSpec::Git(_) => true,
+                    SourceLocationSpec::Path(path) => {
+                        !PathSpec {
+                            path: path.path.clone(),
+                        }
+                        .is_binary()
+                    }
+                };
+                if is_source {
+                    Ok(source)
+                } else {
+                    Err(PixiSpec::Source(Box::new(source)))
+                }
+            }
             _ => Err(self),
         }
     }
@@ -343,9 +390,7 @@ impl PixiSpec {
         match self {
             Self::Version(_) => true,
             Self::DetailedVersion(_) => true,
-            Self::Url(url) => url.is_binary(),
-            Self::Git(_) => false,
-            Self::Path(path) => path.is_binary(),
+            Self::Source(source) => source.is_binary(),
         }
     }
 
@@ -359,11 +404,8 @@ impl PixiSpec {
     /// (non-binary).
     pub fn is_mutable(&self) -> bool {
         match self {
-            Self::Version(_) => false,
-            Self::DetailedVersion(_) => false,
-            Self::Url(_) => false,
-            Self::Git(_) => false,
-            Self::Path(path) => !path.is_binary(),
+            Self::Version(_) | Self::DetailedVersion(_) => false,
+            Self::Source(source) => source.is_mutable(),
         }
     }
 
@@ -407,25 +449,32 @@ impl PixiSpec {
 ///
 /// This type only represents source packages. Use [`PixiSpec`] to represent
 /// both binary and source packages.
+#[serde_as]
+#[skip_serializing_none]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct SourceSpec {
     /// The location of the source.
     #[serde(flatten)]
     pub location: SourceLocationSpec,
 
     /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub version: Option<VersionSpec>,
 
     /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub build: Option<StringMatcher>,
 
     /// The build number of the package
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     pub build_number: Option<BuildNumberSpec>,
 
     /// Optional extra dependencies to select for the package
     pub extras: Option<Vec<String>>,
 
     /// Plain string flags used to select package variants.
+    #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
     pub flags: Option<Vec<StringMatcher>>,
 
     /// The subdir of the channel
@@ -586,15 +635,73 @@ impl SourceLocationSpec {
     pub fn is_git(&self) -> bool {
         matches!(self, SourceLocationSpec::Git(_))
     }
+
+    /// Returns true if this spec represents a local path.
+    pub fn is_path(&self) -> bool {
+        matches!(self, SourceLocationSpec::Path(_))
+    }
+
+    /// Returns true if this spec represents a URL.
+    pub fn is_url(&self) -> bool {
+        matches!(self, SourceLocationSpec::Url(_))
+    }
+
+    /// Returns the inner [`UrlSourceSpec`] if this location is a URL.
+    pub fn as_url(&self) -> Option<&UrlSourceSpec> {
+        match self {
+            SourceLocationSpec::Url(url) => Some(url),
+            _ => None,
+        }
+    }
+
+    /// Returns the inner [`GitSpec`] if this location is a git repository.
+    pub fn as_git(&self) -> Option<&GitSpec> {
+        match self {
+            SourceLocationSpec::Git(git) => Some(git),
+            _ => None,
+        }
+    }
+
+    /// Returns the inner [`PathSourceSpec`] if this location is a path.
+    pub fn as_path(&self) -> Option<&PathSourceSpec> {
+        match self {
+            SourceLocationSpec::Path(path) => Some(path),
+            _ => None,
+        }
+    }
+}
+
+impl SourceSpec {
+    /// Returns true if the underlying location resolves to a binary archive.
+    ///
+    /// Git locations are always source. Path and URL locations are inspected
+    /// for known conda archive extensions.
+    pub fn is_binary(&self) -> bool {
+        match &self.location {
+            SourceLocationSpec::Url(url) => UrlSpec::from(url.clone()).is_binary(),
+            SourceLocationSpec::Git(_) => false,
+            SourceLocationSpec::Path(path) => PathSpec {
+                path: path.path.clone(),
+            }
+            .is_binary(),
+        }
+    }
+
+    /// Returns true if the underlying location is a local source path.
+    pub fn is_mutable(&self) -> bool {
+        match &self.location {
+            SourceLocationSpec::Url(_) | SourceLocationSpec::Git(_) => false,
+            SourceLocationSpec::Path(path) => !PathSpec {
+                path: path.path.clone(),
+            }
+            .is_binary(),
+        }
+    }
 }
 
 impl From<SourceSpec> for PixiSpec {
     fn from(value: SourceSpec) -> Self {
-        match value.location {
-            SourceLocationSpec::Url(url) => Self::Url(url.into()),
-            SourceLocationSpec::Git(git) => Self::Git(git),
-            SourceLocationSpec::Path(path) => Self::Path(path.into()),
-        }
+        Self::Source(Box::new(value))
     }
 }
 
@@ -606,7 +713,14 @@ impl From<DetailedSpec> for PixiSpec {
 
 impl From<UrlSpec> for PixiSpec {
     fn from(value: UrlSpec) -> Self {
-        Self::Url(value)
+        Self::Source(Box::new(SourceSpec::from(SourceLocationSpec::Url(
+            UrlSourceSpec {
+                url: value.url,
+                md5: value.md5,
+                sha256: value.sha256,
+                subdirectory: value.subdirectory,
+            },
+        ))))
     }
 }
 
@@ -616,15 +730,27 @@ impl From<UrlSourceSpec> for SourceSpec {
     }
 }
 
+impl From<UrlSourceSpec> for PixiSpec {
+    fn from(value: UrlSourceSpec) -> Self {
+        SourceSpec::from(value).into()
+    }
+}
+
 impl From<GitSpec> for PixiSpec {
     fn from(value: GitSpec) -> Self {
-        Self::Git(value)
+        SourceSpec::from(SourceLocationSpec::Git(value)).into()
     }
 }
 
 impl From<PathSpec> for PixiSpec {
     fn from(value: PathSpec) -> Self {
-        Self::Path(value)
+        SourceSpec::from(SourceLocationSpec::Path(PathSourceSpec { path: value.path })).into()
+    }
+}
+
+impl From<PathSourceSpec> for PixiSpec {
+    fn from(value: PathSourceSpec) -> Self {
+        SourceSpec::from(value).into()
     }
 }
 
@@ -710,8 +836,8 @@ impl From<BinarySpec> for PixiSpec {
         match value {
             BinarySpec::Version(version) => Self::Version(version),
             BinarySpec::DetailedVersion(detailed) => Self::DetailedVersion(detailed),
-            BinarySpec::Url(url) => Self::Url(url.into()),
-            BinarySpec::Path(path) => Self::Path(path.into()),
+            BinarySpec::Url(url) => PixiSpec::from(UrlSpec::from(url)),
+            BinarySpec::Path(path) => PixiSpec::from(PathSpec::from(path)),
         }
     }
 }

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -436,14 +436,18 @@ impl PixiSpec {
 ///
 /// This type only represents source packages. Use [`PixiSpec`] to represent
 /// both binary and source packages.
+///
+/// The `L` type parameter encodes the kind of source location at the type
+/// level: [`UrlSourceSpec`], [`PathSourceSpec`], [`GitSpec`], or the union
+/// [`SourceLocationSpec`].
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct SourceSpec {
+#[serde(rename_all = "kebab-case", bound(serialize = "L: serde::Serialize"))]
+pub struct SourceSpec<L = SourceLocationSpec> {
     /// The location of the source.
     #[serde(flatten)]
-    pub location: SourceLocationSpec,
+    pub location: L,
 
     /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
@@ -483,10 +487,45 @@ pub struct SourceSpec {
     pub track_features: Option<Vec<String>>,
 }
 
-impl From<SourceLocationSpec> for SourceSpec {
-    fn from(value: SourceLocationSpec) -> Self {
+/// Trait implemented by every type that can appear as the `location` of a
+/// [`SourceSpec`]. Lets generic [`SourceSpec`] code answer "is the underlying
+/// archive a binary conda package?" without inspecting the variant.
+pub trait SourceLocation {
+    /// Returns true if the location is known to point to a binary conda
+    /// archive (`.conda`/`.tar.bz2`).
+    fn is_binary(&self) -> bool;
+}
+
+impl SourceLocation for UrlSourceSpec {
+    fn is_binary(&self) -> bool {
+        UrlSourceSpec::is_binary(self)
+    }
+}
+
+impl SourceLocation for PathSourceSpec {
+    fn is_binary(&self) -> bool {
+        PathSourceSpec::is_binary(self)
+    }
+}
+
+impl SourceLocation for GitSpec {
+    fn is_binary(&self) -> bool {
+        false
+    }
+}
+
+impl SourceLocation for SourceLocationSpec {
+    fn is_binary(&self) -> bool {
+        SourceLocationSpec::is_binary(self)
+    }
+}
+
+impl<L> SourceSpec<L> {
+    /// Constructs a new instance from a location with no matchspec fields
+    /// set.
+    pub fn from_location(location: L) -> Self {
         Self {
-            location: value,
+            location,
             version: None,
             build: None,
             build_number: None,
@@ -499,6 +538,66 @@ impl From<SourceLocationSpec> for SourceSpec {
             condition: None,
             track_features: None,
         }
+    }
+
+    /// Maps the underlying location while preserving the matchspec fields.
+    pub fn map_location<M>(self, f: impl FnOnce(L) -> M) -> SourceSpec<M> {
+        SourceSpec {
+            location: f(self.location),
+            version: self.version,
+            build: self.build,
+            build_number: self.build_number,
+            extras: self.extras,
+            flags: self.flags,
+            subdir: self.subdir,
+            namespace: self.namespace,
+            license: self.license,
+            license_family: self.license_family,
+            condition: self.condition,
+            track_features: self.track_features,
+        }
+    }
+}
+
+impl From<SourceLocationSpec> for SourceSpec {
+    fn from(value: SourceLocationSpec) -> Self {
+        Self::from_location(value)
+    }
+}
+
+impl From<UrlSourceSpec> for SourceSpec<UrlSourceSpec> {
+    fn from(value: UrlSourceSpec) -> Self {
+        Self::from_location(value)
+    }
+}
+
+impl From<PathSourceSpec> for SourceSpec<PathSourceSpec> {
+    fn from(value: PathSourceSpec) -> Self {
+        Self::from_location(value)
+    }
+}
+
+impl From<GitSpec> for SourceSpec<GitSpec> {
+    fn from(value: GitSpec) -> Self {
+        Self::from_location(value)
+    }
+}
+
+impl From<SourceSpec<UrlSourceSpec>> for SourceSpec {
+    fn from(value: SourceSpec<UrlSourceSpec>) -> Self {
+        value.map_location(SourceLocationSpec::Url)
+    }
+}
+
+impl From<SourceSpec<PathSourceSpec>> for SourceSpec {
+    fn from(value: SourceSpec<PathSourceSpec>) -> Self {
+        value.map_location(SourceLocationSpec::Path)
+    }
+}
+
+impl From<SourceSpec<GitSpec>> for SourceSpec {
+    fn from(value: SourceSpec<GitSpec>) -> Self {
+        value.map_location(SourceLocationSpec::Git)
     }
 }
 

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -314,10 +314,13 @@ impl PixiSpec {
                 Some(spec.try_into_nameless_match_spec(channel_config)?)
             }
             PixiSpec::Source(source) => match source.location.clone() {
-                SourceLocationSpec::Url(url) => UrlSpec::from(url).try_into_nameless_match_spec().ok(),
+                SourceLocationSpec::Url(url) => {
+                    UrlSpec::from(url).try_into_nameless_match_spec().ok()
+                }
                 SourceLocationSpec::Git(_) => None,
-                SourceLocationSpec::Path(path) => PathSpec::from(path)
-                    .try_into_nameless_match_spec(&channel_config.root_dir)?,
+                SourceLocationSpec::Path(path) => {
+                    PathSpec::from(path).try_into_nameless_match_spec(&channel_config.root_dir)?
+                }
             },
         };
 
@@ -364,16 +367,12 @@ impl PixiSpec {
             PixiSpec::Source(source) => {
                 let source = *source;
                 let is_source = match &source.location {
-                    SourceLocationSpec::Url(url) => {
-                        !UrlSpec::from(url.clone()).is_binary()
-                    }
+                    SourceLocationSpec::Url(url) => !UrlSpec::from(url.clone()).is_binary(),
                     SourceLocationSpec::Git(_) => true,
-                    SourceLocationSpec::Path(path) => {
-                        !PathSpec {
-                            path: path.path.clone(),
-                        }
-                        .is_binary()
+                    SourceLocationSpec::Path(path) => !PathSpec {
+                        path: path.path.clone(),
                     }
+                    .is_binary(),
                 };
                 if is_source {
                     Ok(source)
@@ -744,7 +743,10 @@ impl From<GitSpec> for PixiSpec {
 
 impl From<PathSpec> for PixiSpec {
     fn from(value: PathSpec) -> Self {
-        SourceSpec::from(SourceLocationSpec::Path(PathSourceSpec { path: value.path })).into()
+        SourceSpec::from(SourceLocationSpec::Path(PathSourceSpec {
+            path: value.path,
+        }))
+        .into()
     }
 }
 

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -313,7 +313,7 @@ impl PixiSpec {
             PixiSpec::DetailedVersion(spec) => {
                 Some(spec.try_into_nameless_match_spec(channel_config)?)
             }
-            PixiSpec::Source(source) => match source.location.clone() {
+            PixiSpec::Source(source) => match source.location {
                 SourceLocationSpec::Url(url) => {
                     UrlSpec::from(url).try_into_nameless_match_spec().ok()
                 }
@@ -336,23 +336,20 @@ impl PixiSpec {
             }
             PixiSpec::Source(source) => {
                 let source = *source;
-                match &source.location {
-                    SourceLocationSpec::Url(url) => {
-                        let url_spec = UrlSpec::from(url.clone());
-                        match url_spec.into_source_or_binary() {
-                            Either::Left(_) => Either::Left(source),
-                            Either::Right(binary) => Either::Right(BinarySpec::Url(binary)),
-                        }
-                    }
-                    SourceLocationSpec::Git(_) => Either::Left(source),
+                if !source.is_binary() {
+                    return Either::Left(source);
+                }
+                match source.location {
+                    SourceLocationSpec::Url(url) => Either::Right(BinarySpec::Url(UrlBinarySpec {
+                        url: url.url,
+                        md5: url.md5,
+                        sha256: url.sha256,
+                    })),
                     SourceLocationSpec::Path(path) => {
-                        let path_spec = PathSpec {
-                            path: path.path.clone(),
-                        };
-                        match path_spec.into_source_or_binary() {
-                            Either::Left(_) => Either::Left(source),
-                            Either::Right(binary) => Either::Right(BinarySpec::Path(binary)),
-                        }
+                        Either::Right(BinarySpec::Path(PathBinarySpec { path: path.path }))
+                    }
+                    SourceLocationSpec::Git(_) => {
+                        unreachable!("git locations are never binary")
                     }
                 }
             }
@@ -365,19 +362,10 @@ impl PixiSpec {
     pub fn try_into_source_spec(self) -> Result<SourceSpec, Self> {
         match self {
             PixiSpec::Source(source) => {
-                let source = *source;
-                let is_source = match &source.location {
-                    SourceLocationSpec::Url(url) => !UrlSpec::from(url.clone()).is_binary(),
-                    SourceLocationSpec::Git(_) => true,
-                    SourceLocationSpec::Path(path) => !PathSpec {
-                        path: path.path.clone(),
-                    }
-                    .is_binary(),
-                };
-                if is_source {
-                    Ok(source)
+                if source.is_binary() {
+                    Err(PixiSpec::Source(source))
                 } else {
-                    Err(PixiSpec::Source(Box::new(source)))
+                    Ok(*source)
                 }
             }
             _ => Err(self),
@@ -668,6 +656,18 @@ impl SourceLocationSpec {
             _ => None,
         }
     }
+
+    /// Returns true if the underlying location resolves to a binary archive.
+    ///
+    /// Git locations are always source. Path and URL locations are inspected
+    /// for known conda archive extensions.
+    pub fn is_binary(&self) -> bool {
+        match self {
+            SourceLocationSpec::Url(url) => url.is_binary(),
+            SourceLocationSpec::Git(_) => false,
+            SourceLocationSpec::Path(path) => path.is_binary(),
+        }
+    }
 }
 
 impl SourceSpec {
@@ -676,25 +676,12 @@ impl SourceSpec {
     /// Git locations are always source. Path and URL locations are inspected
     /// for known conda archive extensions.
     pub fn is_binary(&self) -> bool {
-        match &self.location {
-            SourceLocationSpec::Url(url) => UrlSpec::from(url.clone()).is_binary(),
-            SourceLocationSpec::Git(_) => false,
-            SourceLocationSpec::Path(path) => PathSpec {
-                path: path.path.clone(),
-            }
-            .is_binary(),
-        }
+        self.location.is_binary()
     }
 
     /// Returns true if the underlying location is a local source path.
     pub fn is_mutable(&self) -> bool {
-        match &self.location {
-            SourceLocationSpec::Url(_) | SourceLocationSpec::Git(_) => false,
-            SourceLocationSpec::Path(path) => !PathSpec {
-                path: path.path.clone(),
-            }
-            .is_binary(),
-        }
+        matches!(&self.location, SourceLocationSpec::Path(path) if !path.is_binary())
     }
 }
 

--- a/crates/pixi_spec/src/path.rs
+++ b/crates/pixi_spec/src/path.rs
@@ -147,6 +147,12 @@ impl PathSourceSpec {
     pub fn resolve(&self, root_dir: impl AsRef<Path>) -> Result<PathBuf, SpecConversionError> {
         resolve_path(Path::new(self.path.as_str()), root_dir)
     }
+
+    /// Returns true if this path points to a binary archive (e.g.
+    /// `.conda`/`.tar.bz2`).
+    pub fn is_binary(&self) -> bool {
+        CondaArchiveType::try_from(Path::new(self.path.as_str())).is_some()
+    }
 }
 
 /// Path to a source package. Different from [`PathSpec`] in that this type only

--- a/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
+++ b/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
@@ -78,7 +78,8 @@ expression: snapshot
     path: foobar
     version: 1.2.3
   result:
-    error: "ERROR: `version` cannot be used with `path`"
+    path: foobar
+    version: "==1.2.3"
 - input:
     version: //
   result:

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -492,9 +492,7 @@ impl TomlSpec {
 
     /// Build a `SourceSpec` location from the location fields. Caller must
     /// have already validated that exactly one of `url`/`path`/`git` is set.
-    fn build_source_location(
-        loc: TomlLocationSpec,
-    ) -> Result<SourceLocationSpec, SpecError> {
+    fn build_source_location(loc: TomlLocationSpec) -> Result<SourceLocationSpec, SpecError> {
         match (loc.url, loc.path, loc.git) {
             (Some(url), None, None) => Ok(SourceLocationSpec::Url(UrlSourceSpec {
                 url,
@@ -539,8 +537,7 @@ impl TomlSpec {
 
         let spec: PixiSpec;
         if let Some(loc) = self.location {
-            let has_location =
-                loc.url.is_some() || loc.path.is_some() || loc.git.is_some();
+            let has_location = loc.url.is_some() || loc.path.is_some() || loc.git.is_some();
             if has_location {
                 let location = Self::build_source_location(loc)?;
                 spec = PixiSpec::Source(Box::new(SourceSpec {
@@ -1951,10 +1948,7 @@ when = { package = "python", track-features = ["legacy"] }"#;
         let spec: PixiSpec = serde_json::from_value(input).expect("expected parse to succeed");
         let source = spec.as_source().expect("expected a source spec");
         assert!(matches!(source.location, SourceLocationSpec::Path(_)));
-        assert_eq!(
-            source.condition.as_ref().unwrap().to_string(),
-            "__unix"
-        );
+        assert_eq!(source.condition.as_ref().unwrap().to_string(), "__unix");
     }
 
     #[test]
@@ -2164,10 +2158,7 @@ when = "__unix""#;
             .expect("expected `when` to combine with `path`");
         let source = spec.as_source().expect("expected a source spec");
         assert!(matches!(source.location, SourceLocationSpec::Path(_)));
-        assert_eq!(
-            source.condition.as_ref().unwrap().to_string(),
-            "__unix"
-        );
+        assert_eq!(source.condition.as_ref().unwrap().to_string(), "__unix");
     }
 
     #[test]

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::{
     BinarySpec, DetailedSpec, GitReference, GitSpec, PathSourceSpec, PathSpec, PixiSpec,
-    SourceLocationSpec, Subdirectory, SubdirectoryError, UrlSourceSpec, UrlSpec,
+    SourceLocationSpec, SourceSpec, Subdirectory, SubdirectoryError, UrlSourceSpec, UrlSpec,
 };
 
 /// A TOML representation of a package specification.
@@ -439,7 +439,7 @@ impl TomlSpec {
             (false, false, false)
         };
 
-        let non_detailed_keys = [
+        let location_keys = [
             is_git.then_some("`git`"),
             is_path.then_some("`path`"),
             is_url.then_some("`url`"),
@@ -449,24 +449,17 @@ impl TomlSpec {
         .collect::<Vec<_>>()
         .join(", ");
 
-        // Common field checks
-        if !non_detailed_keys.is_empty() {
+        // `file-name` and `channel` only make sense for channel-resolved
+        // (non-source) packages.
+        if !location_keys.is_empty() {
             for (field_name, is_some) in [
-                ("`version`", self.version.is_some()),
-                ("`build`", self.build.is_some()),
-                ("`build-number`", self.build_number.is_some()),
                 ("`file-name`", self.file_name.is_some()),
-                ("`extras`", self.extras.is_some()),
-                ("`flags`", self.flags.is_some()),
                 ("`channel`", self.channel.is_some()),
-                ("`subdir`", self.subdir.is_some()),
-                ("`when`", self.when.is_some()),
-                ("`track-features`", self.track_features.is_some()),
             ] {
                 if is_some {
                     return Err(SpecError::InvalidCombination(
                         field_name.into(),
-                        non_detailed_keys.into(),
+                        location_keys.into(),
                     ));
                 }
             }
@@ -497,83 +490,111 @@ impl TomlSpec {
         Ok(())
     }
 
+    /// Build a `SourceSpec` location from the location fields. Caller must
+    /// have already validated that exactly one of `url`/`path`/`git` is set.
+    fn build_source_location(
+        loc: TomlLocationSpec,
+    ) -> Result<SourceLocationSpec, SpecError> {
+        match (loc.url, loc.path, loc.git) {
+            (Some(url), None, None) => Ok(SourceLocationSpec::Url(UrlSourceSpec {
+                url,
+                md5: loc.md5,
+                sha256: loc.sha256,
+                subdirectory: loc
+                    .subdirectory
+                    .map(Subdirectory::try_from)
+                    .transpose()?
+                    .unwrap_or_default(),
+            })),
+            (None, Some(path), None) => Ok(SourceLocationSpec::Path(PathSourceSpec {
+                path: path.into(),
+            })),
+            (None, None, Some(git)) => {
+                let rev = match (loc.branch, loc.rev, loc.tag) {
+                    (Some(branch), None, None) => Some(GitReference::Branch(branch)),
+                    (None, Some(rev), None) => Some(GitReference::Rev(rev)),
+                    (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
+                    (None, None, None) => None,
+                    _ => return Err(SpecError::MultipleGitRefs),
+                };
+                let subdirectory = loc
+                    .subdirectory
+                    .map(Subdirectory::try_from)
+                    .transpose()?
+                    .unwrap_or_default();
+                Ok(SourceLocationSpec::Git(GitSpec {
+                    git,
+                    rev,
+                    subdirectory,
+                }))
+            }
+            (None, None, None) => unreachable!("caller verified at least one identifier present"),
+            (_, _, _) => Err(SpecError::MultipleIdentifiers),
+        }
+    }
+
     /// Convert the TOML representation into an actual [`PixiSpec`].
     pub fn into_spec(self) -> Result<PixiSpec, SpecError> {
         self.validate_field_combinations()?;
 
         let spec: PixiSpec;
         if let Some(loc) = self.location {
-            spec = match (loc.url, loc.path, loc.git) {
-                (Some(url), None, None) => PixiSpec::Url(UrlSpec {
-                    url,
+            let has_location =
+                loc.url.is_some() || loc.path.is_some() || loc.git.is_some();
+            if has_location {
+                let location = Self::build_source_location(loc)?;
+                spec = PixiSpec::Source(Box::new(SourceSpec {
+                    location,
+                    version: self.version,
+                    build: self.build,
+                    build_number: self.build_number,
+                    extras: self.extras,
+                    flags: self.flags,
+                    subdir: self.subdir,
+                    namespace: None,
+                    license: self.license,
+                    license_family: self.license_family,
+                    condition: self.when.map(TomlWhen::into_condition).transpose()?,
+                    track_features: self.track_features,
+                }));
+                return Ok(spec);
+            } else {
+                let is_detailed = self.version.is_some()
+                    || self.build.is_some()
+                    || self.build_number.is_some()
+                    || self.file_name.is_some()
+                    || self.extras.is_some()
+                    || self.flags.is_some()
+                    || self.channel.is_some()
+                    || self.subdir.is_some()
+                    || loc.md5.is_some()
+                    || loc.sha256.is_some()
+                    || self.license.is_some()
+                    || self.license_family.is_some()
+                    || self.when.is_some()
+                    || self.track_features.is_some();
+                if !is_detailed {
+                    return Err(SpecError::MissingDetailedIdentifier);
+                }
+
+                spec = PixiSpec::DetailedVersion(Box::new(DetailedSpec {
+                    version: self.version,
+                    build: self.build,
+                    build_number: self.build_number,
+                    file_name: self.file_name,
+                    extras: self.extras,
+                    flags: self.flags,
+                    channel: self.channel,
+                    subdir: self.subdir,
                     md5: loc.md5,
                     sha256: loc.sha256,
-                    subdirectory: loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default(),
-                }),
-                (None, Some(path), None) => PixiSpec::Path(PathSpec { path: path.into() }),
-                (None, None, Some(git)) => {
-                    let rev = match (loc.branch, loc.rev, loc.tag) {
-                        (Some(branch), None, None) => Some(GitReference::Branch(branch)),
-                        (None, Some(rev), None) => Some(GitReference::Rev(rev)),
-                        (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
-                        (None, None, None) => None,
-                        _ => {
-                            return Err(SpecError::MultipleGitRefs);
-                        }
-                    };
-                    let subdirectory = loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default();
-                    PixiSpec::Git(GitSpec {
-                        git,
-                        rev,
-                        subdirectory,
-                    })
-                }
-                (None, None, None) => {
-                    let is_detailed = self.version.is_some()
-                        || self.build.is_some()
-                        || self.build_number.is_some()
-                        || self.file_name.is_some()
-                        || self.extras.is_some()
-                        || self.flags.is_some()
-                        || self.channel.is_some()
-                        || self.subdir.is_some()
-                        || loc.md5.is_some()
-                        || loc.sha256.is_some()
-                        || self.license.is_some()
-                        || self.license_family.is_some()
-                        || self.when.is_some()
-                        || self.track_features.is_some();
-                    if !is_detailed {
-                        return Err(SpecError::MissingDetailedIdentifier);
-                    }
-
-                    PixiSpec::DetailedVersion(Box::new(DetailedSpec {
-                        version: self.version,
-                        build: self.build,
-                        build_number: self.build_number,
-                        file_name: self.file_name,
-                        extras: self.extras,
-                        flags: self.flags,
-                        channel: self.channel,
-                        subdir: self.subdir,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        license: self.license,
-                        license_family: self.license_family,
-                        condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                        track_features: self.track_features,
-                    }))
-                }
-                (_, _, _) => return Err(SpecError::MultipleIdentifiers),
-            };
+                    license: self.license,
+                    license_family: self.license_family,
+                    condition: self.when.map(TomlWhen::into_condition).transpose()?,
+                    track_features: self.track_features,
+                }));
+                return Ok(spec);
+            }
         } else {
             let is_detailed = self.version.is_some()
                 || self.build.is_some()
@@ -1925,9 +1946,15 @@ when = { package = "python", track-features = ["legacy"] }"#;
     }
 
     #[test]
-    fn test_when_reject_combined_with_path_json() {
+    fn test_when_accepts_combined_with_path_json() {
         let input = json!({ "path": "../foo", "when": "__unix" });
-        assert_snapshot!(parse_json_error(input), @"`when` cannot be used with `path`");
+        let spec: PixiSpec = serde_json::from_value(input).expect("expected parse to succeed");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Path(_)));
+        assert_eq!(
+            source.condition.as_ref().unwrap().to_string(),
+            "__unix"
+        );
     }
 
     #[test]
@@ -2129,16 +2156,18 @@ when = { all = ["__unix", "python[version='>=3.10']"] }"#;
     }
 
     #[test]
-    fn test_when_reject_combined_with_path_toml() {
+    fn test_when_accepts_combined_with_path_toml() {
         let input = r#"path = "../foo"
 when = "__unix""#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `when` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ when = "__unix"
-          ╰────
-        "###);
+        let mut value = toml_span::parse(input).expect("valid TOML");
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected `when` to combine with `path`");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Path(_)));
+        assert_eq!(
+            source.condition.as_ref().unwrap().to_string(),
+            "__unix"
+        );
     }
 
     #[test]
@@ -2160,24 +2189,35 @@ when = "__unix""#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_json() {
+    fn test_v3_extras_with_path_json() {
         let input = json!({ "path": "../foo", "extras": ["dev"] });
-        assert_snapshot!(parse_json_error(input), @"`extras` cannot be used with `path`");
+        let spec: PixiSpec = serde_json::from_value(input).expect("expected parse to succeed");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Path(_)));
+        assert_eq!(source.extras, Some(vec!["dev".to_string()]));
     }
 
     #[test]
-    fn test_v3_reject_flags_with_git_json() {
+    fn test_v3_flags_with_git_json() {
         let input = json!({ "git": "https://example.com/foo.git", "flags": ["cuda"] });
-        assert_snapshot!(parse_json_error(input), @"`flags` cannot be used with `git`");
+        let spec: PixiSpec = serde_json::from_value(input).expect("expected parse to succeed");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Git(_)));
+        let flags = source.flags.as_ref().unwrap();
+        assert_eq!(flags.len(), 1);
+        assert_eq!(flags[0].to_string(), "cuda");
     }
 
     #[test]
-    fn test_v3_reject_track_features_with_url_json() {
+    fn test_v3_track_features_with_url_json() {
         let input = json!({
             "url": "https://example.com/foo.conda",
             "track-features": ["legacy"],
         });
-        assert_snapshot!(parse_json_error(input), @"`track-features` cannot be used with `url`");
+        let spec: PixiSpec = serde_json::from_value(input).expect("expected parse to succeed");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Url(_)));
+        assert_eq!(source.track_features, Some(vec!["legacy".to_string()]));
     }
 
     #[test]
@@ -2237,40 +2277,89 @@ flags = ["*[unclosed"]"#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_toml() {
+    fn test_v3_extras_with_path_toml() {
         let input = r#"path = "../foo"
 extras = ["dev"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `extras` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ extras = ["dev"]
-          ╰────
-        "###);
+        let mut value = toml_span::parse(input).expect("valid TOML");
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected `extras` to combine with `path`");
+        let source = spec.as_source().expect("expected a source spec");
+        assert_eq!(source.extras, Some(vec!["dev".to_string()]));
     }
 
     #[test]
-    fn test_v3_reject_flags_with_url_toml() {
+    fn test_v3_flags_with_url_toml() {
         let input = r#"url = "https://example.com/foo.conda"
 flags = ["cuda"]"#;
+        let mut value = toml_span::parse(input).expect("valid TOML");
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected `flags` to combine with `url`");
+        let source = spec.as_source().expect("expected a source spec");
+        let flags = source.flags.as_ref().unwrap();
+        assert_eq!(flags.len(), 1);
+        assert_eq!(flags[0].to_string(), "cuda");
+    }
+
+    #[test]
+    fn test_v3_track_features_with_git_toml() {
+        let input = r#"git = "https://example.com/foo.git"
+track-features = ["legacy"]"#;
+        let mut value = toml_span::parse(input).expect("valid TOML");
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected `track-features` to combine with `git`");
+        let source = spec.as_source().expect("expected a source spec");
+        assert_eq!(source.track_features, Some(vec!["legacy".to_string()]));
+    }
+
+    #[test]
+    fn test_path_with_build_toml() {
+        // The headline use case: combine a path source spec with a build matcher.
+        let input = r#"path = "./foo"
+build = "foo*""#;
+        let mut value = toml_span::parse(input).expect("valid TOML");
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected `build` to combine with `path`");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Path(_)));
+        assert_eq!(source.build.as_ref().unwrap().to_string(), "foo*");
+    }
+
+    #[test]
+    fn test_git_with_version_and_when_toml() {
+        let input = r#"git = "https://example.com/foo.git"
+version = ">=1.0"
+when = "__unix""#;
+        let mut value = toml_span::parse(input).expect("valid TOML");
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected source spec with version+when");
+        let source = spec.as_source().expect("expected a source spec");
+        assert!(matches!(source.location, SourceLocationSpec::Git(_)));
+        assert_eq!(source.version.as_ref().unwrap().to_string(), ">=1.0");
+        assert_eq!(source.condition.as_ref().unwrap().to_string(), "__unix");
+    }
+
+    #[test]
+    fn test_v3_reject_channel_with_path_toml() {
+        let input = r#"path = "../foo"
+channel = "conda-forge""#;
         assert_snapshot!(parse_toml_error(input), @r###"
-         × `flags` cannot be used with `url`
+         × `channel` cannot be used with `path`
           ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ url = "https://example.com/foo.conda"
-        2 │ ╰─▶ flags = ["cuda"]
+        1 │ ╭─▶ path = "../foo"
+        2 │ ╰─▶ channel = "conda-forge"
           ╰────
         "###);
     }
 
     #[test]
-    fn test_v3_reject_track_features_with_git_toml() {
+    fn test_v3_reject_file_name_with_git_toml() {
         let input = r#"git = "https://example.com/foo.git"
-track-features = ["legacy"]"#;
+file-name = "foo-1.2.3-py38h0db86a8_1.conda""#;
         assert_snapshot!(parse_toml_error(input), @r###"
-         × `track-features` cannot be used with `git`
+         × `file-name` cannot be used with `git`
           ╭─[pixi.toml:1:1]
         1 │ ╭─▶ git = "https://example.com/foo.git"
-        2 │ ╰─▶ track-features = ["legacy"]
+        2 │ ╰─▶ file-name = "foo-1.2.3-py38h0db86a8_1.conda"
           ╰────
         "###);
     }

--- a/crates/pixi_spec/src/url.rs
+++ b/crates/pixi_spec/src/url.rs
@@ -150,6 +150,14 @@ impl From<UrlSourceSpec> for UrlSpec {
     }
 }
 
+impl UrlSourceSpec {
+    /// Returns true if the URL points to a binary conda archive
+    /// (`.conda`/`.tar.bz2`).
+    pub fn is_binary(&self) -> bool {
+        CondaArchiveIdentifier::try_from_url(&self.url).is_some()
+    }
+}
+
 /// A specification of a source archive from a URL.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize)]
 pub struct UrlBinarySpec {

--- a/docs/concepts/package_specifications.md
+++ b/docs/concepts/package_specifications.md
@@ -289,6 +289,22 @@ For git repositories, you can specify:
 - **rev**: Specific git revision/commit SHA
 - **subdirectory**: Path within the repository
 
+### Combining source locations with MatchSpec fields
+
+A source spec (`path`, `git`, or source `url`) can be combined with the same
+MatchSpec fields you would use for a channel-resolved dependency, such as
+`version`, `build`, `build-number`, `extras`, `flags`, `when`,
+`track-features`, `license`, `license-family`, and `subdir`. This is useful
+when you want to constrain which build of a source package is selected, or
+to gate the dependency on a condition:
+
+```toml title="pixi.toml"
+--8<-- "docs/source_files/pixi_tomls/package_specifications.toml:source-with-matchspec-fields"
+```
+
+Fields that don't apply to source packages (`channel`, `file-name`, and
+`md5`/`sha256` for non-URL sources) are still rejected.
+
 ## PyPI package specifications
 
 Pixi also supports installing package dependencies from PyPI using `pixi add --pypi` and in your `pixi.toml` and `pyproject.toml`.

--- a/docs/source_files/pixi_tomls/package_specifications.toml
+++ b/docs/source_files/pixi_tomls/package_specifications.toml
@@ -67,6 +67,23 @@ git = "https://github.com/org/repo"
 rev = "abc123def"
 # --8<-- [end:git-fields]
 
+# --8<-- [start:source-with-matchspec-fields]
+# Source specs can be combined with the usual matchspec fields
+# (`version`, `build`, `build-number`, `extras`, `flags`, `when`,
+# `track-features`, `license`, `license-family`, `subdir`).
+[dependencies.local-package-with-build]
+path = "./packages/mypackage"
+# Restrict the build string that the source build must produce
+build = "py311*"
+
+[dependencies.git-package-with-when]
+git = "https://github.com/org/repo"
+branch = "main"
+# Only apply this dependency on Linux
+when = "__linux"
+flags = ["cuda"]
+# --8<-- [end:source-with-matchspec-fields]
+
 
 # --8<-- [start:pypi-fields]
 [pypi-dependencies]


### PR DESCRIPTION
### Description

This PR refactors the `PixiSpec` enum to consolidate the separate `Url`, `Git`, and `Path` variants into a single `Source` variant that wraps a `SourceSpec`. This change enables source packages to carry additional metadata like `version`, `build`, `flags`, `when`, and `extras` alongside their location information.

**Key changes:**

1. **Unified source representation**: Replaced three separate `PixiSpec` variants (`Url`, `Git`, `Path`) with a single `Source(Box<SourceSpec>)` variant that combines location information with optional metadata fields.

2. **Enhanced SourceSpec**: The `SourceSpec` struct now includes fields for `version`, `build`, `build_number`, `extras`, `flags`, `subdir`, `license`, `license_family`, `condition`, and `track_features` - allowing source packages to be matched against version specs and other criteria.

3. **Relaxed validation rules**: Previously, fields like `version`, `build`, `when`, `extras`, `flags`, and `track-features` were rejected when combined with source locations. Now they are accepted and stored in the `SourceSpec`, enabling use cases like:
   - `path = "./foo"` with `build = "foo*"` (match source packages by build string)
   - `git = "https://example.com/foo.git"` with `version = ">=1.0"` and `when = "__unix"`
   - `url = "https://example.com/foo.conda"` with `extras = ["dev"]`

4. **Preserved restrictions**: Fields `file-name` and `channel` remain restricted to non-source packages (they only make sense for channel-resolved packages).

5. **Backward compatibility**: Updated all conversion methods (`as_url()`, `as_git()`, `as_path()`, `into_url()`, etc.) to work with the new structure, delegating to `SourceLocationSpec` accessors.

6. **Test updates**: Updated test cases to reflect the new behavior - tests that previously expected errors for combining source locations with metadata now verify that the combinations work correctly.

### How Has This Been Tested?

- Updated existing test cases that verify field combination validation
- Added new test cases demonstrating valid combinations:
  - `test_path_with_build_toml`: Path source with build matcher
  - `test_git_with_version_and_when_toml`: Git source with version and condition
  - `test_v3_extras_with_path_json/toml`: Path source with extras
  - `test_v3_flags_with_git_json/toml`: Git source with flags
  - `test_v3_track_features_with_url_json/toml`: URL source with track-features
- Verified that restrictions on `file-name` and `channel` with source locations still work correctly
- All existing tests pass with the refactored structure

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (docstrings updated)
- [x] I have added sufficient tests to cover my changes (test cases updated and new ones added)

https://claude.ai/code/session_01DHFdrEA6ufVHjLU4RkAx2d