### PR TITLE
feat(progress): desktop notification summarizing installed/removed packages

### DIFF
--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -276,7 +276,13 @@ pub async fn execute() -> miette::Result<()> {
     };
 
     // Execute the command
-    execute_command(command, &global_options).await
+    let result = execute_command(command, &global_options).await;
+
+    // Let the user know all operations finished, in case they switched away
+    // while pixi was working.
+    pixi_progress::osc::notify_done(result.is_ok());
+
+    result
 }
 
 #[cfg(feature = "console-subscriber")]

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -152,7 +152,7 @@ pub enum ContinuePyPIPrefixUpdate<'a> {
 /// Remove site-packages installed for an outdated interpreter so the next run
 /// starts from a clean slate.
 ///
-/// `layout` describes the old interpreter's install scheme — uv needs it to
+/// `layout` describes the old interpreter's install scheme -- uv needs it to
 /// resolve and validate the paths recorded in each wheel's `RECORD`. The
 /// caller builds it from the old [`PythonInfo`] plus the env prefix.
 async fn uninstall_outdated_site_packages(
@@ -474,7 +474,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             .create_installation_plan(pypi_records, &planner_config)
             .await?;
 
-        // Early exit if nothing to do — skip expensive network setup
+        // Early exit if nothing to do -- skip expensive network setup
         if installation_plan.is_noop() {
             tracing::info!("Nothing to do");
             return Ok(());
@@ -488,7 +488,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             .await
     }
 
-    /// Cheap planning setup — no network I/O.
+    /// Cheap planning setup -- no network I/O.
     async fn setup_planner_config(
         &self,
         pixi_records: &[PixiRecord],
@@ -542,7 +542,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         })
     }
 
-    /// Expensive setup — builds HTTP client, fetches flat indexes.
+    /// Expensive setup -- builds HTTP client, fetches flat indexes.
     /// Only called when the installation plan has real work to do.
     async fn upgrade_to_full_config(
         &self,
@@ -740,7 +740,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             duplicates,
         } = installation_plan;
 
