### PR TITLE
fix: limit concurrent global update

### DIFF
--- a/crates/pixi_command_dispatcher/src/command_dispatcher/builder.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/builder.rs
@@ -7,6 +7,7 @@ use crate::cache::{
 };
 use crate::compute_data::{
     AllowExecuteLinkScripts, AllowLinkOptions, BackendSourceBuildSemaphore, CondaSolveSemaphore,
+    IoConcurrencySemaphore,
 };
 use crate::environment::WorkspaceEnvRegistry;
 use crate::injected_config::{
@@ -405,6 +406,9 @@ impl CommandDispatcherBuilder {
         let backend_source_build_semaphore = limits
             .max_concurrent_builds
             .map(|n| Arc::new(Semaphore::new(n)));
+        let io_concurrency_semaphore = limits
+            .max_io_concurrency
+            .map(|n| Arc::new(Semaphore::new(n)));
 
         let channel_config = self.channel_config.unwrap_or_else(|| {
             let path: &std::path::Path = root_dir.as_ref();
@@ -434,6 +438,7 @@ impl CommandDispatcherBuilder {
             url_checkout_semaphore,
             conda_solve_semaphore,
             backend_source_build_semaphore,
+            io_concurrency_semaphore,
             workspace_env_registry,
         });
 
@@ -509,6 +514,9 @@ impl CommandDispatcherBuilder {
         }
         if let Some(sem) = data.backend_source_build_semaphore.clone() {
             engine_builder = engine_builder.with_data(BackendSourceBuildSemaphore(sem));
+        }
+        if let Some(sem) = data.io_concurrency_semaphore.clone() {
+            engine_builder = engine_builder.with_data(IoConcurrencySemaphore(sem));
         }
         let engine = engine_builder.build();
 

--- a/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/mod.rs
@@ -157,6 +157,12 @@ pub(crate) struct CommandDispatcherData {
     /// through the compute engine. `None` means unbounded.
     pub backend_source_build_semaphore: Option<Arc<Semaphore>>,
 
+    /// Semaphore that bounds concurrent filesystem operations while linking
+    /// packages into prefixes. Shared across all installs so concurrent
+    /// environment installs cannot exhaust the file descriptor limit. `None`
+    /// means unbounded.
+    pub io_concurrency_semaphore: Option<Arc<Semaphore>>,
+
     /// Registry of workspace environment specs reachable by id. Callers
     /// allocate refs via [`CommandDispatcher::workspace_env_registry`]
     /// and pass them into Keys that carry an

--- a/crates/pixi_command_dispatcher/src/compute_data.rs
+++ b/crates/pixi_command_dispatcher/src/compute_data.rs
@@ -226,6 +226,26 @@ impl HasCondaSolveSemaphore for DataStore {
     }
 }
 
+/// Newtype around the semaphore that bounds concurrent filesystem
+/// operations during package installation. Enforces the
+/// `max_io_concurrency` limit from [`crate::Limits`]. A single semaphore is
+/// shared across all installs so installing many environments at once cannot
+/// exhaust the file descriptor limit.
+#[derive(Clone)]
+pub struct IoConcurrencySemaphore(pub Arc<Semaphore>);
+
+/// Access the semaphore bounding concurrent install filesystem operations.
+/// Returns `None` when no semaphore was registered, treated as unbounded.
+pub trait HasIoConcurrencySemaphore {
+    fn io_concurrency_semaphore(&self) -> Option<&Arc<Semaphore>>;
+}
+
+impl HasIoConcurrencySemaphore for DataStore {
+    fn io_concurrency_semaphore(&self) -> Option<&Arc<Semaphore>> {
+        self.try_get::<IoConcurrencySemaphore>().map(|s| &s.0)
+    }
+}
+
 /// Newtype around the semaphore that bounds concurrent backend source
 /// builds. Enforces the `max_concurrent_builds` limit from
 /// [`crate::Limits`].

--- a/crates/pixi_command_dispatcher/src/install_binary.rs
+++ b/crates/pixi_command_dispatcher/src/install_binary.rs
@@ -11,7 +11,9 @@ use pixi_compute_engine::DataStore;
 use rattler::install::{Installer, InstallerError};
 use rattler_conda_types::{Platform, RepoDataRecord, prefix::Prefix};
 
-use crate::compute_data::{HasAllowExecuteLinkScripts, HasAllowLinkOptions, HasPackageCache};
+use crate::compute_data::{
+    HasAllowExecuteLinkScripts, HasAllowLinkOptions, HasIoConcurrencySemaphore, HasPackageCache,
+};
 use crate::install_pixi::reporter::WrappingInstallReporter;
 use pixi_compute_network::HasDownloadClient;
 
@@ -40,6 +42,10 @@ pub async fn install_binary_records(
         .with_package_cache(data.package_cache().clone())
         .with_execute_link_scripts(data.allow_execute_link_scripts())
         .with_link_options(data.allow_link_options());
+
+    if let Some(io_semaphore) = data.io_concurrency_semaphore() {
+        installer = installer.with_io_concurrency_semaphore(io_semaphore.clone());
+    }
 
     if let Some(reporter) = reporter {
         installer = installer.with_reporter(WrappingInstallReporter(reporter));

--- a/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
@@ -15,7 +15,8 @@ use crate::CommandDispatcherError;
 use crate::CondaPackageFormat;
 use crate::cache::markers::{SourceBuildArtifactsDir, SourceBuildWorkspacesDir};
 use crate::compute_data::{
-    HasAllowExecuteLinkScripts, HasAllowLinkOptions, HasPackageCache, HasPixiInstallReporter,
+    HasAllowExecuteLinkScripts, HasAllowLinkOptions, HasIoConcurrencySemaphore, HasPackageCache,
+    HasPixiInstallReporter,
 };
 use crate::install_pixi::{
     InstallPixiEnvironmentError, InstallPixiEnvironmentResult, InstallPixiEnvironmentSpec,
@@ -241,6 +242,9 @@ async fn install_inner(
         .with_ignored_packages(spec.ignore_packages.take().unwrap_or_default())
         .with_execute_link_scripts(data.allow_execute_link_scripts())
         .with_link_options(data.allow_link_options());
+    if let Some(io_semaphore) = data.io_concurrency_semaphore() {
+        installer = installer.with_io_concurrency_semaphore(io_semaphore.clone());
+    }
     if let Some(installed) = spec.installed.take() {
         installer = installer.with_installed_packages(installed);
     }

--- a/crates/pixi_command_dispatcher/src/util/limits.rs
+++ b/crates/pixi_command_dispatcher/src/util/limits.rs
@@ -23,6 +23,13 @@ pub struct Limits {
     /// The maximum number of concurrent URL archive fetches. Same
     /// rationale as `max_concurrent_git_checkouts`.
     pub max_concurrent_url_checkouts: Limit,
+
+    /// The maximum number of concurrent filesystem operations performed while
+    /// linking packages into prefixes. This bounds the file descriptors held
+    /// during installation: the rattler installer opens many files at once,
+    /// and installing several environments concurrently multiplies that, so a
+    /// shared limit keeps the total from exhausting the file descriptor limit.
+    pub max_io_concurrency: Limit,
 }
 
 /// Defines the type of limit to apply.
@@ -58,6 +65,9 @@ pub(crate) struct ResolvedLimits {
 
     /// The maximum number of concurrent URL archive fetches.
     pub max_concurrent_url_checkouts: Option<usize>,
+
+    /// The maximum number of concurrent filesystem operations during install.
+    pub max_io_concurrency: Option<usize>,
 }
 
 impl From<Limits> for ResolvedLimits {
@@ -93,11 +103,22 @@ impl From<Limits> for ResolvedLimits {
             Limit::Default => Some(8),
         };
 
+        // Default to 100 concurrent filesystem operations: this matches the
+        // rattler installer's own default, but as a single semaphore shared
+        // across all concurrent installs it no longer multiplies with the
+        // number of environments being installed at once.
+        let max_io_concurrency = match value.max_io_concurrency {
+            Limit::None => None,
+            Limit::Max(max) => Some(max.get()),
+            Limit::Default => Some(100),
+        };
+
         Self {
             max_concurrent_solves,
             max_concurrent_builds,
             max_concurrent_git_checkouts,
             max_concurrent_url_checkouts,
+            max_io_concurrency,
         }
     }
 }


### PR DESCRIPTION
### Description

Especially on macOS file descriptors are a rare resource.
Limiting the concurrent updates should help

Fixes #6246

### How Has This Been Tested?

It's difficult to reproduce on Linux so just check if the user reopens the issue

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
