### PR TITLE
fix: support conda extras for satisfiabily and solve groups

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -2710,3 +2710,179 @@ host-lib = "*"
     version: 0.4.2
     "###);
 }
+
+/// A binary package that declares two extra groups (`foo` and `bar`) must be
+/// solvable from two environments that each select a different extra, even when
+/// those environments share a solve group.
+///
+/// `my-package` advertises `experimental_extra_depends = { foo: [dep-foo],
+/// bar: [dep-bar] }` in its repodata. Environment `env-foo` depends on
+/// `my-package[foo]` and `env-bar` on `my-package[bar]`. Sharing a solve group
+/// keeps the resolved versions consistent across both environments, but
+/// per-environment extraction must still pull in only the dependencies of the
+/// extra each environment actually selected: `env-foo` gets `dep-foo` and not
+/// `dep-bar`, and vice versa.
+#[tokio::test]
+async fn test_package_extras_select_per_environment_in_solve_group() {
+    setup_tracing();
+
+    // `dep-foo` and `dep-bar` are the packages pulled in by the `foo` and `bar`
+    // extras respectively. `my-package` advertises both extra groups through
+    // its `experimental_extra_depends` repodata field. All three live in the
+    // same local channel so the solver can resolve them once an extra selects
+    // them.
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("dep-foo", "1.0.0").finish());
+    package_database.add_package(Package::build("dep-bar", "1.0.0").finish());
+
+    let mut my_package = Package::build("my-package", "1.0.0").finish();
+    my_package.package_record.experimental_extra_depends = std::collections::BTreeMap::from([
+        ("foo".to_string(), vec!["dep-foo".to_string()]),
+        ("bar".to_string(), vec!["dep-bar".to_string()]),
+    ]);
+    package_database.add_package(my_package);
+
+    let channel = package_database.into_channel().await.unwrap();
+
+    let pixi = PixiControl::new().unwrap();
+
+    // Two environments, both depending on `my-package` but selecting a
+    // different extra, sharing the `shared` solve group.
+    let manifest_content = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+
+[feature.foo.dependencies]
+my-package = {{ version = "*", extras = ["foo"] }}
+
+[feature.bar.dependencies]
+my-package = {{ version = "*", extras = ["bar"] }}
+
+[environments]
+env-foo = {{ features = ["foo"], solve-group = "shared" }}
+env-bar = {{ features = ["bar"], solve-group = "shared" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest_content).unwrap();
+
+    let lock_file = pixi
+        .update_lock_file()
+        .await
+        .expect("lock file generation should succeed for a package with extras");
+
+    let platform = Platform::current();
+
+    // Both environments must be present in the lock file.
+    assert!(
+        lock_file.environment("env-foo").is_some(),
+        "lock file should contain the env-foo environment"
+    );
+    assert!(
+        lock_file.environment("env-bar").is_some(),
+        "lock file should contain the env-bar environment"
+    );
+
+    // Both environments contain the source package itself.
+    assert!(
+        lock_file.contains_conda_package("env-foo", platform, "my-package"),
+        "env-foo should contain my-package"
+    );
+    assert!(
+        lock_file.contains_conda_package("env-bar", platform, "my-package"),
+        "env-bar should contain my-package"
+    );
+
+    // env-foo selected the `foo` extra: it must contain `dep-foo` only.
+    assert!(
+        lock_file.contains_conda_package("env-foo", platform, "dep-foo"),
+        "env-foo selected extra foo and must contain dep-foo"
+    );
+    assert!(
+        !lock_file.contains_conda_package("env-foo", platform, "dep-bar"),
+        "env-foo did not select extra bar and must not contain dep-bar"
+    );
+
+    // env-bar selected the `bar` extra: it must contain `dep-bar` only.
+    assert!(
+        lock_file.contains_conda_package("env-bar", platform, "dep-bar"),
+        "env-bar selected extra bar and must contain dep-bar"
+    );
+    assert!(
+        !lock_file.contains_conda_package("env-bar", platform, "dep-foo"),
+        "env-bar did not select extra foo and must not contain dep-foo"
+    );
+}
+
+/// A lock file for two solve-group environments that each select a different
+/// extra of the same package must satisfy its manifest.
+///
+/// This exercises the satisfiability check (rather than just the solve): the
+/// reachability walk has to follow each package's `experimental_extra_depends`
+/// for the extra its environment selected. If it does not, `dep-foo` / `dep-bar`
+/// are flagged as unused locked packages and the lock is wrongly considered
+/// out-of-date, re-solving on every invocation. The second
+/// `update_lock_file` therefore must report the lock as already up-to-date.
+#[tokio::test]
+async fn test_package_extras_lock_file_is_satisfiable() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("dep-foo", "1.0.0").finish());
+    package_database.add_package(Package::build("dep-bar", "1.0.0").finish());
+
+    let mut my_package = Package::build("my-package", "1.0.0").finish();
+    my_package.package_record.experimental_extra_depends = std::collections::BTreeMap::from([
+        ("foo".to_string(), vec!["dep-foo".to_string()]),
+        ("bar".to_string(), vec!["dep-bar".to_string()]),
+    ]);
+    package_database.add_package(my_package);
+
+    let channel = package_database.into_channel().await.unwrap();
+
+    let pixi = PixiControl::new().unwrap();
+
+    let manifest_content = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+
+[feature.foo.dependencies]
+my-package = {{ version = "*", extras = ["foo"] }}
+
+[feature.bar.dependencies]
+my-package = {{ version = "*", extras = ["bar"] }}
+
+[environments]
+env-foo = {{ features = ["foo"], solve-group = "shared" }}
+env-bar = {{ features = ["bar"], solve-group = "shared" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest_content).unwrap();
+
+    // First invocation: generate the lock file.
+    let workspace = pixi.workspace().unwrap();
+    let (_, was_updated) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("first lock file generation should succeed");
+    assert!(was_updated, "first invocation should create the lock file");
+
+    // Second invocation: the existing lock must be found satisfiable so the
+    // lock file is not rewritten.
+    let workspace = pixi.workspace().unwrap();
+    let (_, was_updated_second) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("second lock file check should succeed");
+    assert!(
+        !was_updated_second,
+        "a lock file selecting package extras must satisfy its manifest and not be re-solved"
+    );
+}

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -691,6 +691,8 @@ async fn verify_package_platform_satisfiability(
 
     // Keep a list of all conda packages that we have already visited
     let mut conda_packages_visited = HashSet::new();
+    // Extras already followed per package, so each is expanded once.
+    let mut conda_extras_followed: HashMap<CondaPackageIdx, HashSet<String>> = HashMap::new();
     let mut pypi_packages_visited = HashSet::new();
     let mut pypi_requirements_visited = pypi_requirements
         .iter()
@@ -717,11 +719,18 @@ async fn verify_package_platform_satisfiability(
         // Determine the package that matches the requirement of matchspec.
         let found_package = match package {
             Dependency::Input(name, spec, source) => {
-                let found_package = match spec.into_source_or_binary() {
+                let (found_package, extras) = match spec.into_source_or_binary() {
                     Either::Left(source_spec) => {
                         expected_conda_source_dependencies.insert(name.clone());
-                        find_matching_source_package(locked_pixi_records, name, source_spec, source)
-                            .map_err(CommandDispatcherError::Failed)?
+                        let extras = source_spec.extras.clone().unwrap_or_default();
+                        let found_package = find_matching_source_package(
+                            locked_pixi_records,
+                            name,
+                            source_spec,
+                            source,
+                        )
+                        .map_err(CommandDispatcherError::Failed)?;
+                        (found_package, extras)
                     }
                     Either::Right(binary_spec) => {
                         let spec = binary_spec
@@ -732,6 +741,7 @@ async fn verify_package_platform_satisfiability(
                                     spec_conversion_to_match_spec_error(e),
                                 ))
                             })?;
+                        let extras = spec.extras.clone().unwrap_or_default();
                         match find_matching_package(
                             locked_pixi_records,
                             &virtual_packages,
@@ -740,7 +750,7 @@ async fn verify_package_platform_satisfiability(
                         )
                         .map_err(CommandDispatcherError::Failed)?
                         {
-                            Some(pkg) => pkg,
+                            Some(pkg) => (pkg, extras),
                             None => continue,
                         }
                     }
@@ -748,25 +758,28 @@ async fn verify_package_platform_satisfiability(
 
                 expected_conda_packages
                     .insert(locked_pixi_records.records[found_package.0].name().clone());
-                FoundPackage::Conda(found_package)
+                FoundPackage::Conda(found_package, extras)
             }
             Dependency::Conda(spec, source) => {
+                let extras = spec.extras.clone().unwrap_or_default();
                 match find_matching_package(locked_pixi_records, &virtual_packages, spec, source)
                     .map_err(CommandDispatcherError::Failed)?
                 {
                     Some(pkg) => {
                         expected_conda_packages
                             .insert(locked_pixi_records.records[pkg.0].name().clone());
-                        FoundPackage::Conda(pkg)
+                        FoundPackage::Conda(pkg, extras)
                     }
                     None => continue,
                 }
             }
             Dependency::CondaSource(name, source_spec, source) => {
                 expected_conda_source_dependencies.insert(name.clone());
+                let extras = source_spec.extras.clone().unwrap_or_default();
                 FoundPackage::Conda(
                     find_matching_source_package(locked_pixi_records, name, source_spec, source)
                         .map_err(CommandDispatcherError::Failed)?,
+                    extras,
                 )
             }
             Dependency::PyPi(requirement, source, origin) => {
@@ -820,7 +833,7 @@ async fn verify_package_platform_satisfiability(
                     let pkg_idx = CondaPackageIdx(*repodata_idx);
                     conda_packages_used_by_pypi
                         .insert(locked_pixi_records.records[pkg_idx.0].name().clone());
-                    FoundPackage::Conda(pkg_idx)
+                    FoundPackage::Conda(pkg_idx, Vec::new())
                 } else {
                     match to_normalize(&requirement.name)
                         .map(|name| locked_pypi_records.index_by_name(&name))
@@ -880,15 +893,32 @@ async fn verify_package_platform_satisfiability(
 
         // Add all the requirements of the package to the queue.
         match found_package {
-            FoundPackage::Conda(idx) => {
-                if !conda_packages_visited.insert(idx) {
-                    // We already visited this package, so we can skip adding its dependencies to
-                    // the queue
-                    continue;
-                }
+            FoundPackage::Conda(idx, extras) => {
+                let newly_visited = conda_packages_visited.insert(idx);
 
                 let record = &locked_pixi_records.records[idx.0];
-                for depends in &record.package_record().depends {
+
+                // Regular deps on first visit, plus deps of any newly requested
+                // extra (else extra-only packages look unused).
+                let mut depends_to_walk: Vec<&String> = Vec::new();
+                if newly_visited {
+                    depends_to_walk.extend(record.package_record().depends.iter());
+                }
+                {
+                    let followed = conda_extras_followed.entry(idx).or_default();
+                    for extra in &extras {
+                        if followed.insert(extra.clone())
+                            && let Some(extra_depends) = record
+                                .package_record()
+                                .experimental_extra_depends
+                                .get(extra)
+                        {
+                            depends_to_walk.extend(extra_depends.iter());
+                        }
+                    }
+                }
+
+                for depends in depends_to_walk {
                     let spec = MatchSpec::from_str(
                         depends.as_str(),
                         ParseMatchSpecOptions::lenient()
@@ -1132,7 +1162,8 @@ async fn verify_package_platform_satisfiability(
 }
 
 enum FoundPackage {
-    Conda(CondaPackageIdx),
+    // Requested extra groups for this conda package.
+    Conda(CondaPackageIdx, Vec<String>),
     PyPi(PypiPackageIdx, Vec<uv_normalize::ExtraName>),
 }
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -2795,22 +2795,31 @@ async fn spawn_extract_environment_task(
 
     #[derive(Clone, Eq, PartialEq, Hash)]
     enum PackageName {
-        Conda(rattler_conda_types::PackageName),
+        // `Some(extra)` follows that extra group's `experimental_extra_depends`.
+        Conda((rattler_conda_types::PackageName, Option<String>)),
         Pypi((uv_normalize::PackageName, Option<ExtraName>)),
     }
 
     enum PackageRecord<'a> {
-        Conda(&'a PixiRecord),
+        Conda((&'a PixiRecord, Option<String>)),
         Pypi((&'a LockedPypiRecord, Option<ExtraName>)),
     }
 
-    // Determine the conda packages we need.
-    let mut conda_package_names: Vec<_> = environment
-        .combined_dependencies(Some(platform))
-        .names()
-        .cloned()
-        .map(PackageName::Conda)
-        .collect();
+    // Queue each conda dep, plus an entry per requested extra so the walk
+    // follows that extra's `experimental_extra_depends`.
+    let combined_conda_dependencies = environment.combined_dependencies(Some(platform));
+    let mut conda_package_names: Vec<PackageName> = Vec::new();
+    for (name, spec) in combined_conda_dependencies.iter_specs() {
+        conda_package_names.push(PackageName::Conda((name.clone(), None)));
+        if let Some(extras) = spec
+            .as_detailed()
+            .and_then(|detailed| detailed.extras.as_ref())
+        {
+            for extra in extras {
+                conda_package_names.push(PackageName::Conda((name.clone(), Some(extra.clone()))));
+            }
+        }
+    }
 
     // Also include packages from dev dependencies.
     // Dev dependencies are source packages that bring in their own dependencies.
@@ -2885,7 +2894,7 @@ async fn spawn_extract_environment_task(
         // Add the resolved dev dependency package names to the queue
         for dep in resolved_dev_deps {
             if let Some(name) = dep.conda_package_name() {
-                conda_package_names.push(PackageName::Conda(name));
+                conda_package_names.push(PackageName::Conda((name, None)));
             }
         }
     }
@@ -2922,19 +2931,40 @@ async fn spawn_extract_environment_task(
     let mut queue = itertools::chain(conda_package_names, pypi_package_names).collect::<Vec<_>>();
     let mut queued_names = queue.iter().cloned().collect::<HashSet<_>>();
 
+    // Queue entries a dependency implies: the package, plus one per requested
+    // extra (so extra-only packages aren't pruned).
+    let conda_dependency_entries = |dependency: &str| -> Vec<PackageName> {
+        let base_name = rattler_conda_types::PackageName::from_matchspec_str_unchecked(dependency);
+        let mut entries = vec![PackageName::Conda((base_name, None))];
+        if dependency.contains('[')
+            && let Ok(spec) = rattler_conda_types::MatchSpec::from_str(
+                dependency,
+                rattler_conda_types::ParseMatchSpecOptions::lenient()
+                    .with_repodata_revision(rattler_conda_types::RepodataRevision::V3),
+            )
+            && let rattler_conda_types::PackageNameMatcher::Exact(name) = spec.name
+        {
+            for extra in spec.extras.into_iter().flatten() {
+                entries.push(PackageName::Conda((name.clone(), Some(extra))));
+            }
+        }
+        entries
+    };
+
     let mut pixi_records = Vec::new();
+    let mut seen_conda_records = HashSet::new();
     let mut pypi_records = HashMap::new();
     while let Some(package) = queue.pop() {
         let record = match package {
-            PackageName::Conda(name) => grouped_repodata_records
+            PackageName::Conda((name, extra)) => grouped_repodata_records
                 .by_name(&name)
-                .map(PackageRecord::Conda),
+                .map(|record| PackageRecord::Conda((record, extra))),
             PackageName::Pypi((name, extra)) => {
                 let pep_name = to_normalize(&name).into_diagnostic()?;
                 if let Some(found_record) = grouped_pypi_records.by_name(&pep_name) {
                     Some(PackageRecord::Pypi((found_record, extra)))
                 } else if let Some((_, _, found_record)) = conda_package_identifiers.get(&name) {
-                    Some(PackageRecord::Conda(found_record))
+                    Some(PackageRecord::Conda((found_record, None)))
                 } else {
                     None
                 }
@@ -2948,20 +2978,36 @@ async fn spawn_extract_environment_task(
         };
 
         match record {
-            PackageRecord::Conda(record) => {
-                // Find all dependencies in the record and add them to the queue.
+            PackageRecord::Conda((record, extra)) => {
+                // Regular dependencies.
                 for dependency in record.package_record().depends.iter() {
-                    let dependency_name =
-                        PackageName::Conda(rattler_conda_types::PackageName::new_unchecked(
-                            dependency.split_once(' ').unwrap_or((dependency, "")).0,
-                        ));
-                    if queued_names.insert(dependency_name.clone()) {
-                        queue.push(dependency_name);
+                    for entry in conda_dependency_entries(dependency) {
+                        if queued_names.insert(entry.clone()) {
+                            queue.push(entry);
+                        }
                     }
                 }
 
-                // Store the record itself as part of the subset
-                pixi_records.push(record);
+                // Dependencies contributed by the requested extra.
+                if let Some(extra) = &extra
+                    && let Some(extra_dependencies) = record
+                        .package_record()
+                        .experimental_extra_depends
+                        .get(extra)
+                {
+                    for dependency in extra_dependencies {
+                        for entry in conda_dependency_entries(dependency) {
+                            if queued_names.insert(entry.clone()) {
+                                queue.push(entry);
+                            }
+                        }
+                    }
+                }
+
+                // Store the record once.
+                if seen_conda_records.insert(record.package_record().name.clone()) {
+                    pixi_records.push(record);
+                }
             }
             PackageRecord::Pypi((record, extra)) => {
                 // Evaluate all dependencies

--- a/tests/data/satisfiability/conda-extras/pixi.lock
+++ b/tests/data/satisfiability/conda-extras/pixi.lock
@@ -1,0 +1,37 @@
+version: 7
+platforms:
+- name: linux-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/extras-test/
+    packages: {}
+  env-bar:
+    channels:
+    - url: https://conda.anaconda.org/extras-test/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/extras-test/noarch/dep-bar-1.0.0-0.conda
+      - conda: https://conda.anaconda.org/extras-test/noarch/my-package-1.0.0-0.conda
+  env-foo:
+    channels:
+    - url: https://conda.anaconda.org/extras-test/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/extras-test/noarch/dep-foo-1.0.0-0.conda
+      - conda: https://conda.anaconda.org/extras-test/noarch/my-package-1.0.0-0.conda
+packages:
+- conda: https://conda.anaconda.org/extras-test/noarch/dep-bar-1.0.0-0.conda
+  sha256: cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe
+  md5: cafebabecafebabecafebabecafebabe
+- conda: https://conda.anaconda.org/extras-test/noarch/dep-foo-1.0.0-0.conda
+  sha256: feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface
+  md5: feedfacefeedfacefeedfacefeedface
+- conda: https://conda.anaconda.org/extras-test/noarch/my-package-1.0.0-0.conda
+  sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+  md5: deadbeefdeadbeefdeadbeefdeadbeef
+  extra_depends:
+    bar:
+    - dep-bar
+    foo:
+    - dep-foo

--- a/tests/data/satisfiability/conda-extras/pixi.toml
+++ b/tests/data/satisfiability/conda-extras/pixi.toml
@@ -1,0 +1,20 @@
+[workspace]
+channels = ["https://conda.anaconda.org/extras-test"]
+platforms = ["linux-64"]
+
+# `my-package` advertises two extra groups in its repodata
+# (`extra_depends = { foo: [dep-foo], bar: [dep-bar] }`). Two environments select
+# a different extra each and share a solve group. The lock file must satisfy this
+# manifest: the reachability walk has to follow each package's `extra_depends`
+# for the extra its environment selected, otherwise `dep-foo` / `dep-bar` are
+# flagged as unused locked packages.
+
+[feature.foo.dependencies]
+my-package = { version = "*", extras = ["foo"] }
+
+[feature.bar.dependencies]
+my-package = { version = "*", extras = ["bar"] }
+
+[environments]
+env-bar = { features = ["bar"], solve-group = "shared" }
+env-foo = { features = ["foo"], solve-group = "shared" }


### PR DESCRIPTION
### Description

When a conda package is depended on with an extra selected (for example `my-package = { version = "*", extras = ["foo"] }`), the dependencies that the extra brings in are now correctly included in the locked environment. Previously those packages were dropped from the lock file.

This also fixes a related issue where a lock file that selects package extras was never recognized as satisfying its manifest, causing it to be re-solved on every invocation.

### How Has This Been Tested?

- Added integration tests covering two environments that share a solve group and each select a different extra of the same package, verifying each environment contains only the dependencies of the extra it selected.
- Added a satisfiability test fixture covering the same scenario.
- Existing satisfiability and source-package test suites pass.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
