### PR TITLE
fix: global share command dispatcher

### DIFF
--- a/crates/pixi_cli/src/global/add.rs
+++ b/crates/pixi_cli/src/global/add.rs
@@ -66,6 +66,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
         // Sync environment
         let sync_changes = project.sync_environment(env_name, None).await?;
+        project.clear_progress();
 
         // Figure out added packages and their corresponding versions from EnvironmentUpdate
         let requested_package_names: Vec<_> =

--- a/crates/pixi_cli/src/global/expose.rs
+++ b/crates/pixi_cli/src/global/expose.rs
@@ -85,6 +85,7 @@ pub async fn add(args: AddArgs) -> miette::Result<()> {
             project.manifest.add_exposed_mapping(env_name, mapping)?;
         }
         state_changes |= project.sync_environment(env_name, None).await?;
+        project.clear_progress();
         project.manifest.save().await?;
         Ok(state_changes)
     }
@@ -124,6 +125,7 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
             .manifest
             .remove_exposed_name(env_name, exposed_name)?;
         state_changes |= project.sync_environment(env_name, None).await?;
+        project.clear_progress();
         project.manifest.save().await?;
         Ok(state_changes)
     }

--- a/crates/pixi_cli/src/global/install.rs
+++ b/crates/pixi_cli/src/global/install.rs
@@ -240,6 +240,7 @@ async fn setup_environment(
     let environment_update = project
         .install_environment_with_options(env_name, args.force_reinstall)
         .await?;
+    project.clear_progress();
 
     // Sync exposed name
     sync_exposed_names(env_name, project, args).await?;

--- a/crates/pixi_cli/src/global/remove.rs
+++ b/crates/pixi_cli/src/global/remove.rs
@@ -97,6 +97,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let state_changes = project
             .sync_environment(env_name, Some(removed_dependencies))
             .await?;
+        project.clear_progress();
 
         project.manifest.save().await?;
         Ok(state_changes)

--- a/crates/pixi_cli/src/global/shortcut.rs
+++ b/crates/pixi_cli/src/global/shortcut.rs
@@ -70,6 +70,7 @@ pub async fn add(args: AddArgs) -> miette::Result<()> {
             project.manifest.add_shortcut(env_name, name)?;
         }
         state_changes |= project.sync_environment(env_name, None).await?;
+        project.clear_progress();
         Ok(state_changes)
     }
 
@@ -119,6 +120,7 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
         }
 
         state_changes |= project.sync_environment(env_name, None).await?;
+        project.clear_progress();
         project.manifest.save().await?;
         Ok(state_changes)
     }

--- a/crates/pixi_cli/src/global/sync.rs
+++ b/crates/pixi_cli/src/global/sync.rs
@@ -39,8 +39,31 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     let mut errors = Vec::new();
-    for env_name in project.environments().keys() {
-        match project.sync_environment(env_name, None).await {
+
+    // Phase 1: install all environments in parallel, sharing one dispatcher.
+    let env_names: Vec<_> = project.environments().keys().cloned().collect();
+    let install_results = futures::future::join_all(
+        env_names
+            .iter()
+            .map(|env_name| project.sync_environment_install(env_name, None)),
+    )
+    .await;
+    project.clear_progress();
+
+    // Phase 2: expose executables, shortcuts and completions sequentially, since
+    // they write into directories shared across all environments.
+    for (env_name, install_result) in env_names.iter().zip(install_results) {
+        let result = match install_result {
+            Ok(mut state_changes) => match project.sync_environment_expose(env_name).await {
+                Ok(expose_changes) => {
+                    state_changes |= expose_changes;
+                    Ok(state_changes)
+                }
+                Err(err) => Err(err),
+            },
+            Err(err) => Err(err),
+        };
+        match result {
             Ok(state_change) => {
                 if state_change.has_changed() {
                     has_changed = true;

--- a/crates/pixi_cli/src/global/update.rs
+++ b/crates/pixi_cli/src/global/update.rs
@@ -118,40 +118,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
     };
 
-    // Run install directly for a single environment.
-    if env_names.len() == 1 {
-        let env_name = &env_names[0];
-        let mut project = project_original;
-        let result = install_and_determine_expose_type(&project, env_name).await;
-        match result {
-            Ok(env_result) => {
-                let env_name = env_result.env_name.clone();
-                match apply_manifest_changes(&mut project, env_result).await {
-                    Ok(state_changes) => state_changes.report(),
-                    Err(err) => {
-                        revert_environment_after_error(&env_name, &project).await?;
-                        return Err(err);
-                    }
-                }
-            }
-            Err(err) => {
-                let _ = project.manifest.save().await;
-                return Err(err);
-            }
-        }
-        project.manifest.save().await?;
-        return Ok(());
-    }
-
-    // Install in parallel with for multiple environments.
-    let install_results: Vec<miette::Result<EnvInstallResult>> =
-        futures::future::join_all(env_names.iter().map(|env_name| {
-            let project = project_original.clone().with_fresh_progress();
-            async move { install_and_determine_expose_type(&project, env_name).await }
-        }))
-        .await;
+    // Install all environments in parallel, sharing one dispatcher.
+    let install_results: Vec<miette::Result<EnvInstallResult>> = futures::future::join_all(
+        env_names
+            .iter()
+            .map(|env_name| install_and_determine_expose_type(&project_original, env_name)),
+    )
+    .await;
 
     let mut project = project_original;
+    project.clear_progress();
     for result in install_results {
         match result {
             Ok(env_result) => {

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -505,11 +505,14 @@ impl Project {
         self
     }
 
-    /// Reset the command dispatcher and progress reporter.
-    pub fn with_fresh_progress(mut self) -> Self {
-        self.command_dispatcher = OnceCell::new();
-        self.top_level_progress = OnceCell::new();
-        self
+    /// Clear any active progress bars without tearing down the reporter.
+    ///
+    /// Installing draws into a shared progress reporter; callers invoke this
+    /// once they are done installing so the bars don't linger.
+    pub fn clear_progress(&self) {
+        if let Some(progress) = self.top_level_progress.get() {
+            progress.on_clear();
+        }
     }
 
     /// Returns the environments in this project.
@@ -696,8 +699,6 @@ impl Project {
                 variant_files: None,
             })
             .await?;
-
-        self.top_level_progress().on_clear();
 
         let install_changes = get_install_changes(result.transaction);
         Ok(EnvironmentUpdate::new(install_changes, dependencies_names))
@@ -1123,6 +1124,24 @@ impl Project {
         env_name: &EnvironmentName,
         removed_packages: Option<Vec<PackageName>>,
     ) -> miette::Result<StateChanges> {
+        let mut state_changes = self
+            .sync_environment_install(env_name, removed_packages)
+            .await?;
+        state_changes |= self.sync_environment_expose(env_name).await?;
+        Ok(state_changes)
+    }
+
+    /// Install phase of [`Self::sync_environment`]: bring the environment's
+    /// installation in line with the manifest.
+    ///
+    /// Safe to run concurrently for multiple environments: it only touches the
+    /// environment's own prefix and the shared, concurrency-safe command
+    /// dispatcher.
+    pub async fn sync_environment_install(
+        &self,
+        env_name: &EnvironmentName,
+        removed_packages: Option<Vec<PackageName>>,
+    ) -> miette::Result<StateChanges> {
         let mut state_changes = StateChanges::new_with_env(env_name.clone());
         if self.environment_in_sync(env_name).await? {
             tracing::debug!(
@@ -1145,6 +1164,19 @@ impl Project {
                 StateChange::UpdatedEnvironment(environment_update),
             );
         }
+        Ok(state_changes)
+    }
+
+    /// Expose phase of [`Self::sync_environment`]: link executables, shortcuts
+    /// and completions for the environment.
+    ///
+    /// Must run sequentially across environments: these write into directories
+    /// shared by all environments (the binary, shortcut and completion dirs).
+    pub async fn sync_environment_expose(
+        &self,
+        env_name: &EnvironmentName,
+    ) -> miette::Result<StateChanges> {
+        let mut state_changes = StateChanges::new_with_env(env_name.clone());
 
         // Expose executables
         state_changes |= self.expose_executables_from_environment(env_name).await?;


### PR DESCRIPTION
### Description

@baszalmstra pointed out that parallel pixi global operations should share one command dispatcher.

- use only one command dispatcher
- no broken progress bars anymore
- also parallelize pixi global sync

### How Has This Been Tested?

Ran locally

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
