### PR TITLE
fix: reject build backends defined as source dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,10 @@ pypi_modifiers = { path = "crates/pypi_modifiers" }
 pyproject-toml = "0.13.7"
 
 bzip2 = "0.6.1"
+lzma-rust2 = { version = "0.16", default-features = false, features = [
+  "xz",
+  "std",
+] }
 rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.13", default-features = false }
@@ -182,7 +186,6 @@ toml = "1.0.0"
 toml-span = "0.7.0"
 toml_edit = "0.23.0"
 tracing = "0.1.41"
-lzma-rust2 = { version = "0.16", default-features = false, features = ["xz", "std"] }
 # Forcing the version due to this PR https://github.com/tokio-rs/tracing/pull/3368
 tracing-subscriber = "=0.3.19"
 tracing-test = "0.2"

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -76,6 +76,13 @@ impl TomlPackageBuild {
             )?,
         };
 
+        if build_backend_spec.is_source() {
+            return Err(TomlError::Generic(
+                GenericError::new("build backends cannot be defined as source dependencies")
+                    .with_opt_span(self.backend.span.clone()),
+            ));
+        }
+
         // Convert the additional dependencies and make sure that they are binary.
         // Prioritize backend.additional_dependencies over top-level additional_dependencies
         let additional_dependencies =
@@ -590,6 +597,46 @@ mod test {
                 .into_iter()
                 .map(String::from)
                 .collect()
+        );
+    }
+
+    #[test]
+    fn test_backend_source_path_rejected() {
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+            backend = { name = "foobar", path = "./local-backend" }
+        "#
+            ),
+            @r#"
+          × build backends cannot be defined as source dependencies
+           ╭─[pixi.toml:2:23]
+         1 │
+         2 │             backend = { name = "foobar", path = "./local-backend" }
+           ·                       ─────────────────────────────────────────────
+         3 │
+           ╰────
+        "#
+        );
+    }
+
+    #[test]
+    fn test_backend_source_git_rejected() {
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+            backend = { name = "foobar", git = "https://example.com/repo.git" }
+        "#
+            ),
+            @r#"
+          × build backends cannot be defined as source dependencies
+           ╭─[pixi.toml:2:23]
+         1 │
+         2 │             backend = { name = "foobar", git = "https://example.com/repo.git" }
+           ·                       ─────────────────────────────────────────────────────────
+         3 │
+           ╰────
+        "#
         );
     }
 

--- a/crates/pixi_url/Cargo.toml
+++ b/crates/pixi_url/Cargo.toml
@@ -15,6 +15,7 @@ flate2.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
 futures.workspace = true
 indicatif.workspace = true
+lzma-rust2.workspace = true
 pixi_record.workspace = true
 pixi_spec.workspace = true
 pixi_utils.workspace = true
@@ -29,7 +30,6 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
-lzma-rust2.workspace = true
 zip.workspace = true
 zstd.workspace = true
 

--- a/schema/model.py
+++ b/schema/model.py
@@ -258,8 +258,8 @@ class Workspace(StrictBaseModel):
 ########################
 
 
-class MatchspecTable(StrictBaseModel):
-    """A precise description of a `conda` package version."""
+class BinaryMatchspecTable(StrictBaseModel):
+    """A precise description of a `conda` binary package version. Excludes source-location fields."""
 
     version: NonEmptyStr | None = Field(
         None,
@@ -298,6 +298,10 @@ class MatchspecTable(StrictBaseModel):
     track_features: list[NonEmptyStr] | None = Field(
         None, description="The track features of the package"
     )
+
+
+class MatchspecTable(BinaryMatchspecTable):
+    """A precise description of a `conda` package version."""
 
     path: NonEmptyStr | None = Field(None, description="The path to the package")
 
@@ -1020,7 +1024,7 @@ class Build(StrictBaseModel):
     )
 
 
-class BuildBackend(MatchspecTable):
+class BuildBackend(BinaryMatchspecTable):
     name: NonEmptyStr | None = Field(None, description="The name of the build backend package")
     channels: list[Channel] | None = Field(
         None, description="The `conda` channels that are used to fetch the build backend from"

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -448,12 +448,6 @@
             "minLength": 1
           }
         },
-        "branch": {
-          "title": "Branch",
-          "description": "A git branch to use",
-          "type": "string",
-          "minLength": 1
-        },
         "build": {
           "title": "Build",
           "description": "The build string of the package",
@@ -522,12 +516,6 @@
             "minLength": 1
           }
         },
-        "git": {
-          "title": "Git",
-          "description": "The git URL to the repo",
-          "type": "string",
-          "minLength": 1
-        },
         "license": {
           "title": "License",
           "description": "The license of the package",
@@ -540,51 +528,15 @@
           "type": "string",
           "minLength": 1
         },
-        "md5": {
-          "title": "Md5",
-          "description": "The md5 hash of the package",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{32}$"
-        },
         "name": {
           "title": "Name",
           "description": "The name of the build backend package",
           "type": "string",
           "minLength": 1
         },
