### PR TITLE
fix(reinstall): wire up progress reporter and batch environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6215,6 +6215,7 @@ dependencies = [
  "pixi_install_pypi",
  "pixi_manifest",
  "pixi_pypi_spec",
+ "pixi_reporters",
  "pixi_spec",
  "pixi_utils",
  "pixi_uv_conversions",

--- a/crates/pixi_api/Cargo.toml
+++ b/crates/pixi_api/Cargo.toml
@@ -24,6 +24,7 @@ pixi_core = { workspace = true }
 pixi_install_pypi = { workspace = true }
 pixi_manifest = { workspace = true }
 pixi_pypi_spec = { workspace = true }
+pixi_reporters = { workspace = true }
 pixi_spec = { workspace = true }
 pixi_utils = { workspace = true }
 pixi_uv_conversions = { workspace = true }

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -40,9 +40,7 @@ pub async fn reinstall<I: Interface>(
         .map(|env| workspace.environment_from_name_or_env_var(Some(env)))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Update the prefixes by reinstalling all packages, wiring up the top-level
-    // progress reporter so source builds and package preparation show progress
-    // bars (matching `pixi install`).
+    // Update the prefixes by reinstalling all packages
     get_update_lock_file_and_prefixes(
         &environments,
         Some(pixi_reporters::TopLevelProgress::from_global()),
@@ -58,10 +56,7 @@ pub async fn reinstall<I: Interface>(
     )
     .await?;
 
-    let installed_envs: Vec<_> = environments
-        .iter()
-        .map(|env| env.name().clone())
-        .collect();
+    let installed_envs: Vec<_> = environments.iter().map(|env| env.name().clone()).collect();
 
     // Message what's installed
     let detached_envs_message =

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -40,7 +40,7 @@ pub async fn reinstall<I: Interface>(
         .map(|env| workspace.environment_from_name_or_env_var(Some(env)))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Update the prefixes by reinstalling all packages
+    // Update the prefixes by reinstalling `options.reinstall_packages`
     get_update_lock_file_and_prefixes(
         &environments,
         Some(pixi_reporters::TopLevelProgress::from_global()),

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -2,7 +2,7 @@ use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use pixi_core::{
     InstallFilter, UpdateLockFileOptions, Workspace,
-    environment::{LockFileUsage, get_update_lock_file_and_prefix},
+    environment::{LockFileUsage, get_update_lock_file_and_prefixes},
     lock_file::{ReinstallEnvironment, UpdateMode},
 };
 
@@ -35,28 +35,33 @@ pub async fn reinstall<I: Interface>(
         vec![workspace.default_environment().name().to_string()]
     };
 
-    let mut installed_envs = Vec::with_capacity(envs.len());
-    for env in envs {
-        let environment = workspace.environment_from_name_or_env_var(Some(env))?;
+    let environments = envs
+        .into_iter()
+        .map(|env| workspace.environment_from_name_or_env_var(Some(env)))
+        .collect::<Result<Vec<_>, _>>()?;
 
-        // Update the prefix by installing all packages
-        get_update_lock_file_and_prefix(
-            &environment,
-            None,
-            UpdateMode::Revalidate,
-            UpdateLockFileOptions {
-                lock_file_usage,
-                no_install: false,
-                max_concurrent_solves: workspace.config().max_concurrent_solves(),
-                ..Default::default()
-            },
-            options.reinstall_packages.clone(),
-            &InstallFilter::default(),
-        )
-        .await?;
+    // Update the prefixes by reinstalling all packages, wiring up the top-level
+    // progress reporter so source builds and package preparation show progress
+    // bars (matching `pixi install`).
+    get_update_lock_file_and_prefixes(
+        &environments,
+        Some(pixi_reporters::TopLevelProgress::from_global()),
+        UpdateMode::Revalidate,
+        UpdateLockFileOptions {
+            lock_file_usage,
+            no_install: false,
+            max_concurrent_solves: workspace.config().max_concurrent_solves(),
+            ..Default::default()
+        },
+        options.reinstall_packages,
+        &InstallFilter::default(),
+    )
+    .await?;
 
-        installed_envs.push(environment.name().clone());
-    }
+    let installed_envs: Vec<_> = environments
+        .iter()
+        .map(|env| env.name().clone())
+        .collect();
 
     // Message what's installed
     let detached_envs_message =


### PR DESCRIPTION
### Description

`pixi reinstall` was missing the progress UI that `pixi install` shows. There was no "preparing packages" bar, and during source builds the output would appear to hang for long stretches with no indication that a build was in progress.

This change makes `pixi reinstall` use the same progress reporting as `pixi install`, so source builds and package preparation are now visible.

Reported on Discord by @lucascolley.

### How Has This Been Tested?

Manually run `pixi reinstall` in a workspace that uses a source-built package (e.g. one with a `pixi-build-python` backend) and confirm:
- the "preparing packages" progress bar appears
- the currently-building package is shown
- behavior matches `pixi install`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code