### PR TITLE
fix: reinstall when registry install collides with non-registry lock entry

### DIFF
--- a/crates/pixi_install_pypi/src/plan/test/mod.rs
+++ b/crates/pixi_install_pypi/src/plan/test/mod.rs
@@ -731,9 +731,8 @@ fn test_installed_registry_required_archive_same_version() {
         InstalledDistOptions::default(),
     );
 
-    let archive_url =
-        Url::parse("https://some-other-registry.org/aiofiles-0.6.0-py3-none-any.whl")
-            .expect("could not parse archive url");
+    let archive_url = Url::parse("https://some-other-registry.org/aiofiles-0.6.0-py3-none-any.whl")
+        .expect("could not parse archive url");
     let required = RequiredPackages::new().add_archive("aiofiles", "0.6.0", archive_url);
 
     let plan = harness::install_planner();

--- a/crates/pixi_install_pypi/src/plan/test/mod.rs
+++ b/crates/pixi_install_pypi/src/plan/test/mod.rs
@@ -678,6 +678,83 @@ fn test_installed_git_require_registry() {
     );
 }
 
+/// Regression test for prefix-dev/pixi#2677.
+///
+/// When a package was previously installed from the PyPI registry, but the lock
+/// file now requires it from a git source with the SAME version number, we
+/// must reinstall from git. Previously, the version-equality check in the
+/// `InstalledDistKind::Registry` branch would short-circuit to `Keep`,
+/// silently leaving the registry build in place.
+#[test]
+fn test_installed_registry_required_git_same_version() {
+    let site_packages = MockedSitePackages::new().add_registry(
+        "aiofiles",
+        "0.6.0",
+        InstalledDistOptions::default(),
+    );
+
+    let locked_git_url = Url::parse(
+        "git+https://github.com/myfork/aiofiles.git?rev=abc1234#1234567890abcdef1234567890abcdef12345678",
+    )
+    .expect("could not parse git url");
+    let required = RequiredPackages::new().add_git("aiofiles", "0.6.0", locked_git_url.clone());
+
+    let plan = harness::install_planner();
+    let required_dists = required.to_required_dists();
+    let installs = plan
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            &uv_configuration::BuildOptions::default(),
+        )
+        .expect("should install");
+
+    assert_matches!(
+        installs.reinstalls[0].1,
+        NeedReinstall::SourceMismatch { .. },
+        "expected SourceMismatch but got {:?}",
+        installs.reinstalls[0].1
+    );
+}
+
+/// Regression test for prefix-dev/pixi#2677 (archive variant).
+///
+/// Symmetric to the git case: a registry-installed package whose lock entry
+/// now points at a direct archive URL with the same version must be
+/// reinstalled.
+#[test]
+fn test_installed_registry_required_archive_same_version() {
+    let site_packages = MockedSitePackages::new().add_registry(
+        "aiofiles",
+        "0.6.0",
+        InstalledDistOptions::default(),
+    );
+
+    let archive_url =
+        Url::parse("https://some-other-registry.org/aiofiles-0.6.0-py3-none-any.whl")
+            .expect("could not parse archive url");
+    let required = RequiredPackages::new().add_archive("aiofiles", "0.6.0", archive_url);
+
+    let plan = harness::install_planner();
+    let required_dists = required.to_required_dists();
+    let installs = plan
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            &uv_configuration::BuildOptions::default(),
+        )
+        .expect("should install");
+
+    assert_matches!(
+        installs.reinstalls[0].1,
+        NeedReinstall::SourceMismatch { .. },
+        "expected SourceMismatch but got {:?}",
+        installs.reinstalls[0].1
+    );
+}
+
 /// When the git commit differs we should reinstall
 #[test]
 fn test_installed_git_require_git_commit_mismatch() {

--- a/crates/pixi_install_pypi/src/plan/validation.rs
+++ b/crates/pixi_install_pypi/src/plan/validation.rs
@@ -9,7 +9,7 @@ use uv_cache_info::CacheInfoError;
 use uv_distribution_types::{Dist, InstalledDist, InstalledDistKind};
 use uv_pypi_types::{ParsedGitUrl, ParsedUrlError};
 
-use crate::utils::{check_url_freshness, strip_direct_scheme};
+use crate::utils::{check_url_freshness, is_direct_url, strip_direct_scheme};
 
 use super::{NeedReinstall, models::ValidateCurrentInstall};
 use pixi_uv_conversions::ConversionError;
@@ -38,13 +38,28 @@ pub(crate) fn need_reinstall(
     // Check if the installed version is the same as the required version
     match &installed_dist.kind {
         InstalledDistKind::Registry(reg) => {
-            if !matches!(required_pkg.location, UrlOrPath::Url(_)) {
-                return Ok(ValidateCurrentInstall::Reinstall(
-                    NeedReinstall::SourceMismatch {
-                        locked_location: required_pkg.location.to_string(),
-                        installed_location: "registry".to_string(),
-                    },
-                ));
+            // The package on disk came from a registry. Anything other than a
+            // registry URL in the lock file (a path, a git URL, a `direct+` URL)
+            // is a source mismatch and must be reinstalled — even when the
+            // version numbers happen to coincide. See prefix-dev/pixi#2677.
+            match &required_pkg.location {
+                UrlOrPath::Path(_) => {
+                    return Ok(ValidateCurrentInstall::Reinstall(
+                        NeedReinstall::SourceMismatch {
+                            locked_location: required_pkg.location.to_string(),
+                            installed_location: "registry".to_string(),
+                        },
+                    ));
+                }
+                UrlOrPath::Url(url) if is_direct_url(url.scheme()) => {
+                    return Ok(ValidateCurrentInstall::Reinstall(
+                        NeedReinstall::SourceMismatch {
+                            locked_location: required_pkg.location.to_string(),
+                            installed_location: "registry".to_string(),
+                        },
+                    ));
+                }
+                UrlOrPath::Url(_) => {}
             }
 
             let specifier = to_uv_version(&required_pkg.version)?;


### PR DESCRIPTION
### Description

When a PyPI package was previously installed from the registry but the lock file now points at a git or direct URL source with the same version number, pixi was leaving the stale registry build in place instead of reinstalling from the locked source. Users hit this when forking a package and pinning their fork via `{ git = "..." }`: the lock file was correct, but `pixi run` kept executing the upstream PyPI code until the fork's version was manually bumped.

This change makes pixi reinstall in that situation so the package on disk matches the lock file.

Fixes #2677
Fixes #6190

### How Has This Been Tested?

Added two regression tests in `pixi_install_pypi` covering the git source and direct archive source variants of the collision. Both fail before the fix and pass after. Full crate test suite passes.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.