### PR TITLE
fix: scope PyPI source-build cache by conda environment

### DIFF
--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -30,9 +30,9 @@ use pixi_reporters::{UvReporter, UvReporterOptions};
 use pixi_uv_conversions::{
     ConversionError, as_uv_req, configure_insecure_hosts_for_tls_bypass,
     convert_uv_requirements_to_pep508, into_pinned_git_spec, into_uv_git_reference,
-    into_uv_git_sha, pypi_options_to_build_options, pypi_options_to_index_locations,
-    to_index_strategy, to_prerelease_mode, to_requirements, to_uv_normalize, to_uv_version,
-    to_version_specifiers,
+    into_uv_git_sha, pypi_build_config_settings, pypi_options_to_build_options,
+    pypi_options_to_index_locations, to_index_strategy, to_prerelease_mode, to_requirements,
+    to_uv_normalize, to_uv_version, to_version_specifiers,
 };
 use pypi_modifiers::{
     pypi_marker_env::determine_marker_environment,
@@ -554,7 +554,11 @@ pub async fn resolve_pypi(
 
     let dependency_metadata = DependencyMetadata::default();
 
-    let config_settings = ConfigSettings::default();
+    // Scope source builds to the conda environment. See issue #6226.
+    let config_settings = match repodata_building_records.as_ref() {
+        Ok(records) => pypi_build_config_settings(&records.records),
+        Err(_) => ConfigSettings::default(),
+    };
     let build_params = UvBuildDispatchParams::new(
         &registry_client,
         &context.cache,

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -19,8 +19,9 @@ use pixi_record::{LockedGitUrl, PixiRecord};
 use pixi_spec::Subdirectory;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
-    configure_insecure_hosts_for_tls_bypass, into_pixi_reference, pypi_options_to_build_options,
-    pypi_options_to_index_locations, to_index_strategy, to_requirements,
+    configure_insecure_hosts_for_tls_bypass, into_pixi_reference, pypi_build_config_settings,
+    pypi_options_to_build_options, pypi_options_to_index_locations, to_index_strategy,
+    to_requirements,
 };
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
 use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record};
@@ -633,8 +634,11 @@ async fn read_local_package_metadata(
         )
     };
 
-    // Create build dispatch parameters
-    let config_settings = ConfigSettings::default();
+    // Scope source builds to the conda environment. See issue #6226.
+    let config_settings = match ctx.building_pixi_records.as_ref() {
+        Ok(records) => pypi_build_config_settings(&records.records),
+        Err(_) => ConfigSettings::default(),
+    };
     let build_params = UvBuildDispatchParams::new(
         &registry_client,
         &ctx.uv_context.cache,

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -24,7 +24,7 @@ use pixi_utils::prefix::Prefix;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
     BuildIsolation, configure_insecure_hosts_for_tls_bypass, locked_indexes_to_index_locations,
-    pypi_options_to_build_options, to_exclude_newer, to_index_strategy,
+    pypi_build_config_settings, pypi_options_to_build_options, to_exclude_newer, to_index_strategy,
 };
 use plan::{InstallPlanner, InstallReason, NeedReinstall, PyPIInstallationPlan};
 use pypi_modifiers::{
@@ -517,7 +517,9 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             pypi_options_to_build_options(self.build_config.no_build, self.build_config.no_binary)
                 .into_diagnostic()?;
 
-        let config_settings = ConfigSettings::default();
+        // Scope source builds to the conda environment, matching the key used
+        // during resolution. See issue #6226.
+        let config_settings = pypi_build_config_settings(pixi_records);
 
         // Setup the interpreter from the conda prefix
         let python_location = self.config.prefix.root().join(python_interpreter_path);

--- a/crates/pixi_record/src/lib.rs
+++ b/crates/pixi_record/src/lib.rs
@@ -121,6 +121,58 @@ impl PixiRecord {
     }
 }
 
