### PR TITLE
feat: add anonymous installation ping to install scripts

### DIFF
--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -58,6 +58,40 @@ fn user_agent() -> String {
     format!("pixi {}", consts::PIXI_VERSION)
 }
 
+/// Send a best-effort anonymous ping after a successful self-update, tagging
+/// the OS, architecture and target version. It never blocks or fails the
+/// update (short timeout, all errors ignored) and is skipped when
+/// `PIXI_NO_TELEMETRY` or `DO_NOT_TRACK` is set.
+async fn send_update_ping(target_version: Option<&Version>) {
+    if std::env::var_os("PIXI_NO_TELEMETRY").is_some() || std::env::var_os("DO_NOT_TRACK").is_some()
+    {
+        return;
+    }
+
+    let version = target_version
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "latest".to_string());
+
+    let url = format!(
+        "{}?x-pxid={}&event=self-update&os={}&arch={}&version={}",
+        consts::INSTALL_PING_URL,
+        consts::INSTALL_PING_PXID,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        version,
+    );
+
+    let Ok((_, client)) = build_reqwest_clients(None, None) else {
+        return;
+    };
+    let _ = client
+        .get(url)
+        .header("User-Agent", user_agent())
+        .timeout(std::time::Duration::from_secs(3))
+        .send()
+        .await;
+}
+
 fn default_archive_name() -> Option<String> {
     if cfg!(target_os = "macos") {
         if cfg!(target_arch = "x86_64") {
@@ -409,6 +443,9 @@ pub async fn execute(args: Args, global_options: &GlobalOptions) -> miette::Resu
     if let Some(fetch_release_warning) = fetch_release_warning {
         tracing::warn!(fetch_release_warning);
     }
+
+    // Best-effort anonymous ping; must not affect the update result.
+    send_update_ping(target_version.as_ref()).await;
 
     Ok(())
 }

--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -72,20 +72,25 @@ async fn send_update_ping(target_version: Option<&Version>) {
         .map(|v| v.to_string())
         .unwrap_or_else(|| "latest".to_string());
 
-    let url = format!(
-        "{}?x-pxid={}&event=self-update&os={}&arch={}&version={}",
-        consts::INSTALL_PING_URL,
-        consts::INSTALL_PING_PXID,
+    // Encode the metadata as a synthetic page URL. Scarf reports on the `Page`
+    // dimension (normally inferred from the referrer), so each event/version/
+    // platform combination shows up as its own page in the dashboard.
+    let page = format!(
+        "https://pixi.sh/ping/self-update/{}/{}-{}",
+        version,
         std::env::consts::OS,
         std::env::consts::ARCH,
-        version,
     );
 
     let Ok((_, client)) = build_reqwest_clients(None, None) else {
         return;
     };
     let _ = client
-        .get(url)
+        .get(consts::INSTALL_PING_URL)
+        .query(&[
+            ("x-pxid", consts::INSTALL_PING_PXID),
+            ("Page", page.as_str()),
+        ])
         .header("User-Agent", user_agent())
         .timeout(std::time::Duration::from_secs(3))
         .send()

--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -62,7 +62,10 @@ fn user_agent() -> String {
 /// the OS, architecture and target version. It never blocks or fails the
 /// update (short timeout, all errors ignored) and is skipped when
 /// `PIXI_NO_TELEMETRY` or `DO_NOT_TRACK` is set.
-async fn send_update_ping(target_version: Option<&Version>) {
+async fn send_update_ping(
+    client: &reqwest_middleware::ClientWithMiddleware,
+    target_version: Option<&Version>,
+) {
     if std::env::var_os("PIXI_NO_TELEMETRY").is_some() || std::env::var_os("DO_NOT_TRACK").is_some()
     {
         return;
@@ -82,9 +85,6 @@ async fn send_update_ping(target_version: Option<&Version>) {
         std::env::consts::ARCH,
     );
 
-    let Ok((_, client)) = build_reqwest_clients(None, None) else {
-        return;
-    };
     let _ = client
         .get(consts::INSTALL_PING_URL)
         .query(&[
@@ -450,7 +450,7 @@ pub async fn execute(args: Args, global_options: &GlobalOptions) -> miette::Resu
     }
 
     // Best-effort anonymous ping; must not affect the update result.
-    send_update_ping(target_version.as_ref()).await;
+    send_update_ping(&client, target_version.as_ref()).await;
 
     Ok(())
 }

--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -75,6 +75,12 @@ async fn send_update_ping(
         .map(|v| v.to_string())
         .unwrap_or_else(|| "latest".to_string());
 
+    eprintln!(
+        "Sending an anonymous update ping to prefix.dev (version, OS, arch). \
+         Set PIXI_NO_TELEMETRY=1 or DO_NOT_TRACK=1 to opt out. \
+         See https://pixi.sh/latest/reference/telemetry/"
+    );
+
     // Encode the metadata as a synthetic page URL. Scarf reports on the `Page`
     // dimension (normally inferred from the referrer), so each event/version/
     // platform combination shows up as its own page in the dashboard.
@@ -85,13 +91,14 @@ async fn send_update_ping(
         std::env::consts::ARCH,
     );
 
+    // Fire-and-forget: we deliberately ignore the result. A failed ping must
+    // never affect the update, so any error (timeout, network, HTTP) is dropped.
     let _ = client
         .get(consts::INSTALL_PING_URL)
         .query(&[
             ("x-pxid", consts::INSTALL_PING_PXID),
             ("Page", page.as_str()),
         ])
-        .header("User-Agent", user_agent())
         .timeout(std::time::Duration::from_secs(3))
         .send()
         .await;

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -124,6 +124,11 @@ pub const RELEASES_API_BY_TAG: &str = "https://api.github.com/repos/prefix-dev/p
 pub const RELEASES_API_LATEST: &str =
     "https://api.github.com/repos/prefix-dev/pixi/releases/latest";
 
+/// Endpoint for the anonymous installation/update ping. The same pixel id is
+/// used by the install scripts (`install/install.sh`, `install/install.ps1`).
+pub const INSTALL_PING_URL: &str = "https://installation-ping.prefix.dev/a.png";
+pub const INSTALL_PING_PXID: &str = "21354c5b-2936-42bc-9d4b-9d6253815afd";
+
 pub const CLAP_CONFIG_OPTIONS: &str = "Config Options";
 pub const CLAP_GIT_OPTIONS: &str = "Git Options";
 pub const CLAP_GLOBAL_OPTIONS: &str = "Global Options";

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -131,6 +131,8 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
     | `PIXI_DOWNLOAD_URL`  | Overrides the download URL for the Pixi binary (useful for mirrors or custom builds). | GitHub releases, e.g. [linux-64](https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-unknown-linux-musl.tar.gz)       |
     | `NETRC`              | Path to a custom `.netrc` file for authentication with private repositories.          |                       |
     | `TMP_DIR`            | The temporary directory the script uses to download to and unpack the binary from.    | `/tmp`                |
+    | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping (see note below).    |                       |
+    | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the [Console Do Not Track](https://consoledonottrack.com/) standard. |                       |
 
     For example, on Apple Silicon, you can force the installation of the x86 version:
     ```shell
@@ -185,6 +187,8 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
     | `PIXI_HOME`          | The location of the installation.                                                 | `$Env:USERPROFILE\.pixi`    |
     | `PIXI_NO_PATH_UPDATE`| If set, the `$PATH` will not be updated to add `pixi` to it.                      | `false`                     |
     | `PIXI_DOWNLOAD_URL`  | Overrides the download URL for the Pixi binary (useful for mirrors or custom builds). | GitHub releases, e.g. [win-64](https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-pc-windows-msvc.zip)           |
+    | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping (see note below).    |                             |
+    | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the [Console Do Not Track](https://consoledonottrack.com/) standard. |           |
 
     For example, set the version:
     ```powershell
@@ -201,6 +205,12 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
 
     !!! tip "Security Note"
         The PowerShell install script automatically masks any credentials embedded in the download URL when displaying messages, replacing them with `***:***@` to prevent credentials from appearing in logs or console output.
+
+!!! note "Anonymous installation ping"
+    After a successful install, the script sends a single anonymous request that helps us estimate how many installations happen. It contains no personal data and is best-effort: it has a short timeout and never blocks or fails the installation. To disable it, set `PIXI_NO_TELEMETRY=1` or `DO_NOT_TRACK=1` before running the script:
+    ```shell
+    curl -fsSL https://pixi.sh/install.sh | PIXI_NO_TELEMETRY=1 bash
+    ```
 
 ## Autocompletion
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,6 +35,9 @@ Now restart your terminal or shell to make the installation take effect.
     You can check the installation `sh` script: [download](https://pixi.sh/install.sh) and the `ps1`: [download](https://pixi.sh/install.ps1).
     The scripts are open source and available on [GitHub](https://github.com/prefix-dev/pixi/tree/main/install).
 
+!!! info "Telemetry"
+    After a successful install the script sends a single anonymous ping so we can count installations. Prefix `PIXI_NO_TELEMETRY=1` (or `DO_NOT_TRACK=1`) to the command above to opt out, e.g. `curl -fsSL https://pixi.sh/install.sh | PIXI_NO_TELEMETRY=1 bash`. See [Telemetry](reference/telemetry.md) for what is sent.
+
 !!! note "Don't forget to add autocompletion!"
     After installing Pixi, you can enable autocompletion for your shell.
     See the [Autocompletion](#autocompletion) section below for instructions.
@@ -131,7 +134,7 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
     | `PIXI_DOWNLOAD_URL`  | Overrides the download URL for the Pixi binary (useful for mirrors or custom builds). | GitHub releases, e.g. [linux-64](https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-unknown-linux-musl.tar.gz)       |
     | `NETRC`              | Path to a custom `.netrc` file for authentication with private repositories.          |                       |
     | `TMP_DIR`            | The temporary directory the script uses to download to and unpack the binary from.    | `/tmp`                |
-    | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping (see note below).    |                       |
+    | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping ([Telemetry](reference/telemetry.md)). |                       |
     | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the common `DO_NOT_TRACK` convention.              |                       |
 
     For example, on Apple Silicon, you can force the installation of the x86 version:
@@ -187,7 +190,7 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
     | `PIXI_HOME`          | The location of the installation.                                                 | `$Env:USERPROFILE\.pixi`    |
     | `PIXI_NO_PATH_UPDATE`| If set, the `$PATH` will not be updated to add `pixi` to it.                      | `false`                     |
     | `PIXI_DOWNLOAD_URL`  | Overrides the download URL for the Pixi binary (useful for mirrors or custom builds). | GitHub releases, e.g. [win-64](https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-pc-windows-msvc.zip)           |
-    | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping (see note below).    |                             |
+    | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping ([Telemetry](reference/telemetry.md)). |                             |
     | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the common `DO_NOT_TRACK` convention.              |                             |
 
     For example, set the version:
@@ -207,7 +210,7 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
         The PowerShell install script automatically masks any credentials embedded in the download URL when displaying messages, replacing them with `***:***@` to prevent credentials from appearing in logs or console output.
 
 !!! note "Anonymous installation ping"
-    After a successful install, the script sends a single anonymous request that helps us estimate how many installations happen. It contains no personal data and is best-effort: it has a short timeout and never blocks or fails the installation. To disable it, set `PIXI_NO_TELEMETRY=1` or `DO_NOT_TRACK=1` before running the script:
+    After a successful install, the script sends a single best-effort request that helps us estimate how many installations happen. It carries the Pixi version and your OS/architecture; like any HTTP request it also exposes standard metadata such as your IP address. It has a short timeout and never blocks or fails the installation. `pixi self-update` sends the same kind of ping. See [Telemetry](reference/telemetry.md) for exactly what is sent and where. To disable it, set `PIXI_NO_TELEMETRY=1` or `DO_NOT_TRACK=1`:
     ```shell
     curl -fsSL https://pixi.sh/install.sh | PIXI_NO_TELEMETRY=1 bash
     ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,7 +132,7 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
     | `NETRC`              | Path to a custom `.netrc` file for authentication with private repositories.          |                       |
     | `TMP_DIR`            | The temporary directory the script uses to download to and unpack the binary from.    | `/tmp`                |
     | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping (see note below).    |                       |
-    | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the [Console Do Not Track](https://consoledonottrack.com/) standard. |                       |
+    | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the common `DO_NOT_TRACK` convention.              |                       |
 
     For example, on Apple Silicon, you can force the installation of the x86 version:
     ```shell
@@ -188,7 +188,7 @@ its [compile steps](https://github.com/conda/rattler/tree/main#give-it-a-try).
     | `PIXI_NO_PATH_UPDATE`| If set, the `$PATH` will not be updated to add `pixi` to it.                      | `false`                     |
     | `PIXI_DOWNLOAD_URL`  | Overrides the download URL for the Pixi binary (useful for mirrors or custom builds). | GitHub releases, e.g. [win-64](https://github.com/prefix-dev/pixi/releases/latest/download/pixi-x86_64-pc-windows-msvc.zip)           |
     | `PIXI_NO_TELEMETRY`  | If set, the script will not send the anonymous installation ping (see note below).    |                             |
-    | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the [Console Do Not Track](https://consoledonottrack.com/) standard. |           |
+    | `DO_NOT_TRACK`       | Same as `PIXI_NO_TELEMETRY`; honors the common `DO_NOT_TRACK` convention.              |                             |
 
     For example, set the version:
     ```powershell

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -47,6 +47,16 @@ Pixi can also be configured via environment variables.
         </ul>
       </td>
     </tr>
+    <tr>
+      <td><code>PIXI_NO_TELEMETRY</code></td>
+      <td>If set to any value, disables the anonymous ping sent by the install scripts and by <code>pixi self-update</code>. See <a href="../telemetry/">Telemetry</a>.</td>
+      <td>Not set (ping enabled).</td>
+    </tr>
+    <tr>
+      <td><code>DO_NOT_TRACK</code></td>
+      <td>Same effect as <code>PIXI_NO_TELEMETRY</code>; honors the ecosystem-wide <a href="https://consoledonottrack.com"><code>DO_NOT_TRACK</code></a> convention.</td>
+      <td>Not set (ping enabled).</td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -1,0 +1,83 @@
+# Telemetry
+
+Pixi sends a small, anonymous ping in two situations:
+
+1. **After a successful installation** through the `install.sh` / `install.ps1` scripts.
+2. **After `pixi self-update`** successfully updates the binary.
+
+That is the *only* telemetry in Pixi. During normal use — resolving, installing,
+building, running tasks — Pixi does not phone home. The ping exists so we can
+estimate how many people install and update Pixi and on which platforms.
+
+Both pings are **best-effort**: they use a short (3 second) timeout and any
+error is ignored, so they can never block, slow down, or fail an install or
+update.
+
+## What is sent
+
+Each ping encodes the following into the request:
+
+- The **event** (`install` or `self-update`).
+- The Pixi **version**.
+- The **operating system** (`linux`, `macos`, or `windows`).
+- The **CPU architecture** (e.g. `x86_64`, `aarch64`).
+
+As with *any* HTTP request, the receiving server also sees standard request
+metadata that Pixi does not add on purpose but cannot avoid:
+
+- Your **IP address**.
+- The **User-Agent** (which for the ping is just `pixi/<version>`).
+- The **time** of the request.
+
+Pixi does **not** send your account, project contents, environment or package
+lists, file paths, or any generated persistent/unique identifier. We do not
+correlate pings into a per-machine profile.
+
+!!! note
+    We intentionally avoid claiming this is "completely anonymous" or contains
+    "no personal data". Because the request carries your IP address, it is more
+    accurate to describe it as **anonymous by design**: we only look at
+    aggregate numbers, and nothing in the payload identifies you.
+
+## Where it is sent
+
+The ping goes to `https://installation-ping.prefix.dev`, a prefix.dev-hosted
+endpoint. Routing through our own domain means the backend can change without
+having to update the install scripts or a released Pixi binary.
+
+Behind that endpoint the request is handled by [Scarf](https://about.scarf.sh),
+which aggregates the pings into install/update counts. Scarf receives the
+request (including the metadata above) and processes it according to their
+[privacy policy](https://about.scarf.sh/privacy-policy). We only use the
+resulting aggregate statistics; we do not retain a raw per-request log for our
+own analysis.
+
+## How to opt out
+
+Set either environment variable before installing or updating. Pixi treats
+`PIXI_NO_TELEMETRY` as its own convention and also honors the ecosystem-wide
+[`DO_NOT_TRACK`](https://consoledonottrack.com) convention. Both disable the
+ping in the install scripts **and** in `pixi self-update`.
+
+=== "Linux & macOS"
+    ```bash
+    # During installation
+    curl -fsSL https://pixi.sh/install.sh | PIXI_NO_TELEMETRY=1 bash
+
+    # For self-update (and any future CLI ping), export it in your shell
+    export PIXI_NO_TELEMETRY=1
+    pixi self-update
+    ```
+
+=== "Windows"
+    ```powershell
+    # During installation
+    $env:PIXI_NO_TELEMETRY=1; powershell -ExecutionPolicy Bypass -c "irm -useb https://pixi.sh/install.ps1 | iex"
+
+    # For self-update (and any future CLI ping)
+    $env:PIXI_NO_TELEMETRY=1
+    pixi self-update
+    ```
+
+To disable it permanently, set the variable in your shell's startup file (e.g.
+`~/.bashrc`, `~/.zshrc`, or your PowerShell profile).

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -211,6 +211,17 @@ try {
     Remove-Item -Path $ZIP_FILE
 }
 
+# Send an anonymous installation ping (best-effort, never fails the install).
+# Opt out by setting PIXI_NO_TELEMETRY or DO_NOT_TRACK.
+if (-not $Env:PIXI_NO_TELEMETRY -and -not $Env:DO_NOT_TRACK) {
+    try {
+        $PingUrl = 'https://installation-ping.prefix.dev/a.png?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd'
+        Invoke-WebRequest -Uri $PingUrl -UseBasicParsing -TimeoutSec 3 | Out-Null
+    } catch {
+        # Ignore telemetry errors
+    }
+}
+
 # Add pixi to PATH if the folder is not already in the PATH variable
 if (!$NoPathUpdate) {
     $PATH = Get-Env 'PATH'

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -221,6 +221,7 @@ if (-not $Env:PIXI_NO_TELEMETRY -and -not $Env:DO_NOT_TRACK) {
         $Page = "https://pixi.sh/ping/install/$PixiVersion/windows-$PingArch"
         $PingBase = 'https://installation-ping.prefix.dev/a.png'
         $PingUrl = "$PingBase`?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd&Page=$([uri]::EscapeDataString($Page))"
+        Write-Host "Sending an anonymous installation ping to prefix.dev (version, OS, arch). Set PIXI_NO_TELEMETRY=1 or DO_NOT_TRACK=1 to opt out. See https://pixi.sh/latest/reference/telemetry/"
         Invoke-WebRequest -Uri $PingUrl -UseBasicParsing -TimeoutSec 3 | Out-Null
     } catch {
         # Ignore telemetry errors

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -215,7 +215,12 @@ try {
 # Opt out by setting PIXI_NO_TELEMETRY or DO_NOT_TRACK.
 if (-not $Env:PIXI_NO_TELEMETRY -and -not $Env:DO_NOT_TRACK) {
     try {
-        $PingUrl = 'https://installation-ping.prefix.dev/a.png?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd'
+        $PingArch = if ($ARCH -like 'aarch64*') { 'aarch64' } elseif ($ARCH -like 'i686*') { 'i686' } else { 'x86_64' }
+        # Metadata is encoded into the `Page` query parameter so it shows up as a
+        # distinct page in Scarf. Invoke-WebRequest URL-encodes the parameter value.
+        $Page = "https://pixi.sh/ping/install/$PixiVersion/windows-$PingArch"
+        $PingBase = 'https://installation-ping.prefix.dev/a.png'
+        $PingUrl = "$PingBase`?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd&Page=$([uri]::EscapeDataString($Page))"
         Invoke-WebRequest -Uri $PingUrl -UseBasicParsing -TimeoutSec 3 | Out-Null
     } catch {
         # Ignore telemetry errors

--- a/install/install.sh
+++ b/install/install.sh
@@ -199,7 +199,16 @@ __wrap__() {
     # Send an anonymous installation ping (best-effort, never fails the install).
     # Opt out by setting PIXI_NO_TELEMETRY or DO_NOT_TRACK.
     if [ -z "${PIXI_NO_TELEMETRY:-}" ] && [ -z "${DO_NOT_TRACK:-}" ]; then
-        PING_URL="https://installation-ping.prefix.dev/a.png?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd"
+        case "$PLATFORM" in
+        apple-darwin) OS_TAG="macos" ;;
+        *linux*) OS_TAG="linux" ;;
+        *windows*) OS_TAG="windows" ;;
+        *) OS_TAG="unknown" ;;
+        esac
+        # Metadata is encoded into the (pre-encoded) `Page` query parameter so it
+        # shows up as a distinct page in Scarf; '%2F' are the path separators.
+        PAGE="https%3A%2F%2Fpixi.sh%2Fping%2Finstall%2F${VERSION}%2F${OS_TAG}-${ARCH}"
+        PING_URL="https://installation-ping.prefix.dev/a.png?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd&Page=${PAGE}"
         if hash curl 2>/dev/null; then
             curl -sSL --max-time 3 "$PING_URL" >/dev/null 2>&1 || true
         elif hash wget 2>/dev/null; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -196,6 +196,17 @@ __wrap__() {
 
     echo "The 'pixi' binary is installed into '${PIXI_BIN_DIR}'"
 
+    # Send an anonymous installation ping (best-effort, never fails the install).
+    # Opt out by setting PIXI_NO_TELEMETRY or DO_NOT_TRACK.
+    if [ -z "${PIXI_NO_TELEMETRY:-}" ] && [ -z "${DO_NOT_TRACK:-}" ]; then
+        PING_URL="https://installation-ping.prefix.dev/a.png?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd"
+        if hash curl 2>/dev/null; then
+            curl -sSL --max-time 3 "$PING_URL" >/dev/null 2>&1 || true
+        elif hash wget 2>/dev/null; then
+            wget -q -T 3 -O /dev/null "$PING_URL" >/dev/null 2>&1 || true
+        fi
+    fi
+
     # shell update can be suppressed by `PIXI_NO_PATH_UPDATE` env var
     if [ -n "${PIXI_NO_PATH_UPDATE:-}" ]; then
         echo "No path update because PIXI_NO_PATH_UPDATE is set"

--- a/install/install.sh
+++ b/install/install.sh
@@ -209,6 +209,7 @@ __wrap__() {
         # shows up as a distinct page in Scarf; '%2F' are the path separators.
         PAGE="https%3A%2F%2Fpixi.sh%2Fping%2Finstall%2F${VERSION}%2F${OS_TAG}-${ARCH}"
         PING_URL="https://installation-ping.prefix.dev/a.png?x-pxid=21354c5b-2936-42bc-9d4b-9d6253815afd&Page=${PAGE}"
+        echo "Sending an anonymous installation ping to prefix.dev (version, OS, arch). Set PIXI_NO_TELEMETRY=1 or DO_NOT_TRACK=1 to opt out. See https://pixi.sh/latest/reference/telemetry/"
         if hash curl 2>/dev/null; then
             curl -sSL --max-time 3 "$PING_URL" >/dev/null 2>&1 || true
         elif hash wget 2>/dev/null; then

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,6 +204,7 @@ nav:
       - Pixi Configuration: reference/pixi_configuration.md
       - CLI: reference/cli/pixi.md
       - Environment Variables: reference/environment_variables.md
+      - Telemetry: reference/telemetry.md
   - Misc:
       - Changelog: CHANGELOG.md
       - Pixi Vision: misc/vision.md


### PR DESCRIPTION
## Summary

Adds a best-effort anonymous installation ping to the `install.sh` and `install.ps1` scripts so we can estimate how many installations happen.

- Fires only **after a successful install**.
- Best-effort: 3s timeout, errors swallowed — it can never block or fail the installation.
- Honors opt-out via `PIXI_NO_TELEMETRY` or the common `DO_NOT_TRACK` convention.
- The endpoint is a prefix.dev-hosted proxy (`installation-ping.prefix.dev`), so the backend can change later without touching the scripts.

## Docs

`docs/installation.md` documents both opt-out variables in the installer option tables and adds a transparent note explaining the ping and how to disable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)