### PR TITLE
feat: support custom TOML manifest paths

### DIFF
--- a/crates/pixi/tests/integration_rust/lock_tests.rs
+++ b/crates/pixi/tests/integration_rust/lock_tests.rs
@@ -1,7 +1,9 @@
 use crate::common::{LockFileExt, PixiControl};
 use pixi_test_utils::{MockRepoData, Package};
 use rattler_conda_types::Platform;
+use rattler_lock::LockFile;
 use tempfile::TempDir;
+use url::Url;
 
 /// Test that `pixi lock --dry-run` doesn't modify the lock file on disk
 #[tokio::test]
@@ -143,5 +145,58 @@ async fn test_lock_dry_run_implies_no_install() {
     assert!(
         !env_path.exists(),
         "Environment should not be created with --dry-run"
+    );
+}
+
+#[tokio::test]
+async fn custom_manifest_path_writes_custom_lock_file() {
+    let mut package_database = MockRepoData::default();
+    let platform = Platform::current();
+
+    package_database.add_package(
+        Package::build("foo", "1.0.0")
+            .with_subdir(platform)
+            .finish(),
+    );
+
+    let channel_dir = TempDir::new().unwrap();
+    package_database
+        .write_repodata(channel_dir.path())
+        .await
+        .unwrap();
+
+    let pixi = PixiControl::new().unwrap();
+    let manifest_path = pixi.workspace_path().join("custom-pixi.toml");
+    let lock_path = pixi.workspace_path().join("custom-pixi.lock");
+    let default_lock_path = pixi.workspace_path().join("pixi.lock");
+    let channel = Url::from_directory_path(channel_dir.path()).unwrap();
+
+    fs_err::write(
+        &manifest_path,
+        format!(
+            r#"
+            [workspace]
+            name = "foo"
+            channels = ["{channel}"]
+            platforms = ["{platform}"]
+
+            [dependencies]
+            foo = "*"
+            "#
+        ),
+    )
+    .unwrap();
+
+    let mut lock = pixi.lock();
+    lock.args.workspace_config.manifest_path = Some(manifest_path);
+    lock.args.no_install_config.no_install = true;
+    lock.await.unwrap();
+
+    assert!(lock_path.is_file());
+    assert!(!default_lock_path.exists());
+    assert!(
+        LockFile::from_path(&lock_path)
+            .unwrap()
+            .contains_conda_package("default", platform, "foo")
     );
 }

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -27,7 +27,7 @@ use pixi_pypi_spec::PypiPackageName;
 /// Workspace configuration
 #[derive(Parser, Debug, Default, Clone)]
 pub struct WorkspaceConfig {
-    /// The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+    /// The path to a manifest file or the workspace directory
     #[arg(long, short, global = true, conflicts_with = "workspace", help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     pub manifest_path: Option<PathBuf>,
 

--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -290,13 +290,13 @@ mod tests {
         let script = r#"
 (add)
 _arguments "${_arguments_options[@]}" \
-'--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
+'--manifest-path=[The path to a manifest file or the workspace directory]:MANIFEST_PATH:_files' \
 '*::specs -- Specify the dependencies you wish to add to the project:' \
 && ret=0
 ;;
 (run)
 _arguments "${_arguments_options[@]}" \
-'--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
+'--manifest-path=[The path to a manifest file or the workspace directory]:MANIFEST_PATH:_files' \
 '--color=[Whether the log needs to be colored]:COLOR:(always never auto)' \
 '(--frozen)--locked[Require pixi.lock is up-to-date]' \
 '(--locked)--frozen[Don'\''t check if pixi.lock is up-to-date, install as lock file states]' \
@@ -399,7 +399,7 @@ _arguments "${_arguments_options[@]}" \
   # Runs task in project
   export extern "pixi run" [
     ...task: string@"nu-complete pixi run"           # The pixi task or a task shell command you want to run in the project's environment, which can be an executable in the environment's PATH
-    --manifest-path: string   # The path to `pixi.toml`, `pyproject.toml`, or the project directory
+    --manifest-path: string   # The path to a manifest file or the workspace directory
     --no-lockfile-update      # Legacy flag, do not use, will be removed in subsequent version
     --frozen                  # Install the environment as defined in the lock file, doesn't update lock file if it isn't up-to-date with the manifest file
     --locked                  # Check if lock file is up-to-date before installing the environment, aborts when lock file isn't up-to-date with the manifest file

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__nushell_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__nushell_completion.snap
@@ -5,7 +5,7 @@ expression: result
   # Runs task in project
   export extern "pixi run" [
     ...task: string@"nu-complete pixi run"           # The pixi task or a task shell command you want to run in the project's environment, which can be an executable in the environment's PATH
-    --manifest-path: string   # The path to `pixi.toml`, `pyproject.toml`, or the project directory
+    --manifest-path: string   # The path to a manifest file or the workspace directory
     --no-lockfile-update      # Legacy flag, do not use, will be removed in subsequent version
     --frozen                  # Install the environment as defined in the lock file, doesn't update lock file if it isn't up-to-date with the manifest file
     --locked                  # Check if lock file is up-to-date before installing the environment, aborts when lock file isn't up-to-date with the manifest file

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__zsh_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__zsh_completion.snap
@@ -5,7 +5,7 @@ expression: result
 
 (add)
 _arguments "${_arguments_options[@]}" \
-'--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
+'--manifest-path=[The path to a manifest file or the workspace directory]:MANIFEST_PATH:_files' \
 '*::specs -- Specify the dependencies you wish to add to the project:' \
 && ret=0
 ;;
@@ -19,7 +19,7 @@ else
     return 1
 fi
 _arguments "${_arguments_options[@]}" \
-'--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
+'--manifest-path=[The path to a manifest file or the workspace directory]:MANIFEST_PATH:_files' \
 '--color=[Whether the log needs to be colored]:COLOR:(always never auto)' \
 '(--frozen)--locked[Require pixi.lock is up-to-date]' \
 '(--locked)--frozen[Don'\''t check if pixi.lock is up-to-date, install as lock file states]' \
@@ -44,5 +44,4 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
-
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -635,7 +635,21 @@ impl Workspace {
     /// Returns the path to the lock file of the project
     /// [consts::PROJECT_LOCK_FILE]
     pub fn lock_file_path(&self) -> PathBuf {
-        self.root.join(consts::PROJECT_LOCK_FILE)
+        match self
+            .workspace
+            .provenance
+            .path
+            .file_name()
+            .and_then(|file_name| file_name.to_str())
+        {
+            Some(
+                consts::WORKSPACE_MANIFEST
+                | consts::PYPROJECT_MANIFEST
+                | consts::MOJOPROJECT_MANIFEST,
+            ) => self.root.join(consts::PROJECT_LOCK_FILE),
+            Some(file_name) => self.root.join(file_name).with_extension("lock"),
+            None => self.root.join(consts::PROJECT_LOCK_FILE),
+        }
     }
 
     /// Returns the default environment of the project.
@@ -1895,6 +1909,23 @@ platforms = []
             dot_pixi.join(consts::WORKSPACE_CACHE_DIR)
         );
         assert_eq!(workspace.build_dir(), workspace.default_build_dir());
+    }
+
+    #[test]
+    fn custom_manifest_lock_file_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = Workspace::from_str(
+            &temp_dir.path().join("custom-pixi.toml"),
+            WORKSPACE_MANIFEST_STR,
+        )
+        .unwrap();
+
+        assert_eq!(
+            workspace.lock_file_path(),
+            dunce::canonicalize(temp_dir.path())
+                .unwrap()
+                .join("custom-pixi.lock")
+        );
     }
 
     #[test]

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -894,6 +894,38 @@ mod test {
         )
     }
 