+/// A stable, order-independent fingerprint over a set of conda records.
+///
+/// Used to scope PyPI source-build cache keys per environment, so a wheel
+/// built against one set of conda dependencies isn't reused in another that
+/// resolves different ones. See <https://github.com/prefix-dev/pixi/issues/6226>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CondaEnvironmentFingerprint(u64);
+
+impl CondaEnvironmentFingerprint {
+    /// Computes the fingerprint over the given conda records.
+    pub fn new<'a>(records: impl IntoIterator<Item = &'a PixiRecord>) -> Self {
+        use std::hash::{Hash, Hasher};
+
+        use xxhash_rust::xxh3::Xxh3;
+
+        // Names are unique within an environment, so sorting by name makes the
+        // result order-independent.
+        let mut records: Vec<&PixiRecord> = records.into_iter().collect();
+        records.sort_unstable_by(|a, b| {
+            a.package_record()
+                .name
+                .as_normalized()
+                .cmp(b.package_record().name.as_normalized())
+        });
+
+        let mut hasher = Xxh3::new();
+        for record in records {
+            let package_record = record.package_record();
+            package_record.name.as_normalized().hash(&mut hasher);
+            package_record.version.to_string().hash(&mut hasher);
+            package_record.build.hash(&mut hasher);
+            package_record.subdir.hash(&mut hasher);
+            if let Some(sha256) = package_record.sha256.as_ref() {
+                sha256.as_slice().hash(&mut hasher);
+            }
+            // Source packages have no binary hash; use the content-derived
+            // identifier and pinned source instead.
+            if let Some(source) = record.as_source() {
+                source.identifier_hash.hash(&mut hasher);
+                source.manifest_source.hash(&mut hasher);
+            }
+        }
+        Self(hasher.finish())
+    }
+}
+
+impl std::fmt::Display for CondaEnvironmentFingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:016x}", self.0)
+    }
+}
+
 impl From<SourceRecord> for PixiRecord {
     fn from(value: SourceRecord) -> Self {
         PixiRecord::Source(Arc::new(value))
@@ -514,5 +566,100 @@ impl AsRef<PackageRecord> for PixiRecord {
             PixiRecord::Binary(record) => &record.package_record,
             PixiRecord::Source(record) => record.as_ref().as_ref(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, str::FromStr};
+
+    use rattler_conda_types::{VersionWithSource, package::DistArchiveIdentifier};
+
+    use super::*;
+
+    fn binary_record(name: &str, version: &str, build: &str) -> PixiRecord {
+        let mut package_record = PackageRecord::new(
+            PackageName::from_str(name).unwrap(),
+            version.parse::<VersionWithSource>().unwrap(),
+            build.to_string(),
+        );
+        package_record.subdir = "linux-64".into();
+        let record = RepoDataRecord {
+            package_record,
+            identifier: DistArchiveIdentifier::try_from_filename(&format!(
+                "{name}-{version}-{build}.conda"
+            ))
+            .unwrap(),
+            url: url::Url::parse("https://example.com/pkg.conda").unwrap(),
+            channel: None,
+        };
+        PixiRecord::Binary(Arc::new(record))
+    }
+
+    fn source_record(name: &str, identifier_hash: &str, path: &str) -> PixiRecord {
+        let mut package_record = PackageRecord::new(
+            PackageName::from_str(name).unwrap(),
+            "1.0.0".parse::<VersionWithSource>().unwrap(),
+            "h0".to_string(),
+        );
+        package_record.subdir = "linux-64".into();
+        let record = SourceRecord {
+            data: FullSourceRecordData {
+                package_record,
+                sources: BTreeMap::new(),
+            },
+            manifest_source: PinnedSourceSpec::Path(PinnedPathSpec {
+                path: typed_path::Utf8TypedPathBuf::from(path),
+            }),
+            build_source: None,
+            variants: BTreeMap::new(),
+            identifier_hash: identifier_hash.to_string(),
+            build_packages: Vec::new(),
+            host_packages: Vec::new(),
+        };
+        PixiRecord::Source(Arc::new(record))
+    }
+
+    fn fingerprint(records: &[PixiRecord]) -> String {
+        CondaEnvironmentFingerprint::new(records).to_string()
+    }
+
+    #[test]
+    fn fingerprint_is_order_independent() {
+        let gdal = binary_record("libgdal", "3.10.3", "h0");
+        let python = binary_record("python", "3.12.0", "h1");
+        assert_eq!(
+            fingerprint(&[gdal.clone(), python.clone()]),
+            fingerprint(&[python, gdal]),
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_with_conda_dependency_version() {
+        // The motivating case from issue #6226.
+        let gdal_310 = binary_record("libgdal", "3.10.3", "h0");
+        let gdal_313 = binary_record("libgdal", "3.13.0", "h0");
+        assert_ne!(fingerprint(&[gdal_310]), fingerprint(&[gdal_313]));
+    }
+
+    #[test]
+    fn fingerprint_changes_with_conda_dependency_build() {
+        let gdal_h0 = binary_record("libgdal", "3.10.3", "h0");
+        let gdal_h1 = binary_record("libgdal", "3.10.3", "h1");
+        assert_ne!(fingerprint(&[gdal_h0]), fingerprint(&[gdal_h1]));
+    }
+
+    #[test]
+    fn fingerprint_changes_with_source_identifier() {
+        let a = source_record("my-pkg", "aaaaaaaa", "./my-pkg");
+        let b = source_record("my-pkg", "bbbbbbbb", "./my-pkg");
+        assert_ne!(fingerprint(&[a]), fingerprint(&[b]));
+    }
+
+    #[test]
+    fn fingerprint_changes_with_source_location() {
+        let a = source_record("my-pkg", "aaaaaaaa", "./my-pkg");
+        let b = source_record("my-pkg", "aaaaaaaa", "./other");
+        assert_ne!(fingerprint(&[a]), fingerprint(&[b]));
     }
 }

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -15,18 +15,40 @@ use pixi_manifest::pypi::{
         PypiOptions,
     },
 };
-use pixi_record::{LockedGitUrl, PinnedGitCheckout, PinnedGitSpec};
+use pixi_record::{
+    CondaEnvironmentFingerprint, LockedGitUrl, PinnedGitCheckout, PinnedGitSpec, PixiRecord,
+};
 use pixi_spec::GitReference as PixiReference;
 use std::{collections::HashSet, fmt::Write};
 use uv_configuration::BuildOptions;
 use uv_configuration::TrustedHost;
-use uv_distribution_types::{GitSourceDist, Index, IndexLocations, IndexUrl};
+use uv_distribution_types::{
+    ConfigSettingEntry, ConfigSettings, GitSourceDist, Index, IndexLocations, IndexUrl,
+};
 use uv_normalize::{InvalidNameError, PackageName};
 use uv_pep508::{VerbatimUrl, VerbatimUrlError};
 use uv_python::PythonEnvironment;
 use uv_redacted::DisplaySafeUrl;
 
 use crate::{ConversionError, VersionError};
+
+/// The `config_settings` key under which the conda-environment fingerprint is
+/// injected.
+const CONDA_ENVIRONMENT_CONFIG_SETTING: &str = "pixi-conda-environment";
+
+/// Builds the [`ConfigSettings`] for PyPI resolution and installation, seeded
+/// with a fingerprint of the conda environment.
+///
+/// uv folds `config_settings` into the cache key of wheels it builds from
+/// source, so this scopes source builds per environment. Prebuilt registry
+/// wheels are unaffected. See <https://github.com/prefix-dev/pixi/issues/6226>.
+pub fn pypi_build_config_settings(conda_records: &[PixiRecord]) -> ConfigSettings {
+    let fingerprint = CondaEnvironmentFingerprint::new(conda_records);
+    let entry =
+        ConfigSettingEntry::from_str(&format!("{CONDA_ENVIRONMENT_CONFIG_SETTING}={fingerprint}"))
+            .expect("the fingerprint is always a valid `KEY=VALUE` config setting");
+    std::iter::once(entry).collect()
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConvertFlatIndexLocationError {


### PR DESCRIPTION
### Description

Wheels that pixi builds from source can link against native libraries provided by the conda environment (for example `libgdal`). Until now those built wheels were cached without regard to which conda environment they were built against, so a wheel built in one environment could be reused in another with different conda dependencies, leading to wrong or broken native linkage.

This change scopes the source-build cache to the conda environment, so a wheel built against one set of conda dependencies is no longer reused in an environment that resolves different ones.

Open questions:

- Should this apply to all source builds, or only to packages built without build isolation? It currently applies to all source builds, since even isolated builds link against the conda environment's native libraries.
- The cache is scoped to the whole conda environment, so an unrelated conda change can still trigger a rebuild. Scoping to only the relevant packages was considered, but the native library a wheel links against (such as `libgdal`) is not itself a PyPI package and is not declared anywhere we can read ahead of time, so any narrower scope risks silently reusing a mis-linked wheel. Only source builds are affected; prebuilt wheels are untouched.

Fixes #6226

### How Has This Been Tested?

Added unit tests covering the environment fingerprint: it changes when a conda dependency version, build, or source location changes, and stays stable regardless of record ordering.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient tests to cover my changes.