### PR TITLE
feat: support --no-config / --config-file

### DIFF
--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use pep508_rs::MarkerTree;
 use pixi_cli::cli_config::GitRev;
 use pixi_consts::consts;
-use pixi_core::{DependencyType, Workspace};
+use pixi_core::DependencyType;
 use pixi_manifest::{FeaturesExt, SpecType};
 use pixi_pypi_spec::{PixiPypiSource, PixiPypiSpec, PypiPackageName, VersionOrStar};
 use rattler_conda_types::{PackageName, Platform};
@@ -110,7 +110,7 @@ async fn add_with_channel() {
         .await
         .unwrap();
 
-    let project = Workspace::from_path(pixi.manifest_path().as_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     let mut specs = project
         .default_environment()
         .combined_dependencies(Some(Platform::current()))
@@ -353,7 +353,7 @@ async fn add_pypi_functionality() {
         .unwrap();
 
     // Read project from file and check if the dev extras are added.
-    let project = Workspace::from_path(pixi.manifest_path().as_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     project
         .default_environment()
         .pypi_dependencies(None)
@@ -493,7 +493,7 @@ index-url = "{index_url}"
         .unwrap();
 
     // Check if the extras are added
-    let project = Workspace::from_path(pixi.manifest_path().as_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     project
         .default_environment()
         .pypi_dependencies(None)
@@ -514,7 +514,7 @@ index-url = "{index_url}"
         .unwrap();
 
     // Check if the extras are removed
-    let project = Workspace::from_path(pixi.manifest_path().as_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     project
         .default_environment()
         .pypi_dependencies(None)
@@ -532,7 +532,7 @@ index-url = "{index_url}"
         .unwrap();
 
     // Check if the extras added and the version is set
-    let project = Workspace::from_path(pixi.manifest_path().as_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     project
         .default_environment()
         .pypi_dependencies(None)

--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -31,6 +31,8 @@ use pixi_cli::{
     global, init, install, lock, remove, search, task, update, workspace,
 };
 use pixi_core::DependencyType;
+
+use super::isolated_config_source;
 use std::{
     future::{Future, IntoFuture},
     io,
@@ -283,7 +285,7 @@ impl IntoFuture for AddBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        add::execute(self.args).boxed_local()
+        async move { add::execute(self.args).await }.boxed_local()
     }
 }
 
@@ -328,7 +330,7 @@ impl IntoFuture for RemoveBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        remove::execute(self.args).boxed_local()
+        async move { remove::execute(self.args).await }.boxed_local()
     }
 }
 pub struct TaskAddBuilder {
@@ -364,6 +366,7 @@ impl TaskAddBuilder {
     /// Execute the CLI command
     pub async fn execute(self) -> miette::Result<()> {
         task::execute(task::Args {
+            config_source: isolated_config_source(),
             operation: task::Operation::Add(self.args),
             workspace_config: WorkspaceConfig {
                 manifest_path: self.manifest_path,
@@ -389,6 +392,7 @@ impl TaskAliasBuilder {
     /// Execute the CLI command
     pub async fn execute(self) -> miette::Result<()> {
         task::execute(task::Args {
+            config_source: isolated_config_source(),
             operation: task::Operation::Alias(self.args),
             workspace_config: WorkspaceConfig {
                 manifest_path: self.manifest_path,
@@ -429,10 +433,14 @@ impl IntoFuture for ProjectChannelAddBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        workspace::channel::execute(workspace::channel::Args {
-            workspace_config: self.workspace_config,
-            command: workspace::channel::Command::Add(self.args),
-        })
+        async move {
+            workspace::channel::execute(workspace::channel::Args {
+                config_source: isolated_config_source(),
+                workspace_config: self.workspace_config,
+                command: workspace::channel::Command::Add(self.args),
+            })
+            .await
+        }
         .boxed_local()
     }
 }
@@ -462,10 +470,14 @@ impl IntoFuture for ProjectChannelRemoveBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        workspace::channel::execute(workspace::channel::Args {
-            workspace_config: self.workspace_config,
-            command: workspace::channel::Command::Remove(self.args),
-        })
+        async move {
+            workspace::channel::execute(workspace::channel::Args {
+                config_source: isolated_config_source(),
+                workspace_config: self.workspace_config,
+                command: workspace::channel::Command::Remove(self.args),
+            })
+            .await
+        }
         .boxed_local()
     }
 }
@@ -513,7 +525,7 @@ impl IntoFuture for InstallBuilder {
     type Output = miette::Result<()>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
     fn into_future(self) -> Self::IntoFuture {
-        install::execute(self.args).boxed_local()
+        async move { install::execute(self.args).await }.boxed_local()
     }
 }
 
@@ -551,13 +563,17 @@ impl IntoFuture for ProjectEnvironmentAddBuilder {
     type Output = miette::Result<()>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
     fn into_future(self) -> Self::IntoFuture {
-        workspace::environment::execute(workspace::environment::Args {
-            workspace_config: WorkspaceConfig {
-                manifest_path: self.manifest_path,
-                ..Default::default()
-            },
-            command: workspace::environment::Command::Add(self.args),
-        })
+        async move {
+            workspace::environment::execute(workspace::environment::Args {
+                config_source: isolated_config_source(),
+                workspace_config: WorkspaceConfig {
+                    manifest_path: self.manifest_path,
+                    ..Default::default()
+                },
+                command: workspace::environment::Command::Add(self.args),
+            })
+            .await
+        }
         .boxed_local()
     }
 }
@@ -616,7 +632,7 @@ impl IntoFuture for UpdateBuilder {
     type Output = miette::Result<()>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
     fn into_future(self) -> Self::IntoFuture {
-        update::execute(self.args).boxed_local()
+        async move { update::execute(self.args).await }.boxed_local()
     }
 }
 
@@ -642,7 +658,7 @@ impl IntoFuture for LockBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        lock::execute(self.args).boxed_local()
+        async move { lock::execute(self.args).await }.boxed_local()
     }
 }
 
@@ -695,7 +711,7 @@ impl IntoFuture for BuildBuilder {
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        build::execute(self.args).boxed_local()
+        async move { build::execute(self.args).await }.boxed_local()
     }
 }
 

--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -103,6 +103,15 @@ pub fn string_from_iter(iter: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<
     iter.into_iter().map(|s| s.as_ref().to_string()).collect()
 }
 
+/// `ConfigSourceCli` with `--no-config` set, used for every command the test
+/// harness builds so the developer's `~/.pixi/config.toml` doesn't leak in.
+pub(crate) fn isolated_config_source() -> pixi_config::ConfigSourceCli {
+    pixi_config::ConfigSourceCli {
+        no_config: true,
+        ..Default::default()
+    }
+}
+
 pub trait LockFileExt {
     /// Check if this package is contained in the lock file
     fn contains_conda_package(&self, environment: &str, platform: Platform, name: &str) -> bool;
@@ -354,9 +363,14 @@ impl PixiControl {
         Ok(())
     }
 
-    /// Loads the workspace manifest and returns it.
+    /// Loads the workspace manifest and returns it. Uses `--no-config`
+    /// semantics so the developer's `~/.pixi/config.toml` doesn't leak in.
     pub fn workspace(&self) -> miette::Result<Workspace> {
-        let mut workspace = Workspace::from_path(&self.manifest_path()).into_diagnostic()?;
+        let mut workspace = Workspace::from_path_with_source(
+            &self.manifest_path(),
+            &pixi_config::GlobalConfigSource::None,
+        )
+        .into_diagnostic()?;
         if let Some(backend_override) = &self.backend_override {
             workspace = workspace.with_backend_override(backend_override.clone());
         }
@@ -481,6 +495,7 @@ impl PixiControl {
                     lock_file_usage: LockFileUsageConfig::default(),
                 },
                 config: Default::default(),
+                config_source: isolated_config_source(),
                 editable: false,
             },
         }
@@ -492,6 +507,7 @@ impl PixiControl {
         SearchBuilder {
             args: search::Args {
                 package: name,
+                config_source: isolated_config_source(),
                 project_config: WorkspaceConfig {
                     manifest_path: Some(self.manifest_path()),
                     ..Default::default()
@@ -520,6 +536,7 @@ impl PixiControl {
                     lock_file_usage: LockFileUsageConfig::default(),
                 },
                 config: Default::default(),
+                config_source: isolated_config_source(),
             },
         }
     }
@@ -696,6 +713,7 @@ impl PixiControl {
                     locked: false,
                 },
                 config: Default::default(),
+                config_source: isolated_config_source(),
                 all: false,
                 skip: None,
                 skip_with_deps: None,
@@ -719,6 +737,7 @@ impl PixiControl {
         UpdateBuilder {
             args: update::Args {
                 config: Default::default(),
+                config_source: isolated_config_source(),
                 project_config: WorkspaceConfig {
                     manifest_path: Some(self.manifest_path()),
                     ..Default::default()
@@ -736,7 +755,10 @@ impl PixiControl {
     /// If you want to lock file to be up-to-date with the project call
     /// [`Self::update_lock_file`].
     pub async fn lock_file(&self) -> miette::Result<LockFile> {
-        let workspace = Workspace::from_path(&self.manifest_path())?;
+        let workspace = Workspace::from_path_with_source(
+            &self.manifest_path(),
+            &pixi_config::GlobalConfigSource::None,
+        )?;
         workspace.load_lock_file().await?.into_lock_file()
     }
 
@@ -756,6 +778,7 @@ impl PixiControl {
     pub fn lock(&self) -> LockBuilder {
         LockBuilder {
             args: lock::Args {
+                config_source: isolated_config_source(),
                 workspace_config: WorkspaceConfig {
                     manifest_path: Some(self.manifest_path()),
                     backend_override: self.backend_override.clone(),
@@ -776,6 +799,7 @@ impl PixiControl {
             args: build::Args {
                 backend_override: self.backend_override.clone(),
                 config_cli: Default::default(),
+                config_source: isolated_config_source(),
                 lock_and_install_config: Default::default(),
                 target_platform: rattler_conda_types::Platform::current(),
                 build_platform: rattler_conda_types::Platform::current(),
@@ -831,6 +855,7 @@ impl TasksControl<'_> {
         feature_name: Option<String>,
     ) -> miette::Result<()> {
         task::execute(task::Args {
+            config_source: isolated_config_source(),
             workspace_config: WorkspaceConfig {
                 manifest_path: Some(self.pixi.manifest_path()),
                 ..Default::default()

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -729,8 +729,9 @@ async fn test_old_lock_install() {
         workspace_root.join("tests/data/satisfiability/old_lock_file/pixi.lock"),
     )
     .unwrap();
-    let project = Workspace::from_path(
+    let project = Workspace::from_path_with_source(
         &workspace_root.join("tests/data/satisfiability/old_lock_file/pyproject.toml"),
+        &pixi_config::GlobalConfigSource::None,
     )
     .unwrap();
     pixi_core::environment::get_update_lock_file_and_prefix(
@@ -788,7 +789,11 @@ async fn test_v6_local_archive_path_upgrade() {
     );
 
     // Re-resolve — should detect the mismatch and re-solve.
-    let project = Workspace::from_path(&test_dir.join("pixi.toml")).unwrap();
+    let project = Workspace::from_path_with_source(
+        &test_dir.join("pixi.toml"),
+        &pixi_config::GlobalConfigSource::None,
+    )
+    .unwrap();
     pixi_core::environment::get_update_lock_file_and_prefix(
         &project.default_environment(),
         None,

--- a/crates/pixi/tests/integration_rust/project_tests.rs
+++ b/crates/pixi/tests/integration_rust/project_tests.rs
@@ -44,7 +44,7 @@ async fn add_remove_channel() {
         .unwrap();
 
     // There should be a loadable project manifest in the directory
-    let project = Workspace::from_path(&pixi.manifest_path()).unwrap();
+    let project = pixi.workspace().unwrap();
 
     // Our channel should be in the list of channels
     let local_channel =
@@ -62,7 +62,7 @@ async fn add_remove_channel() {
         .unwrap();
 
     // Load again
-    let project = Workspace::from_path(&pixi.manifest_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     let channels = project.default_environment().channels();
     // still present
     assert!(channels.contains(&local_channel));
@@ -78,7 +78,7 @@ async fn add_remove_channel() {
         .unwrap();
 
     // Load again
-    let project = Workspace::from_path(&pixi.manifest_path()).unwrap();
+    let project = pixi.workspace().unwrap();
     let channels = project.default_environment().channels();
 
     // Channel has been removed

--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 use url::Url;
 
 use crate::{
-    common::{LockFileExt, PixiControl},
+    common::{LockFileExt, PixiControl, isolated_config_source},
     setup_tracing,
 };
 use pixi_cli::publish;
@@ -633,6 +633,7 @@ async fn test_publish_fails_before_build_or_upload_when_one_variant_is_unsatisfi
     let err = publish::execute(publish::Args {
         backend_override: Some(BackendOverride::from_memory(instantiator)),
         config_cli: Default::default(),
+        config_source: isolated_config_source(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_string_prefix: None,
@@ -2456,6 +2457,7 @@ async fn test_publish_without_target_builds_but_does_not_upload() {
     publish::execute(publish::Args {
         backend_override: Some(BackendOverride::from_memory(instantiator)),
         config_cli: Default::default(),
+        config_source: isolated_config_source(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_string_prefix: None,
@@ -2523,6 +2525,7 @@ backend.version = "0.1.0"
     let _ = publish::execute(publish::Args {
         backend_override: None,
         config_cli: Default::default(),
+        config_source: isolated_config_source(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_string_prefix: None,
@@ -2646,6 +2649,7 @@ host-lib = "*"
             PassthroughBackend::instantiator(),
         )),
         config_cli: Default::default(),
+        config_source: isolated_config_source(),
         target_platform: Platform::current(),
         build_platform: Platform::current(),
         build_string_prefix: None,

--- a/crates/pixi/tests/integration_rust/upgrade_tests.rs
+++ b/crates/pixi/tests/integration_rust/upgrade_tests.rs
@@ -1,7 +1,6 @@
 use indexmap::IndexMap;
 use insta::assert_snapshot;
 use pixi_cli::upgrade::{Args, parse_specs_for_platform};
-use pixi_core::Workspace;
 use rattler_conda_types::Platform;
 use tempfile::TempDir;
 use url::Url;
@@ -56,8 +55,9 @@ async fn pypi_dependency_index_preserved_on_upgrade() {
     let mut args = Args::default();
     args.workspace_config.manifest_path = Some(pixi.manifest_path());
     args.no_install_config.no_install = true;
+    args.config_source.no_config = true;
 
-    let workspace = Workspace::from_path(&pixi.manifest_path()).unwrap();
+    let workspace = pixi.workspace().unwrap();
 
     let workspace_value = workspace.workspace.value.clone();
     let feature = workspace_value.default_feature();
@@ -139,6 +139,7 @@ async fn upgrade_command_updates_platform_specific_version() {
     let mut args = Args::default();
     args.workspace_config.manifest_path = Some(pixi.manifest_path());
     args.no_install_config.no_install = true;
+    args.config_source.no_config = true;
 
     pixi_cli::upgrade::execute(args).await.unwrap();
 
@@ -190,6 +191,7 @@ async fn upgrade_command_updates_all_platform_specific_targets() {
     let mut args = Args::default();
     args.workspace_config.manifest_path = Some(pixi.manifest_path());
     args.no_install_config.no_install = true;
+    args.config_source.no_config = true;
 
     pixi_cli::upgrade::execute(args).await.unwrap();
 
@@ -278,6 +280,7 @@ async fn pypi_dependency_upgrade_uses_custom_index() {
     let mut args = Args::default();
     args.workspace_config.manifest_path = Some(pixi.manifest_path());
     args.no_install_config.no_install = true;
+    args.config_source.no_config = true;
     args.specs.packages = Some(vec!["foo".to_string()]);
 
     pixi_cli::upgrade::execute(args).await.unwrap();

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -90,6 +90,9 @@ pub struct Args {
     #[clap(flatten)]
     pub config: ConfigCli,
 
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// Whether the pypi requirement should be editable
     #[arg(long, requires = "pypi")]
     pub editable: bool,
@@ -125,6 +128,7 @@ impl From<&Args> for GitOptions {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let mut workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(args.config.clone());

--- a/crates/pixi_cli/src/build.rs
+++ b/crates/pixi_cli/src/build.rs
@@ -15,6 +15,9 @@ pub struct Args {
     #[clap(flatten)]
     pub config_cli: ConfigCli,
 
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// Backend override for testing purposes. This field is ignored by clap
     /// and should only be set programmatically in tests.
     #[clap(skip)]
@@ -91,6 +94,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     publish::execute(publish::Args {
         config_cli: args.config_cli,
+        config_source: args.config_source,
         backend_override: args.backend_override,
         target_platform: args.target_platform,
         build_platform: args.build_platform,

--- a/crates/pixi_cli/src/clean.rs
+++ b/crates/pixi_cli/src/clean.rs
@@ -39,6 +39,9 @@ pub enum Command {
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     #[command(subcommand)]
@@ -110,6 +113,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_closest_package(false)
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use clap::{Parser, ValueEnum};
-use pixi_config::{Config, ConfigCli};
+use pixi_config::ConfigCli;
 use pixi_core::{WorkspaceLocator, environment::sanity_check_workspace};
 use pixi_manifest::{EnvironmentName, FeatureName, HasFeaturesIter, PrioritizedChannel};
 use pixi_utils::conda_environment_file::CondaEnvFile;
@@ -55,6 +55,9 @@ pub struct Args {
 
     #[clap(flatten)]
     pub config: ConfigCli,
+
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
@@ -126,14 +129,15 @@ fn convert_uv_requirements_txt_to_pep508(
 }
 
 async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
+    let source = args.config_source.source();
     let (input_file, platforms, workspace_config) =
         (args.file, args.platforms, args.workspace_config);
-    let config = Config::from(args.config);
 
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(source)
         .with_search_start(workspace_config.workspace_locator_start())
         .locate()?
-        .with_cli_config(config.clone());
+        .with_cli_config(args.config);
 
     sanity_check_workspace(&workspace).await?;
 
@@ -187,7 +191,8 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
 
             // TODO: Improve this:
             //  - Use .condarc as channel config
-            let (conda_deps, pypi_deps, channels) = env_file.to_manifest(&config.clone())?;
+            let (conda_deps, pypi_deps, channels) =
+                env_file.to_manifest(workspace.workspace().config())?;
             workspace.manifest().add_channels(
                 channels.iter().map(|c| PrioritizedChannel::from(c.clone())),
                 &feature_name,

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
-use pixi_config;
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_global::{BinDir, EnvRoot};
@@ -29,6 +28,9 @@ static WIDTH: usize = 19;
 /// Information about the system, workspace and environments for the current machine.
 #[derive(Parser, Debug)]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// Show cache and environment size
     #[arg(long)]
     extended: bool,
@@ -380,7 +382,9 @@ fn last_updated(path: impl Into<PathBuf>) -> miette::Result<String> {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
+    let source = args.config_source.source();
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(source.clone())
         .with_search_start(args.project_config.workspace_locator_start())
         .locate()
         .ok();
@@ -473,7 +477,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let config = workspace
         .map(|p| p.config().clone())
-        .unwrap_or_else(pixi_config::Config::load_global);
+        .unwrap_or_else(|| pixi_config::Config::load_global_with(&source));
 
     let auth_file: PathBuf = if let Ok(auth_file) = std::env::var("RATTLER_AUTH_FILE") {
         auth_file.into()

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -34,6 +34,9 @@ use crate::cli_config::WorkspaceConfig;
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     #[clap(flatten)]
@@ -72,9 +75,10 @@ const SKIP_CUTOFF: usize = 5;
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let mut workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
-        .with_cli_config(args.config);
+        .with_cli_config(args.config.clone());
 
     // Apply backend override if provided (primarily for testing)
     if let Some(backend_override) = args.workspace_config.backend_override.clone() {

--- a/crates/pixi_cli/src/list.rs
+++ b/crates/pixi_cli/src/list.rs
@@ -156,6 +156,9 @@ pub const DEFAULT_FIELDS: [Field; 6] = [
 #[derive(Debug, Parser)]
 #[clap(arg_required_else_help = false)]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// List only packages matching a regular expression
     #[arg()]
     pub regex: Option<String>,
@@ -197,6 +200,7 @@ pub struct Args {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -16,6 +16,9 @@ use crate::cli_config::WorkspaceConfig;
 #[clap(arg_required_else_help = false)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     #[clap(flatten)]
@@ -38,6 +41,7 @@ pub struct Args {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let mut workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -58,6 +58,9 @@ use rattler_package_streaming::seek::read_package_file;
 #[clap(verbatim_doc_comment)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub config_cli: ConfigCli,
 
     /// Backend override for testing purposes.
@@ -512,6 +515,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace_locator = determine_discovery_start(&args.path).await?;
 
     let mut workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(workspace_locator.clone())
         .with_closest_package(false)
         .locate()?

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -21,6 +21,9 @@ use crate::cli_interface::CliInterface;
 /// If you want to re-install all environments, you can use the `--all` flag.
 #[derive(Parser, Debug)]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// Specifies the package that should be reinstalled.
     /// If no package is given, the whole environment will be reinstalled.
     #[arg(value_name = "PACKAGE")]
@@ -71,6 +74,7 @@ impl From<Args> for ReinstallOptions {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.project_config.workspace_locator_start())
         .locate()?
         .with_cli_config(args.config.clone());

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -32,6 +32,9 @@ use error::DependencyRemovalError;
 #[clap(arg_required_else_help = true)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     #[clap(flatten)]
@@ -61,6 +64,7 @@ impl TryFrom<&Args> for DependencyOptions {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(args.config.clone());

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -47,6 +47,9 @@ use crate::process_exit;
 #[derive(Parser, Debug, Default)]
 #[clap(trailing_var_arg = true, disable_help_flag = true)]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// The pixi task or a task shell command you want to run in the workspace's
     /// environment, which can be an executable in the environment's PATH.
     pub task: Vec<String>,
@@ -120,6 +123,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Load the workspace
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(cli_config);

--- a/crates/pixi_cli/src/search.rs
+++ b/crates/pixi_cli/src/search.rs
@@ -37,6 +37,9 @@ pub struct Args {
     pub channels: ChannelsConfig,
 
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub project_config: WorkspaceConfig,
 
     /// The platform(s) to search for.
@@ -80,6 +83,7 @@ pub async fn execute_impl<W: Write>(
     out: &mut W,
 ) -> miette::Result<Vec<RepoDataRecord>> {
     let workspace = match WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.project_config.workspace_locator_start())
         .locate()
     {

--- a/crates/pixi_cli/src/shell.rs
+++ b/crates/pixi_cli/src/shell.rs
@@ -29,6 +29,9 @@ use pixi_utils::prefix::Prefix;
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     workspace_config: WorkspaceConfig,
 
     #[clap(flatten)]
@@ -325,6 +328,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .merge_config(args.config.clone().into());
 
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(config);

--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -29,6 +29,9 @@ use crate::cli_config::{LockAndInstallConfig, WorkspaceConfig};
 /// itself.
 #[derive(Parser, Debug)]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// Sets the shell, options: [`bash`,  `zsh`,  `xonsh`,  `cmd`,
     /// `powershell`,  `fish`,  `nushell`]
     #[arg(short, long)]
@@ -159,6 +162,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .merge_config(args.prompt_config.merge_config(args.config.clone().into()));
 
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.project_config.workspace_locator_start())
         .locate()?
         .with_cli_config(config);

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -242,6 +242,9 @@ impl From<AliasArgs> for Task {
 #[derive(Parser, Debug)]
 #[clap(trailing_var_arg = true, arg_required_else_help = true)]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// Add, remove, or update a task
     #[clap(subcommand)]
     pub operation: Operation,
@@ -316,6 +319,7 @@ fn print_tasks(
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -32,6 +32,9 @@ use std::collections::HashMap;
     console::style("blue").fg(Color::Blue)
 ))]
 pub struct Args {
+    #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
     /// List only packages matching a regular expression
     #[arg()]
     pub regex: Option<String>,
@@ -61,6 +64,7 @@ pub struct Args {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -24,6 +24,9 @@ use crate::cli_config::WorkspaceConfig;
 #[derive(Parser, Debug, Default)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub config: ConfigCli,
 
     #[clap(flatten)]
@@ -124,11 +127,11 @@ impl UpdateSpecs {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let config = args.config;
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.project_config.workspace_locator_start())
         .locate()?
-        .with_cli_config(config);
+        .with_cli_config(args.config);
 
     let specs = UpdateSpecs::from(args.specs);
 

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -27,6 +27,9 @@ use crate::cli_config::{LockFileUpdateConfig, NoInstallConfig, WorkspaceConfig};
 #[derive(Parser, Debug, Default)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     #[clap(flatten)]
@@ -35,7 +38,7 @@ pub struct Args {
     pub lock_file_update_config: LockFileUpdateConfig,
 
     #[clap(flatten)]
-    config: ConfigCli,
+    pub config: ConfigCli,
 
     #[clap(flatten)]
     pub specs: UpgradeSpecsArgs,
@@ -66,6 +69,7 @@ pub struct UpgradeSpecsArgs {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(args.config.clone());

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -17,6 +17,9 @@ use crate::{
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -86,6 +89,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/description.rs
+++ b/crates/pixi_cli/src/workspace/description.rs
@@ -11,6 +11,9 @@ use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -41,6 +44,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -16,6 +16,9 @@ use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -66,6 +69,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/export/conda_environment.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_environment.rs
@@ -18,6 +18,9 @@ use crate::cli_config::WorkspaceConfig;
 #[derive(Debug, Default, Parser)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// Explicit path to export the environment file to.
@@ -406,6 +409,7 @@ fn channels_with_nodefaults(channels: Vec<NamedChannelOrUrl>) -> Vec<NamedChanne
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
     let environment = workspace.environment_from_name_or_env_var(args.environment)?;
@@ -467,6 +471,7 @@ mod tests {
             platform: Some(Platform::Osx64),
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -496,6 +501,7 @@ mod tests {
             platform: None,
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -526,6 +532,7 @@ mod tests {
             platform: None,
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -561,6 +568,7 @@ mod tests {
             platform: None,
             environment: Some("alternative".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -591,6 +599,7 @@ mod tests {
             platform: None,
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -620,6 +629,7 @@ mod tests {
             platform: Some(Platform::OsxArm64),
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -657,6 +667,7 @@ mod tests {
             platform: Some(Platform::Osx64),
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: None,
             from_lock_file: false,
         };
@@ -751,6 +762,7 @@ mod tests {
             platform: Some(Platform::Osx64),
             environment: Some("default".to_string()),
             workspace_config: WorkspaceConfig::default(),
+            config_source: Default::default(),
             name: Some(env_name.clone()),
             from_lock_file: false,
         };

--- a/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
@@ -18,6 +18,9 @@ use crate::cli_config::{LockFileUpdateConfig, NoInstallConfig, WorkspaceConfig};
 #[clap(arg_required_else_help = false)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// Output directory for rendered explicit environment spec files
@@ -172,6 +175,7 @@ fn render_env_platform(
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?
         .with_cli_config(args.config.clone());

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -14,6 +14,9 @@ use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -39,6 +42,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/name.rs
+++ b/crates/pixi_cli/src/workspace/name.rs
@@ -11,6 +11,9 @@ use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -38,6 +41,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -14,6 +14,9 @@ use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     #[clap(subcommand)]
@@ -67,6 +70,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/register.rs
+++ b/crates/pixi_cli/src/workspace/register.rs
@@ -11,6 +11,9 @@ use pixi_core::workspace::WorkspaceRegistry;
 #[derive(Parser, Debug, Clone)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -104,6 +107,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
         None => {
             let workspace = WorkspaceLocator::for_cli()
+                .with_global_config_source(args.config_source.source())
                 .with_closest_package(false)
                 .with_search_start(args.workspace_config.workspace_locator_start())
                 .locate()?;

--- a/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
@@ -12,6 +12,9 @@ use crate::cli_config::WorkspaceConfig;
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -37,6 +40,7 @@ pub enum Command {
 pub async fn execute(args: Args) -> miette::Result<()> {
     let is_verify = matches!(args.command, Command::Verify);
     let workspace_locator = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .with_ignore_pixi_version_check(!is_verify);
 

--- a/crates/pixi_cli/src/workspace/system_requirements/mod.rs
+++ b/crates/pixi_cli/src/workspace/system_requirements/mod.rs
@@ -27,6 +27,9 @@ pub enum SystemRequirementEnum {
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -46,6 +49,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_cli/src/workspace/version/mod.rs
+++ b/crates/pixi_cli/src/workspace/version/mod.rs
@@ -12,6 +12,9 @@ use crate::cli_config::WorkspaceConfig;
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
+    pub config_source: pixi_config::ConfigSourceCli,
+
+    #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
     /// The subcommand to execute
@@ -35,6 +38,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -149,6 +149,63 @@ static NETFS_REDIRECT_WARNED: LazyLock<Mutex<HashSet<CacheKind>>> =
 /// Workspace-scoped overrides flow through [`Config::cache_dir_for`] instead.
 static GLOBAL_CACHE_CONFIG: LazyLock<CacheConfig> = LazyLock::new(|| Config::load_global().cache);
 
+/// Describes where the system + user-level config layer comes from. Built from
+/// [`ConfigSourceCli`] (which mirrors `--no-config` / `--config-file`) and
+/// passed into [`Config::load_global_with`] and [`Config::load_with`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum GlobalConfigSource {
+    /// Search the system and user-level paths (the default).
+    #[default]
+    Search,
+    /// Skip every system and user-level config file.
+    None,
+    /// Load only this file as the global layer.
+    File(PathBuf),
+}
+
+/// CLI flags that select where the global (system + user-level) config layer is
+/// read from. Flattened into each subcommand's `Args` so `--no-config` /
+/// `--config-file` are available per command.
+#[derive(Parser, Debug, Default, Clone)]
+pub struct ConfigSourceCli {
+    /// Don't read system or user-level configuration files. Project-local
+    /// `<project>/.pixi/config.toml` is still loaded.
+    #[arg(
+        long,
+        env = "PIXI_NO_CONFIG",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        default_value_t = false,
+        conflicts_with = "config_file",
+        help_heading = consts::CLAP_CONFIG_OPTIONS
+    )]
+    pub no_config: bool,
+
+    /// Load configuration from this file instead of searching system and
+    /// user-level paths. Project-local `<project>/.pixi/config.toml` is still
+    /// merged on top.
+    #[arg(
+        long,
+        value_name = "PATH",
+        env = "PIXI_CONFIG_FILE",
+        conflicts_with = "no_config",
+        help_heading = consts::CLAP_CONFIG_OPTIONS
+    )]
+    pub config_file: Option<PathBuf>,
+}
+
+impl ConfigSourceCli {
+    /// Translate the flags into a [`GlobalConfigSource`].
+    pub fn source(&self) -> GlobalConfigSource {
+        if self.no_config {
+            GlobalConfigSource::None
+        } else if let Some(path) = &self.config_file {
+            GlobalConfigSource::File(path.clone())
+        } else {
+            GlobalConfigSource::Search
+        }
+    }
+}
+
 /// Get pixi home directory, default to `$HOME/.pixi`
 ///
 /// It may be overridden by the `PIXI_HOME` environment variable.
@@ -629,51 +686,51 @@ fn resolve_cache_root(cache_cfg: &CacheConfig) -> Option<(PathBuf, CacheDirSourc
 pub struct ConfigCli {
     /// Path to the file containing the authentication token.
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    auth_file: Option<PathBuf>,
+    pub auth_file: Option<PathBuf>,
 
     /// Max concurrent network requests, default is `50`
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    concurrent_downloads: Option<usize>,
+    pub concurrent_downloads: Option<usize>,
 
     /// Max concurrent solves, default is the number of CPUs
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    concurrent_solves: Option<usize>,
+    pub concurrent_solves: Option<usize>,
 
     /// Set pinning strategy
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS, value_enum)]
-    pinning_strategy: Option<PinningStrategy>,
+    pub pinning_strategy: Option<PinningStrategy>,
 
     /// Specifies whether to use the keyring to look up credentials for PyPI.
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    pypi_keyring_provider: Option<KeyringProvider>,
+    pub pypi_keyring_provider: Option<KeyringProvider>,
 
     /// Run post-link scripts (insecure)
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    run_post_link_scripts: bool,
+    pub run_post_link_scripts: bool,
 
     /// Disallow symbolic links during package installation
     #[arg(long, env = "PIXI_NO_SYMBOLIC_LINKS", help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    no_symbolic_links: bool,
+    pub no_symbolic_links: bool,
 
     /// Disallow hard links during package installation
     #[arg(long, env = "PIXI_NO_HARD_LINKS", help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    no_hard_links: bool,
+    pub no_hard_links: bool,
 
     /// Disallow ref links (copy-on-write) during package installation
     #[arg(long, env = "PIXI_NO_REF_LINKS", help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    no_ref_links: bool,
+    pub no_ref_links: bool,
 
     /// Do not verify the TLS certificate of the server.
     #[arg(long, action = ArgAction::SetTrue, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    tls_no_verify: bool,
+    pub tls_no_verify: bool,
 
     /// Which TLS root certificates to use: 'webpki' (bundled Mozilla roots) or 'system' (system store).
     #[arg(long, env = "PIXI_TLS_ROOT_CERTS", help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    tls_root_certs: Option<TlsRootCerts>,
+    pub tls_root_certs: Option<TlsRootCerts>,
 
     /// Use environment activation cache (experimental)
     #[arg(long, help_heading = consts::CLAP_CONFIG_OPTIONS)]
-    use_environment_activation_cache: bool,
+    pub use_environment_activation_cache: bool,
 }
 
 #[derive(Parser, Debug, Clone, Default)]
@@ -1917,22 +1974,22 @@ impl Config {
         Ok(())
     }
 
-    /// Load the global config file from various global paths.
+    /// Load the global (system + user-level) config layer using the given
+    /// source.
     ///
-    /// # Returns
+    /// - [`GlobalConfigSource::None`]: return [`Config::default`].
+    /// - [`GlobalConfigSource::File`]: load only that file.
+    /// - [`GlobalConfigSource::Search`]: load `/etc/pixi/config.toml` and
+    ///   every entry in [`config_path_global`], merging them in order. This
+    ///   case is cached process-wide because the underlying files are
+    ///   env-independent.
     ///
-    /// The loaded global config
-    ///
-    /// # Caching
-    ///
-    /// The system + global file layers are env-independent, so we cache them
-    /// on the first call. The cached value is cloned and the env-derived CLI
-    /// defaults are layered on each call, so per-process env changes still
-    /// take effect. Without this cache pixi would re-parse the same files (and
-    /// re-emit any deprecation warnings) once for [`Config::with_cli_config`]
-    /// and again when the workspace creates its own [`Config::load`].
-    pub fn load_global() -> Config {
-        static FILE_LAYERS: LazyLock<Config> = LazyLock::new(|| {
+    /// The project-local `<project>/.pixi/config.toml` layer that
+    /// [`Config::load_with`] adds on top is unaffected.
+    pub fn load_global_with(source: &GlobalConfigSource) -> Config {
+        // Cache only the default search-the-disk layers; non-default sources
+        // (--no-config / --config-file) are per-invocation and can vary.
+        static SEARCH_LAYERS: LazyLock<Config> = LazyLock::new(|| {
             let mut config = Config::load_system();
             for p in config_path_global() {
                 match Config::from_path(&p) {
@@ -1948,13 +2005,32 @@ impl Config {
             config
         });
 
-        // Layer the env-derived defaults on each call so changes to the
-        // process environment within a single pixi invocation still apply.
-        // This will add any environment variables defined in the `clap`
-        // attributes to the config.
+        let file_layers = match source {
+            GlobalConfigSource::None => Config::default(),
+            GlobalConfigSource::File(path) => match Config::from_path(path) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to load config file '{}' (from --config-file / \
+                         PIXI_CONFIG_FILE): {}",
+                        path.display(),
+                        e
+                    );
+                    Config::default()
+                }
+            },
+            GlobalConfigSource::Search => SEARCH_LAYERS.clone(),
+        };
+
+        // Layer env-derived CLI defaults so process-env changes still apply.
         let mut default_cli = ConfigCli::default();
         default_cli.update_from(std::env::args().take(0));
-        FILE_LAYERS.clone().merge_config(default_cli.into())
+        file_layers.merge_config(default_cli.into())
+    }
+
+    /// Load the global config layer using the default search behavior.
+    pub fn load_global() -> Config {
+        Self::load_global_with(&GlobalConfigSource::Search)
     }
 
     /// Load the global config and layer the given cli config on top of it.
@@ -1963,13 +2039,11 @@ impl Config {
         config.merge_config(cli.clone().into())
     }
 
-    /// Load the config from the given path (project root).
-    ///
-    /// # Returns
-    ///
-    /// The loaded config (merged with the global config)
-    pub fn load(project_root: &Path) -> Config {
-        let mut config = Self::load_global();
+    /// Load the config from the given path (project root), using the supplied
+    /// source for the global layer. Project-local
+    /// `<project>/.pixi/config.toml` is merged on top.
+    pub fn load_with(project_root: &Path, source: &GlobalConfigSource) -> Config {
+        let mut config = Self::load_global_with(source);
         let local_config_path = project_root
             .join(consts::PIXI_DIR)
             .join(consts::CONFIG_FILE);
@@ -1984,6 +2058,12 @@ impl Config {
         }
 
         config
+    }
+
+    /// Load the config from the given path (project root) using the default
+    /// global search.
+    pub fn load(project_root: &Path) -> Config {
+        Self::load_with(project_root, &GlobalConfigSource::Search)
     }
 
     // Get all possible keys of the configuration

--- a/crates/pixi_core/src/workspace/discovery.rs
+++ b/crates/pixi_core/src/workspace/discovery.rs
@@ -2,6 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use itertools::Itertools;
 use miette::{Diagnostic, NamedSource, Report};
+use pixi_config::GlobalConfigSource;
 use pixi_consts::consts;
 use pixi_manifest::{
     ExplicitManifestError, LoadManifestsError, Manifests, TomlError, WarningWithSource,
@@ -72,6 +73,8 @@ pub struct WorkspaceLocator {
     emit_warnings: bool,
     consider_environment: bool,
     ignore_pixi_version_check: bool,
+    /// Source for the global (system + user-level) config layer.
+    global_config_source: GlobalConfigSource,
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -156,6 +159,15 @@ impl WorkspaceLocator {
     pub fn with_closest_package(self, with_closest_package: bool) -> Self {
         Self {
             with_closest_package,
+            ..self
+        }
+    }
+
+    /// Drive the global config layer from `source` (typically derived from
+    /// `--no-config` / `--config-file` on the top-level CLI).
+    pub fn with_global_config_source(self, source: GlobalConfigSource) -> Self {
+        Self {
+            global_config_source: source,
             ..self
         }
     }
@@ -293,7 +305,7 @@ impl WorkspaceLocator {
             );
         }
 
-        let workspace = Workspace::from_manifests(discovered_manifests);
+        let workspace = Workspace::from_manifests(discovered_manifests, &self.global_config_source);
 
         Ok(workspace)
     }

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -207,8 +207,12 @@ pub type MatchSpecs = indexmap::IndexMap<PackageName, (MatchSpec, SpecType)>;
 pub type SourceSpecs = indexmap::IndexMap<PackageName, (SourceSpec, SpecType)>;
 
 impl Workspace {
-    /// Constructs a new instance from an internal manifest representation
-    pub(crate) fn from_manifests(manifest: Manifests) -> Self {
+    /// Core constructor: takes parsed manifests and loads the workspace config
+    /// using `source` for the system + user-level layer.
+    pub(crate) fn from_manifests(
+        manifest: Manifests,
+        source: &pixi_config::GlobalConfigSource,
+    ) -> Self {
         let env_vars = Workspace::init_env_vars(&manifest.workspace.value.environments);
         // Get the absolute path of the manifest, preserving symlinks by only
         // canonicalizing the parent directory
@@ -239,7 +243,7 @@ impl Workspace {
             })
             .collect::<HashMap<String, s3_middleware::S3Config>>();
 
-        let config = Config::load(&root);
+        let config = Config::load_with(&root, source);
         Self {
             root,
             manifest_location_name,
@@ -256,23 +260,37 @@ impl Workspace {
         }
     }
 
-    /// Loads a project from manifest file. The `manifest_path` is expected to
-    /// be a workspace manifest.
+    /// Loads a workspace from a manifest file using the default global-config
+    /// search. Pass a source to [`Workspace::from_path_with_source`] to honor
+    /// `--no-config` / `--config-file`.
     pub fn from_path(manifest_path: &Path) -> Result<Self, LoadManifestsError> {
+        Self::from_path_with_source(manifest_path, &pixi_config::GlobalConfigSource::Search)
+    }
+
+    /// Loads a workspace from a manifest file, using `source` for the global
+    /// config layer.
+    pub fn from_path_with_source(
+        manifest_path: &Path,
+        source: &pixi_config::GlobalConfigSource,
+    ) -> Result<Self, LoadManifestsError> {
         let WithWarnings {
             value: manifests, ..
         } = Manifests::from_workspace_manifest_path(manifest_path.to_path_buf())?;
-        Ok(Self::from_manifests(manifests))
+        Ok(Self::from_manifests(manifests, source))
     }
 
-    /// Constructs a workspace from source loaded from a specific location.
+    /// Constructs a workspace from a manifest string loaded from a specific
+    /// location. Uses the default global-config search.
     pub fn from_str(manifest_path: &Path, content: &str) -> Result<Self, LoadManifestsError> {
         let WithWarnings {
             value: manifests, ..
         } = Manifests::from_workspace_source(
             content.with_provenance(ManifestProvenance::from_path(manifest_path.to_path_buf())?),
         )?;
-        Ok(Self::from_manifests(manifests))
+        Ok(Self::from_manifests(
+            manifests,
+            &pixi_config::GlobalConfigSource::Search,
+        ))
     }
 
     /// Initialize empty map of environments variables

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -62,6 +62,13 @@ pixi add [OPTIONS] <SPEC>...
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 
 ## Git Options
 - <a id="arg---git" href="#arg---git">`--git (-g) <GIT>`</a>

--- a/docs/reference/cli/pixi/clean.md
+++ b/docs/reference/cli/pixi/clean.md
@@ -29,6 +29,15 @@ pixi clean [OPTIONS] [COMMAND]
 - <a id="arg---workspaces-registry" href="#arg---workspaces-registry">`--workspaces-registry`</a>
 :  Only remove disassociated workspace registries
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/import.md
+++ b/docs/reference/cli/pixi/import.md
@@ -61,6 +61,13 @@ pixi import [OPTIONS] <FILE>
 <br>**env**: `PIXI_TLS_ROOT_CERTS`
 - <a id="arg---use-environment-activation-cache" href="#arg---use-environment-activation-cache">`--use-environment-activation-cache`</a>
 :  Use environment activation cache (experimental)
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>

--- a/docs/reference/cli/pixi/info.md
+++ b/docs/reference/cli/pixi/info.md
@@ -19,6 +19,15 @@ pixi info [OPTIONS]
 - <a id="arg---json" href="#arg---json">`--json`</a>
 :  Whether to show the output as JSON or not
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -30,6 +30,13 @@ pixi install [OPTIONS]
 <br>May be provided more than once.
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -36,6 +36,15 @@ pixi list [OPTIONS] [REGEX]
 - <a id="arg---explicit" href="#arg---explicit">`--explicit (-x)`</a>
 :  Only list packages that are explicitly defined in the workspace
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Update Options
 - <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
 :  Install the environment as defined in the lock file, doesn't update lock file if it isn't up-to-date with the manifest file

--- a/docs/reference/cli/pixi/lock.md
+++ b/docs/reference/cli/pixi/lock.md
@@ -21,6 +21,15 @@ pixi lock [OPTIONS]
 - <a id="arg---dry-run" href="#arg---dry-run">`--dry-run`</a>
 :  Compute the lock file without writing to disk. Implies --no-install
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Update Options
 - <a id="arg---no-install" href="#arg---no-install">`--no-install`</a>
 :  Don't modify the environment, only modify the lock file

--- a/docs/reference/cli/pixi/publish.md
+++ b/docs/reference/cli/pixi/publish.md
@@ -53,6 +53,13 @@ pixi publish [OPTIONS]
 :  Archive format and optional compression level, e.g. `conda`, `tar-bz2`, `conda:max`, `conda:15`, `tar-bz2:9`. Numeric ranges match rattler-build: -7..=22 for `.conda`, 1..=9 for `.tar.bz2`
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/reinstall.md
+++ b/docs/reference/cli/pixi/reinstall.md
@@ -26,6 +26,13 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 :  Install all environments
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -30,6 +30,13 @@ pixi remove [OPTIONS] <SPEC>...
 <br>**default**: `default`
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -35,6 +35,13 @@ pixi run [OPTIONS] [TASK]...
 :
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/search.md
+++ b/docs/reference/cli/pixi/search.md
@@ -33,6 +33,15 @@ pixi search [OPTIONS] <PACKAGE>
 - <a id="arg---json" href="#arg---json">`--json`</a>
 :  Output in JSON format
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -23,6 +23,13 @@ pixi shell-hook [OPTIONS]
 <br>**default**: `false`
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/shell.md
+++ b/docs/reference/cli/pixi/shell.md
@@ -18,6 +18,13 @@ pixi shell [OPTIONS]
 :  The environment to activate in the shell
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/task.md
+++ b/docs/reference/cli/pixi/task.md
@@ -22,6 +22,15 @@ pixi task [OPTIONS] <COMMAND>
 | [`list`](task/list.md) | List all tasks in the workspace |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/tree.md
+++ b/docs/reference/cli/pixi/tree.md
@@ -25,6 +25,15 @@ pixi tree [OPTIONS] [REGEX]
 - <a id="arg---invert" href="#arg---invert">`--invert (-i)`</a>
 :  Invert tree and show what depends on given package in the regex argument
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Update Options
 - <a id="arg---frozen" href="#arg---frozen">`--frozen`</a>
 :  Install the environment as defined in the lock file, doesn't update lock file if it isn't up-to-date with the manifest file

--- a/docs/reference/cli/pixi/update.md
+++ b/docs/reference/cli/pixi/update.md
@@ -34,6 +34,13 @@ pixi update [OPTIONS] [PACKAGES]...
 :  Output the changes in JSON format
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -30,6 +30,13 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 :  Only show the changes that would be made, without actually updating the manifest, lock file, or environment
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/workspace/channel.md
+++ b/docs/reference/cli/pixi/workspace/channel.md
@@ -21,6 +21,15 @@ pixi workspace channel [OPTIONS] <COMMAND>
 | [`remove`](channel/remove.md) | Remove channel(s) from the manifest and updates the lock file |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/description.md
+++ b/docs/reference/cli/pixi/workspace/description.md
@@ -20,6 +20,15 @@ pixi workspace description [OPTIONS] <COMMAND>
 | [`set`](description/set.md) | Set the workspace description |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/environment.md
+++ b/docs/reference/cli/pixi/workspace/environment.md
@@ -21,6 +21,15 @@ pixi workspace environment [OPTIONS] <COMMAND>
 | [`remove`](environment/remove.md) | Remove an environment from the manifest file |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/export/conda-environment.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-environment.md
@@ -27,6 +27,15 @@ pixi workspace export conda-environment [OPTIONS] [OUTPUT_PATH]
 - <a id="arg---from-lock-file" href="#arg---from-lock-file">`--from-lock-file`</a>
 :  Render the environment with packages pinned to the versions resolved in the lock file instead of the manifest specs
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
@@ -33,6 +33,13 @@ pixi workspace export conda-explicit-spec [OPTIONS] <OUTPUT_DIR>
 <br>**default**: `false`
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>
 :  Path to the file containing the authentication token
 - <a id="arg---concurrent-downloads" href="#arg---concurrent-downloads">`--concurrent-downloads <CONCURRENT_DOWNLOADS>`</a>

--- a/docs/reference/cli/pixi/workspace/feature.md
+++ b/docs/reference/cli/pixi/workspace/feature.md
@@ -20,6 +20,15 @@ pixi workspace feature [OPTIONS] <COMMAND>
 | [`remove`](feature/remove.md) | Remove a feature from the manifest file |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/name.md
+++ b/docs/reference/cli/pixi/workspace/name.md
@@ -20,6 +20,15 @@ pixi workspace name [OPTIONS] <COMMAND>
 | [`set`](name/set.md) | Set the workspace name |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/platform.md
+++ b/docs/reference/cli/pixi/workspace/platform.md
@@ -21,6 +21,15 @@ pixi workspace platform [OPTIONS] <COMMAND>
 | [`remove`](platform/remove.md) | Remove platform(s) from the workspace file and updates the lock file |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/register.md
+++ b/docs/reference/cli/pixi/workspace/register.md
@@ -29,6 +29,15 @@ pixi workspace register [OPTIONS] [COMMAND]
 - <a id="arg---force" href="#arg---force">`--force (-f)`</a>
 :  Overwrite the workspace entry if the name of the workspace already exists in the registry
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/requires-pixi.md
+++ b/docs/reference/cli/pixi/workspace/requires-pixi.md
@@ -22,6 +22,15 @@ pixi workspace requires-pixi [OPTIONS] <COMMAND>
 | [`verify`](requires-pixi/verify.md) | Verify the pixi minimum version requirement |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/system-requirements.md
+++ b/docs/reference/cli/pixi/workspace/system-requirements.md
@@ -20,6 +20,15 @@ pixi workspace system-requirements [OPTIONS] <COMMAND>
 | [`list`](system-requirements/list.md) | List the environments in the manifest file |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/cli/pixi/workspace/version.md
+++ b/docs/reference/cli/pixi/workspace/version.md
@@ -23,6 +23,15 @@ pixi workspace version [OPTIONS] <COMMAND>
 | [`patch`](version/patch.md) | Bump the workspace version to PATCH |
 
 
+## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
+
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -29,6 +29,16 @@ Pixi can also be configured via environment variables.
       </td>
     </tr>
     <tr>
+      <td><code>PIXI_NO_CONFIG</code></td>
+      <td>When set to a truthy value (e.g. <code>1</code>), pixi skips loading system and user-level configuration files (such as <code>/etc/pixi/config.toml</code> and <code>~/.pixi/config.toml</code>). Project-local <code>&lt;project&gt;/.pixi/config.toml</code> is still loaded. Equivalent to passing <code>--no-config</code>. Useful in CI, scripts, and tests that need to be insulated from a developer's global settings.</td>
+      <td>Not set.</td>
+    </tr>
+    <tr>
+      <td><code>PIXI_CONFIG_FILE</code></td>
+      <td>Path to a configuration file to load <em>instead of</em> the system and user-level config files. Project-local <code>&lt;project&gt;/.pixi/config.toml</code> is still merged on top. Equivalent to passing <code>--config-file &lt;PATH&gt;</code>.</td>
+      <td>Not set.</td>
+    </tr>
+    <tr>
       <td><code>PIXI_OVERRIDE_PLATFORM</code></td>
       <td>
         Overrides the detected host platform used to select and install environments.

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -47,6 +47,18 @@ configuration read from lower priority locations are overwritten.
 To find the locations where `pixi` looks for configuration files, run
 `pixi info -vvv`.
 
+### Skipping or overriding config discovery
+
+Two global flags (and their environment-variable equivalents) let you opt out
+of the system and user-level config layers — the project-local
+`<project>/.pixi/config.toml` is always merged on top:
+
+- `--no-config` / `PIXI_NO_CONFIG=1` — skip all system and user-level config
+  files. Useful in CI, scripts, and tests that need to be insulated from a
+  developer's machine-wide settings.
+- `--config-file <PATH>` / `PIXI_CONFIG_FILE=<PATH>` — load only the given
+  file as the global layer instead of searching the locations above.
+
 ## Configuration options
 
 ??? info "Naming convention in configuration"


### PR DESCRIPTION
### Description

Adds `--no-config` and `--config-file <PATH>` (also `PIXI_NO_CONFIG` and `PIXI_CONFIG_FILE`) so users can opt out of, or override, the system and user-level `config.toml` lookup. The two flags are mutually exclusive. The project-local `<project>/.pixi/config.toml` is still honored.

Without this, settings in a developer's `~/.pixi/config.toml` (e.g. `pinning-strategy = "no-pin"`) leak into commands and tests that assume defaults, which is what caused #6217.

This is a relatively big change but it simply boils down to: 
1. `--no-config` / `--config` is added to the global CLI arguments (every command gets this flag).
2. The configuration is passed into each CLI command.
3. The configuration is used to parse the global config.

Fixes #6217

### How Has This Been Tested?

- The seven tests reported in #6217 now pass with `PIXI_HOME` pointing at a config file containing `pinning-strategy = "no-pin"`.
- The same tests still pass without that file (no regression).
- Manual checks against the built binary:
  - `pixi --no-config info`, `pixi info --no-config`, and `PIXI_NO_CONFIG=1 pixi info` all skip the user-level config.
  - `pixi --config-file <PATH> info` and `PIXI_CONFIG_FILE=<PATH> pixi info` both load only the specified file.
  - `pixi --no-config --config-file <PATH> ...` is rejected by the parser.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.