### PR TITLE
feat(pixi-build-ros): discover sibling ROS packages + marker-driven workspace globbing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6150,6 +6150,7 @@ dependencies = [
  "pathdiff",
  "pixi_build_backend",
  "pixi_build_types",
+ "pixi_glob",
  "rattler_build_jinja",
  "rattler_build_recipe",
  "rattler_build_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6147,6 +6147,7 @@ dependencies = [
  "indexmap 2.14.0",
  "insta",
  "miette 7.6.0",
+ "pathdiff",
  "pixi_build_backend",
  "pixi_build_types",
  "rattler_build_jinja",
@@ -6162,6 +6163,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/crates/pixi_build_backend/src/generated_recipe.rs
+++ b/crates/pixi_build_backend/src/generated_recipe.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use miette::Diagnostic;
-use pixi_build_types::ProjectModel;
+use pixi_build_types::{InputGlobSet, ProjectModel};
 use rattler_build_jinja::Variable;
 use rattler_build_recipe::stage0::{
     About, ConditionalList, Item, License, Package, SingleOutputRecipe, Value,
@@ -66,6 +66,13 @@ pub trait GenerateRecipe {
     ///   package, if any. Backends can use it to inspect sibling packages (e.g. the ROS
     ///   backend uses it to discover sibling `package.xml` files and emit them as source
     ///   dependencies). `None` when the package is built outside of a workspace context.
+    /// * `checkout_root` - Absolute path to the root of this package's source checkout.
+    ///   For a git or url source dependency this is the directory pixi unpacked the
+    ///   checkout into, BEFORE any `subdirectory` is applied — distinct from
+    ///   `workspace_directory` (a pixi-workspace concept) and from `manifest_path`
+    ///   (the package's own dir). Backends that need to reason about siblings inside
+    ///   the same checkout (e.g. ROS workspace sibling-package discovery) anchor their
+    ///   search here when no pixi workspace is available.
     #[allow(clippy::too_many_arguments)]
     async fn generate_recipe(
         &self,
@@ -79,6 +86,7 @@ pub trait GenerateRecipe {
         cache_dir: Option<PathBuf>,
         workspace_scratch_directory: Option<PathBuf>,
         workspace_directory: Option<PathBuf>,
+        checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe>;
 
     /// Returns a list of globs that should be used to find the input files
@@ -153,9 +161,17 @@ pub struct GeneratedRecipe {
     /// backends MUST emit inclusion patterns before any `!`-prefixed
     /// exclusions that should override them.
     pub metadata_input_globs: Vec<String>,
+    /// Optional structured form of [`Self::metadata_input_globs`].  Backends
+    /// that can describe their inputs precisely (e.g. workspace discovery
+    /// with markers) populate this; pixi prefers it over the flat list when
+    /// it is non-empty and falls back otherwise.
+    pub metadata_input_glob_sets: Vec<InputGlobSet>,
     /// Globs whose matched files trigger a rebuild. Same ordering rule as
     /// [`Self::metadata_input_globs`].
     pub build_input_globs: Vec<String>,
+    /// Optional structured form of [`Self::build_input_globs`].  See
+    /// [`Self::metadata_input_glob_sets`] for semantics.
+    pub build_input_glob_sets: Vec<InputGlobSet>,
 }
 
 /// Helper to create a concrete `Value<Url>` from an optional string
@@ -288,7 +304,9 @@ impl GeneratedRecipe {
         Ok(GeneratedRecipe {
             recipe,
             metadata_input_globs: Vec::new(),
+            metadata_input_glob_sets: Vec::new(),
             build_input_globs: Vec::new(),
+            build_input_glob_sets: Vec::new(),
         })
     }
 }

--- a/crates/pixi_build_backend/src/generated_recipe.rs
+++ b/crates/pixi_build_backend/src/generated_recipe.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
@@ -62,6 +62,10 @@ pub trait GenerateRecipe {
     ///   The backend picks its own subdirectory inside and owns invalidation. See
     ///   `pixi_build_types::procedures::initialize::InitializeParams::workspace_scratch_directory`
     ///   for the convention.
+    /// * `workspace_directory` - Absolute path to the root of the workspace that owns this
+    ///   package, if any. Backends can use it to inspect sibling packages (e.g. the ROS
+    ///   backend uses it to discover sibling `package.xml` files and emit them as source
+    ///   dependencies). `None` when the package is built outside of a workspace context.
     #[allow(clippy::too_many_arguments)]
     async fn generate_recipe(
         &self,
@@ -74,6 +78,7 @@ pub trait GenerateRecipe {
         channels: Vec<ChannelUrl>,
         cache_dir: Option<PathBuf>,
         workspace_scratch_directory: Option<PathBuf>,
+        workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe>;
 
     /// Returns a list of globs that should be used to find the input files
@@ -85,8 +90,8 @@ pub trait GenerateRecipe {
         _config: &Self::Config,
         _workdir: impl AsRef<Path>,
         _editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
-        Ok(BTreeSet::new())
+    ) -> miette::Result<Vec<String>> {
+        Ok(Vec::new())
     }
 
     /// Returns "default" variants for the given host platform. This allows
@@ -143,8 +148,14 @@ pub enum GenerateRecipeError<MetadataProviderError: Diagnostic + 'static> {
 #[derive(Clone)]
 pub struct GeneratedRecipe {
     pub recipe: SingleOutputRecipe,
-    pub metadata_input_globs: BTreeSet<String>,
-    pub build_input_globs: BTreeSet<String>,
+    /// Globs whose matched files contribute to the metadata-cache fingerprint.
+    /// Pixi evaluates them with gitignore "last match wins" semantics, so
+    /// backends MUST emit inclusion patterns before any `!`-prefixed
+    /// exclusions that should override them.
+    pub metadata_input_globs: Vec<String>,
+    /// Globs whose matched files trigger a rebuild. Same ordering rule as
+    /// [`Self::metadata_input_globs`].
+    pub build_input_globs: Vec<String>,
 }
 
 /// Helper to create a concrete `Value<Url>` from an optional string
@@ -276,8 +287,8 @@ impl GeneratedRecipe {
 
         Ok(GeneratedRecipe {
             recipe,
-            metadata_input_globs: BTreeSet::new(),
-            build_input_globs: BTreeSet::new(),
+            metadata_input_globs: Vec::new(),
+            build_input_globs: Vec::new(),
         })
     }
 }

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -102,6 +102,7 @@ pub struct IntermediateBackend<T: GenerateRecipe> {
     pub(crate) cache_dir: Option<PathBuf>,
     pub(crate) workspace_scratch_directory: Option<PathBuf>,
     pub(crate) workspace_directory: Option<PathBuf>,
+    pub(crate) checkout_root: Option<PathBuf>,
 }
 impl<T: GenerateRecipe> IntermediateBackend<T> {
     #[allow(clippy::too_many_arguments)]
@@ -117,6 +118,7 @@ impl<T: GenerateRecipe> IntermediateBackend<T> {
         cache_dir: Option<PathBuf>,
         workspace_scratch_directory: Option<PathBuf>,
         workspace_directory: Option<PathBuf>,
+        checkout_root: Option<PathBuf>,
     ) -> miette::Result<Self> {
         // Determine the root directory of the manifest
         let (source_dir, manifest_rel_path) = match source_dir {
@@ -182,6 +184,7 @@ impl<T: GenerateRecipe> IntermediateBackend<T> {
             cache_dir,
             workspace_scratch_directory,
             workspace_directory,
+            checkout_root,
         })
     }
 }
@@ -220,6 +223,7 @@ where
             params.cache_directory,
             params.workspace_scratch_directory,
             params.workspace_directory,
+            params.checkout_root,
         )?;
 
         Ok((Box::new(instance), InitializeResult {}))
@@ -288,6 +292,7 @@ where
                 self.cache_dir.clone(),
                 self.workspace_scratch_directory.clone(),
                 self.workspace_directory.clone(),
+                self.checkout_root.clone(),
             )
             .await?;
 
@@ -571,13 +576,21 @@ where
 
                 // The input globs are the same for all outputs
                 input_globs: None,
+                input_glob_sets: None,
                 // TODO: Implement caching
             });
         }
 
+        let metadata_input_glob_sets = if generated_recipe.metadata_input_glob_sets.is_empty() {
+            None
+        } else {
+            Some(generated_recipe.metadata_input_glob_sets)
+        };
+
         Ok(CondaOutputsResult {
             outputs,
             input_globs: generated_recipe.metadata_input_globs,
+            input_glob_sets: metadata_input_glob_sets,
         })
     }
 
@@ -632,6 +645,7 @@ where
                 self.cache_dir.clone(),
                 self.workspace_scratch_directory.clone(),
                 self.workspace_directory.clone(),
+                self.checkout_root.clone(),
             )
             .await?;
 
@@ -849,9 +863,16 @@ where
         )?;
         input_globs.append(&mut recipe.build_input_globs);
 
+        let build_input_glob_sets = if recipe.build_input_glob_sets.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut recipe.build_input_glob_sets))
+        };
+
         Ok(CondaBuildV1Result {
             output_file: output_path,
             input_globs,
+            input_glob_sets: build_input_glob_sets,
             name: output.name().as_normalized().to_string(),
             version: output.version().clone(),
             build: output.build_string().into_owned(),

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -101,6 +101,7 @@ pub struct IntermediateBackend<T: GenerateRecipe> {
     pub(crate) target_config: OrderMap<TargetSelector, T::Config>,
     pub(crate) cache_dir: Option<PathBuf>,
     pub(crate) workspace_scratch_directory: Option<PathBuf>,
+    pub(crate) workspace_directory: Option<PathBuf>,
 }
 impl<T: GenerateRecipe> IntermediateBackend<T> {
     #[allow(clippy::too_many_arguments)]
@@ -115,6 +116,7 @@ impl<T: GenerateRecipe> IntermediateBackend<T> {
         logging_output_handler: LoggingOutputHandler,
         cache_dir: Option<PathBuf>,
         workspace_scratch_directory: Option<PathBuf>,
+        workspace_directory: Option<PathBuf>,
     ) -> miette::Result<Self> {
         // Determine the root directory of the manifest
         let (source_dir, manifest_rel_path) = match source_dir {
@@ -179,6 +181,7 @@ impl<T: GenerateRecipe> IntermediateBackend<T> {
             logging_output_handler,
             cache_dir,
             workspace_scratch_directory,
+            workspace_directory,
         })
     }
 }
@@ -216,6 +219,7 @@ where
             self.logging_output_handler.clone(),
             params.cache_directory,
             params.workspace_scratch_directory,
+            params.workspace_directory,
         )?;
 
         Ok((Box::new(instance), InitializeResult {}))
@@ -283,6 +287,7 @@ where
                 params.channels,
                 self.cache_dir.clone(),
                 self.workspace_scratch_directory.clone(),
+                self.workspace_directory.clone(),
             )
             .await?;
 
@@ -626,6 +631,7 @@ where
                 params.channels,
                 self.cache_dir.clone(),
                 self.workspace_scratch_directory.clone(),
+                self.workspace_directory.clone(),
             )
             .await?;
 

--- a/crates/pixi_build_backend/src/tools.rs
+++ b/crates/pixi_build_backend/src/tools.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     path::{Path, PathBuf},
 };
 
@@ -70,7 +70,7 @@ pub struct LoadedVariantConfig {
     pub variant_config: VariantConfig,
 
     /// Input globs that identity the files that were loaded.
-    pub input_globs: BTreeSet<String>,
+    pub input_globs: Vec<String>,
 }
 
 /// Track a potential variants.yaml location: always add it to `input_globs`