+    #[test]
+    fn test_explicit_custom_toml_manifest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let manifest_path = temp_dir.path().join("custom-pixi.toml");
+        fs_err::write(
+            &manifest_path,
+            r#"
+            [workspace]
+            name = "foo"
+            channels = []
+            platforms = []
+            "#,
+        )
+        .unwrap();
+
+        let manifests =
+            WorkspaceDiscoverer::new(DiscoveryStart::ExplicitManifest(manifest_path.clone()))
+                .discover()
+                .unwrap()
+                .unwrap()
+                .value;
+
+        assert_eq!(
+            manifests.workspace.provenance.path,
+            dunce::canonicalize(manifest_path).unwrap()
+        );
+        assert_eq!(
+            manifests.workspace.value.workspace.name.as_deref(),
+            Some("foo")
+        );
+    }
+
     /// Smoke-test the `polyglot-particles` example: workspace deps must
     /// resolve into the host/build/run/backend tables across separate
     /// member manifests, with the relative `particle_core` path re-anchored

--- a/crates/pixi_manifest/src/manifests/provenance.rs
+++ b/crates/pixi_manifest/src/manifests/provenance.rs
@@ -94,6 +94,7 @@ impl ManifestKind {
             consts::WORKSPACE_MANIFEST => Some(Self::Pixi),
             consts::PYPROJECT_MANIFEST => Some(Self::Pyproject),
             consts::MOJOPROJECT_MANIFEST => Some(Self::MojoProject),
+            _ if path.extension().and_then(OsStr::to_str) == Some("toml") => Some(Self::Pixi),
             _ => None,
         }
     }
