### PR TITLE
fix(pixi-build-r): resolve license file to absolute path

### DIFF
--- a/crates/pixi_build_r/src/metadata.rs
+++ b/crates/pixi_build_r/src/metadata.rs
@@ -409,10 +409,25 @@ impl MetadataProvider for DescriptionMetadataProvider {
     }
 
     fn license_files(&mut self) -> Result<Option<Vec<String>>, Self::Error> {
+        // Resolve the license file path to an absolute path under the package
+        // source root. rattler-build's license-copying step reads from the work
+        // directory populated by the recipe's `source:` block; since this backend
+        // does not emit one (the build script runs `R CMD INSTALL` directly
+        // against the source root), relative names like `LICENSE` would never be
+        // found. An absolute path bypasses the work-directory lookup.
+        let manifest_root = self.manifest_root.clone();
         let data = self.ensure_data()?;
         Ok(data.license.as_ref().and_then(|l| {
             let parsed = parse_r_license(l);
-            parsed.license_file.map(|f| vec![f])
+            parsed.license_file.map(|f| {
+                let p = std::path::Path::new(&f);
+                let resolved = if p.is_absolute() {
+                    f
+                } else {
+                    manifest_root.join(p).to_string_lossy().into_owned()
+                };
+                vec![resolved]
+            })
         }))
     }
 
@@ -530,7 +545,73 @@ License: MIT + file LICENSE
         assert_eq!(provider.license().unwrap(), Some("MIT".to_string()));
         assert_eq!(
             provider.license_files().unwrap(),
-            Some(vec!["LICENSE".to_string()])
+            Some(vec![
+                temp_dir
+                    .path()
+                    .join("LICENSE")
+                    .to_string_lossy()
+                    .into_owned()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_license_file_is_absolute_under_source_root() {
+        // The recipe omits a `source:` block, so rattler-build has no work
+        // directory in which to find a bare `LICENSE`. The returned path must
+        // be absolute and rooted at the package source so the file is copied.
+        let content = r#"Package: testpkg
+Version: 1.0.0
+License: GPL-3 + file LICENSE
+"#;
+        let temp_dir = create_test_description(content);
+        let mut provider = DescriptionMetadataProvider::new(temp_dir.path());
+
+        let files = provider.license_files().unwrap().unwrap();
+        assert_eq!(files.len(), 1);
+        let p = std::path::Path::new(&files[0]);
+        assert!(
+            p.is_absolute(),
+            "license file path must be absolute, got: {}",
+            files[0]
+        );
+        assert_eq!(p, temp_dir.path().join("LICENSE"));
+    }
+
+    #[test]
+    fn test_license_file_only_resolves_to_absolute() {
+        // `License: file LICENSE` (no SPDX part) must also produce an absolute
+        // path so out-of-source git builds find it.
+        let content = r#"Package: testpkg
+Version: 1.0.0
+License: file LICENSE
+"#;
+        let temp_dir = create_test_description(content);
+        let mut provider = DescriptionMetadataProvider::new(temp_dir.path());
+
+        let files = provider.license_files().unwrap().unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            std::path::Path::new(&files[0]),
+            temp_dir.path().join("LICENSE")
+        );
+    }
+
+    #[test]
+    fn test_license_file_preserves_custom_name() {
+        // The DESCRIPTION may reference e.g. `LICENCE`, `LICENSE.md`, `COPYING`;
+        // we must use exactly what was declared rather than normalising it.
+        let content = r#"Package: testpkg
+Version: 1.0.0
+License: MIT + file LICENCE
+"#;
+        let temp_dir = create_test_description(content);
+        let mut provider = DescriptionMetadataProvider::new(temp_dir.path());
+
+        let files = provider.license_files().unwrap().unwrap();
+        assert_eq!(
+            std::path::Path::new(&files[0]),
+            temp_dir.path().join("LICENCE")
         );
     }
 


### PR DESCRIPTION
### Description

Fixes the `pixi-build-r` backend so it can build CRAN-style R packages whose `DESCRIPTION` declares `License: <SPDX> + file LICENSE` (the vast majority of CRAN), including when the package source is fetched via `package.build.source.git`.

Previously these builds failed at the final step with `No license files were copied`, even though the package itself compiled. Plain `License: <SPDX>` packages were unaffected.

### How Has This Been Tested?

- Added unit tests in `crates/pixi_build_r/src/metadata.rs` covering `MIT + file LICENSE`, bare `file LICENSE`, and non-standard filenames like `LICENCE`.
- Ran `cargo test -p pixi-build-r` (35 passed, 0 failed). Existing `insta` snapshots are unchanged.
- Manually verified against an R package using `License: <SPDX> + file LICENSE` with a git source: `pixi install` now completes and the resulting conda package contains the LICENSE file under `info/licenses/`. The path-source case still works.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.