@@ -79,7 +79,7 @@ pub struct LoadedVariantConfig {
 fn track_variant_path(
     variant_path: PathBuf,
     source_dir: &Path,
-    input_globs: &mut BTreeSet<String>,
+    input_globs: &mut Vec<String>,
     variant_files: &mut Vec<PathBuf>,
 ) {
     if let Some(rel) = pathdiff::diff_paths(&variant_path, source_dir) {
@@ -88,7 +88,7 @@ fn track_variant_path(
         } else {
             rel.to_string_lossy().to_string()
         };
-        input_globs.insert(normalized);
+        input_globs.push(normalized);
     }
     if variant_path.is_file() {
         variant_files.push(variant_path);
@@ -106,7 +106,7 @@ impl LoadedVariantConfig {
         additional_variant_files: impl Iterator<Item = &'a Path>,
     ) -> Result<Self, VariantConfigError> {
         let mut variant_files = Vec::new();
-        let mut input_globs = BTreeSet::new();
+        let mut input_globs = Vec::new();
 
         // Check if there is a `variants.yaml` file next to the recipe that we
         // should potentially use.
@@ -458,8 +458,6 @@ pub fn output_directory(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use fs_err as fs;
     use rattler_conda_types::Platform;
     use tempfile::tempdir;
@@ -491,7 +489,10 @@ mod tests {
 
         // variants.yaml in source_dir should appear in input_globs
         assert!(
-            loaded.input_globs.contains(VARIANTS_CONFIG_FILE),
+            loaded
+                .input_globs
+                .iter()
+                .any(|g| g == VARIANTS_CONFIG_FILE),
             "input_globs should contain {VARIANTS_CONFIG_FILE} but was: {:?}",
             loaded.input_globs
         );
@@ -523,7 +524,10 @@ mod tests {
         // second block should NOT fire (recipe_path_parent == source_dir).
         // The glob should still be present from the first block.
         assert!(
-            loaded.input_globs.contains(VARIANTS_CONFIG_FILE),
+            loaded
+                .input_globs
+                .iter()
+                .any(|g| g == VARIANTS_CONFIG_FILE),
             "input_globs should contain {VARIANTS_CONFIG_FILE} but was: {:?}",
             loaded.input_globs
         );
@@ -550,12 +554,14 @@ mod tests {
         )
         .unwrap();
 
+        // Insertion order: first the variants.yaml next to the recipe, then
+        // the one in source_dir.
         assert_eq!(
             loaded.input_globs,
-            BTreeSet::from([
+            vec![
                 String::from("custom/variants.yaml"),
                 String::from(VARIANTS_CONFIG_FILE),
-            ])
+            ]
         );
     }
 }

--- a/crates/pixi_build_backend/src/tools.rs
+++ b/crates/pixi_build_backend/src/tools.rs
@@ -489,10 +489,7 @@ mod tests {
 
         // variants.yaml in source_dir should appear in input_globs
         assert!(
-            loaded
-                .input_globs
-                .iter()
-                .any(|g| g == VARIANTS_CONFIG_FILE),
+            loaded.input_globs.iter().any(|g| g == VARIANTS_CONFIG_FILE),
             "input_globs should contain {VARIANTS_CONFIG_FILE} but was: {:?}",
             loaded.input_globs
         );
@@ -524,10 +521,7 @@ mod tests {
         // second block should NOT fire (recipe_path_parent == source_dir).
         // The glob should still be present from the first block.
         assert!(
-            loaded
-                .input_globs
-                .iter()
-                .any(|g| g == VARIANTS_CONFIG_FILE),
+            loaded.input_globs.iter().any(|g| g == VARIANTS_CONFIG_FILE),
             "input_globs should contain {VARIANTS_CONFIG_FILE} but was: {:?}",
             loaded.input_globs
         );

--- a/crates/pixi_build_backend/src/utils/test.rs
+++ b/crates/pixi_build_backend/src/utils/test.rs
@@ -69,6 +69,7 @@ where
     )
     .initialize(InitializeParams {
         workspace_directory: None,
+        checkout_root: None,
         source_directory: source_dir,
         manifest_path,
         project_model,

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -65,6 +65,7 @@ mod imp {
             _channels: Vec<ChannelUrl>,
             _cache_dir: Option<PathBuf>,
             _workspace_scratch_directory: Option<PathBuf>,
+            _workspace_directory: Option<PathBuf>,
         ) -> miette::Result<GeneratedRecipe> {
             GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
                 .into_diagnostic()
@@ -130,6 +131,7 @@ async fn test_conda_build_v1() {
         some_config,
         target_config,
         LoggingOutputHandler::default(),
+        None,
         None,
         None,
     )

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -66,6 +66,7 @@ mod imp {
             _cache_dir: Option<PathBuf>,
             _workspace_scratch_directory: Option<PathBuf>,
             _workspace_directory: Option<PathBuf>,
+            _checkout_root: Option<PathBuf>,
         ) -> miette::Result<GeneratedRecipe> {
             GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
                 .into_diagnostic()
@@ -131,6 +132,7 @@ async fn test_conda_build_v1() {
         some_config,
         target_config,
         LoggingOutputHandler::default(),
+        None,
         None,
         None,
         None,

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -101,6 +101,7 @@ impl InMemoryBackend for PassthroughBackend {
         Ok(CondaOutputsResult {
             outputs,
             input_globs: Default::default(),
+            input_glob_sets: None,
         })
     }
 
@@ -205,6 +206,7 @@ impl InMemoryBackend for PassthroughBackend {
         Ok(CondaBuildV1Result {
             output_file,
             input_globs: self.config.build_globs.clone().unwrap_or_default(),
+            input_glob_sets: None,
             name: self.index_json.name.as_normalized().to_owned(),
             version: self.index_json.version.clone(),
             build: build_string,
@@ -612,6 +614,7 @@ fn create_output(
             .map(convert_run_exports_json)
             .unwrap_or_default(),
         input_globs: None,
+        input_glob_sets: None,
     }
 }
 

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -919,7 +919,7 @@ pub struct PassthroughBackendConfig {
     pub noarch: Option<bool>,
 
     /// Build globs
-    pub build_globs: Option<BTreeSet<String>>,
+    pub build_globs: Option<Vec<String>>,
 }
 
 /// Observer that allows collecting backend events from an ObservableBackend.

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -61,6 +61,7 @@ impl GenerateRecipe for CMakeGenerator {
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
         _workspace_directory: Option<PathBuf>,
+        _checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root, because `manifest_path` can be
         // either a direct file path or a directory path.
@@ -271,6 +272,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -316,6 +318,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -353,6 +356,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -408,6 +412,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -432,6 +437,7 @@ mod tests {
         )
         .initialize(InitializeParams {
             workspace_directory: None,
+            checkout_root: None,
             source_directory: None,
             manifest_path: PathBuf::from("pixi.toml"),
             project_model: Some(project_model),
@@ -479,6 +485,7 @@ mod tests {
             )
             .initialize(InitializeParams {
                 workspace_directory: None,
+                checkout_root: None,
                 source_directory: None,
                 manifest_path: PathBuf::from("pixi.toml"),
                 project_model: Some(project_model.clone()),
@@ -633,6 +640,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -694,6 +702,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -742,6 +751,7 @@ mod tests {
                 None,
                 &HashSet::from_iter([NormalizedKey("c_stdlib".into())]),
                 vec![],
+                None,
                 None,
                 None,
                 None,

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -60,6 +60,7 @@ impl GenerateRecipe for CMakeGenerator {
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
+        _workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root, because `manifest_path` can be
         // either a direct file path or a directory path.
@@ -160,7 +161,7 @@ impl GenerateRecipe for CMakeGenerator {
         config: &Self::Config,
         workdir: impl AsRef<Path>,
         _editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
+    ) -> miette::Result<Vec<String>> {
         let workdir = workdir.as_ref();
         let mut globs = match inputs::exact_inputs_from_ninja(workdir) {
             Ok(set) => set,
@@ -173,7 +174,7 @@ impl GenerateRecipe for CMakeGenerator {
             }
         };
         globs.extend(config.extra_input_globs.iter().cloned());
-        Ok(globs)
+        Ok(globs.into_iter().collect())
     }
 
     fn default_variants(
@@ -269,6 +270,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -313,6 +315,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -350,6 +353,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -401,6 +405,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -627,6 +632,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -687,6 +693,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -735,6 +742,7 @@ mod tests {
                 None,
                 &HashSet::from_iter([NormalizedKey("c_stdlib".into())]),
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__tests__input_globs_includes_extra_globs.snap
@@ -3,10 +3,10 @@ source: crates/pixi_build_cmake/src/main.rs
 expression: result
 ---
 Ok(
-    {
+    [
         "**/*.{c,cc,cxx,cpp,h,hpp,hxx}",
         "**/*.{cmake,cmake.in}",
         "**/CMakeLists.txt",
         "custom/*.c",
-    },
+    ],
 )

--- a/crates/pixi_build_discovery/src/discovery.rs
+++ b/crates/pixi_build_discovery/src/discovery.rs
@@ -388,10 +388,16 @@ impl DiscoveredBackend {
 
         let channels = retrieve_channels(&source_dir, channel_config)?;
 
+        // If this package.xml lives inside a pixi workspace, hand the backend
+        // the actual workspace root so it can discover sibling ROS packages.
+        // Otherwise (a bare package.xml outside any workspace), fall back to
+        // the package's own directory.
+        let workspace_root = workspace_root_for(&source_dir).unwrap_or_else(|| source_dir.clone());
+
         Ok(Self {
             backend_spec: BackendSpec::JsonRpc(JsonRpcBackendSpec::default_ros_build(channels)),
             init_params: BackendInitializationParams {
-                workspace_root: source_dir.clone(),
+                workspace_root,
                 build_source: None,
                 source_anchor: source_dir,
                 manifest_path: package_xml_absolute_path
@@ -442,4 +448,21 @@ fn retrieve_channels(
         })
         .collect::<Result<_, _>>()?;
     Ok(channels)
+}
+
+/// Look for a pixi workspace manifest at or above `start` and return its
+/// containing directory. Returns `None` if no workspace is found or if
+/// discovery fails for any reason; the caller decides on the fallback.
+fn workspace_root_for(start: &Path) -> Option<PathBuf> {
+    let manifests = WorkspaceDiscoverer::new(DiscoveryStart::SearchRoot(start.to_path_buf()))
+        .discover()
+        .ok()
+        .flatten()?;
+    manifests
+        .value
+        .workspace
+        .provenance
+        .path
+        .parent()
+        .map(Path::to_path_buf)
 }

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__direct_package_xml.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__direct_package_xml.snap
@@ -13,7 +13,7 @@ backend-spec:
     channels:
       - "https://prefix.dev/conda-forge"
 init-params:
-  workspace-root: "file://<ROOT>/ros-package"
+  workspace-root: "file://<ROOT>/"
   build-source: ~
   source-anchor: "file://<ROOT>/ros-package"
   manifest-path: "file://<ROOT>/ros-package"

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@ros-package.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@ros-package.snap
@@ -5,4 +5,4 @@ input_file: tests/data/discovery/ros-package/TEST-CASE
 ---
   × the source directory '<CARGO_ROOT>/tests/data/discovery/ros-package', does not contain a supported manifest
   help: ROS packages require you to specify the 'package.xml' file path directly, due to supporting more backends in the future. Or ensure that the source directory contains a valid manifest file:
-        pixi.toml, pyproject.toml, mojoproject.toml, recipe.yaml, recipe.yml.
+        pixi.toml, pyproject.toml, mojoproject.toml, recipe.yaml, recipe.yml, package.xml.

--- a/crates/pixi_build_frontend/src/backend/json_rpc.rs
+++ b/crates/pixi_build_frontend/src/backend/json_rpc.rs
@@ -146,6 +146,7 @@ impl JsonRpcBackend {
         source_dir: PathBuf,
         manifest_path: PathBuf,
         workspace_root: PathBuf,
+        checkout_root: Option<PathBuf>,
         package_manifest: Option<ProjectModel>,
         configuration: Option<serde_json::Value>,
         target_configuration: Option<OrderMap<TargetSelector, serde_json::Value>>,
@@ -156,6 +157,7 @@ impl JsonRpcBackend {
         debug_assert!(source_dir.is_absolute());
         debug_assert!(manifest_path.is_absolute());
         debug_assert!(workspace_root.is_absolute());
+        debug_assert!(checkout_root.as_ref().is_none_or(|p| p.is_absolute()));
         // Spawn the tool and capture stdin/stdout.
         let command = tool.command();
         let program_name = command.get_program().to_string_lossy().into_owned();
@@ -197,6 +199,7 @@ impl JsonRpcBackend {
             source_dir,
             manifest_path,
             workspace_root,
+            checkout_root,
             package_manifest,
             configuration,
             target_configuration,
@@ -217,6 +220,7 @@ impl JsonRpcBackend {
         source_dir: PathBuf,
         manifest_path: PathBuf,
         workspace_root: PathBuf,
+        checkout_root: Option<PathBuf>,
         project_model: Option<ProjectModel>,
         configuration: Option<serde_json::Value>,
         target_configuration: Option<OrderMap<TargetSelector, serde_json::Value>>,
@@ -261,6 +265,7 @@ impl JsonRpcBackend {
                     manifest_path: manifest_path.clone(),
                     source_directory: Some(source_dir),
                     workspace_directory: Some(workspace_root),
+                    checkout_root,
                     cache_directory: cache_dir,
                     workspace_scratch_directory,
                 }),

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -18,11 +18,7 @@ use rattler_build_types::NormalizedKey;
 use rattler_conda_types::{ChannelUrl, Platform};
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::{
-    collections::BTreeMap,
-    path::Path,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 #[derive(Default, Clone)]
 pub struct MojoGenerator {}
@@ -43,6 +39,7 @@ impl GenerateRecipe for MojoGenerator {
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
         _workspace_directory: Option<PathBuf>,
+        _checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root, because `manifest_path` can be
         // either a direct file path or a directory path.
@@ -270,6 +267,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -322,6 +320,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -362,6 +361,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -431,6 +431,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -477,6 +478,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -531,6 +533,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -575,6 +578,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -658,6 +662,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -719,6 +724,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,

--- a/crates/pixi_build_mojo/src/main.rs
+++ b/crates/pixi_build_mojo/src/main.rs
@@ -19,7 +19,7 @@ use rattler_conda_types::{ChannelUrl, Platform};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     path::Path,
     sync::Arc,
 };
@@ -42,6 +42,7 @@ impl GenerateRecipe for MojoGenerator {
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
+        _workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root, because `manifest_path` can be
         // either a direct file path or a directory path.
@@ -112,7 +113,7 @@ impl GenerateRecipe for MojoGenerator {
             )
             .with_secrets(model.secrets.iter().cloned().collect());
 
-        generated_recipe.build_input_globs = Self::globs().collect::<BTreeSet<_>>();
+        generated_recipe.build_input_globs = Self::globs().collect();
 
         Ok(generated_recipe)
     }
@@ -122,7 +123,7 @@ impl GenerateRecipe for MojoGenerator {
         config: &Self::Config,
         _workdir: impl AsRef<Path>,
         _editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
+    ) -> miette::Result<Vec<String>> {
         Ok(Self::globs()
             .chain(config.extra_input_globs.clone())
             .collect())
@@ -268,6 +269,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -319,6 +321,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -359,6 +362,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -426,6 +430,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -472,6 +477,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -524,6 +530,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -568,6 +575,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -649,6 +657,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -710,6 +719,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_mojo/src/snapshots/pixi_build_mojo__tests__input_globs_includes_extra_globs.snap
@@ -3,8 +3,8 @@ source: crates/pixi_build_mojo/src/main.rs
 expression: result
 ---
 Ok(
-    {
+    [
         "**/*.mojo",
         "**/.c",
-    },
+    ],
 )

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -25,7 +25,7 @@ use rattler_conda_types::{
 };
 use std::collections::HashSet;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -130,6 +130,7 @@ impl GenerateRecipe for PythonGenerator {
         channels: Vec<ChannelUrl>,
         cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
+        _workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
@@ -370,7 +371,7 @@ impl GenerateRecipe for PythonGenerator {
         let pyproject_manifest = if pyproject_manifest_path.exists() {
             let contents = fs::read_to_string(&pyproject_manifest_path).into_diagnostic()?;
             generated_recipe.build_input_globs =
-                BTreeSet::from([pyproject_manifest_path.to_string_lossy().to_string()]);
+                vec![pyproject_manifest_path.to_string_lossy().to_string()];
             Some(toml::from_str(&contents).into_diagnostic()?)
         } else {
             None
@@ -438,7 +439,7 @@ impl GenerateRecipe for PythonGenerator {
         config: &Self::Config,
         _workdir: impl AsRef<Path>,
         editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
+    ) -> miette::Result<Vec<String>> {
         let base_globs = Vec::from([
             // Project configuration
             "setup.py",
@@ -707,6 +708,7 @@ version = "0.1.0"
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -751,6 +753,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -798,6 +801,7 @@ version = "0.1.0"
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -839,6 +843,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -913,6 +918,7 @@ version = "0.1.0"
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -962,6 +968,7 @@ version = "0.1.0"
                 None,
                 &std::collections::HashSet::<pixi_build_backend::variants::NormalizedKey>::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -1082,6 +1089,7 @@ version = "0.1.0"
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1089,7 +1097,8 @@ version = "0.1.0"
         assert!(
             generated_recipe
                 .build_input_globs
-                .contains(CYTHON_INPUT_GLOBS[0])
+                .iter()
+                .any(|g| g == CYTHON_INPUT_GLOBS[0])
         );
     }
 
@@ -1121,6 +1130,7 @@ version = "0.1.0"
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1128,7 +1138,8 @@ version = "0.1.0"
         assert!(
             generated_recipe
                 .build_input_globs
-                .contains(CYTHON_INPUT_GLOBS[0])
+                .iter()
+                .any(|g| g == CYTHON_INPUT_GLOBS[0])
         );
     }
 
@@ -1141,7 +1152,12 @@ version = "0.1.0"
         .await
         .expect("Failed to generate recipe");
 
-        assert!(!recipe.build_input_globs.contains(CYTHON_INPUT_GLOBS[0]));
+        assert!(
+            !recipe
+                .build_input_globs
+                .iter()
+                .any(|g| g == CYTHON_INPUT_GLOBS[0])
+        );
     }
 
     #[test]
@@ -1222,6 +1238,7 @@ build-backend = "hatchling.build"
                 vec![ChannelUrl::from(
                     url::Url::parse("https://prefix.dev/conda-forge").unwrap(),
                 )],
+                None,
                 None,
                 None,
             )
@@ -1337,6 +1354,7 @@ build-backend = "setuptools.build_meta"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -131,6 +131,7 @@ impl GenerateRecipe for PythonGenerator {
         cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
         _workspace_directory: Option<PathBuf>,
+        _checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         let params = python_params.unwrap_or_default();
 
@@ -709,6 +710,7 @@ version = "0.1.0"
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -753,6 +755,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -802,6 +805,7 @@ version = "0.1.0"
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -843,6 +847,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -919,6 +924,7 @@ version = "0.1.0"
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -968,6 +974,7 @@ version = "0.1.0"
                 None,
                 &std::collections::HashSet::<pixi_build_backend::variants::NormalizedKey>::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -1090,6 +1097,7 @@ version = "0.1.0"
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1128,6 +1136,7 @@ version = "0.1.0"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -1238,6 +1247,7 @@ build-backend = "hatchling.build"
                 vec![ChannelUrl::from(
                     url::Url::parse("https://prefix.dev/conda-forge").unwrap(),
                 )],
+                None,
                 None,
                 None,
                 None,
@@ -1354,6 +1364,7 @@ build-backend = "setuptools.build_meta"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,

--- a/crates/pixi_build_python/src/metadata.rs
+++ b/crates/pixi_build_python/src/metadata.rs
@@ -957,6 +957,7 @@ Documentation = "https://docs.example.com"
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1004,6 +1005,7 @@ requires-python = ">=3.13"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,

--- a/crates/pixi_build_python/src/metadata.rs
+++ b/crates/pixi_build_python/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeSet, path::PathBuf, str::FromStr};
+use std::{cell::RefCell, path::PathBuf, str::FromStr};
 
 use miette::Diagnostic;
 use once_cell::unsync::OnceCell;
@@ -99,17 +99,17 @@ impl PyprojectMetadataProvider {
     ///
     /// # Returns
     ///
-    /// A `BTreeSet` of glob patterns as strings. Common patterns include:
+    /// A `Vec` of glob patterns as strings. Common patterns include:
     /// - `"pyproject.toml"` - The package's manifest file
-    pub fn input_globs(&self) -> BTreeSet<String> {
-        let mut input_globs = BTreeSet::new();
+    pub fn input_globs(&self) -> Vec<String> {
+        let mut input_globs = Vec::new();
 
         let Some(_) = self.pyproject_manifest.get() else {
             return input_globs;
         };
 
         // Add the pyproject.toml manifest file itself.
-        input_globs.insert(String::from("pyproject.toml"));
+        input_globs.push(String::from("pyproject.toml"));
 
         input_globs
     }
@@ -651,7 +651,7 @@ requires = ["setuptools", "wheel"]
 
         let globs = provider.input_globs();
         assert_eq!(globs.len(), 1);
-        assert!(globs.contains("pyproject.toml"));
+        assert!(globs.iter().any(|g| g == "pyproject.toml"));
     }
 
     #[test]
@@ -956,6 +956,7 @@ Documentation = "https://docs.example.com"
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -1003,6 +1004,7 @@ requires-python = ">=3.13"
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__c_compilers_create_extra_input_globs.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__c_compilers_create_extra_input_globs.snap
@@ -3,16 +3,16 @@ source: crates/pixi_build_python/src/main.rs
 expression: result
 ---
 Ok(
-    {
-        "**/*.py",
-        "**/*.{c,h}",
+    [
+        "setup.py",
+        "setup.cfg",
+        "pyproject.toml",
+        "requirements*.txt",
         "Pipfile",
         "Pipfile.lock",
         "poetry.lock",
-        "pyproject.toml",
-        "requirements*.txt",
-        "setup.cfg",
-        "setup.py",
         "tox.ini",
-    },
+        "**/*.py",
+        "**/*.{c,h}",
+    ],
 )

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__cxx_compilers_create_extra_input_globs.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__cxx_compilers_create_extra_input_globs.snap
@@ -3,16 +3,16 @@ source: crates/pixi_build_python/src/main.rs
 expression: result
 ---
 Ok(
-    {
-        "**/*.py",
-        "**/*.{cc,cxx,cpp,hpp,hxx}",
+    [
+        "setup.py",
+        "setup.cfg",
+        "pyproject.toml",
+        "requirements*.txt",
         "Pipfile",
         "Pipfile.lock",
         "poetry.lock",
-        "pyproject.toml",
-        "requirements*.txt",
-        "setup.cfg",
-        "setup.py",
         "tox.ini",
-    },
+        "**/*.py",
+        "**/*.{cc,cxx,cpp,hpp,hxx}",
+    ],
 )

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__input_globs_includes_extra_globs.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__input_globs_includes_extra_globs.snap
@@ -3,16 +3,16 @@ source: crates/pixi_build_python/src/main.rs
 expression: result
 ---
 Ok(
-    {
-        "**/*.py",
-        "Pipfile",
-        "Pipfile.lock",
-        "custom/*.py",
-        "poetry.lock",
+    [
+        "setup.py",
+        "setup.cfg",
         "pyproject.toml",
         "requirements*.txt",
-        "setup.cfg",
-        "setup.py",
+        "Pipfile",
+        "Pipfile.lock",
+        "poetry.lock",
         "tox.ini",
-    },
+        "**/*.py",
+        "custom/*.py",
+    ],
 )

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__input_globs_includes_extra_globs_editable.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__input_globs_includes_extra_globs_editable.snap
@@ -3,15 +3,15 @@ source: crates/pixi_build_python/src/main.rs
 expression: result
 ---
 Ok(
-    {
-        "Pipfile",
-        "Pipfile.lock",
-        "custom/*.py",
-        "poetry.lock",
+    [
+        "setup.py",
+        "setup.cfg",
         "pyproject.toml",
         "requirements*.txt",
-        "setup.cfg",
-        "setup.py",
+        "Pipfile",
+        "Pipfile.lock",
+        "poetry.lock",
         "tox.ini",
-    },
+        "custom/*.py",
+    ],
 )

--- a/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__rust_compilers_create_extra_input_globs.snap
+++ b/crates/pixi_build_python/src/snapshots/pixi_build_python__tests__rust_compilers_create_extra_input_globs.snap
@@ -3,17 +3,17 @@ source: crates/pixi_build_python/src/main.rs
 expression: result
 ---
 Ok(
-    {
-        "**/*.py",
-        "**/*.rs",
-        "**/Cargo.toml",
+    [
+        "setup.py",
+        "setup.cfg",
+        "pyproject.toml",
+        "requirements*.txt",
         "Pipfile",
         "Pipfile.lock",
         "poetry.lock",
-        "pyproject.toml",
-        "requirements*.txt",
-        "setup.cfg",
-        "setup.py",
         "tox.ini",
-    },
+        "**/*.py",
+        "**/*.rs",
+        "**/Cargo.toml",
+    ],
 )

--- a/crates/pixi_build_r/src/main.rs
+++ b/crates/pixi_build_r/src/main.rs
@@ -77,6 +77,7 @@ impl GenerateRecipe for RGenerator {
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
         _workspace_directory: Option<PathBuf>,
+        _checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root
         let manifest_root = if manifest_path.is_file() {
@@ -351,6 +352,7 @@ LinkingTo: Rcpp
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -412,6 +414,7 @@ LinkingTo: Rcpp
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -509,6 +512,7 @@ Imports:
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -618,6 +622,7 @@ Imports:
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,

--- a/crates/pixi_build_r/src/main.rs
+++ b/crates/pixi_build_r/src/main.rs
@@ -76,6 +76,7 @@ impl GenerateRecipe for RGenerator {
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
+        _workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root
         let manifest_root = if manifest_path.is_file() {
@@ -225,7 +226,7 @@ impl GenerateRecipe for RGenerator {
         config: &Self::Config,
         _workdir: impl AsRef<Path>,
         _editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
+    ) -> miette::Result<Vec<String>> {
         let mut globs = BTreeSet::from(
             [
                 // R package structure files
@@ -265,7 +266,7 @@ impl GenerateRecipe for RGenerator {
         // Add extra globs from config
         globs.extend(config.extra_input_globs.clone());
 
-        Ok(globs)
+        Ok(globs.into_iter().collect())
     }
 
     fn default_variants(
@@ -349,6 +350,7 @@ LinkingTo: Rcpp
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -412,6 +414,7 @@ LinkingTo: Rcpp
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -444,11 +447,12 @@ LinkingTo: Rcpp
             .extract_input_globs_from_build(&config, PathBuf::new(), false)
             .unwrap();
 
-        assert!(globs.contains("DESCRIPTION"));
-        assert!(globs.contains("NAMESPACE"));
-        assert!(globs.contains("**/*.R"));
-        assert!(globs.contains("**/*.c"));
-        assert!(globs.contains("**/*.cpp"));
+        let contains = |needle: &str| globs.iter().any(|g| g == needle);
+        assert!(contains("DESCRIPTION"));
+        assert!(contains("NAMESPACE"));
+        assert!(contains("**/*.R"));
+        assert!(contains("**/*.c"));
+        assert!(contains("**/*.cpp"));
     }
 
     #[test]
@@ -463,7 +467,7 @@ LinkingTo: Rcpp
             .extract_input_globs_from_build(&config, PathBuf::new(), false)
             .unwrap();
 
-        assert!(globs.contains("inst/**/*"));
+        assert!(globs.iter().any(|g| g == "inst/**/*"));
     }
 
     #[tokio::test]
@@ -505,6 +509,7 @@ Imports:
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -613,6 +618,7 @@ Imports:
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/pixi_build_r/src/metadata.rs
+++ b/crates/pixi_build_r/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, collections::HashMap, path::PathBuf, sync::LazyLock};
+use std::{collections::HashMap, path::PathBuf, sync::LazyLock};
 
 use miette::Diagnostic;
 use once_cell::unsync::OnceCell;
@@ -325,11 +325,11 @@ impl DescriptionMetadataProvider {
     }
 
     /// Returns input globs for R package files
-    pub fn input_globs(&self) -> BTreeSet<String> {
-        let mut globs = BTreeSet::new();
+    pub fn input_globs(&self) -> Vec<String> {
+        let mut globs = Vec::new();
 
         if self.description_data.get().is_some() {
-            globs.insert("DESCRIPTION".to_string());
+            globs.push("DESCRIPTION".to_string());
         }
 
         globs

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -286,6 +286,7 @@ impl Protocol for RattlerBuildBackend {
 
                 // The input globs are the same for all outputs
                 input_globs: None,
+                input_glob_sets: None,
                 // TODO: Implement caching
             });
         }
@@ -299,6 +300,7 @@ impl Protocol for RattlerBuildBackend {
         Ok(CondaOutputsResult {
             outputs,
             input_globs,
+            input_glob_sets: None,
         })
     }
 
@@ -484,6 +486,7 @@ impl Protocol for RattlerBuildBackend {
                 extract_mutable_package_sources(&output),
                 self.config.extra_input_globs.clone(),
             )?,
+            input_glob_sets: None,
             name: output.name().as_normalized().to_string(),
             version: output.version().clone(),
             build: output.build_string().into_owned(),
@@ -723,6 +726,7 @@ mod tests {
                 let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
                     .initialize(InitializeParams {
                         workspace_directory: None,
+                        checkout_root: None,
                         source_directory: None,
                         manifest_path: recipe_path.to_path_buf(),
                         project_model: None,
@@ -789,6 +793,7 @@ mod tests {
         let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 workspace_directory: None,
+                checkout_root: None,
                 source_directory: None,
                 manifest_path: recipe_path,
                 project_model: None,
@@ -836,6 +841,7 @@ mod tests {
         let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 workspace_directory: None,
+                checkout_root: None,
                 source_directory: None,
                 manifest_path: recipe_path.clone(),
                 project_model: None,
@@ -902,6 +908,7 @@ numpy:
         let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 workspace_directory: None,
+                checkout_root: None,
                 source_directory: None,
                 manifest_path: recipe_path,
                 project_model: None,
@@ -976,6 +983,7 @@ numpy:
         let factory = RattlerBuildBackendInstantiator::new(LoggingOutputHandler::default())
             .initialize(InitializeParams {
                 workspace_directory: None,
+                checkout_root: None,
                 source_directory: None,
                 manifest_path: recipe_path,
                 project_model: None,

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -546,7 +546,7 @@ fn build_input_globs(
     source: &Path,
     package_sources: Option<Vec<PathBuf>>,
     extra_globs: Vec<String>,
-) -> miette::Result<BTreeSet<String>> {
+) -> miette::Result<Vec<String>> {
     // Get parent directory path
     let src_parent = if source.is_file() {
         // use the parent path as glob
@@ -557,7 +557,7 @@ fn build_input_globs(
     };
 
     // Always add the current directory of the package to the globs
-    let mut input_globs = BTreeSet::from([build_relative_glob(manifest_root, &src_parent)?]);
+    let mut input_globs = vec![build_relative_glob(manifest_root, &src_parent)?];
 
     // If there are sources add them to the globs as well
     if let Some(package_sources) = package_sources {
@@ -567,7 +567,7 @@ fn build_input_globs(
             } else {
                 src_parent.join(source)
             };
-            input_globs.insert(build_relative_glob(manifest_root, &source)?);
+            input_globs.push(build_relative_glob(manifest_root, &source)?);
         }
     }
 
@@ -582,10 +582,10 @@ fn build_input_globs(
 fn get_metadata_input_globs(
     manifest_root: &Path,
     recipe_source_path: &Path,
-) -> miette::Result<BTreeSet<String>> {
+) -> miette::Result<Vec<String>> {
     match build_relative_glob(manifest_root, recipe_source_path) {
-        Ok(rel) if !rel.is_empty() => Ok(BTreeSet::from_iter([rel])),
-        Ok(_) => Ok(Default::default()),
+        Ok(rel) if !rel.is_empty() => Ok(vec![rel]),
+        Ok(_) => Ok(Vec::new()),
         Err(e) => Err(e),
     }
 }
@@ -1213,7 +1213,7 @@ numpy:
         let recipe_path = base_path.join("recipe.yaml");
         fs::write(&recipe_path, "fake").unwrap();
         let globs = super::build_input_globs(base_path, &recipe_path, None, Vec::new()).unwrap();
-        assert_eq!(globs, BTreeSet::from([String::from("**")]));
+        assert_eq!(globs, vec![String::from("**")]);
 
         // Case 2: source is a directory, with a file and a dir as package sources
         let pkg_dir = base_path.join("pkg");
@@ -1230,11 +1230,11 @@ numpy:
         .unwrap();
         assert_eq!(
             globs,
-            BTreeSet::from([
+            vec![
                 String::from("**"),
                 String::from("pkg/file.txt"),
-                String::from("pkg/dir/**")
-            ])
+                String::from("pkg/dir/**"),
+            ]
         );
 
         // Case 3: source is a file in a subdirectory (custom recipe path)
@@ -1243,7 +1243,7 @@ numpy:
         fs::create_dir_all(&custom_dir).unwrap();
         fs::write(&custom_recipe, "fake").unwrap();
         let globs = super::build_input_globs(base_path, &custom_recipe, None, Vec::new()).unwrap();
-        assert_eq!(globs, BTreeSet::from([String::from("custom/**")]));
+        assert_eq!(globs, vec![String::from("custom/**")]);
     }
 
     #[test]
@@ -1269,7 +1269,7 @@ numpy:
         .unwrap();
         assert_eq!(
             globs,
-            BTreeSet::from([String::from("source/**"), String::from("pkgsrc/**")])
+            vec![String::from("source/**"), String::from("pkgsrc/**")]
         );
     }
 
@@ -1298,7 +1298,7 @@ numpy:
         // The relative path from base_path to rel_dir should be "rel_folder/**"
         assert_eq!(
             globs,
-            BTreeSet::from_iter(["**", "rel_folder/**"].into_iter().map(ToString::to_string))
+            vec![String::from("**"), String::from("rel_folder/**")]
         );
     }
 
@@ -1309,30 +1309,27 @@ numpy:
         let manifest_root = PathBuf::from("/foo/bar");
         let path = PathBuf::from("/foo/bar/recipe.yaml");
         let globs = super::get_metadata_input_globs(&manifest_root, &path).unwrap();
-        assert_eq!(globs, BTreeSet::from([String::from("recipe.yaml")]));
+        assert_eq!(globs, vec![String::from("recipe.yaml")]);
         // Case: file with no name (root)
         let manifest_root = PathBuf::from("/");
         let path = PathBuf::from("/");
         let globs = super::get_metadata_input_globs(&manifest_root, &path).unwrap();
-        assert_eq!(globs, BTreeSet::from([String::from("**")]));
+        assert_eq!(globs, vec![String::from("**")]);
         // Case: file with .yml extension
         let manifest_root = PathBuf::from("/foo/bar");
         let path = PathBuf::from("/foo/bar/recipe.yml");
         let globs = super::get_metadata_input_globs(&manifest_root, &path).unwrap();
-        assert_eq!(globs, BTreeSet::from([String::from("recipe.yml")]));
+        assert_eq!(globs, vec![String::from("recipe.yml")]);
         // Case: file in subdir
         let manifest_root = PathBuf::from("/foo");
         let path = PathBuf::from("/foo/bar/recipe.yaml");
         let globs = super::get_metadata_input_globs(&manifest_root, &path).unwrap();
-        assert_eq!(globs, BTreeSet::from([String::from("bar/recipe.yaml")]));
+        assert_eq!(globs, vec![String::from("bar/recipe.yaml")]);
         // Case: custom recipe in nested subdir
         let manifest_root = PathBuf::from("/tmp/xxx");
         let path = PathBuf::from("/tmp/xxx/custom/my_recipe.yaml");
         let globs = super::get_metadata_input_globs(&manifest_root, &path).unwrap();
-        assert_eq!(
-            globs,
-            BTreeSet::from([String::from("custom/my_recipe.yaml")])
-        );
+        assert_eq!(globs, vec![String::from("custom/my_recipe.yaml")]);
     }
 
     #[test]
@@ -1350,15 +1347,17 @@ numpy:
         let globs =
             super::build_input_globs(base_path, &recipe_path, None, extra_globs.clone()).unwrap();
 
+        let contains = |needle: &str| globs.iter().any(|g| g == needle);
+
         // Verify that all extra globs are included in the result
         for extra_glob in &extra_globs {
             assert!(
-                globs.contains(extra_glob),
+                contains(extra_glob),
                 "Result should contain extra glob: {extra_glob}"
             );
         }
 
         // Verify that the basic manifest glob is still present
-        assert!(globs.contains("**"));
+        assert!(contains("**"));
     }
 }

--- a/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@boltons__recipe.yaml.snap
+++ b/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@boltons__recipe.yaml.snap
@@ -41,7 +41,7 @@ input_file: tests/recipe/boltons/recipe.yaml
     }
   ],
   "inputGlobs": [
-    "recipe.yaml",
-    "variants.yaml"
+    "variants.yaml",
+    "recipe.yaml"
   ]
 }

--- a/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@custom-build-string__recipe.yaml.snap
+++ b/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@custom-build-string__recipe.yaml.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_build_rattler_build/src/protocol.rs
-assertion_line: 723
 expression: conda_outputs_snapshot(result)
 input_file: tests/recipe/custom-build-string/recipe.yaml
 ---
@@ -22,7 +21,7 @@ input_file: tests/recipe/custom-build-string/recipe.yaml
     }
   ],
   "inputGlobs": [
-    "recipe.yaml",
-    "variants.yaml"
+    "variants.yaml",
+    "recipe.yaml"
   ]
 }

--- a/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage-variants__recipe.yaml.snap
+++ b/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage-variants__recipe.yaml.snap
@@ -163,7 +163,7 @@ input_file: tests/recipe/pin-subpackage-variants/recipe.yaml
     }
   ],
   "inputGlobs": [
-    "recipe.yaml",
-    "variants.yaml"
+    "variants.yaml",
+    "recipe.yaml"
   ]
 }

--- a/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage__recipe.yaml.snap
+++ b/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@pin-subpackage__recipe.yaml.snap
@@ -48,7 +48,7 @@ input_file: tests/recipe/pin-subpackage/recipe.yaml
     }
   ],
   "inputGlobs": [
-    "recipe.yaml",
-    "variants.yaml"
+    "variants.yaml",
+    "recipe.yaml"
   ]
 }

--- a/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@variants__recipe.yaml.snap
+++ b/crates/pixi_build_rattler_build/src/snapshots/pixi_build_rattler_build__protocol__tests__conda_outputs@variants__recipe.yaml.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_build_rattler_build/src/protocol.rs
-assertion_line: 723
 expression: conda_outputs_snapshot(result)
 input_file: tests/recipe/variants/recipe.yaml
 ---
@@ -101,7 +100,7 @@ input_file: tests/recipe/variants/recipe.yaml
     }
   ],
   "inputGlobs": [
-    "recipe.yaml",
-    "variants.yaml"
+    "variants.yaml",
+    "recipe.yaml"
   ]
 }

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -21,6 +21,7 @@ fs-err = { workspace = true }
 http-cache-reqwest = { workspace = true }
 indexmap = { workspace = true }
 miette = { workspace = true }
+pathdiff = { workspace = true }
 pixi_build_backend = { workspace = true }
 pixi_build_types = { workspace = true }
 rattler_build_jinja = { workspace = true }
@@ -36,6 +37,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
+tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -24,6 +24,7 @@ miette = { workspace = true }
 pathdiff = { workspace = true }
 pixi_build_backend = { workspace = true }
 pixi_build_types = { workspace = true }
+pixi_glob = { workspace = true }
 rattler_build_jinja = { workspace = true }
 rattler_build_recipe = { workspace = true }
 rattler_build_types = { workspace = true }

--- a/crates/pixi_build_ros/src/config.rs
+++ b/crates/pixi_build_ros/src/config.rs
@@ -37,6 +37,13 @@ pub struct RosBackendConfig {
     /// Extra package mapping sources.
     #[serde(default)]
     pub extra_package_mappings: Vec<PackageMappingSource>,
+
+    /// When `true`, skip workspace-sibling discovery for this package and
+    /// resolve every dependency as a binary through RoboStack instead. Useful
+    /// for pinning a single package against a stability baseline while
+    /// iterating on the rest of the workspace.
+    #[serde(default)]
+    pub ignore_workspace_sources: bool,
 }
 
 impl RosBackendConfig {
@@ -81,6 +88,8 @@ impl BackendConfig for RosBackendConfig {
             } else {
                 target_config.extra_package_mappings.clone()
             },
+            ignore_workspace_sources: target_config.ignore_workspace_sources
+                || self.ignore_workspace_sources,
         })
     }
 }

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -58,6 +58,7 @@ impl GenerateRecipe for RosGenerator {
         _cache_dir: Option<PathBuf>,
         workspace_scratch_directory: Option<PathBuf>,
         workspace_directory: Option<PathBuf>,
+        checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root
         let manifest_root = if manifest_path.is_file() {
@@ -131,13 +132,13 @@ impl GenerateRecipe for RosGenerator {
             package_mapping_files,
         )?;
 
-        // `parse_and_render` already populated `metadata_input_globs` with the
-        // provider's anchored package-local patterns (`setup.py`,
-        // `CMakeLists.txt`, ...). Lift them out for now and re-append after
-        // discovery so they sit *after* discovery's broad `!<dir>/**`
-        // exclusions; pixi's last-match-wins matcher then leaves them
-        // intact.
-        let provider_globs = std::mem::take(&mut generated_recipe.metadata_input_globs);
+        // `parse_and_render` already populated `metadata_input_globs` with
+        // the provider's anchored package-local patterns (`setup.py`,
+        // `CMakeLists.txt`, ...).  Workspace-discovery globs (the
+        // `../**/package.xml` / `**/COLCON_IGNORE` family and the
+        // `!**/.*/**` hidden-folder exclusion) are no longer emitted on
+        // the flat list: they're carried by `metadata_input_glob_sets`
+        // with marker semantics that the flat form can't express.
 
         // Load package mappings
         let robostack_yaml: &str = include_str!("../robostack.yaml");
@@ -161,19 +162,27 @@ impl GenerateRecipe for RosGenerator {
         // package.xml deps that match a sibling into source dependencies, so
         // pixi resolves them against the sibling directory instead of looking
         // them up as a binary through RoboStack.
-        if let Some(workspace_root) = workspace_directory.as_deref()
+        //
+        // Prefer `checkout_root` (set by newer pixi versions) when available
+        // because it correctly resolves to the git/url checkout root for
+        // remote source dependencies — `workspace_directory` for those
+        // cases points at the package's subdirectory and would miss every
+        // sibling.  For path sources the two values agree.  Older pixi
+        // versions don't send `checkout_root`; fall back to
+        // `workspace_directory` so this backend keeps working there.
+        let discovery_root = checkout_root.as_deref().or(workspace_directory.as_deref());
+        if let Some(workspace_root) = discovery_root
             && !config.ignore_workspace_sources
         {
             let discovery = workspace_discovery::discover_ros_packages(workspace_root)?;
 
-            for glob in &discovery.input_globs {
-                let rewritten = workspace_discovery::rewrite_glob_for_manifest_root(
-                    glob,
-                    workspace_root,
-                    &manifest_root,
-                );
-                generated_recipe.metadata_input_globs.push(rewritten);
-            }
+            // Emit the structured form.  Pointing `root` at the workspace
+            // lets pixi walk from there directly without ascending via
+            // `../..` patterns; the marker semantics handle pruning at
+            // `COLCON_IGNORE` / `AMENT_IGNORE` / `CATKIN_IGNORE`.
+            let mut structured = discovery.input_glob_set;
+            structured.root = Some(workspace_root.to_path_buf());
+            generated_recipe.metadata_input_glob_sets.push(structured);
 
             let sibling_specs = workspace_discovery::sibling_source_spec_map(
                 &discovery.packages,
@@ -211,11 +220,19 @@ impl GenerateRecipe for RosGenerator {
             );
         }
 
-        // Re-append the provider globs at the very end of the list so they
-        // sit after any discovery exclusions and aren't suppressed by them.
-        generated_recipe
-            .metadata_input_globs
-            .extend(provider_globs);
+        // Mirror the provider's package-local literals (`setup.py`,
+        // `CMakeLists.txt`, ...) into the structured list as a second
+        // group rooted at the package manifest (the consumer's default).
+        if !generated_recipe.metadata_input_globs.is_empty() {
+            generated_recipe
+                .metadata_input_glob_sets
+                .push(pixi_build_types::InputGlobSet {
+                    patterns: generated_recipe.metadata_input_globs.clone(),
+                    markers: Vec::new(),
+                    exclude_hidden: true,
+                    root: None,
+                });
+        }
 
         // Add standard build dependencies
         let mut build_deps: Vec<&str> = vec![
@@ -525,6 +542,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -655,6 +673,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe")
@@ -743,6 +762,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -973,6 +993,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe with explicit package.xml path");
@@ -1009,6 +1030,7 @@ mod tests {
                 vec![ChannelUrl::from(
                     url::Url::parse("https://prefix.dev/robostack-jazzy").unwrap(),
                 )],
+                None,
                 None,
                 None,
                 None,
@@ -1060,6 +1082,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Explicit distro should override channel");
@@ -1104,6 +1127,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -1139,6 +1163,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -1265,7 +1290,7 @@ mod tests {
     }
 
     fn write_minimal_package_xml(dir: &std::path::Path, name: &str, deps: &[&str]) {
-        std::fs::create_dir_all(dir).unwrap();
+        fs::create_dir_all(dir).unwrap();
         let depend_tags: String = deps
             .iter()
             .map(|d| format!("  <depend>{d}</depend>\n"))
@@ -1282,7 +1307,7 @@ mod tests {
 {depend_tags}</package>
 "#
         );
-        std::fs::write(dir.join("package.xml"), xml).unwrap();
+        fs::write(dir.join("package.xml"), xml).unwrap();
     }
 
     /// Returns the first concrete item whose package name equals `conda_name`.
@@ -1306,7 +1331,11 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let workspace_root = workspace.path();
 
-        write_minimal_package_xml(&workspace_root.join("src").join("pkg_a"), "pkg_a", &["pkg_b"]);
+        write_minimal_package_xml(
+            &workspace_root.join("src").join("pkg_a"),
+            "pkg_a",
+            &["pkg_b"],
+        );
         write_minimal_package_xml(&workspace_root.join("src").join("pkg_b"), "pkg_b", &[]);
 
         let pkg_a_manifest = workspace_root.join("src").join("pkg_a");
@@ -1329,6 +1358,7 @@ mod tests {
                 None,
                 None,
                 Some(workspace_root.to_path_buf()),
+                None,
             )
             .await
             .expect("generate_recipe should succeed");
@@ -1341,9 +1371,8 @@ mod tests {
             "expected ros-jazzy-pkg-b to be a source dep, got: {sibling_in_build}"
         );
 
-        let sibling_in_run =
-            find_concrete(&generated.recipe.requirements.run, "ros-jazzy-pkg-b")
-                .expect("sibling should also appear in run requirements");
+        let sibling_in_run = find_concrete(&generated.recipe.requirements.run, "ros-jazzy-pkg-b")
+            .expect("sibling should also appear in run requirements");
         assert!(
             sibling_in_run.0.url.is_some(),
             "expected ros-jazzy-pkg-b in run to be source, got: {sibling_in_run}"
@@ -1376,6 +1405,7 @@ mod tests {
                 None,
                 None,
                 Some(workspace_root.to_path_buf()),
+                None,
             )
             .await
             .expect("generate_recipe should succeed");
@@ -1424,6 +1454,7 @@ mod tests {
                 None,
                 None,
                 Some(workspace_root.to_path_buf()),
+                None,
             )
             .await
             .expect("generate_recipe should succeed");
@@ -1448,8 +1479,8 @@ mod tests {
         let workspace = tempfile::tempdir().unwrap();
         let workspace_root = workspace.path();
         write_minimal_package_xml(&workspace_root.join("src").join("pkg_a"), "pkg_a", &[]);
-        std::fs::create_dir_all(workspace_root.join("build")).unwrap();
-        std::fs::write(workspace_root.join("build").join("COLCON_IGNORE"), b"").unwrap();
+        fs::create_dir_all(workspace_root.join("build")).unwrap();
+        fs::write(workspace_root.join("build").join("COLCON_IGNORE"), b"").unwrap();
 
         let model = project_fixture!({ "targets": { "defaultTarget": {} } });
         let config = RosBackendConfig {
@@ -1469,41 +1500,38 @@ mod tests {
                 None,
                 None,
                 Some(workspace_root.to_path_buf()),
+                None,
             )
             .await
             .expect("generate_recipe should succeed");
 
-        // From src/pkg_a the workspace_root is two levels up; the rewritten
-        // globs should carry that `../..` prefix.
-        let all: Vec<String> = generated.metadata_input_globs.iter().cloned().collect();
+        // The flat `metadata_input_globs` carries only the provider's
+        // anchored package-local literals.  Workspace discovery patterns
+        // are now expressed structurally via `metadata_input_glob_sets`.
+        let flat: Vec<String> = generated.metadata_input_globs.to_vec();
         assert!(
-            all.iter().any(|g| g.ends_with("/**/package.xml")),
-            "expected a workspace-rooted package.xml include, got: {all:?}"
+            flat.iter().any(|g| g == "package.xml"),
+            "expected provider glob 'package.xml' in flat list, got: {flat:?}"
         );
         assert!(
-            all.iter().any(|g| g.ends_with("/**/COLCON_IGNORE")),
-            "expected a workspace-rooted COLCON_IGNORE include, got: {all:?}"
+            !flat.iter().any(|g| g.contains("COLCON_IGNORE")),
+            "workspace discovery patterns should not appear in flat list, got: {flat:?}"
         );
         assert!(
-            all.iter().any(|g| g.starts_with("!") && g.contains("/build/**")),
-            "expected an exclusion glob for the pruned build/ directory, got: {all:?}"
+            !flat
+                .iter()
+                .any(|g| g == "!**/.*/**" || g.ends_with("/!**/.*/**")),
+            "hidden-folder exclusion should not appear in flat list, got: {flat:?}"
         );
 
-        // Provider globs (anchored package-local manifests) must sit AFTER
-        // the discovery exclusions so last-match-wins doesn't let a broad
-        // !<dir>/** cancel them. Concretely: the index of "package.xml" must
-        // be greater than the index of any "!.../**" exclusion.
-        let provider_pos = all
-            .iter()
-            .position(|g| g == "package.xml")
-            .expect("provider glob package.xml should be present");
-        let last_excl_pos = all
-            .iter()
-            .rposition(|g| g.starts_with('!'))
-            .expect("at least one discovery exclusion should be present");
+        // The structured list carries the workspace discovery (with markers)
+        // plus a second group for the provider literals.
+        let groups = &generated.metadata_input_glob_sets;
         assert!(
-            provider_pos > last_excl_pos,
-            "provider globs must come after discovery exclusions; got at {provider_pos} vs last excl at {last_excl_pos}: {all:?}"
+            groups
+                .iter()
+                .any(|g| g.markers.iter().any(|m| m == "COLCON_IGNORE")),
+            "expected a structured group with COLCON_IGNORE as a marker, got: {groups:?}"
         );
     }
 
@@ -1515,7 +1543,7 @@ mod tests {
         // pkg_b is buried under a COLCON_IGNORE'd directory, so discovery should
         // skip it and the recipe must fall back to RoboStack (binary).
         write_minimal_package_xml(&workspace_root.join("vendor").join("pkg_b"), "pkg_b", &[]);
-        std::fs::write(workspace_root.join("vendor").join("COLCON_IGNORE"), b"").unwrap();
+        fs::write(workspace_root.join("vendor").join("COLCON_IGNORE"), b"").unwrap();
 
         let model = project_fixture!({ "targets": { "defaultTarget": {} } });
         let config = RosBackendConfig {
@@ -1535,6 +1563,7 @@ mod tests {
                 None,
                 None,
                 Some(workspace_root.to_path_buf()),
+                None,
             )
             .await
             .expect("generate_recipe should succeed");
@@ -1571,6 +1600,7 @@ mod tests {
                 None,
                 None,
                 Some(workspace_root.to_path_buf()),
+                None,
             )
             .await
             .expect("generate_recipe should succeed");

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -4,8 +4,9 @@ mod distro;
 mod metadata;
 pub mod package_map;
 pub mod package_xml;
+pub mod workspace_discovery;
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -37,6 +38,14 @@ pub struct RosGenerator {}
 impl GenerateRecipe for RosGenerator {
     type Config = RosBackendConfig;
 
+    #[tracing::instrument(
+        name = "ros_generate_recipe",
+        skip_all,
+        fields(
+            manifest_path = %manifest_path.display(),
+            workspace = workspace_directory.as_ref().map(|p| p.display().to_string()).unwrap_or_else(|| "<none>".to_string()),
+        ),
+    )]
     async fn generate_recipe(
         &self,
         model: &pixi_build_types::ProjectModel,
@@ -48,6 +57,7 @@ impl GenerateRecipe for RosGenerator {
         channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
         workspace_scratch_directory: Option<PathBuf>,
+        workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Determine the manifest root
         let manifest_root = if manifest_path.is_file() {
@@ -121,6 +131,14 @@ impl GenerateRecipe for RosGenerator {
             package_mapping_files,
         )?;
 
+        // `parse_and_render` already populated `metadata_input_globs` with the
+        // provider's anchored package-local patterns (`setup.py`,
+        // `CMakeLists.txt`, ...). Lift them out for now and re-append after
+        // discovery so they sit *after* discovery's broad `!<dir>/**`
+        // exclusions; pixi's last-match-wins matcher then leaves them
+        // intact.
+        let provider_globs = std::mem::take(&mut generated_recipe.metadata_input_globs);
+
         // Load package mappings
         let robostack_yaml: &str = include_str!("../robostack.yaml");
         let robostack_mapping: HashMap<String, package_map::PackageMapEntry> =
@@ -132,12 +150,72 @@ impl GenerateRecipe for RosGenerator {
         let package_map_data = load_package_map_data(&all_mapping_sources);
 
         // Get requirements from package.xml
-        let package_requirements = package_xml_to_conda_requirements(
+        let mut package_requirements = package_xml_to_conda_requirements(
             &package_xml,
             &distro,
             host_platform,
             &package_map_data,
         )?;
+
+        // Discover sibling ROS packages in the workspace and rewrite any
+        // package.xml deps that match a sibling into source dependencies, so
+        // pixi resolves them against the sibling directory instead of looking
+        // them up as a binary through RoboStack.
+        if let Some(workspace_root) = workspace_directory.as_deref()
+            && !config.ignore_workspace_sources
+        {
+            let discovery = workspace_discovery::discover_ros_packages(workspace_root)?;
+
+            for glob in &discovery.input_globs {
+                let rewritten = workspace_discovery::rewrite_glob_for_manifest_root(
+                    glob,
+                    workspace_root,
+                    &manifest_root,
+                );
+                generated_recipe.metadata_input_globs.push(rewritten);
+            }
+
+            let sibling_specs = workspace_discovery::sibling_source_spec_map(
+                &discovery.packages,
+                &package_xml.name,
+                &manifest_root,
+                &distro_name,
+            );
+
+            // Apply per-class: a manual entry in the model for the same conda
+            // name suppresses discovery's override for that class only.
+            let build_overrides = workspace_discovery::filter_unspecified(
+                &sibling_specs,
+                &generated_recipe.recipe.requirements.build,
+            );
+            let host_overrides = workspace_discovery::filter_unspecified(
+                &sibling_specs,
+                &generated_recipe.recipe.requirements.host,
+            );
+            let run_overrides = workspace_discovery::filter_unspecified(
+                &sibling_specs,
+                &generated_recipe.recipe.requirements.run,
+            );
+
+            package_requirements.build = workspace_discovery::apply_sibling_overrides(
+                package_requirements.build,
+                &build_overrides,
+            );
+            package_requirements.host = workspace_discovery::apply_sibling_overrides(
+                package_requirements.host,
+                &host_overrides,
+            );
+            package_requirements.run = workspace_discovery::apply_sibling_overrides(
+                package_requirements.run,
+                &run_overrides,
+            );
+        }
+
+        // Re-append the provider globs at the very end of the list so they
+        // sit after any discovery exclusions and aren't suppressed by them.
+        generated_recipe
+            .metadata_input_globs
+            .extend(provider_globs);
 
         // Add standard build dependencies
         let mut build_deps: Vec<&str> = vec![
@@ -236,7 +314,7 @@ impl GenerateRecipe for RosGenerator {
         config: &Self::Config,
         _workdir: impl AsRef<Path>,
         editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
+    ) -> miette::Result<Vec<String>> {
         let mut globs: Vec<&str> = vec![
             "**/*.c",
             "**/*.cpp",
@@ -265,11 +343,9 @@ impl GenerateRecipe for RosGenerator {
             globs.extend(["**/*.py", "**/*.pyx"]);
         }
 
-        let mut result: BTreeSet<String> = globs.iter().map(|s| s.to_string()).collect();
+        let mut result: Vec<String> = globs.iter().map(|s| s.to_string()).collect();
         if let Some(extra) = &config.extra_input_globs {
-            for g in extra {
-                result.insert(g.clone());
-            }
+            result.extend(extra.iter().cloned());
         }
         Ok(result)
     }
@@ -448,6 +524,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -577,6 +654,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe")
@@ -665,6 +743,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -893,6 +972,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe with explicit package.xml path");
@@ -929,6 +1009,7 @@ mod tests {
                 vec![ChannelUrl::from(
                     url::Url::parse("https://prefix.dev/robostack-jazzy").unwrap(),
                 )],
+                None,
                 None,
                 None,
             )
@@ -978,6 +1059,7 @@ mod tests {
                 )],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Explicit distro should override channel");
@@ -1021,6 +1103,7 @@ mod tests {
                 )],
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -1056,6 +1139,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -1177,6 +1261,324 @@ mod tests {
         assert!(
             run_deps.iter().any(|d| d == "ros-noetic-ros-custom2-msgs"),
             "Expected ros-noetic-ros-custom2-msgs in run deps: {run_deps:?}"
+        );
+    }
+
+    fn write_minimal_package_xml(dir: &std::path::Path, name: &str, deps: &[&str]) {
+        std::fs::create_dir_all(dir).unwrap();
+        let depend_tags: String = deps
+            .iter()
+            .map(|d| format!("  <depend>{d}</depend>\n"))
+            .collect();
+        let xml = format!(
+            r#"<?xml version="1.0"?>
+<package format="3">
+  <name>{name}</name>
+  <version>0.0.1</version>
+  <description>test</description>
+  <maintainer email="test@example.com">Tester</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+{depend_tags}</package>
+"#
+        );
+        std::fs::write(dir.join("package.xml"), xml).unwrap();
+    }
+
+    /// Returns the first concrete item whose package name equals `conda_name`.
+    fn find_concrete<'a>(
+        list: &'a rattler_build_recipe::stage0::ConditionalList<SerializableMatchSpec>,
+        conda_name: &str,
+    ) -> Option<&'a SerializableMatchSpec> {
+        list.iter().find_map(|item| match item {
+            Item::Value(v) => v.as_concrete().filter(|s| {
+                s.0.name
+                    .as_exact()
+                    .map(|n| n.as_normalized() == conda_name)
+                    .unwrap_or(false)
+            }),
+            _ => None,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_workspace_discovery_emits_source_dep_for_sibling() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = workspace.path();
+
+        write_minimal_package_xml(&workspace_root.join("src").join("pkg_a"), "pkg_a", &["pkg_b"]);
+        write_minimal_package_xml(&workspace_root.join("src").join("pkg_b"), "pkg_b", &[]);
+
+        let pkg_a_manifest = workspace_root.join("src").join("pkg_a");
+
+        let model = project_fixture!({ "targets": { "defaultTarget": {} } });
+        let config = RosBackendConfig {
+            distro: Some("jazzy".to_string()),
+            ..Default::default()
+        };
+
+        let generated = RosGenerator::default()
+            .generate_recipe(
+                &model,
+                &config,
+                pkg_a_manifest.clone(),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                Some(workspace_root.to_path_buf()),
+            )
+            .await
+            .expect("generate_recipe should succeed");
+
+        let sibling_in_build =
+            find_concrete(&generated.recipe.requirements.build, "ros-jazzy-pkg-b")
+                .expect("sibling should appear in build requirements");
+        assert!(
+            sibling_in_build.0.url.is_some(),
+            "expected ros-jazzy-pkg-b to be a source dep, got: {sibling_in_build}"
+        );
+
+        let sibling_in_run =
+            find_concrete(&generated.recipe.requirements.run, "ros-jazzy-pkg-b")
+                .expect("sibling should also appear in run requirements");
+        assert!(
+            sibling_in_run.0.url.is_some(),
+            "expected ros-jazzy-pkg-b in run to be source, got: {sibling_in_run}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_discovery_opt_out_falls_back_to_binary() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = workspace.path();
+        write_minimal_package_xml(&workspace_root.join("pkg_a"), "pkg_a", &["pkg_b"]);
+        write_minimal_package_xml(&workspace_root.join("pkg_b"), "pkg_b", &[]);
+
+        let model = project_fixture!({ "targets": { "defaultTarget": {} } });
+        let config = RosBackendConfig {
+            distro: Some("jazzy".to_string()),
+            ignore_workspace_sources: true,
+            ..Default::default()
+        };
+
+        let generated = RosGenerator::default()
+            .generate_recipe(
+                &model,
+                &config,
+                workspace_root.join("pkg_a"),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                Some(workspace_root.to_path_buf()),
+            )
+            .await
+            .expect("generate_recipe should succeed");
+
+        let sibling = find_concrete(&generated.recipe.requirements.build, "ros-jazzy-pkg-b")
+            .expect("sibling should still be present as binary");
+        assert!(
+            sibling.0.url.is_none(),
+            "opt-out should keep binary spec, got source: {sibling}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_discovery_yields_to_manual_model_entry() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = workspace.path();
+        write_minimal_package_xml(&workspace_root.join("pkg_a"), "pkg_a", &["pkg_b"]);
+        write_minimal_package_xml(&workspace_root.join("pkg_b"), "pkg_b", &[]);
+
+        // Model declares ros-jazzy-pkg-b in run only, with an explicit version.
+        // Discovery must not override that entry, but build/host still get the
+        // source dep because the manual entry was per-class.
+        let model = project_fixture!({
+            "targets": {
+                "defaultTarget": {
+                    "runDependencies": {
+                        "ros-jazzy-pkg-b": { "binary": { "version": "==1.2.3" } }
+                    }
+                }
+            }
+        });
+        let config = RosBackendConfig {
+            distro: Some("jazzy".to_string()),
+            ..Default::default()
+        };
+
+        let generated = RosGenerator::default()
+            .generate_recipe(
+                &model,
+                &config,
+                workspace_root.join("pkg_a"),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                Some(workspace_root.to_path_buf()),
+            )
+            .await
+            .expect("generate_recipe should succeed");
+
+        let in_run = find_concrete(&generated.recipe.requirements.run, "ros-jazzy-pkg-b")
+            .expect("run entry should remain");
+        assert!(
+            in_run.0.url.is_none(),
+            "manual model entry must stay binary, got source: {in_run}"
+        );
+
+        let in_build = find_concrete(&generated.recipe.requirements.build, "ros-jazzy-pkg-b")
+            .expect("build entry should exist");
+        assert!(
+            in_build.0.url.is_some(),
+            "build override should still kick in, got binary: {in_build}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_discovery_globs_injected_into_metadata() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = workspace.path();
+        write_minimal_package_xml(&workspace_root.join("src").join("pkg_a"), "pkg_a", &[]);
+        std::fs::create_dir_all(workspace_root.join("build")).unwrap();
+        std::fs::write(workspace_root.join("build").join("COLCON_IGNORE"), b"").unwrap();
+
+        let model = project_fixture!({ "targets": { "defaultTarget": {} } });
+        let config = RosBackendConfig {
+            distro: Some("jazzy".to_string()),
+            ..Default::default()
+        };
+
+        let generated = RosGenerator::default()
+            .generate_recipe(
+                &model,
+                &config,
+                workspace_root.join("src").join("pkg_a"),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                Some(workspace_root.to_path_buf()),
+            )
+            .await
+            .expect("generate_recipe should succeed");
+
+        // From src/pkg_a the workspace_root is two levels up; the rewritten
+        // globs should carry that `../..` prefix.
+        let all: Vec<String> = generated.metadata_input_globs.iter().cloned().collect();
+        assert!(
+            all.iter().any(|g| g.ends_with("/**/package.xml")),
+            "expected a workspace-rooted package.xml include, got: {all:?}"
+        );
+        assert!(
+            all.iter().any(|g| g.ends_with("/**/COLCON_IGNORE")),
+            "expected a workspace-rooted COLCON_IGNORE include, got: {all:?}"
+        );
+        assert!(
+            all.iter().any(|g| g.starts_with("!") && g.contains("/build/**")),
+            "expected an exclusion glob for the pruned build/ directory, got: {all:?}"
+        );
+
+        // Provider globs (anchored package-local manifests) must sit AFTER
+        // the discovery exclusions so last-match-wins doesn't let a broad
+        // !<dir>/** cancel them. Concretely: the index of "package.xml" must
+        // be greater than the index of any "!.../**" exclusion.
+        let provider_pos = all
+            .iter()
+            .position(|g| g == "package.xml")
+            .expect("provider glob package.xml should be present");
+        let last_excl_pos = all
+            .iter()
+            .rposition(|g| g.starts_with('!'))
+            .expect("at least one discovery exclusion should be present");
+        assert!(
+            provider_pos > last_excl_pos,
+            "provider globs must come after discovery exclusions; got at {provider_pos} vs last excl at {last_excl_pos}: {all:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_discovery_skips_pkg_under_colcon_ignore() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = workspace.path();
+        write_minimal_package_xml(&workspace_root.join("pkg_a"), "pkg_a", &["pkg_b"]);
+        // pkg_b is buried under a COLCON_IGNORE'd directory, so discovery should
+        // skip it and the recipe must fall back to RoboStack (binary).
+        write_minimal_package_xml(&workspace_root.join("vendor").join("pkg_b"), "pkg_b", &[]);
+        std::fs::write(workspace_root.join("vendor").join("COLCON_IGNORE"), b"").unwrap();
+
+        let model = project_fixture!({ "targets": { "defaultTarget": {} } });
+        let config = RosBackendConfig {
+            distro: Some("jazzy".to_string()),
+            ..Default::default()
+        };
+
+        let generated = RosGenerator::default()
+            .generate_recipe(
+                &model,
+                &config,
+                workspace_root.join("pkg_a"),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                Some(workspace_root.to_path_buf()),
+            )
+            .await
+            .expect("generate_recipe should succeed");
+
+        let sibling = find_concrete(&generated.recipe.requirements.build, "ros-jazzy-pkg-b")
+            .expect("ignored sibling should still appear via RoboStack fallback");
+        assert!(
+            sibling.0.url.is_none(),
+            "ignored sibling must not be turned into a source dep: {sibling}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_discovery_does_not_add_self_as_source() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = workspace.path();
+        write_minimal_package_xml(&workspace_root.join("pkg_a"), "pkg_a", &[]);
+
+        let model = project_fixture!({ "targets": { "defaultTarget": {} } });
+        let config = RosBackendConfig {
+            distro: Some("jazzy".to_string()),
+            ..Default::default()
+        };
+
+        let generated = RosGenerator::default()
+            .generate_recipe(
+                &model,
+                &config,
+                workspace_root.join("pkg_a"),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                Some(workspace_root.to_path_buf()),
+            )
+            .await
+            .expect("generate_recipe should succeed");
+
+        let self_in_build = find_concrete(&generated.recipe.requirements.build, "ros-jazzy-pkg-a");
+        assert!(
+            self_in_build.is_none(),
+            "current package must not list itself as a source dep: {self_in_build:?}"
         );
     }
 }

--- a/crates/pixi_build_ros/src/metadata.rs
+++ b/crates/pixi_build_ros/src/metadata.rs
@@ -3,8 +3,6 @@
 //! Implements the `MetadataProvider` trait to extract package metadata from
 //! package.xml and format names according to ROS conventions.
 
-use std::collections::BTreeSet;
-
 use miette::IntoDiagnostic;
 use pixi_build_backend::generated_recipe::{GeneratedRecipe, MetadataProvider};
 use pixi_build_types::ProjectModel;
@@ -47,19 +45,15 @@ struct RosPackageXmlMetadataProvider {
 }
 
 impl RosPackageXmlMetadataProvider {
-    fn input_globs(&self) -> BTreeSet<String> {
-        let mut globs: BTreeSet<String> = BTreeSet::from([
+    fn input_globs(&self) -> Vec<String> {
+        let mut globs: Vec<String> = vec![
             "package.xml".to_string(),
             "CMakeLists.txt".to_string(),
             "setup.py".to_string(),
             "setup.cfg".to_string(),
-        ]);
-        for g in &self.extra_input_globs {
-            globs.insert(g.clone());
-        }
-        for f in &self.package_mapping_files {
-            globs.insert(f.clone());
-        }
+        ];
+        globs.extend(self.extra_input_globs.iter().cloned());
+        globs.extend(self.package_mapping_files.iter().cloned());
         globs
     }
 }
@@ -194,8 +188,8 @@ mod tests {
         };
 
         let globs = provider.input_globs();
-        assert!(globs.contains("package.xml"));
-        assert!(globs.contains("CMakeLists.txt"));
-        assert!(globs.contains("/tmp/custom_mapping.yaml"));
+        assert!(globs.iter().any(|g| g == "package.xml"));
+        assert!(globs.iter().any(|g| g == "CMakeLists.txt"));
+        assert!(globs.iter().any(|g| g == "/tmp/custom_mapping.yaml"));
     }
 }

--- a/crates/pixi_build_ros/src/package_map.rs
+++ b/crates/pixi_build_ros/src/package_map.rs
@@ -437,7 +437,7 @@ pub struct ConditionalRequirements {
 }
 
 /// Extract a package name from an Item, if it's a concrete spec.
-fn item_package_name(item: &Item<SerializableMatchSpec>) -> Option<String> {
+pub(crate) fn item_package_name(item: &Item<SerializableMatchSpec>) -> Option<String> {
     match item {
         Item::Value(v) => v
             .as_concrete()

--- a/crates/pixi_build_ros/src/workspace_discovery.rs
+++ b/crates/pixi_build_ros/src/workspace_discovery.rs
@@ -1,0 +1,503 @@
+//! Discover sibling ROS packages inside a workspace.
+//!
+//! Walks a workspace root looking for `package.xml` files, honoring the
+//! standard colcon ignore markers (`COLCON_IGNORE`, `AMENT_IGNORE`,
+//! `CATKIN_IGNORE`). Returns the discovered packages keyed by the `<name>`
+//! element together with a glob list suitable for pixi's metadata
+//! invalidation cache.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use fs_err as fs;
+use miette::Diagnostic;
+use rattler_build_recipe::stage0::{ConditionalList, Item, SerializableMatchSpec, Value};
+use thiserror::Error;
+use url::Url;
+
+use crate::package_map::item_package_name;
+use crate::package_xml::{PackageXml, PackageXmlError};
+
+const IGNORE_MARKERS: &[&str] = &["COLCON_IGNORE", "AMENT_IGNORE", "CATKIN_IGNORE"];
+
+/// Result of walking a workspace root for ROS packages.
+#[derive(Debug, Clone, Default)]
+pub struct WorkspaceDiscovery {
+    /// Map from the `<name>` of each discovered package to the absolute path of
+    /// its `package.xml`.
+    pub packages: HashMap<String, PathBuf>,
+    /// Gitignore-style glob patterns relative to the workspace root.
+    ///
+    /// Layout is "includes first, then exclusions" so pixi's last-match-wins
+    /// matcher correctly cancels the discovery-include in pruned subtrees.
+    /// Callers that mix these globs with other patterns (for example a
+    /// metadata-provider's anchored `setup.py` or a user's `**/*.urdf`)
+    /// should append those other patterns *after* the list returned here, so
+    /// they aren't suppressed by the broad `!<dir>/**` exclusions.
+    pub input_globs: Vec<String>,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum WorkspaceDiscoveryError {
+    #[error(
+        "duplicate ROS package name `{name}` declared by both:\n  - {first}\n  - {second}"
+    )]
+    #[diagnostic(help(
+        "Each ROS package in a workspace must have a unique <name> in its package.xml."
+    ))]
+    DuplicateName {
+        name: String,
+        first: PathBuf,
+        second: PathBuf,
+    },
+
+    #[error("failed to read directory entry under {path}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to read {path}")]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse {path}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: PackageXmlError,
+    },
+}
+
+/// Discover every ROS package nested under `workspace_root`.
+///
+/// Directories containing any of `COLCON_IGNORE`, `AMENT_IGNORE`, or
+/// `CATKIN_IGNORE` are pruned from the walk. Colcon writes these markers into
+/// its own `build/`, `install/`, and `log/` directories, so honoring the
+/// markers also handles those without any directory-name hardcoding.
+///
+/// Returns an error if two `package.xml` files declare the same `<name>`.
+pub fn discover_ros_packages(
+    workspace_root: &Path,
+) -> Result<WorkspaceDiscovery, WorkspaceDiscoveryError> {
+    let _span = tracing::info_span!(
+        "ros_workspace_discovery",
+        workspace_root = %workspace_root.display(),
+    )
+    .entered();
+    let started = std::time::Instant::now();
+
+    let mut packages: HashMap<String, PathBuf> = HashMap::new();
+    let mut pruned_dirs: Vec<PathBuf> = Vec::new();
+
+    if workspace_root.is_dir() {
+        walk(workspace_root, workspace_root, &mut packages, &mut pruned_dirs)?;
+    }
+
+    tracing::info!(
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        packages = packages.len(),
+        pruned_dirs = pruned_dirs.len(),
+        "ROS workspace discovery finished"
+    );
+
+    let mut input_globs = vec![
+        "**/package.xml".to_string(),
+        "**/COLCON_IGNORE".to_string(),
+        "**/AMENT_IGNORE".to_string(),
+        "**/CATKIN_IGNORE".to_string(),
+    ];
+    // Skip the contents of any dot-prefixed directory in one shot, so we do
+    // not have to enumerate every `.git` / `.pixi` / `.vscode` / etc. that
+    // happens to live under the workspace. Marker-bearing dirs (which may or
+    // may not be hidden) still get their own specific exclusion below.
+    input_globs.push("!**/.*/**".to_string());
+    for dir in pruned_dirs {
+        input_globs.push(format!("!{}/**", path_to_forward_slashes(&dir)));
+    }
+
+    Ok(WorkspaceDiscovery {
+        packages,
+        input_globs,
+    })
+}
+
+fn walk(
+    workspace_root: &Path,
+    dir: &Path,
+    packages: &mut HashMap<String, PathBuf>,
+    pruned_dirs: &mut Vec<PathBuf>,
+) -> Result<(), WorkspaceDiscoveryError> {
+    if IGNORE_MARKERS.iter().any(|m| dir.join(m).is_file()) {
+        record_pruned(workspace_root, dir, pruned_dirs);
+        return Ok(());
+    }
+
+    let package_xml = dir.join("package.xml");
+    if package_xml.is_file() {
+        let content =
+            fs::read_to_string(&package_xml).map_err(|source| WorkspaceDiscoveryError::ReadFile {
+                path: package_xml.clone(),
+                source: source.into(),
+            })?;
+        let parsed = PackageXml::parse(&content).map_err(|source| WorkspaceDiscoveryError::Parse {
+            path: package_xml.clone(),
+            source,
+        })?;
+
+        if let Some(existing) = packages.get(&parsed.name) {
+            return Err(WorkspaceDiscoveryError::DuplicateName {
+                name: parsed.name,
+                first: existing.clone(),
+                second: package_xml,
+            });
+        }
+        packages.insert(parsed.name, package_xml);
+    }
+
+    let entries = fs::read_dir(dir).map_err(|source| WorkspaceDiscoveryError::Io {
+        path: dir.to_path_buf(),
+        source: source.into(),
+    })?;
+
+    for entry in entries {
+        let entry = entry.map_err(|source| WorkspaceDiscoveryError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        // Skip dot-prefixed directories the same way colcon does: this covers
+        // `.pixi`, `.git`, `.vscode`, etc. without hardcoding any specific
+        // name. The check is only applied to subdirectories, never to the
+        // workspace root itself. A single `!**/.*/**` glob (emitted by the
+        // caller) covers the invalidation side for all of these without
+        // needing to enumerate them, so we do not record each one here.
+        if is_hidden_dir(&path) {
+            continue;
+        }
+        walk(workspace_root, &path, packages, pruned_dirs)?;
+    }
+
+    Ok(())
+}
+
+fn is_hidden_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+}
+
+fn record_pruned(workspace_root: &Path, dir: &Path, pruned_dirs: &mut Vec<PathBuf>) {
+    if let Some(rel) = pathdiff::diff_paths(dir, workspace_root)
+        && !rel.as_os_str().is_empty()
+    {
+        pruned_dirs.push(rel);
+    }
+}
+
+fn path_to_forward_slashes(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+/// Build a matchspec string of the form
+/// `ros-<distro>-<name>[url="source://?path=<rel-to-manifest>"]` that, when
+/// parsed via `SerializableMatchSpec::from`, yields a source dependency
+/// pointing at the sibling's `package.xml`.
+pub fn sibling_source_spec(conda_name: &str, sibling_package_xml: &Path, manifest_root: &Path) -> String {
+    let rel = pathdiff::diff_paths(sibling_package_xml, manifest_root)
+        .unwrap_or_else(|| sibling_package_xml.to_path_buf());
+    let rel = path_to_forward_slashes(&rel);
+
+    let mut url = Url::from_str("source://").expect("static URL parses");
+    url.query_pairs_mut().append_pair("path", &rel);
+    format!("{conda_name}[url=\"{url}\"]")
+}
+
+/// Build the conda-formatted package name for a ROS package.
+pub fn conda_name_for(distro: &str, ros_name: &str) -> String {
+    format!("ros-{}-{}", distro, ros_name.replace('_', "-"))
+}
+
+/// Compute the `conda-name -> source-spec-string` map for every sibling
+/// package discovered under the workspace, excluding the current package.
+pub fn sibling_source_spec_map(
+    discovered: &HashMap<String, PathBuf>,
+    current_package_name: &str,
+    manifest_root: &Path,
+    distro_name: &str,
+) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for (ros_name, package_xml_path) in discovered {
+        if ros_name == current_package_name {
+            continue;
+        }
+        let conda_name = conda_name_for(distro_name, ros_name);
+        let spec = sibling_source_spec(&conda_name, package_xml_path, manifest_root);
+        map.insert(conda_name, spec);
+    }
+    map
+}
+
+/// Filter a sibling source-spec map down to entries whose conda name is **not**
+/// already declared in `existing`. Used to honor the "manual entries in
+/// pixi.toml always win over discovery" rule on a per-requirement-class basis.
+pub fn filter_unspecified<'a>(
+    overrides: &'a HashMap<String, String>,
+    existing: &ConditionalList<SerializableMatchSpec>,
+) -> HashMap<String, &'a str> {
+    let declared: std::collections::HashSet<String> =
+        existing.iter().filter_map(item_package_name).collect();
+    overrides
+        .iter()
+        .filter(|(name, _)| !declared.contains(*name))
+        .map(|(name, spec)| (name.clone(), spec.as_str()))
+        .collect()
+}
+
+/// Replace every binary `Item` in `list` whose package name appears as a key
+/// in `overrides` with a source `Item` built from the override's spec string.
+/// Items that don't match are kept as-is.
+pub fn apply_sibling_overrides(
+    list: ConditionalList<SerializableMatchSpec>,
+    overrides: &HashMap<String, &str>,
+) -> ConditionalList<SerializableMatchSpec> {
+    if overrides.is_empty() {
+        return list;
+    }
+    let items: Vec<Item<SerializableMatchSpec>> = list
+        .iter()
+        .map(|item| {
+            if let Some(name) = item_package_name(item)
+                && let Some(source_spec) = overrides.get(&name)
+            {
+                Item::Value(Value::new_concrete(
+                    SerializableMatchSpec::from(*source_spec),
+                    None,
+                ))
+            } else {
+                item.clone()
+            }
+        })
+        .collect();
+    ConditionalList::new(items)
+}
+
+/// Rewrite a discovery glob (relative to the workspace root) so it can be
+/// evaluated from the package's `manifest_root`. The glob system rebases
+/// `../`-style up-traversal patterns to a shared search root, so prefixing
+/// each pattern with the relative path from `manifest_root` to
+/// `workspace_root` is enough.
+pub fn rewrite_glob_for_manifest_root(glob: &str, workspace_root: &Path, manifest_root: &Path) -> String {
+    let rel = match pathdiff::diff_paths(workspace_root, manifest_root) {
+        Some(p) if !p.as_os_str().is_empty() => path_to_forward_slashes(&p),
+        _ => return glob.to_string(),
+    };
+    if let Some(rest) = glob.strip_prefix('!') {
+        format!("!{rel}/{rest}")
+    } else {
+        format!("{rel}/{glob}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_package_xml(dir: &Path, name: &str) {
+        fs::create_dir_all(dir).unwrap();
+        let xml = format!(
+            r#"<?xml version="1.0"?>
+<package format="3">
+  <name>{name}</name>
+  <version>0.0.1</version>
+  <description>test</description>
+  <maintainer email="test@example.com">Tester</maintainer>
+  <license>MIT</license>
+</package>
+"#
+        );
+        fs::write(dir.join("package.xml"), xml).unwrap();
+    }
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, b"").unwrap();
+    }
+
+    #[test]
+    fn discovers_top_level_packages() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("pkg_a"), "pkg_a");
+        write_package_xml(&root.join("pkg_b"), "pkg_b");
+
+        let result = discover_ros_packages(root).unwrap();
+
+        assert_eq!(result.packages.len(), 2);
+        assert_eq!(
+            result.packages.get("pkg_a").unwrap(),
+            &root.join("pkg_a").join("package.xml"),
+        );
+        assert_eq!(
+            result.packages.get("pkg_b").unwrap(),
+            &root.join("pkg_b").join("package.xml"),
+        );
+    }
+
+    #[test]
+    fn discovers_nested_packages() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("src").join("pkg_a"), "pkg_a");
+        write_package_xml(&root.join("src").join("nested").join("pkg_b"), "pkg_b");
+
+        let result = discover_ros_packages(root).unwrap();
+        assert_eq!(result.packages.len(), 2);
+        assert!(result.packages.contains_key("pkg_a"));
+        assert!(result.packages.contains_key("pkg_b"));
+    }
+
+    #[test]
+    fn colcon_ignore_prunes_subtree() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("pkg_a"), "pkg_a");
+        // pkg_b is inside a directory with COLCON_IGNORE
+        write_package_xml(&root.join("build").join("pkg_b"), "pkg_b");
+        touch(&root.join("build").join("COLCON_IGNORE"));
+
+        let result = discover_ros_packages(root).unwrap();
+        assert_eq!(result.packages.len(), 1);
+        assert!(result.packages.contains_key("pkg_a"));
+        assert!(result.input_globs.iter().any(|g| g == "!build/**"));
+    }
+
+    #[test]
+    fn ament_and_catkin_ignore_also_prune() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("a").join("pkg"), "in_ament");
+        touch(&root.join("a").join("AMENT_IGNORE"));
+        write_package_xml(&root.join("b").join("pkg"), "in_catkin");
+        touch(&root.join("b").join("CATKIN_IGNORE"));
+        write_package_xml(&root.join("c").join("pkg"), "visible");
+
+        let result = discover_ros_packages(root).unwrap();
+        assert_eq!(result.packages.len(), 1);
+        assert!(result.packages.contains_key("visible"));
+    }
+
+    #[test]
+    fn duplicate_name_is_an_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("a"), "same_name");
+        write_package_xml(&root.join("b"), "same_name");
+
+        let err = discover_ros_packages(root).unwrap_err();
+        match err {
+            WorkspaceDiscoveryError::DuplicateName { name, .. } => {
+                assert_eq!(name, "same_name");
+            }
+            other => panic!("expected DuplicateName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_workspace_returns_no_packages_but_keeps_globs() {
+        let tmp = tempdir().unwrap();
+        let result = discover_ros_packages(tmp.path()).unwrap();
+        assert!(result.packages.is_empty());
+        assert!(result.input_globs.iter().any(|g| g == "**/package.xml"));
+        assert!(result.input_globs.iter().any(|g| g == "**/COLCON_IGNORE"));
+    }
+
+    #[test]
+    fn nonexistent_workspace_root_returns_empty() {
+        let result = discover_ros_packages(Path::new("/this/path/does/not/exist")).unwrap();
+        assert!(result.packages.is_empty());
+    }
+
+    #[test]
+    fn hidden_directories_are_pruned() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("src").join("pkg_a"), "pkg_a");
+
+        // Simulate the contents of a built `.pixi/envs` tree: installed
+        // packages bring their own package.xml files which must not be
+        // mistaken for sibling sources.
+        write_package_xml(
+            &root
+                .join(".pixi")
+                .join("envs")
+                .join("default")
+                .join("share")
+                .join("foo"),
+            "foo",
+        );
+        // Hidden dirs other than .pixi should also be skipped (matches colcon).
+        write_package_xml(&root.join(".git").join("worktree").join("pkg_b"), "pkg_b");
+
+        let result = discover_ros_packages(root).unwrap();
+        assert_eq!(result.packages.len(), 1);
+        assert!(result.packages.contains_key("pkg_a"));
+        let contains = |needle: &str| result.input_globs.iter().any(|g| g == needle);
+        assert!(
+            contains("!**/.*/**"),
+            "expected the single hidden-dir exclusion glob, got: {:?}",
+            result.input_globs
+        );
+        // Per-hidden-dir exclusions are no longer emitted: the static
+        // `!**/.*/**` covers all of them in one shot.
+        assert!(
+            !contains("!.pixi/**"),
+            "per-hidden-dir exclusion must not be emitted any more, got: {:?}",
+            result.input_globs
+        );
+        assert!(
+            !contains("!.git/**"),
+            "per-hidden-dir exclusion must not be emitted any more, got: {:?}",
+            result.input_globs
+        );
+    }
+
+    /// Exclusions must come after the includes so pixi's last-match-wins
+    /// matcher actually cancels the includes inside pruned subtrees.
+    #[test]
+    fn input_globs_emit_includes_before_excludes() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        write_package_xml(&root.join("pkg"), "pkg");
+        touch(&root.join("build").join("COLCON_IGNORE"));
+
+        let result = discover_ros_packages(root).unwrap();
+        let first_exclude = result
+            .input_globs
+            .iter()
+            .position(|g| g.starts_with('!'))
+            .expect("expected at least one exclusion");
+        let last_include = result
+            .input_globs
+            .iter()
+            .rposition(|g| !g.starts_with('!'))
+            .expect("expected at least one include");
+        assert!(
+            last_include < first_exclude,
+            "all includes must come before any exclusion, got: {:?}",
+            result.input_globs
+        );
+    }
+}

--- a/crates/pixi_build_ros/src/workspace_discovery.rs
+++ b/crates/pixi_build_ros/src/workspace_discovery.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 
 use fs_err as fs;
 use miette::Diagnostic;
+use pixi_build_types::InputGlobSet;
+use pixi_glob::GlobSet;
 use rattler_build_recipe::stage0::{ConditionalList, Item, SerializableMatchSpec, Value};
 use thiserror::Error;
 use url::Url;
@@ -19,6 +21,7 @@ use url::Url;
 use crate::package_map::item_package_name;
 use crate::package_xml::{PackageXml, PackageXmlError};
 
+const PACKAGE_XML: &str = "package.xml";
 const IGNORE_MARKERS: &[&str] = &["COLCON_IGNORE", "AMENT_IGNORE", "CATKIN_IGNORE"];
 
 /// Result of walking a workspace root for ROS packages.
@@ -27,22 +30,19 @@ pub struct WorkspaceDiscovery {
     /// Map from the `<name>` of each discovered package to the absolute path of
     /// its `package.xml`.
     pub packages: HashMap<String, PathBuf>,
-    /// Gitignore-style glob patterns relative to the workspace root.
-    ///
-    /// Layout is "includes first, then exclusions" so pixi's last-match-wins
-    /// matcher correctly cancels the discovery-include in pruned subtrees.
-    /// Callers that mix these globs with other patterns (for example a
-    /// metadata-provider's anchored `setup.py` or a user's `**/*.urdf`)
-    /// should append those other patterns *after* the list returned here, so
-    /// they aren't suppressed by the broad `!<dir>/**` exclusions.
-    pub input_globs: Vec<String>,
+    /// Structured glob description of the discovery, suitable for pixi's
+    /// metadata invalidation cache.  Pixi replays the same walk later
+    /// using the marker semantics carried here; we deliberately don't
+    /// emit a flat `Vec<String>` form because per-pruned-dir exclusions
+    /// (`!build/**`, `!log/**`, ...) and the hidden-folder exclusion
+    /// (`!**/.*/**`) can't be expressed losslessly without the markers
+    /// the structured form carries.
+    pub input_glob_set: InputGlobSet,
 }
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum WorkspaceDiscoveryError {
-    #[error(
-        "duplicate ROS package name `{name}` declared by both:\n  - {first}\n  - {second}"
-    )]
+    #[error("duplicate ROS package name `{name}` declared by both:\n  - {first}\n  - {second}")]
     #[diagnostic(help(
         "Each ROS package in a workspace must have a unique <name> in its package.xml."
     ))]
@@ -52,11 +52,11 @@ pub enum WorkspaceDiscoveryError {
         second: PathBuf,
     },
 
-    #[error("failed to read directory entry under {path}")]
-    Io {
+    #[error("workspace walk failed at {path}")]
+    Walk {
         path: PathBuf,
         #[source]
-        source: std::io::Error,
+        source: Box<pixi_glob::GlobSetError>,
     },
 
     #[error("failed to read {path}")]
@@ -93,114 +93,72 @@ pub fn discover_ros_packages(
     let started = std::time::Instant::now();
 
     let mut packages: HashMap<String, PathBuf> = HashMap::new();
-    let mut pruned_dirs: Vec<PathBuf> = Vec::new();
 
     if workspace_root.is_dir() {
-        walk(workspace_root, workspace_root, &mut packages, &mut pruned_dirs)?;
+        let mut marker_filenames = Vec::with_capacity(IGNORE_MARKERS.len() + 1);
+        marker_filenames.push(PACKAGE_XML);
+        marker_filenames.extend(IGNORE_MARKERS.iter().copied());
+
+        // Hidden directories (`.git`, `.pixi`, `.vscode`, ...) are skipped
+        // by the walker; matches colcon's behaviour and avoids descending
+        // into the installed `.pixi/envs/.../share/...` tree whose
+        // `package.xml`s are not workspace siblings.
+        let matches = GlobSet::create([format!("**/{PACKAGE_XML}").as_str()])
+            .with_exclude_hidden(true)
+            .with_ignore_marker_filenames(marker_filenames)
+            .collect_matching(workspace_root)
+            .map_err(|source| WorkspaceDiscoveryError::Walk {
+                path: workspace_root.to_path_buf(),
+                source: Box::new(source),
+            })?;
+
+        for matched in matches {
+            let package_xml = matched.into_path();
+            let content = fs::read_to_string(&package_xml).map_err(|source| {
+                WorkspaceDiscoveryError::ReadFile {
+                    path: package_xml.clone(),
+                    source,
+                }
+            })?;
+            let parsed =
+                PackageXml::parse(&content).map_err(|source| WorkspaceDiscoveryError::Parse {
+                    path: package_xml.clone(),
+                    source,
+                })?;
+
+            if let Some(existing) = packages.get(&parsed.name) {
+                return Err(WorkspaceDiscoveryError::DuplicateName {
+                    name: parsed.name,
+                    first: existing.clone(),
+                    second: package_xml,
+                });
+            }
+            packages.insert(parsed.name, package_xml);
+        }
     }
 
     tracing::info!(
         elapsed_ms = started.elapsed().as_millis() as u64,
         packages = packages.len(),
-        pruned_dirs = pruned_dirs.len(),
         "ROS workspace discovery finished"
     );
 
-    let mut input_globs = vec![
-        "**/package.xml".to_string(),
-        "**/COLCON_IGNORE".to_string(),
-        "**/AMENT_IGNORE".to_string(),
-        "**/CATKIN_IGNORE".to_string(),
-    ];
-    // Skip the contents of any dot-prefixed directory in one shot, so we do
-    // not have to enumerate every `.git` / `.pixi` / `.vscode` / etc. that
-    // happens to live under the workspace. Marker-bearing dirs (which may or
-    // may not be hidden) still get their own specific exclusion below.
-    input_globs.push("!**/.*/**".to_string());
-    for dir in pruned_dirs {
-        input_globs.push(format!("!{}/**", path_to_forward_slashes(&dir)));
-    }
+    let mut markers: Vec<String> = Vec::with_capacity(IGNORE_MARKERS.len() + 1);
+    markers.push(PACKAGE_XML.to_string());
+    markers.extend(IGNORE_MARKERS.iter().map(|m| m.to_string()));
+    let input_glob_set = InputGlobSet {
+        patterns: vec![format!("**/{PACKAGE_XML}")],
+        markers,
+        exclude_hidden: true,
+        // Caller (pixi-build-ros::main) fills in the workspace root
+        // before emitting the recipe.
+        root: None,
+    };
 
     Ok(WorkspaceDiscovery {
         packages,
-        input_globs,
+        input_glob_set,
     })
-}
-
-fn walk(
-    workspace_root: &Path,
-    dir: &Path,
-    packages: &mut HashMap<String, PathBuf>,
-    pruned_dirs: &mut Vec<PathBuf>,
-) -> Result<(), WorkspaceDiscoveryError> {
-    if IGNORE_MARKERS.iter().any(|m| dir.join(m).is_file()) {
-        record_pruned(workspace_root, dir, pruned_dirs);
-        return Ok(());
-    }
-
-    let package_xml = dir.join("package.xml");
-    if package_xml.is_file() {
-        let content =
-            fs::read_to_string(&package_xml).map_err(|source| WorkspaceDiscoveryError::ReadFile {
-                path: package_xml.clone(),
-                source: source.into(),
-            })?;
-        let parsed = PackageXml::parse(&content).map_err(|source| WorkspaceDiscoveryError::Parse {
-            path: package_xml.clone(),
-            source,
-        })?;
-
-        if let Some(existing) = packages.get(&parsed.name) {
-            return Err(WorkspaceDiscoveryError::DuplicateName {
-                name: parsed.name,
-                first: existing.clone(),
-                second: package_xml,
-            });
-        }
-        packages.insert(parsed.name, package_xml);
-    }
-
-    let entries = fs::read_dir(dir).map_err(|source| WorkspaceDiscoveryError::Io {
-        path: dir.to_path_buf(),
-        source: source.into(),
-    })?;
-
-    for entry in entries {
-        let entry = entry.map_err(|source| WorkspaceDiscoveryError::Io {
-            path: dir.to_path_buf(),
-            source,
-        })?;
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        // Skip dot-prefixed directories the same way colcon does: this covers
-        // `.pixi`, `.git`, `.vscode`, etc. without hardcoding any specific
-        // name. The check is only applied to subdirectories, never to the
-        // workspace root itself. A single `!**/.*/**` glob (emitted by the
-        // caller) covers the invalidation side for all of these without
-        // needing to enumerate them, so we do not record each one here.
-        if is_hidden_dir(&path) {
-            continue;
-        }
-        walk(workspace_root, &path, packages, pruned_dirs)?;
-    }
-
-    Ok(())
-}
-
-fn is_hidden_dir(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .is_some_and(|name| name.starts_with('.'))
-}
-
-fn record_pruned(workspace_root: &Path, dir: &Path, pruned_dirs: &mut Vec<PathBuf>) {
-    if let Some(rel) = pathdiff::diff_paths(dir, workspace_root)
-        && !rel.as_os_str().is_empty()
-    {
-        pruned_dirs.push(rel);
-    }
 }
 
 fn path_to_forward_slashes(path: &Path) -> String {
@@ -211,7 +169,11 @@ fn path_to_forward_slashes(path: &Path) -> String {
 /// `ros-<distro>-<name>[url="source://?path=<rel-to-manifest>"]` that, when
 /// parsed via `SerializableMatchSpec::from`, yields a source dependency
 /// pointing at the sibling's `package.xml`.
-pub fn sibling_source_spec(conda_name: &str, sibling_package_xml: &Path, manifest_root: &Path) -> String {
+pub fn sibling_source_spec(
+    conda_name: &str,
+    sibling_package_xml: &Path,
+    manifest_root: &Path,
+) -> String {
     let rel = pathdiff::diff_paths(sibling_package_xml, manifest_root)
         .unwrap_or_else(|| sibling_package_xml.to_path_buf());
     let rel = path_to_forward_slashes(&rel);
@@ -290,27 +252,10 @@ pub fn apply_sibling_overrides(
     ConditionalList::new(items)
 }
 
-/// Rewrite a discovery glob (relative to the workspace root) so it can be
-/// evaluated from the package's `manifest_root`. The glob system rebases
-/// `../`-style up-traversal patterns to a shared search root, so prefixing
-/// each pattern with the relative path from `manifest_root` to
-/// `workspace_root` is enough.
-pub fn rewrite_glob_for_manifest_root(glob: &str, workspace_root: &Path, manifest_root: &Path) -> String {
-    let rel = match pathdiff::diff_paths(workspace_root, manifest_root) {
-        Some(p) if !p.as_os_str().is_empty() => path_to_forward_slashes(&p),
-        _ => return glob.to_string(),
-    };
-    if let Some(rest) = glob.strip_prefix('!') {
-        format!("!{rel}/{rest}")
-    } else {
-        format!("{rel}/{glob}")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use fs_err as fs;
     use tempfile::tempdir;
 
     fn write_package_xml(dir: &Path, name: &str) {
@@ -381,7 +326,15 @@ mod tests {
         let result = discover_ros_packages(root).unwrap();
         assert_eq!(result.packages.len(), 1);
         assert!(result.packages.contains_key("pkg_a"));
-        assert!(result.input_globs.iter().any(|g| g == "!build/**"));
+        // Pixi re-runs the discovery with the same marker semantics to
+        // learn that `build/` is pruned; the marker carries that intent.
+        assert!(
+            result
+                .input_glob_set
+                .markers
+                .iter()
+                .any(|m| m == "COLCON_IGNORE")
+        );
     }
 
     #[test]
@@ -416,12 +369,24 @@ mod tests {
     }
 
     #[test]
-    fn empty_workspace_returns_no_packages_but_keeps_globs() {
+    fn empty_workspace_returns_no_packages_but_keeps_glob_set() {
         let tmp = tempdir().unwrap();
         let result = discover_ros_packages(tmp.path()).unwrap();
         assert!(result.packages.is_empty());
-        assert!(result.input_globs.iter().any(|g| g == "**/package.xml"));
-        assert!(result.input_globs.iter().any(|g| g == "**/COLCON_IGNORE"));
+        assert_eq!(
+            result.input_glob_set.patterns,
+            vec!["**/package.xml".to_string()]
+        );
+        assert!(
+            result
+                .input_glob_set
+                .markers
+                .iter()
+                .any(|m| m == "COLCON_IGNORE"),
+            "expected COLCON_IGNORE marker, got: {:?}",
+            result.input_glob_set.markers
+        );
+        assert!(result.input_glob_set.exclude_hidden);
     }
 
     #[test]
@@ -454,50 +419,6 @@ mod tests {
         let result = discover_ros_packages(root).unwrap();
         assert_eq!(result.packages.len(), 1);
         assert!(result.packages.contains_key("pkg_a"));
-        let contains = |needle: &str| result.input_globs.iter().any(|g| g == needle);
-        assert!(
-            contains("!**/.*/**"),
-            "expected the single hidden-dir exclusion glob, got: {:?}",
-            result.input_globs
-        );
-        // Per-hidden-dir exclusions are no longer emitted: the static
-        // `!**/.*/**` covers all of them in one shot.
-        assert!(
-            !contains("!.pixi/**"),
-            "per-hidden-dir exclusion must not be emitted any more, got: {:?}",
-            result.input_globs
-        );
-        assert!(
-            !contains("!.git/**"),
-            "per-hidden-dir exclusion must not be emitted any more, got: {:?}",
-            result.input_globs
-        );
-    }
-
-    /// Exclusions must come after the includes so pixi's last-match-wins
-    /// matcher actually cancels the includes inside pruned subtrees.
-    #[test]
-    fn input_globs_emit_includes_before_excludes() {
-        let tmp = tempdir().unwrap();
-        let root = tmp.path();
-        write_package_xml(&root.join("pkg"), "pkg");
-        touch(&root.join("build").join("COLCON_IGNORE"));
-
-        let result = discover_ros_packages(root).unwrap();
-        let first_exclude = result
-            .input_globs
-            .iter()
-            .position(|g| g.starts_with('!'))
-            .expect("expected at least one exclusion");
-        let last_include = result
-            .input_globs
-            .iter()
-            .rposition(|g| !g.starts_with('!'))
-            .expect("expected at least one include");
-        assert!(
-            last_include < first_exclude,
-            "all includes must come before any exclusion, got: {:?}",
-            result.input_globs
-        );
+        assert!(result.input_glob_set.exclude_hidden);
     }
 }

--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -44,6 +44,7 @@ impl GenerateRecipe for RustGenerator {
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
         _workspace_directory: Option<PathBuf>,
+        _checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Construct a CargoMetadataProvider to read the Cargo.toml file
         // and extract metadata from it.
@@ -283,6 +284,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -368,6 +370,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -412,6 +415,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -462,6 +466,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -509,6 +514,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -542,6 +548,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -647,6 +654,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await;
 
@@ -677,6 +685,7 @@ mod tests {
                 None,
                 &std::collections::HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -719,6 +728,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -795,6 +805,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -888,6 +899,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,
@@ -995,6 +1007,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
                 None,

--- a/crates/pixi_build_rust/src/main.rs
+++ b/crates/pixi_build_rust/src/main.rs
@@ -43,6 +43,7 @@ impl GenerateRecipe for RustGenerator {
         _channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
         _workspace_scratch_directory: Option<PathBuf>,
+        _workspace_directory: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
         // Construct a CargoMetadataProvider to read the Cargo.toml file
         // and extract metadata from it.
@@ -212,7 +213,7 @@ impl GenerateRecipe for RustGenerator {
         config: &Self::Config,
         _workdir: impl AsRef<Path>,
         _editable: bool,
-    ) -> miette::Result<BTreeSet<String>> {
+    ) -> miette::Result<Vec<String>> {
         Ok([
             "**/*.rs",
             // Cargo configuration files
@@ -281,6 +282,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -310,19 +312,21 @@ mod tests {
             .extract_input_globs_from_build(&config, PathBuf::new(), false)
             .unwrap();
 
+        let contains = |needle: &str| result.iter().any(|g| g == needle);
+
         // Verify that all extra globs are included in the result
         for extra_glob in &config.extra_input_globs {
             assert!(
-                result.contains(extra_glob),
+                contains(extra_glob),
                 "Result should contain extra glob: {extra_glob}"
             );
         }
 
         // Verify that default globs are still present
-        assert!(result.contains("**/*.rs"));
-        assert!(result.contains("Cargo.toml"));
-        assert!(result.contains("Cargo.lock"));
-        assert!(result.contains("build.rs"));
+        assert!(contains("**/*.rs"));
+        assert!(contains("Cargo.toml"));
+        assert!(contains("Cargo.lock"));
+        assert!(contains("build.rs"));
     }
 
     #[macro_export]
@@ -361,6 +365,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -409,6 +414,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -453,6 +459,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -501,6 +508,7 @@ mod tests {
                 vec![],
                 None,
                 None,
+                None,
             )
             .await
             .expect("Failed to generate recipe");
@@ -534,6 +542,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -607,9 +616,9 @@ mod tests {
         );
 
         insta::assert_yaml_snapshot!(&generated_recipe.metadata_input_globs, @r###"
-        - "../../Cargo.toml"
-        - "../Cargo.toml"
         - Cargo.toml
+        - "../Cargo.toml"
+        - "../../Cargo.toml"
         "###);
     }
 
@@ -635,6 +644,7 @@ mod tests {
                 None,
                 &std::collections::HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -667,6 +677,7 @@ mod tests {
                 None,
                 &std::collections::HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -708,6 +719,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -783,6 +795,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -875,6 +888,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )
@@ -981,6 +995,7 @@ mod tests {
                 None,
                 &HashSet::new(),
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/pixi_build_rust/src/metadata.rs
+++ b/crates/pixi_build_rust/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr};
 
 use cargo_toml::{
     AbstractFilesystem, Error as CargoTomlError, Filesystem, Inheritable, Manifest, Package,
@@ -90,19 +90,19 @@ impl CargoMetadataProvider {
     ///
     /// # Returns
     ///
-    /// A `BTreeSet` of glob patterns as strings. Common patterns include:
+    /// A `Vec` of glob patterns as strings. Common patterns include:
     /// - `"Cargo.toml"` - The package's manifest file
     /// - `"../../**/Cargo.toml"` - Workspace manifest files (when workspace
     ///   inheritance is used)
-    pub fn input_globs(&self) -> BTreeSet<String> {
-        let mut input_globs = BTreeSet::new();
+    pub fn input_globs(&self) -> Vec<String> {
+        let mut input_globs = Vec::new();
 
         let Some(_) = self.cargo_manifest.get() else {
             return input_globs;
         };
 
         // Add the Cargo.toml manifest file itself.
-        input_globs.insert(String::from("Cargo.toml"));
+        input_globs.push(String::from("Cargo.toml"));
 
         // If the manifest has workspace inheritance, include that as well.
         if let Some((_, workspace_path)) = self.workspace_manifest.get() {
@@ -121,7 +121,7 @@ impl CargoMetadataProvider {
                 &self.manifest_root,
             ) {
                 if workspace_selected {
-                    input_globs.insert(format!(
+                    input_globs.push(format!(
                         "{}/Cargo.toml",
                         path.display().to_string().replace("\\", "/")
                     ));
@@ -659,7 +659,7 @@ version.workspace = true
         let _ = provider.version().unwrap();
 
         let globs = provider.input_globs();
-        assert!(globs.contains("Cargo.toml"));
+        assert!(globs.iter().any(|g| g == "Cargo.toml"));
         // When workspace is in the same file, no additional glob is needed
         assert_eq!(
             globs.len(),
@@ -709,7 +709,7 @@ description.workspace = true
         assert_eq!(version_result.unwrap().unwrap().to_string(), "2.0.0");
 
         let globs = provider.input_globs();
-        assert!(globs.contains("Cargo.toml"));
+        assert!(globs.iter().any(|g| g == "Cargo.toml"));
         // Should include workspace glob since workspace inheritance from separate file
         // is detected
         assert!(
@@ -747,7 +747,7 @@ version = "1.0.0"
             1,
             "Expected exactly 1 glob when no workspace is present, got: {globs:?}"
         );
-        assert!(globs.contains("Cargo.toml"));
+        assert!(globs.iter().any(|g| g == "Cargo.toml"));
 
         // Verify no workspace-related globs are present
         let has_workspace_glob = globs
@@ -793,7 +793,7 @@ description = "Direct package values"
             1,
             "Expected exactly 1 glob when workspace exists but no inheritance is used, got: {globs:?}"
         );
-        assert!(globs.contains("Cargo.toml"));
+        assert!(globs.iter().any(|g| g == "Cargo.toml"));
     }
 
     #[test]

--- a/crates/pixi_build_types/src/input_glob_set.rs
+++ b/crates/pixi_build_types/src/input_glob_set.rs
@@ -1,0 +1,106 @@
+//! Structured description of input globs a backend used while producing a
+//! result.  This type mirrors `pixi_glob::GlobSet`'s constructor surface
+//! so a backend can describe its inputs in a form pixi can replay
+//! verbatim, including marker-driven workspace discovery and hidden-folder
+//! handling that the flat `Vec<String>` form cannot express.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+/// One group of inputs the backend wants pixi to monitor.  When a result
+/// carries multiple `InputGlobSet`s pixi walks each independently and unions
+/// the resulting match sets, so different groups can carry mutually
+/// incompatible includes/excludes/markers without interfering.
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct InputGlobSet {
+    /// Gitignore-style patterns: bare patterns include, `!`-prefixed
+    /// patterns exclude.  Order matters under last-match-wins.
+    pub patterns: Vec<String>,
+
+    /// File names the walker probes for in each directory it enters.  A
+    /// marker present in a directory dispatches against [`Self::patterns`]:
+    /// match an include → record the marker path as a leaf and stop
+    /// descent; match an exclude or nothing → prune the subtree.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub markers: Vec<String>,
+
+    /// When `true` (the default), hidden directories (names starting with
+    /// `.`) are skipped unless an include pattern opts them in explicitly.
+    #[serde(default = "default_true")]
+    pub exclude_hidden: bool,
+
+    /// Walk root for this group.  `None` means the caller-supplied root
+    /// (typically the package manifest directory at consumer call sites).
+    /// When `Some`, an absolute path is used as-is and a relative path is
+    /// joined onto the caller-supplied root, so a backend can target a
+    /// workspace via `root: Some("../..")` or `root: Some(<workspace>)`
+    /// without baking `../..` segments into every pattern.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root: Option<PathBuf>,
+}
+
+impl Default for InputGlobSet {
+    fn default() -> Self {
+        Self {
+            patterns: Vec::new(),
+            markers: Vec::new(),
+            exclude_hidden: true,
+            root: None,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn omitted_markers_and_hidden_default() {
+        let json = r#"{"patterns": ["**/*.rs"]}"#;
+        let parsed: InputGlobSet = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.patterns, vec!["**/*.rs".to_string()]);
+        assert!(parsed.markers.is_empty());
+        assert!(parsed.exclude_hidden);
+        assert!(parsed.root.is_none());
+    }
+
+    #[test]
+    fn full_round_trip() {
+        let original = InputGlobSet {
+            patterns: vec!["**/package.xml".to_string()],
+            markers: vec!["package.xml".to_string(), "COLCON_IGNORE".to_string()],
+            exclude_hidden: true,
+            root: Some(PathBuf::from("../..")),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: InputGlobSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn empty_markers_and_none_root_are_skipped_when_serializing() {
+        let v = InputGlobSet {
+            patterns: vec!["**/*.cpp".to_string()],
+            markers: Vec::new(),
+            exclude_hidden: true,
+            root: None,
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        assert!(
+            !json.contains("markers"),
+            "empty markers should be skipped, got: {json}"
+        );
+        assert!(
+            !json.contains("root"),
+            "absent root should be skipped, got: {json}"
+        );
+    }
+}

--- a/crates/pixi_build_types/src/lib.rs
+++ b/crates/pixi_build_types/src/lib.rs
@@ -2,6 +2,7 @@
 mod capabilities;
 mod channel_configuration;
 mod conda_package_metadata;
+mod input_glob_set;
 pub mod procedures;
 mod project_model;
 mod variant;
@@ -11,6 +12,7 @@ use std::{fmt::Display, sync::LazyLock};
 pub use capabilities::{BackendCapabilities, FrontendCapabilities};
 pub use channel_configuration::ChannelConfiguration;
 pub use conda_package_metadata::CondaPackageMetadata;
+pub use input_glob_set::InputGlobSet;
 pub use project_model::{
     BinaryPackageSpec, ConstraintSpec, GitReference, GitSpec, NamedSpec, PackageSpec, PathSpec,
     PinBound, PinCompatibleSpec, PinExpression, ProjectModel, SourcePackageLocationSpec,

--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -6,7 +6,7 @@
 //! build the package.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     path::PathBuf,
 };
 
@@ -271,7 +271,11 @@ pub struct CondaBuildV1Result {
     /// The globs that were used as input to the build. If any of the files that
     /// match these globs changes, the package should be considered
     /// "out-of-date".
-    pub input_globs: BTreeSet<String>,
+    ///
+    /// Order is significant: pixi feeds these into a gitignore-style matcher,
+    /// so inclusion patterns must precede any `!`-prefixed exclusions that
+    /// should override them.
+    pub input_globs: Vec<String>,
 
     /// The normalized name of the package.
     pub name: String,

--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -5,10 +5,7 @@
 //! source dependencies and other build steps before the backend is invoked to
 //! build the package.
 
-use std::{
-    collections::BTreeMap,
-    path::PathBuf,
-};
+use std::{collections::BTreeMap, path::PathBuf};
 
 use rattler_conda_types::{
     ChannelUrl, MatchSpec, PackageName, Platform, RepoDataRecord, VersionWithSource,
@@ -17,7 +14,7 @@ use rattler_conda_types::{
 use serde::{Deserialize, Serialize};
 use serde_with::{DefaultOnError, DisplayFromStr, serde_as};
 
-use crate::VariantValue;
+use crate::{InputGlobSet, VariantValue};
 
 pub const METHOD_NAME: &str = "conda/build_v1";
 
@@ -276,6 +273,13 @@ pub struct CondaBuildV1Result {
     /// so inclusion patterns must precede any `!`-prefixed exclusions that
     /// should override them.
     pub input_globs: Vec<String>,
+
+    /// Optional structured description of the same inputs.  When present,
+    /// pixi uses this in preference to [`Self::input_globs`]; older clients
+    /// fall back to the flat list above.  Backends migrating to this field
+    /// SHOULD populate both for compatibility during the transition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_glob_sets: Option<Vec<InputGlobSet>>,
 
     /// The normalized name of the package.
     pub name: String,

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -6,17 +6,14 @@
 //!
 //! This API was introduced in Pixi Build API version 1.
 
-use std::{
-    collections::BTreeMap,
-    path::PathBuf,
-};
+use std::{collections::BTreeMap, path::PathBuf};
 
 use ordermap::OrderSet;
 use rattler_conda_types::{ChannelUrl, NoArchType, PackageName, Platform, VersionWithSource};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use crate::{ConstraintSpec, PackageSpec, VariantValue, project_model::NamedSpec};
+use crate::{ConstraintSpec, InputGlobSet, PackageSpec, VariantValue, project_model::NamedSpec};
 
 pub const METHOD_NAME: &str = "conda/outputs";
 
@@ -77,6 +74,14 @@ pub struct CondaOutputsResult {
     /// which inherits the same semantics, so reordering would silently
     /// undo exclusions.
     pub input_globs: Vec<String>,
+
+    /// Optional structured description of the same inputs.  When present,
+    /// pixi uses this in preference to [`Self::input_globs`]; older clients
+    /// that don't recognise the field fall back to the flat list above.
+    /// Backends migrating to this field SHOULD populate both for
+    /// compatibility during the transition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_glob_sets: Option<Vec<InputGlobSet>>,
 }
 
 #[serde_as]
@@ -120,6 +125,13 @@ pub struct CondaOutput {
     /// [`CondaOutputsResult::input_globs`] will be used. Order matters; see
     /// [`CondaOutputsResult::input_globs`].
     pub input_globs: Option<Vec<String>>,
+
+    /// Optional structured form for this output's inputs.  When present,
+    /// supersedes [`Self::input_globs`] for newer pixi clients; older
+    /// clients fall back to the flat list.  Backends migrating to this
+    /// field SHOULD populate both for compatibility during the transition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_glob_sets: Option<Vec<InputGlobSet>>,
 }
 
 #[serde_as]

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -7,7 +7,7 @@
 //! This API was introduced in Pixi Build API version 1.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     path::PathBuf,
 };
 
@@ -70,7 +70,13 @@ pub struct CondaOutputsResult {
     /// The files that were read as part of the computation. These files are
     /// hashed and stored in the lock file. If the files change, the
     /// lock file will be invalidated.
-    pub input_globs: BTreeSet<String>,
+    ///
+    /// Backends MUST emit globs in gitignore-style "last match wins" order:
+    /// list inclusion patterns first, then any `!`-prefixed exclusions that
+    /// should override them. Pixi feeds these straight into its `GlobSet`
+    /// which inherits the same semantics, so reordering would silently
+    /// undo exclusions.
+    pub input_globs: Vec<String>,
 }
 
 #[serde_as]
@@ -111,8 +117,9 @@ pub struct CondaOutput {
     // pub cache: Option<CondaCacheMetadata>,
 
     /// Explicit input globs for this specific output. If this is `None`,
-    /// [`CondaOutputsResult::input_globs`] will be used.
-    pub input_globs: Option<BTreeSet<String>>,
+    /// [`CondaOutputsResult::input_globs`] will be used. Order matters; see
+    /// [`CondaOutputsResult::input_globs`].
+    pub input_globs: Option<Vec<String>>,
 }
 
 #[serde_as]

--- a/crates/pixi_build_types/src/procedures/initialize.rs
+++ b/crates/pixi_build_types/src/procedures/initialize.rs
@@ -42,6 +42,21 @@ pub struct InitializeParams {
     /// This is an absolute path.
     pub workspace_directory: Option<PathBuf>,
 
+    /// Root of the git or url checkout this package was unpacked
+    /// into, BEFORE any `subdirectory` is applied.  `None` for
+    /// local-path sources (there is no checkout in that case;
+    /// backends fall back to [`Self::workspace_directory`] for
+    /// cross-package discovery).
+    ///
+    /// Distinct from [`Self::workspace_directory`] (which is anchored
+    /// at a discovered pixi workspace) and from
+    /// [`Self::source_directory`] (the package's own directory).
+    /// Backends that need to reason about siblings inside the same
+    /// remote checkout (e.g. ROS workspace sibling-package discovery)
+    /// anchor their search here when it is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkout_root: Option<PathBuf>,
+
     /// Optionally the cache directory to use for any caching activity.
     pub cache_directory: Option<PathBuf>,
 

--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -5,7 +5,7 @@ mod ext;
 pub use ext::BackendSourceBuildExt;
 
 use std::{
-    collections::{BTreeMap, BTreeSet, BinaryHeap},
+    collections::{BTreeMap, BTreeSet},
     fmt::Display,
     path::PathBuf,
     sync::Arc,
@@ -132,7 +132,11 @@ pub struct BackendBuiltSource {
 
     /// The globs that were used as input to the build. Use these for
     /// re-verifying the build.
-    pub input_globs: BinaryHeap<String>,
+    ///
+    /// Order is preserved: pixi's `GlobSet` is gitignore last-match-wins, so
+    /// inclusion patterns must precede any negated exclusions that should
+    /// override them.
+    pub input_globs: Vec<String>,
 
     /// The actual files that matched the globs at build time. This allows
     /// detecting file deletions and additions.

--- a/crates/pixi_command_dispatcher/src/build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build/mod.rs
@@ -13,6 +13,7 @@ pub use build_environment::BuildEnvironment;
 pub use dependencies::{
     Dependencies, DependenciesError, DependencySource, KnownEnvironment, PixiRunExports, WithSource,
 };
+use pixi_consts::consts::KNOWN_MANIFEST_FILES;
 use pixi_record::{CanonicalSourceLocation, PinnedBuildSourceSpec, PinnedSourceSpec};
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -158,10 +159,9 @@ impl CanonicalSourceCodeLocation {
                 path.path.hash(&mut hasher);
                 self.source_code().hash(&mut hasher);
                 let unique_key = URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes());
-                if let Some(file_name) = path.path.file_name() {
-                    format!("{file_name}-{unique_key}")
-                } else {
-                    unique_key
+                match display_name_for_source_path(&path.path) {
+                    Some(name) => format!("{name}-{unique_key}"),
+                    None => unique_key,
                 }
             }
         }
@@ -175,6 +175,37 @@ impl From<PinnedSourceCodeLocation> for CanonicalSourceCodeLocation {
             build_source: value.build_source.map(|source| source.into_pinned().into()),
         }
     }
+}
+
+/// Pick a human-readable name for a path-like source location.
+///
+/// When the path ends in a well-known manifest filename (e.g. `package.xml`,
+/// `pixi.toml`, `recipe.yaml`), the parent directory's name carries the
+/// package identity and is used instead; otherwise the file name is used
+/// as-is. Returns `None` only if neither is available.
+pub(super) fn display_name_for_source_path(path: &typed_path::Utf8TypedPathBuf) -> Option<String> {
+    let name = path.file_name()?;
+    if KNOWN_MANIFEST_FILES.contains(&name)
+        && let Some(parent) = path.parent()
+        && let Some(parent_name) = parent.file_name()
+    {
+        return Some(parent_name.to_string());
+    }
+    Some(name.to_string())
+}
+
+/// Same as [`display_name_for_source_path`] but for `std::path::Path`.
+pub(super) fn display_name_for_std_path(path: &std::path::Path) -> Option<String> {
+    let name = path.file_name().and_then(|s| s.to_str())?;
+    if KNOWN_MANIFEST_FILES.contains(&name)
+        && let Some(parent_name) = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+    {
+        return Some(parent_name.to_string());
+    }
+    Some(name.to_string())
 }
 
 /// Try to deduce a name from a url.
@@ -228,6 +259,56 @@ mod tests {
                     (url, pretty_url_name(&parsed_url))
                 })
                 .collect::<IndexMap<_, _>>()
+        );
+    }
+
+    #[test]
+    fn display_name_substitutes_parent_for_manifest_paths() {
+        use typed_path::Utf8TypedPathBuf;
+
+        // Known manifest filenames: parent dir wins.
+        assert_eq!(
+            display_name_for_source_path(&Utf8TypedPathBuf::from("/ws/src/my_pkg/package.xml"))
+                .as_deref(),
+            Some("my_pkg"),
+        );
+        assert_eq!(
+            display_name_for_source_path(&Utf8TypedPathBuf::from("/proj/pixi.toml")).as_deref(),
+            Some("proj"),
+        );
+        assert_eq!(
+            display_name_for_source_path(&Utf8TypedPathBuf::from("/proj/pyproject.toml"))
+                .as_deref(),
+            Some("proj"),
+        );
+        assert_eq!(
+            display_name_for_source_path(&Utf8TypedPathBuf::from("/proj/recipe.yaml")).as_deref(),
+            Some("proj"),
+        );
+
+        // Unknown filenames: file name wins.
+        assert_eq!(
+            display_name_for_source_path(&Utf8TypedPathBuf::from("/proj/data.txt")).as_deref(),
+            Some("data.txt"),
+        );
+        // Directory checkout: dir name wins.
+        assert_eq!(
+            display_name_for_source_path(&Utf8TypedPathBuf::from("/proj/my_pkg")).as_deref(),
+            Some("my_pkg"),
+        );
+    }
+
+    #[test]
+    fn display_name_for_std_path_matches_typed_variant() {
+        use std::path::Path;
+
+        assert_eq!(
+            display_name_for_std_path(Path::new("/ws/src/my_pkg/package.xml")).as_deref(),
+            Some("my_pkg"),
+        );
+        assert_eq!(
+            display_name_for_std_path(Path::new("/proj/data.txt")).as_deref(),
+            Some("data.txt"),
         );
     }
 }

--- a/crates/pixi_command_dispatcher/src/build/work_dir_key.rs
+++ b/crates/pixi_command_dispatcher/src/build/work_dir_key.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::BTreeMap,
-    ffi::OsStr,
     hash::{Hash, Hasher},
 };
 
@@ -58,15 +57,13 @@ impl WorkDirKey {
         self.build_backend.hash(&mut hasher);
         let unique_key = URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes());
 
-        let name = match &self.source {
+        let name: Option<String> = match &self.source {
             SourceRecordOrCheckout::Record { package_name, .. } => {
-                Some(package_name.as_normalized())
+                Some(package_name.as_normalized().to_string())
             }
-            SourceRecordOrCheckout::Checkout { checkout } => checkout
-                .path
-                .as_std_path()
-                .file_name()
-                .and_then(OsStr::to_str),
+            SourceRecordOrCheckout::Checkout { checkout } => {
+                super::display_name_for_std_path(checkout.path.as_std_path())
+            }
         };
 
         match name {

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -960,8 +960,9 @@ impl BuildBackendMetadataInner {
 struct RawCondaOutputs {
     /// The outputs as reported by the build backend.
     outputs: Vec<pixi_build_types::procedures::conda_outputs::CondaOutput>,
-    /// Globs of files from which the metadata was derived.
-    input_globs: std::collections::BinaryHeap<String>,
+    /// Globs of files from which the metadata was derived. Order matters:
+    /// pixi's `GlobSet` is gitignore last-match-wins.
+    input_globs: Vec<String>,
     /// Paths of files that match the input globs.
     input_files: std::collections::BTreeSet<PathBuf>,
     /// The timestamp of when the metadata was computed.

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -3,7 +3,6 @@ use miette::Diagnostic;
 use once_cell::sync::Lazy;
 use pixi_build_discovery::CommandSpec;
 use pixi_build_types::procedures::conda_outputs::CondaOutputsParams;
-use pixi_glob::GlobSet;
 use pixi_record::{CanonicalSourceLocation, PinnedBuildSourceSpec, PinnedSourceSpec, VariantValue};
 use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceLocationSpec};
 use rattler_conda_types::ChannelUrl;
@@ -15,6 +14,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use thiserror::Error;
+use tracing::instrument;
 
 use crate::build::CanonicalSourceCodeLocation;
 use crate::cache::markers::BackendMetadataDir;
@@ -47,6 +47,23 @@ fn warn_once_per_backend(backend_name: &str) {
             "metadata cache disabled for build backend '{}' (system/path-based backends always regenerate metadata)",
             backend_name
         );
+    }
+}
+
+/// Return the checkout root sent to the backend as `checkout_root`,
+/// or `None` for local-path sources.  Git and url checkouts have a
+/// well-defined unpack root that may differ from the manifest's own
+/// directory when a `subdirectory` is configured; path sources have
+/// no separate root concept and use `workspace_directory` as their
+/// cross-package discovery anchor instead.
+pub(crate) fn checkout_root_for(
+    checkout: &pixi_compute_sources::SourceCheckout,
+) -> Option<&std::path::Path> {
+    match &checkout.pinned {
+        pixi_record::PinnedSourceSpec::Path(_) => None,
+        pixi_record::PinnedSourceSpec::Git(_) | pixi_record::PinnedSourceSpec::Url(_) => {
+            Some(checkout.root_dir.as_std_path())
+        }
     }
 }
 
@@ -267,6 +284,7 @@ impl BuildBackendMetadataInner {
     ///   returned for comparison (e.g. to reuse the ID if outputs match).
     /// - `Ok(Err(None))` if no cache entry exists.
     async fn verify_cache_freshness(
+        ctx: &mut ComputeCtx,
         cache_entry: Option<CacheEntry<BuildBackendMetadataCache>>,
         build_source_checkout: &SourceCheckout,
         project_model_hash: Option<ProjectModelHash>,
@@ -358,16 +376,36 @@ impl BuildBackendMetadataInner {
             };
         }
 
-        let glob_set = GlobSet::create(cache_entry.input_globs.iter().map(String::as_str));
-        for matching_file in glob_set
-            .collect_matching(build_source_dir.as_std_path())
-            .map_err(BuildBackendMetadataError::from)?
-        {
-            let path = matching_file.into_path();
-            if cache_entry.input_files.contains(&path) {
+        // Invalidate when the walk picks up a file the cache entry never
+        // recorded (i.e. one that was added since the last run). The
+        // existing entries in `input_files` were freshness-checked above;
+        // this second pass only catches newcomers.
+        //
+        // `input_files` stores paths relative to `build_source_dir` (see
+        // the `strip_prefix` at the write site), so the absolute paths
+        // returned by the walker must be relativized before the membership
+        // check or every path looks "new".  When the cache entry carries
+        // the structured `input_glob_sets` we use that instead of the flat
+        // `input_globs`; this is what unlocks the marker-driven workspace
+        // walk for ROS-style backends.
+        let globs_root = build_source_dir.as_std_path();
+        let new_file_candidates = crate::input_globs::collect_input_files_via_engine(
+            ctx,
+            &cache_entry.input_globs,
+            cache_entry.input_glob_sets.as_deref(),
+            globs_root,
+        )
+        .await
+        .map_err(BuildBackendMetadataError::GlobSet)?;
+        for abs_path in new_file_candidates {
+            let key_path = abs_path
+                .strip_prefix(globs_root)
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|_| abs_path.clone());
+            if !cache_entry.input_files.contains(&key_path) {
                 tracing::info!(
                     "found cached outputs but a new matching file at '{}' has been detected, invalidating cache.",
-                    path.display()
+                    abs_path.display()
                 );
                 return Ok(Err(Some(cache_entry)));
             }
@@ -425,6 +463,7 @@ impl BuildBackendMetadataInner {
     /// checkout.
     async fn call_conda_outputs(
         &self,
+        ctx: &mut ComputeCtx,
         metadata_dir: &pixi_path::AbsPresumedDirPath,
         build_source_checkout: &SourceCheckout,
         source_unique_key: &str,
@@ -499,24 +538,28 @@ impl BuildBackendMetadataInner {
 
         // Determine the files that match the input globs.
         let globs_root = build_source_checkout.path.as_dir_or_file_parent();
-        let input_glob_set = GlobSet::create(outputs.input_globs.iter().map(String::as_str));
         let globs_root_path = globs_root.as_std_path();
-        let input_glob_files = input_glob_set
-            .collect_matching(globs_root_path)
-            .map_err(BuildBackendMetadataError::from)?
-            .into_iter()
-            .map(|entry| {
-                let path = entry.into_path();
-                path.strip_prefix(globs_root_path)
-                    .ok()
-                    .unwrap_or(&path)
-                    .to_path_buf()
-            })
-            .collect();
+        let input_glob_files = crate::input_globs::collect_input_files_via_engine(
+            ctx,
+            &outputs.input_globs,
+            outputs.input_glob_sets.as_deref(),
+            globs_root_path,
+        )
+        .await
+        .map_err(BuildBackendMetadataError::GlobSet)?
+        .into_iter()
+        .map(|path| {
+            path.strip_prefix(globs_root_path)
+                .ok()
+                .unwrap_or(&path)
+                .to_path_buf()
+        })
+        .collect();
 
         Ok(RawCondaOutputs {
             outputs: outputs.outputs,
             input_globs: outputs.input_globs.into_iter().collect(),
+            input_glob_sets: outputs.input_glob_sets,
             input_files: input_glob_files,
             timestamp,
         })
@@ -543,6 +586,14 @@ impl BuildBackendMetadataInnerKey {
 impl Key for BuildBackendMetadataInnerKey {
     type Value = Result<Arc<BuildBackendMetadata>, BuildBackendMetadataError>;
 
+    #[instrument(
+        skip_all,
+        name = "build-backend-metadata",
+        fields(
+            source = %self.0.manifest_source,
+            host_platform = %self.0.build_environment.host_platform,
+        )
+    )]
     async fn compute(&self, ctx: &mut ComputeCtx) -> Self::Value {
         // Reporter lifecycle: queue up-front so the reporter can count
         // us before any real work starts. The `on_started` event carries
@@ -771,6 +822,7 @@ impl BuildBackendMetadataInner {
         }
 
         match Self::verify_cache_freshness(
+            ctx,
             cache_read_result,
             &checkouts.build_source_checkout,
             project_model_hash,
@@ -842,6 +894,7 @@ impl BuildBackendMetadataInner {
             .compute(
                 &InstantiateBackendKey::new(
                     checkouts.manifest_source_checkout.path.as_std_path(),
+                    checkout_root_for(&checkouts.manifest_source_checkout),
                     checkouts.manifest_source_anchor.clone(),
                     checkouts
                         .build_source_checkout
@@ -894,6 +947,7 @@ impl BuildBackendMetadataInner {
 
         let raw = self
             .call_conda_outputs(
+                ctx,
                 &metadata_dir,
                 &checkouts.build_source_checkout,
                 &source_unique_key,
@@ -917,6 +971,7 @@ impl BuildBackendMetadataInner {
             build_variants: self.variant_configuration.clone(),
             build_variant_files: self.variant_files.iter().cloned().collect(),
             input_globs: raw.input_globs,
+            input_glob_sets: raw.input_glob_sets,
             input_files: raw.input_files,
             source: canonical_source,
             project_model_hash,
@@ -963,6 +1018,9 @@ struct RawCondaOutputs {
     /// Globs of files from which the metadata was derived. Order matters:
     /// pixi's `GlobSet` is gitignore last-match-wins.
     input_globs: Vec<String>,
+    /// Structured form of [`Self::input_globs`].  Some only when the
+    /// backend's response carried `inputGlobSets`.
+    input_glob_sets: Option<Vec<pixi_build_types::InputGlobSet>>,
     /// Paths of files that match the input globs.
     input_files: std::collections::BTreeSet<PathBuf>,
     /// The timestamp of when the metadata was computed.
@@ -1076,6 +1134,7 @@ mod tests {
             ignore_run_exports: CondaOutputIgnoreRunExports::default(),
             run_exports: CondaOutputRunExports::default(),
             input_globs: None,
+            input_glob_sets: None,
         }
     }
 

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -22,7 +22,7 @@
 //! memory for the lifetime of the process.
 
 use std::{
-    collections::{BTreeMap, BinaryHeap},
+    collections::BTreeMap,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
@@ -138,8 +138,12 @@ pub fn compute_artifact_cache_key(
 pub struct ArtifactSidecar {
     /// Glob patterns that match the set of files the build reads. Used at
     /// lookup time to detect newly-added matching files.
-    #[serde(default, skip_serializing_if = "BinaryHeap::is_empty")]
-    pub input_globs: BinaryHeap<String>,
+    ///
+    /// Order is preserved: pixi's `GlobSet` is gitignore last-match-wins, so
+    /// inclusion patterns must precede any negated exclusions that should
+    /// override them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_globs: Vec<String>,
 
     /// Paths of the files actually read by the build, relative to the source
     /// directory, paired with their mtime at build time.

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -189,9 +189,11 @@ pub struct BuildBackendMetadataCacheEntry {
     /// we prefer to store direct file paths instead. However, this does not
     /// work for all backends so we also support globs.
     ///
-    /// If the source itself is immutable this is None.
-    #[serde(default, skip_serializing_if = "BinaryHeap::is_empty")]
-    pub input_globs: BinaryHeap<String>,
+    /// Order is preserved: pixi's `GlobSet` is gitignore last-match-wins, so
+    /// inclusion patterns must precede any negated exclusions that should
+    /// override them. If the source itself is immutable this is empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_globs: Vec<String>,
 
     /// Paths relative to the source checkout of files that were used to
     /// determine the metadata. This is the result of the matching the globs

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -195,6 +195,13 @@ pub struct BuildBackendMetadataCacheEntry {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub input_globs: Vec<String>,
 
+    /// Structured form of [`Self::input_globs`].  Populated when the
+    /// backend response carried `input_glob_sets`; pixi prefers this when
+    /// re-walking for new-file detection because it can express
+    /// marker-driven pruning that the flat list cannot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_glob_sets: Option<Vec<pixi_build_types::InputGlobSet>>,
+
     /// Paths relative to the source checkout of files that were used to
     /// determine the metadata. This is the result of the matching the globs
     /// against the filesystem.

--- a/crates/pixi_command_dispatcher/src/input_globs.rs
+++ b/crates/pixi_command_dispatcher/src/input_globs.rs
@@ -1,0 +1,58 @@
+//! Compute-engine-driven helper for walking the input globs a backend
+//! reported.  Both the flat `input_globs: Vec<String>` and the
+//! structured `input_glob_sets: Option<Vec<InputGlobSet>>` are consumed:
+//! the flat form is folded into a synthetic [`InputGlobSet`] (no
+//! markers, default hidden handling, caller's root) and walked
+//! alongside any structured groups via [`InputGlobSetWalkKey`], so two
+//! consumers that arrive at the same `(absolute_root, patterns,
+//! markers, exclude_hidden)` tuple share a single walk for the engine's
+//! lifetime.
+
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use pixi_build_types::InputGlobSet;
+use pixi_compute_engine::ComputeCtx;
+use pixi_glob::GlobSetError;
+
+use crate::keys::InputGlobSetWalkKey;
+
+/// Walk every group implied by the input declaration, deduping the
+/// resulting paths.  See module docs for the consumption rules.
+pub async fn collect_input_files_via_engine(
+    ctx: &mut ComputeCtx,
+    input_globs: &[String],
+    input_glob_sets: Option<&[InputGlobSet]>,
+    caller_root: &Path,
+) -> Result<Vec<PathBuf>, Arc<GlobSetError>> {
+    let mut all: Vec<PathBuf> = Vec::new();
+
+    if !input_globs.is_empty() {
+        let flat_as_group = InputGlobSet {
+            patterns: input_globs.to_vec(),
+            markers: Vec::new(),
+            exclude_hidden: true,
+            root: None,
+        };
+        let key = InputGlobSetWalkKey::from_group(&flat_as_group, caller_root);
+        let paths = ctx.compute(&key).await?;
+        all.extend(paths.iter().cloned());
+    }
+
+    if let Some(groups) = input_glob_sets {
+        for group in groups {
+            let key = InputGlobSetWalkKey::from_group(group, caller_root);
+            let paths = ctx.compute(&key).await?;
+            all.extend(paths.iter().cloned());
+        }
+    }
+
+    // Dedupe; a backend transitioning to `input_glob_sets` emits both
+    // forms for back-compat and we'd otherwise count overlapping matches
+    // twice.
+    all.sort();
+    all.dedup();
+    Ok(all)
+}

--- a/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
@@ -81,6 +81,18 @@ pub struct InstantiateBackendKey {
     /// construction.
     pub source_path: PathBuf,
 
+    /// Explicit source root override.  `Some(path)` for git/url
+    /// sources, carrying the directory pixi unpacked the checkout
+    /// into BEFORE any `subdirectory` is applied.  `None` for local
+    /// path sources; in that case the discovered
+    /// `init_params.workspace_root` (which already factors in a
+    /// `pixi.toml` walk-up) is the source root we send to the
+    /// backend, matching the rule "for path sources, either the
+    /// workspace root or the package source itself".  Plumbed to the
+    /// backend via
+    /// [`pixi_build_types::procedures::initialize::InitializeParams::checkout_root`].
+    pub checkout_root: Option<PathBuf>,
+
     /// Anchor used to resolve relative source refs in the discovered
     /// backend's `BackendSpec`.
     pub manifest_source_anchor: SourceAnchor,
@@ -100,6 +112,7 @@ pub struct InstantiateBackendKey {
 impl InstantiateBackendKey {
     pub fn new(
         source_path: impl AsRef<std::path::Path>,
+        checkout_root: Option<&std::path::Path>,
         manifest_source_anchor: SourceAnchor,
         build_source_dir: AbsPresumedDirPathBuf,
         exclude_newer: Option<ResolvedExcludeNewer>,
@@ -107,8 +120,11 @@ impl InstantiateBackendKey {
         let source_path = source_path.as_ref();
         let canonical =
             dunce::canonicalize(source_path).unwrap_or_else(|_| source_path.to_path_buf());
+        let canonical_checkout_root =
+            checkout_root.map(|r| dunce::canonicalize(r).unwrap_or_else(|_| r.to_path_buf()));
         Self {
             source_path: canonical,
+            checkout_root: canonical_checkout_root,
             manifest_source_anchor,
             build_source_dir,
             exclude_newer,
@@ -312,6 +328,7 @@ impl InstantiateBackendKey {
 
         spawn_json_rpc(
             source_dir,
+            self.checkout_root.clone(),
             &discovered.init_params,
             &self.project_model_overrides,
             tool,
@@ -350,6 +367,7 @@ impl InstantiateBackendKey {
                 manifest_path: init_params.manifest_path.clone(),
                 source_directory: Some(source_dir.to_path_buf()),
                 workspace_directory: Some(init_params.workspace_root.clone()),
+                checkout_root: self.checkout_root.clone(),
                 cache_directory: Some(cache_dir_root),
                 workspace_scratch_directory,
                 project_model,
@@ -576,8 +594,10 @@ fn check_project_model_invariant(
 
 /// Spawn a JSON-RPC backend for `tool` and wrap it in the standard
 /// [`BackendHandle`] mutex.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_json_rpc(
     source_dir: PathBuf,
+    checkout_root: Option<PathBuf>,
     init_params: &BackendInitializationParams,
     project_model_overrides: &ProjectModelOverrides,
     tool: Tool,
@@ -590,6 +610,7 @@ async fn spawn_json_rpc(
         source_dir,
         init_params.manifest_path.clone(),
         init_params.workspace_root.clone(),
+        checkout_root,
         project_model,
         init_params.configuration.clone(),
         init_params.target_configuration.clone(),

--- a/crates/pixi_command_dispatcher/src/keys/input_glob_set_walk.rs
+++ b/crates/pixi_command_dispatcher/src/keys/input_glob_set_walk.rs
@@ -1,0 +1,140 @@
+//! Compute-engine Key that walks the filesystem according to an
+//! [`InputGlobSet`].  The walk root is captured as a *resolved* absolute
+//! path so two consumers that arrive at the same workspace via different
+//! `caller_root + group.root` combinations dedupe naturally through the
+//! engine.
+//!
+//! Used by the cache-freshness and post-RPC `input_files` computations
+//! in `build_backend_metadata` to share a single workspace walk across
+//! every backend that points at it during one `pixi lock` run.
+
+use std::{
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use derive_more::Display;
+use pixi_build_types::InputGlobSet;
+use pixi_compute_engine::{ComputeCtx, Key};
+
+/// Inputs for [`InputGlobSetWalkKey`].  Holds the resolved walk root and
+/// the walker knobs; everything that affects the result is part of the
+/// hash so the engine dedupes correctly.
+#[derive(Debug, Clone)]
+pub struct InputGlobSetWalkSpec {
+    /// Resolved absolute walk root.  Constructors that take a relative
+    /// path should join it onto the caller-supplied root before stashing
+    /// it here, and canonicalize when feasible.
+    pub root: PathBuf,
+    /// Gitignore-style patterns; order matters for last-match-wins.
+    pub patterns: Vec<String>,
+    /// Marker filenames; per-directory presence dispatches against
+    /// `patterns`.  Order is not semantically meaningful, but we hash a
+    /// sorted view for stable identity.
+    pub markers: Vec<String>,
+    /// Whether the walker skips hidden directories.
+    pub exclude_hidden: bool,
+}
+
+impl InputGlobSetWalkSpec {
+    /// Build a spec from an [`InputGlobSet`] resolved against
+    /// `caller_root`.  Mirrors the resolution rule used by
+    /// `crate::input_globs::collect_input_files_via_engine`: absolute
+    /// `root` overrides, relative `root` joins, `None` falls back to
+    /// `caller_root`.
+    pub fn from_group(group: &InputGlobSet, caller_root: &Path) -> Self {
+        let resolved = match group.root.as_deref() {
+            Some(p) if p.is_absolute() => p.to_path_buf(),
+            Some(p) => caller_root.join(p),
+            None => caller_root.to_path_buf(),
+        };
+        Self {
+            root: resolved,
+            patterns: group.patterns.clone(),
+            markers: group.markers.clone(),
+            exclude_hidden: group.exclude_hidden,
+        }
+    }
+}
+
+impl PartialEq for InputGlobSetWalkSpec {
+    fn eq(&self, other: &Self) -> bool {
+        if self.root != other.root
+            || self.patterns != other.patterns
+            || self.exclude_hidden != other.exclude_hidden
+        {
+            return false;
+        }
+        let mut a: Vec<&String> = self.markers.iter().collect();
+        let mut b: Vec<&String> = other.markers.iter().collect();
+        a.sort();
+        b.sort();
+        a == b
+    }
+}
+
+impl Eq for InputGlobSetWalkSpec {}
+
+impl Hash for InputGlobSetWalkSpec {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.root.hash(state);
+        self.patterns.hash(state);
+        let mut sorted: Vec<&String> = self.markers.iter().collect();
+        sorted.sort();
+        for m in sorted {
+            m.hash(state);
+        }
+        self.exclude_hidden.hash(state);
+    }
+}
+
+/// Compute-engine Key for "walk this group from this resolved root."
+/// Cached by the engine for the dispatcher's lifetime; the same
+/// `(root, patterns, markers, exclude_hidden)` tuple resolves to a single
+/// walk no matter how many consumers ask for it.
+#[derive(Clone, Debug, Display, Eq, Hash, PartialEq)]
+#[display("{}", _0.root.display())]
+pub struct InputGlobSetWalkKey(pub Arc<InputGlobSetWalkSpec>);
+
+impl InputGlobSetWalkKey {
+    pub fn new(spec: InputGlobSetWalkSpec) -> Self {
+        Self(Arc::new(spec))
+    }
+
+    pub fn from_group(group: &InputGlobSet, caller_root: &Path) -> Self {
+        Self::new(InputGlobSetWalkSpec::from_group(group, caller_root))
+    }
+}
+
+impl Key for InputGlobSetWalkKey {
+    type Value = Result<Arc<Vec<PathBuf>>, Arc<pixi_glob::GlobSetError>>;
+
+    #[tracing::instrument(
+        skip_all,
+        name = "input-glob-set-walk",
+        fields(root = %self.0.root.display()),
+    )]
+    async fn compute(&self, _ctx: &mut ComputeCtx) -> Self::Value {
+        let spec = self.0.clone();
+        tokio::task::spawn_blocking(move || {
+            let matches = pixi_glob::GlobSet::create(spec.patterns.iter().map(String::as_str))
+                .with_ignore_marker_filenames(spec.markers.iter().map(String::as_str))
+                .with_exclude_hidden(spec.exclude_hidden)
+                .collect_matching(&spec.root)
+                .map_err(Arc::new)?;
+            Ok(Arc::new(
+                matches.into_iter().map(|m| m.into_path()).collect(),
+            ))
+        })
+        .await
+        .unwrap_or_else(|err| match err.try_into_panic() {
+            Ok(panic) => std::panic::resume_unwind(panic),
+            // spawn_blocking only fails when the runtime is shutting down,
+            // which from a Key body we treat as the same as a benign empty
+            // result: the surrounding compute is about to be cancelled
+            // anyway.
+            Err(_) => Ok(Arc::new(Vec::new())),
+        })
+    }
+}

--- a/crates/pixi_command_dispatcher/src/keys/mod.rs
+++ b/crates/pixi_command_dispatcher/src/keys/mod.rs
@@ -4,6 +4,7 @@
 //! work units it composes. Source-record assembly is inlined into the
 //! orchestrator rather than promoted to its own Key, so the graph stays flat.
 
+pub mod input_glob_set_walk;
 pub mod resolve_source_package;
 pub(crate) mod resolve_source_record;
 pub mod solve_conda;
@@ -11,6 +12,7 @@ pub mod solve_pixi_environment;
 pub mod source_build;
 pub mod source_metadata;
 
+pub use input_glob_set_walk::{InputGlobSetWalkKey, InputGlobSetWalkSpec};
 pub use resolve_source_package::{ResolveSourcePackageKey, ResolveSourcePackageSpec};
 pub use solve_conda::{SolveCondaKey, SolveCondaKeyError, SolveCondaSpec};
 pub use solve_pixi_environment::{SolvePixiEnvironmentKey, SolvePixiEnvironmentSpec};

--- a/crates/pixi_command_dispatcher/src/keys/solve_conda.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_conda.rs
@@ -232,12 +232,28 @@ impl Key for SolveCondaKey {
         // records we're about to feed to the solver. Their
         // `.depends` (post run-exports) is authoritative for which
         // binaries might actually need repodata entries.
+        let derive_started = std::time::Instant::now();
         let source_repodata_fetch_specs = derive_fetch_specs_from_source_repodata(&spec);
         let dev_source_fetch_specs = derive_fetch_specs_from_dev_sources(&spec, &channel_config);
+        let total_fetch_specs = binary_match_specs.len()
+            + constraint_match_specs.len()
+            + source_repodata_fetch_specs.len()
+            + dev_source_fetch_specs.len();
+        tracing::debug!(
+            elapsed_ms = derive_started.elapsed().as_millis() as u64,
+            binary_specs = binary_match_specs.len(),
+            constraint_specs = constraint_match_specs.len(),
+            source_derived_specs = source_repodata_fetch_specs.len(),
+            dev_derived_specs = dev_source_fetch_specs.len(),
+            total_fetch_specs,
+            source_records = spec.source_repodata.iter().map(|sm| sm.records.len()).sum::<usize>(),
+            "derived gateway match-specs from source records"
+        );
 
         // Clone the gateway handle so we don't hold an immutable
         // borrow on `ctx` across the subsequent mutable-borrow solve.
         let gateway = ctx.global_data().gateway().clone();
+        let fetch_started = std::time::Instant::now();
         // `solve-conda` runs inside the parent operation's
         // `scope_active` (e.g. the pixi-solve or backend-instantiate
         // op that triggered it), so `OperationId::current()` gives
@@ -262,6 +278,26 @@ impl Key for SolveCondaKey {
             query = query.with_reporter(WrappingGatewayReporter(reporter));
         }
         let binary_repodata = query.await?;
+        // `binary_repodata.len()` returns the number of subdir buckets,
+        // not the number of records. Sum across them to get the real
+        // count the solver is about to chew through.
+        let binary_record_count: usize =
+            binary_repodata.iter().map(|r| r.iter().count()).sum();
+        let source_record_count: usize = spec
+            .source_repodata
+            .iter()
+            .map(|sm| sm.records.len())
+            .sum();
+        tracing::debug!(
+            elapsed_ms = fetch_started.elapsed().as_millis() as u64,
+            channels = spec.channels.len(),
+            repodata_subdirs = binary_repodata.len(),
+            binary_records = binary_record_count,
+            source_records = source_record_count,
+            dev_source_records = spec.dev_source_records.len(),
+            installed_records = spec.installed.len(),
+            "gateway recursive repodata fetch completed"
+        );
 
         // Build the full solve spec and hand off to ctx.solve_conda
         // (semaphore + reporter lifecycle).
@@ -282,7 +318,15 @@ impl Key for SolveCondaKey {
             exclude_newer: spec.exclude_newer.clone(),
         };
 
+        let solve_started = std::time::Instant::now();
         let records = ctx.solve_conda(conda_spec).await?;
+        tracing::debug!(
+            elapsed_ms = solve_started.elapsed().as_millis() as u64,
+            input_binary_records = binary_record_count,
+            input_source_records = source_record_count,
+            output_records = records.len(),
+            "rattler conda solve completed"
+        );
         Ok(Arc::new(records))
     }
 }

--- a/crates/pixi_command_dispatcher/src/keys/solve_conda.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_conda.rs
@@ -246,7 +246,11 @@ impl Key for SolveCondaKey {
             source_derived_specs = source_repodata_fetch_specs.len(),
             dev_derived_specs = dev_source_fetch_specs.len(),
             total_fetch_specs,
-            source_records = spec.source_repodata.iter().map(|sm| sm.records.len()).sum::<usize>(),
+            source_records = spec
+                .source_repodata
+                .iter()
+                .map(|sm| sm.records.len())
+                .sum::<usize>(),
             "derived gateway match-specs from source records"
         );
 
@@ -281,13 +285,9 @@ impl Key for SolveCondaKey {
         // `binary_repodata.len()` returns the number of subdir buckets,
         // not the number of records. Sum across them to get the real
         // count the solver is about to chew through.
-        let binary_record_count: usize =
-            binary_repodata.iter().map(|r| r.iter().count()).sum();
-        let source_record_count: usize = spec
-            .source_repodata
-            .iter()
-            .map(|sm| sm.records.len())
-            .sum();
+        let binary_record_count: usize = binary_repodata.iter().map(|r| r.iter().count()).sum();
+        let source_record_count: usize =
+            spec.source_repodata.iter().map(|sm| sm.records.len()).sum();
         tracing::debug!(
             elapsed_ms = fetch_started.elapsed().as_millis() as u64,
             channels = spec.channels.len(),

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -270,6 +270,13 @@ async fn compute_inner(
     env_spec: Arc<crate::EnvironmentSpec>,
     channel_config: Arc<rattler_conda_types::ChannelConfig>,
 ) -> Result<Arc<Vec<PixiRecord>>, SolvePixiEnvironmentError> {
+    let compute_started = Instant::now();
+    tracing::debug!(
+        env = %spec.env_ref,
+        platform = %env_spec.build_environment.host_platform,
+        "begin compute_inner for pixi env solve"
+    );
+
     // Derive a common exclude_newer cutoff so every transitive
     // source dep uses the same value.
     let exclude_newer = env_spec
@@ -277,7 +284,13 @@ async fn compute_inner(
         .clone()
         .unwrap_or_else(|| ResolvedExcludeNewer::from_datetime(chrono::Utc::now()));
 
+    let dev_sources_started = Instant::now();
     let dev_source_records = process_dev_sources(ctx, &spec).await?;
+    tracing::debug!(
+        elapsed_ms = dev_sources_started.elapsed().as_millis() as u64,
+        records = dev_source_records.len(),
+        "process_dev_sources completed"
+    );
 
     // Split explicit requirements into source and binary halves;
     // same for dev-source-contributed deps.
@@ -307,6 +320,8 @@ async fn compute_inner(
     // through every nested solve so a given source package gets the
     // same hint regardless of which branch of the recursion reached
     // it.
+    let walk_started = Instant::now();
+    let seed_count = seeds.len();
     let resolved = walk_and_resolve(
         ctx,
         seeds,
@@ -315,6 +330,12 @@ async fn compute_inner(
         &spec.installed_source_hints,
     )
     .await?;
+    tracing::debug!(
+        elapsed_ms = walk_started.elapsed().as_millis() as u64,
+        seeds = seed_count,
+        resolved_records = resolved.len(),
+        "walk_and_resolve source BFS completed"
+    );
 
     // Group resolved records by source location for SolveCondaKey.
     // Ordering matters: SolveCondaKey hashes `source_repodata`
@@ -388,6 +409,11 @@ async fn compute_inner(
             SolveCondaKeyError::Gateway(a) => SolvePixiEnvironmentError::QueryError(a),
         })?;
     tracing::debug!("top-level solve completed in {:?}", started.elapsed());
+    tracing::debug!(
+        elapsed_ms = compute_started.elapsed().as_millis() as u64,
+        env = %spec.env_ref,
+        "compute_inner finished for pixi env solve"
+    );
 
     Ok(Arc::new((*result).clone()))
 }

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -232,6 +232,7 @@ async fn compute_inner(
         .compute(
             &InstantiateBackendKey::new(
                 manifest_checkout.path.as_std_path(),
+                crate::build_backend_metadata::checkout_root_for(&manifest_checkout),
                 manifest_anchor.clone(),
                 build_source_dir,
                 spec.exclude_newer.clone(),

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -51,6 +51,7 @@ pub mod environment;
 mod ephemeral_env;
 mod errors;
 mod injected_config;
+mod input_globs;
 mod input_hash;
 mod install_binary;
 mod install_pixi;

--- a/crates/pixi_command_dispatcher/src/solve_binary.rs
+++ b/crates/pixi_command_dispatcher/src/solve_binary.rs
@@ -63,6 +63,10 @@ impl SolveCondaExt for ComputeCtx {
         let lifecycle =
             ReporterLifecycle::<CondaSolveReporterLifecycle>::queued(reporter.as_deref(), &spec);
 
+        // Time the semaphore wait separately from the actual solve so we
+        // can tell whether a slow solve is genuinely CPU-bound work or just
+        // queued behind other solves holding the slot.
+        let acquire_started = std::time::Instant::now();
         let _permit = match semaphore.as_ref() {
             Some(s) => Some(
                 s.acquire()
@@ -71,9 +75,24 @@ impl SolveCondaExt for ComputeCtx {
             ),
             None => None,
         };
+        let acquire_elapsed_ms = acquire_started.elapsed().as_millis() as u64;
+        tracing::debug!(
+            acquire_elapsed_ms,
+            permit = semaphore.is_some(),
+            "conda solve semaphore acquired"
+        );
         let _lifecycle = lifecycle.start();
 
-        match spec.solve_on_blocking_pool(channel_config).await {
+        let solve_started = std::time::Instant::now();
+        let result = spec.solve_on_blocking_pool(channel_config).await;
+        let solve_elapsed_ms = solve_started.elapsed().as_millis() as u64;
+        tracing::debug!(
+            acquire_elapsed_ms,
+            solve_elapsed_ms,
+            "solve_on_blocking_pool returned"
+        );
+
+        match result {
             Ok(records) => Ok(records),
             Err(SolveCondaBlockingError::Solve(e)) => Err(e),
             Err(SolveCondaBlockingError::Panic(p)) => std::panic::resume_unwind(p),

--- a/crates/pixi_compute_sources/src/checkout.rs
+++ b/crates/pixi_compute_sources/src/checkout.rs
@@ -15,8 +15,18 @@ use thiserror::Error;
 /// on `pinned` for cache identity.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct SourceCheckout {
-    /// Local path to the source.
+    /// Local path to the source.  Includes any `subdirectory` applied
+    /// on top of the checkout root, so this is the directory containing
+    /// the manifest.
     pub path: AbsPathBuf,
+
+    /// Local path to the root of the checkout, BEFORE any
+    /// `subdirectory` is applied.  Equal to [`Self::path`] when there
+    /// is no subdirectory (e.g. for a local path source).  Backends
+    /// that need to reason about siblings inside the same checkout
+    /// (e.g. ROS sibling-package discovery) anchor their search here
+    /// instead of at [`Self::path`].
+    pub root_dir: AbsPathBuf,
 
     /// The exact source specification.
     pub pinned: PinnedSourceSpec,
@@ -37,14 +47,16 @@ impl SourceCheckout {
 
         let path = if !pinned.source.subdirectory.is_empty() {
             root_dir
+                .clone()
                 .join(pinned.source.subdirectory.as_path())
                 .into_assume_dir()
         } else {
-            root_dir
+            root_dir.clone()
         };
 
         Self {
             path: path.into(),
+            root_dir: root_dir.into(),
             pinned: PinnedSourceSpec::Git(pinned),
         }
     }

--- a/crates/pixi_compute_sources/src/ext.rs
+++ b/crates/pixi_compute_sources/src/ext.rs
@@ -51,8 +51,15 @@ impl SourceCheckoutExt for ComputeCtx {
                 SourceLocationSpec::Path(path) => {
                     let result = self.resolve_typed_path(path.path.to_path());
                     async move {
+                        let resolved = result?;
                         Ok(SourceCheckout {
-                            path: result?,
+                            path: resolved.clone(),
+                            // Path sources have no "checkout root"
+                            // distinct from the path itself; the
+                            // caller layer (build-backend metadata
+                            // construction) is what decides whether
+                            // to widen this to a workspace root.
+                            root_dir: resolved,
                             pinned: PinnedSourceSpec::Path(PinnedPathSpec { path: path.path }),
                         })
                     }
@@ -72,8 +79,10 @@ impl SourceCheckoutExt for ComputeCtx {
             PinnedSourceSpec::Path(path_spec) => {
                 let path_result = self.resolve_typed_path(path_spec.path.to_path());
                 async move {
+                    let resolved = path_result?;
                     Ok(SourceCheckout {
-                        path: path_result?,
+                        path: resolved.clone(),
+                        root_dir: resolved,
                         pinned: PinnedSourceSpec::Path(path_spec),
                     })
                 }

--- a/crates/pixi_compute_sources/src/url.rs
+++ b/crates/pixi_compute_sources/src/url.rs
@@ -177,8 +177,13 @@ impl UrlSourceCheckoutExt for ComputeCtx {
         let fut = self.compute(&CheckoutUrl(url_spec));
         async move {
             let UrlCheckout { pinned_url, dir } = fut.await.as_ref().clone()?;
+            // `CheckoutUrl` already strips the archive root and
+            // returns the unpacked directory; for the non-subdirectory
+            // case `dir` IS the checkout root.
+            let dir: AbsPathBuf = dir.into();
             Ok(SourceCheckout {
-                path: dir.into(),
+                path: dir.clone(),
+                root_dir: dir,
                 pinned: PinnedSourceSpec::Url(pinned_url),
             })
         }
@@ -197,6 +202,7 @@ impl UrlSourceCheckoutExt for ComputeCtx {
         let fut = self.compute(&CheckoutUrl(url_spec));
         async move {
             let fetch = fut.await.as_ref().clone()?;
+            let root_dir = fetch.dir.clone();
             let path = if !pinned_url_spec.subdirectory.is_empty() {
                 fetch
                     .dir
@@ -207,6 +213,7 @@ impl UrlSourceCheckoutExt for ComputeCtx {
             };
             Ok(SourceCheckout {
                 path: path.into(),
+                root_dir: root_dir.into(),
                 pinned: PinnedSourceSpec::Url(pinned_url_spec),
             })
         }

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -140,6 +140,7 @@ pub static KNOWN_MANIFEST_FILES: LazyLock<Vec<&'static str>> = LazyLock::new(|| 
     v.push(PYPROJECT_MANIFEST);
     v.push(MOJOPROJECT_MANIFEST);
     v.extend(RATTLER_BUILD_FILE_NAMES);
+    v.extend(ROS_BACKEND_FILE_NAMES);
     v
 });
 pub static TASK_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().blue());

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -947,6 +947,7 @@ mod tests {
             ignore_run_exports: CondaOutputIgnoreRunExports::default(),
             run_exports: CondaOutputRunExports::default(),
             input_globs: None,
+            input_glob_sets: None,
         }
     }
 

--- a/crates/pixi_glob/src/glob_hash.rs
+++ b/crates/pixi_glob/src/glob_hash.rs
@@ -46,20 +46,22 @@ impl GlobHash {
         }
 
         let glob_set = GlobSet::create(globs);
-        // Collect matching entries and convert to concrete DirEntry list, propagating errors.
-        let mut entries = glob_set.collect_matching(root_dir)?;
-
-        // Sort deterministically by path
-        entries.sort_by_key(|e| e.path().to_path_buf());
+        // Collect matching paths and sort deterministically before hashing.
+        let mut paths: Vec<PathBuf> = glob_set
+            .collect_matching(root_dir)?
+            .into_iter()
+            .map(|m| m.into_path())
+            .collect();
+        paths.sort();
 
         #[cfg(test)]
         let mut matching_files = Vec::new();
 
         let mut hasher = Sha256::default();
-        for entry in entries {
+        for path in paths {
             // Construct a normalized file path to ensure consistent hashing across
             // platforms. And add it to the hash.
-            let relative_path = entry.path().strip_prefix(root_dir).unwrap_or(entry.path());
+            let relative_path = path.strip_prefix(root_dir).unwrap_or(&path);
             let normalized_file_path = relative_path.to_string_lossy().replace("\\", "/");
             rattler_digest::digest::Update::update(&mut hasher, normalized_file_path.as_bytes());
 
@@ -67,11 +69,9 @@ impl GlobHash {
             matching_files.push(normalized_file_path);
 
             // Concatenate the contents of the file to the hash.
-            File::open(entry.path())
+            File::open(&path)
                 .and_then(|mut file| normalize_line_endings(&mut file, &mut hasher))
-                .map_err(move |e| {
-                    GlobHashError::NormalizeLineEnds(entry.path().to_path_buf(), e)
-                })?;
+                .map_err(move |e| GlobHashError::NormalizeLineEnds(path, e))?;
         }
 
         let hash = hasher.finalize();

--- a/crates/pixi_glob/src/glob_mtime.rs
+++ b/crates/pixi_glob/src/glob_mtime.rs
@@ -59,15 +59,9 @@ impl GlobModificationTime {
 
         for entry in entries {
             let matched_path = entry.path().to_path_buf();
-            let md = match entry.metadata() {
-                Ok(md) => md,
-                Err(e) => {
-                    return Err(GlobModificationTimeError::CalculateMTime(
-                        matched_path,
-                        std::io::Error::other(e.to_string()),
-                    ));
-                }
-            };
+            let md = entry
+                .metadata()
+                .map_err(|e| GlobModificationTimeError::CalculateMTime(matched_path.clone(), e))?;
             let modified = md
                 .modified()
                 .map_err(|e| GlobModificationTimeError::CalculateMTime(matched_path.clone(), e))?;

--- a/crates/pixi_glob/src/glob_set/mod.rs
+++ b/crates/pixi_glob/src/glob_set/mod.rs
@@ -115,6 +115,35 @@ mod tests {
         "###);
     }
 
+    // Pin the gitignore "last-match-wins" semantics that `GlobSet` inherits
+    // from `ignore::overrides::Override`. Callers that emit a mix of
+    // inclusion and exclusion patterns must keep exclusions *after* the
+    // inclusions they intend to negate, otherwise the negation is undone by
+    // the later, broader include.
+    #[test]
+    fn collect_matching_order_is_last_match_wins() {
+        let temp_dir = tempdir().unwrap();
+        let root_path = temp_dir.path();
+        File::create(root_path.join("include1.txt")).unwrap();
+        File::create(root_path.join("exclude.txt")).unwrap();
+
+        // Exclude before include: the include re-matches `exclude.txt`.
+        let exclude_then_include = GlobSet::create(vec!["!exclude.txt", "**/*.txt"]);
+        let paths = sorted_paths(
+            exclude_then_include.collect_matching(root_path).unwrap(),
+            root_path,
+        );
+        assert_eq!(paths, vec!["exclude.txt", "include1.txt"]);
+
+        // Include before exclude: exclusion sticks.
+        let include_then_exclude = GlobSet::create(vec!["**/*.txt", "!exclude.txt"]);
+        let paths = sorted_paths(
+            include_then_exclude.collect_matching(root_path).unwrap(),
+            root_path,
+        );
+        assert_eq!(paths, vec!["include1.txt"]);
+    }
+
     // Check some general globbing support and make sure the correct things do not match
     #[test]
     fn collect_matching_relative_globs() {

--- a/crates/pixi_glob/src/glob_set/mod.rs
+++ b/crates/pixi_glob/src/glob_set/mod.rs
@@ -14,16 +14,87 @@
 mod walk;
 mod walk_root;
 
-use std::path::{Path, PathBuf};
+use std::{
+    fs::Metadata,
+    io,
+    path::{Path, PathBuf},
+};
 
 use thiserror::Error;
 
 use walk_root::{WalkRoot, WalkRootsError};
 
+/// A single result from [`GlobSet::collect_matching`].
+///
+/// `Pattern` matches retain the underlying `ignore::DirEntry` so callers
+/// can reuse the metadata cached by the directory walk on platforms that
+/// hand it back from `readdir` (notably Windows).  `Leaf` matches come
+/// from the leaf-marker side channel: the walker only ever saw the
+/// containing directory, so callers that need metadata have to stat the
+/// file themselves.
+#[derive(Debug)]
+pub enum Match {
+    /// Result of a positive glob match emitted by the walker.
+    Pattern(ignore::DirEntry),
+    /// Leaf marker hit; the walker pruned the subtree after recording it.
+    Leaf(PathBuf),
+}
+
+impl Match {
+    /// Borrowed view of the matched path.
+    pub fn path(&self) -> &Path {
+        match self {
+            Match::Pattern(d) => d.path(),
+            Match::Leaf(p) => p.as_path(),
+        }
+    }
+
+    /// Consume the match, returning the owned path.
+    pub fn into_path(self) -> PathBuf {
+        match self {
+            Match::Pattern(d) => d.into_path(),
+            Match::Leaf(p) => p,
+        }
+    }
+
+    /// Resolve the entry's metadata, reusing the walker's cached copy for
+    /// `Pattern` matches and falling back to a fresh `stat` for `Leaf`
+    /// matches.
+    pub fn metadata(&self) -> io::Result<Metadata> {
+        match self {
+            Match::Pattern(d) => d.metadata().map_err(io::Error::other),
+            Match::Leaf(p) => fs_err::metadata(p),
+        }
+    }
+}
+
 /// A glob set implemented using the `ignore` crate (globset + fast walker).
+///
+/// In addition to gitignore-style patterns, callers can declare *markers*:
+/// file names that the walker looks for in every directory it enters.
+/// When a marker file is present, its full path is matched against the
+/// pattern set:
+///
+/// - matches an include pattern → the marker is recorded as a result and
+///   descent under that directory stops (leaf semantics);
+/// - matches anything else (an exclude `!` pattern, or no pattern at all)
+///   → the entire subtree is skipped (prune semantics).
+///
+/// In other words, listed markers always affect the walk; include patterns
+/// promote them from "prune" (default) to "leaf".  This lets a single
+/// pattern set express both ordinary glob matching and the structural
+/// pruning / leaf detection needed by workspace-discovery callers (e.g.
+/// ROS).
 pub struct GlobSet {
-    /// Include patterns (gitignore-style), without leading '!'.
+    /// Include/exclude patterns (gitignore-style), grouped by their walk root.
     pub walk_roots: WalkRoot,
+    /// File names whose presence in a directory triggers a per-dir
+    /// override-match against [`GlobSet::walk_roots`].  See the type docs.
+    pub markers: Vec<String>,
+    /// When true (the default), hidden files and directories (names that
+    /// start with `.`) are skipped during the walk unless the user's
+    /// patterns explicitly opt them in.
+    pub exclude_hidden: bool,
 }
 
 #[derive(Error, Debug)]
@@ -44,24 +115,59 @@ impl GlobSet {
     pub fn create<'t>(globs: impl IntoIterator<Item = &'t str>) -> GlobSet {
         GlobSet {
             walk_roots: WalkRoot::build(globs).expect("should not fail"),
+            markers: Vec::new(),
+            exclude_hidden: true,
         }
     }
 
-    /// Walks files matching all include/exclude patterns using a single parallel walker.
-    /// Returns a flat Vec of results to keep lifetimes simple and predictable.
-    pub fn collect_matching(&self, root_dir: &Path) -> Result<Vec<ignore::DirEntry>, GlobSetError> {
-        if self.walk_roots.is_empty() {
-            return Ok(vec![]);
+    /// Builder-style setter for [`GlobSet::exclude_hidden`].  Pass `false`
+    /// to walk into hidden directories regardless of the pattern shape.
+    pub fn with_exclude_hidden(mut self, exclude_hidden: bool) -> Self {
+        self.exclude_hidden = exclude_hidden;
+        self
+    }
+
+    /// Builder-style setter that replaces [`GlobSet::markers`].  Each
+    /// supplied file name causes the walker, on entering a directory, to
+    /// probe for that file and apply the leaf-or-prune dispatch described
+    /// in the type-level documentation.
+    pub fn with_ignore_marker_filenames<'m, I>(mut self, filenames: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str> + 'm,
+    {
+        self.markers = filenames
+            .into_iter()
+            .map(|s| s.as_ref().to_owned())
+            .collect();
+        self
+    }
+
+    /// Walks `root_dir` collecting [`Match`] entries: files that match the
+    /// configured patterns plus per-directory leaf markers, while pruning at
+    /// directories whose marker hits an exclude pattern.  Ordering is not
+    /// guaranteed.
+    pub fn collect_matching(&self, root_dir: &Path) -> Result<Vec<Match>, GlobSetError> {
+        let has_patterns = !self.walk_roots.is_empty();
+        let has_markers = !self.markers.is_empty();
+        if !has_patterns && !has_markers {
+            return Ok(Vec::new());
         }
 
-        let rebased = self.walk_roots.rebase(root_dir)?;
-        walk::walk_globs(&rebased.root, &rebased.globs)
+        let (root, globs) = if has_patterns {
+            let rebased = self.walk_roots.rebase(root_dir)?;
+            (rebased.root, rebased.globs)
+        } else {
+            (root_dir.to_path_buf(), Vec::new())
+        };
+
+        walk::walk_globs(&root, &globs, &self.markers, self.exclude_hidden)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::GlobSet;
+    use super::{GlobSet, Match};
     use fs_err::{self as fs, File};
     use insta::assert_yaml_snapshot;
     use std::path::{Path, PathBuf};
@@ -79,11 +185,11 @@ mod tests {
         path.to_path_buf()
     }
 
-    fn sorted_paths(entries: Vec<ignore::DirEntry>, root: &std::path::Path) -> Vec<String> {
+    fn sorted_paths(entries: Vec<Match>, root: &std::path::Path) -> Vec<String> {
         let mut paths: Vec<_> = entries
             .into_iter()
-            .map(|entry| {
-                relative_path(entry.path(), root)
+            .map(|m| {
+                relative_path(&m.into_path(), root)
                     .display()
                     .to_string()
                     .replace('\\', "/")
@@ -386,5 +492,281 @@ mod tests {
         - link_dir/linked_file.txt
         - regular.txt
         "#);
+    }
+
+    fn workspace_root_for_marker_tests() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root from pixi_glob manifest")
+            .join("tests")
+            .join("data")
+            .join("pixi-build")
+            .join("ros-workspace")
+    }
+
+    #[test]
+    fn leaf_marker_finds_all_package_xml_in_ros_workspace() {
+        let root = workspace_root_for_marker_tests();
+        let glob_set =
+            GlobSet::create(["**/package.xml"]).with_ignore_marker_filenames(["package.xml"]);
+        let paths = sorted_paths(glob_set.collect_matching(&root).unwrap(), &root);
+        assert_eq!(
+            paths,
+            vec![
+                "src/distro_less_package/package.xml".to_string(),
+                "src/navigator/package.xml".to_string(),
+                "src/navigator_implicit/package.xml".to_string(),
+                "src/navigator_py/package.xml".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn leaf_marker_at_root_is_returned_as_single_hit() {
+        let tmp = tempdir().unwrap();
+        File::create(tmp.path().join("package.xml")).unwrap();
+        fs::create_dir_all(tmp.path().join("nested/subdir")).unwrap();
+        File::create(tmp.path().join("nested/subdir/package.xml")).unwrap();
+
+        let glob_set =
+            GlobSet::create(["**/package.xml"]).with_ignore_marker_filenames(["package.xml"]);
+        let entries = glob_set.collect_matching(tmp.path()).unwrap();
+        // Root has the leaf; descent stops there and the nested copy is invisible.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path(), tmp.path().join("package.xml"));
+    }
+
+    #[test]
+    fn prune_marker_hides_subtree() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("a")).unwrap();
+        File::create(tmp.path().join("a/package.xml")).unwrap();
+
+        fs::create_dir_all(tmp.path().join("b")).unwrap();
+        File::create(tmp.path().join("b/package.xml")).unwrap();
+        File::create(tmp.path().join("b/COLCON_IGNORE")).unwrap();
+
+        let glob_set = GlobSet::create(["**/package.xml"])
+            .with_ignore_marker_filenames(["package.xml", "COLCON_IGNORE"]);
+        let paths = sorted_paths(glob_set.collect_matching(tmp.path()).unwrap(), tmp.path());
+        assert_eq!(paths, vec!["a/package.xml".to_string()]);
+    }
+
+    #[test]
+    fn exclude_hidden_false_yields_hidden_files() {
+        let tmp = tempdir().unwrap();
+        let hidden_dir = tmp.path().join(".hidden");
+        fs::create_dir_all(&hidden_dir).unwrap();
+        File::create(hidden_dir.join("inside.txt")).unwrap();
+        File::create(tmp.path().join("visible.txt")).unwrap();
+
+        // Default (true) hides `.hidden/inside.txt`.
+        let default_paths = sorted_paths(
+            GlobSet::create(["**/*.txt"])
+                .collect_matching(tmp.path())
+                .unwrap(),
+            tmp.path(),
+        );
+        assert_eq!(default_paths, vec!["visible.txt".to_string()]);
+
+        // Opt out via `with_exclude_hidden(false)`.
+        let inclusive_paths = sorted_paths(
+            GlobSet::create(["**/*.txt"])
+                .with_exclude_hidden(false)
+                .collect_matching(tmp.path())
+                .unwrap(),
+            tmp.path(),
+        );
+        assert_eq!(
+            inclusive_paths,
+            vec![".hidden/inside.txt".to_string(), "visible.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn missing_root_returns_empty() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let glob_set =
+            GlobSet::create(["**/package.xml"]).with_ignore_marker_filenames(["package.xml"]);
+        let entries = glob_set.collect_matching(&missing).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    /// Build a synthetic ROS-style workspace and compare:
+    ///   (a) today's path: `GlobSet::collect_matching` with the patterns
+    ///       pixi-build-ros currently emits, run once per package.
+    ///   (b) unified GlobSet with leaf + prune markers, run once for the
+    ///       whole workspace.
+    ///
+    /// Run with:
+    ///   cargo test -p pixi_glob --release -- --ignored bench_workspace_discovery --nocapture
+    #[test]
+    #[ignore = "manual benchmark; not deterministic enough for CI"]
+    fn bench_workspace_discovery() {
+        use std::collections::BTreeSet;
+        use std::time::Instant;
+
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().join("ws");
+        fs::create_dir_all(&workspace).unwrap();
+
+        let pkg_count = 200usize;
+        let files_per_pkg = 50usize;
+        for i in 0..pkg_count {
+            let pkg = workspace.join("src").join(format!("pkg_{i:03}"));
+            fs::create_dir_all(pkg.join("src")).unwrap();
+            fs::create_dir_all(pkg.join("include")).unwrap();
+            File::create(pkg.join("package.xml")).unwrap();
+            File::create(pkg.join("CMakeLists.txt")).unwrap();
+            for j in 0..files_per_pkg {
+                File::create(pkg.join("src").join(format!("a_{j:03}.cpp"))).unwrap();
+                File::create(pkg.join("include").join(format!("a_{j:03}.h"))).unwrap();
+            }
+        }
+
+        eprintln!(
+            "synthetic workspace: {pkg_count} pkgs, {} files",
+            pkg_count * (files_per_pkg * 2 + 2)
+        );
+
+        let pkg_dirs: Vec<PathBuf> = (0..pkg_count)
+            .map(|i| workspace.join("src").join(format!("pkg_{i:03}")))
+            .collect();
+        let ros_globs = [
+            "../../**/package.xml",
+            "../../**/COLCON_IGNORE",
+            "../../**/AMENT_IGNORE",
+            "../../**/CATKIN_IGNORE",
+            "!../../**/.*/**",
+            "package.xml",
+            "CMakeLists.txt",
+            "setup.py",
+            "setup.cfg",
+        ];
+        let mut all_glob_hits: BTreeSet<PathBuf> = BTreeSet::new();
+        let glob_start = Instant::now();
+        for pkg in &pkg_dirs {
+            let glob_set = GlobSet::create(ros_globs.iter().copied());
+            for hit in glob_set.collect_matching(pkg).unwrap() {
+                all_glob_hits.insert(hit.into_path());
+            }
+        }
+        let glob_elapsed = glob_start.elapsed();
+        eprintln!(
+            "GlobSet x {pkg_count} packages: {:?}, unique hits = {}",
+            glob_elapsed,
+            all_glob_hits.len()
+        );
+
+        let walk_start = Instant::now();
+        let leaves = GlobSet::create(["**/package.xml"])
+            .with_ignore_marker_filenames([
+                "package.xml",
+                "COLCON_IGNORE",
+                "AMENT_IGNORE",
+                "CATKIN_IGNORE",
+            ])
+            .collect_matching(&workspace)
+            .unwrap();
+        let walk_elapsed = walk_start.elapsed();
+        eprintln!(
+            "marker walk x 1: {:?}, leaves = {}",
+            walk_elapsed,
+            leaves.len()
+        );
+
+        if walk_elapsed.as_nanos() > 0 {
+            let ratio = glob_elapsed.as_nanos() as f64 / walk_elapsed.as_nanos() as f64;
+            eprintln!("speedup: {ratio:.1}x");
+        }
+
+        assert_eq!(leaves.len(), pkg_count);
+    }
+
+    /// Same comparison against a real workspace. Set `PIXI_BENCH_WS` to the
+    /// workspace root before running.
+    ///
+    /// Run with:
+    ///   $env:PIXI_BENCH_WS = "F:/projects/issues/navigation2"; \
+    ///     cargo test -p pixi_glob --release -- --ignored bench_workspace_real --nocapture
+    #[test]
+    #[ignore = "needs PIXI_BENCH_WS env var pointing at a real workspace"]
+    fn bench_workspace_real() {
+        use std::collections::BTreeSet;
+        use std::time::Instant;
+
+        let Some(ws) = std::env::var_os("PIXI_BENCH_WS") else {
+            eprintln!("PIXI_BENCH_WS unset; skipping");
+            return;
+        };
+        let workspace = PathBuf::from(ws);
+        eprintln!("workspace: {}", workspace.display());
+
+        let marker_patterns = ["**/package.xml"];
+        let marker_names = [
+            "package.xml",
+            "COLCON_IGNORE",
+            "AMENT_IGNORE",
+            "CATKIN_IGNORE",
+        ];
+        let leaves: Vec<PathBuf> = GlobSet::create(marker_patterns)
+            .with_ignore_marker_filenames(marker_names)
+            .collect_matching(&workspace)
+            .unwrap()
+            .into_iter()
+            .map(|m| m.into_path())
+            .collect();
+        let pkg_dirs: Vec<PathBuf> = leaves
+            .iter()
+            .filter_map(|p| p.parent().map(Path::to_path_buf))
+            .collect();
+        eprintln!("packages found: {}", pkg_dirs.len());
+
+        let ros_globs = [
+            "../../**/package.xml",
+            "../../**/COLCON_IGNORE",
+            "../../**/AMENT_IGNORE",
+            "../../**/CATKIN_IGNORE",
+            "!../../**/.*/**",
+            "package.xml",
+            "CMakeLists.txt",
+            "setup.py",
+            "setup.cfg",
+        ];
+
+        let mut all_glob_hits: BTreeSet<PathBuf> = BTreeSet::new();
+        let glob_start = Instant::now();
+        for pkg in &pkg_dirs {
+            let glob_set = GlobSet::create(ros_globs.iter().copied());
+            for hit in glob_set.collect_matching(pkg).unwrap() {
+                all_glob_hits.insert(hit.into_path());
+            }
+        }
+        let glob_elapsed = glob_start.elapsed();
+        eprintln!(
+            "GlobSet x {} packages: {:?}, unique hits = {}",
+            pkg_dirs.len(),
+            glob_elapsed,
+            all_glob_hits.len()
+        );
+
+        let walk_start = Instant::now();
+        let leaves2 = GlobSet::create(marker_patterns)
+            .with_ignore_marker_filenames(marker_names)
+            .collect_matching(&workspace)
+            .unwrap();
+        let walk_elapsed = walk_start.elapsed();
+        eprintln!(
+            "marker walk x 1: {:?}, leaves = {}",
+            walk_elapsed,
+            leaves2.len()
+        );
+
+        if walk_elapsed.as_nanos() > 0 {
+            let ratio = glob_elapsed.as_nanos() as f64 / walk_elapsed.as_nanos() as f64;
+            eprintln!("speedup: {ratio:.1}x");
+        }
     }
 }

--- a/crates/pixi_glob/src/glob_set/walk.rs
+++ b/crates/pixi_glob/src/glob_set/walk.rs
@@ -6,24 +6,29 @@ use std::sync::Arc;
 
 use crate::glob_set::walk_root::SimpleGlob;
 
-use super::GlobSetError;
+use super::{GlobSetError, Match};
 
-type SharedResults = Arc<Mutex<Option<Vec<Result<ignore::DirEntry, GlobSetError>>>>>;
+type SharedResults = Arc<Mutex<Option<Vec<Result<Match, GlobSetError>>>>>;
 
 struct CollectBuilder {
     // Shared aggregation storage wrapped in an Option so we can `take` at the end.
     sink: SharedResults,
     // The root we are walking, used for error reporting
     err_root: PathBuf,
+    // When false, drop file entries the walker yields — used for leaf-only
+    // walks where the override is empty and every file would otherwise pass.
+    collect_patterns: bool,
 }
 
 struct CollectVisitor {
     // Local per-thread buffer to append results without holding the lock.
-    local: Vec<Result<ignore::DirEntry, GlobSetError>>,
+    local: Vec<Result<Match, GlobSetError>>,
     // Reference to the shared sink.
     sink: SharedResults,
     // The root we are walking, used for error reporting
     err_root: PathBuf,
+    // Mirror of `CollectBuilder::collect_patterns`.
+    collect_patterns: bool,
 }
 
 impl Drop for CollectVisitor {
@@ -41,20 +46,27 @@ impl<'s> ignore::ParallelVisitorBuilder<'s> for CollectBuilder {
             local: Vec::new(),
             sink: Arc::clone(&self.sink),
             err_root: self.err_root.clone(),
+            collect_patterns: self.collect_patterns,
         })
     }
 }
 
 impl ignore::ParallelVisitor for CollectVisitor {
-    /// This function loops over all matches, ignores directories, and ignores PermissionDenied and
-    /// NotFound errors
+    /// Loop over all matches, drop directories, drop NotFound/PermissionDenied races.
     fn visit(&mut self, dir_entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
         match dir_entry {
             Ok(dir_entry) => {
                 if dir_entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
                     return ignore::WalkState::Continue;
                 }
-                self.local.push(Ok(dir_entry));
+                if !self.collect_patterns {
+                    // Leaf-only walk: an empty override doesn't suppress
+                    // yield, so we drop file entries here. Leaves still
+                    // arrive via the side-channel sink set up by
+                    // `filter_entry`.
+                    return ignore::WalkState::Continue;
+                }
+                self.local.push(Ok(Match::Pattern(dir_entry)));
             }
             Err(e) => {
                 if let Some(ioe) = e.io_error() {
@@ -74,27 +86,49 @@ impl ignore::ParallelVisitor for CollectVisitor {
     }
 }
 
-/// Walk over the globs in the specific root
+/// Walk `effective_walk_root` collecting paths that match `globs`.  When
+/// `markers` is non-empty, each directory the walker enters is also probed
+/// for the presence of those file names; a marker hit is then matched
+/// against the same pattern override that drives ordinary glob matching,
+/// and resolves to one of:
+///
+/// - **leaf**: marker matches an include pattern → the marker path is
+///   appended to the results and descent stops at this directory;
+/// - **prune**: marker matches an exclude (`!`) pattern → the whole
+///   subtree is skipped;
+/// - **noop**: marker matches nothing → walking continues normally.
 pub fn walk_globs(
     effective_walk_root: &Path,
     globs: &[SimpleGlob],
-) -> Result<Vec<ignore::DirEntry>, GlobSetError> {
+    markers: &[String],
+    exclude_hidden: bool,
+) -> Result<Vec<Match>, GlobSetError> {
     let mut ob = ignore::overrides::OverrideBuilder::new(effective_walk_root);
     let glob_patterns = globs
         .iter()
         .map(|g| anchor_literal_pattern(g.to_pattern()))
         .collect_vec();
 
-    // Always add ignore hidden folders unless the user explicitly included them
-    // because we add patterns as overrides, which overrides any `WalkBuilder` settings.
-    let ignore_patterns = set_ignore_hidden_patterns(&glob_patterns);
+    // When hidden exclusion is enabled, the existing helper inspects the
+    // patterns to decide which approach to use: either rely on
+    // `WalkBuilder::hidden(true)` outright or, when broad patterns like
+    // `**` would otherwise drag hidden entries back in, append explicit
+    // negations.  When the caller has opted out we don't do anything here
+    // and just leave `WalkBuilder::hidden(false)` to yield everything.
+    let ignore_patterns = if exclude_hidden {
+        set_ignore_hidden_patterns(&glob_patterns)
+    } else {
+        None
+    };
 
     for provided_pattern in &glob_patterns {
         ob.add(provided_pattern)
             .map_err(GlobSetError::BuildOverrides)?;
     }
 
-    let enable_ignoring_hidden = if let Some(ref patterns) = ignore_patterns {
+    let walker_hidden_setting = if !exclude_hidden {
+        false
+    } else if let Some(ref patterns) = ignore_patterns {
         // If we added negated patterns for hidden folders, we want to allow searching through hidden folders
         // unless the user explicitly included them
         tracing::trace!("Adding ignore patterns for hidden folders: {:?}", patterns);
@@ -108,28 +142,104 @@ pub fn walk_globs(
 
     let overrides = ob.build().map_err(GlobSetError::BuildOverrides)?;
 
-    let mut builder = ignore::WalkBuilder::new(effective_walk_root);
+    // `ignore::WalkBuilder::filter_entry` is not invoked on the root entry,
+    // so resolve any marker hits there before starting the walk, mirroring
+    // the per-directory dispatch logic: a marker that matches an exclude or
+    // that matches nothing prunes the subtree; a marker that matches an
+    // include records a leaf.
+    let mut root_leaves = Vec::new();
+    for marker in markers {
+        let marker_path = effective_walk_root.join(marker);
+        if !marker_path.is_file() {
+            continue;
+        }
+        match overrides.matched(&marker_path, false) {
+            ignore::Match::Whitelist(_) if root_leaves.is_empty() => {
+                root_leaves.push(Match::Leaf(marker_path));
+            }
+            ignore::Match::Whitelist(_) => {}
+            // Ignore or None both prune.
+            _ => return Ok(Vec::new()),
+        }
+    }
+    if !root_leaves.is_empty() {
+        return Ok(root_leaves);
+    }
 
-    let walker_builder = builder
+    let leaf_sink: Arc<Mutex<Vec<Match>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let mut builder = ignore::WalkBuilder::new(effective_walk_root);
+    builder
         .follow_links(true)
         .git_ignore(false)
         .git_exclude(true)
-        .hidden(enable_ignoring_hidden)
+        .hidden(walker_hidden_setting)
         .git_global(false)
         .ignore(false)
-        .overrides(overrides)
-        .build_parallel();
+        .overrides(overrides.clone());
+
+    if !markers.is_empty() {
+        let markers: Vec<String> = markers.to_vec();
+        let overrides_for_filter = overrides.clone();
+        let leaf_sink_for_filter = Arc::clone(&leaf_sink);
+        builder.filter_entry(move |entry| {
+            let Some(ft) = entry.file_type() else {
+                return false;
+            };
+            if !ft.is_dir() {
+                // Non-directories pass through to the pattern matcher.
+                return true;
+            }
+            // Pass over all markers present in this dir. A marker that
+            // matches an exclude (or no pattern at all) prunes the subtree;
+            // a marker that matches an include records a leaf. Pruning wins
+            // when both fire in the same directory.
+            let mut leaf_match: Option<PathBuf> = None;
+            for marker in &markers {
+                let marker_path = entry.path().join(marker);
+                if !marker_path.is_file() {
+                    continue;
+                }
+                match overrides_for_filter.matched(&marker_path, false) {
+                    ignore::Match::Whitelist(_) if leaf_match.is_none() => {
+                        leaf_match = Some(marker_path);
+                    }
+                    ignore::Match::Whitelist(_) => {}
+                    // Ignore or None both prune.
+                    _ => return false,
+                }
+            }
+            if let Some(leaf) = leaf_match {
+                leaf_sink_for_filter.lock().push(Match::Leaf(leaf));
+                return false;
+            }
+            true
+        });
+    }
+
+    let walker = builder.build_parallel();
 
     let collected: SharedResults = Arc::new(Mutex::new(Some(Vec::new())));
     let start = std::time::Instant::now();
 
-    let mut builder = CollectBuilder {
+    let mut collect = CollectBuilder {
         sink: Arc::clone(&collected),
         err_root: effective_walk_root.to_path_buf(),
+        collect_patterns: !globs.is_empty(),
     };
-    walker_builder.visit(&mut builder);
+    walker.visit(&mut collect);
 
-    let results = collected.lock().take().unwrap_or_default();
+    let mut results: Vec<Match> = collected
+        .lock()
+        .take()
+        .unwrap_or_default()
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut leaves = std::mem::take(&mut *leaf_sink.lock());
+    if !leaves.is_empty() {
+        results.append(&mut leaves);
+    }
 
     // Log some statistics as long as we are unsure with regards to performance
     let matched = results.len();
@@ -141,13 +251,14 @@ pub fn walk_globs(
     tracing::trace!(
         include = include_patterns,
         excludes = exclude_patterns,
+        markers = ?markers,
         matched,
         elapsed_ms = elapsed.as_millis(),
         root = ?effective_walk_root,
         "glob pass completed"
     );
 
-    results.into_iter().collect()
+    Ok(results)
 }
 
 /// Ensures plain file names behave as "current directory" matches for the ignore crate.

--- a/crates/pixi_glob/src/lib.rs
+++ b/crates/pixi_glob/src/lib.rs
@@ -10,4 +10,4 @@ mod glob_set;
 pub use glob_hash::{GlobHash, GlobHashError};
 pub use glob_hash_cache::{GlobHashCache, GlobHashKey};
 pub use glob_mtime::{GlobModificationTime, GlobModificationTimeError};
-pub use glob_set::{GlobSet, GlobSetError};
+pub use glob_set::{GlobSet, GlobSetError, Match};

--- a/crates/pixi_reporters/src/lib.rs
+++ b/crates/pixi_reporters/src/lib.rs
@@ -12,9 +12,10 @@ use git::GitCheckoutProgress;
 use indicatif::{MultiProgress, ProgressBar};
 use main_progress_bar::MainProgressBar;
 use parking_lot::Mutex;
+use futures::stream::StreamExt;
 use pixi_command_dispatcher::{
-    CommandDispatcherBuilder, InstallPixiEnvironmentSpec, PixiSolveEnvironmentSpec,
-    SolveCondaEnvironmentSpec,
+    BuildBackendMetadataInner, BuildBackendMetadataReporter, CommandDispatcherBuilder,
+    InstallPixiEnvironmentSpec, PixiSolveEnvironmentSpec, SolveCondaEnvironmentSpec,
 };
 use pixi_compute_reporters::{OperationId, OperationRegistry};
 pub use release_notes::format_release_notes;
@@ -34,6 +35,10 @@ pub struct TopLevelProgress {
     /// `OperationId` → bar slot in `conda_solve_reporter`. Lets
     /// `on_started` / `on_finished` find the bar created at `on_queued`.
     solve_bars: Mutex<HashMap<OperationId, usize>>,
+    /// `OperationId` → bar slot in `conda_solve_reporter` for build-backend
+    /// metadata fetches. Kept separate from `solve_bars` so they can be
+    /// resolved independently in the reporter callbacks.
+    backend_metadata_bars: Mutex<HashMap<OperationId, usize>>,
     repodata_reporter: RepodataReporter,
     sync_reporter: SyncReporter,
 }
@@ -89,6 +94,7 @@ impl TopLevelProgress {
             source_checkout_reporter,
             conda_solve_reporter,
             solve_bars: Mutex::new(HashMap::new()),
+            backend_metadata_bars: Mutex::new(HashMap::new()),
             repodata_reporter,
             sync_reporter: install_reporter,
         }
@@ -109,6 +115,7 @@ impl TopLevelProgress {
             .with_conda_solve_reporter(self.clone())
             .with_pixi_install_reporter(self.clone())
             .with_instantiate_backend_reporter(self.clone())
+            .with_build_backend_metadata_reporter(self.clone())
             .with_git_checkout_reporter(self.source_checkout_reporter.clone())
             .with_backend_source_build_reporter(backend_source_build_reporter)
             .with_gateway_reporter(self.clone())
@@ -221,5 +228,40 @@ impl pixi_command_dispatcher::GatewayReporter for TopLevelProgress {
         _op_id: OperationId,
     ) -> Option<Box<dyn rattler_repodata_gateway::Reporter>> {
         Some(Box::new(self.repodata_reporter.clone()))
+    }
+}
+
+impl BuildBackendMetadataReporter for TopLevelProgress {
+    fn on_queued(&self, env: &BuildBackendMetadataInner) -> OperationId {
+        let id = self.alloc();
+        let bar = self
+            .conda_solve_reporter
+            .queued(format!("backend metadata: {}", env.manifest_source));
+        self.backend_metadata_bars.lock().insert(id, bar);
+        id
+    }
+
+    fn on_started(
+        &self,
+        id: OperationId,
+        backend_output_stream: Box<dyn futures::Stream<Item = String> + Unpin + Send>,
+    ) {
+        if let Some(bar) = self.backend_metadata_bars.lock().get(&id).copied() {
+            self.conda_solve_reporter.start(bar);
+        }
+        // The backend's stdout/stderr is interesting at -vvv, but we don't
+        // want to interleave it into the progress bar. Drain the stream in
+        // the background so the producer never blocks; the lines are
+        // already visible to anyone running with `RUST_LOG`-level tracing.
+        tokio::spawn(async move {
+            let mut stream = backend_output_stream;
+            while stream.next().await.is_some() {}
+        });
+    }
+
+    fn on_finished(&self, id: OperationId, _failed: bool) {
+        if let Some(bar) = self.backend_metadata_bars.lock().remove(&id) {
+            self.conda_solve_reporter.finish(bar);
+        }
     }
 }

--- a/crates/pixi_reporters/src/lib.rs
+++ b/crates/pixi_reporters/src/lib.rs
@@ -8,11 +8,11 @@ pub mod uv_reporter;
 
 use std::{collections::HashMap, sync::Arc};
 
+use futures::stream::StreamExt;
 use git::GitCheckoutProgress;
 use indicatif::{MultiProgress, ProgressBar};
 use main_progress_bar::MainProgressBar;
 use parking_lot::Mutex;
-use futures::stream::StreamExt;
 use pixi_command_dispatcher::{
     BuildBackendMetadataInner, BuildBackendMetadataReporter, CommandDispatcherBuilder,
     InstallPixiEnvironmentSpec, PixiSolveEnvironmentSpec, SolveCondaEnvironmentSpec,

--- a/crates/pixi_reporters/src/main_progress_bar.rs
+++ b/crates/pixi_reporters/src/main_progress_bar.rs
@@ -208,19 +208,42 @@ impl<T: Tracker> State<T> {
             .iter()
             .max_by(|a, b| a.tracker.cmp(&b.tracker));
         let wide_msg = match (first, running_items.len()) {
-            (None, _) => String::new(),
             (Some(first), 1) => first.tracker.name().to_string(),
             (Some(first), _) => {
-                format!("{} (+{})", first.tracker.name(), running_items.len() - 1,)
+                format!("{} (+{})", first.tracker.name(), running_items.len() - 1)
+            }
+            (None, _) => {
+                // Nothing actively running, but if there are still
+                // queued items, surface one so the bar isn't visually
+                // dead while the dispatcher is waiting on a slot.
+                let mut seen_queued = HashSet::new();
+                let queued_items = tracker
+                    .values()
+                    .filter(|item| item.started.is_none() && item.finished.is_none())
+                    .filter(|item| seen_queued.insert(item.tracker.name()))
+                    .collect::<Vec<_>>();
+                let first_queued = queued_items.iter().max_by(|a, b| a.tracker.cmp(&b.tracker));
+                match (first_queued, queued_items.len()) {
+                    (Some(first), 1) => format!("queued: {}", first.tracker.name()),
+                    (Some(first), _) => {
+                        format!("queued: {} (+{})", first.tracker.name(), queued_items.len() - 1)
+                    }
+                    (None, _) => String::new(),
+                }
             }
         };
 
+        // Treat anything that hasn't finished yet (queued OR running) as
+        // pending so the spinner animates while we're waiting on a slot
+        // and only goes dim when there's truly nothing in flight.
+        let has_pending = tracker.values().any(|item| item.finished.is_none());
+
         // Set the style of the progress bar.
-        let active = !running_items.is_empty();
+        let active = has_pending;
         self.pb.set_style(
             ProgressStyle::with_template(
                 &format!("{{spinner:.{spinner}}} {{prefix:20!}} [{{bar:20!.bright.yellow/dim.white}}] {{pos_count:>2.dim}}{slash}{{len_count:2.dim}} {{wide_msg:.dim}}",
-                         spinner = if running_items.is_empty() { "dim" } else { "green" },
+                         spinner = if has_pending { "green" } else { "dim" },
                          slash = console::style("/").dim(),
                 ))
                 .expect("failed to create progress bar style")

--- a/crates/pixi_reporters/src/main_progress_bar.rs
+++ b/crates/pixi_reporters/src/main_progress_bar.rs
@@ -226,7 +226,11 @@ impl<T: Tracker> State<T> {
                 match (first_queued, queued_items.len()) {
                     (Some(first), 1) => format!("queued: {}", first.tracker.name()),
                     (Some(first), _) => {
-                        format!("queued: {} (+{})", first.tracker.name(), queued_items.len() - 1)
+                        format!(
+                            "queued: {} (+{})",
+                            first.tracker.name(),
+                            queued_items.len() - 1
+                        )
                     }
                     (None, _) => String::new(),
                 }

--- a/crates/pixi_task/src/file_hashes.rs
+++ b/crates/pixi_task/src/file_hashes.rs
@@ -107,25 +107,21 @@ impl FileHashes {
         // by the Installer.
         initialize_rayon_once();
 
-        // Process entries in parallel using rayon
+        // Process entries in parallel using rayon. `collect_matching` already
+        // filters out directories, so every entry is a regular file.
         entries.into_par_iter().for_each(|entry| {
             let tx = tx.clone();
             let collect_root = Arc::clone(&collect_root);
+            let path = entry.into_path();
 
             let result: Result<(PathBuf, String), FileHashesError> =
-                if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
-                    // Skip directories
-                    return;
-                } else {
-                    compute_file_hash(entry.path()).map(|hash| {
-                        let path = entry
-                            .path()
-                            .strip_prefix(&*collect_root)
-                            .expect("path is not prefixed by the root");
-                        tracing::info!("Added hash for file: {:?}", path);
-                        (path.to_owned(), hash)
-                    })
-                };
+                compute_file_hash(&path).map(|hash| {
+                    let rel = path
+                        .strip_prefix(&*collect_root)
+                        .expect("path is not prefixed by the root");
+                    tracing::info!("Added hash for file: {:?}", rel);
+                    (rel.to_owned(), hash)
+                });
 
             // Send result to channel - if it fails, we just continue with the next item
             let _ = tx.send(result);

--- a/docs/build/backends/pixi-build-ros.md
+++ b/docs/build/backends/pixi-build-ros.md
@@ -132,11 +132,31 @@ This does not work with the `robostack-staging` channel, as it contains packages
 
 Because the definition of a dependency in a `package.xml` file is not similar to a conda package name, the backend needs to map ROS dependencies to conda packages.
 
+- **Workspace siblings**: Other ROS packages in the same workspace are discovered automatically and resolved as **source** dependencies, built from their sibling directory. See [Workspace Source Discovery](#workspace-source-discovery).
 - **Known dependencies**: Mapped using the [`robostack.yaml`](https://github.com/prefix-dev/pixi-build-backends/blob/main/backends/pixi-build-ros/robostack.yaml).
 - **Custom mappings**: You can provide additional mappings in your `pixi.toml` under [`[package.build.config.extra-package-mappings]`](#extra-package-mappings)
 - **Other packages**: Mapped to `ros-<distro>-<package-name>` format.
 
 The `<distro>` part of the package name is automatically generated based on the `distro` configuration.
+
+### Workspace Source Discovery
+
+When a `package.xml` declares a `<depend>` (or `build_depend` / `run_depend` / `exec_depend`) on another ROS package that lives in the same workspace, the backend automatically resolves it as a source dependency. There is no need to hand-write `path = "..."` entries in `pixi.toml` for every sibling reference.
+
+Concretely, the backend walks the workspace root looking for every `package.xml`, and for each declared dependency in the current package whose `<name>` matches a sibling's `<name>`, it emits `ros-<distro>-<sibling-name>` as a source dep pointing at the sibling's `package.xml` instead of mapping it through RoboStack as a binary.
+
+Discovery follows colcon conventions: directories that contain a `COLCON_IGNORE`, `AMENT_IGNORE`, or `CATKIN_IGNORE` marker file are pruned from the walk. Colcon writes these markers into its own `build/`, `install/`, and `log/` directories on first use, so those are skipped automatically once a colcon build has run.
+
+Two `package.xml` files declaring the same `<name>` is an error.
+
+A manual entry in `pixi.toml` always wins over discovery, per requirement class. For example, if you declare:
+
+```toml
+[package.run-dependencies]
+ros-jazzy-pkg-b = { binary = { version = "==1.2.3" } }
+```
+
+then `ros-jazzy-pkg-b` stays a pinned binary in the `run` class, while discovery still applies in `build` and `host` if the same sibling is referenced there. Use this to pin a single sibling against a stability baseline while still iterating on the rest of the workspace. To skip discovery entirely for a single package, set [`ignore-workspace-sources = true`](#ignore-workspace-sources) on that package.
 
 ## Configuration Options
 
@@ -209,6 +229,19 @@ Default input globs include:
 - Message definitions: `msg/**/*.msg`
 - Service definitions: `srv/**/*.srv`
 - Action definitions: `action/**/*.action`
+
+### `ignore-workspace-sources`
+
+- **Type**: `Boolean`
+- **Default**: `false`
+- **Target Merge Behavior**: `Or` &mdash; if either the base or platform-specific value is `true`, discovery is skipped
+
+When set to `true`, [workspace source discovery](#workspace-source-discovery) is skipped for this package: every dependency declared in `package.xml` is resolved through RoboStack as a binary, even if a sibling with the same name exists in the workspace. Useful to pin a single package against a stability baseline while iterating on the rest of the workspace.
+
+```toml
+[package.build.config]
+ignore-workspace-sources = true
+```
 
 ### `extra-package-mappings`
 

--- a/tests/data/pixi-build/ros-workspace/src/navigator_implicit/CMakeLists.txt
+++ b/tests/data/pixi-build/ros-workspace/src/navigator_implicit/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(navigator)
+project(navigator_implicit)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -11,19 +11,19 @@ find_package(rclcpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(turtlesim REQUIRED)
 
-add_executable(navigator src/navigator.cpp)
-target_include_directories(navigator PUBLIC
+add_executable(navigator_implicit src/navigator.cpp)
+target_include_directories(navigator_implicit PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
-target_compile_features(navigator PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_compile_features(navigator_implicit PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 ament_target_dependencies(
-  navigator
+  navigator_implicit
   "rclcpp"
   "geometry_msgs"
   "turtlesim"
 )
 
-install(TARGETS navigator
+install(TARGETS navigator_implicit
   DESTINATION lib/${PROJECT_NAME})
 
 # if(BUILD_TESTING)

--- a/tests/data/pixi-build/ros-workspace/src/navigator_implicit/package.xml
+++ b/tests/data/pixi-build/ros-workspace/src/navigator_implicit/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>navigator</name>
+  <name>navigator_implicit</name>
   <version>0.0.0</version>
   <description>TODO: Package description</description>
   <maintainer email="ruben.arts@hotmail.com">rarts</maintainer>


### PR DESCRIPTION
### Description

Two related changes that ship together:

1. **ROS sibling-package source dependency discovery.** `pixi-build-ros` walks the workspace root for `package.xml` files and emits any siblings declared in this package's `<depend>` tags as `source://` dependencies, so a workspace can build its own ROS packages from source without per-package manual wiring.

2. **Marker-driven workspace globbing.** A new optional `inputGlobSets` field on the backend protocol lets backends describe their inputs precisely (patterns, prune/leaf marker filenames like `COLCON_IGNORE`, hidden-folder handling, walk root). `pixi-build-ros` uses it to point pixi at the workspace root with marker semantics so pixi can re-walk it later for cache invalidation. Pixi dedupes identical walks across consumers within a single lock via a compute-engine key, so a 30-package ROS workspace walks itself once instead of 30 times.

The protocol field is additive and optional: older pixi continues to use the existing flat `inputGlobs` list and ignores `inputGlobSets`; newer pixi prefers the structured form when present.

What this enables: ROS workspaces with sibling source dependencies (the main motivation, [#5946](https://github.com/prefix-dev/pixi/issues/5946)).

### How Has This Been Tested?

`cargo check --workspace --tests` on Windows. Unit tests cover `GlobSet`'s marker dispatch, `InputGlobSet` serde round-trip, the workspace discovery walker, and the dispatcher's compute-engine walk key. Benchmarked against `F:\projects\issues\navigation2`: identical package set discovered.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Sonnet/Opus 4.x via Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.