### PR TITLE
feat(pixi-build): plumb workspace scratch directory and cache ROS distro fetches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6140,8 +6140,10 @@ dependencies = [
 name = "pixi-build-ros"
 version = "0.4.2"
 dependencies = [
+ "astral-reqwest-middleware",
  "async-trait",
  "fs-err",
+ "http-cache-reqwest",
  "indexmap 2.14.0",
  "insta",
  "miette 7.6.0",

--- a/crates/pixi_build_backend/src/generated_recipe.rs
+++ b/crates/pixi_build_backend/src/generated_recipe.rs
@@ -57,6 +57,11 @@ pub trait GenerateRecipe {
     /// * `channels` - The channels that are being used for this build. This can be
     ///   used for backend-specific logic that depends on which channels are available.
     /// * `cache_dir` - Optional cache directory for storing cached data (e.g., HTTP responses).
+    /// * `workspace_scratch_directory` - Optional per-workspace scratch directory the backend
+    ///   may use to persist derived state across runs and across multiple backend instances.
+    ///   The backend picks its own subdirectory inside and owns invalidation. See
+    ///   `pixi_build_types::procedures::initialize::InitializeParams::workspace_scratch_directory`
+    ///   for the convention.
     #[allow(clippy::too_many_arguments)]
     async fn generate_recipe(
         &self,
@@ -68,6 +73,7 @@ pub trait GenerateRecipe {
         variants: &HashSet<NormalizedKey>,
         channels: Vec<ChannelUrl>,
         cache_dir: Option<PathBuf>,
+        workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe>;
 
     /// Returns a list of globs that should be used to find the input files

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -100,6 +100,7 @@ pub struct IntermediateBackend<T: GenerateRecipe> {
     pub(crate) config: T::Config,
     pub(crate) target_config: OrderMap<TargetSelector, T::Config>,
     pub(crate) cache_dir: Option<PathBuf>,
+    pub(crate) workspace_scratch_directory: Option<PathBuf>,
 }
 impl<T: GenerateRecipe> IntermediateBackend<T> {
     #[allow(clippy::too_many_arguments)]
@@ -113,6 +114,7 @@ impl<T: GenerateRecipe> IntermediateBackend<T> {
         target_config: OrderMap<TargetSelector, serde_json::Value>,
         logging_output_handler: LoggingOutputHandler,
         cache_dir: Option<PathBuf>,
+        workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<Self> {
         // Determine the root directory of the manifest
         let (source_dir, manifest_rel_path) = match source_dir {
@@ -176,6 +178,7 @@ impl<T: GenerateRecipe> IntermediateBackend<T> {
             target_config,
             logging_output_handler,
             cache_dir,
+            workspace_scratch_directory,
         })
     }
 }
@@ -212,6 +215,7 @@ where
             target_config,
             self.logging_output_handler.clone(),
             params.cache_directory,
+            params.workspace_scratch_directory,
         )?;
 
         Ok((Box::new(instance), InitializeResult {}))
@@ -278,6 +282,7 @@ where
                 &variant_config.variants.keys().cloned().collect(),
                 params.channels,
                 self.cache_dir.clone(),
+                self.workspace_scratch_directory.clone(),
             )
             .await?;
 
@@ -620,6 +625,7 @@ where
                 &variants.keys().cloned().collect(),
                 params.channels,
                 self.cache_dir.clone(),
+                self.workspace_scratch_directory.clone(),
             )
             .await?;
 

--- a/crates/pixi_build_backend/src/utils/test.rs
+++ b/crates/pixi_build_backend/src/utils/test.rs
@@ -75,6 +75,7 @@ where
         configuration: None,
         target_configuration: None,
         cache_directory: None,
+        workspace_scratch_directory: None,
     })
     .await
     .unwrap();

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -64,6 +64,7 @@ mod imp {
             _variants: &HashSet<pixi_build_backend::variants::NormalizedKey>,
             _channels: Vec<ChannelUrl>,
             _cache_dir: Option<PathBuf>,
+            _workspace_scratch_directory: Option<PathBuf>,
         ) -> miette::Result<GeneratedRecipe> {
             GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
                 .into_diagnostic()
@@ -129,6 +130,7 @@ async fn test_conda_build_v1() {
         some_config,
         target_config,
         LoggingOutputHandler::default(),
+        None,
         None,
     )
     .unwrap();

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -59,6 +59,7 @@ impl GenerateRecipe for CMakeGenerator {
         variants: &HashSet<NormalizedKey>,
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
+        _workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root, because `manifest_path` can be
         // either a direct file path or a directory path.
@@ -267,6 +268,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -310,6 +312,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -347,6 +350,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -398,6 +402,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -428,6 +433,7 @@ mod tests {
             configuration: None,
             target_configuration: None,
             cache_directory: None,
+            workspace_scratch_directory: None,
         })
         .await
         .unwrap();
@@ -474,6 +480,7 @@ mod tests {
                 configuration: Some(serde_json::json!({ "compilers": ["cuda"] })),
                 target_configuration: None,
                 cache_directory: None,
+                workspace_scratch_directory: None,
             })
             .await
             .unwrap();
@@ -619,6 +626,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -678,6 +686,7 @@ mod tests {
                 &HashSet::default(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -726,6 +735,7 @@ mod tests {
                 None,
                 &HashSet::from_iter([NormalizedKey("c_stdlib".into())]),
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/pixi_build_frontend/src/backend/json_rpc.rs
+++ b/crates/pixi_build_frontend/src/backend/json_rpc.rs
@@ -150,6 +150,7 @@ impl JsonRpcBackend {
         configuration: Option<serde_json::Value>,
         target_configuration: Option<OrderMap<TargetSelector, serde_json::Value>>,
         cache_dir: Option<PathBuf>,
+        workspace_scratch_directory: Option<PathBuf>,
         tool: Tool,
     ) -> Result<Self, InitializeError> {
         debug_assert!(source_dir.is_absolute());
@@ -200,6 +201,7 @@ impl JsonRpcBackend {
             configuration,
             target_configuration,
             cache_dir,
+            workspace_scratch_directory,
             tx,
             rx,
             Some(stderr),
@@ -219,6 +221,7 @@ impl JsonRpcBackend {
         configuration: Option<serde_json::Value>,
         target_configuration: Option<OrderMap<TargetSelector, serde_json::Value>>,
         cache_dir: Option<PathBuf>,
+        workspace_scratch_directory: Option<PathBuf>,
         sender: impl TransportSenderT + Send,
         receiver: impl TransportReceiverT + Send,
         stderr: Option<Lines<BufReader<ChildStderr>>>,
@@ -259,6 +262,7 @@ impl JsonRpcBackend {
                     source_directory: Some(source_dir),
                     workspace_directory: Some(workspace_root),
                     cache_directory: cache_dir,
+                    workspace_scratch_directory,
                 }),
             )
             .await

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -41,6 +41,7 @@ impl GenerateRecipe for MojoGenerator {
         variants: &HashSet<NormalizedKey>,
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
+        _workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root, because `manifest_path` can be
         // either a direct file path or a directory path.
@@ -266,6 +267,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -316,6 +318,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -356,6 +359,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -421,6 +425,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -467,6 +472,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -517,6 +523,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -561,6 +568,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -640,6 +648,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -701,6 +710,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -129,6 +129,7 @@ impl GenerateRecipe for PythonGenerator {
         variants: &HashSet<NormalizedKey>,
         channels: Vec<ChannelUrl>,
         cache_dir: Option<PathBuf>,
+        _workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
@@ -697,6 +698,7 @@ version = "0.1.0"
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -742,6 +744,7 @@ version = "0.1.0"
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -786,6 +789,7 @@ version = "0.1.0"
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -827,6 +831,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -899,6 +904,7 @@ version = "0.1.0"
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -948,6 +954,7 @@ version = "0.1.0"
                 None,
                 &std::collections::HashSet::<pixi_build_backend::variants::NormalizedKey>::new(),
                 vec![],
+                None,
                 None,
             )
             .await?)
@@ -1066,6 +1073,7 @@ version = "0.1.0"
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1103,6 +1111,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -1205,6 +1214,7 @@ build-backend = "hatchling.build"
                 vec![ChannelUrl::from(
                     url::Url::parse("https://prefix.dev/conda-forge").unwrap(),
                 )],
+                None,
                 None,
             )
             .await
@@ -1319,6 +1329,7 @@ build-backend = "setuptools.build_meta"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/pixi_build_python/src/metadata.rs
+++ b/crates/pixi_build_python/src/metadata.rs
@@ -955,6 +955,7 @@ Documentation = "https://docs.example.com"
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1002,6 +1003,7 @@ requires-python = ">=3.13"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/pixi_build_r/src/main.rs
+++ b/crates/pixi_build_r/src/main.rs
@@ -75,6 +75,7 @@ impl GenerateRecipe for RGenerator {
         variants: &HashSet<NormalizedKey>,
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
+        _workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root
         let manifest_root = if manifest_path.is_file() {
@@ -347,6 +348,7 @@ LinkingTo: Rcpp
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -408,6 +410,7 @@ LinkingTo: Rcpp
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -502,6 +505,7 @@ Imports:
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -609,6 +613,7 @@ Imports:
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -729,6 +729,7 @@ mod tests {
                         configuration: None,
                         target_configuration: None,
                         cache_directory: None,
+                        workspace_scratch_directory: None,
                     })
                     .await
                     .unwrap();
@@ -794,6 +795,7 @@ mod tests {
                 configuration: None,
                 target_configuration: None,
                 cache_directory: None,
+                workspace_scratch_directory: None,
             })
             .await
             .unwrap();
@@ -840,6 +842,7 @@ mod tests {
                 configuration: None,
                 target_configuration: None,
                 cache_directory: None,
+                workspace_scratch_directory: None,
             })
             .await
             .unwrap();
@@ -905,6 +908,7 @@ numpy:
                 configuration: None,
                 target_configuration: None,
                 cache_directory: None,
+                workspace_scratch_directory: None,
             })
             .await
             .unwrap();
@@ -978,6 +982,7 @@ numpy:
                 configuration: None,
                 target_configuration: None,
                 cache_directory: None,
+                workspace_scratch_directory: None,
             })
             .await
             .unwrap();

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -18,6 +18,7 @@ slow_integration_tests = []
 [dependencies]
 async-trait = { workspace = true }
 fs-err = { workspace = true }
