### PR TITLE
test: add failing repro for dependency-group upgrade bug (#6239)

### DIFF
--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -533,10 +533,9 @@ impl ManifestDocument {
             return Some(PypiDependencyLocation::PixiPypiDependencies);
         }
 
-        // Check whether the package is actually present in a given PEP 508
-        // requirement array, rather than merely whether the array exists. This
-        // is required so that a package defined in e.g. `[dependency-groups]`
-        // is not mistakenly reported as living in `[project.dependencies]`.
+        // Whether `package_name` is present in the given PEP 508 requirement
+        // array. Membership (not just the array's existence) decides the
+        // location, so a package is reported in the section it truly belongs to.
         let array_contains_package = |keys: &[&str], array_name: &str| -> bool {
             let Ok(Some(array)) = self.manifest().get_toml_array(keys, array_name) else {
                 return false;

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -533,28 +533,31 @@ impl ManifestDocument {
             return Some(PypiDependencyLocation::PixiPypiDependencies);
         }
 
-        if self
-            .manifest()
-            .get_toml_array(&["project"], "dependencies")
-            .is_ok()
-        {
+        // Check whether the package is actually present in a given PEP 508
+        // requirement array, rather than merely whether the array exists. This
+        // is required so that a package defined in e.g. `[dependency-groups]`
+        // is not mistakenly reported as living in `[project.dependencies]`.
+        let array_contains_package = |keys: &[&str], array_name: &str| -> bool {
+            let Ok(Some(array)) = self.manifest().get_toml_array(keys, array_name) else {
+                return false;
+            };
+            array.iter().any(|item| {
+                item.as_str()
+                    .and_then(|s| s.parse::<pep508_rs::Requirement>().ok())
+                    .is_some_and(|req| req.name == *package_name.as_normalized())
+            })
+        };
+
+        if array_contains_package(&["project"], "dependencies") {
             return Some(PypiDependencyLocation::Dependencies);
         }
         let name = feature_name.to_string();
 
-        if self
-            .manifest()
-            .get_toml_array(&["project", "optional-dependencies"], &name)
-            .is_ok()
-        {
+        if array_contains_package(&["project", "optional-dependencies"], &name) {
             return Some(PypiDependencyLocation::OptionalDependencies);
         }
 
-        if self
-            .manifest()
-            .get_toml_array(&["dependency-groups"], &name)
-            .is_ok()
-        {
+        if array_contains_package(&["dependency-groups"], &name) {
             return Some(PypiDependencyLocation::DependencyGroups);
         }
 
@@ -959,23 +962,34 @@ dev = ["dev"]
             DocumentMut::from_str(manifest_content).unwrap(),
         ));
 
-        let dev_feature = FeatureName::from_str("dev").unwrap();
-        let pytest = PypiPackageName::from_str("pytest").unwrap();
+        let location_name = |pkg: &str, feature: &FeatureName| -> &'static str {
+            let name = PypiPackageName::from_str(pkg).unwrap();
+            match document.pypi_dependency_location(&name, None, feature) {
+                Some(PypiDependencyLocation::PixiPypiDependencies) => "PixiPypiDependencies",
+                Some(PypiDependencyLocation::Dependencies) => "Dependencies",
+                Some(PypiDependencyLocation::OptionalDependencies) => "OptionalDependencies",
+                Some(PypiDependencyLocation::DependencyGroups) => "DependencyGroups",
+                None => "None",
+            }
+        };
 
-        let location = document.pypi_dependency_location(&pytest, None, &dev_feature);
+        let dev_feature = FeatureName::from_str("dev").unwrap();
 
         // `pytest` is defined in `[dependency-groups].dev`, so it must be
-        // reported as living in the dependency-groups section.
-        let location_name = match location {
-            Some(PypiDependencyLocation::PixiPypiDependencies) => "PixiPypiDependencies",
-            Some(PypiDependencyLocation::Dependencies) => "Dependencies",
-            Some(PypiDependencyLocation::OptionalDependencies) => "OptionalDependencies",
-            Some(PypiDependencyLocation::DependencyGroups) => "DependencyGroups",
-            None => "None",
-        };
+        // reported as living in the dependency-groups section, not in
+        // `[project.dependencies]`.
         assert_eq!(
-            location_name, "DependencyGroups",
-            "pytest belongs to [dependency-groups].dev but was located in {location_name}"
+            location_name("pytest", &dev_feature),
+            "DependencyGroups",
+            "pytest belongs to [dependency-groups].dev"
+        );
+
+        // A package genuinely listed in `[project.dependencies]` must still be
+        // reported there.
+        assert_eq!(
+            location_name("requests", &FeatureName::default()),
+            "Dependencies",
+            "requests belongs to [project.dependencies]"
         );
     }
 

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -926,6 +926,59 @@ NumPy = ">=1.20.0" # table inline comment
         insta::assert_snapshot!(document.to_string());
     }
 
+    /// Reproduction for https://github.com/prefix-dev/pixi/issues/6239
+    ///
+    /// When a pyproject.toml has both a `[project.dependencies]` array and a
+    /// `[dependency-groups]` section, `pypi_dependency_location` must report
+    /// that a package belonging to a dependency group lives in
+    /// `DependencyGroups` (not `Dependencies`). Otherwise `pixi upgrade`
+    /// writes the upgraded constraint into `[project.dependencies]`.
+    #[test]
+    pub fn repro_6239_dependency_group_location() {
+        let manifest_content = r#"[project]
+name = "test"
+dependencies = [
+    "requests>=2.28.1,<3.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0,<9",
+    "ruff>=0.5,<0.6",
+]
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+
+[tool.pixi.environments]
+dev = ["dev"]
+"#;
+
+        let document = ManifestDocument::PyProjectToml(TomlDocument::new(
+            DocumentMut::from_str(manifest_content).unwrap(),
+        ));
+
+        let dev_feature = FeatureName::from_str("dev").unwrap();
+        let pytest = PypiPackageName::from_str("pytest").unwrap();
+
+        let location = document.pypi_dependency_location(&pytest, None, &dev_feature);
+
+        // `pytest` is defined in `[dependency-groups].dev`, so it must be
+        // reported as living in the dependency-groups section.
+        let location_name = match location {
+            Some(PypiDependencyLocation::PixiPypiDependencies) => "PixiPypiDependencies",
+            Some(PypiDependencyLocation::Dependencies) => "Dependencies",
+            Some(PypiDependencyLocation::OptionalDependencies) => "OptionalDependencies",
+            Some(PypiDependencyLocation::DependencyGroups) => "DependencyGroups",
+            None => "None",
+        };
+        assert_eq!(
+            location_name, "DependencyGroups",
+            "pytest belongs to [dependency-groups].dev but was located in {location_name}"
+        );
+    }
+
     /// This test checks that removing a pypi dependency
     /// uses the same source name as the one used to add it.
     #[test]


### PR DESCRIPTION
### Description

Running `pixi upgrade` on a `pyproject.toml` that declares PyPI packages in
`[dependency-groups]` (or `[project.optional-dependencies]`) moved those packages
into the main `[project.dependencies]` array. This collapsed the separation between
environments that users rely on to keep dev/test tooling out of their default
environment, and left the original group entries with stale constraints.

The cause was that the manifest's location lookup treated "a `[project.dependencies]`
array exists" as "the package lives here", so any project with that array would
capture every PyPI package regardless of where it was actually declared. The lookup
now decides the location by whether the package is genuinely a member of a section,
so an upgraded constraint is written back to the section the package really came from
and environment separation is preserved.

Fixes #6239

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

Added a regression test (`repro_6239_dependency_group_location`) that asserts a package
declared in `[dependency-groups].dev` resolves to the dependency-groups section while a
package in `[project.dependencies]` still resolves to the default dependencies.
`cargo test -p pixi_manifest` passes (249 tests).

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Code Web (first time)

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.