@@ -215,5 +216,14 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn custom_toml_manifest_is_pixi_manifest() {
+        let path = PathBuf::from("custom-pixi.toml");
+        let provenance = ManifestProvenance::from_path(path.clone()).unwrap();
+
+        assert_eq!(provenance.path, path);
+        assert_eq!(provenance.kind, ManifestKind::Pixi);
     }
 }

--- a/crates/pixi_manifest/src/manifests/provenance.rs
+++ b/crates/pixi_manifest/src/manifests/provenance.rs
@@ -23,7 +23,12 @@ pub struct ManifestProvenance {
 #[derive(Debug, Error, Diagnostic)]
 pub enum ProvenanceError {
     /// Returned when the manifest file format is not recognized.
-    #[error("unrecognized manifest file format. Expected either pixi.toml or pyproject.toml.")]
+    #[error(
+        "unrecognized manifest path. Expected a .toml file or a directory containing {}, {}, or {}.",
+        consts::WORKSPACE_MANIFEST,
+        consts::PYPROJECT_MANIFEST,
+        consts::MOJOPROJECT_MANIFEST
+    )]
     UnrecognizedManifestFormat,
 }
 
@@ -225,5 +230,15 @@ mod tests {
 
         assert_eq!(provenance.path, path);
         assert_eq!(provenance.kind, ManifestKind::Pixi);
+    }
+
+    #[test]
+    fn non_toml_manifest_path_error_mentions_toml() {
+        let error = ManifestProvenance::from_path(PathBuf::from("foo.bar")).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "unrecognized manifest path. Expected a .toml file or a directory containing pixi.toml, pyproject.toml, or mojoproject.toml."
+        );
     }
 }

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__explicit_workspace_discoverer@empty.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__explicit_workspace_discoverer@empty.snap
@@ -2,4 +2,4 @@
 source: crates/pixi_manifest/src/discovery.rs
 expression: snapshot
 ---
-  × unrecognized manifest file format. Expected either pixi.toml or pyproject.toml.
+  × unrecognized manifest path. Expected a .toml file or a directory containing pixi.toml, pyproject.toml, or mojoproject.toml.

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -97,7 +97,7 @@ pixi add [OPTIONS] <SPEC>...
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/clean.md
+++ b/docs/reference/cli/pixi/clean.md
@@ -40,7 +40,7 @@ pixi clean [OPTIONS] [COMMAND]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/config/append.md
+++ b/docs/reference/cli/pixi/config/append.md
@@ -31,7 +31,7 @@ pixi config append [OPTIONS] <KEY> <VALUE>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/config/edit.md
+++ b/docs/reference/cli/pixi/config/edit.md
@@ -28,7 +28,7 @@ pixi config edit [OPTIONS] [EDITOR]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/config/list.md
+++ b/docs/reference/cli/pixi/config/list.md
@@ -31,7 +31,7 @@ pixi config list [OPTIONS] [KEY]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/config/prepend.md
+++ b/docs/reference/cli/pixi/config/prepend.md
@@ -31,7 +31,7 @@ pixi config prepend [OPTIONS] <KEY> <VALUE>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/config/set.md
+++ b/docs/reference/cli/pixi/config/set.md
@@ -30,7 +30,7 @@ pixi config set [OPTIONS] <KEY> [VALUE]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/config/unset.md
+++ b/docs/reference/cli/pixi/config/unset.md
@@ -28,7 +28,7 @@ pixi config unset [OPTIONS] <KEY>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/import.md
+++ b/docs/reference/cli/pixi/import.md
@@ -71,7 +71,7 @@ pixi import [OPTIONS] <FILE>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/info.md
+++ b/docs/reference/cli/pixi/info.md
@@ -30,7 +30,7 @@ pixi info [OPTIONS]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -80,7 +80,7 @@ pixi install [OPTIONS]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -58,7 +58,7 @@ pixi list [OPTIONS] [REGEX]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/lock.md
+++ b/docs/reference/cli/pixi/lock.md
@@ -37,7 +37,7 @@ pixi lock [OPTIONS]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/reinstall.md
+++ b/docs/reference/cli/pixi/reinstall.md
@@ -76,7 +76,7 @@ pixi reinstall [OPTIONS] [PACKAGE]...
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -93,7 +93,7 @@ pixi remove [OPTIONS] <SPEC>...
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -94,7 +94,7 @@ pixi run [OPTIONS] [TASK]...
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/search.md
+++ b/docs/reference/cli/pixi/search.md
@@ -44,7 +44,7 @@ pixi search [OPTIONS] <PACKAGE>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -83,7 +83,7 @@ pixi shell-hook [OPTIONS]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/shell.md
+++ b/docs/reference/cli/pixi/shell.md
@@ -78,7 +78,7 @@ pixi shell [OPTIONS]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/task.md
+++ b/docs/reference/cli/pixi/task.md
@@ -33,7 +33,7 @@ pixi task [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/tree.md
+++ b/docs/reference/cli/pixi/tree.md
@@ -47,7 +47,7 @@ pixi tree [OPTIONS] [REGEX]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/update.md
+++ b/docs/reference/cli/pixi/update.md
@@ -74,7 +74,7 @@ pixi update [OPTIONS] [PACKAGES]...
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -81,7 +81,7 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace.md
+++ b/docs/reference/cli/pixi/workspace.md
@@ -30,7 +30,7 @@ pixi workspace [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/channel.md
+++ b/docs/reference/cli/pixi/workspace/channel.md
@@ -32,7 +32,7 @@ pixi workspace channel [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/description.md
+++ b/docs/reference/cli/pixi/workspace/description.md
@@ -31,7 +31,7 @@ pixi workspace description [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/environment.md
+++ b/docs/reference/cli/pixi/workspace/environment.md
@@ -32,7 +32,7 @@ pixi workspace environment [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/export/conda-environment.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-environment.md
@@ -40,7 +40,7 @@ pixi workspace export conda-environment [OPTIONS] [OUTPUT_PATH]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
@@ -84,7 +84,7 @@ pixi workspace export conda-explicit-spec [OPTIONS] <OUTPUT_DIR>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/feature.md
+++ b/docs/reference/cli/pixi/workspace/feature.md
@@ -31,7 +31,7 @@ pixi workspace feature [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/name.md
+++ b/docs/reference/cli/pixi/workspace/name.md
@@ -31,7 +31,7 @@ pixi workspace name [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/platform.md
+++ b/docs/reference/cli/pixi/workspace/platform.md
@@ -34,7 +34,7 @@ pixi workspace platform [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/register.md
+++ b/docs/reference/cli/pixi/workspace/register.md
@@ -40,7 +40,7 @@ pixi workspace register [OPTIONS] [COMMAND]
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/requires-pixi.md
+++ b/docs/reference/cli/pixi/workspace/requires-pixi.md
@@ -33,7 +33,7 @@ pixi workspace requires-pixi [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/docs/reference/cli/pixi/workspace/version.md
+++ b/docs/reference/cli/pixi/workspace/version.md
@@ -34,7 +34,7 @@ pixi workspace version [OPTIONS] <COMMAND>
 
 ## Global Options
 - <a id="arg---manifest-path" href="#arg---manifest-path">`--manifest-path (-m) <MANIFEST_PATH>`</a>
-:  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
+:  The path to a manifest file or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 

--- a/tests/integration_python/test_manifest_path.py
+++ b/tests/integration_python/test_manifest_path.py
@@ -33,6 +33,21 @@ def test_explicit_manifest_correct_location(pixi: Path, tmp_path: Path) -> None:
     assert actual == expected
 
 
+def test_manifest_path_rejects_non_toml_file(pixi: Path, tmp_path: Path) -> None:
+    manifest = tmp_path / "foo.bar"
+    manifest.write_text("bar")
+
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        expected_exit_code=ExitCode.FAILURE,
+        stderr_contains=(
+            "Expected a .toml file or a directory containing pixi.toml, "
+            "pyproject.toml, or mojoproject.toml."
+        ),
+        strip_ansi=True,
+    )
+
+
 def test_ignore_env_vars_when_manifest_path_differs(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """When running a nested pixi command with --manifest-path pointing to a different
     project, the inherited PIXI_ENVIRONMENT_NAME should be ignored because it refers


### PR DESCRIPTION
Resolves https://github.com/prefix-dev/pixi/issues/5967

This diff allows `--manifest-path` to point at a Pixi manifest with any `.toml` filename, instead of only
accepting `pixi.toml` and `pyproject.toml`. Custom TOML manifests are treated as Pixi manifests when explicitly provided, and their lockfiles now use the same stem as the manifest, so `custom-pixi.toml` writes to `custom-pixi.lock` rather than `pixi.lock`.

The reference docs were updated to describe `--manifest-path` as accepting a manifest file or workspace directory. I also added a few tests that cover custom manifest provenance, explicit discovery, custom lockfile path derivation, and the end-to-end pixi lock `--manifest-path custom-pixi.toml` behavior.