+http-cache-reqwest = { workspace = true }
 indexmap = { workspace = true }
 miette = { workspace = true }
 pixi_build_backend = { workspace = true }
@@ -28,6 +29,7 @@ rattler_build_types = { workspace = true }
 rattler_conda_types = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 roxmltree = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/pixi_build_ros/src/distro.rs
+++ b/crates/pixi_build_ros/src/distro.rs
@@ -3,9 +3,11 @@
 //! Fetches the ROS distribution index from GitHub and extracts distribution
 //! metadata (ROS1 vs ROS2, Python version, package list).
 
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 
+use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
 use miette::Diagnostic;
+use reqwest_middleware::ClientBuilder;
 use serde::Deserialize;
 use thiserror::Error;
 
@@ -15,7 +17,10 @@ const INDEX_URL: &str = "https://raw.githubusercontent.com/ros/rosdistro/master/
 #[derive(Debug, Error, Diagnostic)]
 pub enum DistroError {
     #[error("failed to fetch ROS distribution index")]
-    FetchIndex(#[source] reqwest::Error),
+    Fetch(#[from] reqwest_middleware::Error),
+
+    #[error("failed to read ROS distribution index response body")]
+    Body(#[from] reqwest::Error),
 
     #[error("failed to parse ROS distribution index YAML")]
     ParseIndex(#[source] serde_yaml::Error),
@@ -35,13 +40,26 @@ pub struct Distro {
 
 impl Distro {
     /// Fetch distribution info from the ROS distribution index.
-    pub async fn fetch(name: &str) -> Result<Self, DistroError> {
-        let index_yaml = reqwest::get(INDEX_URL)
-            .await
-            .map_err(DistroError::FetchIndex)?
-            .text()
-            .await
-            .map_err(DistroError::FetchIndex)?;
+    ///
+    /// When `http_cache_dir` is provided, the index response is cached on disk so
+    /// repeated backend invocations within the same workspace avoid hitting the
+    /// network. The directory is created on demand by the HTTP cache manager.
+    pub async fn fetch(name: &str, http_cache_dir: Option<&Path>) -> Result<Self, DistroError> {
+        let client = reqwest::Client::new();
+        let mut builder = ClientBuilder::from_client(client.into());
+        if let Some(cache_dir) = http_cache_dir {
+            builder = builder.with(Cache(HttpCache {
+                mode: CacheMode::Default,
+                manager: CACacheManager {
+                    path: cache_dir.to_path_buf(),
+                    remove_opts: Default::default(),
+                },
+                options: HttpCacheOptions::default(),
+            }));
+        }
+        let client = builder.build();
+
+        let index_yaml = client.get(INDEX_URL).send().await?.text().await?;
 
         let index: DistroIndex =
             serde_yaml::from_str(&index_yaml).map_err(DistroError::ParseIndex)?;

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -47,6 +47,7 @@ impl GenerateRecipe for RosGenerator {
         _variants: &HashSet<NormalizedKey>,
         channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
+        workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root
         let manifest_root = if manifest_path.is_file() {
@@ -77,7 +78,14 @@ impl GenerateRecipe for RosGenerator {
                 )
             })?;
 
-        let distro = Distro::fetch(&distro_name).await?;
+        // Subdirectory inside the workspace scratch dir owned exclusively by this
+        // backend. `pixi-build-ros-v0` lets us bump the cache layout without
+        // colliding with concurrent backends or older cached entries.
+        let http_cache_dir = workspace_scratch_directory
+            .as_deref()
+            .map(|root| root.join("pixi-build-ros-v0").join("http-cache"));
+
+        let distro = Distro::fetch(&distro_name, http_cache_dir.as_deref()).await?;
 
         // Parse package.xml
         let package_xml_path = manifest_root.join("package.xml");
@@ -439,6 +447,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -567,6 +576,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe")
@@ -655,6 +665,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -881,6 +892,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe with explicit package.xml path");
@@ -917,6 +929,7 @@ mod tests {
                 vec![ChannelUrl::from(
                     url::Url::parse("https://prefix.dev/robostack-jazzy").unwrap(),
                 )],
+                None,
                 None,
             )
             .await
@@ -964,6 +977,7 @@ mod tests {
                     url::Url::parse("https://prefix.dev/robostack-jazzy").unwrap(),
                 )],
                 None,
+                None,
             )
             .await
             .expect("Explicit distro should override channel");
@@ -1006,6 +1020,7 @@ mod tests {
                     url::Url::parse("https://prefix.dev/conda-forge").unwrap(),
                 )],
                 None,
+                None,
             )
             .await;
 
@@ -1041,6 +1056,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await;

--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -42,6 +42,7 @@ impl GenerateRecipe for RustGenerator {
         variants: &HashSet<NormalizedKey>,
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
+        _workspace_scratch_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Construct a CargoMetadataProvider to read the Cargo.toml file
         // and extract metadata from it.
@@ -279,6 +280,7 @@ mod tests {
                 &std::collections::HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -360,6 +362,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -404,6 +407,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -450,6 +454,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -495,6 +500,7 @@ mod tests {
                 &HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -528,6 +534,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -629,6 +636,7 @@ mod tests {
                 &std::collections::HashSet::new(),
                 vec![],
                 None,
+                None,
             )
             .await;
 
@@ -659,6 +667,7 @@ mod tests {
                 None,
                 &std::collections::HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await;
@@ -699,6 +708,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -773,6 +783,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -864,6 +875,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await
@@ -969,6 +981,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/pixi_build_types/src/procedures/initialize.rs
+++ b/crates/pixi_build_types/src/procedures/initialize.rs
@@ -45,6 +45,23 @@ pub struct InitializeParams {
     /// Optionally the cache directory to use for any caching activity.
     pub cache_directory: Option<PathBuf>,
 
+    /// Optional per-workspace scratch directory the backend may use to
+    /// persist its own derived state across runs and across multiple
+    /// backend instances within the same workspace. Pixi creates this
+    /// directory and guarantees it survives across `pixi lock` and
+    /// `pixi install` runs; it is removed by `pixi clean`.
+    ///
+    /// Convention: the backend creates one or more subdirectories
+    /// inside, choosing names that avoid colliding with other
+    /// backends. The name does not have to match the backend's own
+    /// name; for example a backend may version its own cache layout
+    /// by suffixing (`my-cache-v2/`). The backend owns invalidation;
+    /// pixi will not stat or otherwise reason about anything stored
+    /// here. Concurrent backend instances may run simultaneously
+    /// against the same path, so writes should be atomic
+    /// (write-tempfile-then-rename style).
+    pub workspace_scratch_directory: Option<PathBuf>,
+
     /// Project model that the backend should use even though it is an option
     /// it is highly recommended to use this field. Otherwise, it will be very
     /// easy to break backwards compatibility.

--- a/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
@@ -249,14 +249,25 @@ impl InstantiateBackendKey {
     ) -> Result<BackendHandle, Arc<InstantiateBackendError>> {
         let source_dir = self.canonical_build_source_dir()?;
 
-        // Cache root is needed by both branches below; fetch once so
+        // Cache root and the per-workspace scratch directory are both
+        // needed by the branches below; fetch the `CacheDirs` once so
         // the dependency edge to `CacheDirsKey` is recorded once.
-        let cache_dir_root: PathBuf = ctx
-            .compute(&CacheDirsKey)
-            .await
-            .root()
-            .to_owned()
-            .into_std_path_buf();
+        let cache_dirs = ctx.compute(&CacheDirsKey).await;
+        let cache_dir_root: PathBuf = cache_dirs.root().to_owned().into_std_path_buf();
+        let workspace_scratch_directory: Option<PathBuf> = cache_dirs
+            .workspace()
+            .map(|w| w.to_owned().into_std_path_buf().join("scratch-v0"))
+            .and_then(|dir| match fs_err::create_dir_all(&dir) {
+                Ok(()) => Some(dir),
+                Err(err) => {
+                    tracing::warn!(
+                        directory = %dir.display(),
+                        error = %err,
+                        "failed to create workspace scratch directory; backends will receive None"
+                    );
+                    None
+                }
+            });
 
         // Apply the engine's backend override to the resolved spec.
         let resolved_command = ctx
@@ -272,6 +283,7 @@ impl InstantiateBackendKey {
                     &source_dir,
                     &discovered.init_params,
                     cache_dir_root,
+                    workspace_scratch_directory,
                 );
             }
             ResolvedBackendCommand::Spec(CommandSpec::System(system_spec)) => (
@@ -305,6 +317,7 @@ impl InstantiateBackendKey {
             tool,
             api_version,
             cache_dir_root,
+            workspace_scratch_directory,
         )
         .await
     }
@@ -327,6 +340,7 @@ impl InstantiateBackendKey {
         source_dir: &std::path::Path,
         init_params: &BackendInitializationParams,
         cache_dir_root: PathBuf,
+        workspace_scratch_directory: Option<PathBuf>,
     ) -> Result<BackendHandle, Arc<InstantiateBackendError>> {
         let project_model = self
             .project_model_overrides
@@ -337,6 +351,7 @@ impl InstantiateBackendKey {
                 source_directory: Some(source_dir.to_path_buf()),
                 workspace_directory: Some(init_params.workspace_root.clone()),
                 cache_directory: Some(cache_dir_root),
+                workspace_scratch_directory,
                 project_model,
                 configuration: init_params.configuration.clone(),
                 target_configuration: init_params.target_configuration.clone(),
@@ -568,6 +583,7 @@ async fn spawn_json_rpc(
     tool: Tool,
     api_version: PixiBuildApiVersion,
     cache_dir_root: PathBuf,
+    workspace_scratch_directory: Option<PathBuf>,
 ) -> Result<BackendHandle, Arc<InstantiateBackendError>> {
     let project_model = project_model_overrides.apply(init_params.project_model.clone());
     let backend = JsonRpcBackend::setup(
@@ -578,6 +594,7 @@ async fn spawn_json_rpc(
         init_params.configuration.clone(),
         init_params.target_configuration.clone(),
         Some(cache_dir_root),
+        workspace_scratch_directory,
         tool,
     )
     .await


### PR DESCRIPTION
### Description

Adds a `workspaceScratchDirectory` field to the backend `initialize` procedure and plumbs it through to every sibling backend (cmake/mojo/python/r/ros/rust).

The scratch directory is a per-workspace location pixi creates and guarantees survives across `pixi lock` and `pixi install`; `pixi clean` is the only thing that removes it. Backends use it to persist their own derived state (HTTP response caches, parsed-index caches, anything they can re-derive but would prefer not to). The contract:

- Backends pick their own subdirectory inside, choosing names that avoid colliding with other backends. The subdir name does not have to match the backend's own name; for example a backend may version its cache layout by suffixing (`my-cache-v2/`).
- The backend owns invalidation. Pixi never stats or reasons about anything stored here.
- Concurrent backend instances may run simultaneously against the same path (e.g. the same backend invoked for multiple packages in one lock), so writes should be atomic (write-tempfile-then-rename style).

`pixi-build-ros` is the first user. It stores an HTTP cache for ROS distro index fetches in `<scratch>/pixi-build-ros-v0/http-cache/`, replacing the previous behaviour where every lock re-downloaded the ~10 MB index from GitHub.

What this enables: ROS workspaces stop re-fetching the distro index on every lock. Other backends gain a place to put state they'd otherwise have to discard between runs. As one example, a cargo backend could point a shared `target/` here so multiple package builds within the same workspace reuse the same incremental-compilation cache instead of each rebuilding from scratch.

### How Has This Been Tested?

`cargo check --workspace --tests` on Windows. Local `pixi lock` on a ROS workspace confirms the second-run distro fetch is served from the on-disk cache.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Sonnet/Opus 4.x via Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas