### PR TITLE
docs: link to parselmouth mapping browser in conda/PyPI page

### DIFF
--- a/docs/concepts/conda_pypi.md
+++ b/docs/concepts/conda_pypi.md
@@ -57,6 +57,10 @@ Pixi first runs the conda (`rattler`) solver, which will resolve the conda depen
 Then it maps the conda packages to PyPI packages, using [`parselmouth`](https://github.com/prefix-dev/parselmouth).
 Then it runs the PyPI (`uv`) solver, which will resolve the remaining PyPI dependencies.
 
+!!! tip "Explore the mapping"
+    You can browse the conda-to-PyPI name mapping that `parselmouth` provides using the
+    [parselmouth mapping browser](https://prefix-dev.github.io/parselmouth/).
+
 The consequence is that Pixi will install the conda package (and not the PyPI package) if both are available and specified as dependencies.
 
 Here is an example of how this works in practice:


### PR DESCRIPTION
Add a tip linking to the parselmouth mapping browser at https://prefix-dev.github.io/parselmouth/ so users can explore the conda-to-PyPI name mapping.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude web

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->