### PR TITLE
refactor(pixi_spec): allow v3 matchspec selectors for source dependencies

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -158,7 +158,7 @@ preview = ["pixi-build"]
     if let Some(package) = &workspace.package {
         if let Some(source_spec) = &package.value.build.source {
             match &source_spec {
-                pixi_spec::SourceLocationSpec::Path(path_spec) => {
+                pixi_spec::SourceSpec::Path(path_spec) => {
                     // Test that the path resolves to the correct absolute location
                     let resolved_path = path_spec.resolve(pixi.workspace_path()).unwrap();
                     let expected_path = alternative_source_dir.canonicalize().unwrap();
@@ -254,7 +254,7 @@ preview = ["pixi-build"]
         && let Some(source_spec) = &package.value.build.source
     {
         match &source_spec {
-            pixi_spec::SourceLocationSpec::Path(path_spec) => {
+            pixi_spec::SourceSpec::Path(path_spec) => {
                 let resolved_path = path_spec.resolve(pixi.workspace_path()).unwrap();
                 let expected_path = absolute_source_dir.canonicalize().unwrap();
                 let resolved_canonical = resolved_path.canonicalize().unwrap();
@@ -325,7 +325,7 @@ preview = ["pixi-build"]
         && let Some(source_spec) = &package.value.build.source
     {
         match &source_spec {
-            pixi_spec::SourceLocationSpec::Path(path_spec) => {
+            pixi_spec::SourceSpec::Path(path_spec) => {
                 // Test that the original relative path is preserved
                 assert_eq!(path_spec.path.as_str(), "./subdir/source");
 
@@ -395,6 +395,301 @@ my-package = {{ path = "./my-package" }}
         Platform::current(),
         "my-package",
     ));
+}
+
+/// A source package can declare extra groups through
+/// `[package.extra-dependencies.<group>]`. A workspace that depends on the
+/// source package and selects a group via `extras = ["<group>"]` must pull the
+/// group's dependencies into the lock file.
+#[tokio::test]
+async fn test_source_dependency_extras_are_pulled_in() {
+    setup_tracing();
+
+    // Channel providing the package referenced by the optional `test` group.
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("extra-pkg", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_manifest = r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.test]
+extra-pkg = ">=1.0"
+"#;
+    fs::write(source_dir.join("pixi.toml"), source_manifest).unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package", extras = ["test"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "my-package",
+        ),
+        "the source package itself must be locked"
+    );
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-pkg",
+        ),
+        "selecting the `test` extra must pull its dependency into the lock file"
+    );
+}
+
+/// Counterpart to [`test_source_dependency_extras_are_pulled_in`]: when the
+/// workspace does not select the optional group, the group's dependencies must
+/// not appear in the lock file.
+#[tokio::test]
+async fn test_source_dependency_unselected_extras_are_absent() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("extra-pkg", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_manifest = r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.test]
+extra-pkg = ">=1.0"
+"#;
+    fs::write(source_dir.join("pixi.toml"), source_manifest).unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "my-package",
+        ),
+        "the source package itself must be locked"
+    );
+    assert!(
+        !lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-pkg",
+        ),
+        "without selecting the `test` extra its dependency must not be locked"
+    );
+}
+
+/// A source package can depend on another source package. This mirrors the
+/// `example-rust` -> `example-rattler-build` shape, with the inner source
+/// declared as a `[package.run-dependencies]` path dependency. Both packages
+/// are built by the passthrough backend, and the inner package's own run
+/// dependency must be resolved transitively into the lock file.
+#[tokio::test]
+async fn test_source_dependency_on_source_run_dependency() {
+    setup_tracing();
+
+    // Channel providing the inner source package's own (binary) dependency.
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("transitive-dep", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    // Inner source package, located next to the outer package's manifest.
+    let recipe_dir = pixi.workspace_path().join("example-rust").join("recipe");
+    fs::create_dir_all(&recipe_dir).unwrap();
+    let inner_manifest = r#"
+[package]
+name = "example-rattler-build"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.run-dependencies]
+transitive-dep = ">=1.0"
+"#;
+    fs::write(recipe_dir.join("pixi.toml"), inner_manifest).unwrap();
+
+    // Outer source package depending on the inner one via a path.
+    let outer_manifest = r#"
+[package]
+name = "example-rust"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.run-dependencies]
+example-rattler-build = { path = "./recipe" }
+"#;
+    fs::write(
+        pixi.workspace_path().join("example-rust").join("pixi.toml"),
+        outer_manifest,
+    )
+    .unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+example-rust = {{ path = "./example-rust" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    for pkg in ["example-rust", "example-rattler-build", "transitive-dep"] {
+        assert!(
+            lock_file.contains_conda_package(
+                consts::DEFAULT_ENVIRONMENT_NAME,
+                Platform::current(),
+                pkg,
+            ),
+            "{pkg} should be locked"
+        );
+    }
+}
+
+/// Same `example-rust` -> `example-rattler-build` source-on-source shape, but
+/// the inner source is declared in a `[package.extra-dependencies.<group>]`
+/// group and pulled in by the workspace selecting `extras = ["recipe"]`. The
+/// inner source package and its transitive dependency must end up in the lock
+/// file just like a run dependency would.
+#[tokio::test]
+async fn test_source_dependency_on_source_extra_dependency() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("transitive-dep", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let recipe_dir = pixi.workspace_path().join("example-rust").join("recipe");
+    fs::create_dir_all(&recipe_dir).unwrap();
+    let inner_manifest = r#"
+[package]
+name = "example-rattler-build"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.run-dependencies]
+transitive-dep = ">=1.0"
+"#;
+    fs::write(recipe_dir.join("pixi.toml"), inner_manifest).unwrap();
+
+    let outer_manifest = r#"
+[package]
+name = "example-rust"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.recipe]
+example-rattler-build = { path = "./recipe" }
+"#;
+    fs::write(
+        pixi.workspace_path().join("example-rust").join("pixi.toml"),
+        outer_manifest,
+    )
+    .unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+example-rust = {{ path = "./example-rust", extras = ["recipe"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    for pkg in ["example-rust", "example-rattler-build", "transitive-dep"] {
+        assert!(
+            lock_file.contains_conda_package(
+                consts::DEFAULT_ENVIRONMENT_NAME,
+                Platform::current(),
+                pkg,
+            ),
+            "{pkg} should be locked (pulled in through the `recipe` extra)"
+        );
+    }
 }
 
 /// Test that verifies [package.build] source.path is resolved relative to the

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -5,7 +5,7 @@ use pixi_core::{
     workspace::{PypiDeps, UpdateDeps, WorkspaceMut},
 };
 use pixi_manifest::{FeatureName, KnownPreviewFeature, SpecType};
-use pixi_spec::{GitSpec, SourceLocationSpec, Subdirectory};
+use pixi_spec::{GitSpec, SourceSpec, Subdirectory};
 use rattler_conda_types::{MatchSpec, PackageName};
 
 mod options;
@@ -62,15 +62,12 @@ pub async fn add_conda_dep(
         source_specs = passed_specs
             .iter()
             .map(|(name, (_spec, spec_type))| {
-                let git_spec = GitSpec {
-                    git: git.clone(),
-                    rev: Some(git_options.reference.clone()),
-                    subdirectory: subdirectory.clone(),
-                };
-                (
-                    name.clone(),
-                    (SourceLocationSpec::Git(git_spec).into(), *spec_type),
-                )
+                let git_spec = GitSpec::new(
+                    git.clone(),
+                    Some(git_options.reference.clone()),
+                    subdirectory.clone(),
+                );
+                (name.clone(), (SourceSpec::Git(git_spec), *spec_type))
             })
             .collect();
     } else {

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -579,6 +579,16 @@ fn create_output(
         }
     }
 
+    // Extra groups come from the project model, and -
+    // when the backend was handed a pre-built package - from its index.json.
+    let mut extra_dependencies =
+        convert_extra_depends(&index_json.experimental_extra_depends);
+    for (group, specs) in
+        extract_extra_dependencies(&project_model.targets, params.host_platform, &variant)
+    {
+        extra_dependencies.entry(group).or_default().extend(specs);
+    }
+
     CondaOutput {
         build_dependencies: Some(extract_dependencies(
             &project_model.targets,
@@ -588,7 +598,7 @@ fn create_output(
         )),
         host_dependencies: Some(host_deps),
         run_dependencies,
-        extra_dependencies: convert_extra_depends(&index_json.experimental_extra_depends),
+        extra_dependencies,
         metadata: CondaOutputMetadata {
             name: project_model
                 .name
@@ -628,7 +638,25 @@ fn extract_dependencies<F: Fn(&Target) -> Option<&OrderMap<SourcePackageName, Pa
     platform: Platform,
     variant: &BTreeMap<String, VariantValue>,
 ) -> CondaOutputDependencies {
-    let depends = targets
+    let depends = applicable_targets(targets, platform)
+        .into_iter()
+        .flat_map(|target| extract(target).into_iter().flat_map(OrderMap::iter))
+        .map(|(name, spec)| NamedSpec {
+            name: name.clone(),
+            spec: resolve_dependency_spec(name, spec, variant),
+        })
+        .collect();
+
+    CondaOutputDependencies {
+        depends,
+        constraints: Vec::new(),
+    }
+}
+
+/// Returns the default target plus any platform-specific targets whose selector
+/// matches `platform`.
+fn applicable_targets(targets: &Option<Targets>, platform: Platform) -> Vec<&Target> {
+    targets
         .iter()
         .flat_map(|targets| {
             targets
@@ -639,46 +667,64 @@ fn extract_dependencies<F: Fn(&Target) -> Option<&OrderMap<SourcePackageName, Pa
                         .targets
                         .iter()
                         .flatten()
-                        .flat_map(|(selector, target)| {
+                        .flat_map(move |(selector, target)| {
                             matches_target_selector(selector, platform).then_some(target)
                         }),
                 )
-                .flat_map(|target| extract(target).into_iter().flat_map(OrderMap::iter))
-                .map(|(name, spec)| {
-                    // If this is a star dependency and we have a variant for it, replace the spec
-                    let resolved_spec = if is_star_requirement(spec) {
-                        if let Some(variant_value) = variant.get(name.as_str()) {
-                            // Replace with a version spec using the variant value
-                            BinaryPackageSpec {
-                                version: Some(
-                                    rattler_conda_types::VersionSpec::from_str(
-                                        variant_value.to_string().as_str(),
-                                        rattler_conda_types::ParseStrictness::Lenient,
-                                    )
-                                    .unwrap(),
-                                ),
-                                ..Default::default()
-                            }
-                            .into()
-                        } else {
-                            spec.clone()
-                        }
-                    } else {
-                        spec.clone()
-                    };
-
-                    NamedSpec {
-                        name: name.clone(),
-                        spec: resolved_spec,
-                    }
-                })
         })
-        .collect();
+        .collect()
+}
 
-    CondaOutputDependencies {
-        depends,
-        constraints: Vec::new(),
+/// Resolves a single dependency spec, substituting the variant value when the
+/// spec is a bare star requirement and a matching variant exists.
+fn resolve_dependency_spec(
+    name: &SourcePackageName,
+    spec: &PackageSpec,
+    variant: &BTreeMap<String, VariantValue>,
+) -> PackageSpec {
+    if is_star_requirement(spec)
+        && let Some(variant_value) = variant.get(name.as_str())
+    {
+        return BinaryPackageSpec {
+            version: Some(
+                rattler_conda_types::VersionSpec::from_str(
+                    variant_value.to_string().as_str(),
+                    rattler_conda_types::ParseStrictness::Lenient,
+                )
+                .unwrap(),
+            ),
+            ..Default::default()
+        }
+        .into();
     }
+
+    spec.clone()
+}
+
+/// Extracts the extra groups declared by the project
+/// model for the given platform, mirroring how `extract_dependencies` walks
+/// targets. Groups declared across multiple matching targets are merged.
+fn extract_extra_dependencies(
+    targets: &Option<Targets>,
+    platform: Platform,
+    variant: &BTreeMap<String, VariantValue>,
+) -> BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> {
+    let mut result: BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> = BTreeMap::new();
+    for target in applicable_targets(targets, platform) {
+        let Some(extras) = target.extra_dependencies.as_ref() else {
+            continue;
+        };
+        for (group, deps) in extras {
+            let entry = result.entry(group.clone()).or_default();
+            for (name, spec) in deps {
+                entry.push(NamedSpec {
+                    name: name.clone(),
+                    spec: resolve_dependency_spec(name, spec, variant),
+                });
+            }
+        }
+    }
+    result
 }
 
 /// Resolves a run_export spec string (like "sdl2 *") by substituting variant values.

--- a/crates/pixi_build_discovery/src/discovery.rs
+++ b/crates/pixi_build_discovery/src/discovery.rs
@@ -16,7 +16,7 @@ use pixi_manifest::{
     DiscoveryStart, ExplicitManifestError, PackageManifest, PrioritizedChannel, WithProvenance,
     WorkspaceDiscoverer, WorkspaceDiscoveryError, WorkspaceManifest,
 };
-use pixi_spec::{SourceLocationSpec, SpecConversionError};
+use pixi_spec::{SourceSpec, SpecConversionError};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::ChannelConfig;
 use thiserror::Error;
@@ -48,7 +48,7 @@ pub struct BackendInitializationParams {
     pub workspace_root: PathBuf,
 
     /// The location of the source code.
-    pub build_source: Option<SourceLocationSpec>,
+    pub build_source: Option<SourceSpec>,
 
     /// The anchor for relative paths to the location of the source code.
     pub source_anchor: PathBuf,

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@inherit__nested.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@inherit__nested.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_build_discovery/tests/discovery.rs
+assertion_line: 81
 expression: backend
 input_file: tests/data/discovery/inherit/nested/TEST-CASE
 ---

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@nested__nested.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@nested__nested.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_build_discovery/tests/discovery.rs
+assertion_line: 81
 expression: backend
 input_file: tests/data/discovery/nested/nested/TEST-CASE
 ---

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@simple.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@simple.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_build_discovery/tests/discovery.rs
+assertion_line: 81
 expression: backend
 input_file: tests/data/discovery/simple/TEST-CASE
 ---

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -12,7 +12,7 @@ use ordermap::OrderMap;
 use pixi_build_types::{self as pbt};
 
 use pixi_manifest::{PackageManifest, PackageTarget, TargetSelector, Targets};
-use pixi_spec::{GitReference, PixiSpec, SourceSpec, SpecConversionError};
+use pixi_spec::{GitReference, MatchspecFields, PixiSpec, SourceSpec, SpecConversionError};
 use rattler_conda_types::{ChannelConfig, NamelessMatchSpec, PackageName};
 
 /// Conversion from a `PixiSpec` to a `pbt::PixiSpecV1`.
@@ -25,32 +25,31 @@ fn to_pixi_spec_v1(
     // Convert into correct type for pixi
     let pbt_spec = match source_or_binary {
         itertools::Either::Left(source) => {
-            let SourceSpec {
-                location,
+            let MatchspecFields {
                 version,
                 build,
                 build_number,
                 extras: None,
                 flags: None,
                 subdir,
-                namespace: None,
                 license,
                 license_family: None,
                 condition: None,
                 track_features: None,
-            } = source
+            } = source.matchspec().clone()
             else {
                 unimplemented!(
                     "a particular field is not implemented in the pixi to pbt conversion"
                 );
             };
-            let location = match location {
-                pixi_spec::SourceLocationSpec::Url(url_source_spec) => {
+            let location = match source {
+                SourceSpec::Url(url_source_spec) => {
                     let pixi_spec::UrlSourceSpec {
                         url,
                         md5,
                         sha256,
                         subdirectory,
+                        matchspec: _,
                     } = url_source_spec;
                     pbt::SourcePackageLocationSpec::Url(pbt::UrlSpec {
                         url,
@@ -59,11 +58,12 @@ fn to_pixi_spec_v1(
                         subdirectory: subdirectory.to_option_string(),
                     })
                 }
-                pixi_spec::SourceLocationSpec::Git(git_spec) => {
+                SourceSpec::Git(git_spec) => {
                     let pixi_spec::GitSpec {
                         git,
                         rev,
                         subdirectory,
+                        matchspec: _,
                     } = git_spec;
                     pbt::SourcePackageLocationSpec::Git(pbt::GitSpec {
                         git,
@@ -76,7 +76,7 @@ fn to_pixi_spec_v1(
                         subdirectory: subdirectory.to_option_string(),
                     })
                 }
-                pixi_spec::SourceLocationSpec::Path(path_source_spec) => {
+                SourceSpec::Path(path_source_spec) => {
                     pbt::SourcePackageLocationSpec::Path(pbt::PathSpec {
                         path: path_source_spec.path.to_string(),
                     })
@@ -408,8 +408,7 @@ mod tests {
 
         let mut package_target = PackageTarget::default();
         let constrained = PackageName::from_str("constrained").unwrap();
-        let spec =
-            PixiSpec::Version(VersionSpec::from_str(">=1.0", ParseStrictness::Strict).unwrap());
+        let spec = PixiSpec::from(VersionSpec::from_str(">=1.0", ParseStrictness::Strict).unwrap());
         package_target
             .try_add_dependency(
                 &constrained,

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -95,17 +95,16 @@ impl GlobalSpecs {
         project: &pixi_global::Project,
     ) -> Result<Vec<pixi_global::project::GlobalSpec>, GlobalSpecsConversionError> {
         let git_or_path_spec = if let Some(git_url) = &self.git {
-            let git_spec = pixi_spec::GitSpec {
-                git: git_url.clone(),
-                rev: self.rev.clone().map(Into::into),
-                subdirectory: self
-                    .subdir
+            let git_spec = pixi_spec::GitSpec::new(
+                git_url.clone(),
+                self.rev.clone().map(Into::into),
+                self.subdir
                     .clone()
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
-            };
-            Some(PixiSpec::Git(git_spec))
+            );
+            Some(PixiSpec::from(git_spec))
         } else if let Some(path) = &self.path {
             let absolute_path = dunce::canonicalize(path.as_str())
                 .map_err(|_| GlobalSpecsConversionError::AbsolutizePath(path.to_string()))?;
@@ -159,10 +158,10 @@ impl GlobalSpecs {
                         manifest_root.to_string_lossy().to_string(),
                     )
                 })?;
-            Some(PixiSpec::Path(pixi_spec::PathSpec {
-                path: Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
+            Some(PixiSpec::from(pixi_spec::PathSpec::new(
+                Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
                     .to_typed_path_buf(),
-            }))
+            )))
         } else {
             fn pathlike(s: &str) -> bool {
                 s.contains(".conda") || s.contains('/') || s.contains('\\')
@@ -315,8 +314,8 @@ mod tests {
                 assert_eq!(global_specs.len(), 1);
                 let installed_spec = &global_specs[0];
 
-                let PixiSpec::Path(path_spec) = &installed_spec.spec else {
-                    panic!("expected path spec");
+                let PixiSpec::PathBinary(path_spec) = &installed_spec.spec else {
+                    panic!("expected binary path spec");
                 };
 
                 let resolved_path = path_spec

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -31,7 +31,7 @@ use pixi_path::AbsPathBuf;
 use pixi_progress::global_multi_progress;
 use pixi_record::{PinnedPathSpec, PinnedSourceSpec};
 use pixi_reporters::TopLevelProgress;
-use pixi_spec::SourceLocationSpec;
+use pixi_spec::SourceSpec;
 use pixi_utils::variants::{VariantConfig, VariantValue};
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_networking::{AuthenticationStorage, s3_middleware};
@@ -711,7 +711,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Pre-resolve a SourceRecord per unique package name via RSP; each
     // returned variant becomes a separate SourceBuildKey invocation.
     let unique_names: BTreeSet<_> = packages.iter().map(|p| p.metadata.name.clone()).collect();
-    let source_location: SourceLocationSpec = manifest_source.clone().into();
+    let source_location: SourceSpec = manifest_source.clone().into();
     let mut resolved_records = Vec::new();
     for name in unique_names {
         let rsp = ResolveSourcePackageSpec {

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -404,8 +404,13 @@ pub fn parse_specs_for_platform(
         })
         // Only upgrade version specs
         .filter_map(|(name, req)| match req {
-            PixiSpec::DetailedVersion(version_spec) => {
-                let mut nameless_match_spec = version_spec
+            PixiSpec::Version(_) => {
+                // A bare version spec carries no extra selectors, so upgrading
+                // means dropping the constraint entirely.
+                Some((name.clone(), (MatchSpec::from(name), spec_type)))
+            }
+            PixiSpec::Detailed(detailed) => {
+                let mut nameless_match_spec = detailed
                     .try_into_nameless_match_spec(&workspace.workspace().channel_config())
                     .ok()?;
                 // If it is a detailed spec, always unset version
@@ -441,7 +446,6 @@ pub fn parse_specs_for_platform(
                     ),
                 ))
             }
-            PixiSpec::Version(_) => Some((name.clone(), (MatchSpec::from(name), spec_type))),
             _ => {
                 tracing::debug!("skipping non-version spec {:?}", req);
                 None

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -1,8 +1,13 @@
 use pixi_build_types::{BinaryPackageSpec, SourcePackageLocationSpec, SourcePackageSpec};
-use pixi_spec::{BinarySpec, DetailedSpec, UrlBinarySpec};
+use pixi_spec::{BinarySpec, DetailedSpec, MatchspecFields, UrlBinarySpec};
 use rattler_conda_types::NamedChannelOrUrl;
 
 /// Converts a [`SourcePackageSpec`] to a [`pixi_spec::SourceSpec`].
+///
+/// The [`SourcePackageSpec`] carries match-spec selectors (`version`, `build`,
+/// `build_number`, `subdir`, `license`) alongside the source location. After
+/// the six-variant `PixiSpec` refactor those selectors live in
+/// [`MatchspecFields`] on the inner source-location variant.
 pub fn from_source_spec_v1(source: SourcePackageSpec) -> pixi_spec::SourceSpec {
     let SourcePackageSpec {
         location,
@@ -12,29 +17,23 @@ pub fn from_source_spec_v1(source: SourcePackageSpec) -> pixi_spec::SourceSpec {
         subdir,
         license,
     } = source;
-    let location = from_source_package_location_spec(location);
-    pixi_spec::SourceSpec {
-        location,
+    let matchspec = MatchspecFields {
         version,
         build,
         build_number,
         subdir,
         license,
-        extras: None,
-        flags: None,
-        namespace: None,
-        license_family: None,
-        condition: None,
-        track_features: None,
-    }
+        ..MatchspecFields::default()
+    };
+    let mut location = from_source_package_location_spec(location);
+    *location.matchspec_mut() = matchspec;
+    location
 }
 
-pub fn from_source_package_location_spec(
-    spec: SourcePackageLocationSpec,
-) -> pixi_spec::SourceLocationSpec {
+pub fn from_source_package_location_spec(spec: SourcePackageLocationSpec) -> pixi_spec::SourceSpec {
     match spec {
         SourcePackageLocationSpec::Url(url) => {
-            pixi_spec::SourceLocationSpec::Url(pixi_spec::UrlSourceSpec {
+            pixi_spec::SourceSpec::Url(pixi_spec::UrlSourceSpec {
                 url: url.url,
                 md5: url.md5,
                 sha256: url.sha256,
@@ -42,36 +41,35 @@ pub fn from_source_package_location_spec(
                     .subdirectory
                     .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
                     .unwrap_or_default(),
+                matchspec: MatchspecFields::default(),
             })
         }
 
-        SourcePackageLocationSpec::Git(git) => {
-            pixi_spec::SourceLocationSpec::Git(pixi_spec::GitSpec {
-                git: git.git,
-                rev: git.rev.map(|r| match r {
-                    pixi_build_frontend::types::GitReference::Branch(b) => {
-                        pixi_spec::GitReference::Branch(b)
-                    }
-                    pixi_build_frontend::types::GitReference::Tag(t) => {
-                        pixi_spec::GitReference::Tag(t)
-                    }
-                    pixi_build_frontend::types::GitReference::Rev(rev) => {
-                        pixi_spec::GitReference::Rev(rev)
-                    }
-                    pixi_build_frontend::types::GitReference::DefaultBranch => {
-                        pixi_spec::GitReference::DefaultBranch
-                    }
-                }),
-                subdirectory: git
-                    .subdirectory
-                    .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
-                    .unwrap_or_default(),
-            })
-        }
+        SourcePackageLocationSpec::Git(git) => pixi_spec::SourceSpec::Git(pixi_spec::GitSpec {
+            git: git.git,
+            rev: git.rev.map(|r| match r {
+                pixi_build_frontend::types::GitReference::Branch(b) => {
+                    pixi_spec::GitReference::Branch(b)
+                }
+                pixi_build_frontend::types::GitReference::Tag(t) => pixi_spec::GitReference::Tag(t),
+                pixi_build_frontend::types::GitReference::Rev(rev) => {
+                    pixi_spec::GitReference::Rev(rev)
+                }
+                pixi_build_frontend::types::GitReference::DefaultBranch => {
+                    pixi_spec::GitReference::DefaultBranch
+                }
+            }),
+            subdirectory: git
+                .subdirectory
+                .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
+                .unwrap_or_default(),
+            matchspec: MatchspecFields::default(),
+        }),
 
         SourcePackageLocationSpec::Path(path) => {
-            pixi_spec::SourceLocationSpec::Path(pixi_spec::PathSourceSpec {
+            pixi_spec::SourceSpec::Path(pixi_spec::PathSourceSpec {
                 path: path.path.into(),
+                matchspec: MatchspecFields::default(),
             })
         }
     }

--- a/crates/pixi_command_dispatcher/src/build/pin_compatible.rs
+++ b/crates/pixi_command_dispatcher/src/build/pin_compatible.rs
@@ -118,10 +118,10 @@ mod tests {
 
         let result =
             resolve_pin_compatible(&PackageName::new_unchecked("python"), &spec, &map).unwrap();
-        let PixiSpec::Version(vs) = result else {
-            panic!("expected Version");
+        let PixiSpec::Detailed(d) = result else {
+            panic!("expected Detailed");
         };
-        assert_eq!(vs.to_string(), ">=3.11,<3.12.0a0");
+        assert_eq!(d.version.as_ref().unwrap().to_string(), ">=3.11,<3.12.0a0");
     }
 
     #[test]

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -3,7 +3,7 @@ use miette::Diagnostic;
 use once_cell::sync::Lazy;
 use pixi_build_types::procedures::conda_outputs::CondaOutputsParams;
 use pixi_record::{CanonicalSourceLocation, PinnedBuildSourceSpec, PinnedSourceSpec, VariantValue};
-use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceLocationSpec};
+use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceSpec};
 use rattler_conda_types::ChannelUrl;
 use std::time::SystemTime;
 use std::{
@@ -732,13 +732,12 @@ impl BuildBackendMetadataInner {
             .map_err(BuildBackendMetadataError::Discovery)?;
 
         let manifest_source_anchor =
-            SourceAnchor::from(SourceLocationSpec::from(self.manifest_source.clone()));
+            SourceAnchor::from(SourceSpec::from(self.manifest_source.clone()));
 
         let build_source_checkout_and_spec = match &discovered_backend.init_params.build_source {
             None => None,
             Some(build_source) => {
-                let relative_build_source_spec = if let SourceLocationSpec::Path(path) =
-                    build_source
+                let relative_build_source_spec = if let SourceSpec::Path(path) = build_source
                     && path.path.is_relative()
                 {
                     Some(normalize_typed(path.path.to_path()).to_string())

--- a/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use pixi_build_types::{ConstraintSpec, PackageSpec};
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_record::{DevSourceRecord, PinnedSourceSpec};
-use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceLocationSpec};
+use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceSpec};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::PackageName;
 use thiserror::Error;
@@ -156,7 +156,7 @@ impl Key for DevSourceMetadataKey {
             .map_err(|e| DevSourceMetadataError::BuildBackendMetadata(Box::new(e)))?;
 
         // Create a SourceAnchor for resolving relative paths in dependencies.
-        let source_anchor = SourceAnchor::from(SourceLocationSpec::from(
+        let source_anchor = SourceAnchor::from(SourceSpec::from(
             build_backend_metadata.source.manifest_source().clone(),
         ));
 

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -2,7 +2,7 @@ use std::{borrow::Borrow, collections::BTreeMap, path::PathBuf, sync::Arc};
 
 use miette::Diagnostic;
 use pixi_record::VariantValue;
-use pixi_spec::{SourceLocationSpec, SpecConversionError};
+use pixi_spec::{SourceSpec, SpecConversionError};
 use rattler_conda_types::{
     ChannelUrl, ConvertSubdirError, InvalidPackageNameError, PackageName, ParseChannelError,
 };
@@ -172,8 +172,8 @@ pub enum SourceRecordError {
     )]
     DuplicateSourceDependency {
         package: PackageName,
-        source1: Box<SourceLocationSpec>,
-        source2: Box<SourceLocationSpec>,
+        source1: Box<SourceSpec>,
+        source2: Box<SourceSpec>,
     },
 
     #[error("the dependencies of some packages in the environment form a cycle")]

--- a/crates/pixi_command_dispatcher/src/installed_source_hints.rs
+++ b/crates/pixi_command_dispatcher/src/installed_source_hints.rs
@@ -13,7 +13,7 @@
 //! the same package.
 //!
 //! [`InstalledSourceHints`] flattens the tree once at the top and keys
-//! hints on `(PackageName, SourceLocationSpec)`. The same `Arc` of this
+//! hints on `(PackageName, SourceSpec)`. The same `Arc` of this
 //! type flows unchanged through every nested SPEK, so every layer of the
 //! walk looks up the same canonical hint for a given package.
 //!
@@ -45,7 +45,7 @@ use std::{
 use pixi_record::{
     PinnedBuildSourceSpec, PinnedSourceSpec, UnresolvedPixiRecord, UnresolvedSourceRecord,
 };
-use pixi_spec::SourceLocationSpec;
+use pixi_spec::SourceSpec;
 use rattler_conda_types::PackageName;
 
 use crate::PtrArc;
@@ -53,10 +53,10 @@ use crate::PtrArc;
 /// Flattened + canonicalized source-record hints for a pixi solve.
 #[derive(Debug, Default, Clone)]
 pub struct InstalledSourceHints {
-    by_key: HashMap<(PackageName, SourceLocationSpec), InstalledSourceHint>,
+    by_key: HashMap<(PackageName, SourceSpec), InstalledSourceHint>,
 }
 
-/// The canonical install hint for one `(PackageName, SourceLocationSpec)`
+/// The canonical install hint for one `(PackageName, SourceSpec)`
 /// pair: which pin represents it in this environment, and which build /
 /// host package sets to seed the nested solves with.
 ///
@@ -84,8 +84,9 @@ impl InstalledSourceHints {
     /// Walk `installed` recursively, collapsing duplicates by
     /// `(name, source_location)` and picking a canonical representative
     /// per group.
+    #[allow(clippy::mutable_key_type)]
     pub fn from_records(installed: &[UnresolvedPixiRecord]) -> Self {
-        let mut candidates: HashMap<(PackageName, SourceLocationSpec), Vec<InstalledSourceHint>> =
+        let mut candidates: HashMap<(PackageName, SourceSpec), Vec<InstalledSourceHint>> =
             HashMap::new();
         // Memoize by Arc pointer identity so a source record reached
         // through multiple parents is descended into once. Without this
@@ -106,18 +107,14 @@ impl InstalledSourceHints {
         Self { by_key }
     }
 
-    pub fn get(
-        &self,
-        name: &PackageName,
-        location: &SourceLocationSpec,
-    ) -> Option<&InstalledSourceHint> {
+    pub fn get(&self, name: &PackageName, location: &SourceSpec) -> Option<&InstalledSourceHint> {
         self.by_key.get(&(name.clone(), location.clone()))
     }
 
     /// Find a hint that matches `(name, location)` where `location` may be
     /// unpinned (e.g. `git+url?rev=main` from a manifest). The hint key is
     /// stored using the locked `PinnedSourceSpec`'s
-    /// `SourceLocationSpec` projection (e.g. `git+url?rev=sha`), so a
+    /// `SourceSpec` projection (e.g. `git+url?rev=sha`), so a
     /// direct `get` only matches when the caller already has a pinned
     /// location. This method also accepts unpinned specs by checking
     /// [`PinnedSourceSpec::matches_source_spec`] against each name-matched
@@ -128,7 +125,7 @@ impl InstalledSourceHints {
     pub fn find_for_location(
         &self,
         name: &PackageName,
-        location: &SourceLocationSpec,
+        location: &SourceSpec,
     ) -> Option<&InstalledSourceHint> {
         if let Some(hint) = self.by_key.get(&(name.clone(), location.clone())) {
             return Some(hint);
@@ -155,9 +152,10 @@ impl Default for PtrArc<InstalledSourceHints> {
     }
 }
 
+#[allow(clippy::mutable_key_type)]
 fn collect(
     records: &[UnresolvedPixiRecord],
-    out: &mut HashMap<(PackageName, SourceLocationSpec), Vec<InstalledSourceHint>>,
+    out: &mut HashMap<(PackageName, SourceSpec), Vec<InstalledSourceHint>>,
     visited: &mut HashSet<*const UnresolvedSourceRecord>,
 ) {
     for record in records {
@@ -166,7 +164,7 @@ fn collect(
         };
         let key = (
             source.name().clone(),
-            SourceLocationSpec::from(source.manifest_source.clone()),
+            SourceSpec::from(source.manifest_source.clone()),
         );
         out.entry(key).or_default().push(InstalledSourceHint {
             manifest_source: source.manifest_source.clone(),
@@ -221,13 +219,13 @@ mod tests {
     use std::sync::Arc;
 
     use pixi_record::{PartialSourceRecordData, SourceRecordData, UnresolvedSourceRecord};
-    use pixi_spec::{PathSourceSpec, SourceLocationSpec};
+    use pixi_spec::{PathSourceSpec, SourceSpec};
     use rattler_conda_types::PackageName;
 
     use super::*;
 
-    fn path_location(path: &str) -> SourceLocationSpec {
-        SourceLocationSpec::Path(PathSourceSpec { path: path.into() })
+    fn path_location(path: &str) -> SourceSpec {
+        SourceSpec::Path(PathSourceSpec::new(path))
     }
 
     fn make_source(
@@ -336,7 +334,7 @@ mod tests {
     fn nested_same_name_different_location_produces_both_hints() {
         // Test 2's shape at the type level: top-level `foo` from one
         // path and a nested `foo` reached through a different path
-        // land as two distinct hints (distinct `SourceLocationSpec`).
+        // land as two distinct hints (distinct `SourceSpec`).
         let nested = make_source("foo", "./nested-foo", Vec::new(), Vec::new());
         let outer = make_source("bar", "./bar", Vec::new(), vec![nested]);
         let top_level_foo = make_source("foo", "./foo", Vec::new(), Vec::new());
@@ -382,13 +380,13 @@ mod tests {
         }))
     }
 
-    fn unpinned_git_location(url: &str) -> SourceLocationSpec {
+    fn unpinned_git_location(url: &str) -> SourceSpec {
         use pixi_spec::{GitReference, GitSpec};
-        SourceLocationSpec::Git(GitSpec {
-            git: url::Url::parse(url).expect("valid git url"),
-            rev: Some(GitReference::Branch("main".into())),
-            subdirectory: Default::default(),
-        })
+        SourceSpec::Git(GitSpec::new(
+            url::Url::parse(url).expect("valid git url"),
+            Some(GitReference::Branch("main".into())),
+            Default::default(),
+        ))
     }
 
     #[test]

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
@@ -12,7 +12,7 @@ use pixi_build_types::procedures::conda_outputs::CondaOutput;
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_compute_reporters::OperationId;
 use pixi_record::{PinnedSourceSpec, SourceRecord};
-use pixi_spec::SourceLocationSpec;
+use pixi_spec::SourceSpec;
 use rattler_conda_types::PackageName;
 use tracing::instrument;
 
@@ -39,13 +39,13 @@ use pixi_compute_sources::SourceCheckoutExt;
 pub struct ResolveSourcePackageSpec {
     pub package: PackageName,
     /// Unpinned; SMK pins it.
-    pub source_location: SourceLocationSpec,
+    pub source_location: SourceSpec,
     pub preferred_build_source: Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     pub env_ref: EnvironmentRef,
     /// Source-record hints inherited from the enclosing SPEK; forwarded
     /// verbatim into nested build/host solves so every layer of the
     /// recursion agrees on one canonical hint per
-    /// `(PackageName, SourceLocationSpec)`. The hint matching
+    /// `(PackageName, SourceSpec)`. The hint matching
     /// `(package, source_location)` seeds this RSP's nested build / host
     /// solves with the previous resolution's `build_packages` /
     /// `host_packages`; all other hints flow through for deeper layers.

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -17,7 +17,7 @@ use pixi_compute_reporters::OperationId;
 use pixi_record::{
     FullSourceRecordData, PinnedSourceSpec, PixiRecord, SourceRecord, UnresolvedPixiRecord,
 };
-use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceLocationSpec};
+use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_variant::VariantValue;
 use rattler_conda_types::{PackageName, PackageRecord, package::RunExportsJson};
@@ -113,7 +113,7 @@ async fn assemble_source_record_inner(
     env_ref: &EnvironmentRef,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
 ) -> Result<Arc<SourceRecord>, SourceRecordError> {
-    let source_location = SourceLocationSpec::from(source.manifest_source().clone());
+    let source_location = SourceSpec::from(source.manifest_source().clone());
     let source_anchor = SourceAnchor::from(source_location.clone());
     let channel_config = ctx.compute(&ChannelConfigKey).await;
     let pkg_name = output.metadata.name.clone();
@@ -225,7 +225,7 @@ async fn assemble_source_record_inner(
             output.metadata.subdir,
         );
 
-    let mut sources: HashMap<PackageName, SourceLocationSpec> = HashMap::new();
+    let mut sources: HashMap<PackageName, SourceSpec> = HashMap::new();
 
     // Record a source-typed PixiSpec's location into `sources`, erroring
     // if the same (name, location) is registered twice.
@@ -233,16 +233,16 @@ async fn assemble_source_record_inner(
         if let Either::Left(source) = spec.clone().into_source_or_binary() {
             match sources.entry(name.clone()) {
                 std::collections::hash_map::Entry::Occupied(entry) => {
-                    if entry.get() == &source.location {
+                    if entry.get() == &source {
                         return Err(SourceRecordError::DuplicateSourceDependency {
                             package: name.clone(),
                             source1: Box::new(entry.get().clone()),
-                            source2: Box::new(source.location.clone()),
+                            source2: Box::new(source.clone()),
                         });
                     }
                 }
                 std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(source.location.clone());
+                    entry.insert(source.clone());
                 }
             }
         }
@@ -374,7 +374,7 @@ async fn assemble_source_record_inner(
         flags: output.metadata.flags.clone(),
     };
 
-    let sources_by_str: BTreeMap<String, SourceLocationSpec> = sources
+    let sources_by_str: BTreeMap<String, SourceSpec> = sources
         .into_iter()
         .map(|(name, source)| (name.as_source().to_string(), source))
         .collect();

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -23,8 +23,7 @@ use pixi_compute_engine::{ComputeCtx, Demand, Key, ParallelBuilder};
 use pixi_compute_reporters::OperationId;
 use pixi_record::{DevSourceRecord, PinnedSourceSpec, PixiRecord, UnresolvedPixiRecord};
 use pixi_spec::{
-    BinarySpec, DevSourceSpec, PixiSpec, ResolvedExcludeNewer, SourceAnchor, SourceLocationSpec,
-    SourceSpec,
+    BinarySpec, DevSourceSpec, PixiSpec, ResolvedExcludeNewer, SourceAnchor, SourceSpec,
 };
 use pixi_spec_containers::DependencyMap;
 use pixi_variant::VariantValue;
@@ -103,7 +102,7 @@ pub struct SolvePixiEnvironmentSpec {
     /// hints. Built once at the top-level caller via
     /// [`InstalledSourceHints::from_records`] and propagated unchanged
     /// through nested solves so every layer of the recursion agrees on
-    /// one canonical hint per `(PackageName, SourceLocationSpec)`.
+    /// one canonical hint per `(PackageName, SourceSpec)`.
     ///
     /// [`PtrArc`] (pointer-identity `Hash`/`Eq`) because the map flows
     /// verbatim through the recursive solve; callers that share the
@@ -316,7 +315,7 @@ async fn compute_inner(
         .collect();
 
     // Source-record hints for this solve. Keyed on
-    // `(PackageName, SourceLocationSpec)`; the same `Arc` flows
+    // `(PackageName, SourceSpec)`; the same `Arc` flows
     // through every nested solve so a given source package gets the
     // same hint regardless of which branch of the recursion reached
     // it.
@@ -442,6 +441,7 @@ async fn compute_inner(
 /// the seeds. Binary match specs are NOT collected here; they're
 /// derived downstream inside [`SolveCondaKey`] from the same
 /// assembled records (see `derive_fetch_specs_from_source_repodata`).
+#[allow(clippy::mutable_key_type)]
 async fn walk_and_resolve(
     ctx: &mut ComputeCtx,
     seeds: Vec<(PackageName, SourceSpec)>,
@@ -450,7 +450,7 @@ async fn walk_and_resolve(
     installed_source_hints: &PtrArc<InstalledSourceHints>,
 ) -> Result<Vec<Arc<pixi_record::SourceRecord>>, SolvePixiEnvironmentError> {
     let mut all_records: Vec<Arc<pixi_record::SourceRecord>> = Vec::new();
-    let mut seen_sources: HashSet<(PackageName, SourceLocationSpec)> = HashSet::new();
+    let mut seen_sources: HashSet<(PackageName, SourceSpec)> = HashSet::new();
 
     // Fallback cycle frame used when a pushed RSP's guard fires but
     // the engine's cycle ring carried no RSP frames (e.g. the cycle
@@ -469,9 +469,9 @@ async fn walk_and_resolve(
     // cannot preserve across completed peers.
     let push = |p: &mut ParallelBuilder<'_>,
                 pending: &mut FuturesUnordered<_>,
-                seen: &mut HashSet<(PackageName, SourceLocationSpec)>,
+                seen: &mut HashSet<(PackageName, SourceSpec)>,
                 name: PackageName,
-                location: SourceLocationSpec,
+                location: SourceSpec,
                 parent: Option<PackageName>| {
         if !seen.insert((name.clone(), location.clone())) {
             return;
@@ -530,14 +530,7 @@ async fn walk_and_resolve(
     };
 
     for (name, spec) in seeds {
-        push(
-            &mut p,
-            &mut pending,
-            &mut seen_sources,
-            name,
-            spec.location,
-            None,
-        );
+        push(&mut p, &mut pending, &mut seen_sources, name, spec, None);
     }
 
     while let Some(result) = pending.next().await {
@@ -547,9 +540,14 @@ async fn walk_and_resolve(
         // for source refs and queue newly-seen pairs, tagging each
         // with the parent package that pulled it in.
         for record in records.iter() {
-            let anchor =
-                SourceAnchor::from(SourceLocationSpec::from(record.manifest_source().clone()));
-            for depend_str in &record.package_record().depends {
+            let anchor = SourceAnchor::from(SourceSpec::from(record.manifest_source().clone()));
+            for depend_str in record.package_record().depends.iter().chain(
+                record
+                    .package_record()
+                    .experimental_extra_depends
+                    .values()
+                    .flatten(),
+            ) {
                 let Ok(match_spec) = MatchSpec::from_str(
                     depend_str,
                     ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3),
@@ -596,7 +594,7 @@ async fn process_dev_sources(
             let name = name.clone();
             let env_ref = spec.env_ref.clone();
             let preferred_build_source = spec.preferred_build_source.get(&name).cloned();
-            let fut = ctx.pin_and_checkout(dev_spec.source.location.clone());
+            let fut = ctx.pin_and_checkout(dev_spec.source.clone());
             async move {
                 let checkout = fut
                     .await

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -15,7 +15,7 @@ use pixi_build_types::procedures::{
 };
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_record::{PixiRecord, UnresolvedPixiRecord, UnresolvedSourceRecord, VariantValue};
-use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceLocationSpec};
+use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceSpec};
 use pixi_variant::VariantSelector;
 use rattler_conda_types::{
     ChannelUrl, PackageRecord, RepoDataRecord, package::DistArchiveIdentifier, prefix::Prefix,
@@ -164,7 +164,7 @@ async fn compute_inner(
     // We need this identifier only to form the artifact cache key — on
     // a cache hit there's no further reason to talk to a backend, so
     // doing the spawn before the lookup is pure waste.
-    let manifest_anchor = SourceAnchor::from(SourceLocationSpec::from(manifest_source.clone()));
+    let manifest_anchor = SourceAnchor::from(SourceSpec::from(manifest_source.clone()));
     let build_source_dir = build_source_checkout
         .path
         .as_dir_or_file_parent()
@@ -307,7 +307,7 @@ async fn compute_inner(
     //   the env being defined)
     // - host deps see build records
     // - run deps (+ run_exports) see build + host records
-    let source_anchor = SourceAnchor::from(SourceLocationSpec::from(manifest_source.clone()));
+    let source_anchor = SourceAnchor::from(SourceSpec::from(manifest_source.clone()));
     let mut build_pixi_records: Vec<PixiRecord> = build_records
         .iter()
         .cloned()

--- a/crates/pixi_command_dispatcher/src/keys/source_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_metadata.rs
@@ -14,7 +14,7 @@ use derive_more::Display;
 use pixi_build_types::procedures::conda_outputs::CondaOutput;
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_record::{PinnedSourceSpec, SourceRecord};
-use pixi_spec::SourceLocationSpec;
+use pixi_spec::SourceSpec;
 use rattler_conda_types::PackageName;
 use tracing::instrument;
 
@@ -80,7 +80,7 @@ pub struct SourceMetadataSpec {
     pub package: PackageName,
     /// Unpinned source location; pinned inside the compute unless
     /// `manifest_pin_override` carries a compatible pin (see below).
-    pub source_location: SourceLocationSpec,
+    pub source_location: SourceSpec,
     /// Optional override for the package's build source.
     pub preferred_build_source: Option<PinnedSourceSpec>,
     /// Optional caller-supplied pin for the manifest source. When set

--- a/crates/pixi_command_dispatcher/src/reporter.rs
+++ b/crates/pixi_command_dispatcher/src/reporter.rs
@@ -171,9 +171,7 @@ pub trait BackendSourceBuildReporter: Send + Sync {
 pub(crate) fn has_direct_conda_dependency(
     dependencies: &pixi_spec_containers::DependencyMap<rattler_conda_types::PackageName, PixiSpec>,
 ) -> bool {
-    dependencies.iter_specs().any(|(_, spec)| match spec {
-        PixiSpec::Url(url) => url.is_binary(),
-        PixiSpec::Path(path) => path.is_binary(),
-        _ => false,
-    })
+    dependencies
+        .iter_specs()
+        .any(|(_, spec)| matches!(spec, PixiSpec::UrlBinary(_) | PixiSpec::PathBinary(_)))
 }

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -26,7 +26,7 @@ use pixi_spec_containers::DependencyMap;
 use pixi_test_utils::format_diagnostic;
 use pixi_utils::variants::VariantConfig;
 use rattler_conda_types::{
-    ChannelUrl, GenericVirtualPackage, PackageName, Platform, VersionSpec, prefix::Prefix,
+    ChannelUrl, GenericVirtualPackage, PackageName, Platform, prefix::Prefix,
 };
 use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
 use url::Url;
@@ -225,11 +225,11 @@ pub async fn simple_test() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "foobar-desktop".parse().unwrap(),
-                GitSpec {
-                    git: git_repo.url.parse().unwrap(),
-                    rev: Some(GitReference::Rev(git_repo.commits[0].clone())),
-                    subdirectory: Subdirectory::try_from("recipe").unwrap(),
-                }
+                GitSpec::new(
+                    git_repo.url.parse().unwrap(),
+                    Some(GitReference::Rev(git_repo.commits[0].clone())),
+                    Subdirectory::try_from("recipe").unwrap(),
+                )
                 .into(),
             )]),
             env_ref: env_ref_of(vec![channel_url.clone()], build_env.clone()),
@@ -305,7 +305,7 @@ pub async fn instantiate_backend_with_compatible_api_version() {
     dispatcher
         .instantiate_tool_environment(InstantiateToolEnvironmentSpec::new(
             backend_name,
-            PixiSpec::Version(VersionSpec::Any),
+            PixiSpec::any(),
             Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
         ))
         .await
@@ -330,7 +330,7 @@ pub async fn instantiate_backend_without_compatible_api_version() {
     let err = dispatcher
         .instantiate_tool_environment(InstantiateToolEnvironmentSpec::new(
             backend_name,
-            PixiSpec::Version(VersionSpec::Any),
+            PixiSpec::any(),
             Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
         ))
         .await
@@ -357,7 +357,7 @@ pub async fn instantiate_backend_with_compatible_api_version_respects_exclude_ne
     dispatcher
         .instantiate_tool_environment(InstantiateToolEnvironmentSpec::new(
             backend_name.clone(),
-            PixiSpec::Version(VersionSpec::Any),
+            PixiSpec::any(),
             Vec::from([Url::from_directory_path(channel_dir.clone())
                 .unwrap()
                 .into()]),
@@ -372,7 +372,7 @@ pub async fn instantiate_backend_with_compatible_api_version_respects_exclude_ne
             )),
             ..InstantiateToolEnvironmentSpec::new(
                 backend_name,
-                PixiSpec::Version(VersionSpec::Any),
+                PixiSpec::any(),
                 Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
             )
         })
@@ -412,7 +412,7 @@ pub async fn instantiate_backend_with_compatible_api_version_honors_exclude_newe
             ),
             ..InstantiateToolEnvironmentSpec::new(
                 backend_name,
-                PixiSpec::Version(VersionSpec::Any),
+                PixiSpec::any(),
                 Vec::from([channel_url]),
             )
         })
@@ -443,7 +443,7 @@ pub async fn instantiate_backend_without_compatible_api_version_cancels_duplicat
     // Build the spec once and issue two identical concurrent requests.
     let spec = InstantiateToolEnvironmentSpec::new(
         backend_name,
-        PixiSpec::Version(VersionSpec::Any),
+        PixiSpec::any(),
         Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
     );
 
@@ -511,7 +511,7 @@ pub async fn dropping_future_cancels_background_task() {
     // and the task would progress to installation if not cancelled.
     let spec = InstantiateToolEnvironmentSpec::new(
         PackageName::new_unchecked("backend-with-compatible-api-version"),
-        PixiSpec::Version(VersionSpec::Any),
+        PixiSpec::any(),
         Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
     );
 
@@ -2052,7 +2052,7 @@ pub async fn test_installed_pins_binary_version() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version(version),
+                PixiSpec::from(version),
             )]),
             installed: std::sync::Arc::from(installed),
             env_ref: env_ref.clone(),
@@ -2182,7 +2182,7 @@ pub async fn test_installed_host_packages_pin_nested_solve() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2337,7 +2337,7 @@ pub async fn test_installed_hint_reused_across_variants() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: binary_env_ref,
@@ -2448,7 +2448,7 @@ pub async fn test_duplicate_installed_source_hints_are_order_independent() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2466,7 +2466,7 @@ pub async fn test_duplicate_installed_source_hints_are_order_independent() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.2.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.2.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2632,7 +2632,7 @@ foo = { path = "../foo" }
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2650,7 +2650,7 @@ foo = { path = "../foo" }
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.2.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.2.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),

--- a/crates/pixi_compute_sources/src/ext.rs
+++ b/crates/pixi_compute_sources/src/ext.rs
@@ -5,12 +5,12 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use pixi_compute_engine::ComputeCtx;
 use pixi_record::{PinnedPathSpec, PinnedSourceSpec};
-use pixi_spec::{SourceLocationSpec, UrlSpec};
+use pixi_spec::{SourceSpec, UrlSpec};
 
 use crate::path::RootDirExt;
 use crate::{GitSourceCheckoutExt, SourceCheckout, SourceCheckoutError, UrlSourceCheckoutExt};
 
-/// Dispatch a checkout based on a [`SourceLocationSpec`] or a fully
+/// Dispatch a checkout based on a [`SourceSpec`] or a fully
 /// pinned [`PinnedSourceSpec`].
 pub trait SourceCheckoutExt {
     /// Resolve a source-location spec into a [`SourceCheckout`].
@@ -22,7 +22,7 @@ pub trait SourceCheckoutExt {
     /// - **URL** specs download and extract the archive.
     fn pin_and_checkout(
         &mut self,
-        source_location_spec: SourceLocationSpec,
+        source_location_spec: SourceSpec,
     ) -> impl Future<Output = Result<SourceCheckout, SourceCheckoutError>> + Send + use<Self>;
 
     /// Like [`Self::pin_and_checkout`] but for a fully-pinned spec
@@ -36,11 +36,11 @@ pub trait SourceCheckoutExt {
 impl SourceCheckoutExt for ComputeCtx {
     fn pin_and_checkout(
         &mut self,
-        source_location_spec: SourceLocationSpec,
+        source_location_spec: SourceSpec,
     ) -> impl Future<Output = Result<SourceCheckout, SourceCheckoutError>> + Send + use<> {
         let fut: BoxFuture<'static, Result<SourceCheckout, SourceCheckoutError>> =
             match source_location_spec {
-                SourceLocationSpec::Url(url) => self
+                SourceSpec::Url(url) => self
                     .pin_and_checkout_url(UrlSpec {
                         url: url.url,
                         md5: url.md5,
@@ -48,7 +48,7 @@ impl SourceCheckoutExt for ComputeCtx {
                         subdirectory: url.subdirectory,
                     })
                     .boxed(),
-                SourceLocationSpec::Path(path) => {
+                SourceSpec::Path(path) => {
                     let result = self.resolve_typed_path(path.path.to_path());
                     async move {
                         let resolved = result?;
@@ -65,7 +65,7 @@ impl SourceCheckoutExt for ComputeCtx {
                     }
                     .boxed()
                 }
-                SourceLocationSpec::Git(git_spec) => self.pin_and_checkout_git(git_spec).boxed(),
+                SourceSpec::Git(git_spec) => self.pin_and_checkout_git(git_spec).boxed(),
             };
         fut
     }

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -25,11 +25,7 @@ async fn pin_and_checkout_git_default_branch() {
         ..Default::default()
     });
 
-    let spec = GitSpec {
-        git: repo.base_url.clone(),
-        rev: None,
-        subdirectory: Subdirectory::default(),
-    };
+    let spec = GitSpec::new(repo.base_url.clone(), None, Subdirectory::default());
 
     let checkout = engine
         .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
@@ -72,11 +68,11 @@ async fn git_checkout_fires_full_reporter_lifecycle() {
 
     engine
         .with_ctx(async |ctx| {
-            ctx.pin_and_checkout_git(GitSpec {
-                git: repo.base_url.clone(),
-                rev: None,
-                subdirectory: Subdirectory::default(),
-            })
+            ctx.pin_and_checkout_git(GitSpec::new(
+                repo.base_url.clone(),
+                None,
+                Subdirectory::default(),
+            ))
             .await
         })
         .await

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -402,7 +402,7 @@ pub fn extract_git_requirements_from_workspace(project: &Workspace) -> Vec<GitSp
             for (_, dep_spec) in dependencies {
                 for spec in dep_spec {
                     if let PixiSpec::Git(spec) = spec {
-                        requirements.push(spec.clone());
+                        requirements.push(*spec);
                     }
                 }
             }

--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -597,6 +597,22 @@ pub enum PlatformUnsat {
     },
 
     #[error(
+        "the resolved extra group '{group}' of source package '{package}' no longer matches what the backend would re-derive from the manifest{added_msg}{removed_msg}",
+        added_msg = if added.is_empty() { String::new() } else { format!("; added: {}", added.join(", ")) },
+        removed_msg = if removed.is_empty() { String::new() } else { format!("; removed: {}", removed.join(", ")) },
+    )]
+    SourceExtraDependenciesChanged {
+        /// The source package whose extra group drifted.
+        package: String,
+        /// The extra group name.
+        group: String,
+        /// Specs the backend now declares that the locked group is missing.
+        added: Vec<String>,
+        /// Specs the locked group carries that the backend no longer declares.
+        removed: Vec<String>,
+    },
+
+    #[error(
         "the locked package build source for '{0}' does not match the requested build source, {1}"
     )]
     PackageBuildSourceMismatch(String, SourceMismatchError),

--- a/crates/pixi_core/src/lock_file/satisfiability/legacy/key.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/legacy/key.rs
@@ -12,7 +12,7 @@ use pixi_command_dispatcher::{
     keys::{ResolveSourcePackageKey, ResolveSourcePackageSpec},
 };
 use pixi_record::{PinnedBuildSourceSpec, PinnedSourceSpec, UnresolvedPixiRecord, VariantValue};
-use pixi_spec::SourceLocationSpec;
+use pixi_spec::SourceSpec;
 use rattler_conda_types::PackageName;
 use thiserror::Error;
 use tracing::instrument;
@@ -161,7 +161,7 @@ impl Key for LegacySourceEnvKey {
         let variants = ctx
             .compute(&ResolveSourcePackageKey::new(ResolveSourcePackageSpec {
                 package: self.package.clone(),
-                source_location: SourceLocationSpec::from(self.manifest_source.clone()),
+                source_location: SourceSpec::from(self.manifest_source.clone()),
                 preferred_build_source: self.preferred_build_source.clone(),
                 env_ref: self.env_ref.clone(),
                 installed_source_hints: self.installed_source_hints.clone(),

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -21,7 +21,7 @@ use pixi_manifest::{EnvironmentName, FeaturesExt};
 use pixi_record::{
     DevSourceRecord, LockFileResolver, PixiRecord, SourceRecordData, UnresolvedPixiRecord,
 };
-use pixi_spec::{PixiSpec, SourceAnchor, SourceLocationSpec, SourceSpec, SpecConversionError};
+use pixi_spec::{PixiSpec, SourceAnchor, SourceSpec, SpecConversionError};
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
     as_uv_req, pep508_requirement_to_uv_requirement, to_normalize, to_uv_specifiers, to_uv_version,
@@ -422,7 +422,7 @@ async fn resolve_single_dev_dependency(
 ) -> Result<Vec<Dependency>, CommandDispatcherError<PlatformUnsat>> {
     let pinned_source = command_dispatcher
         .engine()
-        .with_ctx(async |ctx| ctx.pin_and_checkout(source_spec.location).await)
+        .with_ctx(async |ctx| ctx.pin_and_checkout(source_spec).await)
         .await
         .map_err_into_dispatcher(PlatformUnsat::from)?;
 
@@ -942,7 +942,7 @@ async fn verify_package_platform_satisfiability(
                                 record.name().as_source(),
                                 record.manifest_source
                             )),
-                            SourceLocationSpec::from(record.manifest_source.clone()).into(),
+                            SourceSpec::from(record.manifest_source.clone()).into(),
                         ),
                     };
 
@@ -956,7 +956,9 @@ async fn verify_package_platform_satisfiability(
                         ))
                     }) {
                         let anchored_location = anchor.resolve(source.clone());
-                        let source_spec = SourceSpec::new(anchored_location, spec);
+                        let mut source_spec = anchored_location;
+                        *source_spec.matchspec_mut() =
+                            pixi_spec::MatchspecFields::from_nameless_match_spec(&spec);
                         conda_stack.push(Dependency::CondaSource(
                             package_name.clone(),
                             source_spec,
@@ -1274,7 +1276,7 @@ fn find_matching_source_package(
 
     source_package
         .manifest_source
-        .satisfies(&source_spec.location)
+        .satisfies(&source_spec)
         .map_err(|e| PlatformUnsat::SourcePackageMismatch(name.as_source().to_string(), e))?;
 
     let match_spec = source_spec.to_nameless_match_spec();

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use pixi_command_dispatcher::{
     CommandDispatcherError,
     build::{
-        Dependencies, PixiRunExports, dependencies::filter_match_specs,
-        pin_compatible::PinCompatibilityMap,
+        Dependencies, PixiRunExports, convert_extra_dependencies,
+        dependencies::filter_match_specs, pin_compatible::PinCompatibilityMap,
     },
 };
 use pixi_record::{
@@ -318,6 +318,53 @@ fn verify_locked_run_deps_against_backend(
         .collect::<Result<Vec<_>, _>>()?;
     diff_dep_sequences(record.constrains(), &expected_constrains)
         .map_err(|diff| diff.into_unsat(record.name(), SourceRunDepKind::RunConstrains))?;
+
+    // Verify the extra groups the backend declares still match what the lock
+    // file carries. Mirror the solve-path
+    // stringification in `resolve_source_record` exactly (resolve against the
+    // same pin-compatibility map, then `to_match_spec`) so the comparison is
+    // byte-for-byte. Without this, a manifest edit to an extra group goes
+    // unnoticed and the stale lock is treated as satisfied.
+    let expected_extras: std::collections::BTreeMap<String, Vec<String>> =
+        convert_extra_dependencies(&matching_output.extra_dependencies, None, &compat_map)
+            .map_err(|err| {
+                Box::new(PlatformUnsat::SourcePackageMetadataChanged(
+                    record.name().as_source().to_string(),
+                    err.to_string(),
+                ))
+            })?
+            .into_iter()
+            .map(|(group, specs)| {
+                let strings = specs
+                    .into_specs()
+                    .map(|(name, spec)| {
+                        spec.to_match_spec(&name, channel_config)
+                            .map(|m| m.to_string())
+                            .map_err(|err| spec_unsat(&name, &err))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((group.into_inner(), strings))
+            })
+            .collect::<Result<std::collections::BTreeMap<String, Vec<String>>, Box<PlatformUnsat>>>(
+            )?;
+
+    // Compare every group present on either side. A group missing from one
+    // side compares against the empty list, so an added group surfaces as
+    // `added` and a dropped group as `removed`.
+    let locked_extras = record.experimental_extra_depends();
+    let empty: Vec<String> = Vec::new();
+    for group in locked_extras.keys().chain(expected_extras.keys()) {
+        let locked = locked_extras.get(group).unwrap_or(&empty);
+        let expected = expected_extras.get(group).unwrap_or(&empty);
+        diff_dep_sequences(locked, expected).map_err(|diff| {
+            Box::new(PlatformUnsat::SourceExtraDependenciesChanged {
+                package: record.name().as_source().to_string(),
+                group: group.clone(),
+                added: diff.added,
+                removed: diff.removed,
+            })
+        })?;
+    }
 
     Ok(())
 }
@@ -1486,6 +1533,120 @@ mod tests {
                 assert_eq!(removed, vec!["bar <2".to_string()]);
             }
             other => panic!("expected RunConstrains drift, got: {other}"),
+        }
+    }
+
+    // -- Unit tests for extra-dependency (optional group) drift ---------
+
+    use pixi_build_types::ExtraGroupName;
+
+    /// Build an `extra_dependencies` map carrying a single group.
+    fn extra_group(
+        group: &str,
+        deps: Vec<NamedSpec<PackageSpec>>,
+    ) -> BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> {
+        let mut map = BTreeMap::new();
+        map.insert(ExtraGroupName::new(group.to_string()).unwrap(), deps);
+        map
+    }
+
+    /// A locked record whose extras match what the backend re-derives
+    /// must verify clean.
+    #[test]
+    fn verify_locked_run_deps_passes_when_extras_match() {
+        let mut record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        if let SourceRecordData::Full(full) = &mut record.data {
+            full.package_record.experimental_extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["extra-pkg >=1".to_string()])]);
+        }
+        let mut output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+        output.extra_dependencies = extra_group("test", vec![binary_dep("extra-pkg", ">=1")]);
+
+        let result = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG);
+        assert!(result.is_ok(), "matching extras must not drift: {result:?}");
+    }
+
+    /// The backend declares an extra group the locked record never
+    /// captured. Editing `[package.run-dependencies.<group>]` in the
+    /// manifest must invalidate the lock, surfacing the new spec.
+    #[test]
+    fn verify_locked_run_deps_detects_extra_group_addition() {
+        let record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        let mut output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+        output.extra_dependencies = extra_group("test", vec![binary_dep("extra-pkg", ">=1")]);
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("backend added an extra group the lock file lacks");
+        match *err {
+            super::super::PlatformUnsat::SourceExtraDependenciesChanged {
+                group,
+                added,
+                removed,
+                ..
+            } => {
+                assert_eq!(group, "test");
+                assert_eq!(added, vec!["extra-pkg >=1".to_string()]);
+                assert!(removed.is_empty());
+            }
+            other => panic!("expected SourceExtraDependenciesChanged, got: {other}"),
+        }
+    }
+
+    /// The locked record carries an extra group the backend no longer
+    /// declares. The stale spec must surface as a removal.
+    #[test]
+    fn verify_locked_run_deps_detects_extra_group_removal() {
+        let mut record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        if let SourceRecordData::Full(full) = &mut record.data {
+            full.package_record.experimental_extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["extra-pkg >=1".to_string()])]);
+        }
+        let output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("backend dropped an extra group that's still locked");
+        match *err {
+            super::super::PlatformUnsat::SourceExtraDependenciesChanged {
+                group,
+                added,
+                removed,
+                ..
+            } => {
+                assert_eq!(group, "test");
+                assert!(added.is_empty());
+                assert_eq!(removed, vec!["extra-pkg >=1".to_string()]);
+            }
+            other => panic!("expected SourceExtraDependenciesChanged, got: {other}"),
+        }
+    }
+
+    /// The group is present on both sides but its dependency spec
+    /// changed (e.g. the manifest bumped the version bound). The drift
+    /// must report both the new and the old spec.
+    #[test]
+    fn verify_locked_run_deps_detects_extra_spec_change() {
+        let mut record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        if let SourceRecordData::Full(full) = &mut record.data {
+            full.package_record.experimental_extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["extra-pkg >=1".to_string()])]);
+        }
+        let mut output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+        output.extra_dependencies = extra_group("test", vec![binary_dep("extra-pkg", ">=2")]);
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("the extra group's spec changed bound");
+        match *err {
+            super::super::PlatformUnsat::SourceExtraDependenciesChanged {
+                group,
+                added,
+                removed,
+                ..
+            } => {
+                assert_eq!(group, "test");
+                assert_eq!(added, vec!["extra-pkg >=2".to_string()]);
+                assert_eq!(removed, vec!["extra-pkg >=1".to_string()]);
+            }
+            other => panic!("expected SourceExtraDependenciesChanged, got: {other}"),
         }
     }
 }

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -10,7 +10,7 @@ use pixi_command_dispatcher::{
 use pixi_record::{
     PinnedBuildSourceSpec, PinnedSourceSpec, PixiRecord, SourceMismatchError, SourceRecordData,
 };
-use pixi_spec::{SourceAnchor, SourceLocationSpec, SpecConversionError};
+use pixi_spec::{SourceAnchor, SourceSpec, SpecConversionError};
 use rattler_conda_types::{MatchSpec, Matches, NamelessMatchSpec, PackageName};
 use std::collections::HashSet;
 
@@ -69,13 +69,10 @@ pub(super) fn verify_build_source_matches_manifest(
         lock_file_source_location.map(PinnedBuildSourceSpec::into_pinned),
     ) {
         (None, None) => ok,
-        (Some(SourceLocationSpec::Url(murl_spec)), Some(PinnedSourceSpec::Url(lurl_spec))) => {
+        (Some(SourceSpec::Url(murl_spec)), Some(PinnedSourceSpec::Url(lurl_spec))) => {
             lurl_spec.satisfies(&murl_spec).map_err(sat_err)
         }
-        (
-            Some(SourceLocationSpec::Git(mut mgit_spec)),
-            Some(PinnedSourceSpec::Git(mut lgit_spec)),
-        ) => {
+        (Some(SourceSpec::Git(mut mgit_spec)), Some(PinnedSourceSpec::Git(mut lgit_spec))) => {
             // Ignore subdirectory for comparison, they should not
             // trigger lock file invalidation.
             mgit_spec.subdirectory = Default::default();
@@ -87,7 +84,7 @@ pub(super) fn verify_build_source_matches_manifest(
             }
             lgit_spec.satisfies(&mgit_spec).map_err(sat_err)
         }
-        (Some(SourceLocationSpec::Path(mpath_spec)), Some(PinnedSourceSpec::Path(lpath_spec))) => {
+        (Some(SourceSpec::Path(mpath_spec)), Some(PinnedSourceSpec::Path(lpath_spec))) => {
             lpath_spec.satisfies(&mpath_spec).map_err(sat_err)
         }
         // If they not equal kind we error-out
@@ -175,8 +172,7 @@ pub(super) async fn verify_partial_source_record_against_backend(
     // empty slices reflect the truth or a stale snapshot. Forcing one
     // re-lock populates the canonical slices so subsequent runs hit
     // the fast verification path.
-    let source_anchor =
-        SourceAnchor::from(SourceLocationSpec::from(record.manifest_source.clone()));
+    let source_anchor = SourceAnchor::from(SourceSpec::from(record.manifest_source.clone()));
     if let Some(build_deps) = matching_output.build_dependencies.as_ref() {
         verify_locked_against_backend_specs(
             build_deps,
@@ -546,7 +542,7 @@ impl<'a> LockedConda<'a> {
     /// Returns `true` if any locked source record with the given
     /// `name` has a pinned manifest source compatible with
     /// `location` (per [`PinnedSourceSpec::matches_source_spec`]).
-    fn satisfies_source(&self, name: &PackageName, location: &SourceLocationSpec) -> bool {
+    fn satisfies_source(&self, name: &PackageName, location: &SourceSpec) -> bool {
         self.records_for(name).iter().any(|r| match r {
             pixi_record::UnresolvedPixiRecord::Source(s) => {
                 s.manifest_source.matches_source_spec(location)
@@ -632,12 +628,12 @@ fn verify_locked_against_backend_specs(
             }
             PackageSpec::Source(source) => {
                 let resolved = from_source_spec_v1(source.clone()).resolve(source_anchor);
-                if !locked_view.satisfies_source(&dep_name, &resolved.location) {
+                if !locked_view.satisfies_source(&dep_name, &resolved) {
                     return Err(Box::new(PlatformUnsat::SourceBuildHostSourceMissing {
                         package: package.as_source().to_string(),
                         env,
                         name: dep_name.as_source().to_string(),
-                        location: resolved.location.to_string(),
+                        location: resolved.to_string(),
                     }));
                 }
             }
@@ -781,7 +777,7 @@ fn build_full_source_record_from_output(
         },
         flags: output.metadata.flags.clone(),
     };
-    let sources: std::collections::BTreeMap<String, SourceLocationSpec> = match &record.data {
+    let sources: std::collections::BTreeMap<String, SourceSpec> = match &record.data {
         SourceRecordData::Full(full) => full.sources.clone(),
         SourceRecordData::Partial(partial) => partial.sources.clone(),
     };
@@ -821,7 +817,7 @@ mod tests {
         PartialSourceRecordData, PinnedPathSpec, PinnedSourceSpec, SourceRecordData,
         UnresolvedPixiRecord, UnresolvedSourceRecord,
     };
-    use pixi_spec::{SourceAnchor, SourceLocationSpec};
+    use pixi_spec::{SourceAnchor, SourceSpec};
     use rattler_conda_types::{
         ChannelConfig, NoArchType, PackageName, PackageRecord, Platform, RepoDataRecord,
         VersionSpec, VersionWithSource, package::DistArchiveIdentifier,
@@ -1001,11 +997,9 @@ mod tests {
             depends: vec![binary_dep("numpy", ">=1")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let result = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1030,11 +1024,9 @@ mod tests {
             depends: vec![binary_dep("numpy", ">=2")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let err = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1072,11 +1064,9 @@ mod tests {
             depends: vec![binary_dep("bar", "")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let err = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1106,11 +1096,9 @@ mod tests {
             depends: vec![binary_dep("cmake", "")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let err = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1172,11 +1160,9 @@ mod tests {
             depends: vec![pin_compatible_dep("numpy")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
 
         let err = verify_locked_against_backend_specs(
             &host_deps,
@@ -1216,11 +1202,9 @@ mod tests {
             depends: vec![pin_compatible_dep("numpy")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
 
         let result = verify_locked_against_backend_specs(
             &host_deps,
@@ -1262,11 +1246,9 @@ mod tests {
             )],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
 
         let err = verify_locked_against_backend_specs(
             &host_deps,

--- a/crates/pixi_global/src/project/global_spec.rs
+++ b/crates/pixi_global/src/project/global_spec.rs
@@ -49,7 +49,7 @@ impl GlobalSpec {
     }
 
     /// Converts a [`MatchSpec`] into a [`GlobalSpec`].
-    /// this can only result in a [`PixiSpec::Version`] or [`PixiSpec::DetailedVersion`] because
+    /// this can only result in a [`PixiSpec::Detailed`] because
     /// a `MatchSpec` has no direct support for source specifications
     pub fn try_from_matchspec_with_name(
         match_spec: MatchSpec,

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -1495,7 +1495,7 @@ impl Project {
         let command_dispatcher = self.command_dispatcher()?;
         let checkout = command_dispatcher
             .engine()
-            .with_ctx(async |ctx| ctx.pin_and_checkout(source_spec.location).await)
+            .with_ctx(async |ctx| ctx.pin_and_checkout(source_spec).await)
             .await
             .map_err_into_dispatcher(std::convert::identity)
             .map_err(|e| InferPackageNameError::BuildBackendMetadata(Box::new(e)))?;

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -1,7 +1,7 @@
 //! Defines the build section for the pixi manifest.
 
 use indexmap::IndexMap;
-use pixi_spec::{PixiSpec, SourceLocationSpec};
+use pixi_spec::{PixiSpec, SourceSpec};
 use rattler_conda_types::{Flag, NamedChannelOrUrl};
 
 use crate::TargetSelector;
@@ -25,7 +25,7 @@ pub struct PackageBuild {
     pub channels: Option<Vec<NamedChannelOrUrl>>,
 
     /// Optional package source specification
-    pub source: Option<SourceLocationSpec>,
+    pub source: Option<SourceSpec>,
 
     /// Additional configuration for the build backend.
     pub config: Option<serde_value::Value>,
@@ -230,7 +230,7 @@ mod tests {
         // Verify it's a path source and contains the relative path
         if let Some(source) = &build.value.source {
             match &source {
-                pixi_spec::SourceLocationSpec::Path(path_spec) => {
+                pixi_spec::SourceSpec::Path(path_spec) => {
                     assert_eq!(path_spec.path.as_str(), "../other-source");
                 }
                 _ => panic!("Expected a path source spec"),
@@ -259,7 +259,7 @@ mod tests {
         // Verify it's a path source and contains the home directory path
         if let Some(source) = &build.value.source {
             match &source {
-                pixi_spec::SourceLocationSpec::Path(path_spec) => {
+                pixi_spec::SourceSpec::Path(path_spec) => {
                     assert_eq!(path_spec.path.as_str(), "~/my-source");
                 }
                 _ => panic!("Expected a path source spec"),
@@ -285,7 +285,7 @@ mod tests {
 
         if let Some(source) = &build.value.source {
             match &source {
-                pixi_spec::SourceLocationSpec::Path(path_spec) => {
+                pixi_spec::SourceSpec::Path(path_spec) => {
                     // Test that the path spec can resolve relative paths correctly
                     let resolved = path_spec.resolve(workspace_root).unwrap();
 
@@ -314,7 +314,7 @@ mod tests {
 
         if let Some(source) = &build.value.source {
             match &source {
-                pixi_spec::SourceLocationSpec::Path(path_spec) => {
+                pixi_spec::SourceSpec::Path(path_spec) => {
                     // Test that absolute paths are returned as-is during resolution
                     let resolved = path_spec.resolve("/workspace/root").unwrap();
                     assert_eq!(resolved, Path::new("/absolute/path/to/source"));
@@ -350,7 +350,7 @@ mod tests {
 
             if let Some(source) = &build.value.source {
                 match &source {
-                    pixi_spec::SourceLocationSpec::Path(path_spec) => {
+                    pixi_spec::SourceSpec::Path(path_spec) => {
                         // Verify the path is preserved correctly
                         assert_eq!(
                             path_spec.path.as_str(),

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -901,7 +901,7 @@ hTTPx = ">=0.28.1,<0.29" # Some comment.
         document
             .add_dependency(
                 &PackageName::from_str("HtTpX").unwrap(),
-                &PixiSpec::Version("0.1.*".parse().unwrap()),
+                &PixiSpec::from("0.1.*".parse::<rattler_conda_types::VersionSpec>().unwrap()),
                 SpecType::Run,
                 None,
                 &FeatureName::default(),

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -762,7 +762,7 @@ mod tests {
 
         // Add foo = "==2.0" with Overwrite behavior
         let foo = PackageName::from_str("foo").unwrap();
-        let spec = PixiSpec::Version(
+        let spec = PixiSpec::from(
             VersionSpec::from_str("==2.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
 
@@ -814,7 +814,7 @@ mod tests {
         let foo = PackageName::from_str("foo").unwrap();
 
         // Add foo = "==1.0"
-        let spec1 = PixiSpec::Version(
+        let spec1 = PixiSpec::from(
             VersionSpec::from_str("==1.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
         manifest_mut
@@ -829,7 +829,7 @@ mod tests {
             .unwrap();
 
         // Add foo = "==2.0" (should overwrite)
-        let spec2 = PixiSpec::Version(
+        let spec2 = PixiSpec::from(
             VersionSpec::from_str("==2.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
         manifest_mut
@@ -844,7 +844,7 @@ mod tests {
             .unwrap();
 
         // Add foo = "==3.0" (should overwrite again)
-        let spec3 = PixiSpec::Version(
+        let spec3 = PixiSpec::from(
             VersionSpec::from_str("==3.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
         manifest_mut
@@ -897,7 +897,7 @@ mod tests {
 
         // Try to add foo = "==2.0" with IgnoreDuplicate
         let foo = PackageName::from_str("foo").unwrap();
-        let spec = PixiSpec::Version(
+        let spec = PixiSpec::from(
             VersionSpec::from_str("==2.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
 

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use pixi_spec::{SourceLocationSpec, TomlLocationSpec, TomlSpec};
+use pixi_spec::{SourceSpec, TomlLocationSpec, TomlSpec};
 use pixi_toml::{Same, TomlBTreeSet, TomlFromStr, TomlIndexMap, TomlWith};
 use rattler_conda_types::{Flag, NamedChannelOrUrl, PackageName};
 use std::borrow::Cow;
@@ -25,7 +25,7 @@ pub struct TomlPackageBuild {
     pub backend: PixiSpanned<TomlBuildBackend>,
     pub channels: Option<PixiSpanned<Vec<NamedChannelOrUrl>>>,
     pub additional_dependencies: UniquePackageMap,
-    pub source: Option<SourceLocationSpec>,
+    pub source: Option<SourceSpec>,
     pub configuration: Option<serde_value::Value>,
     pub flags: Vec<Flag>,
     pub target: IndexMap<PixiSpanned<TargetSelector>, TomlPackageBuildTarget>,
@@ -243,17 +243,14 @@ static BOTH_ADDITIONAL_DEPS_WARNING: Once = Once::new();
 
 fn spec_from_spanned_toml_location(
     spanned_toml: Spanned<TomlLocationSpec>,
-) -> Result<SourceLocationSpec, DeserError> {
-    let source_location_spec = spanned_toml
-        .value
-        .into_source_location_spec()
-        .map_err(|err| {
-            DeserError::from(Error {
-                kind: toml_span::ErrorKind::Custom(Cow::Owned(err.to_string())),
-                span: spanned_toml.span,
-                line_info: None,
-            })
-        })?;
+) -> Result<SourceSpec, DeserError> {
+    let source_location_spec = spanned_toml.value.into_source_spec().map_err(|err| {
+        DeserError::from(Error {
+            kind: toml_span::ErrorKind::Custom(Cow::Owned(err.to_string())),
+            span: spanned_toml.span,
+            line_info: None,
+        })
+    })?;
 
     Ok(source_location_spec)
 }

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -963,8 +963,7 @@ mod test {
         let spec = &pkg.build.backend.spec;
         // The resolved backend spec must carry the workspace-declared version.
         match spec {
-            pixi_spec::PixiSpec::Version(v) => assert_eq!(v.to_string(), "==1.2.3"),
-            pixi_spec::PixiSpec::DetailedVersion(detailed) => {
+            pixi_spec::PixiSpec::Detailed(detailed) => {
                 assert_eq!(detailed.version.as_ref().unwrap().to_string(), "==1.2.3")
             }
             other => panic!("unexpected backend spec: {other:?}"),

--- a/crates/pixi_manifest/src/toml/package.rs
+++ b/crates/pixi_manifest/src/toml/package.rs
@@ -438,10 +438,10 @@ impl TomlPackage {
         let file_validation_dir: Option<PathBuf> =
             match (&build_result.value.source, root_directory) {
                 // Git or URL source: skip validation (files are in remote location)
-                (Some(pixi_spec::SourceLocationSpec::Git(_)), _)
-                | (Some(pixi_spec::SourceLocationSpec::Url(_)), _) => None,
+                (Some(pixi_spec::SourceSpec::Git(_)), _)
+                | (Some(pixi_spec::SourceSpec::Url(_)), _) => None,
                 // Path source: resolve the path and use that directory for validation
-                (Some(pixi_spec::SourceLocationSpec::Path(path_spec)), root_dir) => {
+                (Some(pixi_spec::SourceSpec::Path(path_spec)), root_dir) => {
                     path_spec.resolve(root_dir).ok()
                 }
                 // No source: use the manifest directory

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 333
+assertion_line: 389
 expression: parsed.value
 ---
 PackageBuild {
@@ -9,7 +9,7 @@ PackageBuild {
             normalized: None,
             source: "foobar",
         },
-        spec: DetailedVersion(
+        spec: Detailed(
             DetailedSpec {
                 version: Some(
                     Any,

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-use pixi_spec::{PixiSpec, SourceSpec, TomlLocationSpec};
+use pixi_spec::{PixiSpec, TomlLocationSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_toml::{TomlHashMap, TomlIndexMap};
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
@@ -81,9 +81,7 @@ impl TomlTarget {
                 dev_map
                     .into_iter()
                     .map(|(name, toml_loc)| {
-                        toml_loc
-                            .into_source_location_spec()
-                            .map(|location| (name, SourceSpec::from(location)))
+                        toml_loc.into_source_spec().map(|location| (name, location))
                     })
                     .collect::<Result<IndexMap<_, _>, _>>()
             })

--- a/crates/pixi_manifest/src/utils/inheritable_package_map.rs
+++ b/crates/pixi_manifest/src/utils/inheritable_package_map.rs
@@ -431,7 +431,7 @@ mod test {
             .get(&PackageName::from_str("numpy").unwrap())
             .unwrap();
         match spec {
-            PixiSpec::DetailedVersion(detailed) => {
+            PixiSpec::Detailed(detailed) => {
                 assert_eq!(detailed.version.as_ref().unwrap().to_string(), "1.*");
                 assert!(detailed.channel.is_some());
             }
@@ -454,7 +454,7 @@ mod test {
             .get(&PackageName::from_str("boltons").unwrap())
             .unwrap();
         match spec {
-            PixiSpec::DetailedVersion(detailed) => {
+            PixiSpec::Detailed(detailed) => {
                 assert_eq!(detailed.version.as_ref().unwrap().to_string(), ">=24");
                 assert!(
                     detailed.channel.is_some(),

--- a/crates/pixi_pypi_spec/src/lib.rs
+++ b/crates/pixi_pypi_spec/src/lib.rs
@@ -28,6 +28,7 @@ pub use version_or_star::VersionOrStar;
 /// - `Url`: From a direct URL to a package archive
 #[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged, rename_all = "kebab-case")]
+#[allow(clippy::large_enum_variant)]
 pub enum PixiPypiSource {
     /// From a package registry with version constraints.
     Registry {
@@ -349,11 +350,11 @@ mod tests {
     #[test]
     fn test_is_source_dependency_for_git() {
         let spec = PixiPypiSpec::new(PixiPypiSource::Git {
-            git: GitSpec {
-                git: Url::parse("https://github.com/example/repo").unwrap(),
-                rev: None,
-                subdirectory: Default::default(),
-            },
+            git: GitSpec::new(
+                Url::parse("https://github.com/example/repo").unwrap(),
+                None,
+                Default::default(),
+            ),
         });
         assert!(spec.is_source_dependency());
     }
@@ -395,11 +396,11 @@ mod tests {
         // Spec with extras
         let spec = PixiPypiSpec::with_extras_and_markers(
             PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/example/repo").unwrap(),
-                    rev: None,
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/example/repo").unwrap(),
+                    None,
+                    Default::default(),
+                ),
             },
             vec![extra.clone()],
             MarkerTree::default(),
@@ -420,11 +421,11 @@ mod tests {
         // Spec with markers
         let spec = PixiPypiSpec::with_extras_and_markers(
             PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/example/repo").unwrap(),
-                    rev: None,
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/example/repo").unwrap(),
+                    None,
+                    Default::default(),
+                ),
             },
             vec![],
             markers.clone(),
@@ -570,11 +571,11 @@ mod tests {
         assert_eq!(
             as_pypi_req,
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
-                    rev: Some(GitReference::DefaultBranch),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
+                    Some(GitReference::DefaultBranch),
+                    Default::default()
+                ),
             })
         );
 
@@ -583,13 +584,13 @@ mod tests {
         assert_eq!(
             as_pypi_req,
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
-                    rev: Some(GitReference::Rev(
+                git: GitSpec::new(
+                    Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
+                    Some(GitReference::Rev(
                         "b283011c6df4a9e034baca9aea19aa8e5a70e3ab".to_string()
                     )),
-                    subdirectory: Default::default(),
-                },
+                    Default::default()
+                ),
             })
         );
 
@@ -678,11 +679,11 @@ mod tests {
         assert_eq!(
             PixiPypiSpec::try_from(parsed).unwrap(),
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
-                    rev: Some(GitReference::Rev("main".to_string())),
-                    subdirectory: Default::default()
-                },
+                git: GitSpec::new(
+                    Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
+                    Some(GitReference::Rev("main".to_string())),
+                    Default::default()
+                ),
             })
         );
 
@@ -694,11 +695,11 @@ mod tests {
         assert_eq!(
             PixiPypiSpec::try_from(parsed).unwrap(),
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
-                    rev: Some(GitReference::DefaultBranch),
-                    subdirectory: Subdirectory::try_from("python/ribasim").unwrap(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
+                    Some(GitReference::DefaultBranch),
+                    Subdirectory::try_from("python/ribasim").unwrap()
+                ),
             })
         );
     }

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -27,11 +27,11 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             "git" => {
                                 let subdirectory = extract_directory_from_url(&url);
                                 let git_url = GitUrl::try_from(url).unwrap();
-                                let git_spec = GitSpec {
-                                    git: git_url.repository().clone(),
-                                    rev: Some(git_url.reference().clone().into()),
+                                let git_spec = GitSpec::new(
+                                    git_url.repository().clone(),
+                                    Some(git_url.reference().clone().into()),
                                     subdirectory,
-                                };
+                                );
 
                                 PixiPypiSpec::with_extras_and_markers(
                                     PixiPypiSource::Git { git: git_spec },
@@ -74,11 +74,11 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                     {
                         let git_url = GitUrl::try_from(url).unwrap();
                         let subdirectory = extract_directory_from_url(git_url.repository());
-                        let git_spec = GitSpec {
-                            git: git_url.repository().clone(),
-                            rev: Some(git_url.reference().clone().into()),
+                        let git_spec = GitSpec::new(
+                            git_url.repository().clone(),
+                            Some(git_url.reference().clone().into()),
                             subdirectory,
-                        };
+                        );
                         PixiPypiSpec::with_extras_and_markers(
                             PixiPypiSource::Git { git: git_spec },
                             req.extras,

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -150,15 +150,14 @@ impl RawPyPiRequirement {
                 };
                 PixiPypiSpec::with_extras_and_markers(
                     PixiPypiSource::Git {
-                        git: GitSpec {
+                        git: GitSpec::new(
                             git,
                             rev,
-                            subdirectory: self
-                                .subdirectory
+                            self.subdirectory
                                 .map(pixi_spec::Subdirectory::try_from)
                                 .transpose()?
                                 .unwrap_or_default(),
-                        },
+                        ),
                     },
                     self.extras,
                     self.marker,
@@ -336,6 +335,7 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         git,
                         rev,
                         subdirectory,
+                        matchspec: _,
                     },
             } => {
                 let mut table = toml_edit::Table::new().into_inline_table();
@@ -678,11 +678,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: None,
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    None,
+                    Default::default()
+                ),
             })
         );
     }
@@ -697,11 +697,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: Some(GitReference::Branch("main".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    Some(GitReference::Branch("main".to_string())),
+                    Default::default()
+                ),
             })
         );
     }
@@ -716,11 +716,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: Some(GitReference::Tag("v.1.2.3".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    Some(GitReference::Tag("v.1.2.3".to_string())),
+                    Default::default()
+                ),
             })
         );
     }
@@ -735,11 +735,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/pallets/flask.git").unwrap(),
-                    rev: Some(GitReference::Tag("3.0.0".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/pallets/flask.git").unwrap(),
+                    Some(GitReference::Tag("3.0.0".to_string())),
+                    Default::default()
+                ),
             }),
         );
     }
@@ -754,11 +754,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: Some(GitReference::Rev("123456".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    Some(GitReference::Rev("123456".to_string())),
+                    Default::default()
+                ),
             })
         );
     }

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -271,9 +271,9 @@ impl UnresolvedPixiRecord {
     }
 
     /// Source dependency locations. Empty for binary records.
-    pub fn sources(&self) -> &std::collections::BTreeMap<String, pixi_spec::SourceLocationSpec> {
+    pub fn sources(&self) -> &std::collections::BTreeMap<String, pixi_spec::SourceSpec> {
         static EMPTY: std::sync::LazyLock<
-            std::collections::BTreeMap<String, pixi_spec::SourceLocationSpec>,
+            std::collections::BTreeMap<String, pixi_spec::SourceSpec>,
         > = std::sync::LazyLock::new(std::collections::BTreeMap::new);
         match self {
             UnresolvedPixiRecord::Binary(_) => &EMPTY,

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -6,9 +6,7 @@ use pixi_git::{
     url::{RepositoryUrl, redact_credentials},
 };
 use pixi_path::normalize::normalize_typed;
-use pixi_spec::{
-    GitReference, GitSpec, PathSourceSpec, SourceLocationSpec, Subdirectory, UrlSourceSpec,
-};
+use pixi_spec::{GitReference, GitSpec, PathSourceSpec, SourceSpec, Subdirectory, UrlSourceSpec};
 use rattler_digest::{Md5Hash, Sha256Hash};
 use rattler_lock::UrlOrPath;
 use serde::{Deserialize, Serialize};
@@ -148,7 +146,7 @@ impl PinnedSourceSpec {
     ///
     /// ```
     /// use pixi_record::{PinnedSourceSpec, PinnedGitSpec, PinnedGitCheckout};
-    /// use pixi_spec::{SourceSpec, SourceLocationSpec, GitSpec, GitReference};
+    /// use pixi_spec::{GitReference, GitSpec, SourceSpec};
     /// use pixi_git::sha::GitSha;
     /// use url::Url;
     /// use std::str::FromStr;
@@ -164,25 +162,25 @@ impl PinnedSourceSpec {
     ///     },
     /// });
     ///
-    /// let source_spec = SourceLocationSpec::Git(GitSpec {
-    ///     git: Url::parse("https://github.com/user/repo.git")?,
-    ///     rev: None,
-    ///     subdirectory: Default::default(),
-    /// });
+    /// let source_spec = SourceSpec::Git(GitSpec::new(
+    ///     Url::parse("https://github.com/user/repo.git")?,
+    ///     None,
+    ///     Default::default(),
+    /// ));
     ///
     /// assert!(pinned_git.matches_source_spec(&source_spec));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn matches_source_spec(&self, source_spec: &SourceLocationSpec) -> bool {
+    pub fn matches_source_spec(&self, source_spec: &SourceSpec) -> bool {
         match (self, &source_spec) {
             // Path sources: paths must be exactly equal
-            (PinnedSourceSpec::Path(pinned_path), SourceLocationSpec::Path(source_path)) => {
+            (PinnedSourceSpec::Path(pinned_path), SourceSpec::Path(source_path)) => {
                 pinned_path.path == source_path.path
             }
 
             // Git sources: repository URLs must match, subdirectories must match if specified
-            (PinnedSourceSpec::Git(pinned_git), SourceLocationSpec::Git(source_git)) => {
+            (PinnedSourceSpec::Git(pinned_git), SourceSpec::Git(source_git)) => {
                 use pixi_git::url::RepositoryUrl;
 
                 // Compare repository URLs (ignoring commit/branch details)
@@ -213,7 +211,7 @@ impl PinnedSourceSpec {
             }
 
             // URL sources: URLs must be exactly equal
-            (PinnedSourceSpec::Url(pinned_url), SourceLocationSpec::Url(source_url)) => {
+            (PinnedSourceSpec::Url(pinned_url), SourceSpec::Url(source_url)) => {
                 pinned_url.url == source_url.url
             }
 
@@ -873,17 +871,11 @@ impl PinnedGitSpec {
 impl PinnedSourceSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked source satisfies the requested source.
-    pub fn satisfies(&self, spec: &SourceLocationSpec) -> Result<(), SourceMismatchError> {
+    pub fn satisfies(&self, spec: &SourceSpec) -> Result<(), SourceMismatchError> {
         match (self, &spec) {
-            (PinnedSourceSpec::Path(locked), SourceLocationSpec::Path(spec)) => {
-                locked.satisfies(spec)
-            }
-            (PinnedSourceSpec::Url(locked), SourceLocationSpec::Url(spec)) => {
-                locked.satisfies(spec)
-            }
-            (PinnedSourceSpec::Git(locked), SourceLocationSpec::Git(spec)) => {
-                locked.satisfies(spec)
-            }
+            (PinnedSourceSpec::Path(locked), SourceSpec::Path(spec)) => locked.satisfies(spec),
+            (PinnedSourceSpec::Url(locked), SourceSpec::Url(spec)) => locked.satisfies(spec),
+            (PinnedSourceSpec::Git(locked), SourceSpec::Git(spec)) => locked.satisfies(spec),
             (_, _) => Err(SourceMismatchError::SourceTypeMismatch),
         }
     }
@@ -917,41 +909,36 @@ impl Display for PinnedGitSpec {
     }
 }
 
-impl From<PinnedSourceSpec> for SourceLocationSpec {
+impl From<PinnedSourceSpec> for SourceSpec {
     fn from(value: PinnedSourceSpec) -> Self {
         match value {
-            PinnedSourceSpec::Url(url) => SourceLocationSpec::Url(url.into()),
-            PinnedSourceSpec::Git(git) => SourceLocationSpec::Git(git.into()),
+            PinnedSourceSpec::Url(url) => SourceSpec::Url(url.into()),
+            PinnedSourceSpec::Git(git) => SourceSpec::Git(git.into()),
 
-            PinnedSourceSpec::Path(path) => SourceLocationSpec::Path(path.into()),
+            PinnedSourceSpec::Path(path) => SourceSpec::Path(path.into()),
         }
     }
 }
 
 impl From<PinnedPathSpec> for PathSourceSpec {
     fn from(value: PinnedPathSpec) -> Self {
-        Self { path: value.path }
+        Self::new(value.path)
     }
 }
 
 impl From<PinnedUrlSpec> for UrlSourceSpec {
     fn from(value: PinnedUrlSpec) -> Self {
-        Self {
-            url: value.url,
-            sha256: Some(value.sha256),
-            md5: value.md5,
-            subdirectory: value.subdirectory,
-        }
+        Self::new(value.url, value.md5, Some(value.sha256), value.subdirectory)
     }
 }
 
 impl From<PinnedGitSpec> for GitSpec {
     fn from(value: PinnedGitSpec) -> Self {
-        Self {
-            git: value.git,
-            subdirectory: value.source.subdirectory,
-            rev: Some(value.source.reference),
-        }
+        Self::new(
+            value.git,
+            Some(value.source.reference),
+            value.source.subdirectory,
+        )
     }
 }
 
@@ -982,6 +969,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1001,6 +989,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec);
@@ -1020,6 +1009,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix);
@@ -1039,6 +1029,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1058,6 +1049,7 @@ mod tests {
             git: Url::parse("git+https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix);
@@ -1082,6 +1074,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("d2e32".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1103,6 +1096,7 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1126,6 +1120,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1149,6 +1144,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1173,6 +1169,7 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1182,7 +1179,7 @@ mod tests {
         ));
     }
 
-    use pixi_spec::{PathSourceSpec, SourceLocationSpec, UrlSourceSpec};
+    use pixi_spec::{PathSourceSpec, SourceSpec, UrlSourceSpec};
     use typed_path::Utf8TypedPathBuf;
 
     #[test]
@@ -1191,8 +1188,9 @@ mod tests {
             path: Utf8TypedPathBuf::from("/path/to/source"),
         });
 
-        let spec = SourceLocationSpec::Path(PathSourceSpec {
+        let spec = SourceSpec::Path(PathSourceSpec {
             path: Utf8TypedPathBuf::from("/path/to/source"),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1204,8 +1202,9 @@ mod tests {
             path: Utf8TypedPathBuf::from("/path/to/source"),
         });
 
-        let spec = SourceLocationSpec::Path(PathSourceSpec {
+        let spec = SourceSpec::Path(PathSourceSpec {
             path: Utf8TypedPathBuf::from("/different/path"),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1222,10 +1221,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo.git").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match despite .git suffix difference
@@ -1243,10 +1243,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match despite .git suffix difference
@@ -1264,10 +1265,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo2").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1284,10 +1286,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match - spec doesn't care about subdirectory
@@ -1305,10 +1308,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1325,10 +1329,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir2").unwrap(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1345,10 +1350,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should not match - spec requires a subdirectory that pinned doesn't have
@@ -1367,11 +1373,12 @@ mod tests {
             subdirectory: Default::default(),
         });
 
-        let spec = SourceLocationSpec::Url(UrlSourceSpec {
+        let spec = SourceSpec::Url(UrlSourceSpec {
             url: Url::parse("https://example.com/archive.tar.gz").unwrap(),
             sha256: None,
             md5: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1389,11 +1396,12 @@ mod tests {
             subdirectory: Default::default(),
         });
 
-        let spec = SourceLocationSpec::Url(UrlSourceSpec {
+        let spec = SourceSpec::Url(UrlSourceSpec {
             url: Url::parse("https://example.com/different.tar.gz").unwrap(),
             sha256: None,
             md5: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1405,10 +1413,11 @@ mod tests {
             path: Utf8TypedPathBuf::from("/path/to/source"),
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1425,11 +1434,12 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Url(UrlSourceSpec {
+        let spec = SourceSpec::Url(UrlSourceSpec {
             url: Url::parse("https://example.com/archive.tar.gz").unwrap(),
             sha256: None,
             md5: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1447,8 +1457,9 @@ mod tests {
             subdirectory: Default::default(),
         });
 
-        let spec = SourceLocationSpec::Path(PathSourceSpec {
+        let spec = SourceSpec::Path(PathSourceSpec {
             path: Utf8TypedPathBuf::from("/path/to/source"),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1469,10 +1480,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Rev("v2.0.0".to_string())),
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1491,10 +1503,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Branch("main".to_string())),
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1511,10 +1524,11 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::Git(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match - GitHub URLs are case-insensitive

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -28,7 +28,7 @@
 //! state transitions without field-by-field reconstruction.
 
 use pixi_git::sha::GitSha;
-use pixi_spec::{GitReference, SourceLocationSpec};
+use pixi_spec::{GitReference, SourceSpec};
 use rattler_conda_types::{
     Flag, MatchSpec, Matches, NamelessMatchSpec, PackageName, PackageRecord, PackageUrl,
     package::RunExportsJson,
@@ -310,7 +310,7 @@ pub struct PartialSourceRecordData {
 
     /// Specifies which packages are expected to be installed as source packages
     /// and from which location.
-    pub sources: BTreeMap<String, SourceLocationSpec>,
+    pub sources: BTreeMap<String, SourceSpec>,
 }
 
 /// Complete metadata for a fully-evaluated source package.
@@ -324,7 +324,7 @@ pub struct FullSourceRecordData {
 
     /// Specifies which packages are expected to be installed as source packages
     /// and from which location.
-    pub sources: BTreeMap<String, SourceLocationSpec>,
+    pub sources: BTreeMap<String, SourceSpec>,
 }
 
 /// Runtime-checked variant used at the lock file boundary.
@@ -552,7 +552,7 @@ impl SourceRecord<FullSourceRecordData> {
     }
 
     /// Source dependency locations.
-    pub fn sources(&self) -> &BTreeMap<String, SourceLocationSpec> {
+    pub fn sources(&self) -> &BTreeMap<String, SourceSpec> {
         &self.data.sources
     }
 
@@ -659,7 +659,7 @@ impl SourceRecord<PartialSourceRecordData> {
     }
 
     /// Source dependency locations.
-    pub fn sources(&self) -> &BTreeMap<String, SourceLocationSpec> {
+    pub fn sources(&self) -> &BTreeMap<String, SourceSpec> {
         &self.data.sources
     }
 }
@@ -687,7 +687,7 @@ impl SourceRecord<SourceRecordData> {
     }
 
     /// Source dependency locations.
-    pub fn sources(&self) -> &BTreeMap<String, SourceLocationSpec> {
+    pub fn sources(&self) -> &BTreeMap<String, SourceSpec> {
         match &self.data {
             SourceRecordData::Full(full) => &full.sources,
             SourceRecordData::Partial(partial) => &partial.sources,
@@ -783,7 +783,7 @@ impl SourceRecord<SourceRecordData> {
         let sources = data
             .sources
             .into_iter()
-            .map(|(k, v)| (k, SourceLocationSpec::from(v)))
+            .map(|(k, v)| (k, SourceSpec::from(v)))
             .collect();
 
         let record_data = match data.metadata {

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -686,6 +686,14 @@ impl SourceRecord<SourceRecordData> {
         }
     }
 
+    /// Extra groups, keyed by group name.
+    pub fn experimental_extra_depends(&self) -> &BTreeMap<String, Vec<String>> {
+        match &self.data {
+            SourceRecordData::Full(full) => &full.package_record.experimental_extra_depends,
+            SourceRecordData::Partial(partial) => &partial.experimental_extra_depends,
+        }
+    }
+
     /// Source dependency locations.
     pub fn sources(&self) -> &BTreeMap<String, SourceSpec> {
         match &self.data {

--- a/crates/pixi_spec/src/dev_source.rs
+++ b/crates/pixi_spec/src/dev_source.rs
@@ -25,7 +25,7 @@ use crate::SourceSpec;
 /// This would be represented as:
 /// ```ignore
 /// DevSourceSpec {
-///     source: SourceSpec::Path(PathSourceSpec { path: "../my-package" }),
+///     source: SourceSpec::Path(PathSourceSpec { path: "../my-package", .. }),
 /// }
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize)]

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -5,9 +5,10 @@ use serde::{Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
 
-use crate::Subdirectory;
+use crate::{MatchspecFields, Subdirectory};
 
-/// A specification of a package from a git repository.
+/// A specification of a package from a git repository, optionally
+/// constrained by match-spec selectors (`version`, `build`, `extras`, …).
 #[derive(Debug, Clone, Hash, Eq, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct GitSpec {
@@ -21,6 +22,22 @@ pub struct GitSpec {
     /// The git subdirectory of the package
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Match-spec selectors applied to the built output (flattened).
+    #[serde(flatten)]
+    pub matchspec: MatchspecFields,
+}
+
+impl GitSpec {
+    /// Constructs a new [`GitSpec`] with no matchspec selectors.
+    pub fn new(git: Url, rev: Option<GitReference>, subdirectory: Subdirectory) -> Self {
+        Self {
+            git,
+            rev,
+            subdirectory,
+            matchspec: MatchspecFields::default(),
+        }
+    }
 }
 
 impl Display for GitSpec {

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -7,11 +7,36 @@
 //! represent both source and binary packages. The `PixiSpec` type can
 //! optionally be converted to a `NamelessMatchSpec` which is used to match
 //! binary packages.
+//!
+//! # Variants
+//!
+//! [`PixiSpec`] has seven variants, encoding the binary-vs-source distinction
+//! at the type level rather than via runtime URL/path inspection:
+//!
+//! * [`PixiSpec::Version`] - a bare version spec string (e.g. `">=1"`, `"*"`).
+//! * [`PixiSpec::Detailed`] - a detailed channel-based binary spec written as
+//!   a table (e.g. `{ version = ">=1", build = "py*" }`).
+//! * [`PixiSpec::UrlBinary`] - URL pointing at a binary conda archive.
+//! * [`PixiSpec::PathBinary`] - local path pointing at a binary conda archive.
+//! * [`PixiSpec::UrlSource`] - URL pointing at a source archive, with optional
+//!   matchspec selectors used to pick which built output to use.
+//! * [`PixiSpec::PathSource`] - local directory or source path, with optional
+//!   matchspec selectors.
+//! * [`PixiSpec::Git`] - git repository, with optional matchspec selectors.
+//!
+//! `Version` and `Detailed` are kept separate so the on-disk distinction
+//! between the bare string form `"*"` and the table form `{ version = "*" }`
+//! survives a serialization round-trip.
+//!
+//! The binary variants do not carry matchspec selectors: a `.conda` archive
+//! is already a fully-specified package, so `version`, `build`, etc. would be
+//! meaningless.
 
 mod detailed;
 mod dev_source;
 mod exclude_newer;
 mod git;
+mod matchspec_fields;
 mod path;
 mod pin;
 mod source_anchor;
@@ -26,11 +51,12 @@ pub use dev_source::DevSourceSpec;
 pub use exclude_newer::{ExcludeNewer, ResolvedExcludeNewer};
 pub use git::{GitReference, GitReferenceError, GitSpec};
 use itertools::Either;
+pub use matchspec_fields::MatchspecFields;
 pub use path::{PathBinarySpec, PathSourceSpec, PathSpec};
 pub use pin::{Pin, PinBound, PinError, PinExpression};
 use rattler_conda_types::{
-    BuildNumberSpec, ChannelConfig, MatchSpec, MatchSpecCondition, NamedChannelOrUrl,
-    NamelessMatchSpec, PackageName, ParseChannelError, StringMatcher, VersionSpec,
+    ChannelConfig, MatchSpec, NamedChannelOrUrl, NamelessMatchSpec, PackageName, ParseChannelError,
+    VersionSpec, package::CondaArchiveType,
 };
 #[cfg(feature = "rattler_lock")]
 pub use rattler_lock::Verbatim;
@@ -38,6 +64,7 @@ pub use source_anchor::SourceAnchor;
 pub use subdirectory::{Subdirectory, SubdirectoryError};
 use thiserror::Error;
 pub use toml::{TomlLocationSpec, TomlSpec, TomlVersionSpecStr};
+use url::url_is_binary;
 pub use url::{UrlBinarySpec, UrlSourceSpec, UrlSpec};
 
 /// An error that is returned when a spec cannot be converted into another spec
@@ -67,42 +94,52 @@ pub enum SpecConversionError {
 
 /// A package specification for pixi.
 ///
-/// This type can represent both source and binary packages. Use the
-/// [`Self::try_into_nameless_match_spec`] method to convert this type into a
-/// type that only represents binary packages.
-#[derive(Debug, Clone, Hash, ::serde::Serialize, PartialEq, Eq)]
-#[serde(untagged)]
+/// See the crate-level docs for the meaning of each variant.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum PixiSpec {
-    /// The spec is represented solely by a version string. The package should
-    /// be retrieved from a channel.
-    ///
-    /// This is similar to the `DetailedVersion` variant but with a simplified
-    /// version spec.
+    /// A bare version spec string (e.g. `"*"`, `">=1.2.3"`).
     Version(VersionSpec),
 
-    /// The spec is represented by a detailed version spec. The package should
-    /// be retrieved from a channel.
-    DetailedVersion(Box<DetailedSpec>),
+    /// A detailed channel-based binary spec written as a table.
+    Detailed(Box<DetailedSpec>),
 
-    /// The spec is represented as an archive that can be downloaded from the
-    /// specified URL. The package should be retrieved from the URL and can
-    /// either represent a source or binary package depending on the archive
-    /// type.
-    Url(UrlSpec),
+    /// URL pointing at a binary conda archive (`.conda` / `.tar.bz2`).
+    UrlBinary(UrlBinarySpec),
 
-    /// The spec is represented as a git repository. The package represents a
-    /// source distribution of some kind.
-    Git(GitSpec),
+    /// Local path pointing at a binary conda archive (`.conda` / `.tar.bz2`).
+    PathBinary(PathBinarySpec),
 
-    /// The spec is represented as a local path. The package should be retrieved
-    /// from the local filesystem. The package can be either a source or binary
-    /// package.
-    Path(PathSpec),
+    /// URL pointing at a source archive (e.g. `.zip`, `.tar.gz`), with
+    /// optional matchspec selectors used to pick which built output to use.
+    UrlSource(Box<UrlSourceSpec>),
+
+    /// Local directory or source path, with optional matchspec selectors.
+    PathSource(Box<PathSourceSpec>),
+
+    /// Git repository, with optional matchspec selectors.
+    Git(Box<GitSpec>),
 }
 
 impl Default for PixiSpec {
     fn default() -> Self {
-        PixiSpec::Version(VersionSpec::Any)
+        PixiSpec::any()
+    }
+}
+
+impl ::serde::Serialize for PixiSpec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        match self {
+            PixiSpec::Version(version) => serializer.serialize_str(&version.to_string()),
+            PixiSpec::Detailed(detailed) => detailed.serialize(serializer),
+            PixiSpec::UrlBinary(spec) => spec.serialize(serializer),
+            PixiSpec::PathBinary(spec) => spec.serialize(serializer),
+            PixiSpec::UrlSource(spec) => spec.serialize(serializer),
+            PixiSpec::PathSource(spec) => spec.serialize(serializer),
+            PixiSpec::Git(spec) => spec.serialize(serializer),
+        }
     }
 }
 
@@ -110,10 +147,12 @@ impl Display for PixiSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             PixiSpec::Version(version) => write!(f, "{version}"),
-            PixiSpec::DetailedVersion(detailed) => write!(f, "{detailed}"),
-            PixiSpec::Url(url) => write!(f, "{url}"),
+            PixiSpec::Detailed(detailed) => write!(f, "{detailed}"),
+            PixiSpec::UrlBinary(url) => write!(f, "{url}"),
+            PixiSpec::PathBinary(path) => write!(f, "{path}"),
+            PixiSpec::UrlSource(url) => write!(f, "{url}"),
+            PixiSpec::PathSource(path) => write!(f, "{path}"),
             PixiSpec::Git(git) => write!(f, "{git}"),
-            PixiSpec::Path(path) => write!(f, "{path}"),
         }
     }
 }
@@ -126,7 +165,7 @@ impl From<VersionSpec> for PixiSpec {
 
 impl PixiSpec {
     /// Creates a new instance that matches any version.
-    pub const fn any() -> Self {
+    pub fn any() -> Self {
         Self::Version(VersionSpec::Any)
     }
 
@@ -136,31 +175,54 @@ impl PixiSpec {
         channel_config: &ChannelConfig,
     ) -> Self {
         if let Some(url) = spec.url {
-            Self::Url(UrlSpec {
-                url,
-                md5: spec.md5,
-                sha256: spec.sha256,
-                // A nameless matchspec always describes a binary spec which cannot have a
-                // subdirectory
-                subdirectory: Subdirectory::default(),
-            })
-        } else if spec.build.is_none()
-            && spec.build_number.is_none()
-            && spec.file_name.is_none()
-            && spec.extras.is_none()
-            && spec.flags.is_none()
-            && spec.channel.is_none()
-            && spec.subdir.is_none()
-            && spec.md5.is_none()
-            && spec.sha256.is_none()
-            && spec.license.is_none()
-            && spec.license_family.is_none()
-            && spec.condition.is_none()
-            && spec.track_features.is_none()
-        {
-            Self::Version(spec.version.unwrap_or(VersionSpec::Any))
+            // Detect whether the URL points to a binary archive.
+            if url_is_binary(&url) {
+                Self::UrlBinary(UrlBinarySpec {
+                    url,
+                    md5: spec.md5,
+                    sha256: spec.sha256,
+                })
+            } else {
+                Self::UrlSource(Box::new(UrlSourceSpec {
+                    url,
+                    md5: spec.md5,
+                    sha256: spec.sha256,
+                    subdirectory: Subdirectory::default(),
+                    matchspec: MatchspecFields {
+                        version: spec.version,
+                        build: spec.build,
+                        build_number: spec.build_number,
+                        extras: spec.extras,
+                        flags: spec.flags,
+                        subdir: spec.subdir,
+                        license: spec.license,
+                        license_family: spec.license_family,
+                        condition: spec.condition,
+                        track_features: spec.track_features,
+                    },
+                }))
+            }
         } else {
-            Self::DetailedVersion(Box::new(DetailedSpec {
+            // A bare nameless spec (no fields other than possibly `version`)
+            // round-trips to a `PixiSpec::Version`, so it serializes as the
+            // bare string `"*"` (or `">=1"`, ...) instead of a table.
+            let is_bare = spec.build.is_none()
+                && spec.build_number.is_none()
+                && spec.file_name.is_none()
+                && spec.extras.is_none()
+                && spec.flags.is_none()
+                && spec.channel.is_none()
+                && spec.subdir.is_none()
+                && spec.md5.is_none()
+                && spec.sha256.is_none()
+                && spec.license.is_none()
+                && spec.license_family.is_none()
+                && spec.condition.is_none()
+                && spec.track_features.is_none();
+            if is_bare {
+                return Self::Version(spec.version.unwrap_or(VersionSpec::Any));
+            }
+            Self::Detailed(Box::new(DetailedSpec {
                 version: spec.version,
                 build: spec.build,
                 build_number: spec.build_number,
@@ -187,33 +249,74 @@ impl PixiSpec {
     pub fn has_version_spec(&self) -> bool {
         match self {
             Self::Version(v) => v != &VersionSpec::Any,
-            Self::DetailedVersion(v) => v.version.as_ref().is_some_and(|v| v != &VersionSpec::Any),
+            Self::Detailed(d) => d.version.as_ref().is_some_and(|v| v != &VersionSpec::Any),
+            Self::UrlSource(u) => u
+                .matchspec
+                .version
+                .as_ref()
+                .is_some_and(|v| v != &VersionSpec::Any),
+            Self::PathSource(p) => p
+                .matchspec
+                .version
+                .as_ref()
+                .is_some_and(|v| v != &VersionSpec::Any),
+            Self::Git(g) => g
+                .matchspec
+                .version
+                .as_ref()
+                .is_some_and(|v| v != &VersionSpec::Any),
             _ => false,
         }
     }
 
-    /// Returns a [`VersionSpec`] if this instance is a version spec.
+    /// Returns a [`VersionSpec`] if this instance carries one.
     pub fn as_version_spec(&self) -> Option<&VersionSpec> {
         match self {
             Self::Version(v) => Some(v),
-            Self::DetailedVersion(v) => v.version.as_ref(),
+            Self::Detailed(d) => d.version.as_ref(),
+            Self::UrlSource(u) => u.matchspec.version.as_ref(),
+            Self::PathSource(p) => p.matchspec.version.as_ref(),
+            Self::Git(g) => g.matchspec.version.as_ref(),
             _ => None,
         }
     }
 
-    /// Returns a [`DetailedSpec`] if this instance is a detailed version
-    /// spec.
+    /// Returns a [`DetailedSpec`] if this instance is a detailed spec.
     pub fn as_detailed(&self) -> Option<&DetailedSpec> {
         match self {
-            Self::DetailedVersion(v) => Some(v),
+            Self::Detailed(d) => Some(d),
             _ => None,
         }
     }
 
-    /// Returns a [`UrlSpec`] if this instance is a detailed version spec.
-    pub fn as_url(&self) -> Option<&UrlSpec> {
+    /// Returns a [`UrlSourceSpec`] if this instance is a URL source spec.
+    pub fn as_url_source(&self) -> Option<&UrlSourceSpec> {
         match self {
-            Self::Url(v) => Some(v),
+            Self::UrlSource(u) => Some(u),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`UrlBinarySpec`] if this instance is a URL binary spec.
+    pub fn as_url_binary(&self) -> Option<&UrlBinarySpec> {
+        match self {
+            Self::UrlBinary(u) => Some(u),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`PathSourceSpec`] if this instance is a path source spec.
+    pub fn as_path_source(&self) -> Option<&PathSourceSpec> {
+        match self {
+            Self::PathSource(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`PathBinarySpec`] if this instance is a path binary spec.
+    pub fn as_path_binary(&self) -> Option<&PathBinarySpec> {
+        match self {
+            Self::PathBinary(p) => Some(p),
             _ => None,
         }
     }
@@ -221,15 +324,39 @@ impl PixiSpec {
     /// Returns a [`GitSpec`] if this instance is a git spec.
     pub fn as_git(&self) -> Option<&GitSpec> {
         match self {
-            Self::Git(v) => Some(v),
+            Self::Git(g) => Some(g),
             _ => None,
         }
     }
 
-    /// Returns a [`PathSpec`] if this instance is a path spec.
-    pub fn as_path(&self) -> Option<&PathSpec> {
+    /// Returns a [`UrlSpec`] reconstructed from a URL-typed variant.
+    pub fn as_url(&self) -> Option<UrlSpec> {
         match self {
-            Self::Path(v) => Some(v),
+            Self::UrlBinary(u) => Some(UrlSpec {
+                url: u.url.clone(),
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: Subdirectory::default(),
+            }),
+            Self::UrlSource(u) => Some(UrlSpec {
+                url: u.url.clone(),
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: u.subdirectory.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`PathSpec`] reconstructed from a path-typed variant.
+    pub fn as_path(&self) -> Option<PathSpec> {
+        match self {
+            Self::PathBinary(p) => Some(PathSpec {
+                path: p.path.clone(),
+            }),
+            Self::PathSource(p) => Some(PathSpec {
+                path: p.path.clone(),
+            }),
             _ => None,
         }
     }
@@ -238,7 +365,10 @@ impl PixiSpec {
     pub fn into_version(self) -> Option<VersionSpec> {
         match self {
             Self::Version(v) => Some(v),
-            Self::DetailedVersion(v) => v.version,
+            Self::Detailed(d) => d.version,
+            Self::UrlSource(u) => u.matchspec.version,
+            Self::PathSource(p) => p.matchspec.version,
+            Self::Git(g) => g.matchspec.version,
             _ => None,
         }
     }
@@ -246,11 +376,7 @@ impl PixiSpec {
     /// Converts this instance into a [`DetailedSpec`] if possible.
     pub fn into_detailed(self) -> Option<DetailedSpec> {
         match self {
-            Self::DetailedVersion(v) => Some(*v),
-            Self::Version(v) => Some(DetailedSpec {
-                version: Some(v),
-                ..DetailedSpec::default()
-            }),
+            Self::Detailed(d) => Some(*d),
             _ => None,
         }
     }
@@ -258,7 +384,18 @@ impl PixiSpec {
     /// Converts this instance into a [`UrlSpec`] if possible.
     pub fn into_url(self) -> Option<UrlSpec> {
         match self {
-            Self::Url(v) => Some(v),
+            Self::UrlBinary(u) => Some(UrlSpec {
+                url: u.url,
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: Subdirectory::default(),
+            }),
+            Self::UrlSource(u) => Some(UrlSpec {
+                url: u.url,
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: u.subdirectory,
+            }),
             _ => None,
         }
     }
@@ -266,7 +403,7 @@ impl PixiSpec {
     /// Converts this instance into a [`GitSpec`] if possible.
     pub fn into_git(self) -> Option<GitSpec> {
         match self {
-            Self::Git(v) => Some(v),
+            Self::Git(g) => Some(*g),
             _ => None,
         }
     }
@@ -274,7 +411,8 @@ impl PixiSpec {
     /// Converts this instance into a [`PathSpec`] if possible.
     pub fn into_path(self) -> Option<PathSpec> {
         match self {
-            Self::Path(v) => Some(v),
+            Self::PathBinary(p) => Some(PathSpec { path: p.path }),
+            Self::PathSource(p) => Some(PathSpec { path: p.path }),
             _ => None,
         }
     }
@@ -291,33 +429,27 @@ impl PixiSpec {
                 version: Some(version),
                 ..NamelessMatchSpec::default()
             }),
-            PixiSpec::DetailedVersion(spec) => {
-                Some(spec.try_into_nameless_match_spec(channel_config)?)
+            PixiSpec::Detailed(spec) => Some(spec.try_into_nameless_match_spec(channel_config)?),
+            PixiSpec::UrlBinary(url) => Some(url.into()),
+            PixiSpec::PathBinary(path) => {
+                Some(path.try_into_nameless_match_spec(&channel_config.root_dir)?)
             }
-            PixiSpec::Url(url) => url.try_into_nameless_match_spec().ok(),
-            PixiSpec::Git(_) => None,
-            PixiSpec::Path(path) => path.try_into_nameless_match_spec(&channel_config.root_dir)?,
+            PixiSpec::UrlSource(_) | PixiSpec::PathSource(_) | PixiSpec::Git(_) => None,
         };
 
         Ok(spec)
     }
 
-    /// Converts this instance in a source or binary spec.
+    /// Converts this instance into a source or binary spec.
     pub fn into_source_or_binary(self) -> Either<SourceSpec, BinarySpec> {
         match self {
             PixiSpec::Version(version) => Either::Right(BinarySpec::Version(version)),
-            PixiSpec::DetailedVersion(detailed) => {
-                Either::Right(BinarySpec::DetailedVersion(detailed))
-            }
-            PixiSpec::Url(url) => url
-                .into_source_or_binary()
-                .map_left(|url| SourceLocationSpec::Url(url).into())
-                .map_right(BinarySpec::Url),
-            PixiSpec::Git(git) => Either::Left(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .into_source_or_binary()
-                .map_left(|path| SourceLocationSpec::Path(path).into())
-                .map_right(BinarySpec::Path),
+            PixiSpec::Detailed(detailed) => Either::Right(BinarySpec::DetailedVersion(detailed)),
+            PixiSpec::UrlBinary(url) => Either::Right(BinarySpec::Url(url)),
+            PixiSpec::PathBinary(path) => Either::Right(BinarySpec::Path(path)),
+            PixiSpec::UrlSource(url) => Either::Left(SourceSpec::Url(*url)),
+            PixiSpec::PathSource(path) => Either::Left(SourceSpec::Path(*path)),
+            PixiSpec::Git(git) => Either::Left(SourceSpec::Git(*git)),
         }
     }
 
@@ -326,28 +458,19 @@ impl PixiSpec {
     #[allow(clippy::result_large_err)]
     pub fn try_into_source_spec(self) -> Result<SourceSpec, Self> {
         match self {
-            PixiSpec::Url(url) => url
-                .try_into_source_url()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
-            PixiSpec::Git(git) => Ok(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .try_into_source_path()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
+            PixiSpec::UrlSource(url) => Ok(SourceSpec::Url(*url)),
+            PixiSpec::PathSource(path) => Ok(SourceSpec::Path(*path)),
+            PixiSpec::Git(git) => Ok(SourceSpec::Git(*git)),
             _ => Err(self),
         }
     }
 
     /// Returns true if this spec represents a binary package.
     pub fn is_binary(&self) -> bool {
-        match self {
-            Self::Version(_) => true,
-            Self::DetailedVersion(_) => true,
-            Self::Url(url) => url.is_binary(),
-            Self::Git(_) => false,
-            Self::Path(path) => path.is_binary(),
-        }
+        matches!(
+            self,
+            Self::Version(_) | Self::Detailed(_) | Self::UrlBinary(_) | Self::PathBinary(_)
+        )
     }
 
     /// Returns true if this spec represents a source package.
@@ -359,13 +482,7 @@ impl PixiSpec {
     /// A spec is mutable if it points to a local path-based source
     /// (non-binary).
     pub fn is_mutable(&self) -> bool {
-        match self {
-            Self::Version(_) => false,
-            Self::DetailedVersion(_) => false,
-            Self::Url(_) => false,
-            Self::Git(_) => false,
-            Self::Path(path) => !path.is_binary(),
-        }
+        matches!(self, Self::PathSource(_))
     }
 
     /// Converts this instance into a [`toml_edit::Value`].
@@ -381,16 +498,13 @@ impl PixiSpec {
         channel_config: &ChannelConfig,
     ) -> Result<NamelessMatchSpec, SpecConversionError> {
         match self.into_source_or_binary() {
-            Either::Left(_source) => Ok(NamelessMatchSpec::default()),
+            Either::Left(source) => Ok(source.to_nameless_match_spec()),
             Either::Right(binary) => binary.try_into_nameless_match_spec(channel_config),
         }
     }
 
     /// Convert this spec into a fully-named [`MatchSpec`] for the given
-    /// package `name`. Source-typed specs round-trip through
-    /// [`SourceSpec::to_nameless_match_spec`], binary-typed specs through
-    /// [`BinarySpec::try_into_nameless_match_spec`]; the result is wrapped
-    /// in a `MatchSpec` carrying `name`.
+    /// package `name`.
     pub fn to_match_spec(
         self,
         name: &PackageName,
@@ -404,73 +518,14 @@ impl PixiSpec {
     }
 }
 
-/// A specification for a source package.
-///
-/// This type only represents source packages. Use [`PixiSpec`] to represent
-/// both binary and source packages.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize)]
-pub struct SourceSpec {
-    /// The location of the source.
-    #[serde(flatten)]
-    pub location: SourceLocationSpec,
-
-    /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
-    pub version: Option<VersionSpec>,
-
-    /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
-    pub build: Option<StringMatcher>,
-
-    /// The build number of the package
-    pub build_number: Option<BuildNumberSpec>,
-
-    /// Optional extra dependencies to select for the package
-    pub extras: Option<Vec<String>>,
-
-    /// Plain string flags used to select package variants.
-    pub flags: Option<Vec<StringMatcher>>,
-
-    /// The subdir of the channel
-    pub subdir: Option<String>,
-
-    /// The namespace of the package (currently not used)
-    pub namespace: Option<String>,
-
-    /// The license of the package
-    pub license: Option<String>,
-
-    /// The license family of the package
-    pub license_family: Option<String>,
-
-    /// The condition under which this match spec applies.
-    pub condition: Option<MatchSpecCondition>,
-
-    /// The track features of the package
-    pub track_features: Option<Vec<String>>,
-}
-
-impl From<SourceLocationSpec> for SourceSpec {
-    fn from(value: SourceLocationSpec) -> Self {
-        Self {
-            location: value,
-            version: None,
-            build: None,
-            build_number: None,
-            extras: None,
-            flags: None,
-            subdir: None,
-            namespace: None,
-            license: None,
-            license_family: None,
-            condition: None,
-            track_features: None,
-        }
-    }
-}
-
 /// A specification for a source location.
+///
+/// Each variant inner type optionally carries [`MatchspecFields`] selectors,
+/// so a `SourceSpec` carries both the location and any match
+/// constraints that apply to the built output transitively.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
-pub enum SourceLocationSpec {
+pub enum SourceSpec {
     /// The spec is represented as an archive that can be downloaded from the
     /// specified URL.
     Url(UrlSourceSpec),
@@ -482,156 +537,165 @@ pub enum SourceLocationSpec {
     Path(PathSourceSpec),
 }
 
-impl Display for SourceLocationSpec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self {
-            SourceLocationSpec::Url(url) => write!(f, "{url}"),
-            SourceLocationSpec::Git(git) => write!(f, "{git}"),
-            SourceLocationSpec::Path(path) => write!(f, "{path}"),
-        }
-    }
-}
-
 impl Display for SourceSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.location.fmt(f)
+        match &self {
+            SourceSpec::Url(url) => write!(f, "{url}"),
+            SourceSpec::Git(git) => write!(f, "{git}"),
+            SourceSpec::Path(path) => write!(f, "{path}"),
+        }
     }
 }
 
 impl SourceSpec {
-    /// Constructs a new instance from a location and a nameless match spec.
-    pub fn new(location: SourceLocationSpec, spec: NamelessMatchSpec) -> Self {
-        let NamelessMatchSpec {
-            version,
-            build,
-            build_number,
-            file_name: _,
-            extras,
-            flags,
-            channel: _,
-            subdir,
-            namespace,
-            md5: _,
-            sha256: _,
-            url: _,
-            license,
-            condition,
-            track_features,
-            license_family,
-        } = spec;
-        Self {
-            location,
-            version,
-            build,
-            build_number,
-            extras,
-            flags,
-            subdir,
-            namespace,
-            license,
-            license_family,
-            condition,
-            track_features,
+    /// Returns true if this spec represents a git repository.
+    pub fn is_git(&self) -> bool {
+        matches!(self, SourceSpec::Git(_))
+    }
+
+    /// Returns true if this spec represents a local path.
+    pub fn is_path(&self) -> bool {
+        matches!(self, SourceSpec::Path(_))
+    }
+
+    /// Returns true if this spec represents a URL archive.
+    pub fn is_url(&self) -> bool {
+        matches!(self, SourceSpec::Url(_))
+    }
+
+    /// Returns the matchspec selectors carried by this source location.
+    pub fn matchspec(&self) -> &MatchspecFields {
+        match self {
+            SourceSpec::Url(u) => &u.matchspec,
+            SourceSpec::Git(g) => &g.matchspec,
+            SourceSpec::Path(p) => &p.matchspec,
         }
     }
 
-    /// Convert this instance into a nameless match spec.
-    pub fn to_nameless_match_spec(&self) -> NamelessMatchSpec {
-        let Self {
-            location: _,
-            version,
-            build,
-            build_number,
-            extras,
-            flags,
-            subdir,
-            namespace,
-            license,
-            license_family,
-            condition,
-            track_features,
-        } = self;
-        NamelessMatchSpec {
-            version: version.clone(),
-            build: build.clone(),
-            build_number: build_number.clone(),
-            extras: extras.clone(),
-            flags: flags.clone(),
-            subdir: subdir.clone(),
-            namespace: namespace.clone(),
-            license: license.clone(),
-            license_family: license_family.clone(),
-            condition: condition.clone(),
-            track_features: track_features.clone(),
-            ..NamelessMatchSpec::default()
+    /// Mutable access to the matchspec selectors carried by this location.
+    pub fn matchspec_mut(&mut self) -> &mut MatchspecFields {
+        match self {
+            SourceSpec::Url(u) => &mut u.matchspec,
+            SourceSpec::Git(g) => &mut g.matchspec,
+            SourceSpec::Path(p) => &mut p.matchspec,
         }
+    }
+
+    /// Convert this source location into a [`NamelessMatchSpec`] containing
+    /// only the matchspec selectors (the location itself is not encoded).
+    pub fn to_nameless_match_spec(&self) -> NamelessMatchSpec {
+        self.matchspec().to_nameless_match_spec()
     }
 
     /// Converts this instance into a [`toml_edit::Value`].
     pub fn to_toml_value(&self) -> toml_edit::Value {
-        ::serde::Serialize::serialize(&self.location, toml_edit::ser::ValueSerializer::new())
+        ::serde::Serialize::serialize(self, toml_edit::ser::ValueSerializer::new())
             .expect("conversion to toml cannot fail")
     }
 
     /// Resolves the source location using the provided source anchor.
     pub fn resolve(self, source_anchor: &SourceAnchor) -> Self {
-        Self {
-            location: source_anchor.resolve(self.location),
-            ..self
-        }
+        source_anchor.resolve(self)
     }
 }
 
-impl SourceLocationSpec {
-    /// Returns true if this spec represents a git repository.
-    pub fn is_git(&self) -> bool {
-        matches!(self, SourceLocationSpec::Git(_))
+impl From<UrlSourceSpec> for SourceSpec {
+    fn from(value: UrlSourceSpec) -> Self {
+        SourceSpec::Url(value)
+    }
+}
+
+impl From<PathSourceSpec> for SourceSpec {
+    fn from(value: PathSourceSpec) -> Self {
+        SourceSpec::Path(value)
+    }
+}
+
+impl From<GitSpec> for SourceSpec {
+    fn from(value: GitSpec) -> Self {
+        SourceSpec::Git(value)
     }
 }
 
 impl From<SourceSpec> for PixiSpec {
     fn from(value: SourceSpec) -> Self {
-        match value.location {
-            SourceLocationSpec::Url(url) => Self::Url(url.into()),
-            SourceLocationSpec::Git(git) => Self::Git(git),
-            SourceLocationSpec::Path(path) => Self::Path(path.into()),
+        match value {
+            SourceSpec::Url(url) => Self::UrlSource(Box::new(url)),
+            SourceSpec::Git(git) => Self::Git(Box::new(git)),
+            SourceSpec::Path(path) => Self::PathSource(Box::new(path)),
         }
     }
 }
 
 impl From<DetailedSpec> for PixiSpec {
     fn from(value: DetailedSpec) -> Self {
-        Self::DetailedVersion(Box::new(value))
+        Self::Detailed(Box::new(value))
     }
 }
 
 impl From<UrlSpec> for PixiSpec {
     fn from(value: UrlSpec) -> Self {
-        Self::Url(value)
+        // A bare `UrlSpec` doesn't pre-commit to source-or-binary, so we
+        // inspect the URL to decide which typed variant to produce.
+        if url_is_binary(&value.url) {
+            Self::UrlBinary(UrlBinarySpec {
+                url: value.url,
+                md5: value.md5,
+                sha256: value.sha256,
+            })
+        } else {
+            Self::UrlSource(Box::new(UrlSourceSpec {
+                url: value.url,
+                md5: value.md5,
+                sha256: value.sha256,
+                subdirectory: value.subdirectory,
+                matchspec: MatchspecFields::default(),
+            }))
+        }
     }
 }
 
-impl From<UrlSourceSpec> for SourceSpec {
+impl From<UrlSourceSpec> for PixiSpec {
     fn from(value: UrlSourceSpec) -> Self {
-        SourceLocationSpec::Url(value).into()
+        Self::UrlSource(Box::new(value))
+    }
+}
+
+impl From<UrlBinarySpec> for PixiSpec {
+    fn from(value: UrlBinarySpec) -> Self {
+        Self::UrlBinary(value)
     }
 }
 
 impl From<GitSpec> for PixiSpec {
     fn from(value: GitSpec) -> Self {
-        Self::Git(value)
+        Self::Git(Box::new(value))
     }
 }
 
 impl From<PathSpec> for PixiSpec {
     fn from(value: PathSpec) -> Self {
-        Self::Path(value)
+        // Inspect the path extension to decide source-or-binary.
+        if CondaArchiveType::try_from(std::path::Path::new(value.path.as_str())).is_some() {
+            Self::PathBinary(PathBinarySpec { path: value.path })
+        } else {
+            Self::PathSource(Box::new(PathSourceSpec {
+                path: value.path,
+                matchspec: MatchspecFields::default(),
+            }))
+        }
     }
 }
 
-impl From<PathSourceSpec> for SourceSpec {
+impl From<PathSourceSpec> for PixiSpec {
     fn from(value: PathSourceSpec) -> Self {
-        SourceLocationSpec::Path(value).into()
+        Self::PathSource(Box::new(value))
+    }
+}
+
+impl From<PathBinarySpec> for PixiSpec {
+    fn from(value: PathBinarySpec) -> Self {
+        Self::PathBinary(value)
     }
 }
 
@@ -642,7 +706,7 @@ impl From<PixiSpec> for toml_edit::Value {
     }
 }
 
-/// A specification for a source package.
+/// A specification for a binary package.
 ///
 /// This type only represents binary packages. Use [`PixiSpec`] to represent
 /// both binary and source packages.
@@ -651,9 +715,6 @@ impl From<PixiSpec> for toml_edit::Value {
 pub enum BinarySpec {
     /// The spec is represented solely by a version string. The package should
     /// be retrieved from a channel.
-    ///
-    /// This is similar to the `DetailedVersion` variant but with a simplified
-    /// version spec.
     Version(VersionSpec),
 
     /// The spec is represented by a detailed version spec. The package should
@@ -661,12 +722,11 @@ pub enum BinarySpec {
     DetailedVersion(Box<DetailedSpec>),
 
     /// The spec is represented as an archive that can be downloaded from the
-    /// specified URL. The package should be retrieved from the URL and can
-    /// only represent an archive.
+    /// specified URL.
     Url(UrlBinarySpec),
 
     /// The spec is represented as a local path. The package should be retrieved
-    /// from the local filesystem. The package can only be a binary package.
+    /// from the local filesystem.
     Path(PathBinarySpec),
 }
 
@@ -710,9 +770,9 @@ impl From<BinarySpec> for PixiSpec {
     fn from(value: BinarySpec) -> Self {
         match value {
             BinarySpec::Version(version) => Self::Version(version),
-            BinarySpec::DetailedVersion(detailed) => Self::DetailedVersion(detailed),
-            BinarySpec::Url(url) => Self::Url(url.into()),
-            BinarySpec::Path(path) => Self::Path(path.into()),
+            BinarySpec::DetailedVersion(detailed) => Self::Detailed(detailed),
+            BinarySpec::Url(url) => Self::UrlBinary(url),
+            BinarySpec::Path(path) => Self::PathBinary(path),
         }
     }
 }
@@ -724,7 +784,7 @@ impl From<VersionSpec> for BinarySpec {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<rattler_lock::source::SourceLocation> for SourceLocationSpec {
+impl From<rattler_lock::source::SourceLocation> for SourceSpec {
     fn from(value: rattler_lock::source::SourceLocation) -> Self {
         match value {
             rattler_lock::source::SourceLocation::Url(url) => Self::Url(url.into()),
@@ -735,12 +795,12 @@ impl From<rattler_lock::source::SourceLocation> for SourceLocationSpec {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<SourceLocationSpec> for rattler_lock::source::SourceLocation {
-    fn from(value: SourceLocationSpec) -> Self {
+impl From<SourceSpec> for rattler_lock::source::SourceLocation {
+    fn from(value: SourceSpec) -> Self {
         match value {
-            SourceLocationSpec::Url(url) => Self::Url(url.into()),
-            SourceLocationSpec::Git(git) => Self::Git(git.into()),
-            SourceLocationSpec::Path(path) => Self::Path(path.into()),
+            SourceSpec::Url(url) => Self::Url(url.into()),
+            SourceSpec::Git(git) => Self::Git(git.into()),
+            SourceSpec::Path(path) => Self::Path(path.into()),
         }
     }
 }
@@ -762,6 +822,7 @@ impl From<rattler_lock::source::UrlSourceLocation> for UrlSourceSpec {
             subdirectory: subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
+            matchspec: MatchspecFields::default(),
         }
     }
 }
@@ -795,6 +856,7 @@ impl From<rattler_lock::source::GitSourceLocation> for GitSpec {
                 .subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
+            matchspec: MatchspecFields::default(),
         }
     }
 }
@@ -820,7 +882,10 @@ impl From<GitSpec> for rattler_lock::source::GitSourceLocation {
 #[cfg(feature = "rattler_lock")]
 impl From<rattler_lock::source::PathSourceLocation> for PathSourceSpec {
     fn from(value: rattler_lock::source::PathSourceLocation) -> Self {
-        Self { path: value.path }
+        Self {
+            path: value.path,
+            matchspec: MatchspecFields::default(),
+        }
     }
 }
 
@@ -844,7 +909,7 @@ mod test {
     use serde_json::{Value, json};
     use url::Url;
 
-    use crate::{BinarySpec, PixiSpec};
+    use crate::{BinarySpec, MatchspecFields, PixiSpec};
 
     #[test]
     fn test_is_binary() {
@@ -977,7 +1042,7 @@ mod test {
         };
 
         let pixi_spec = PixiSpec::from_nameless_matchspec(spec.clone(), &channel_config);
-        assert!(matches!(pixi_spec, PixiSpec::DetailedVersion(_)));
+        assert!(matches!(pixi_spec, PixiSpec::Detailed(_)));
 
         let roundtrip = pixi_spec
             .try_into_nameless_match_spec(&channel_config)
@@ -1014,5 +1079,122 @@ mod test {
         let name = PackageName::new_unchecked("openssl");
         let match_spec = spec.to_match_spec(&name, &channel_config).unwrap();
         assert_eq!(match_spec.to_string(), "openssl >=2.0");
+    }
+
+    /// A path source spec carrying matchspec selectors should turn into a
+    /// `MatchSpec` carrying those same selectors (the location itself
+    /// is dropped — `to_match_spec` returns a *binary-shaped* matchspec
+    /// that the solver uses to pick which built output of the source
+    /// satisfies the constraint).
+    #[test]
+    fn test_path_source_with_matchspec_to_match_spec() {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "path": "../my-pkg",
+            "version": ">=1.0",
+            "build": "py310_*",
+            "subdir": "linux-64",
+        }))
+        .unwrap();
+
+        let name = PackageName::new_unchecked("my-pkg");
+        let match_spec = spec.to_match_spec(&name, &channel_config).unwrap();
+
+        assert_eq!(
+            match_spec.name.as_exact().map(PackageName::as_normalized),
+            Some("my-pkg")
+        );
+        assert_eq!(match_spec.version.unwrap().to_string(), ">=1.0");
+        assert_eq!(match_spec.subdir.as_deref(), Some("linux-64"));
+        assert!(match_spec.build.is_some());
+    }
+
+    /// `try_into_nameless_match_spec` on a source variant returns `None`
+    /// (sources don't have a fully-resolved nameless matchspec); use
+    /// `to_match_spec` or read `matchspec()` instead.
+    #[test]
+    fn test_try_into_nameless_match_spec_source_returns_none() {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "git": "https://example.com/foo.git",
+            "version": ">=1.0",
+        }))
+        .unwrap();
+        assert!(matches!(spec, PixiSpec::Git(_)));
+        let result = spec.try_into_nameless_match_spec(&channel_config).unwrap();
+        assert!(result.is_none());
+    }
+
+    /// `MatchspecFields::from_nameless_match_spec` extracts only the
+    /// matchspec subset; binary-only fields (`url`, `md5`, `sha256`,
+    /// `file_name`, `channel`, `namespace`) are dropped.
+    #[test]
+    fn test_matchspec_fields_extraction_drops_binary_fields() {
+        use rattler_conda_types::NamelessMatchSpec;
+        let nameless = NamelessMatchSpec {
+            version: Some(VersionSpec::from_str(">=1.0", Lenient).unwrap()),
+            build_number: Some(">=3".parse().unwrap()),
+            file_name: Some("foo.conda".to_string()),
+            md5: Some(Default::default()),
+            ..NamelessMatchSpec::default()
+        };
+        let fields = MatchspecFields::from_nameless_match_spec(&nameless);
+        assert_eq!(fields.version.as_ref().unwrap().to_string(), ">=1.0");
+        assert!(fields.build_number.is_some());
+        // Re-encoding to NamelessMatchSpec must NOT carry the binary-only
+        // fields back.
+        let round_tripped = fields.to_nameless_match_spec();
+        assert!(round_tripped.file_name.is_none());
+        assert!(round_tripped.md5.is_none());
+        assert!(round_tripped.url.is_none());
+    }
+
+    /// A bare version string round-trips to a `PixiSpec::Version` and
+    /// serializes back to a string, while the table form `{ version = "X" }`
+    /// stays a table - the two on-disk shapes are preserved by the type.
+    #[test]
+    fn test_bare_version_vs_table_form_preserved() {
+        let from_string: PixiSpec = serde_json::from_value(json!("1.2.3")).unwrap();
+        assert!(matches!(from_string, PixiSpec::Version(_)));
+        let json = serde_json::to_value(&from_string).unwrap();
+        assert_eq!(json, json!("==1.2.3"));
+        assert_eq!(from_string.to_string(), "==1.2.3");
+
+        let from_table: PixiSpec = serde_json::from_value(json!({ "version": "1.2.3" })).unwrap();
+        assert!(matches!(from_table, PixiSpec::Detailed(_)));
+        let json = serde_json::to_value(&from_table).unwrap();
+        assert!(json.is_object(), "expected a JSON object, got {json}");
+    }
+
+    /// `from_nameless_matchspec` on a bare nameless spec (no fields other
+    /// than possibly `version`) produces a `PixiSpec::Version`, which
+    /// serializes as the bare string form.
+    #[test]
+    fn test_bare_nameless_becomes_version() {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+        let nameless = MatchSpec::from_str("any-spec", ParseMatchSpecOptions::lenient())
+            .unwrap()
+            .into_nameless()
+            .1;
+        let spec = PixiSpec::from_nameless_matchspec(nameless, &channel_config);
+        assert!(matches!(spec, PixiSpec::Version(_)));
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json, json!("*"));
+        assert_eq!(spec.to_string(), "*");
+    }
+
+    /// A `Detailed` spec with *any* extra field present must serialize
+    /// as a table — the bare-string collapse only applies when only
+    /// `version` is set.
+    #[test]
+    fn test_detailed_with_extra_field_serializes_as_table() {
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "version": "1.2.3",
+            "build": "py37_*",
+        }))
+        .unwrap();
+        let value = serde_json::to_value(&spec).unwrap();
+        assert!(value.is_object(), "expected a JSON object, got {value}");
     }
 }

--- a/crates/pixi_spec/src/matchspec_fields.rs
+++ b/crates/pixi_spec/src/matchspec_fields.rs
@@ -1,0 +1,112 @@
+//! Match-spec selector fields that can decorate a source-side spec
+//! (URL source archive, path source, or git checkout).
+//!
+//! These mirror the subset of `NamelessMatchSpec` that makes sense for
+//! source packages once the source has been resolved into a concrete
+//! built output: `version`, `build`, `build-number`, `extras`, `flags`,
+//! `subdir`, `license`, `license-family`, `when` (parsed into
+//! `condition`), and `track-features`. Binary-only fields like
+//! `file-name`, `channel`, `md5`, `sha256` deliberately stay on
+//! `DetailedSpec` / `UrlBinarySpec` / `PathBinarySpec`.
+
+use rattler_conda_types::{
+    BuildNumberSpec, MatchSpecCondition, NamelessMatchSpec, StringMatcher, VersionSpec,
+};
+use serde_with::{serde_as, skip_serializing_none};
+
+/// Optional match-spec selectors carried alongside a source location.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MatchspecFields {
+    /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`).
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub version: Option<VersionSpec>,
+
+    /// The build string of the package (e.g. `py37_0`, `py*`).
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub build: Option<StringMatcher>,
+
+    /// The build number of the package.
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub build_number: Option<BuildNumberSpec>,
+
+    /// Optional extra dependencies to select for the package.
+    pub extras: Option<Vec<String>>,
+
+    /// Plain string flags used to select package variants.
+    #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
+    pub flags: Option<Vec<StringMatcher>>,
+
+    /// The subdir of the channel.
+    pub subdir: Option<String>,
+
+    /// The license of the package.
+    pub license: Option<String>,
+
+    /// The license family of the package.
+    pub license_family: Option<String>,
+
+    /// The condition (`when` in TOML) under which this spec applies.
+    pub condition: Option<MatchSpecCondition>,
+
+    /// The track features of the package.
+    pub track_features: Option<Vec<String>>,
+}
+
+impl MatchspecFields {
+    /// Returns `true` if every field is `None`.
+    pub fn is_empty(&self) -> bool {
+        self.version.is_none()
+            && self.build.is_none()
+            && self.build_number.is_none()
+            && self.extras.is_none()
+            && self.flags.is_none()
+            && self.subdir.is_none()
+            && self.license.is_none()
+            && self.license_family.is_none()
+            && self.condition.is_none()
+            && self.track_features.is_none()
+    }
+
+    /// Extract the matchspec subset of a [`NamelessMatchSpec`], ignoring
+    /// binary-only fields (`file_name`, `channel`, `md5`, `sha256`, `url`,
+    /// `namespace`).
+    pub fn from_nameless_match_spec(spec: &NamelessMatchSpec) -> Self {
+        Self {
+            version: spec.version.clone(),
+            build: spec.build.clone(),
+            build_number: spec.build_number.clone(),
+            extras: spec.extras.clone(),
+            flags: spec.flags.clone(),
+            subdir: spec.subdir.clone(),
+            license: spec.license.clone(),
+            license_family: spec.license_family.clone(),
+            condition: spec.condition.clone(),
+            track_features: spec.track_features.clone(),
+        }
+    }
+
+    /// Stamp these fields into a [`NamelessMatchSpec`], leaving the
+    /// binary-only fields untouched.
+    pub fn write_into_nameless_match_spec(&self, spec: &mut NamelessMatchSpec) {
+        spec.version = self.version.clone();
+        spec.build = self.build.clone();
+        spec.build_number = self.build_number.clone();
+        spec.extras = self.extras.clone();
+        spec.flags = self.flags.clone();
+        spec.subdir = self.subdir.clone();
+        spec.license = self.license.clone();
+        spec.license_family = self.license_family.clone();
+        spec.condition = self.condition.clone();
+        spec.track_features = self.track_features.clone();
+    }
+
+    /// Build a [`NamelessMatchSpec`] populated from these fields only.
+    pub fn to_nameless_match_spec(&self) -> NamelessMatchSpec {
+        let mut spec = NamelessMatchSpec::default();
+        self.write_into_nameless_match_spec(&mut spec);
+        spec
+    }
+}

--- a/crates/pixi_spec/src/path.rs
+++ b/crates/pixi_spec/src/path.rs
@@ -8,7 +8,7 @@ use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveType};
 use serde_with::serde_as;
 use typed_path::{Utf8NativePathBuf, Utf8TypedPathBuf};
 
-use crate::{BinarySpec, SpecConversionError};
+use crate::{BinarySpec, MatchspecFields, SpecConversionError};
 
 /// A specification of a package from a path.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -51,7 +51,10 @@ impl PathSpec {
         if self.is_binary() {
             Err(self)
         } else {
-            Ok(PathSourceSpec { path: self.path })
+            Ok(PathSourceSpec {
+                path: self.path,
+                matchspec: MatchspecFields::default(),
+            })
         }
     }
 
@@ -69,7 +72,10 @@ impl PathSpec {
         if self.is_binary() {
             Either::Right(PathBinarySpec { path: self.path })
         } else {
-            Either::Left(PathSourceSpec { path: self.path })
+            Either::Left(PathSourceSpec {
+                path: self.path,
+                matchspec: MatchspecFields::default(),
+            })
         }
     }
 }
@@ -85,12 +91,26 @@ impl Display for PathSpec {
 // serialization and deserialization below. See git blame history
 // right before this line was added.
 
-/// Path to a source package. Different from [`PathSpec`] in that this type only
+/// Path to a source package, optionally constrained by match-spec
+/// selectors. Different from [`PathSpec`] in that this type only
 /// refers to source packages.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct PathSourceSpec {
     /// The path to the package. Either a directory or an archive.
     pub path: Utf8TypedPathBuf,
+
+    /// Match-spec selectors applied to the built output.
+    pub matchspec: MatchspecFields,
+}
+
+impl PathSourceSpec {
+    /// Constructs a new [`PathSourceSpec`] with no matchspec selectors.
+    pub fn new(path: impl Into<Utf8TypedPathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            matchspec: MatchspecFields::default(),
+        }
+    }
 }
 
 impl Display for PathSourceSpec {
@@ -105,12 +125,15 @@ impl serde::Serialize for PathSourceSpec {
         S: serde::Serializer,
     {
         #[derive(serde::Serialize)]
-        struct Raw {
+        struct Raw<'a> {
             path: String,
+            #[serde(flatten)]
+            matchspec: &'a MatchspecFields,
         }
 
         Raw {
             path: self.path.to_string(),
+            matchspec: &self.matchspec,
         }
         .serialize(serializer)
     }
@@ -124,10 +147,13 @@ impl<'de> serde::Deserialize<'de> for PathSourceSpec {
         #[derive(serde::Deserialize)]
         struct Raw {
             path: String,
+            #[serde(flatten)]
+            matchspec: MatchspecFields,
         }
 
         Raw::deserialize(deserializer).map(|raw| PathSourceSpec {
             path: raw.path.into(),
+            matchspec: raw.matchspec,
         })
     }
 }
@@ -149,14 +175,20 @@ impl PathSourceSpec {
     }
 }
 
-/// Path to a source package. Different from [`PathSpec`] in that this type only
-/// refers to source packages.
+/// Path to a binary conda archive. Different from [`PathSpec`] in that
+/// this type only refers to binary packages.
 #[serde_as]
 #[derive(Debug, Clone, Hash, Eq, PartialEq, ::serde::Serialize)]
 pub struct PathBinarySpec {
     /// The path to the package. Either a directory or an archive.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub path: Utf8TypedPathBuf,
+}
+
+impl Display for PathBinarySpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path)
+    }
 }
 
 impl From<PathBinarySpec> for PathSpec {

--- a/crates/pixi_spec/src/pin.rs
+++ b/crates/pixi_spec/src/pin.rs
@@ -154,7 +154,7 @@ impl Pin {
             let build_matcher = build_string
                 .parse()
                 .map_err(|e| PinError::BuildStringParse(format!("{e}")))?;
-            return Ok(PixiSpec::DetailedVersion(Box::new(DetailedSpec {
+            return Ok(PixiSpec::Detailed(Box::new(DetailedSpec {
                 version: Some(version_spec),
                 build: Some(build_matcher),
                 ..Default::default()
@@ -183,14 +183,17 @@ impl Pin {
             let build_matcher = build
                 .parse()
                 .map_err(|e| PinError::BuildStringParse(format!("{e}")))?;
-            return Ok(PixiSpec::DetailedVersion(Box::new(DetailedSpec {
+            return Ok(PixiSpec::Detailed(Box::new(DetailedSpec {
                 version: Some(version_spec),
                 build: Some(build_matcher),
                 ..Default::default()
             })));
         }
 
-        Ok(PixiSpec::Version(version_spec))
+        Ok(PixiSpec::Detailed(Box::new(DetailedSpec {
+            version: Some(version_spec),
+            ..Default::default()
+        })))
     }
 }
 
@@ -330,8 +333,8 @@ mod tests {
         };
         let v = Version::from_str("3.11.5").unwrap();
         let spec = pin.resolve(&v, "h12345").unwrap();
-        let PixiSpec::DetailedVersion(detailed) = spec else {
-            panic!("expected DetailedVersion");
+        let PixiSpec::Detailed(detailed) = spec else {
+            panic!("expected Detailed");
         };
         assert_eq!(detailed.version.unwrap().to_string(), "==3.11.5");
         assert!(detailed.build.is_some());
@@ -347,10 +350,10 @@ mod tests {
         };
         let v = Version::from_str("3.11.5").unwrap();
         let spec = pin.resolve(&v, "h12345").unwrap();
-        let PixiSpec::Version(vs) = spec else {
-            panic!("expected Version");
+        let PixiSpec::Detailed(detailed) = spec else {
+            panic!("expected Detailed");
         };
-        assert_eq!(vs.to_string(), ">=3.11,<3.12.0a0");
+        assert_eq!(detailed.version.unwrap().to_string(), ">=3.11,<3.12.0a0");
     }
 
     #[test]
@@ -363,7 +366,10 @@ mod tests {
         };
         let v = Version::from_str("1.0.0").unwrap();
         let spec = pin.resolve(&v, "h0").unwrap();
-        assert!(matches!(spec, PixiSpec::Version(VersionSpec::Any)));
+        let PixiSpec::Detailed(detailed) = spec else {
+            panic!("expected Detailed");
+        };
+        assert!(matches!(detailed.version, Some(VersionSpec::Any)));
     }
 
     #[test]

--- a/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
+++ b/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
@@ -71,14 +71,63 @@ expression: snapshot
     git: "https://github.com/conda-forge/21cmfast-feedstock"
     branch: main
 - input:
+    path: "../mypkg"
+    version: 1.2.3
+  result:
+    path: "../mypkg"
+    version: "==1.2.3"
+- input:
+    path: "../mypkg"
+    version: ">=1.2"
+    build: py37_*
+  result:
+    path: "../mypkg"
+    version: ">=1.2"
+    build: py37_*
+- input:
+    path: "../mypkg"
+    subdir: linux-64
+    track-features:
+      - legacy
+  result:
+    path: "../mypkg"
+    subdir: linux-64
+    track-features:
+      - legacy
+- input:
+    git: "https://github.com/foo/bar"
+    branch: main
+    version: ">=1.0"
+    extras:
+      - cuda
+  result:
+    git: "https://github.com/foo/bar"
+    branch: main
+    version: ">=1.0"
+    extras:
+      - cuda
+- input:
+    url: "https://example.com/foo.tar.gz"
+    version: 1.2.3
+    build-number: ">=3"
+  result:
+    url: "https://example.com/foo.tar.gz"
+    version: "==1.2.3"
+    build-number: ">=3"
+- input:
+    url: "https://example.com/foo.tar.gz"
+    flags:
+      - cuda
+      - "blas:*"
+  result:
+    url: "https://example.com/foo.tar.gz"
+    flags:
+      - cuda
+      - "blas:*"
+- input:
     ver: 1.2.3
   result:
     error: "ERROR: unknown field `ver`"
-- input:
-    path: foobar
-    version: 1.2.3
-  result:
-    error: "ERROR: `version` cannot be used with `path`"
 - input:
     version: //
   result:
@@ -104,6 +153,16 @@ expression: snapshot
     sha256: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
   result:
     error: "ERROR: `sha256` cannot be used with `git`"
+- input:
+    url: "https://example.com/foo.conda"
+    version: 1.2.3
+  result:
+    error: "ERROR: `version` cannot be used with `url`"
+- input:
+    path: foo.conda
+    version: 1.2.3
+  result:
+    error: "ERROR: `version` cannot be used with `path`"
 - input: /path/style
   result:
     error: "ERROR: it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = \"/path/style\" }'"

--- a/crates/pixi_spec/src/source_anchor.rs
+++ b/crates/pixi_spec/src/source_anchor.rs
@@ -1,62 +1,58 @@
-use crate::{GitSpec, PathSourceSpec, SourceLocationSpec, SourceSpec, Subdirectory, UrlSourceSpec};
+use crate::{GitSpec, MatchspecFields, PathSourceSpec, SourceSpec, Subdirectory};
 use pixi_consts::consts::KNOWN_MANIFEST_FILES;
 use pixi_path::normalize;
 use typed_path::Utf8TypedPath;
 
-/// `SourceAnchor` represents the resolved base location of a `SourceSpec`.
+/// `SourceAnchor` represents the resolved base location of a source spec.
 /// It serves as a reference point for interpreting relative or recursive
 /// source specifications, enabling consistent resolution of nested sources.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum SourceAnchor {
     /// The source is relative to the workspace root.
     Workspace,
 
     /// The source is relative to another source package.
-    Source(SourceLocationSpec),
+    Source(SourceSpec),
 }
 
 impl From<SourceSpec> for SourceAnchor {
     fn from(value: SourceSpec) -> Self {
-        SourceAnchor::Source(value.location)
-    }
-}
-
-impl From<SourceLocationSpec> for SourceAnchor {
-    fn from(value: SourceLocationSpec) -> Self {
         SourceAnchor::Source(value)
     }
 }
 
 impl SourceAnchor {
     /// Resolve a source location spec relative to this anchor.
-    pub fn resolve(&self, spec: SourceLocationSpec) -> SourceLocationSpec {
+    pub fn resolve(&self, spec: SourceSpec) -> SourceSpec {
         // If this instance is already anchored to the workspace we can simply return
         // immediately.
         let SourceAnchor::Source(base) = self else {
             return match spec {
-                SourceLocationSpec::Url(url) => SourceLocationSpec::Url(url),
-                SourceLocationSpec::Git(git) => SourceLocationSpec::Git(git),
-                SourceLocationSpec::Path(PathSourceSpec { path }) => {
-                    SourceLocationSpec::Path(PathSourceSpec {
+                SourceSpec::Url(url) => SourceSpec::Url(url),
+                SourceSpec::Git(git) => SourceSpec::Git(git),
+                SourceSpec::Path(PathSourceSpec { path, matchspec }) => {
+                    SourceSpec::Path(PathSourceSpec {
                         // Normalize the input path.
                         path: normalize::normalize_typed(path.to_path()),
+                        matchspec,
                     })
                 }
             };
         };
 
         // Only path specs can be relative.
-        let SourceLocationSpec::Path(PathSourceSpec { path }) = spec else {
+        let SourceSpec::Path(PathSourceSpec { path, matchspec }) = spec else {
             return spec;
         };
 
         // If the path is absolute we can just return it.
         if path.is_absolute() || path.starts_with("~") {
-            return SourceLocationSpec::Path(PathSourceSpec { path });
+            return SourceSpec::Path(PathSourceSpec { path, matchspec });
         }
 
         match base {
-            SourceLocationSpec::Path(PathSourceSpec { path: base }) => {
+            SourceSpec::Path(PathSourceSpec { path: base, .. }) => {
                 // Use the parent directory as the base when the base path points to
                 // a manifest file (e.g., `package-a/pixi.toml` -> `package-a`).
                 // This ensures relative paths like `../package-b` resolve correctly.
@@ -71,17 +67,19 @@ impl SourceAnchor {
                 };
 
                 let relative_path = normalize::normalize_typed(base_dir.join(path).to_path());
-                SourceLocationSpec::Path(PathSourceSpec {
+                SourceSpec::Path(PathSourceSpec {
                     path: relative_path,
+                    matchspec,
                 })
             }
-            SourceLocationSpec::Url(UrlSourceSpec { .. }) => {
+            SourceSpec::Url(_) => {
                 unimplemented!("Cannot resolve relative paths for URL sources")
             }
-            SourceLocationSpec::Git(GitSpec {
+            SourceSpec::Git(GitSpec {
                 git,
                 rev,
                 subdirectory,
+                matchspec: base_matchspec,
             }) => {
                 let base_subdir = subdirectory.as_path().to_string_lossy();
                 let relative_subdir = normalize::normalize_typed(
@@ -96,10 +94,15 @@ impl SourceAnchor {
                 } else {
                     Subdirectory::try_from(subdir_str).unwrap_or_default()
                 };
-                SourceLocationSpec::Git(GitSpec {
+                // The matchspec on the result comes from the original (relative) spec —
+                // the base's matchspec applies to the base, not to its nested children.
+                let _ = base_matchspec;
+                let _ = MatchspecFields::default();
+                SourceSpec::Git(GitSpec {
                     git: git.clone(),
                     rev: rev.clone(),
                     subdirectory,
+                    matchspec,
                 })
             }
         }

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -4,13 +4,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use itertools::Either;
 use pixi_toml::{TomlDigest, TomlFromStr, TomlWith, custom_error_message_with_help};
 use rattler_conda_types::{
     BuildNumberSpec, ChannelConfig, MatchSpec, MatchSpecCondition, NamedChannelOrUrl,
     NamelessMatchSpec, PackageName, PackageNameMatcher, ParseMatchSpecOptions,
     ParseStrictness::{Lenient, Strict},
     RepodataRevision, StringMatcher, VersionSpec,
+    package::CondaArchiveType,
     version_spec::{ParseConstraintError, ParseVersionSpecError},
 };
 use rattler_digest::{Md5Hash, Sha256Hash};
@@ -25,8 +25,9 @@ use toml_span::{
 use url::Url;
 
 use crate::{
-    BinarySpec, DetailedSpec, GitReference, GitSpec, PathSourceSpec, PathSpec, PixiSpec,
-    SourceLocationSpec, Subdirectory, SubdirectoryError, UrlSourceSpec, UrlSpec,
+    BinarySpec, DetailedSpec, GitReference, GitSpec, MatchspecFields, PathBinarySpec,
+    PathSourceSpec, PathSpec, PixiSpec, SourceSpec, Subdirectory, SubdirectoryError, UrlBinarySpec,
+    UrlSourceSpec,
 };
 
 /// A TOML representation of a package specification.
@@ -397,7 +398,7 @@ impl SpecError {
 }
 
 #[derive(Error, Debug)]
-pub enum SourceLocationSpecError {
+pub enum SourceSpecError {
     #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
     NotAGitSpec,
 
@@ -428,6 +429,25 @@ pub enum NotBinary {
     #[error(
         "`git` can only refer to a source distributions but a binary distribution was expected"
     )]
+    Git,
+}
+
+/// Internal tag identifying which kind of `PixiSpec` variant a [`TomlSpec`]
+/// resolves to, after inspecting the URL/path extension at parse time.
+#[derive(Copy, Clone, Debug)]
+enum LocationKind {
+    /// No `url` / `path` / `git`.
+    None,
+    /// A `url = ...` that points at a binary conda archive.
+    UrlBinary,
+    /// A `url = ...` that points at a non-binary archive (`.zip`, `.tar.gz`,
+    /// ...).
+    UrlSource,
+    /// A `path = ...` that points at a binary conda archive.
+    PathBinary,
+    /// A `path = ...` that points at a directory or non-binary archive.
+    PathSource,
+    /// A `git = ...`.
     Git,
 }
 
@@ -535,56 +555,107 @@ impl TomlSpec {
         }
     }
 
-    fn validate_field_combinations(&self) -> Result<(), SpecError> {
-        let (is_git, is_path, is_url) = if let Some(loc) = &self.location {
+    /// Validate combinations of fields once the binary-vs-source nature of
+    /// the location has been decided.
+    ///
+    /// Rules:
+    /// * `branch` / `rev` / `tag` only with `git`.
+    /// * `sha256` / `md5` only with `url`.
+    /// * Only one of `url` / `path` / `git`.
+    /// * `channel` / `file-name` are forbidden with any source location.
+    /// * Matchspec fields (`version`, `build`, …) are forbidden when the URL
+    ///   or path resolves to a *binary* archive — the resulting package is
+    ///   already fully specified — but allowed with source locations.
+    fn validate_field_combinations(&self) -> Result<LocationKind, SpecError> {
+        let location_kind = if let Some(loc) = &self.location {
             if loc.git.is_none() && (loc.branch.is_some() || loc.rev.is_some() || loc.tag.is_some())
             {
                 return Err(SpecError::NotAGitSpec);
             }
-            (loc.git.is_some(), loc.path.is_some(), loc.url.is_some())
+            match (loc.url.as_ref(), loc.path.as_ref(), loc.git.as_ref()) {
+                (Some(url), None, None) => {
+                    if url
+                        .path_segments()
+                        .and_then(Iterator::last)
+                        .and_then(|seg| CondaArchiveType::try_from(Path::new(seg)))
+                        .is_some()
+                    {
+                        LocationKind::UrlBinary
+                    } else {
+                        LocationKind::UrlSource
+                    }
+                }
+                (None, Some(path), None) => {
+                    if CondaArchiveType::try_from(Path::new(path.as_str())).is_some() {
+                        LocationKind::PathBinary
+                    } else {
+                        LocationKind::PathSource
+                    }
+                }
+                (None, None, Some(_)) => LocationKind::Git,
+                (None, None, None) => LocationKind::None,
+                _ => return Err(SpecError::MultipleIdentifiers),
+            }
         } else {
-            (false, false, false)
+            LocationKind::None
         };
 
-        let non_detailed_keys = [
-            is_git.then_some("`git`"),
-            is_path.then_some("`path`"),
-            is_url.then_some("`url`"),
-        ]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .join(", ");
-
-        // Common field checks
-        if !non_detailed_keys.is_empty() {
+        // `channel` and `file-name` are always forbidden with a source
+        // location (binary or otherwise).
+        let source_or_binary_keys = match location_kind {
+            LocationKind::Git => "`git`",
+            LocationKind::UrlSource | LocationKind::UrlBinary => "`url`",
+            LocationKind::PathSource | LocationKind::PathBinary => "`path`",
+            LocationKind::None => "",
+        };
+        if !source_or_binary_keys.is_empty() {
             for (field_name, is_some) in [
-                ("`version`", self.version.is_some()),
-                ("`build`", self.build.is_some()),
-                ("`build-number`", self.build_number.is_some()),
-                ("`file-name`", self.file_name.is_some()),
-                ("`extras`", self.extras.is_some()),
-                ("`flags`", self.flags.is_some()),
                 ("`channel`", self.channel.is_some()),
-                ("`subdir`", self.subdir.is_some()),
-                ("`when`", self.when.is_some()),
-                ("`track-features`", self.track_features.is_some()),
+                ("`file-name`", self.file_name.is_some()),
             ] {
                 if is_some {
                     return Err(SpecError::InvalidCombination(
                         field_name.into(),
-                        non_detailed_keys.into(),
+                        source_or_binary_keys.into(),
                     ));
                 }
             }
         }
 
+        // Matchspec fields are rejected when the location resolves to a
+        // binary archive: a `.conda` archive is already a fully-specified
+        // package, so `version` etc. would be meaningless.
+        let binary_location_key = match location_kind {
+            LocationKind::UrlBinary => Some("`url`"),
+            LocationKind::PathBinary => Some("`path`"),
+            _ => None,
+        };
+        if let Some(key) = binary_location_key {
+            for (field_name, is_some) in [
+                ("`version`", self.version.is_some()),
+                ("`build`", self.build.is_some()),
+                ("`build-number`", self.build_number.is_some()),
+                ("`extras`", self.extras.is_some()),
+                ("`flags`", self.flags.is_some()),
+                ("`subdir`", self.subdir.is_some()),
+                ("`license`", self.license.is_some()),
+                ("`license-family`", self.license_family.is_some()),
+                ("`when`", self.when.is_some()),
+                ("`track-features`", self.track_features.is_some()),
+            ] {
+                if is_some {
+                    return Err(SpecError::InvalidCombination(field_name.into(), key.into()));
+                }
+            }
+        }
+
+        // `sha256` / `md5` only apply to URL specs (binary or source archive).
         if let Some(loc) = &self.location {
-            let non_url_keys = [is_git.then_some("`git`"), is_path.then_some("`path`")]
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
-                .join(", ");
+            let non_url_keys = match location_kind {
+                LocationKind::Git => "`git`",
+                LocationKind::PathSource | LocationKind::PathBinary => "`path`",
+                _ => "",
+            };
 
             if !non_url_keys.is_empty() {
                 for (field_name, is_some) in [
@@ -601,232 +672,166 @@ impl TomlSpec {
             }
         }
 
-        Ok(())
+        Ok(location_kind)
     }
 
     /// Convert the TOML representation into an actual [`PixiSpec`].
     pub fn into_spec(self) -> Result<PixiSpec, SpecError> {
-        self.validate_field_combinations()?;
+        let kind = self.validate_field_combinations()?;
+        let condition = self.when.map(TomlWhen::into_condition).transpose()?;
+        let matchspec = MatchspecFields {
+            version: self.version,
+            build: self.build,
+            build_number: self.build_number,
+            extras: self.extras,
+            flags: self.flags,
+            subdir: self.subdir,
+            license: self.license,
+            license_family: self.license_family,
+            condition,
+            track_features: self.track_features,
+        };
 
-        let spec: PixiSpec;
-        if let Some(loc) = self.location {
-            spec = match (loc.url, loc.path, loc.git) {
-                (Some(url), None, None) => PixiSpec::Url(UrlSpec {
+        match kind {
+            LocationKind::None => {
+                let (md5, sha256) = match &self.location {
+                    Some(loc) => (loc.md5, loc.sha256),
+                    None => (None, None),
+                };
+                let any_field = !matchspec.is_empty()
+                    || self.file_name.is_some()
+                    || self.channel.is_some()
+                    || md5.is_some()
+                    || sha256.is_some();
+                if !any_field {
+                    return Err(SpecError::MissingDetailedIdentifier);
+                }
+                Ok(PixiSpec::Detailed(Box::new(DetailedSpec {
+                    version: matchspec.version,
+                    build: matchspec.build,
+                    build_number: matchspec.build_number,
+                    file_name: self.file_name,
+                    extras: matchspec.extras,
+                    flags: matchspec.flags,
+                    channel: self.channel,
+                    subdir: matchspec.subdir,
+                    md5,
+                    sha256,
+                    license: matchspec.license,
+                    license_family: matchspec.license_family,
+                    condition: matchspec.condition,
+                    track_features: matchspec.track_features,
+                })))
+            }
+            LocationKind::UrlBinary => {
+                let loc = self.location.expect("location set when kind != None");
+                let url = loc.url.expect("url set for UrlBinary kind");
+                Ok(PixiSpec::UrlBinary(UrlBinarySpec {
                     url,
                     md5: loc.md5,
                     sha256: loc.sha256,
-                    subdirectory: loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default(),
-                }),
-                (None, Some(path), None) => PixiSpec::Path(PathSpec { path: path.into() }),
-                (None, None, Some(git)) => {
-                    let rev = match (loc.branch, loc.rev, loc.tag) {
-                        (Some(branch), None, None) => Some(GitReference::Branch(branch)),
-                        (None, Some(rev), None) => Some(GitReference::Rev(rev)),
-                        (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
-                        (None, None, None) => None,
-                        _ => {
-                            return Err(SpecError::MultipleGitRefs);
-                        }
-                    };
-                    let subdirectory = loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default();
-                    PixiSpec::Git(GitSpec {
-                        git,
-                        rev,
-                        subdirectory,
-                    })
-                }
-                (None, None, None) => {
-                    let is_detailed = self.version.is_some()
-                        || self.build.is_some()
-                        || self.build_number.is_some()
-                        || self.file_name.is_some()
-                        || self.extras.is_some()
-                        || self.flags.is_some()
-                        || self.channel.is_some()
-                        || self.subdir.is_some()
-                        || loc.md5.is_some()
-                        || loc.sha256.is_some()
-                        || self.license.is_some()
-                        || self.license_family.is_some()
-                        || self.when.is_some()
-                        || self.track_features.is_some();
-                    if !is_detailed {
-                        return Err(SpecError::MissingDetailedIdentifier);
-                    }
-
-                    PixiSpec::DetailedVersion(Box::new(DetailedSpec {
-                        version: self.version,
-                        build: self.build,
-                        build_number: self.build_number,
-                        file_name: self.file_name,
-                        extras: self.extras,
-                        flags: self.flags,
-                        channel: self.channel,
-                        subdir: self.subdir,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        license: self.license,
-                        license_family: self.license_family,
-                        condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                        track_features: self.track_features,
-                    }))
-                }
-                (_, _, _) => return Err(SpecError::MultipleIdentifiers),
-            };
-        } else {
-            let is_detailed = self.version.is_some()
-                || self.build.is_some()
-                || self.build_number.is_some()
-                || self.file_name.is_some()
-                || self.extras.is_some()
-                || self.flags.is_some()
-                || self.channel.is_some()
-                || self.subdir.is_some()
-                || self.license.is_some()
-                || self.license_family.is_some()
-                || self.when.is_some()
-                || self.track_features.is_some();
-            if !is_detailed {
-                return Err(SpecError::MissingDetailedIdentifier);
+                }))
             }
-
-            spec = PixiSpec::DetailedVersion(Box::new(DetailedSpec {
-                version: self.version,
-                build: self.build,
-                build_number: self.build_number,
-                file_name: self.file_name,
-                extras: self.extras,
-                flags: self.flags,
-                channel: self.channel,
-                subdir: self.subdir,
-                md5: None,
-                sha256: None,
-                license: self.license,
-                license_family: self.license_family,
-                condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                track_features: self.track_features,
-            }));
+            LocationKind::UrlSource => {
+                let loc = self.location.expect("location set when kind != None");
+                let url = loc.url.expect("url set for UrlSource kind");
+                let subdirectory = loc
+                    .subdirectory
+                    .map(Subdirectory::try_from)
+                    .transpose()?
+                    .unwrap_or_default();
+                Ok(PixiSpec::UrlSource(Box::new(UrlSourceSpec {
+                    url,
+                    md5: loc.md5,
+                    sha256: loc.sha256,
+                    subdirectory,
+                    matchspec,
+                })))
+            }
+            LocationKind::PathBinary => {
+                let loc = self.location.expect("location set when kind != None");
+                let path = loc.path.expect("path set for PathBinary kind");
+                Ok(PixiSpec::PathBinary(PathBinarySpec { path: path.into() }))
+            }
+            LocationKind::PathSource => {
+                let loc = self.location.expect("location set when kind != None");
+                let path = loc.path.expect("path set for PathSource kind");
+                Ok(PixiSpec::PathSource(Box::new(PathSourceSpec {
+                    path: path.into(),
+                    matchspec,
+                })))
+            }
+            LocationKind::Git => {
+                let loc = self.location.expect("location set when kind != None");
+                let git = loc.git.expect("git set for Git kind");
+                let rev = match (loc.branch, loc.rev, loc.tag) {
+                    (Some(branch), None, None) => Some(GitReference::Branch(branch)),
+                    (None, Some(rev), None) => Some(GitReference::Rev(rev)),
+                    (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
+                    (None, None, None) => None,
+                    _ => return Err(SpecError::MultipleGitRefs),
+                };
+                let subdirectory = loc
+                    .subdirectory
+                    .map(Subdirectory::try_from)
+                    .transpose()?
+                    .unwrap_or_default();
+                Ok(PixiSpec::Git(Box::new(GitSpec {
+                    git,
+                    rev,
+                    subdirectory,
+                    matchspec,
+                })))
+            }
         }
-
-        Ok(spec)
     }
 
-    /// Convert the TOML representation into an actual [`PixiSpec`].
+    /// Convert the TOML representation into a [`BinarySpec`].
     pub fn into_binary_spec(self) -> Result<BinarySpec, SpecError> {
-        self.validate_field_combinations()?;
+        let kind = self.validate_field_combinations()?;
+        let condition = self.when.map(TomlWhen::into_condition).transpose()?;
 
-        let spec: BinarySpec;
-        if let Some(loc) = self.location {
-            spec = match (loc.url, loc.path, loc.git) {
-                (Some(url), None, None) => {
-                    let url_spec = UrlSpec {
-                        url,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        subdirectory: loc
-                            .subdirectory
-                            .map(Subdirectory::try_from)
-                            .transpose()?
-                            .unwrap_or_default(),
-                    };
-                    if let Either::Right(binary) = url_spec.into_source_or_binary() {
-                        BinarySpec::Url(binary)
-                    } else {
-                        return Err(SpecError::NotABinary(NotBinary::Url));
-                    }
-                }
-                (None, Some(path), None) => {
-                    let path_spec = PathSpec { path: path.into() };
-                    if let Either::Right(binary) = path_spec.into_source_or_binary() {
-                        BinarySpec::Path(binary)
-                    } else {
-                        return Err(SpecError::NotABinary(NotBinary::Path));
-                    }
-                }
-                (None, None, Some(_git)) => {
-                    return Err(SpecError::NotABinary(NotBinary::Git));
-                }
-                (None, None, None) => {
-                    let is_detailed = self.version.is_some()
-                        || self.build.is_some()
-                        || self.build_number.is_some()
-                        || self.file_name.is_some()
-                        || self.extras.is_some()
-                        || self.flags.is_some()
-                        || self.channel.is_some()
-                        || self.subdir.is_some()
-                        || loc.md5.is_some()
-                        || loc.sha256.is_some()
-                        || self.license.is_some()
-                        || self.license_family.is_some()
-                        || self.when.is_some()
-                        || self.track_features.is_some();
-                    if !is_detailed {
-                        return Err(SpecError::MissingDetailedIdentifier);
-                    }
-
-                    BinarySpec::DetailedVersion(Box::new(DetailedSpec {
-                        version: self.version,
-                        build: self.build,
-                        build_number: self.build_number,
-                        file_name: self.file_name,
-                        extras: self.extras,
-                        flags: self.flags,
-                        channel: self.channel,
-                        subdir: self.subdir,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        license: self.license,
-                        license_family: self.license_family,
-                        condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                        track_features: self.track_features,
-                    }))
-                }
-                (_, _, _) => return Err(SpecError::MultipleIdentifiers),
-            };
-        } else {
-            let is_detailed = self.version.is_some()
-                || self.build.is_some()
-                || self.build_number.is_some()
-                || self.file_name.is_some()
-                || self.extras.is_some()
-                || self.flags.is_some()
-                || self.channel.is_some()
-                || self.subdir.is_some()
-                || self.license.is_some()
-                || self.license_family.is_some()
-                || self.when.is_some()
-                || self.track_features.is_some();
-            if !is_detailed {
-                return Err(SpecError::MissingDetailedIdentifier);
+        match kind {
+            LocationKind::None => {
+                let (md5, sha256) = match &self.location {
+                    Some(loc) => (loc.md5, loc.sha256),
+                    None => (None, None),
+                };
+                Ok(BinarySpec::DetailedVersion(Box::new(DetailedSpec {
+                    version: self.version,
+                    build: self.build,
+                    build_number: self.build_number,
+                    file_name: self.file_name,
+                    extras: self.extras,
+                    flags: self.flags,
+                    channel: self.channel,
+                    subdir: self.subdir,
+                    md5,
+                    sha256,
+                    license: self.license,
+                    license_family: self.license_family,
+                    condition,
+                    track_features: self.track_features,
+                })))
             }
-
-            spec = BinarySpec::DetailedVersion(Box::new(DetailedSpec {
-                version: self.version,
-                build: self.build,
-                build_number: self.build_number,
-                file_name: self.file_name,
-                extras: self.extras,
-                flags: self.flags,
-                channel: self.channel,
-                subdir: self.subdir,
-                md5: None,
-                sha256: None,
-                license: self.license,
-                license_family: self.license_family,
-                condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                track_features: self.track_features,
-            }));
-        };
-        Ok(spec)
+            LocationKind::UrlBinary => {
+                let loc = self.location.expect("location set");
+                let url = loc.url.expect("url set");
+                Ok(BinarySpec::Url(UrlBinarySpec {
+                    url,
+                    md5: loc.md5,
+                    sha256: loc.sha256,
+                }))
+            }
+            LocationKind::PathBinary => {
+                let loc = self.location.expect("location set");
+                let path = loc.path.expect("path set");
+                Ok(BinarySpec::Path(PathBinarySpec { path: path.into() }))
+            }
+            LocationKind::UrlSource => Err(SpecError::NotABinary(NotBinary::Url)),
+            LocationKind::PathSource => Err(SpecError::NotABinary(NotBinary::Path)),
+            LocationKind::Git => Err(SpecError::NotABinary(NotBinary::Git)),
+        }
     }
 }
 
@@ -1082,18 +1087,18 @@ fn fold_when_conditions(
 }
 
 impl TomlLocationSpec {
-    fn validate_field_combinations(&self) -> Result<(), SourceLocationSpecError> {
+    fn validate_field_combinations(&self) -> Result<(), SourceSpecError> {
         let (is_git, is_path, is_url) = {
             if self.git.is_none()
                 && (self.branch.is_some() || self.rev.is_some() || self.tag.is_some())
             {
-                return Err(SourceLocationSpecError::NotAGitSpec);
+                return Err(SourceSpecError::NotAGitSpec);
             }
             (self.git.is_some(), self.path.is_some(), self.url.is_some())
         };
 
         if !is_git && !is_path && !is_url {
-            return Err(SourceLocationSpecError::NoSourceType);
+            return Err(SourceSpecError::NoSourceType);
         }
 
         let non_url_keys = [is_git.then_some("`git`"), is_path.then_some("`path`")]
@@ -1108,7 +1113,7 @@ impl TomlLocationSpec {
                 ("`md5`", self.md5.is_some()),
             ] {
                 if is_some {
-                    return Err(SourceLocationSpecError::InvalidCombination(
+                    return Err(SourceSpecError::InvalidCombination(
                         field_name.into(),
                         non_url_keys.into(),
                     ));
@@ -1119,12 +1124,12 @@ impl TomlLocationSpec {
         Ok(())
     }
 
-    /// Convert the TOML representation into a `SourceLocationSpec`.
-    pub fn into_source_location_spec(self) -> Result<SourceLocationSpec, SourceLocationSpecError> {
+    /// Convert the TOML representation into a `SourceSpec`.
+    pub fn into_source_spec(self) -> Result<SourceSpec, SourceSpecError> {
         self.validate_field_combinations()?;
 
         let spec = match (self.url, self.path, self.git) {
-            (Some(url), None, None) => SourceLocationSpec::Url(UrlSourceSpec {
+            (Some(url), None, None) => SourceSpec::Url(UrlSourceSpec {
                 url,
                 md5: self.md5,
                 sha256: self.sha256,
@@ -1133,10 +1138,12 @@ impl TomlLocationSpec {
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
+                matchspec: MatchspecFields::default(),
             }),
-            (None, Some(path), None) => {
-                SourceLocationSpec::Path(PathSourceSpec { path: path.into() })
-            }
+            (None, Some(path), None) => SourceSpec::Path(PathSourceSpec {
+                path: path.into(),
+                matchspec: MatchspecFields::default(),
+            }),
             (None, None, Some(git)) => {
                 let rev = match (self.branch, self.rev, self.tag) {
                     (Some(branch), None, None) => Some(GitReference::Branch(branch)),
@@ -1144,7 +1151,7 @@ impl TomlLocationSpec {
                     (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
                     (None, None, None) => None,
                     _ => {
-                        return Err(SourceLocationSpecError::MultipleGitRefs);
+                        return Err(SourceSpecError::MultipleGitRefs);
                     }
                 };
                 let subdirectory = self
@@ -1152,13 +1159,14 @@ impl TomlLocationSpec {
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default();
-                SourceLocationSpec::Git(GitSpec {
+                SourceSpec::Git(GitSpec {
                     git,
                     rev,
                     subdirectory,
+                    matchspec: MatchspecFields::default(),
                 })
             }
-            (_, _, _) => return Err(SourceLocationSpecError::MultipleIdentifiers),
+            (_, _, _) => return Err(SourceSpecError::MultipleIdentifiers),
         };
         Ok(spec)
     }
@@ -1415,7 +1423,7 @@ impl<'de> toml_span::Deserialize<'de> for PixiSpec {
         match value.take() {
             ValueInner::String(str) => {
                 parse_version_string(&str)
-                    .map(PixiSpec::Version)
+                    .map(PixiSpec::from)
                     .map_err(|msg| {
                         DeserError::from(toml_span::Error {
                             kind: ErrorKind::Custom(msg.into()),
@@ -1481,7 +1489,7 @@ impl<'de> Deserialize<'de> for PixiSpec {
             )
             .string(|str| {
                 parse_version_string(str)
-                    .map(PixiSpec::Version)
+                    .map(PixiSpec::from)
                     .map_err(serde_untagged::de::Error::custom)
             })
             .map(|map| {
@@ -1574,6 +1582,18 @@ mod test {
         format_parse_error(trimmed, TomlDiagnostic(first))
     }
 
+    /// Parse a TOML pixi spec successfully.
+    fn parse_toml_ok(input: &str) -> PixiSpec {
+        let mut value = toml_span::parse(input.trim()).expect("expected valid TOML");
+        <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected parse to succeed")
+    }
+
+    /// Parse a JSON pixi spec successfully.
+    fn parse_json_ok(input: Value) -> PixiSpec {
+        serde_json::from_value::<PixiSpec>(input).expect("expected parse to succeed")
+    }
+
     /// JSON parse failures don't carry source spans, so we just stringify.
     fn parse_json_error(input: Value) -> String {
         serde_json::from_value::<PixiSpec>(input)
@@ -1599,14 +1619,24 @@ mod test {
             json!({ "url": "https://conda.anaconda.org/conda-forge/linux-64/21cmfast-3.3.1-py38h0db86a8_1.conda", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main" }),
+            // Source specs with matchspec selectors:
+            json!({ "path": "../mypkg", "version": "1.2.3" }),
+            json!({ "path": "../mypkg", "version": ">=1.2", "build": "py37_*" }),
+            json!({ "path": "../mypkg", "subdir": "linux-64", "track-features": ["legacy"] }),
+            json!({ "git": "https://github.com/foo/bar", "branch": "main", "version": ">=1.0", "extras": ["cuda"] }),
+            json!({ "url": "https://example.com/foo.tar.gz", "version": "1.2.3", "build-number": ">=3" }),
+            json!({ "url": "https://example.com/foo.tar.gz", "flags": ["cuda", "blas:*"] }),
             // Errors:
             json!({ "ver": "1.2.3" }),
-            json!({ "path": "foobar" , "version": "1.2.3" }),
             json!({ "version": "//" }),
             json!({ "path": "foobar", "version": "//" }),
             json!({ "path": "foobar", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main", "tag": "v1" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
+            // A `.conda` URL is binary; matchspec selectors must be rejected.
+            json!({ "url": "https://example.com/foo.conda", "version": "1.2.3" }),
+            // A `.conda` path is binary; matchspec selectors must be rejected.
+            json!({ "path": "foo.conda", "version": "1.2.3" }),
             json! { "/path/style"},
             json! { "./path/style"},
             json! { "\\path\\style"},
@@ -2032,8 +2062,20 @@ when = { package = "python", track-features = ["legacy"] }"#;
     }
 
     #[test]
-    fn test_when_reject_combined_with_path_json() {
+    fn test_when_accept_combined_with_path_json() {
+        // Matchspec fields including `when` are allowed alongside a path
+        // source (a directory or non-binary archive).
         let input = json!({ "path": "../foo", "when": "__unix" });
+        let spec = parse_json_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert!(path.matchspec.condition.is_some());
+    }
+
+    #[test]
+    fn test_matchspec_reject_with_binary_path_json() {
+        // A path pointing at a `.conda` archive is binary; matchspec
+        // selectors are meaningless there and must be rejected.
+        let input = json!({ "path": "foo.conda", "when": "__unix" });
         assert_snapshot!(parse_json_error(input), @"`when` cannot be used with `path`");
     }
 
@@ -2236,16 +2278,14 @@ when = { all = ["__unix", "python[version='>=3.10']"] }"#;
     }
 
     #[test]
-    fn test_when_reject_combined_with_path_toml() {
+    fn test_when_accept_combined_with_path_toml() {
+        // A `path = ../foo` is a non-binary source location, so matchspec
+        // selectors including `when` are accepted.
         let input = r#"path = "../foo"
 when = "__unix""#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `when` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ when = "__unix"
-          ╰────
-        "###);
+        let spec = parse_toml_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert!(path.matchspec.condition.is_some());
     }
 
     #[test]
@@ -2267,24 +2307,48 @@ when = "__unix""#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_json() {
+    fn test_v3_accept_extras_with_path_json() {
         let input = json!({ "path": "../foo", "extras": ["dev"] });
-        assert_snapshot!(parse_json_error(input), @"`extras` cannot be used with `path`");
+        let spec = parse_json_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert_eq!(
+            path.matchspec.extras.as_deref(),
+            Some(&["dev".to_string()][..])
+        );
     }
 
     #[test]
-    fn test_v3_reject_flags_with_git_json() {
+    fn test_v3_accept_flags_with_git_json() {
         let input = json!({ "git": "https://example.com/foo.git", "flags": ["cuda"] });
-        assert_snapshot!(parse_json_error(input), @"`flags` cannot be used with `git`");
+        let spec = parse_json_ok(input);
+        let git = spec.as_git().expect("expected a git spec");
+        assert!(git.matchspec.flags.is_some());
     }
 
     #[test]
     fn test_v3_reject_track_features_with_url_json() {
+        // `.conda` extension makes this a binary URL; matchspec selectors
+        // are rejected.
         let input = json!({
             "url": "https://example.com/foo.conda",
             "track-features": ["legacy"],
         });
         assert_snapshot!(parse_json_error(input), @"`track-features` cannot be used with `url`");
+    }
+
+    #[test]
+    fn test_v3_accept_track_features_with_source_url_json() {
+        // Non-binary URL extension: matchspec selectors are accepted.
+        let input = json!({
+            "url": "https://example.com/foo.tar.gz",
+            "track-features": ["legacy"],
+        });
+        let spec = parse_json_ok(input);
+        let url = spec.as_url_source().expect("expected a url source spec");
+        assert_eq!(
+            url.matchspec.track_features.as_deref(),
+            Some(&["legacy".to_string()][..])
+        );
     }
 
     #[test]
@@ -2344,20 +2408,20 @@ flags = ["*[unclosed"]"#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_toml() {
+    fn test_v3_accept_extras_with_path_toml() {
         let input = r#"path = "../foo"
 extras = ["dev"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `extras` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ extras = ["dev"]
-          ╰────
-        "###);
+        let spec = parse_toml_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert_eq!(
+            path.matchspec.extras.as_deref(),
+            Some(&["dev".to_string()][..])
+        );
     }
 
     #[test]
-    fn test_v3_reject_flags_with_url_toml() {
+    fn test_v3_reject_flags_with_binary_url_toml() {
+        // `.conda` extension marks this as a binary URL: matchspec rejected.
         let input = r#"url = "https://example.com/foo.conda"
 flags = ["cuda"]"#;
         assert_snapshot!(parse_toml_error(input), @r###"
@@ -2370,15 +2434,116 @@ flags = ["cuda"]"#;
     }
 
     #[test]
-    fn test_v3_reject_track_features_with_git_toml() {
+    fn test_v3_accept_flags_with_source_url_toml() {
+        // `.tar.gz` is not a binary conda archive: matchspec accepted.
+        let input = r#"url = "https://example.com/foo.tar.gz"
+flags = ["cuda"]"#;
+        let spec = parse_toml_ok(input);
+        let url = spec.as_url_source().expect("expected a url source spec");
+        assert!(url.matchspec.flags.is_some());
+    }
+
+    #[test]
+    fn test_v3_accept_track_features_with_git_toml() {
         let input = r#"git = "https://example.com/foo.git"
 track-features = ["legacy"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `track-features` cannot be used with `git`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ git = "https://example.com/foo.git"
-        2 │ ╰─▶ track-features = ["legacy"]
-          ╰────
-        "###);
+        let spec = parse_toml_ok(input);
+        let git = spec.as_git().expect("expected a git spec");
+        assert_eq!(
+            git.matchspec.track_features.as_deref(),
+            Some(&["legacy".to_string()][..])
+        );
+    }
+
+    /// Source-side matchspec round-trips through JSON serialization:
+    /// a spec mixing a source location with several matchspec selectors
+    /// must parse, serialize, and re-parse to an equal `PixiSpec`.
+    #[test]
+    fn test_source_matchspec_roundtrip_full() {
+        let inputs: Vec<Value> = vec![
+            // path + multiple matchspec fields
+            json!({
+                "path": "../my-pkg",
+                "version": "1.2.3",
+                "build": "py37_*",
+                "build-number": ">=3",
+                "extras": ["cuda", "mkl"],
+                "subdir": "linux-64",
+                "license": "BSD-3-Clause",
+                "track-features": ["legacy"],
+            }),
+            // git + matchspec
+            json!({
+                "git": "https://github.com/foo/bar",
+                "branch": "main",
+                "version": ">=1.0",
+                "extras": ["dev"],
+            }),
+            // non-binary url + matchspec
+            json!({
+                "url": "https://example.com/foo.tar.gz",
+                "version": "1.2.3",
+                "build-number": ">=3",
+                "flags": ["cuda"],
+            }),
+        ];
+
+        for input in inputs {
+            let first: PixiSpec =
+                serde_json::from_value(input.clone()).expect("expected initial parse to succeed");
+            let serialized = serde_json::to_value(&first).expect("serialize should succeed");
+            let second: PixiSpec = serde_json::from_value(serialized.clone())
+                .expect("round-trip parse should succeed");
+            assert_eq!(
+                first, second,
+                "round-trip mismatch for input:\n{input}\n\nrendered as: {serialized}"
+            );
+        }
+    }
+
+    /// A path source carrying matchspec selectors round-trips through
+    /// `PixiSpec::try_into_source_spec` and back into a `PixiSpec`, and
+    /// the matchspec fields survive intact via the accessor.
+    #[test]
+    fn test_source_location_spec_matchspec_accessor() {
+        use crate::SourceSpec;
+
+        let spec = parse_toml_ok(
+            r#"path = "../my-pkg"
+version = ">=2.0"
+build = "py310_*"
+extras = ["test"]"#,
+        );
+
+        // Routing into a SourceSpec preserves matchspec.
+        let source = spec
+            .clone()
+            .try_into_source_spec()
+            .expect("expected a source spec");
+        assert!(matches!(source, SourceSpec::Path(_)));
+        let matchspec = source.matchspec();
+        assert_eq!(matchspec.version.as_ref().unwrap().to_string(), ">=2.0");
+        assert!(matchspec.build.is_some());
+        assert_eq!(matchspec.extras.as_deref(), Some(&["test".to_string()][..]));
+
+        // Lifting it back through `From<SourceSpec>` returns the
+        // same `PixiSpec`.
+        let round_tripped = PixiSpec::from(source);
+        assert_eq!(spec, round_tripped);
+    }
+
+    /// `try_into_source_spec` returns the original `PixiSpec` (via `Err`)
+    /// when invoked on a binary variant.
+    #[test]
+    fn test_try_into_source_spec_rejects_binary() {
+        let detailed: PixiSpec = parse_json_ok(json!({ "version": "1.2.3" }));
+        let err = detailed.try_into_source_spec().unwrap_err();
+        assert!(matches!(err, PixiSpec::Detailed(_)));
+
+        let url_binary = parse_json_ok(json!({
+            "url": "https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py.conda",
+        }));
+        let err = url_binary.try_into_source_spec().unwrap_err();
+        assert!(matches!(err, PixiSpec::UrlBinary(_)));
     }
 }

--- a/crates/pixi_spec/src/url.rs
+++ b/crates/pixi_spec/src/url.rs
@@ -1,10 +1,10 @@
-use crate::{BinarySpec, Subdirectory};
+use crate::{BinarySpec, MatchspecFields, Subdirectory};
 use itertools::Either;
-use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveIdentifier};
+use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveType};
 use rattler_digest::{Md5Hash, Sha256Hash};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::fmt::Display;
+use std::{fmt::Display, path::Path};
 use url::Url;
 
 /// A specification of a package from a URL. This is used to represent both
@@ -59,6 +59,7 @@ impl UrlSpec {
                 md5: self.md5,
                 sha256: self.sha256,
                 subdirectory: self.subdirectory,
+                matchspec: MatchspecFields::default(),
             })
         }
     }
@@ -78,14 +79,29 @@ impl UrlSpec {
                 md5: self.md5,
                 sha256: self.sha256,
                 subdirectory: self.subdirectory,
+                matchspec: MatchspecFields::default(),
             })
         }
     }
 
     /// Returns true if the URL points to a binary package.
+    ///
+    /// Detection is purely by file extension (`.conda` or `.tar.bz2`):
+    /// any URL whose last path segment ends in one of these is treated as
+    /// a binary archive at parse time, even if the filename doesn't follow
+    /// the `name-version-build` convention.
     pub fn is_binary(&self) -> bool {
-        CondaArchiveIdentifier::try_from_url(&self.url).is_some()
+        url_is_binary(&self.url)
     }
+}
+
+/// Returns true if `url` looks like a binary conda archive based on its
+/// path extension (`.conda` or `.tar.bz2`).
+pub(crate) fn url_is_binary(url: &Url) -> bool {
+    url.path_segments()
+        .and_then(Iterator::last)
+        .and_then(|seg| CondaArchiveType::try_from(Path::new(seg)))
+        .is_some()
 }
 
 impl Display for UrlSpec {
@@ -101,7 +117,8 @@ impl Display for UrlSpec {
     }
 }
 
-/// A specification of a source archive from a URL.
+/// A specification of a source archive from a URL, optionally constrained
+/// by match-spec selectors (version, build, extras, …).
 #[serde_as]
 #[derive(Debug, Clone, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct UrlSourceSpec {
@@ -121,6 +138,28 @@ pub struct UrlSourceSpec {
     /// The subdirectory of the package inside the archive
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Match-spec selectors applied to the built output (flattened).
+    #[serde(flatten)]
+    pub matchspec: MatchspecFields,
+}
+
+impl UrlSourceSpec {
+    /// Constructs a new [`UrlSourceSpec`] with no matchspec selectors.
+    pub fn new(
+        url: Url,
+        md5: Option<Md5Hash>,
+        sha256: Option<Sha256Hash>,
+        subdirectory: Subdirectory,
+    ) -> Self {
+        Self {
+            url,
+            md5,
+            sha256,
+            subdirectory,
+            matchspec: MatchspecFields::default(),
+        }
+    }
 }
 
 impl Display for UrlSourceSpec {
@@ -150,17 +189,35 @@ impl From<UrlSourceSpec> for UrlSpec {
     }
 }
 
-/// A specification of a source archive from a URL.
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize)]
+/// A specification of a binary conda archive from a URL.
+#[serde_as]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UrlBinarySpec {
     /// The URL of the package
     pub url: Url,
 
     /// The md5 hash of the archive
+    #[serde_as(as = "Option<rattler_digest::serde::SerializableHash<rattler_digest::Md5>>")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub md5: Option<Md5Hash>,
 
     /// The sha256 hash of the archive
+    #[serde_as(as = "Option<rattler_digest::serde::SerializableHash<rattler_digest::Sha256>>")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sha256: Option<Sha256Hash>,
+}
+
+impl Display for UrlBinarySpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url)?;
+        if let Some(md5) = &self.md5 {
+            write!(f, " md5={md5:x}")?;
+        }
+        if let Some(sha256) = &self.sha256 {
+            write!(f, " sha256={sha256:x}")?;
+        }
+        Ok(())
+    }
 }
 
 impl From<UrlBinarySpec> for UrlSpec {

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -112,6 +112,7 @@ pub fn as_uv_req(
                     git,
                     rev,
                     subdirectory,
+                    matchspec: _,
                 },
         } => {
             let git_url = GitUrlWithPrefix::from(git);
@@ -357,13 +358,13 @@ mod tests {
     #[test]
     fn test_git_url() {
         let pypi_req = PixiPypiSpec::new(PixiPypiSource::Git {
-            git: GitSpec {
-                git: Url::parse("ssh://git@github.com/user/test.git").unwrap(),
-                rev: Some(GitReference::Rev(
+            git: GitSpec::new(
+                Url::parse("ssh://git@github.com/user/test.git").unwrap(),
+                Some(GitReference::Rev(
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
-                subdirectory: Default::default(),
-            },
+                Default::default(),
+            ),
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
 
@@ -385,13 +386,13 @@ mod tests {
 
         // With git+ prefix
         let pypi_req = PixiPypiSpec::new(PixiPypiSource::Git {
-            git: GitSpec {
-                git: Url::parse("git+https://github.com/user/test.git").unwrap(),
-                rev: Some(GitReference::Rev(
+            git: GitSpec::new(
+                Url::parse("git+https://github.com/user/test.git").unwrap(),
+                Some(GitReference::Rev(
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
-                subdirectory: Default::default(),
-            },
+                Default::default(),
+            ),
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
         let expected_uv_req = RequirementSource::Git {

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1461,6 +1461,22 @@ The `run-dependencies` are the packages that will be installed in the environmen
 --8<-- "docs/source_files/pixi_tomls/pixi-package-manifest.toml:run-dependencies"
 ```
 
+#### repodata v3 fields
+
+In addition to the usual MatchSpec fields (`version`, `channel`, `build`, ...), conda dependencies accept three repodata v3 fields:
+
+- `extras`: pull in the listed optional dependency groups (see [`extra-dependencies`](#extra-dependencies)) of the dependency. Equivalent to writing `name[group1,group2]` in a MatchSpec.
+- `flags`: require the dependency to have been built with the listed [build flags](#build-flags-example).
+- `when`: only apply the dependency when the given condition is satisfied. The condition is itself a MatchSpec table with a `package` field naming the other dependency to check.
+
+```toml
+[dependencies]
+# Local source dependency: pull in the `test` extras and require it to have been built with `cuda` enabled.
+mypackage = { path = "./mypackage", extras = ["test"], flags = ["cuda"] }
+# Git source dependency: only pull it in when `python` is at least 3.12.
+otherpackage = { git = "https://github.com/example/otherpackage", when = { package = "python", version = ">=3.12" } }
+```
+
 ### `extra-dependencies`
 
 The `extra-dependencies` table defines extra dependency groups for a package. For example, a package that declares `test` and `cuda` groups:

--- a/examples/pixi-build/v3/Cargo.toml
+++ b/examples/pixi-build/v3/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "v3"
+version = "0.1.0"
+
+[dependencies]
+
+[workspace]

--- a/examples/pixi-build/v3/pixi.lock
+++ b/examples/pixi-build/v3/pixi.lock
@@ -11,88 +11,80 @@ environments:
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bat-0.26.1-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.23-hc30ae73_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda_source: v3[685351bb] @ .
+      - conda_source: v3[589d272b] @ .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/bat-0.26.1-h121f529_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.1-h8f8c405_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.5-h7c6738f_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.9.23-h8a7f3fd_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ripgrep-15.1.0-h009cd8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - conda_source: v3[3662e1b6] @ .
+      - conda_source: v3[76967c89] @ .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bat-0.26.1-hd1458d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.23-h7139b31_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: v3[0746a06a] @ .
+      - conda_source: v3[01af6b58] @ .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bat-0.26.1-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.1-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.5-h4b44e0e_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.9.23-h8c5b53a_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: v3[eb6dfb08] @ .
+      - conda_source: v3[59a0e4ab] @ .
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -123,7 +115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda_source: v3[685351bb] @ .
+      - conda_source: v3[589d272b] @ .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -142,7 +134,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - conda_source: v3[3662e1b6] @ .
+      - conda_source: v3[76967c89] @ .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -160,7 +152,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: v3[0746a06a] @ .
+      - conda_source: v3[01af6b58] @ .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -180,7 +172,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: v3[eb6dfb08] @ .
+      - conda_source: v3[59a0e4ab] @ .
   rust:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -188,22 +180,91 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bat-0.26.1-hdab8a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda_source: v3[685351bb] @ .
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda_source: v3[589d272b] @ .
       osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bat-0.26.1-h121f529_0.conda
-      - conda_source: v3[3662e1b6] @ .
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.1-h8f8c405_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.5-h7c6738f_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ripgrep-15.1.0-h009cd8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - conda_source: v3[76967c89] @ .
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bat-0.26.1-hd1458d2_0.conda
-      - conda_source: v3[0746a06a] @ .
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - conda_source: v3[01af6b58] @ .
       win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bat-0.26.1-h77a83cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.1-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.5-h4b44e0e_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
-      - conda_source: v3[eb6dfb08] @ .
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - conda_source: v3[59a0e4ab] @ .
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -338,6 +399,15 @@ packages:
   run_exports: {}
   size: 1041084
   timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+  md5: 331ee9b72b9dff570d56b1302c5ab37d
+  depends:
+  - libgcc 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27694
+  timestamp: 1778269016987
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
   sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
   md5: faac990cb7aedc7f3a2224f2c9b0c26c
@@ -368,6 +438,16 @@ packages:
   license_family: BSD
   size: 92400
   timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-only
+  license_family: GPL
+  size: 33731
+  timestamp: 1750274110928
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
   sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
   md5: 67eef12ce33f7ff99900c212d7076fc2
@@ -411,6 +491,14 @@ packages:
   license_family: BSD
   size: 40163
   timestamp: 1779118517630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
   sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
   md5: d87ff7921124eccd67248aa483c23fec
@@ -469,6 +557,32 @@ packages:
   size: 36745188
   timestamp: 1779236923603
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.23-hc30ae73_0_cpython.conda
+  sha256: dcfc417424b21ffca70dddf7a86ef69270b3e8d2040c748b7356a615470d5298
+  md5: 624ab0484356d86a54297919352d52b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.8.1,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 23677900
+  timestamp: 1749060753022
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -480,6 +594,18 @@ packages:
   license_family: GPL
   size: 345073
   timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
+  sha256: a745b0d0ca5ae53757e42d893a61a5034ed2ad4791728e376dbc5c6a4f9c3eb0
+  md5: 1f9739b74aab91a4c9c7aea7a6987dbb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 1737412
+  timestamp: 1761210874723
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
   sha256: 0f7965acec00e5b35d7b4748ea0da57249ab3db2177d13eb87909c0a142148b5
   md5: 26172b61a3f03c31e56065413ffc1f2f
@@ -1085,6 +1211,27 @@ packages:
   size: 14450441
   timestamp: 1779239702259
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.9.23-h8a7f3fd_0_cpython.conda
+  sha256: ba02d0631c20870676c4757ad5dbf1f5820962e31fae63dccd5e570cb414be98
+  md5: 77a728b43b3d213da1566da0bd7b85e6
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 11403008
+  timestamp: 1749060546150
 - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
   sha256: 4614af680aa0920e82b953fece85a03007e0719c3399f13d7de64176874b80d5
   md5: eefd65452dfe7cce476a519bece46704
@@ -1095,6 +1242,17 @@ packages:
   license_family: GPL
   size: 317819
   timestamp: 1765813692798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ripgrep-15.1.0-h009cd8f_0.conda
+  sha256: 2454a0ea20e28fea47b77191cbb59246e99bb4141092c17c5162aa0bf56d5a78
+  md5: 42dbb90abf031307dadb43d76a43f2b5
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 1591574
+  timestamp: 1773824665697
 - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.95.0-h5655b98_1.conda
   sha256: 178c041365f72c233dd8544eb12c7514247511cf5a8f09813563f71439e684cf
   md5: 706ff40b97887ace0aa0fedfdf71a3d5
@@ -1513,6 +1671,27 @@ packages:
   size: 13560854
   timestamp: 1779238292621
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.23-h7139b31_0_cpython.conda
+  sha256: f0ef9e79987c524b25cb5245770890b568db568ae66edc7fd65ec60bccf3e3df
+  md5: 6e3ac2810142219bd3dbf68ccf3d68cc
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 10975082
+  timestamp: 1749060340280
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
   sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
   md5: f8381319127120ce51e081dce4865cf4
@@ -1523,6 +1702,17 @@ packages:
   license_family: GPL
   size: 313930
   timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ripgrep-15.1.0-h748bcf4_0.conda
+  sha256: cf467a20ee5d00536b06b08e502b2b780536a1627b5b44593d57dbd6c2aac393
+  md5: 9e11fa21d0627ad52f2edfe90a363208
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 1492744
+  timestamp: 1773825226555
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.95.0-h4ff7c5d_1.conda
   sha256: dfca85c99b02aa764f345ca74751e91c137b31415965d1ca8784fc6898dd2cbc
   md5: da183dc2479d6f87d7e856232247bb4d
@@ -1717,6 +1907,38 @@ packages:
   size: 18375338
   timestamp: 1779237800732
   python_site_packages_path: Lib/site-packages
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.9.23-h8c5b53a_0_cpython.conda
+  sha256: 07b9b6dd5e0acee4d967e5263e01b76fae48596b6e0e6fb3733a587b5d0bcea5
+  md5: 2fd01874016cd5e3b9edccf52755082b
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.7.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libsqlite >=3.50.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - python_abi 3.9.* *_cp39
+  license: Python-2.0
+  size: 16971365
+  timestamp: 1749059542957
+- conda: https://conda.anaconda.org/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
+  sha256: 8c8ce1f8437166d0462cdd20cc139f8b1dd7cb0ea8c3925979890d8d374c5fcc
+  md5: 9f30be36b0d0803defa5902c879fa886
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 1670709
+  timestamp: 1761211097693
 - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
   sha256: e389c7e72cef404aa0611eebfe3ed71821eb4a1d11e8e02e96558b78ab24268d
   md5: 244444d407db935f7c1500d21bb00db5
@@ -1836,7 +2058,7 @@ packages:
   license_family: BSD
   size: 388453
   timestamp: 1764777142545
-- conda_source: v3[0746a06a] @ .
+- conda_source: v3[01af6b58] @ .
   variants:
     target_platform: osx-arm64
   constrains:
@@ -1845,7 +2067,11 @@ packages:
     py:
     - python
     rust:
-    - bat
+    - bat *[when="python>=3.10"]
+    - ripgrep
+  flags:
+  - a
+  - b
   build_packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.6-h7e67a1e_0.conda
@@ -1880,7 +2106,77 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: v3[3662e1b6] @ .
+- conda_source: v3[589d272b] @ .
+  variants:
+    target_platform: linux-64
+  depends:
+  - libgcc >=15
+  constrains:
+  - __glibc >=2.17
+  extra_depends:
+    py:
+    - python
+    rust:
+    - bat *[when="python>=3.10"]
+    - ripgrep
+  flags:
+  - a
+  - b
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+- conda_source: v3[59a0e4ab] @ .
+  variants:
+    c_compiler: vs2022
+    target_platform: win-64
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  extra_depends:
+    py:
+    - python
+    rust:
+    - bat *[when="python>=3.10"]
+    - ripgrep
+  flags:
+  - a
+  - b
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_38.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vs_win-64-2022.14-ha74f236_38.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+- conda_source: v3[76967c89] @ .
   variants:
     target_platform: osx-64
   constrains:
@@ -1889,7 +2185,11 @@ packages:
     py:
     - python
     rust:
-    - bat
+    - bat *[when="python>=3.10"]
+    - ripgrep
+  flags:
+  - a
+  - b
   build_packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-64-22.1.6-hcf80936_0.conda
@@ -1924,65 +2224,3 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-- conda_source: v3[685351bb] @ .
-  variants:
-    target_platform: linux-64
-  depends:
-  - libgcc >=15
-  constrains:
-  - __glibc >=2.17
-  extra_depends:
-    py:
-    - python
-    rust:
-    - bat
-  build_packages:
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  host_packages:
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-- conda_source: v3[eb6dfb08] @ .
-  variants:
-    c_compiler: vs2022
-    target_platform: win-64
-  depends:
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  extra_depends:
-    py:
-    - python
-    rust:
-    - bat
-  build_packages:
-  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_38.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vs_win-64-2022.14-ha74f236_38.conda
-  host_packages:
-  - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda

--- a/examples/pixi-build/v3/pixi.lock
+++ b/examples/pixi-build/v3/pixi.lock
@@ -1,0 +1,1988 @@
+version: 7
+platforms:
+- name: linux-64
+- name: osx-64
+- name: osx-arm64
+- name: win-64
+environments:
+  all:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bat-0.26.1-hdab8a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda_source: v3[685351bb] @ .
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bat-0.26.1-h121f529_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.1-h8f8c405_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.5-h7c6738f_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - conda_source: v3[3662e1b6] @ .
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bat-0.26.1-hd1458d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - conda_source: v3[0746a06a] @ .
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bat-0.26.1-h77a83cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.1-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.5-h4b44e0e_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - conda_source: v3[eb6dfb08] @ .
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages: {}
+  py:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda_source: v3[685351bb] @ .
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.1-h8f8c405_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.5-h7c6738f_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - conda_source: v3[3662e1b6] @ .
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - conda_source: v3[0746a06a] @ .
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.1-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.5-h4b44e0e_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - conda_source: v3[eb6dfb08] @ .
+  rust:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bat-0.26.1-hdab8a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda_source: v3[685351bb] @ .
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bat-0.26.1-h121f529_0.conda
+      - conda_source: v3[3662e1b6] @ .
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bat-0.26.1-hd1458d2_0.conda
+      - conda_source: v3[0746a06a] @ .
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bat-0.26.1-h77a83cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda_source: v3[eb6dfb08] @ .
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bat-0.26.1-hdab8a38_0.conda
+  sha256: a2fe0ddb2422b762ba76a83b735c30ed4743b479d523727d6add4cf5a169097b
+  md5: c0a7f62debc71dc633e763e4bbc40ebb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 2959502
+  timestamp: 1764718021203
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+  sha256: 0a7d405064f53b9d91d92515f1460f7906ee5e8523f3cd8973430e81219f4917
+  md5: 8165352fdce2d2025bf884dc0ee85700
+  depends:
+  - ld_impl_linux-64 2.45.1 default_hbd61a6d_102
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 3661455
+  timestamp: 1774197460085
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+  sha256: 78a58d523d072b7f8e591b8f8572822e044b31764ed7e8d170392e7bc6d58339
+  md5: 2a307a17309d358c9b42afdd3199ddcc
+  depends:
+  - binutils_impl_linux-64 2.45.1 default_hfdba357_102
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 36304
+  timestamp: 1774197485247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+  md5: d2ffd7602c02f2b316fd921d39876885
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 260182
+  timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
+  sha256: 2c0b2870210cfc7e8561676844f4bd3884b345c19100e1da84cbfb4994d8f104
+  md5: 1c2eddf7501ef92050d3fbb11df61ee3
+  depends:
+  - binutils_impl_linux-64 >=2.45
+  - libgcc >=15.2.0
+  - libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+  - libgomp >=15.2.0
+  - libsanitizer 15.2.0 h90f66d4_19
+  - libstdcxx >=15.2.0
+  - libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 81043749
+  timestamp: 1778860073982
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  sha256: 3fbe01ebb16418d9f1971a283f969dc0f0e1071119f24164f4293057c79dc58c
+  md5: 46ca2358101b2477cb098c4248795d12
+  depends:
+  - gcc_impl_linux-64 15.2.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libgcc >=15
+  size: 29190
+  timestamp: 1779371750402
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+  md5: 18335a698559cdbcd86150a48bf54ba6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45.1
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 728002
+  timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  sha256: 363018b25fdb5534c79783d912bd4b685a3547f4fc5996357ad548899b0ee8e7
+  md5: 93764a5ca80616e9c10106cdaec92f74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 77294
+  timestamp: 1779278686680
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+  md5: a360c33a5abe61c07959e449fa1453eb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 58592
+  timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1041084
+  timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603817
+  timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 113478
+  timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+  md5: 2c21e66f50753a083cbe6b80f38268fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 92400
+  timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
+  md5: 67eef12ce33f7ff99900c212d7076fc2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.2.0
+  - libstdcxx >=15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 7930689
+  timestamp: 1778269054623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
+  md5: 7dc38adcbf71e6b38748e919e16e0dce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 954962
+  timestamp: 1777986471789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+  md5: 5794b3bdc38177caf969dabd3af08549
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_19
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 5852044
+  timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.1-h5347b49_0.conda
+  sha256: 3f0edf1280e2f6684a986f821eaa3e123d2694a00b31b96ca0d4a4c12c129231
+  md5: 7d0a66598195ef00b6efc55aefc7453b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40163
+  timestamp: 1779118517630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  size: 918956
+  timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3167099
+  timestamp: 1775587756857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
+  build_number: 100
+  sha256: 55eed9bf2a3f6e90311276f0834737fe7c2d9ec3e5e2e557507858df4c7521e6
+  md5: da92e59ff92f2d5ede4f612af20f583f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.1,<4.0a0
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 36745188
+  timestamp: 1779236923603
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
+  sha256: 0f7965acec00e5b35d7b4748ea0da57249ab3db2177d13eb87909c0a142148b5
+  md5: 26172b61a3f03c31e56065413ffc1f2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gcc_impl_linux-64
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  - rust-std-x86_64-unknown-linux-gnu 1.95.0 h2c6d0dc_1
+  - sysroot_linux-64 >=2.17
+  license: MIT
+  license_family: MIT
+  size: 182907915
+  timestamp: 1777536012536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
+  sha256: f0e7e6b6dbec4ff4ef3c9c080a82f52af08c4983b568af0433f217be1045a6fe
+  md5: 371cfdd3ecb3fd19343bf7f21101da48
+  depends:
+  - gcc_linux-64
+  - rust 1.95.0.*
+  - rust-std-x86_64-unknown-linux-gnu 1.95.0.*
+  - sysroot_linux-64 >=2.17
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong_constrains:
+    - __glibc >=2.17
+  size: 11761
+  timestamp: 1780066916977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+  md5: cffd3bdd58090148f4cfcd831f4b26ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3301196
+  timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601375
+  timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
+  sha256: 86981d764e4ea1883409d30447ff9da46127426d31a63df08315aaded768e652
+  md5: c9b86eece2f944541b86441c94117ab3
+  depends:
+  - __win
+  license: ISC
+  size: 130182
+  timestamp: 1779289939595
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+  md5: 489b8e97e666c93f68fdb35c3c9b957f
+  depends:
+  - __unix
+  license: ISC
+  size: 129868
+  timestamp: 1779289852439
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-64-22.1.6-hcf80936_0.conda
+  sha256: 286e3cc2a812a5559701b659fc80ffc6ddc65a9f1e720a35ab8adb27bbb7ebd1
+  md5: 9696a32d22b6f55dd3cfccfb8c632493
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 10609719
+  timestamp: 1779327597076
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.6-h7e67a1e_0.conda
+  sha256: 49dd3a39f82703d308421cdd5e7896e87cf39f7bdfd8bf1fa43abc31e047fcaf
+  md5: 89c554a96da130d076a1e8e96a83abe0
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 10983499
+  timestamp: 1779326748181
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-22.1.6-h694c41f_0.conda
+  sha256: 0a3e8b4e26f172a1abb1ede7030ed9c7f89bf9a3b891abd0f6d8fc90ed21d2df
+  md5: d3766ac7cecc20dbad14233bcf82737e
+  depends:
+  - compiler-rt22_osx-64 22.1.6 hcf80936_0
+  constrains:
+  - clang 22.1.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 16801
+  timestamp: 1779327659046
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-22.1.6-hce30654_0.conda
+  sha256: 11b1934e9c8d685a2b2ff0d83a02e9a24a741551bd7c25a7b3a14a3cc87bf185
+  md5: 918710203c7313cd1c36c0825b548983
+  depends:
+  - compiler-rt22_osx-arm64 22.1.6 h7e67a1e_0
+  constrains:
+  - clang 22.1.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 16753
+  timestamp: 1779326777309
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+  md5: 86d9cba083cd041bfbf242a01a7a1999
+  constrains:
+  - sysroot_linux-64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  size: 1278712
+  timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
+  md5: 683fcb168e1df9a21fa80d5aa2d9330b
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3095909
+  timestamp: 1778268932148
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  sha256: a2385f3611d5cd25378f9cf2367183320731709c067ddd08d43330d3170f15b8
+  md5: bcfe7eae40158c3e355d2f9d3ed41230
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 20765069
+  timestamp: 1778268963689
+- conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-64-26.0-hb5ce262_7.conda
+  sha256: e1a32fb9babf5e88706fcf4180c24436f1c59536af39e91869acd72dee7b0a10
+  md5: 8231d152a1534e90b903a9560295e40d
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4961
+  timestamp: 1771434185962
+- conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-arm64-26.0-h445c915_7.conda
+  sha256: bab5c593f0b2b42031baba06c3b6dfcfd03a445377780300df79ee18880e3afe
+  md5: 6119f38fd8f2f8c4904a5b03dffe7b42
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4995
+  timestamp: 1771434195390
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.95.0-hf6ec828_1.conda
+  sha256: 02f95edb4dc705a737ee251a2d4964754b47e92b6748778bf653cc0dadae0396
+  md5: 1742712cfe633438d29c64166d4dd0fb
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.95.0,<1.95.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 32295381
+  timestamp: 1777535359445
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.95.0-h38e4360_1.conda
+  sha256: bc954e13739766689bcabd84b6100e3e2e23438ecf1ce129c7129f1f56692819
+  md5: 2859d934149ae34c2a1df837a719fcdd
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.95.0,<1.95.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 34462833
+  timestamp: 1777535269179
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
+  sha256: d898e729b5bfa97113c6432bb0a3ec894d760ee16ee3b8395f9a543dcee3af23
+  md5: 09f651703ba6fb9966ee984607337bcf
+  depends:
+  - __win
+  constrains:
+  - rust >=1.95.0,<1.95.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 26285976
+  timestamp: 1777537641520
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
+  sha256: 5d2e2b38a6d2a7653afc93706da04a5a14a6de9834cd34c0a2f4d7af619a3bc6
+  md5: 835766243561e6c6f34b617b9eb89110
+  depends:
+  - __unix
+  constrains:
+  - rust >=1.95.0,<1.95.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 36416714
+  timestamp: 1777535938349
+- conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
+  sha256: 7e7e2556978bc9bd9628c6e39138c684082320014d708fbca0c9050df98c0968
+  md5: 68a978f77c0ba6ca10ce55e188a21857
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4948
+  timestamp: 1771434185960
+- conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
+  sha256: fabfe031ede99898cb2b0b805f6c0d64fcc24ecdb444de3a83002d8135bf4804
+  md5: 5f0ebbfea12d8e5bddff157e271fdb2f
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4971
+  timestamp: 1771434195389
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+  md5: 13dc3adbc692664cd3beabd216434749
+  depends:
+  - __glibc >=2.28
+  - kernel-headers_linux-64 4.18.0 he073ed8_9
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  size: 24008591
+  timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  license: LicenseRef-Public-Domain
+  size: 119135
+  timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
+  sha256: b72270395326dc56de9bd6ca82f63791b3c8c9e2b98e25242a9869a4ca821895
+  md5: f622897afff347b715d046178ad745a5
+  depends:
+  - __win
+  license: MIT
+  license_family: MIT
+  size: 238764
+  timestamp: 1745560912727
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bat-0.26.1-h121f529_0.conda
+  sha256: defc2a1235ca1fce10a9814f21e910049fac60fc006e14c0f04c241db7bf4fc5
+  md5: cc8045a8316dfff0db0ec4da44445977
+  depends:
+  - __osx >=10.13
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 2847205
+  timestamp: 1764718700884
+- conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
+  sha256: 9f242f13537ef1ce195f93f0cc162965d6cc79da578568d6d8e50f70dd025c42
+  md5: 4173ac3b19ec0a4f400b4f782910368b
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 133427
+  timestamp: 1771350680709
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_impl_osx-64-1030.6.3-llvm22_1_h8fe25a2_4.conda
+  sha256: 9e003c254b6c1880e6c8f2d777b20d837db2b7aff161454d857693692fd862dd
+  md5: 5d0b3b0b085354afc3b53c424e40121b
+  depends:
+  - __osx >=11.0
+  - ld64_osx-64 >=956.6,<956.7.0a0
+  - libcxx
+  - libllvm22 >=22.1.0,<22.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 22.1.*
+  - sigtool-codesign
+  constrains:
+  - clang 22.1.*
+  - cctools 1030.6.3.*
+  - ld64 956.6.*
+  license: APSL-2.0
+  license_family: Other
+  size: 744001
+  timestamp: 1772019049683
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1030.6.3-llvm22_1_h0a1bb1c_4.conda
+  sha256: e0eefd2d7b4c8434b1b97ddf51780601e4ea5c964bb053775213868412367bbe
+  md5: d97b4a7d3a90d1cd45ff42ee353efadc
+  depends:
+  - cctools_impl_osx-64 1030.6.3 llvm22_1_h8fe25a2_4
+  - ld64_osx-64 956.6 llvm22_1_h163eae7_4
+  constrains:
+  - cctools 1030.6.3.*
+  license: APSL-2.0
+  license_family: Other
+  size: 23441
+  timestamp: 1772019105060
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang-22-22.1.6-default_h3b8fe2e_1.conda
+  sha256: fe40246c1af697249af19b5b25e93d37fed118f2aebdcf7542e3a79a976f9f22
+  md5: b2d518364cfd384eaf0f0fb0df4e3bc2
+  depends:
+  - __osx >=11.0
+  - compiler-rt22 22.1.6.*
+  - libclang-cpp22.1 22.1.6 default_h9399c5b_1
+  - libcxx >=22.1.6
+  - libllvm22 >=22.1.6,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 823187
+  timestamp: 1779397611834
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-22.1.6-default_he9bf3b8_1.conda
+  sha256: 14e1a84bb3a345f51e18b626159c6e8114837642f45255b81653591694334510
+  md5: 72c91f5cc7213f63223277ff1423f555
+  depends:
+  - cctools_impl_osx-64
+  - clang-22 22.1.6 default_h3b8fe2e_1
+  - compiler-rt 22.1.6.*
+  - compiler-rt_osx-64
+  - ld64_osx-64 * llvm22_1_*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 28954
+  timestamp: 1779397752770
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-22.1.6-hb508bca_31.conda
+  sha256: 111ff04047c826c5d7dc6d906b83a29323b82658dbc9cb9f0b3e4e8643150f51
+  md5: 52f94d9ee8e33f65a31156ec7b512f74
+  depends:
+  - cctools_osx-64
+  - clang_impl_osx-64 22.1.6.*
+  - sdkroot_env_osx-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 21233
+  timestamp: 1779921262215
+- conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-22.1.6-h694c41f_0.conda
+  sha256: af268e3ce7ec453da3fd8d872d47526dce1f294302c7b0a9f0c48c9a4b421613
+  md5: e738e882154d65f1eb3da942449c66ed
+  depends:
+  - compiler-rt22 22.1.6 h1637cdf_0
+  - libcompiler-rt 22.1.6 h1637cdf_0
+  constrains:
+  - clang 22.1.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 16674
+  timestamp: 1779327660420
+- conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt22-22.1.6-h1637cdf_0.conda
+  sha256: dbb939a84124dfc70f68f1daf5c064bb21f4c6b3c76bd90d8bda2de5870e5194
+  md5: 3fac38966a9946e0ee5c24419aa509c3
+  depends:
+  - __osx >=11.0
+  - compiler-rt22_osx-64 22.1.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 99164
+  timestamp: 1779327656257
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
+  sha256: 1294117122d55246bb83ad5b589e2a031aacdf2d0b1f99fd338aa4394f881735
+  md5: 627eca44e62e2b665eeec57a984a7f00
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 12273764
+  timestamp: 1773822733780
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-956.6-llvm22_1_h163eae7_4.conda
+  sha256: e49272192003e0e30edd6877197db3c220bb374a78d5b255d18c7a029cd33c1e
+  md5: 9e6646598daf11bd8ebc60d690162ebd
+  depends:
+  - __osx >=11.0
+  - libcxx
+  - libllvm22 >=22.1.0,<22.2.0a0
+  - sigtool-codesign
+  - tapi >=1600.0.11.8,<1601.0a0
+  constrains:
+  - clang 22.1.*
+  - cctools 1030.6.3.*
+  - cctools_impl_osx-64 1030.6.3.*
+  - ld64 956.6.*
+  license: APSL-2.0
+  license_family: Other
+  size: 1110951
+  timestamp: 1772018988810
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp22.1-22.1.6-default_h9399c5b_1.conda
+  sha256: 776d49dc3e0da85461fdffa69e3a06691148f6cdcf2eb17062dadf9503535d83
+  md5: bca94c29997c06d9ea3441ec7282effb
+  depends:
+  - __osx >=11.0
+  - libcxx >=22.1.6
+  - libllvm22 >=22.1.6,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 15010116
+  timestamp: 1779397478140
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcompiler-rt-22.1.6-h1637cdf_0.conda
+  sha256: e0aac5f20751e06480899382fe7d1bbd858309669085aacf59bf32faccae5a33
+  md5: 045f462fc5a0779336782c1f1f8fe7e4
+  depends:
+  - __osx >=11.0
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 1369363
+  timestamp: 1779327642936
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.6-h19cb2f5_0.conda
+  sha256: 6d60efb63fe4d0299526fcb26e06de1933de55c36fc2ae5a1478f1aa734604bb
+  md5: fa1bbb55bfda7a8a022d508fb03f1625
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 565211
+  timestamp: 1779253305906
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_0.conda
+  sha256: 460afe7ba0882e6d2fcc0ad1568dce27025110ec09c2b9ce9e3b49d61e52ce6b
+  md5: f95dc08366f2a452005062b5bcceac51
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 75654
+  timestamp: 1779279058576
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
+  sha256: 951958d1792238006fdc6fce7f71f1b559534743b26cc1333497d46e5903a2d6
+  md5: 66a0dc7464927d0853b590b6f53ba3ea
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 53583
+  timestamp: 1769456300951
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  sha256: a1c8cecdf9966921e13f0ae921309a1f415dfbd2b791f2117cf7e8f5e61a48b6
+  md5: 210a85a1119f97ea7887188d176db135
+  depends:
+  - __osx >=10.13
+  license: LGPL-2.1-only
+  size: 737846
+  timestamp: 1754908900138
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm22-22.1.6-hab754da_0.conda
+  sha256: b2a76e1c5a2b1d033e4dc554c7c7b0221ce9dad11f25800cbbac87d7e50f2925
+  md5: 1019a1a8c4f01134187332ff81d3184b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 31844159
+  timestamp: 1779268047525
+- conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+  sha256: d9e2006051529aec5578c6efeb13bb6a7200a014b2d5a77a579e83a8049d5f3c
+  md5: becdfbfe7049fa248e52aa37a9df09e2
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 105724
+  timestamp: 1775826029494
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-hf3981d6_1.conda
+  sha256: 1096c740109386607938ab9f09a7e9bca06d86770a284777586d6c378b8fb3fd
+  md5: ec88ba8a245855935b871a7324373105
+  depends:
+  - __osx >=10.13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 79899
+  timestamp: 1769482558610
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsigtool-0.1.3-hc0f2934_0.conda
+  sha256: f87b743d5ab11c1a8ddd800dd9357fc0fabe47686068232ddc1d1eed0d7321ec
+  md5: 3576aba85ce5e9ab15aa0ea376ab864b
+  depends:
+  - __osx >=10.13
+  - openssl >=3.5.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 38085
+  timestamp: 1767044977731
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.1-h8f8c405_0.conda
+  sha256: 5e964e07a14180ce20decfd4897e8f81d48ec78c1cbf4af85c5520f535d9510c
+  md5: 9273c877f78b7486b0dfdd9268327a79
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 1007171
+  timestamp: 1777987093870
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h0d7f165_0.conda
+  sha256: daa69a1dd887b2dbac44327bc5af73a4d41fa63bc6dc609782fdda9aec187895
+  md5: 5eb194ed01ed3f5a64b6fcec1b399d96
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - icu <0.0a0
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  size: 495267
+  timestamp: 1776377547505
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h0712280_0.conda
+  sha256: caf6e73fa53c3dec3227ea67de231b0f7009544252684e816c6f2f414aeb55c9
+  md5: 81ac54c8b2eb51fceb94eb0817b93cf3
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 h0d7f165_0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 40803
+  timestamp: 1776377589058
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  sha256: 4c6da089952b2d70150c74234679d6f7ac04f4a98f9432dec724968f912691e7
+  md5: 30439ff30578e504ee5e0b390afc8c65
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 59000
+  timestamp: 1774073052242
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22-22.1.6-hc181bea_0.conda
+  sha256: 8b5255399c5172ebcb69e3fa3e39697e56cec5039fc604be86f0bfebed43cc7e
+  md5: e322513e24ec0ce10df31a1e9dc7a34f
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libllvm22 22.1.6 hab754da_0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 18982375
+  timestamp: 1779268327561
+- conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22.1.6-h1637cdf_0.conda
+  sha256: efd2689c68b381794fcbfb1a9e8fda937b27c2d55be1fecac70461ba3da84472
+  md5: 2177a59eaea9e065ab16de70843c165a
+  depends:
+  - __osx >=11.0
+  - libllvm22 22.1.6 hab754da_0
+  - llvm-tools-22 22.1.6 hc181bea_0
+  constrains:
+  - llvm        22.1.6
+  - clang-tools 22.1.6
+  - clang       22.1.6
+  - llvmdev     22.1.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 52144
+  timestamp: 1779268434350
+- conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+  sha256: f5f7e006ff4271305ab4cc08eedd855c67a571793c3d18aff73f645f088a8cae
+  md5: 31b8740cf1b2588d4e61c81191004061
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 831711
+  timestamp: 1777423052277
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+  sha256: 334fd49ea31b99114f5afb1ec44555dc8c90640648302a4f8f838ee345d1ec50
+  md5: 5cf0ece4375c73d7a5765e83565a69c7
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2776564
+  timestamp: 1775589970694
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.5-h7c6738f_100_cp314.conda
+  build_number: 100
+  sha256: f99fd77c51d52319f02b7732971b35921a987ac49ca9b60f9c2e280b0dcdd409
+  md5: 915728f929ae3610f084aecdf62f5272
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 14450441
+  timestamp: 1779239702259
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
+  sha256: 4614af680aa0920e82b953fece85a03007e0719c3399f13d7de64176874b80d5
+  md5: eefd65452dfe7cce476a519bece46704
+  depends:
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 317819
+  timestamp: 1765813692798
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.95.0-h5655b98_1.conda
+  sha256: 178c041365f72c233dd8544eb12c7514247511cf5a8f09813563f71439e684cf
+  md5: 706ff40b97887ace0aa0fedfdf71a3d5
+  depends:
+  - rust-std-x86_64-apple-darwin 1.95.0 h38e4360_1
+  license: MIT
+  license_family: MIT
+  size: 206385816
+  timestamp: 1777535390876
+- conda: https://conda.anaconda.org/conda-forge/osx-64/rust_osx-64-1.95.0-hce10650_2.conda
+  sha256: c9d96cfdf8271da6da1c9e4f5102781faeadb50171d7a868cae756ea71c57d28
+  md5: 09b2698f7489199eb2fc42f98777fdcd
+  depends:
+  - clang_osx-64
+  - ld64_osx-64
+  - macosx_deployment_target_osx-64 >=11.0
+  - rust 1.95.0.*
+  - rust-std-x86_64-apple-darwin 1.95.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong_constrains:
+    - __osx >=11.0
+  size: 11785
+  timestamp: 1780067434899
+- conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
+  sha256: b89d89d0b62e0a84093205607d071932cca228d4d6982a5b073eec7e765b146d
+  md5: 1261fc730f1d8af7eeea8a0024b23493
+  depends:
+  - __osx >=10.13
+  - libsigtool 0.1.3 hc0f2934_0
+  - openssl >=3.5.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 123083
+  timestamp: 1767045007433
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+  sha256: 0e814730160c8e214eadd7905e3659d8f52af86fd37d85fd287060748948a2b8
+  md5: 524528dee57e42d77b1af677137de5a5
+  depends:
+  - libcxx >=19.0.0.a0
+  - __osx >=10.13
+  - ncurses >=6.5,<7.0a0
+  license: NCSA
+  size: 213790
+  timestamp: 1775657389876
+- conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+  sha256: 7f0d9c320288532873e2d8486c331ec6d87919c9028208d3f6ac91dc8f99a67b
+  md5: 6e6efb7463f8cef69dbcb4c2205bf60e
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3282953
+  timestamp: 1769460532442
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+  sha256: 47101a4055a70a4876ffc87b750ab2287b67eca793f21c8224be5e1ee6394d3f
+  md5: 727109b184d680772e3122f40136d5ca
+  depends:
+  - __osx >=10.13
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 528148
+  timestamp: 1764777156963
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bat-0.26.1-hd1458d2_0.conda
+  sha256: 055452c522c1664b8db72cdf37ce7629fe05baf8d7165b576db5d79dced75cec
+  md5: d422a09259b374318dca39db7c217363
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 2711114
+  timestamp: 1764718682839
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
+  md5: 620b85a3f45526a8bc4d23fd78fc22f0
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 124834
+  timestamp: 1771350416561
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_impl_osx-arm64-1030.6.3-llvm22_1_hb5e89dc_4.conda
+  sha256: 97075a1afeac8a7a4dca258ac10efb70638e3c734cbf5a6328ca1e0718e09c41
+  md5: 97768bb89683757d7e535f9b7dcba39d
+  depends:
+  - __osx >=11.0
+  - ld64_osx-arm64 >=956.6,<956.7.0a0
+  - libcxx
+  - libllvm22 >=22.1.0,<22.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 22.1.*
+  - sigtool-codesign
+  constrains:
+  - clang 22.1.*
+  - ld64 956.6.*
+  - cctools 1030.6.3.*
+  license: APSL-2.0
+  license_family: Other
+  size: 749166
+  timestamp: 1772019681419
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1030.6.3-llvm22_1_hbe26303_4.conda
+  sha256: c90c927dd77afb7d8115a3777b567d9ab84169ab797436d79789d75d0bd1a399
+  md5: a08c9f61e81b5d4a0a653495545ec2b8
+  depends:
+  - cctools_impl_osx-arm64 1030.6.3 llvm22_1_hb5e89dc_4
+  - ld64_osx-arm64 956.6 llvm22_1_h692d5aa_4
+  constrains:
+  - cctools 1030.6.3.*
+  license: APSL-2.0
+  license_family: Other
+  size: 23468
+  timestamp: 1772019757885
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-22-22.1.6-default_hd632d02_1.conda
+  sha256: 95784fe69f588cf8be808fc26149e8b0c5b63c078ba6dad10ef91425bcf5db5f
+  md5: cba7dc25d762b3df50979de8b5b14030
+  depends:
+  - __osx >=11.0
+  - compiler-rt22 22.1.6.*
+  - libclang-cpp22.1 22.1.6 default_h8e162e0_1
+  - libcxx >=22.1.6
+  - libllvm22 >=22.1.6,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 822299
+  timestamp: 1779394375506
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.6-default_hf7205c7_1.conda
+  sha256: 11fe3d9962ad7301fa8eb755d1069626c90f1916e21a7807da303dfe3c68c455
+  md5: 9153b36fc725af226b3ec918caa21856
+  depends:
+  - cctools_impl_osx-arm64
+  - clang-22 22.1.6 default_hd632d02_1
+  - compiler-rt 22.1.6.*
+  - compiler-rt_osx-arm64
+  - ld64_osx-arm64 * llvm22_1_*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 28909
+  timestamp: 1779394483063
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-22.1.6-h14169a3_31.conda
+  sha256: a0a1e0287abcedb07117104006e4ebf3b5baea8170f115e206f2f15b13a39a8d
+  md5: 2ec47b96c44e88a5effd855bc029437e
+  depends:
+  - cctools_osx-arm64
+  - clang_impl_osx-arm64 22.1.6.*
+  - sdkroot_env_osx-arm64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 21250
+  timestamp: 1779921732363
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-22.1.6-hce30654_0.conda
+  sha256: 149e12bebeab294788e9315b7c28af2588cfe885901deb35a948c147b62dbb61
+  md5: 628bdb214acf2446155494500fc1a63f
+  depends:
+  - compiler-rt22 22.1.6 hd34ed20_0
+  - libcompiler-rt 22.1.6 hd34ed20_0
+  constrains:
+  - clang 22.1.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 16597
+  timestamp: 1779326777807
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt22-22.1.6-hd34ed20_0.conda
+  sha256: 1156047c7d6145aad7532935346a13985d2496ca0b280702d9fb2d5614d4a551
+  md5: f26403e30c9c146df6c5f40c2cfa0f0a
+  depends:
+  - __osx >=11.0
+  - compiler-rt22_osx-arm64 22.1.6.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 99292
+  timestamp: 1779326776559
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm22_1_h692d5aa_4.conda
+  sha256: e4ae2ef85672c094aa3467d466f932ccdc1dda9bd4adac64f4252cc796149091
+  md5: 4c2255bf859bff6c52ed38960e3bc963
+  depends:
+  - __osx >=11.0
+  - libcxx
+  - libllvm22 >=22.1.0,<22.2.0a0
+  - sigtool-codesign
+  - tapi >=1600.0.11.8,<1601.0a0
+  constrains:
+  - clang 22.1.*
+  - ld64 956.6.*
+  - cctools_impl_osx-arm64 1030.6.3.*
+  - cctools 1030.6.3.*
+  license: APSL-2.0
+  license_family: Other
+  size: 1038027
+  timestamp: 1772019602406
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp22.1-22.1.6-default_h8e162e0_1.conda
+  sha256: bfd6801f6b347f7a7d27f13d7cd8377520eb488399ce9a808f970afa041da3b5
+  md5: b538d27c5bac823b326954e8338923a2
+  depends:
+  - __osx >=11.0
+  - libcxx >=22.1.6
+  - libllvm22 >=22.1.6,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 14186407
+  timestamp: 1779394265167
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcompiler-rt-22.1.6-hd34ed20_0.conda
+  sha256: f626060e2a9e75845f5894fd9f4e5d21910dc9eab59f3ea6e427c7b8e305e9d6
+  md5: bb20061b453dcc9397a341edf074c7ff
+  depends:
+  - __osx >=11.0
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 1373135
+  timestamp: 1779326769064
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
+  sha256: 3e2f8ad32ddab88c5114b9aa2160f8c129f515df0e551d0d86ef5744446afdbd
+  md5: 589cc6f6222fdc0eaf8e90bc38fcce7b
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 570038
+  timestamp: 1779253025527
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_0.conda
+  sha256: 3133fb6bfa871288b92c8b8752696686a841bf4ffe035aa3038033c9e15b738e
+  md5: ef22e9ab1dc7c2f334252f565f90b3b8
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 69110
+  timestamp: 1779278728511
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
+  md5: 43c04d9cb46ef176bb2a4c77e324d599
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 40979
+  timestamp: 1769456747661
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
+  md5: 4d5a7445f0b25b6a3ddbb56e790f5251
+  depends:
+  - __osx >=11.0
+  license: LGPL-2.1-only
+  size: 750379
+  timestamp: 1754909073836
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm22-22.1.6-h89af1be_0.conda
+  sha256: e1ca362a1ee853c54547e609459a900d098781ba74651639577375d2e95fe225
+  md5: 51fdd7b15cbbed91fef5e800c34bf741
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 30038453
+  timestamp: 1779257738170
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+  md5: b1fd823b5ae54fbec272cea0811bd8a9
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 92472
+  timestamp: 1775825802659
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
+  md5: 57c4be259f5e0b99a5983799a228ae55
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 73690
+  timestamp: 1769482560514
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
+  sha256: 421f7bd7caaa945d9cd5d374cc3f01e75637ca7372a32d5e7695c825a48a30d1
+  md5: c08557d00807785decafb932b5be7ef5
+  depends:
+  - __osx >=11.0
+  - openssl >=3.5.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 36416
+  timestamp: 1767045062496
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.1-h1b79a29_0.conda
+  sha256: 49daec7c83e70d4efc17b813547824bc2bcf2f7256d84061d24fbfe537da9f74
+  md5: 6681822ea9d362953206352371b6a904
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 920047
+  timestamp: 1777987051643
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h6967ea9_0.conda
+  sha256: 43895a7517c055b8893531290f9dc48bd751eb04be04f14bbce3b6c71b052be6
+  md5: 6c8292c2ee808aeef2406083beaa6da7
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - libxml2 2.15.3
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 465820
+  timestamp: 1776377317454
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-heed7d32_0.conda
+  sha256: 4d9c117b2dd222cf891710d5f6a570ebb275479979843a1477ac54ed50907b40
+  md5: 0c1fdc80534d8f25fd74722aba81f044
+  depends:
+  - __osx >=11.0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 h6967ea9_0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 41663
+  timestamp: 1776377341241
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 47759
+  timestamp: 1774072956767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-22-22.1.6-hb545844_0.conda
+  sha256: c779d3da14aa39091afeb7444489a69b4e843807284af9bcdff571376319b941
+  md5: b4f854f552061ddac6b025cefa5e724e
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libllvm22 22.1.6 h89af1be_0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 17827733
+  timestamp: 1779257848847
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-22.1.6-hd34ed20_0.conda
+  sha256: 06e88f1fb0385642c2ae6bf7faf442dfe8edffe8d5a04747cc230ed1183bedbb
+  md5: 4148f36a329c2246217acf1d4b1416ef
+  depends:
+  - __osx >=11.0
+  - libllvm22 22.1.6 h89af1be_0
+  - llvm-tools-22 22.1.6 hb545844_0
+  constrains:
+  - clang-tools 22.1.6
+  - llvm        22.1.6
+  - clang       22.1.6
+  - llvmdev     22.1.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 52763
+  timestamp: 1779257910100
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+  md5: 343d10ed5b44030a2f67193905aea159
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 805509
+  timestamp: 1777423252320
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
+  md5: 25dcccd4f80f1638428613e0d7c9b4e1
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3106008
+  timestamp: 1775587972483
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.5-h4c637c5_100_cp314.conda
+  build_number: 100
+  sha256: 06dec0e2f50e2f7e6a8808fcb4aff23729a3f23bcb1fca4fcbc3a341d9e38a83
+  md5: f7331c9deaf21c79e5675e72b21d570b
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 13560854
+  timestamp: 1779238292621
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
+  md5: f8381319127120ce51e081dce4865cf4
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 313930
+  timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.95.0-h4ff7c5d_1.conda
+  sha256: dfca85c99b02aa764f345ca74751e91c137b31415965d1ca8784fc6898dd2cbc
+  md5: da183dc2479d6f87d7e856232247bb4d
+  depends:
+  - rust-std-aarch64-apple-darwin 1.95.0 hf6ec828_1
+  license: MIT
+  license_family: MIT
+  size: 190985420
+  timestamp: 1777535570715
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust_osx-arm64-1.95.0-h9bac32b_2.conda
+  sha256: e139d859f9cbdfabecc1cd18d2ad0888e7ceba9909c5bee05f61a3332c177fd8
+  md5: 9e4df6abb71480373e94aae8e531faaf
+  depends:
+  - clang_osx-arm64
+  - ld64_osx-arm64
+  - macosx_deployment_target_osx-arm64 >=11.0
+  - rust 1.95.0.*
+  - rust-std-aarch64-apple-darwin 1.95.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong_constrains:
+    - __osx >=11.0
+  size: 11811
+  timestamp: 1780067379835
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
+  sha256: f3d006e2441f110160a684744d90921bbedbffa247d7599d7e76b5cd048116dc
+  md5: ade77ad7513177297b1d75e351e136ce
+  depends:
+  - __osx >=11.0
+  - libsigtool 0.1.3 h98dc951_0
+  - openssl >=3.5.4,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 114331
+  timestamp: 1767045086274
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
+  sha256: de6893e53664e769c1b1c4103a666d436e3d307c0eb6a09a164e749d116e80f7
+  md5: 555070ad1e18b72de36e9ee7ed3236b3
+  depends:
+  - libcxx >=19.0.0.a0
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: NCSA
+  size: 200192
+  timestamp: 1775657222120
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
+  md5: a9d86bc62f39b94c4661716624eb21b0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3127137
+  timestamp: 1769460817696
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
+  md5: ab136e4c34e97f34fb621d2592a393d8
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 433413
+  timestamp: 1764777166076
+- conda: https://conda.anaconda.org/conda-forge/win-64/bat-0.26.1-h77a83cd_0.conda
+  sha256: a0555257c9d93ac080462f65ea07b2dc86076b20de79c95b8cca57765dd39341
+  md5: 424a742d2dcf0af1586260e6443402d6
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 3144256
+  timestamp: 1764718823884
+- conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+  sha256: 76dfb71df5e8d1c4eded2dbb5ba15bb8fb2e2b0fe42d94145d5eed4c75c35902
+  md5: 4cb8e6b48f67de0b018719cdf1136306
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 56115
+  timestamp: 1771350256444
+- conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_0.conda
+  sha256: a65e518c20d1482182bc0f1f6dd5d992f25ca44c3b32307be39ae8310db8f060
+  md5: 23eb9474a16d4b9f6f27429989e82002
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 71280
+  timestamp: 1779278786150
+- conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+  sha256: 59d01f2dfa8b77491b5888a5ab88ff4e1574c9359f7e229da254cdfe27ddc190
+  md5: 720b39f5ec0610457b725eb3f396219a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  size: 45831
+  timestamp: 1769456418774
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+  sha256: d636d1a25234063642f9c531a7bb58d84c1c496411280a36ea000bd122f078f1
+  md5: 8f83619ab1588b98dd99c90b0bfc5c6d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 106486
+  timestamp: 1775825663227
+- conda: https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+  sha256: 40dcd0b9522a6e0af72a9db0ced619176e7cfdb114855c7a64f278e73f8a7514
+  md5: e4a9fc2bba3b022dad998c78856afe47
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 89411
+  timestamp: 1769482314283
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.1-hf5d6505_0.conda
+  sha256: e70562450332ca8954bc16f3455468cca5ef3695c7d7187ecc87f8fc3c70e9eb
+  md5: 7fea434a17c323256acc510a041b80d7
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 1304178
+  timestamp: 1777986510497
+- conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+  sha256: 88609816e0cc7452bac637aaf65783e5edf4fee8a9f8e22bdc3a75882c536061
+  md5: dbabbd6234dea34040e631f87676292f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 58347
+  timestamp: 1774072851498
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
+  sha256: feb5815125c60f2be4a411e532db1ed1cd2d7261a6a43c54cb6ae90724e2e154
+  md5: 05c7d624cff49dbd8db1ad5ba537a8a3
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  size: 9410183
+  timestamp: 1775589779763
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.5-h4b44e0e_100_cp314.conda
+  build_number: 100
+  sha256: c561d171e5d1f1bb1a83ca6fa6aa49577a2956a245c5040dfaf8ca20c10a096e
+  md5: 3f76bc298eebc1ec1497852f4d7f09d9
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 18375338
+  timestamp: 1779237800732
+  python_site_packages_path: Lib/site-packages
+- conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
+  sha256: e389c7e72cef404aa0611eebfe3ed71821eb4a1d11e8e02e96558b78ab24268d
+  md5: 244444d407db935f7c1500d21bb00db5
+  depends:
+  - rust-std-x86_64-pc-windows-msvc 1.95.0 h17fc481_1
+  license: MIT
+  license_family: MIT
+  size: 203313060
+  timestamp: 1777537787709
+- conda: https://conda.anaconda.org/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
+  sha256: 8e8c0cdde4e371338fe7cc408a2b71a44135ba4d3a5f911180de231f32c333a4
+  md5: 38d16cbf8a44d04459fbcfb662024da8
+  depends:
+  - rust 1.95.0.*
+  - rust-std-x86_64-pc-windows-msvc 1.95.0.*
+  - vs_win-64 >=2019
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 11561
+  timestamp: 1780067165294
+- conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+  sha256: 0e79810fae28f3b69fe7391b0d43f5474d6bd91d451d5f2bde02f55ae481d5e3
+  md5: 0481bfd9814bf525bd4b3ee4b51494c4
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: TCL
+  license_family: BSD
+  size: 3526350
+  timestamp: 1769460339384
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  run_exports: {}
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+  sha256: 61b68e5a4fc71a17f8d64b12e013a2f971ad980bd08e9c389d5e68efe1a67de0
+  md5: 774568633f3b26d7a4a6dd4f9ea6d3e1
+  depends:
+  - vc14_runtime >=14.51.36231
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 20187
+  timestamp: 1780005880049
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+  sha256: 957c7c65583c7107a5e76f39756c6361fcb7b0dc101ac7c0aea86e7ca09fe49c
+  md5: 2cdcd8ea1010920911bb2eacb4c61227
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.51.36231 h1b9f54f_38
+  constrains:
+  - vs2015_runtime 14.51.36231.* *_38
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  run_exports: {}
+  size: 740997
+  timestamp: 1780005875753
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+  sha256: c645fdc1f0f47718431d973386e946754a10200e7ba2c32032560913a970cacd
+  md5: 63ee70d69d7540e821940dac5d4d9ba2
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.51.36231.* *_38
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 123561
+  timestamp: 1780005858779
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_38.conda
+  sha256: d602239c40b42411268dc15f0325d4c67c6e6b51b6f31d4455935f07cd170111
+  md5: 2d59c2ac7e4c06c9d60731d10cd6254a
+  depends:
+  - vswhere
+  constrains:
+  - vs_win-64 2022.14
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - vc >=14.3,<15
+    - vc14_runtime >=14.44.35208
+    - ucrt >=10.0.20348.0
+  size: 24145
+  timestamp: 1780005884976
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs_win-64-2022.14-ha74f236_38.conda
+  sha256: 4a96f5ce6836d4f76daca3ab23f9e153ce0158323bc03ff8d5e9da12b16d462a
+  md5: 7256679ce67559e8c04f119ed509d3d4
+  depends:
+  - vs2022_win-64 19.44.35207.*
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20588
+  timestamp: 1780005904892
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+  sha256: 368d8628424966fd8f9c8018326a9c779e06913dd39e646cf331226acc90e5b2
+  md5: 053b84beec00b71ea8ff7a4f84b55207
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 388453
+  timestamp: 1764777142545
+- conda_source: v3[0746a06a] @ .
+  variants:
+    target_platform: osx-arm64
+  constrains:
+  - __osx >=11.0
+  extra_depends:
+    py:
+    - python
+    rust:
+    - bat
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.6-h7e67a1e_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-22.1.6-hce30654_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-arm64-26.0-h445c915_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.95.0-hf6ec828_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_impl_osx-arm64-1030.6.3-llvm22_1_hb5e89dc_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1030.6.3-llvm22_1_hbe26303_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-22-22.1.6-default_hd632d02_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.6-default_hf7205c7_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-22.1.6-h14169a3_31.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-22.1.6-hce30654_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt22-22.1.6-hd34ed20_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm22_1_h692d5aa_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp22.1-22.1.6-default_h8e162e0_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcompiler-rt-22.1.6-hd34ed20_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.6-h55c6f16_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm22-22.1.6-h89af1be_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h6967ea9_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-heed7d32_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-22-22.1.6-hb545844_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-22.1.6-hd34ed20_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.95.0-h4ff7c5d_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust_osx-arm64-1.95.0-h9bac32b_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+- conda_source: v3[3662e1b6] @ .
+  variants:
+    target_platform: osx-64
+  constrains:
+  - __osx >=11.0
+  extra_depends:
+    py:
+    - python
+    rust:
+    - bat
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_osx-64-22.1.6-hcf80936_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-22.1.6-h694c41f_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-64-26.0-hb5ce262_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.95.0-h38e4360_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_impl_osx-64-1030.6.3-llvm22_1_h8fe25a2_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1030.6.3-llvm22_1_h0a1bb1c_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-22-22.1.6-default_h3b8fe2e_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-22.1.6-default_he9bf3b8_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-22.1.6-hb508bca_31.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-22.1.6-h694c41f_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt22-22.1.6-h1637cdf_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-956.6-llvm22_1_h163eae7_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp22.1-22.1.6-default_h9399c5b_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcompiler-rt-22.1.6-h1637cdf_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.6-h19cb2f5_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm22-22.1.6-hab754da_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libsigtool-0.1.3-hc0f2934_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h0d7f165_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h0712280_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22-22.1.6-hc181bea_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-22.1.6-h1637cdf_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.95.0-h5655b98_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/rust_osx-64-1.95.0-hce10650_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+- conda_source: v3[685351bb] @ .
+  variants:
+    target_platform: linux-64
+  depends:
+  - libgcc >=15
+  constrains:
+  - __glibc >=2.17
+  extra_depends:
+    py:
+    - python
+    rust:
+    - bat
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+- conda_source: v3[eb6dfb08] @ .
+  variants:
+    c_compiler: vs2022
+    target_platform: win-64
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  extra_depends:
+    py:
+    - python
+    rust:
+    - bat
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_38.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vs_win-64-2022.14-ha74f236_38.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda

--- a/examples/pixi-build/v3/pixi.toml
+++ b/examples/pixi-build/v3/pixi.toml
@@ -4,9 +4,11 @@
 
 [package.build]
 backend = { name = "pixi-build-rust", version = "*"  }
+flags = ["a", "b"]
 
 [package.extra-dependencies.rust]
-bat = "*"
+bat = { version = "*", when = { package = "python", version = ">=3.10" } }
+ripgrep = "*"
 
 [package.extra-dependencies.py]
 python = "*"
@@ -21,13 +23,17 @@ platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
 preview = ["pixi-build"]
 
 [feature.all.dependencies]
-v3 = { path = ".", extras = ["rust", "py"]}
+v3 = { path = ".", extras = ["rust", "py"], flags = ["a"] }
+# Should avoid `bat` to be installed in this environment
+python = "<3.10"
 
 [feature.py.dependencies]
 v3 = { path = ".", extras = ["py"]}
 
 [feature.rust.dependencies]
 v3 = { path = ".", extras = ["rust"]}
+# Should allow bat to be installed in this environment
+python = ">=3.10"
 
 [environments]
 all = ["all"]

--- a/examples/pixi-build/v3/pixi.toml
+++ b/examples/pixi-build/v3/pixi.toml
@@ -1,0 +1,35 @@
+# ----------------------------------
+# Package definition
+# -----------------------------------
+
+[package.build]
+backend = { name = "pixi-build-rust", version = "*"  }
+
+[package.extra-dependencies.rust]
+bat = "*"
+
+[package.extra-dependencies.py]
+python = "*"
+
+# ----------------------------------
+# Workspace definition
+# ----------------------------------
+
+[workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+preview = ["pixi-build"]
+
+[feature.all.dependencies]
+v3 = { path = ".", extras = ["rust", "py"]}
+
+[feature.py.dependencies]
+v3 = { path = ".", extras = ["py"]}
+
+[feature.rust.dependencies]
+v3 = { path = ".", extras = ["rust"]}
+
+[environments]
+all = ["all"]
+py = ["py"]
+rust = ["rust"]

--- a/examples/pixi-build/v3/src/main.rs
+++ b/examples/pixi-build/v3/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Allow v3 matchspec selectors for source dependencies. Refactors PixiSpec along the way.


This enables `extras`, `flags` and `when` to work with source dependencies.
Also, recursive source dependencies work.

Example 1:

```toml
[dependencies]
example-rust = { path = ".", extras = ["wolf", "julian"]}

[package]
name = "example-rust"
version = "0.1.0"

[package.build]
backend = { name = "pixi-build-rust", version = "*"  }

[package.extra-dependencies.wolf]
rust = "*"
example-rattler-build = { path = "./recipe/recipe.yaml" }

[package.target.win-64.extra-dependencies.julian]
python = "*"
```

Example 2:

```toml
[dependencies]
example-rust = { path = ".", flags = ["cuda"] }

[package]
name = "example-rust"
version = "0.1.0"

[package.build]
backend = { name = "pixi-build-rust", version = "*"  }
flags = ["cuda", "blas_openblas"]
```


Example 3:

```toml
[dependencies]
example-rust = { path = "." }
python = "3.13"

[package]
name = "example-rust"
version = "0.1.0"

[package.build]
backend = { name = "pixi-build-rust", version = "*"  }

[package.run-dependencies]
numpy = { version = "*", when = { package = "python", version = ">=3.12" } }
```