### PR TITLE
chore: use rust backend for building ros backend

### DIFF
--- a/crates/pixi_build_ros/pixi.toml
+++ b/crates/pixi_build_ros/pixi.toml
@@ -3,7 +3,7 @@ channels = [
   "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
-name = "pixi-build-ros"
+name = "pixi-build-rust"
 version = "*"
 
 [package.run-dependencies]


### PR DESCRIPTION
### Description
We mistakenly used the ros backend to build the ros backend haha.
