### PR TITLE
fix: git url normalization

### DIFF
--- a/crates/pixi/tests/integration_rust/snapshots/integration_rust__add_tests__add_pypi_git-2.snap
+++ b/crates/pixi/tests/integration_rust/snapshots/integration_rust__add_tests__add_pypi_git-2.snap
@@ -2,4 +2,4 @@
 source: crates/pixi/tests/integration_rust/add_tests.rs
 expression: boltons.location
 ---
-git+https://github.com/mahmoud/boltons#[FULL_COMMIT]
+git+https://github.com/mahmoud/boltons.git#[FULL_COMMIT]

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -337,10 +337,11 @@ pub fn into_pinned_git_spec(
         reference,
     );
 
-    // uv stores the percent-encoded drive-letter form internally (see
-    // `encode_windows_drive_letter`). Decode it back here so the lock file
-    // shows `file:///D:/...` rather than `file:///D%3A/...`.
-    let repository: url::Url = (**dist.git.repository()).clone();
+    // `url()` is the original URL; `repository()` is the canonical
+    // (lowercased + `.git`-stripped) form that would corrupt the lockfile
+    // (prefix-dev/pixi#6185). `decode_windows_drive_letter` undoes uv's
+    // percent-encoded drive letters so the lockfile shows `file:///D:/...`.
+    let repository: url::Url = (**dist.git.url()).clone();
     PinnedGitSpec::new(decode_windows_drive_letter(&repository), pinned_checkout)
 }
 
@@ -451,7 +452,8 @@ pub fn to_requirements<'req>(
                     git,
                     subdirectory,
                 } => {
-                    write!(package_string, " @ git+{}", git.repository())?;
+                    // `url()`, not `repository()`, see #6185.
+                    write!(package_string, " @ git+{}", git.url())?;
                     if let Some(reference) = git.reference().as_str() {
                         write!(package_string, "@{reference}")?;
                     }
@@ -871,5 +873,37 @@ mod tests {
 
         let converted = to_requirements(std::iter::once(&uv_req)).unwrap();
         assert_eq!(converted[0].to_string(), "isaaclab");
+    }
+
+    /// #6185: lockfile URL must keep original casing and `.git` suffix.
+    #[test]
+    fn into_pinned_git_spec_preserves_original_url() {
+        use uv_distribution_types::GitSourceDist;
+        use uv_git_types::{GitLfs, GitOid, GitReference as UvGitReference, GitUrl as UvGitUrl};
+        use uv_normalize::PackageName;
+        use uv_pep508::VerbatimUrl;
+
+        let original = "https://github.com/VaasuDevanS/cowsay-python.git";
+        let safe_url = DisplaySafeUrl::parse(original).unwrap();
+        let commit = GitOid::from_str("dcf7236f0b5ece9ed56e91271486e560526049cf").unwrap();
+
+        let git_url = UvGitUrl::from_commit(
+            safe_url.clone(),
+            UvGitReference::DefaultBranch,
+            commit,
+            GitLfs::Disabled,
+        )
+        .unwrap();
+
+        let dist = GitSourceDist {
+            name: PackageName::from_str("cowsay").unwrap(),
+            git: Box::new(git_url),
+            subdirectory: None,
+            url: VerbatimUrl::from_url(safe_url),
+        };
+
+        let pinned = into_pinned_git_spec(dist, None);
+
+        assert_eq!(pinned.git.as_str(), original);
     }
 }

--- a/tests/data/satisfiability/v6-editable-no-rewrite/pixi.lock
+++ b/tests/data/satisfiability/v6-editable-no-rewrite/pixi.lock
@@ -32,7 +32,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: git+https://github.com/python-trio/sniffio#ae020e13b98d276a6558ffc25e82509fd4c288f0
+      - pypi: git+https://github.com/python-trio/sniffio.git#ae020e13b98d276a6558ffc25e82509fd4c288f0
       - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -285,7 +285,7 @@ packages:
   purls: []
   size: 345073
   timestamp: 1765813471974
-- pypi: git+https://github.com/python-trio/sniffio#ae020e13b98d276a6558ffc25e82509fd4c288f0
+- pypi: git+https://github.com/python-trio/sniffio.git#ae020e13b98d276a6558ffc25e82509fd4c288f0
   name: sniffio
   version: 1.3.1
   requires_python: '>=3.7'
@@ -315,7 +315,7 @@ packages:
   version: 0.1.0
   sha256: 0813783311097dc11aad19f784dd9dee3992f3a7b4247f940337ebb498d9ea12
   requires_dist:
-  - sniffio @ git+https://github.com/python-trio/sniffio@v1.3.1
+  - sniffio @ git+https://github.com/python-trio/sniffio.git@v1.3.1
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7


### PR DESCRIPTION
### Description

PyPI git dependencies were being recorded in `pixi.lock` with lowercased paths and stripped `.git` suffixes (e.g. `github.com/VaasuDevanS/cowsay-python.git` became `github.com/vaasudevans/cowsay-python`). This broke CI setups that rely on the original URL, such as SSH key mappings, deploy-token rewrites, and `insteadOf` rules, causing `pixi install --locked` to fail with `Permission denied (publickey)` after upgrading to 0.69.0.

The lockfile now preserves the URL exactly as the user wrote it.

Fixes #6185

### How Has This Been Tested?

- Added a regression unit test for `into_pinned_git_spec` that locks in the original casing and `.git` suffix.
- Updated an existing satisfiability fixture whose lockfile had been recorded with the broken URL form.
- Full `pixi_uv_conversions`, `pixi_record`, `pixi_git`, and `pixi_core` lockfile/satisfiability test suites pass locally.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.