### PR TITLE
fix: disable gpg signing in git fixture repos

### DIFF
--- a/crates/pixi_test_utils/src/git_fixture.rs
+++ b/crates/pixi_test_utils/src/git_fixture.rs
@@ -108,6 +108,18 @@ impl GitRepoFixture {
             .current_dir(&repo_path)
             .output()
             .expect("failed to configure git name");
+        // Disable signing so a global `tag.gpgSign = true` does not launch
+        // $EDITOR for a tag message.
+        std::process::Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("failed to disable commit signing");
+        std::process::Command::new("git")
+            .args(["config", "tag.gpgsign", "false"])
+            .current_dir(&repo_path)
+            .output()
+            .expect("failed to disable tag signing");
 
         // Get commit directories sorted by name
         let mut commit_dirs: Vec<_> = fs_err::read_dir(fixture_base)


### PR DESCRIPTION
### Description

`pixi run test` was launching the user's editor mid-test when they had `tag.gpgSign = true` in their global git config. The git fixture builder created tags that git promoted to signed (annotated) tags, which require a message. The fixture now disables signing in its local repo config so the tests stay hermetic against the developer's global git settings.

Reported by @lucascolley 

### How Has This Been Tested?

Reproduced locally with `tag.gpgSign = true` set globally and confirmed the fixture no longer prompts. `cargo check -p pixi_test_utils` passes.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code