### PR TITLE
chore: reuse build cache by passing `--workspace`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -300,8 +300,8 @@ build-backends = { cmd = "rattler-build build --recipe-dir empty --output-dir . 
 git = ">=2.51.0,<3"
 
 [feature.rust-build.tasks]
-build-debug = { cmd = "cargo build", description = "Build pixi in debug mode" }
-build-release = { cmd = "cargo build --release", description = "Build pixi in release mode" }
+build-debug = { cmd = "cargo build --workspace --bin pixi", description = "Build pixi in debug mode" }
+build-release = { cmd = "cargo build --workspace --bin pixi --release", description = "Build pixi in release mode" }
 build-workspace-debug = { cmd = "cargo build --workspace", description = "Build all workspace members in debug mode" }
 build-workspace-release = { cmd = "cargo build --workspace --release", description = "Build all workspace members in release mode" }
 install = { cmd = "cargo install --path crates/pixi --locked", description = "Install pixi itself locally using cargo" }


### PR DESCRIPTION
### Description

I've noticed, that `pixi run build-workspace` and `pixi run build` recompiles the same crates.

This is what Gemini says about this: 

> This behavior comes down to a core Cargo mechanic called Feature Unification.  
> 
> Even though you are compiling a subset of crates the second time, Cargo is recalculating the dependency graph based only on the packages explicitly selected for that build. Because the required feature flags change between the two commands, Cargo hits a cache miss and is forced to recompile.
> 
> If you want to build a specific binary or package without dropping unified features, keep the --workspace flag active but narrow down the target at the end of the command.

### How Has This Been Tested?

Ran the commands multiple times and verified that caching now works.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Gemini

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
