### PR TITLE
fix(pixi-build-python): reinstall to avoid duplicate dist-info

### DIFF
--- a/crates/pixi_build_python/src/build_script.j2
+++ b/crates/pixi_build_python/src/build_script.j2
@@ -2,7 +2,8 @@
 {%- set OPTIONS = [
     "-vv",
     "--no-deps",
-    "--no-build-isolation"
+    "--no-build-isolation",
+    "--no-index"
 ] + extra_args + (["--editable"] if editable else [])
 -%}
 
@@ -13,11 +14,11 @@
 {% endif -%}
 
 {% if installer == "uv" -%}
-uv pip install --python "{{ PYTHON }}" {{ OPTIONS }} "{{ manifest_root }}"
+uv pip install --python "{{ PYTHON }}" --reinstall {{ OPTIONS }} "{{ manifest_root }}"
 {% elif build_platform == "windows" -%}
-"{{ PYTHON }}" -m pip install --ignore-installed {{ OPTIONS }} "{{ manifest_root }}"
+"{{ PYTHON }}" -m pip install --force-reinstall {{ OPTIONS }} "{{ manifest_root }}"
 {% else %}
-"{{ PYTHON }}" -m pip install --ignore-installed {{ OPTIONS }} "{{ manifest_root }}"
+"{{ PYTHON }}" -m pip install --force-reinstall {{ OPTIONS }} "{{ manifest_root }}"
 {% endif -%}
 
 {% if build_platform == "windows" -%}


### PR DESCRIPTION
### Description

When building a Python package with the `pixi-build-python` backend, the build prefix is reused across builds. Installing the freshly built package on top of a previous one could leave stale `*.dist-info` metadata behind, which then got packaged twice, producing duplicate dist-info directories (most visible with dynamic versioning, where the version changes between builds).

This makes the install reinstall the package cleanly so the previous version is removed first, for both regular and editable installs. It also makes the install hermetic, so dependencies always come from the build environment rather than being fetched over the network.

Fixes #6036

### How Has This Been Tested?

Built a package that uses dynamic versioning twice in the same reused prefix and confirmed only a single, current dist-info ends up in the resulting package.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas