### PR TITLE
fix: tests on main did not update assertion for `.git` suffix

### DIFF
--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -866,7 +866,7 @@ def test_adding_git_deps(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
     # we want to make sure that the lock file contains the branch information
-    assert "pypi: git+https://github.com/mahmoud/boltons?branch=master" in lock_file.read_text()
+    assert "pypi: git+https://github.com/mahmoud/boltons.git?branch=master" in lock_file.read_text()
     # and that the manifest contains the branch information
     manifest = tomllib.loads(manifest_path.read_text())
     assert manifest["pypi-dependencies"]["boltons"]["branch"] == "master"
@@ -888,7 +888,7 @@ def test_adding_git_deps(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
     # we want to make sure that the lock file contains the tag information
-    assert "pypi: git+https://github.com/mahmoud/boltons?tag=25.0.0" in lock_file.read_text()
+    assert "pypi: git+https://github.com/mahmoud/boltons.git?tag=25.0.0" in lock_file.read_text()
     # and that the manifest contains the tag information
     manifest = tomllib.loads(manifest_path.read_text())
     assert manifest["pypi-dependencies"]["boltons"]["tag"] == "25.0.0"
@@ -910,7 +910,7 @@ def test_adding_git_deps(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
     # we want to make sure that the lock file contains the rev information
-    assert "pypi: git+https://github.com/mahmoud/boltons?rev=d70669a" in lock_file.read_text()
+    assert "pypi: git+https://github.com/mahmoud/boltons.git?rev=d70669a" in lock_file.read_text()
     # and that the manifest contains the rev information
     manifest = tomllib.loads(manifest_path.read_text())
     assert manifest["pypi-dependencies"]["boltons"]["rev"] == "d70669a"


### PR DESCRIPTION
### Description

Currently, tests on main are red. Matching the URL-preservation behavior introduced by PR #6203.

### How Has This Been Tested?

Not yet. 

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