-        // Defensive guard — caller should have checked is_noop() already.
+        // Defensive guard -- caller should have checked is_noop() already.
         if installation_plan.is_noop() {
             tracing::info!(
                 "{}",
@@ -1048,6 +1048,13 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         if extraneous.is_empty() && reinstalls.is_empty() {
             return Ok(());
         }
+
+        // Record true removals for the completion notification. Reinstalls are
+        // left out here since they reappear under installs.
+        for dist in extraneous {
+            pixi_progress::osc::record_removal(dist.name().as_ref());
+        }
+
         let start = std::time::Instant::now();
         let layout = setup.venv.interpreter().layout();
         for dist_info in extraneous.iter().chain(reinstalls.iter().map(|(d, _)| d)) {
@@ -1182,6 +1189,11 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
     ) -> miette::Result<()> {
         if all_dists.is_empty() {
             return Ok(());
+        }
+
+        // Record the installs for the completion notification.
+        for dist in &all_dists {
+            pixi_progress::osc::record_install(dist.name().as_ref());
         }
 
         let options = UvReporterOptions::new()

--- a/crates/pixi_progress/src/osc.rs
+++ b/crates/pixi_progress/src/osc.rs
@@ -9,6 +9,81 @@ static IS_TERMINAL: LazyLock<bool> = LazyLock::new(|| std::io::stdout().is_termi
 /// Last emitted percentage, used to avoid redundant writes.
 static LAST_PCT: Mutex<Option<u8>> = Mutex::new(None);
 
+/// Context accumulated during a run to build the completion notification.
+static SUMMARY: Mutex<NotifySummary> = Mutex::new(NotifySummary::new());
+
+/// What happened during a run, used to phrase the completion notification.
+///
+/// `shown` gates the popup: it is only set once real work has happened (visible
+/// progress was emitted or a package changed), so quick commands that did
+/// nothing stay silent. The package lists let the notification say what
+/// actually changed.
+#[derive(Default)]
+struct NotifySummary {
+    shown: bool,
+    installed: Vec<String>,
+    removed: Vec<String>,
+}
+
+/// How many package names to list before collapsing the rest into a count.
+const NAME_LIST_CAP: usize = 3;
+
+impl NotifySummary {
+    const fn new() -> Self {
+        Self {
+            shown: false,
+            installed: Vec::new(),
+            removed: Vec::new(),
+        }
+    }
+
+    /// Phrase the notification text for the finished run.
+    fn message(&self, success: bool) -> String {
+        if !success {
+            return "pixi: failed".to_owned();
+        }
+
+        let mut parts = Vec::new();
+        if !self.installed.is_empty() {
+            parts.push(format!("installed {}", join_names(&self.installed)));
+        }
+        if !self.removed.is_empty() {
+            parts.push(format!("removed {}", join_names(&self.removed)));
+        }
+
+        match parts.is_empty() {
+            true => "pixi: done".to_owned(),
+            false => format!("pixi: {}", parts.join(", ")),
+        }
+    }
+}
+
+/// Join up to [`NAME_LIST_CAP`] names, collapsing any overflow into `+N more`.
+fn join_names(names: &[String]) -> String {
+    if names.len() <= NAME_LIST_CAP {
+        return names.join(", ");
+    }
+    format!(
+        "{}, +{} more",
+        names[..NAME_LIST_CAP].join(", "),
+        names.len() - NAME_LIST_CAP
+    )
+}
+
+/// Record a package that was installed (or changed) during this run.
+pub fn record_install(name: &str) {
+    let mut summary = SUMMARY.lock();
+    summary.shown = true;
+    summary.installed.push(name.to_owned());
+}
+
+/// Record a package that was removed during this run.
+pub fn record_removal(name: &str) {
+    let mut summary = SUMMARY.lock();
+    summary.shown = true;
+    summary.removed.push(name.to_owned());
+}
+
 /// Emit an OSC 9;4 progress sequence to stdout.
 ///
 /// Terminal emulators that support OSC 9;4 (Windows Terminal, iTerm2,
@@ -24,6 +99,7 @@ pub fn set_progress(position: u64, length: u64) {
     let mut last = LAST_PCT.lock();
     if *last != Some(pct) {
         *last = Some(pct);
+        SUMMARY.lock().shown = true;
         let seq = format!("\x1b]9;4;1;{pct}\x1b\\");
         let mut stdout = std::io::stdout().lock();
         let _ = stdout.write_all(seq.as_bytes());
@@ -42,5 +118,99 @@ pub fn clear_progress() {
         let mut stdout = std::io::stdout().lock();
         let _ = stdout.write_all(b"\x1b]9;4;0;0\x1b\\");
         let _ = stdout.flush();
+    }
+}
+
+/// Show a desktop notification via OSC 9 once all operations have finished.
+///
+/// Terminal emulators that support OSC 9 (Windows Terminal, iTerm2, WezTerm,
+/// etc.) surface this as a system popup, useful when the user has switched
+/// away while a long operation runs. The message summarises which packages
+/// were installed or removed, taken from the context recorded during the run.
+///
+/// Only emitted when real work was done during this run, so quick commands
+/// that changed nothing stay silent. The summary is consumed so the popup
+/// fires at most once per run.
+pub fn notify_done(success: bool) {
+    if !*IS_TERMINAL || crate::global_multi_progress().is_hidden() {
+        return;
+    }
+    let summary = std::mem::take(&mut *SUMMARY.lock());
+    if !summary.shown {
+        return;
+    }
+    let seq = format!("\x1b]9;{}\x1b\\", summary.message(success));
+    let mut stdout = std::io::stdout().lock();
+    let _ = stdout.write_all(seq.as_bytes());
+    let _ = stdout.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(installed: &[&str], removed: &[&str]) -> NotifySummary {
+        NotifySummary {
+            shown: true,
+            installed: installed.iter().map(|s| (*s).to_owned()).collect(),
+            removed: removed.iter().map(|s| (*s).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn message_lists_installed_only() {
+        assert_eq!(
+            summary(&["numpy", "pandas"], &[]).message(true),
+            "pixi: installed numpy, pandas"
+        );
+    }
+
+    #[test]
+    fn message_lists_removed_only() {
+        assert_eq!(
+            summary(&[], &["scipy"]).message(true),
+            "pixi: removed scipy"
+        );
+    }
+
+    #[test]
+    fn message_combines_installed_and_removed() {
+        assert_eq!(
+            summary(&["numpy"], &["scipy"]).message(true),
+            "pixi: installed numpy, removed scipy"
+        );
+    }
+
+    #[test]
+    fn message_without_changes_is_done() {
+        assert_eq!(summary(&[], &[]).message(true), "pixi: done");
+    }
+
+    #[test]
+    fn message_on_failure_ignores_packages() {
+        assert_eq!(summary(&["numpy"], &[]).message(false), "pixi: failed");
+    }
+
+    #[test]
+    fn message_collapses_overflowing_names() {
+        assert_eq!(
+            summary(&["a", "b", "c", "d", "e"], &[]).message(true),
+            "pixi: installed a, b, c, +2 more"
+        );
+    }
+
+    #[test]
+    fn join_names_lists_up_to_the_cap() {
+        let names: Vec<String> = ["a", "b", "c"].iter().map(|s| (*s).to_owned()).collect();
+        assert_eq!(join_names(&names), "a, b, c");
+    }
+
+    #[test]
+    fn join_names_collapses_past_the_cap() {
+        let names: Vec<String> = ["a", "b", "c", "d"]
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect();
+        assert_eq!(join_names(&names), "a, b, c, +1 more");
     }
 }

--- a/crates/pixi_reporters/src/sync_reporter.rs
+++ b/crates/pixi_reporters/src/sync_reporter.rs
@@ -223,14 +223,20 @@ impl CombinedInstallReporterInner {
         transaction: &Transaction<PrefixRecord, RepoDataRecord>,
     ) {
         for (operation_id, operation) in transaction.operations.iter().enumerate() {
-            if let Some(record) = operation
-                .record_to_install()
-                .or_else(|| operation.record_to_remove().map(|r| &r.repodata_record))
+            let install_record = operation.record_to_install();
+            if let Some(record) =
+                install_record.or_else(|| operation.record_to_remove().map(|r| &r.repodata_record))
             {
+                let name = record.package_record.name.as_normalized();
+                if install_record.is_some() {
+                    pixi_progress::osc::record_install(name);
+                } else {
+                    pixi_progress::osc::record_removal(name);
+                }
                 self.operation_link_id.insert(
                     (id, operation_id),
                     self.install_progress_bar.queued(PackageWithSize {
-                        name: record.package_record.name.as_normalized().to_string(),
+                        name: name.to_string(),
                         size: record.package_record.size.unwrap_or(1),
                     }),
                 );


### PR DESCRIPTION
Emit an OSC 9 desktop notification when all operations finish, listing the conda and PyPI packages installed and removed. Gated on real work happening so quick commands stay silent

[Screencast (webm)](https://github.com/user-attachments/assets/f94239e8-f7fc-40a8-8d4f-5c94eefe98e5)


### How Has This Been Tested?

By running it

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