-        "path": {
-          "title": "Path",
-          "description": "The path to the package",
-          "type": "string",
-          "minLength": 1
-        },
-        "rev": {
-          "title": "Rev",
-          "description": "A git SHA revision to use",
-          "type": "string",
-          "minLength": 1
-        },
-        "sha256": {
-          "title": "Sha256",
-          "description": "The sha256 hash of the package",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{64}$"
-        },
         "subdir": {
           "title": "Subdir",
           "description": "The subdir of the package, also known as platform",
-          "type": "string",
-          "minLength": 1
-        },
-        "subdirectory": {
-          "title": "Subdirectory",
-          "description": "A subdirectory to use in the repo",
-          "type": "string",
-          "minLength": 1
-        },
-        "tag": {
-          "title": "Tag",
-          "description": "A git tag to use",
           "type": "string",
           "minLength": 1
         },
@@ -596,12 +548,6 @@
             "type": "string",
             "minLength": 1
           }
-        },
-        "url": {
-          "title": "Url",
-          "description": "The URL to the package",
-          "type": "string",
-          "minLength": 1
         },
         "version": {
           "title": "Version",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -191,12 +191,6 @@
             "minLength": 1
           }
         },
-        "branch": {
-          "title": "Branch",
-          "description": "A git branch to use",
-          "type": "string",
-          "minLength": 1
-        },
         "build": {
           "title": "Build",
           "description": "The build string of the package",
@@ -265,12 +259,6 @@
             "minLength": 1
           }
         },
-        "git": {
-          "title": "Git",
-          "description": "The git URL to the repo",
-          "type": "string",
-          "minLength": 1
-        },
         "license": {
           "title": "License",
           "description": "The license of the package",
@@ -283,51 +271,15 @@
           "type": "string",
           "minLength": 1
         },
-        "md5": {
-          "title": "Md5",
-          "description": "The md5 hash of the package",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{32}$"
-        },
         "name": {
           "title": "Name",
           "description": "The name of the build backend package",
           "type": "string",
           "minLength": 1
         },
-        "path": {
-          "title": "Path",
-          "description": "The path to the package",
-          "type": "string",
-          "minLength": 1
-        },
-        "rev": {
-          "title": "Rev",
-          "description": "A git SHA revision to use",
-          "type": "string",
-          "minLength": 1
-        },
-        "sha256": {
-          "title": "Sha256",
-          "description": "The sha256 hash of the package",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{64}$"
-        },
         "subdir": {
           "title": "Subdir",
           "description": "The subdir of the package, also known as platform",
-          "type": "string",
-          "minLength": 1
-        },
-        "subdirectory": {
-          "title": "Subdirectory",
-          "description": "A subdirectory to use in the repo",
-          "type": "string",
-          "minLength": 1
-        },
-        "tag": {
-          "title": "Tag",
-          "description": "A git tag to use",
           "type": "string",
           "minLength": 1
         },
@@ -339,12 +291,6 @@
             "type": "string",
             "minLength": 1
           }
-        },
-        "url": {
-          "title": "Url",
-          "description": "The URL to the package",
-          "type": "string",
-          "minLength": 1
         },
         "version": {
           "title": "Version",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -472,12 +472,6 @@
             "minLength": 1
           }
         },
-        "branch": {
-          "title": "Branch",
-          "description": "A git branch to use",
-          "type": "string",
-          "minLength": 1
-        },
         "build": {
           "title": "Build",
           "description": "The build string of the package",
@@ -546,12 +540,6 @@
             "minLength": 1
           }
         },
-        "git": {
-          "title": "Git",
-          "description": "The git URL to the repo",
-          "type": "string",
-          "minLength": 1
-        },
         "license": {
           "title": "License",
           "description": "The license of the package",
@@ -564,51 +552,15 @@
           "type": "string",
           "minLength": 1
         },
-        "md5": {
-          "title": "Md5",
-          "description": "The md5 hash of the package",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{32}$"
-        },
         "name": {
           "title": "Name",
           "description": "The name of the build backend package",
           "type": "string",
           "minLength": 1
         },
-        "path": {
-          "title": "Path",
-          "description": "The path to the package",
-          "type": "string",
-          "minLength": 1
-        },
-        "rev": {
-          "title": "Rev",
-          "description": "A git SHA revision to use",
-          "type": "string",
-          "minLength": 1
-        },
-        "sha256": {
-          "title": "Sha256",
-          "description": "The sha256 hash of the package",
-          "type": "string",
-          "pattern": "^[a-fA-F0-9]{64}$"
-        },
         "subdir": {
           "title": "Subdir",
           "description": "The subdir of the package, also known as platform",
-          "type": "string",
-          "minLength": 1
-        },
-        "subdirectory": {
-          "title": "Subdirectory",
-          "description": "A subdirectory to use in the repo",
-          "type": "string",
-          "minLength": 1
-        },
-        "tag": {
-          "title": "Tag",
-          "description": "A git tag to use",
           "type": "string",
           "minLength": 1
         },
@@ -620,12 +572,6 @@
             "type": "string",
             "minLength": 1
           }
-        },
-        "url": {
-          "title": "Url",
-          "description": "The URL to the package",
-          "type": "string",
-          "minLength": 1
         },
         "version": {
           "title": "Version",


### PR DESCRIPTION
### Description

Source-location fields (git, path, url, ...) are no longer accepted on [package.build.backend] in the schema or by the TOML parser, including when inherited from [workspace.dependencies].

### How Has This Been Tested?

`pixi run test`

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools:  Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
