### PR TITLE
fix(global): clear conda stack env for prefix-ignore trampolines

### DIFF
--- a/crates/pixi_global/src/install.rs
+++ b/crates/pixi_global/src/install.rs
@@ -15,7 +15,7 @@ use rattler_conda_types::{
     RepodataRevision,
 };
 use rattler_shell::activation::prefix_path_entries;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::{env, path::PathBuf, str::FromStr};
 
 use fs_err::tokio as tokio_fs;
@@ -138,7 +138,7 @@ pub(crate) async fn create_executable_trampolines(
             .join(IGNORE_CONDA_PREFIX_MARKER)
             .is_file()
         {
-            env_for_trampoline.remove("CONDA_PREFIX");
+            remove_incomplete_conda_activation_stack(&mut env_for_trampoline);
         }
         let metadata = Configuration::new(exe, path_diff.clone(), env_for_trampoline);
 
@@ -196,6 +196,14 @@ pub(crate) async fn create_executable_trampolines(
         }
     }
     Ok(state_changes)
+}
+
+fn remove_incomplete_conda_activation_stack(env: &mut HashMap<String, String>) {
+    env.remove("CONDA_PREFIX");
+    env.remove("CONDA_SHLVL");
+    env.remove("CONDA_DEFAULT_ENV");
+    env.remove("CONDA_PROMPT_MODIFIER");
+    env.retain(|key, _| !key.starts_with("CONDA_ENV_SHLVL_"));
 }
 
 /// Compute the difference between two PATH variables (the entries split by `;` or `:`)
@@ -544,6 +552,31 @@ mod tests {
         assert_eq!(
             actual.original_executable, expected.original_executable,
             "testing original_executable"
+        );
+    }
+
+    #[test]
+    fn test_global_ignore_conda_prefix_removes_incomplete_conda_stack() {
+        let mut env = HashMap::from([
+            (
+                "CONDA_PREFIX".to_string(),
+                "/tmp/pixi/envs/fish".to_string(),
+            ),
+            ("CONDA_SHLVL".to_string(), "1".to_string()),
+            ("CONDA_DEFAULT_ENV".to_string(), "fish".to_string()),
+            ("CONDA_PROMPT_MODIFIER".to_string(), "(fish) ".to_string()),
+            (
+                "CONDA_ENV_SHLVL_0".to_string(),
+                "/tmp/pixi/envs/base".to_string(),
+            ),
+            ("KEEP_ME".to_string(), "present".to_string()),
+        ]);
+
+        remove_incomplete_conda_activation_stack(&mut env);
+
+        assert_eq!(
+            env,
+            HashMap::from([("KEEP_ME".to_string(), "present".to_string())])
         );
     }
 

--- a/tests/integration_python/pixi_global/test_trampoline.py
+++ b/tests/integration_python/pixi_global/test_trampoline.py
@@ -507,6 +507,10 @@ def test_trampoline_considers_global_config_json(
     # get envs of the trampoline
     trampoline_env = trampoline_metadata["env"]
     assert "CONDA_PREFIX" not in trampoline_env
+    assert "CONDA_SHLVL" not in trampoline_env
+    assert "CONDA_DEFAULT_ENV" not in trampoline_env
+    assert "CONDA_PROMPT_MODIFIER" not in trampoline_env
+    assert not any(key.startswith("CONDA_ENV_SHLVL_") for key in trampoline_env)
 
     # now execute the binary
     current_env = dict(os.environ)


### PR DESCRIPTION
### Description

Fixes #6002

When a package provides the `global-ignore-conda-prefix` marker, the trampoline configuration currently removes `CONDA_PREFIX` but can still keep Conda stack variables such as `CONDA_SHLVL`. That leaves a long-lived globally installed shell with an incomplete Conda activation state.

This change clears the related Conda stack variables together with `CONDA_PREFIX` for that marker, while preserving unrelated activation variables in the trampoline environment.

### How Has This Been Tested?

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p pixi_global test_global_ignore_conda_prefix_removes_incomplete_conda_stack`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p pixi_global`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `CARGO_TARGET_DIR=target/pixi PATH="$HOME/.cargo/bin:$PATH" cargo build -p pixi`
- `uv run --python 3.12 --with pytest --with inline-snapshot --with pytest-timeout --with pytest-xdist --with pytest-rerunfailures --with dirty-equals --with filelock --with py-rattler --with pyyaml python -m pytest --pixi-build=debug tests/integration_python/pixi_global/test_trampoline.py -k test_trampoline_considers_global_config_json -q`
- `git diff --check`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

Prompt summary: inspect the reported trampoline environment bug, add focused regression coverage, keep the fix narrow, and verify locally.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
