### PR TITLE
fix: seed pypi-options from global config in `--import` and existing pyproject paths

### DIFF
--- a/crates/pixi_api/src/workspace/init/mod.rs
+++ b/crates/pixi_api/src/workspace/init/mod.rs
@@ -63,6 +63,9 @@ pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::
         options.platforms.clone()
     };
 
+    let index_url = config.pypi_config.index_url.clone();
+    let extra_index_urls = config.pypi_config.extra_index_urls.clone();
+
     // Create a 'pixi.toml' manifest and populate it by importing a conda
     // environment file
     let workspace = if let Some(env_file_path) = options.env_file {
@@ -90,8 +93,8 @@ pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::
             author.as_ref(),
             channels,
             &platforms,
-            None,
-            &vec![],
+            index_url.as_ref(),
+            &extra_index_urls,
             config.s3_options,
             Some(&env_vars),
             options.conda_pypi_mapping.as_ref(),
@@ -122,9 +125,6 @@ pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::
         } else {
             config.default_channels().to_vec()
         };
-
-        let index_url = config.pypi_config.index_url;
-        let extra_index_urls = config.pypi_config.extra_index_urls;
 
         // Dialog with user to create a 'pyproject.toml' or 'pixi.toml' manifest
         // If nothing is defined but there is a `pyproject.toml` file, ask the user.
@@ -168,6 +168,8 @@ pub async fn init<I: Interface>(interface: &I, options: InitOptions) -> miette::
                         channels,
                         platforms,
                         environments,
+                        index_url => index_url.as_ref(),
+                        extra_index_urls => &extra_index_urls,
                         s3 => relevant_s3_options(config.s3_options, channels),
                     },
                 )

--- a/crates/pixi_api/src/workspace/init/template.rs
+++ b/crates/pixi_api/src/workspace/init/template.rs
@@ -73,6 +73,13 @@ default = { solve-group = "default" }
 {{env}} = { features = {{ features }}, solve-group = "default" }
 {%- endfor %}
 
+{%- if index_url or extra_index_urls %}
+
+[tool.pixi.pypi-options]
+{% if index_url %}index-url = "{{ index_url }}"{% endif %}
+{% if extra_index_urls %}extra-index-urls = {{ extra_index_urls }}{% endif %}
+{%- endif %}
+
 {%- if s3 %}
 {%- for key in s3 %}
 


### PR DESCRIPTION
### Description

When a user sets `[pypi-config]` in their global pixi config (e.g. `~/.pixi/config.toml`), `pixi init` should seed those PyPI settings into the new workspace as `[pypi-options]`. This already worked for the basic `pixi init` and `pixi init --format pyproject` cases, but not when bootstrapping from a conda environment file with `--import`, or when extending an existing `pyproject.toml`. This PR closes those two gaps so the behavior is consistent across all `pixi init` entry points.

Fixes #3004

### How Has This Been Tested?

Manually exercised all four init paths against a global config containing `index-url` and `extra-index-urls`:

1. `pixi init <dir>` produces `[pypi-options]` in the new `pixi.toml`.
2. `pixi init --format pyproject <dir>` produces `[tool.pixi.pypi-options]` in the new `pyproject.toml`.
3. `pixi init --import env.yml <dir>` produces `[pypi-options]` in the generated `pixi.toml`.
4. `pixi init --format pyproject <dir>` against a pre-existing `pyproject.toml` appends `[tool.pixi.pypi-options]`.

Also verified the negative case: with no global `[pypi-config]` set, no `[pypi-options]` block is emitted in any path.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added sufficient tests to cover my changes.