### PR TITLE
fix(satisfiability): detect extra-dependency drift for source packages

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -10,7 +10,7 @@ use tempfile::TempDir;
 use url::Url;
 
 use crate::{
-    common::{LockFileExt, PixiControl, isolated_config_source},
+    common::{LockFileExt, PixiControl, isolated_config_source, logging::try_init_test_subscriber},
     setup_tracing,
 };
 use pixi_cli::publish;
@@ -395,6 +395,367 @@ my-package = {{ path = "./my-package" }}
         Platform::current(),
         "my-package",
     ));
+}
+
+/// A source package can declare extra groups through
+/// `[package.extra-dependencies.<group>]`. A workspace that depends on the
+/// source package and selects a group via `extras = ["<group>"]` must pull the
+/// group's dependencies into the lock file.
+#[tokio::test]
+async fn test_source_dependency_extras_are_pulled_in() {
+    setup_tracing();
+
+    // Channel providing the package referenced by the optional `test` group.
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("extra-pkg", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_manifest = r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.test]
+extra-pkg = ">=1.0"
+"#;
+    fs::write(source_dir.join("pixi.toml"), source_manifest).unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package", extras = ["test"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "my-package",
+        ),
+        "the source package itself must be locked"
+    );
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-pkg",
+        ),
+        "selecting the `test` extra must pull its dependency into the lock file"
+    );
+}
+
+/// Counterpart to [`test_source_dependency_extras_are_pulled_in`]: when the
+/// workspace does not select the optional group, the group's dependencies must
+/// not appear in the lock file.
+#[tokio::test]
+async fn test_source_dependency_unselected_extras_are_absent() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("extra-pkg", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_manifest = r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.test]
+extra-pkg = ">=1.0"
+"#;
+    fs::write(source_dir.join("pixi.toml"), source_manifest).unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "my-package",
+        ),
+        "the source package itself must be locked"
+    );
+    assert!(
+        !lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-pkg",
+        ),
+        "without selecting the `test` extra its dependency must not be locked"
+    );
+}
+
+/// Requesting an extra the source package does not declare must not fail the
+/// solve (the solver drops unknown extras silently, by design), but it should
+/// warn, naming the unknown extra and listing the extras that do exist.
+#[tokio::test]
+async fn test_source_dependency_unknown_extra_warns() {
+    let writer = try_init_test_subscriber();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("extra-pkg", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let source_manifest = r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.test]
+extra-pkg = ">=1.0"
+"#;
+    fs::write(source_dir.join("pixi.toml"), source_manifest).unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package", extras = ["nonexistent"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    assert!(
+        lock_file.contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "my-package",
+        ),
+        "the source package itself must still be locked despite the unknown extra"
+    );
+
+    let logs = writer.get_output();
+    assert!(
+        logs.contains(
+            "extra 'nonexistent' requested for 'my-package' does not exist (available extras: test)"
+        ),
+        "expected a warning naming the unknown extra and the available extras, got:\n{logs}"
+    );
+}
+
+/// A source package can depend on another source package. This mirrors the
+/// `example-rust` -> `example-rattler-build` shape, with the inner source
+/// declared as a `[package.run-dependencies]` path dependency. Both packages
+/// are built by the passthrough backend, and the inner package's own run
+/// dependency must be resolved transitively into the lock file.
+#[tokio::test]
+async fn test_source_dependency_on_source_run_dependency() {
+    setup_tracing();
+
+    // Channel providing the inner source package's own (binary) dependency.
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("transitive-dep", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    // Inner source package, located next to the outer package's manifest.
+    let recipe_dir = pixi.workspace_path().join("example-rust").join("recipe");
+    fs::create_dir_all(&recipe_dir).unwrap();
+    let inner_manifest = r#"
+[package]
+name = "example-rattler-build"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.run-dependencies]
+transitive-dep = ">=1.0"
+"#;
+    fs::write(recipe_dir.join("pixi.toml"), inner_manifest).unwrap();
+
+    // Outer source package depending on the inner one via a path.
+    let outer_manifest = r#"
+[package]
+name = "example-rust"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.run-dependencies]
+example-rattler-build = { path = "./recipe" }
+"#;
+    fs::write(
+        pixi.workspace_path().join("example-rust").join("pixi.toml"),
+        outer_manifest,
+    )
+    .unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+example-rust = {{ path = "./example-rust" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    for pkg in ["example-rust", "example-rattler-build", "transitive-dep"] {
+        assert!(
+            lock_file.contains_conda_package(
+                consts::DEFAULT_ENVIRONMENT_NAME,
+                Platform::current(),
+                pkg,
+            ),
+            "{pkg} should be locked"
+        );
+    }
+}
+
+/// Same `example-rust` -> `example-rattler-build` source-on-source shape, but
+/// the inner source is declared in a `[package.extra-dependencies.<group>]`
+/// group and pulled in by the workspace selecting `extras = ["recipe"]`. The
+/// inner source package and its transitive dependency must end up in the lock
+/// file just like a run dependency would.
+#[tokio::test]
+async fn test_source_dependency_on_source_extra_dependency() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("transitive-dep", "1.0.0").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let recipe_dir = pixi.workspace_path().join("example-rust").join("recipe");
+    fs::create_dir_all(&recipe_dir).unwrap();
+    let inner_manifest = r#"
+[package]
+name = "example-rattler-build"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.run-dependencies]
+transitive-dep = ">=1.0"
+"#;
+    fs::write(recipe_dir.join("pixi.toml"), inner_manifest).unwrap();
+
+    let outer_manifest = r#"
+[package]
+name = "example-rust"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+
+[package.extra-dependencies.recipe]
+example-rattler-build = { path = "./recipe" }
+"#;
+    fs::write(
+        pixi.workspace_path().join("example-rust").join("pixi.toml"),
+        outer_manifest,
+    )
+    .unwrap();
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+example-rust = {{ path = "./example-rust", extras = ["recipe"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let lock_file = pixi.update_lock_file().await.unwrap();
+
+    for pkg in ["example-rust", "example-rattler-build", "transitive-dep"] {
+        assert!(
+            lock_file.contains_conda_package(
+                consts::DEFAULT_ENVIRONMENT_NAME,
+                Platform::current(),
+                pkg,
+            ),
+            "{pkg} should be locked (pulled in through the `recipe` extra)"
+        );
+    }
 }
 
 /// Test that verifies [package.build] source.path is resolved relative to the

--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -2,7 +2,7 @@ use fs_err as fs;
 use pixi_build_backend_passthrough::{BackendEvent, ObservableBackend, PassthroughBackend};
 use pixi_build_frontend::BackendOverride;
 use pixi_consts::consts;
-use rattler_conda_types::{Platform, package::RunExportsJson};
+use rattler_conda_types::{Platform, PrefixRecord, package::RunExportsJson};
 use rattler_lock::{LockFile, PackageBuildSource};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -3245,5 +3245,61 @@ env-bar = {{ features = ["bar"], solve-group = "shared" }}
     assert!(
         !was_updated_second,
         "a lock file selecting package extras must satisfy its manifest and not be re-solved"
+    );
+}
+
+/// A built source package must record its `experimental_extra_depends` in the
+/// produced repodata, mirroring the source metadata. Regression test: the build
+/// path used to drop the extras (only `flags` survived the `conda_build_v1`
+/// round-trip), so the installed package's repodata reported no extra groups.
+///
+/// The `test` extra's dependency is declared with a `when` condition to check
+/// that the condition is not silently dropped on its way into the built
+/// package's repodata: the resulting spec must still carry its `when=` clause.
+#[tokio::test]
+async fn test_built_source_package_records_extra_depends() {
+    setup_tracing();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    // Source package declaring an extra group with a conditional dependency.
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let extra = r#"
+[package.extra-dependencies.test]
+bat = { version = "*", when = { package = "python", version = ">=3.10" } }
+"#;
+    write_basic_source_package_manifest(&source_dir, "1.0.0", extra);
+
+    // Workspace depends on the source package WITHOUT activating the extra; the
+    // built package must still record all of its extra groups.
+    write_basic_source_workspace_manifest(&pixi.manifest_path(), &[]);
+
+    pixi.install().await.unwrap();
+
+    let prefix = pixi.default_env_path().unwrap();
+    let records: Vec<PrefixRecord> = PrefixRecord::collect_from_prefix(&prefix).unwrap();
+    let my_package = records
+        .iter()
+        .find(|r| r.repodata_record.package_record.name.as_normalized() == "my-package")
+        .expect("my-package should be installed");
+
+    let extras = &my_package
+        .repodata_record
+        .package_record
+        .experimental_extra_depends;
+    let test_group = extras
+        .get("test")
+        .expect("built package must record the `test` extra group");
+    assert!(
+        test_group.iter().any(|spec| spec.contains("bat")),
+        "extra group `test` must contain the `bat` dependency, got {test_group:?}"
+    );
+    assert!(
+        test_group.iter().any(|spec| spec.contains("when=")),
+        "conditional extra dependency must preserve its `when=` clause, got {test_group:?}"
     );
 }

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -5,7 +5,7 @@ use pixi_core::{
     workspace::{PypiDeps, UpdateDeps, WorkspaceMut},
 };
 use pixi_manifest::{FeatureName, HasWorkspaceManifest, KnownPreviewFeature, SpecType};
-use pixi_spec::{GitSpec, SourceLocationSpec, Subdirectory};
+use pixi_spec::{GitSpec, SourceSpec, Subdirectory};
 use rattler_conda_types::{MatchSpec, PackageName};
 
 use crate::workspace::platforms::resolve_platforms;
@@ -72,15 +72,12 @@ pub async fn add_conda_dep(
         source_specs = passed_specs
             .iter()
             .map(|(name, (_spec, spec_type))| {
-                let git_spec = GitSpec {
-                    git: git.clone(),
-                    rev: Some(git_options.reference.clone()),
-                    subdirectory: subdirectory.clone(),
-                };
-                (
-                    name.clone(),
-                    (SourceLocationSpec::Git(git_spec).into(), *spec_type),
-                )
+                let git_spec = GitSpec::new(
+                    git.clone(),
+                    Some(git_options.reference.clone()),
+                    subdirectory.clone(),
+                );
+                (name.clone(), (SourceSpec::from(git_spec), *spec_type))
             })
             .collect();
     } else {

--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -879,6 +879,7 @@ where
                 params.run_dependencies,
                 params.run_constraints,
                 params.run_exports,
+                params.extra_dependencies,
             )),
             finalized_sources: None,
             finalized_cache_dependencies: None,

--- a/crates/pixi_build_backend/src/specs_conversion.rs
+++ b/crates/pixi_build_backend/src/specs_conversion.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use minijinja::Value;
 use ordermap::OrderMap;
 use pixi_build_types::{
-    BinaryPackageSpec, PackageSpec, SourcePackageName, SourcePackageSpec, Target, TargetSelector,
-    Targets,
+    BinaryPackageSpec, ExtraGroupName, PackageSpec, SourcePackageName, SourcePackageSpec, Target,
+    TargetSelector, Targets,
     procedures::conda_build_v1::{
         CondaBuildV1Dependency, CondaBuildV1DependencySource, CondaBuildV1Prefix,
         CondaBuildV1RunExports,
@@ -452,6 +452,7 @@ pub fn from_build_v1_args_to_finalized_dependencies(
     run_dependencies: Option<Vec<CondaBuildV1Dependency>>,
     run_constraints: Option<Vec<CondaBuildV1Dependency>>,
     run_exports: Option<CondaBuildV1RunExports>,
+    extra_dependencies: BTreeMap<ExtraGroupName, Vec<CondaBuildV1Dependency>>,
 ) -> FinalizedDependencies {
     FinalizedDependencies {
         build: build_prefix.map(|prefix| ResolvedDependencies {
@@ -489,7 +490,17 @@ pub fn from_build_v1_args_to_finalized_dependencies(
                 .into_iter()
                 .map(from_build_v1_dependency_to_dependency_info)
                 .collect(),
-            extra_depends: Default::default(),
+            extra_depends: extra_dependencies
+                .into_iter()
+                .map(|(group, deps)| {
+                    (
+                        group.into_inner(),
+                        deps.into_iter()
+                            .map(from_build_v1_dependency_to_dependency_info)
+                            .collect(),
+                    )
+                })
+                .collect(),
             run_exports: run_exports
                 .map(from_build_v1_run_exports_to_run_exports)
                 .unwrap_or_default(),
@@ -499,6 +510,8 @@ pub fn from_build_v1_args_to_finalized_dependencies(
 
 #[cfg(test)]
 mod test {
+    use rattler_conda_types::ParseMatchSpecOptions;
+
     use super::*;
 
     #[test]
@@ -545,6 +558,27 @@ mod test {
             panic!("expected binary dependency");
         };
         assert_eq!(match_spec.condition, Some(condition));
+    }
+
+    #[test]
+    fn test_extra_dependencies_are_finalized() {
+        let dep = CondaBuildV1Dependency {
+            spec: MatchSpec::from_str("gtest", ParseMatchSpecOptions::lenient()).unwrap(),
+            source: None,
+        };
+        let mut extra = BTreeMap::new();
+        extra.insert(ExtraGroupName::new("test").unwrap(), vec![dep]);
+
+        let finalized =
+            from_build_v1_args_to_finalized_dependencies(None, None, None, None, None, extra);
+
+        let group = finalized
+            .run
+            .extra_depends
+            .get("test")
+            .expect("the `test` extra group must be finalized into run.extra_depends");
+        assert_eq!(group.len(), 1);
+        assert_eq!(group[0].spec().to_string(), "gtest");
     }
 
     #[test]

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -109,6 +109,7 @@ async fn test_conda_build_v1() {
         run_constraints: None,
         run_dependencies: None,
         run_exports: None,
+        extra_dependencies: Default::default(),
         output: CondaBuildV1Output {
             name: "minimal-package".parse().unwrap(),
             version: None,

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -579,6 +579,15 @@ fn create_output(
         }
     }
 
+    // Extra groups come from the project model, and -
+    // when the backend was handed a pre-built package - from its index.json.
+    let mut extra_dependencies = convert_extra_depends(&index_json.experimental_extra_depends);
+    for (group, specs) in
+        extract_extra_dependencies(&project_model.targets, params.host_platform, &variant)
+    {
+        extra_dependencies.entry(group).or_default().extend(specs);
+    }
+
     CondaOutput {
         build_dependencies: Some(extract_dependencies(
             &project_model.targets,
@@ -588,7 +597,7 @@ fn create_output(
         )),
         host_dependencies: Some(host_deps),
         run_dependencies,
-        extra_dependencies: convert_extra_depends(&index_json.experimental_extra_depends),
+        extra_dependencies,
         metadata: CondaOutputMetadata {
             name: project_model
                 .name
@@ -628,7 +637,25 @@ fn extract_dependencies<F: Fn(&Target) -> Option<&OrderMap<SourcePackageName, Pa
     platform: Platform,
     variant: &BTreeMap<String, VariantValue>,
 ) -> CondaOutputDependencies {
-    let depends = targets
+    let depends = applicable_targets(targets, platform)
+        .into_iter()
+        .flat_map(|target| extract(target).into_iter().flat_map(OrderMap::iter))
+        .map(|(name, spec)| NamedSpec {
+            name: name.clone(),
+            spec: resolve_dependency_spec(name, spec, variant),
+        })
+        .collect();
+
+    CondaOutputDependencies {
+        depends,
+        constraints: Vec::new(),
+    }
+}
+
+/// Returns the default target plus any platform-specific targets whose selector
+/// matches `platform`.
+fn applicable_targets(targets: &Option<Targets>, platform: Platform) -> Vec<&Target> {
+    targets
         .iter()
         .flat_map(|targets| {
             targets
@@ -639,46 +666,64 @@ fn extract_dependencies<F: Fn(&Target) -> Option<&OrderMap<SourcePackageName, Pa
                         .targets
                         .iter()
                         .flatten()
-                        .flat_map(|(selector, target)| {
+                        .flat_map(move |(selector, target)| {
                             matches_target_selector(selector, platform).then_some(target)
                         }),
                 )
-                .flat_map(|target| extract(target).into_iter().flat_map(OrderMap::iter))
-                .map(|(name, spec)| {
-                    // If this is a star dependency and we have a variant for it, replace the spec
-                    let resolved_spec = if is_star_requirement(spec) {
-                        if let Some(variant_value) = variant.get(name.as_str()) {
-                            // Replace with a version spec using the variant value
-                            BinaryPackageSpec {
-                                version: Some(
-                                    rattler_conda_types::VersionSpec::from_str(
-                                        variant_value.to_string().as_str(),
-                                        rattler_conda_types::ParseStrictness::Lenient,
-                                    )
-                                    .unwrap(),
-                                ),
-                                ..Default::default()
-                            }
-                            .into()
-                        } else {
-                            spec.clone()
-                        }
-                    } else {
-                        spec.clone()
-                    };
-
-                    NamedSpec {
-                        name: name.clone(),
-                        spec: resolved_spec,
-                    }
-                })
         })
-        .collect();
+        .collect()
+}
 
-    CondaOutputDependencies {
-        depends,
-        constraints: Vec::new(),
+/// Resolves a single dependency spec, substituting the variant value when the
+/// spec is a bare star requirement and a matching variant exists.
+fn resolve_dependency_spec(
+    name: &SourcePackageName,
+    spec: &PackageSpec,
+    variant: &BTreeMap<String, VariantValue>,
+) -> PackageSpec {
+    if is_star_requirement(spec)
+        && let Some(variant_value) = variant.get(name.as_str())
+    {
+        return BinaryPackageSpec {
+            version: Some(
+                rattler_conda_types::VersionSpec::from_str(
+                    variant_value.to_string().as_str(),
+                    rattler_conda_types::ParseStrictness::Lenient,
+                )
+                .unwrap(),
+            ),
+            ..Default::default()
+        }
+        .into();
     }
+
+    spec.clone()
+}
+
+/// Extracts the extra groups declared by the project
+/// model for the given platform, mirroring how `extract_dependencies` walks
+/// targets. Groups declared across multiple matching targets are merged.
+fn extract_extra_dependencies(
+    targets: &Option<Targets>,
+    platform: Platform,
+    variant: &BTreeMap<String, VariantValue>,
+) -> BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> {
+    let mut result: BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> = BTreeMap::new();
+    for target in applicable_targets(targets, platform) {
+        let Some(extras) = target.extra_dependencies.as_ref() else {
+            continue;
+        };
+        for (group, deps) in extras {
+            let entry = result.entry(group.clone()).or_default();
+            for (name, spec) in deps {
+                entry.push(NamedSpec {
+                    name: name.clone(),
+                    spec: resolve_dependency_spec(name, spec, variant),
+                });
+            }
+        }
+    }
+    result
 }
 
 /// Resolves a run_export spec string (like "sdl2 *") by substituting variant values.

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -191,6 +191,20 @@ impl InMemoryBackend for PassthroughBackend {
                         .collect();
                 }
 
+                // Reflect the extra dependency groups into the package's
+                // `experimental_extra_depends` so consumers inspecting the built
+                // `.conda` see the expected extra groups.
+                modified_index_json.experimental_extra_depends = params
+                    .extra_dependencies
+                    .iter()
+                    .map(|(group, deps)| {
+                        (
+                            group.as_str().to_string(),
+                            deps.iter().map(|dep| dep.spec.to_string()).collect(),
+                        )
+                    })
+                    .collect();
+
                 create_conda_package_on_the_fly(&modified_index_json, &output_path).map_err(
                     |err| {
                         Box::new(

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@inherit__nested.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@inherit__nested.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_build_discovery/tests/discovery.rs
+assertion_line: 81
 expression: backend
 input_file: tests/data/discovery/inherit/nested/TEST-CASE
 ---

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@nested__nested.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@nested__nested.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_build_discovery/tests/discovery.rs
+assertion_line: 81
 expression: backend
 input_file: tests/data/discovery/nested/nested/TEST-CASE
 ---

--- a/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@simple.snap
+++ b/crates/pixi_build_discovery/tests/snapshots/discovery__discovery@simple.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_build_discovery/tests/discovery.rs
+assertion_line: 81
 expression: backend
 input_file: tests/data/discovery/simple/TEST-CASE
 ---

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -501,6 +501,7 @@ impl Protocol for RattlerBuildBackend {
                 params.run_dependencies,
                 params.run_constraints,
                 params.run_exports,
+                params.extra_dependencies,
             )),
             finalized_sources: None,
             finalized_cache_dependencies: None,

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -12,7 +12,7 @@ use ordermap::OrderMap;
 use pixi_build_types::{self as pbt};
 
 use pixi_manifest::{PackageManifest, PackageTarget, TargetSelector, Targets};
-use pixi_spec::{GitReference, PixiSpec, SourceSpec, SpecConversionError};
+use pixi_spec::{GitReference, MatchspecFields, PixiSpec, SourceLocationSpec, SpecConversionError};
 use rattler_conda_types::{ChannelConfig, NamelessMatchSpec, PackageName};
 
 /// Conversion from a `PixiSpec` to a `pbt::PixiSpecV1`.
@@ -25,33 +25,30 @@ fn to_pixi_spec_v1(
     // Convert into correct type for pixi
     let pbt_spec = match source_or_binary {
         itertools::Either::Left(source) => {
-            let SourceSpec {
-                location,
+            let MatchspecFields {
                 version,
                 build,
                 build_number,
                 extras: None,
                 flags: None,
                 subdir,
-                namespace: None,
                 license,
-                license_family: None,
                 condition: None,
                 track_features: None,
-            } = source
+            } = source.matchspec.clone()
             else {
                 unimplemented!(
                     "a particular field is not implemented in the pixi to pbt conversion"
                 );
             };
-            let location = match location {
-                pixi_spec::SourceLocationSpec::Url(url_source_spec) => {
-                    let pixi_spec::UrlSourceSpec {
+            let location = match source.location {
+                SourceLocationSpec::Url(url_spec) => {
+                    let pixi_spec::UrlSpec {
                         url,
                         md5,
                         sha256,
                         subdirectory,
-                    } = url_source_spec;
+                    } = url_spec;
                     pbt::SourcePackageLocationSpec::Url(pbt::UrlSpec {
                         url,
                         md5,
@@ -59,8 +56,8 @@ fn to_pixi_spec_v1(
                         subdirectory: subdirectory.to_option_string(),
                     })
                 }
-                pixi_spec::SourceLocationSpec::Git(git_spec) => {
-                    let pixi_spec::GitSpec {
+                SourceLocationSpec::Git(git_spec) => {
+                    let pixi_spec::GitLocationSpec {
                         git,
                         rev,
                         subdirectory,
@@ -76,9 +73,9 @@ fn to_pixi_spec_v1(
                         subdirectory: subdirectory.to_option_string(),
                     })
                 }
-                pixi_spec::SourceLocationSpec::Path(path_source_spec) => {
+                SourceLocationSpec::Path(path_spec) => {
                     pbt::SourcePackageLocationSpec::Path(pbt::PathSpec {
-                        path: path_source_spec.path.to_string(),
+                        path: path_spec.path.to_string(),
                     })
                 }
             };
@@ -409,8 +406,7 @@ mod tests {
 
         let mut package_target = PackageTarget::default();
         let constrained = PackageName::from_str("constrained").unwrap();
-        let spec =
-            PixiSpec::Version(VersionSpec::from_str(">=1.0", ParseStrictness::Strict).unwrap());
+        let spec = PixiSpec::from(VersionSpec::from_str(">=1.0", ParseStrictness::Strict).unwrap());
         package_target
             .try_add_dependency(
                 &constrained,

--- a/crates/pixi_build_type_conversions/src/snapshots/pixi_build_type_conversions__project_model__tests__conversions_v1_examples@v3.snap
+++ b/crates/pixi_build_type_conversions/src/snapshots/pixi_build_type_conversions__project_model__tests__conversions_v1_examples@v3.snap
@@ -1,0 +1,93 @@
+---
+source: crates/pixi_build_type_conversions/src/project_model.rs
+expression: project_model
+---
+{
+  "name": null,
+  "buildStringPrefix": null,
+  "buildNumber": null,
+  "version": null,
+  "description": null,
+  "buildFlags": [
+    "a",
+    "b"
+  ],
+  "authors": null,
+  "license": null,
+  "licenseFile": null,
+  "readme": null,
+  "homepage": null,
+  "repository": null,
+  "documentation": null,
+  "targets": {
+    "defaultTarget": {
+      "hostDependencies": {},
+      "buildDependencies": {},
+      "runDependencies": {},
+      "runConstraints": {},
+      "extraDependencies": {
+        "rust": {
+          "bat": {
+            "binary": {
+              "version": "*",
+              "build": null,
+              "buildNumber": null,
+              "fileName": null,
+              "extras": null,
+              "flags": null,
+              "channel": null,
+              "subdir": null,
+              "md5": null,
+              "sha256": null,
+              "url": null,
+              "license": null,
+              "condition": {
+                "MatchSpec": {
+                  "name": "python",
+                  "version": ">=3.10"
+                }
+              }
+            }
+          },
+          "ripgrep": {
+            "binary": {
+              "version": "*",
+              "build": null,
+              "buildNumber": null,
+              "fileName": null,
+              "extras": null,
+              "flags": null,
+              "channel": null,
+              "subdir": null,
+              "md5": null,
+              "sha256": null,
+              "url": null,
+              "license": null,
+              "condition": null
+            }
+          }
+        },
+        "py": {
+          "python": {
+            "binary": {
+              "version": "*",
+              "build": null,
+              "buildNumber": null,
+              "fileName": null,
+              "extras": null,
+              "flags": null,
+              "channel": null,
+              "subdir": null,
+              "md5": null,
+              "sha256": null,
+              "url": null,
+              "license": null,
+              "condition": null
+            }
+          }
+        }
+      }
+    },
+    "targets": {}
+  }
+}

--- a/crates/pixi_build_types/src/procedures/conda_build_v1.rs
+++ b/crates/pixi_build_types/src/procedures/conda_build_v1.rs
@@ -12,9 +12,9 @@ use rattler_conda_types::{
     compression_level::CompressionLevel, package::CondaArchiveType,
 };
 use serde::{Deserialize, Serialize};
-use serde_with::{DefaultOnError, DisplayFromStr, serde_as};
+use serde_with::{DefaultOnError, serde_as};
 
-use crate::{InputGlobSet, VariantValue};
+use crate::{ExtraGroupName, InputGlobSet, VariantValue};
 
 pub const METHOD_NAME: &str = "conda/build_v1";
 
@@ -43,6 +43,9 @@ pub struct CondaBuildV1Params {
 
     /// The run exports
     pub run_exports: Option<CondaBuildV1RunExports>,
+
+    /// The extra dependency groups of the package, keyed by group name
+    pub extra_dependencies: BTreeMap<ExtraGroupName, Vec<CondaBuildV1Dependency>>,
 
     /// The output to build.
     pub output: CondaBuildV1Output,
@@ -147,7 +150,6 @@ impl From<CompressionLevel> for CondaCompressionLevel {
 #[serde(rename_all = "camelCase")]
 pub struct CondaBuildV1Dependency {
     /// The match spec of the dependency.
-    #[serde_as(as = "DisplayFromStr")]
     pub spec: MatchSpec,
 
     /// What introduced this dependency? If the value of this field is
@@ -292,4 +294,84 @@ pub struct CondaBuildV1Result {
 
     /// The subdirectory of the package.
     pub subdir: Platform,
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_conda_types::{MatchSpec, ParseMatchSpecOptions, RepodataRevision};
+
+    use super::{CondaBuildV1Dependency, CondaBuildV1Params};
+
+    /// A `when=` conditional dependency must survive a JSON round-trip across
+    /// the build backend boundary. Guards against representing the spec as a
+    /// string, which would be re-parsed with the legacy syntax surface on the
+    /// receiving side and reject the v3 `when=` bracket key.
+    #[test]
+    fn conditional_dependency_survives_json_roundtrip() {
+        let spec = MatchSpec::from_str(
+            r#"bat[when="python >=3.10"]"#,
+            ParseMatchSpecOptions::default().with_repodata_revision(RepodataRevision::V3),
+        )
+        .unwrap();
+        assert!(
+            spec.condition.is_some(),
+            "the test spec must carry a condition"
+        );
+
+        let dep = CondaBuildV1Dependency {
+            spec: spec.clone(),
+            source: None,
+        };
+        let json = serde_json::to_string(&dep).unwrap();
+        let roundtripped: CondaBuildV1Dependency = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(roundtripped.spec.condition, spec.condition);
+    }
+
+    /// `CondaBuildV1Params::extra_dependencies` carrying a conditional spec
+    /// must round-trip through JSON as well.
+    #[test]
+    fn extra_dependencies_with_condition_survive_json_roundtrip() {
+        let spec = MatchSpec::from_str(
+            r#"bat[when="python >=3.10"]"#,
+            ParseMatchSpecOptions::default().with_repodata_revision(RepodataRevision::V3),
+        )
+        .unwrap();
+        let params = CondaBuildV1Params {
+            channels: vec![],
+            build_prefix: None,
+            host_prefix: None,
+            run_dependencies: None,
+            run_constraints: None,
+            run_exports: None,
+            extra_dependencies: std::collections::BTreeMap::from([(
+                crate::ExtraGroupName::new("test").unwrap(),
+                vec![CondaBuildV1Dependency {
+                    spec: spec.clone(),
+                    source: None,
+                }],
+            )]),
+            output: super::CondaBuildV1Output {
+                name: "pkg".parse().unwrap(),
+                version: None,
+                build: None,
+                subdir: rattler_conda_types::Platform::NoArch,
+                variant: Default::default(),
+            },
+            work_directory: std::path::PathBuf::from("."),
+            output_directory: None,
+            editable: None,
+            package_format: None,
+        };
+
+        let json = serde_json::to_string(&params).unwrap();
+        let roundtripped: CondaBuildV1Params = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            roundtripped.extra_dependencies[&crate::ExtraGroupName::new("test").unwrap()][0]
+                .spec
+                .condition,
+            spec.condition
+        );
+    }
 }

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -95,17 +95,16 @@ impl GlobalSpecs {
         project: &pixi_global::Project,
     ) -> Result<Vec<pixi_global::project::GlobalSpec>, GlobalSpecsConversionError> {
         let git_or_path_spec = if let Some(git_url) = &self.git {
-            let git_spec = pixi_spec::GitSpec {
-                git: git_url.clone(),
-                rev: self.rev.clone().map(Into::into),
-                subdirectory: self
-                    .subdir
+            let git_spec = pixi_spec::GitSpec::new(
+                git_url.clone(),
+                self.rev.clone().map(Into::into),
+                self.subdir
                     .clone()
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
-            };
-            Some(PixiSpec::Git(git_spec))
+            );
+            Some(PixiSpec::from(git_spec))
         } else if let Some(path) = &self.path {
             let absolute_path = dunce::canonicalize(path.as_str())
                 .map_err(|_| GlobalSpecsConversionError::AbsolutizePath(path.to_string()))?;
@@ -159,10 +158,10 @@ impl GlobalSpecs {
                         manifest_root.to_string_lossy().to_string(),
                     )
                 })?;
-            Some(PixiSpec::Path(pixi_spec::PathSpec {
-                path: Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
+            Some(PixiSpec::from(pixi_spec::PathSpec::new(
+                Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
                     .to_typed_path_buf(),
-            }))
+            )))
         } else {
             fn pathlike(s: &str) -> bool {
                 s.contains(".conda") || s.contains('/') || s.contains('\\')
@@ -315,8 +314,8 @@ mod tests {
                 assert_eq!(global_specs.len(), 1);
                 let installed_spec = &global_specs[0];
 
-                let PixiSpec::Path(path_spec) = &installed_spec.spec else {
-                    panic!("expected path spec");
+                let PixiSpec::PathBinary(path_spec) = &installed_spec.spec else {
+                    panic!("expected binary path spec");
                 };
 
                 let resolved_path = path_spec

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -426,8 +426,13 @@ fn parse_specs(
         })
         // Only upgrade version specs
         .filter_map(|(name, req)| match req {
-            PixiSpec::DetailedVersion(version_spec) => {
-                let mut nameless_match_spec = version_spec
+            PixiSpec::Version(_) => {
+                // A bare version spec carries no extra selectors, so upgrading
+                // means dropping the constraint entirely.
+                Some((name.clone(), (MatchSpec::from(name), spec_type)))
+            }
+            PixiSpec::DetailedVersion(detailed) => {
+                let mut nameless_match_spec = detailed
                     .try_into_nameless_match_spec(&workspace.workspace().channel_config())
                     .ok()?;
                 // If it is a detailed spec, always unset version
@@ -463,7 +468,6 @@ fn parse_specs(
                     ),
                 ))
             }
-            PixiSpec::Version(_) => Some((name.clone(), (MatchSpec::from(name), spec_type))),
             _ => {
                 tracing::debug!("skipping non-version spec {:?}", req);
                 None

--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -12,7 +12,7 @@ use itertools::{Either, Itertools};
 use miette::Diagnostic;
 use pixi_build_frontend::json_rpc::CommunicationError;
 use pixi_build_types::{
-    InputGlobSet, VariantValue,
+    ExtraGroupName, InputGlobSet, VariantValue,
     procedures::conda_build_v1::{
         CondaBuildV1Dependency, CondaBuildV1DependencyRunExportSource,
         CondaBuildV1DependencySource, CondaBuildV1Output, CondaBuildV1Params, CondaBuildV1Prefix,
@@ -20,6 +20,7 @@ use pixi_build_types::{
     },
 };
 use pixi_spec::{BinarySpec, PixiSpec, SpecConversionError};
+use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::{
     ChannelConfig, ChannelUrl, MatchSpec, PackageName, Platform, RepoDataRecord, VersionWithSource,
 };
@@ -80,6 +81,9 @@ pub struct BackendSourceBuildV1Method {
 
     /// The run dependencies and constraints
     pub dependencies: Dependencies,
+
+    /// The extra dependency groups, keyed by group name.
+    pub extra_dependencies: BTreeMap<ExtraGroupName, DependencyMap<PackageName, PixiSpec>>,
 
     /// The run exports
     pub run_exports: PixiRunExports,
@@ -178,6 +182,20 @@ impl BackendSourceBuildSpec {
                         params.dependencies.constraints.into_specs(),
                         &channel_config,
                     )),
+                    extra_dependencies: params
+                        .extra_dependencies
+                        .into_iter()
+                        .map(|(group, deps)| {
+                            (
+                                group,
+                                dependencies_to_protocol(
+                                    deps.into_specs()
+                                        .map(|(name, spec)| (name, WithSource::new(spec))),
+                                    &channel_config,
+                                ),
+                            )
+                        })
+                        .collect(),
                     run_exports: Some(CondaBuildV1RunExports {
                         weak: dependencies_to_protocol(
                             params

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -1,5 +1,8 @@
 use pixi_build_types::{BinaryPackageSpec, SourcePackageLocationSpec, SourcePackageSpec};
-use pixi_spec::{BinarySpec, DetailedSpec, UrlBinarySpec};
+use pixi_spec::{
+    BinarySpec, DetailedSpec, GitLocationSpec, MatchspecFields, PathSpec, SourceLocationSpec,
+    UrlBinarySpec, UrlSpec,
+};
 use rattler_conda_types::NamedChannelOrUrl;
 
 /// Converts a [`SourcePackageSpec`] to a [`pixi_spec::SourceSpec`].
@@ -12,68 +15,54 @@ pub fn from_source_spec_v1(source: SourcePackageSpec) -> pixi_spec::SourceSpec {
         subdir,
         license,
     } = source;
-    let location = from_source_package_location_spec(location);
-    pixi_spec::SourceSpec {
-        location,
+    let matchspec = MatchspecFields {
         version,
         build,
         build_number,
         subdir,
         license,
-        extras: None,
-        flags: None,
-        namespace: None,
-        license_family: None,
-        condition: None,
-        track_features: None,
-    }
+        ..MatchspecFields::default()
+    };
+    from_source_package_location_spec(location).with_matchspec(matchspec)
 }
 
 pub fn from_source_package_location_spec(
     spec: SourcePackageLocationSpec,
 ) -> pixi_spec::SourceLocationSpec {
     match spec {
-        SourcePackageLocationSpec::Url(url) => {
-            pixi_spec::SourceLocationSpec::Url(pixi_spec::UrlSourceSpec {
-                url: url.url,
-                md5: url.md5,
-                sha256: url.sha256,
-                subdirectory: url
-                    .subdirectory
-                    .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
-                    .unwrap_or_default(),
-            })
-        }
+        SourcePackageLocationSpec::Url(url) => SourceLocationSpec::Url(UrlSpec {
+            url: url.url,
+            md5: url.md5,
+            sha256: url.sha256,
+            subdirectory: url
+                .subdirectory
+                .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
+                .unwrap_or_default(),
+        }),
 
-        SourcePackageLocationSpec::Git(git) => {
-            pixi_spec::SourceLocationSpec::Git(pixi_spec::GitSpec {
-                git: git.git,
-                rev: git.rev.map(|r| match r {
-                    pixi_build_frontend::types::GitReference::Branch(b) => {
-                        pixi_spec::GitReference::Branch(b)
-                    }
-                    pixi_build_frontend::types::GitReference::Tag(t) => {
-                        pixi_spec::GitReference::Tag(t)
-                    }
-                    pixi_build_frontend::types::GitReference::Rev(rev) => {
-                        pixi_spec::GitReference::Rev(rev)
-                    }
-                    pixi_build_frontend::types::GitReference::DefaultBranch => {
-                        pixi_spec::GitReference::DefaultBranch
-                    }
-                }),
-                subdirectory: git
-                    .subdirectory
-                    .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
-                    .unwrap_or_default(),
-            })
-        }
+        SourcePackageLocationSpec::Git(git) => SourceLocationSpec::Git(GitLocationSpec {
+            git: git.git,
+            rev: git.rev.map(|r| match r {
+                pixi_build_frontend::types::GitReference::Branch(b) => {
+                    pixi_spec::GitReference::Branch(b)
+                }
+                pixi_build_frontend::types::GitReference::Tag(t) => pixi_spec::GitReference::Tag(t),
+                pixi_build_frontend::types::GitReference::Rev(rev) => {
+                    pixi_spec::GitReference::Rev(rev)
+                }
+                pixi_build_frontend::types::GitReference::DefaultBranch => {
+                    pixi_spec::GitReference::DefaultBranch
+                }
+            }),
+            subdirectory: git
+                .subdirectory
+                .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
+                .unwrap_or_default(),
+        }),
 
-        SourcePackageLocationSpec::Path(path) => {
-            pixi_spec::SourceLocationSpec::Path(pixi_spec::PathSourceSpec {
-                path: path.path.into(),
-            })
-        }
+        SourcePackageLocationSpec::Path(path) => SourceLocationSpec::Path(PathSpec {
+            path: path.path.into(),
+        }),
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -726,7 +726,8 @@ impl BuildBackendMetadataInner {
                     None
                 };
 
-                let resolved_location = manifest_source_anchor.resolve(build_source.clone());
+                let resolved_location =
+                    manifest_source_anchor.resolve_location(build_source.clone());
 
                 let checkout = match &self.preferred_build_source {
                     Some(pinned) if pinned.matches_source_spec(&resolved_location) => {

--- a/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
@@ -7,7 +7,7 @@ use miette::Diagnostic;
 use pixi_build_types::{ConstraintSpec, PackageSpec};
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_record::{DevSourceRecord, PinnedSourceSpec};
-use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceLocationSpec};
+use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceSpec};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::PackageName;
 use thiserror::Error;
@@ -156,7 +156,7 @@ impl Key for DevSourceMetadataKey {
             .map_err(|e| DevSourceMetadataError::BuildBackendMetadata(Box::new(e)))?;
 
         // Create a SourceAnchor for resolving relative paths in dependencies.
-        let source_anchor = SourceAnchor::from(SourceLocationSpec::from(
+        let source_anchor = SourceAnchor::from(SourceSpec::from(
             build_backend_metadata.source.manifest_source().clone(),
         ));
 

--- a/crates/pixi_command_dispatcher/src/installed_source_hints.rs
+++ b/crates/pixi_command_dispatcher/src/installed_source_hints.rs
@@ -221,13 +221,13 @@ mod tests {
     use std::sync::Arc;
 
     use pixi_record::{PartialSourceRecordData, SourceRecordData, UnresolvedSourceRecord};
-    use pixi_spec::{PathSourceSpec, SourceLocationSpec};
+    use pixi_spec::PathSpec;
     use rattler_conda_types::PackageName;
 
     use super::*;
 
     fn path_location(path: &str) -> SourceLocationSpec {
-        SourceLocationSpec::Path(PathSourceSpec { path: path.into() })
+        SourceLocationSpec::Path(PathSpec::new(path))
     }
 
     fn make_source(
@@ -383,12 +383,12 @@ mod tests {
     }
 
     fn unpinned_git_location(url: &str) -> SourceLocationSpec {
-        use pixi_spec::{GitReference, GitSpec};
-        SourceLocationSpec::Git(GitSpec {
-            git: url::Url::parse(url).expect("valid git url"),
-            rev: Some(GitReference::Branch("main".into())),
-            subdirectory: Default::default(),
-        })
+        use pixi_spec::{GitLocationSpec, GitReference};
+        SourceLocationSpec::Git(GitLocationSpec::new(
+            url::Url::parse(url).expect("valid git url"),
+            Some(GitReference::Branch("main".into())),
+            Default::default(),
+        ))
     }
 
     #[test]

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -228,21 +228,23 @@ async fn assemble_source_record_inner(
     let mut sources: HashMap<PackageName, SourceLocationSpec> = HashMap::new();
 
     // Record a source-typed PixiSpec's location into `sources`, erroring
-    // if the same (name, location) is registered twice.
+    // if the same (name, location) is registered twice. Only the location
+    // is tracked; the matchspec selectors live on the dependency itself.
     let mut track_source = |name: &PackageName, spec: &PixiSpec| -> Result<(), SourceRecordError> {
         if let Either::Left(source) = spec.clone().into_source_or_binary() {
+            let location = source.location;
             match sources.entry(name.clone()) {
                 std::collections::hash_map::Entry::Occupied(entry) => {
-                    if entry.get() == &source.location {
+                    if entry.get() == &location {
                         return Err(SourceRecordError::DuplicateSourceDependency {
                             package: name.clone(),
                             source1: Box::new(entry.get().clone()),
-                            source2: Box::new(source.location.clone()),
+                            source2: Box::new(location.clone()),
                         });
                     }
                 }
                 std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(source.location.clone());
+                    entry.insert(location);
                 }
             }
         }

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -442,6 +442,7 @@ async fn compute_inner(
 /// the seeds. Binary match specs are NOT collected here; they're
 /// derived downstream inside [`SolveCondaKey`] from the same
 /// assembled records (see `derive_fetch_specs_from_source_repodata`).
+#[allow(clippy::mutable_key_type)]
 async fn walk_and_resolve(
     ctx: &mut ComputeCtx,
     seeds: Vec<(PackageName, SourceSpec)>,
@@ -549,7 +550,13 @@ async fn walk_and_resolve(
         for record in records.iter() {
             let anchor =
                 SourceAnchor::from(SourceLocationSpec::from(record.manifest_source().clone()));
-            for depend_str in &record.package_record().depends {
+            for depend_str in record.package_record().depends.iter().chain(
+                record
+                    .package_record()
+                    .experimental_extra_depends
+                    .values()
+                    .flatten(),
+            ) {
                 let Ok(match_spec) = MatchSpec::from_str(
                     depend_str,
                     ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3),
@@ -561,7 +568,7 @@ async fn walk_and_resolve(
                     continue;
                 };
                 if let Some(source_location) = record.sources().get(child_name.as_normalized()) {
-                    let resolved_location = anchor.resolve(source_location.clone());
+                    let resolved_location = anchor.resolve_location(source_location.clone());
                     push(
                         &mut p,
                         &mut pending,
@@ -596,7 +603,7 @@ async fn process_dev_sources(
             let name = name.clone();
             let env_ref = spec.env_ref.clone();
             let preferred_build_source = spec.preferred_build_source.get(&name).cloned();
-            let fut = ctx.pin_and_checkout(dev_spec.source.location.clone());
+            let fut = ctx.pin_and_checkout(dev_spec.source.clone());
             async move {
                 let checkout = fut
                     .await

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -15,7 +15,7 @@ use pixi_build_types::procedures::{
 };
 use pixi_compute_engine::{ComputeCtx, Key};
 use pixi_record::{PixiRecord, UnresolvedPixiRecord, UnresolvedSourceRecord, VariantValue};
-use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceLocationSpec};
+use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceSpec};
 use pixi_variant::VariantSelector;
 use rattler_conda_types::{
     ChannelUrl, PackageRecord, RepoDataRecord, package::DistArchiveIdentifier, prefix::Prefix,
@@ -164,7 +164,7 @@ async fn compute_inner(
     // We need this identifier only to form the artifact cache key — on
     // a cache hit there's no further reason to talk to a backend, so
     // doing the spawn before the lookup is pure waste.
-    let manifest_anchor = SourceAnchor::from(SourceLocationSpec::from(manifest_source.clone()));
+    let manifest_anchor = SourceAnchor::from(SourceSpec::from(manifest_source.clone()));
     let build_source_dir = build_source_checkout
         .path
         .as_dir_or_file_parent()
@@ -306,7 +306,7 @@ async fn compute_inner(
     //   the env being defined)
     // - host deps see build records
     // - run deps (+ run_exports) see build + host records
-    let source_anchor = SourceAnchor::from(SourceLocationSpec::from(manifest_source.clone()));
+    let source_anchor = SourceAnchor::from(SourceSpec::from(manifest_source.clone()));
     let mut build_pixi_records: Vec<PixiRecord> = build_records
         .iter()
         .cloned()

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -35,7 +35,7 @@ use crate::{
     BuildProfile, CommandDispatcherError, CommandDispatcherErrorResultExt,
     InstallPixiEnvironmentExt, InstallPixiEnvironmentSpec, InstantiateBackendKey,
     ProjectModelOverrides, SourceBuildError,
-    build::{Dependencies, PixiRunExports},
+    build::{Dependencies, PixiRunExports, convert_extra_dependencies},
     compute_data::HasGateway,
 };
 use pixi_compute_cache_dirs::CacheDirsExt;
@@ -393,6 +393,13 @@ async fn compute_inner(
     let run_exports = PixiRunExports::try_from_protocol(&output.run_exports, &compat_map)
         .map_err(SourceBuildError::from)?;
 
+    // Resolve the extra groups the same way as run dependencies so the built
+    // package records them in its `experimental_extra_depends`. Extras do not
+    // receive run-exports, mirroring the metadata path.
+    let extra_dependencies =
+        convert_extra_dependencies(&output.extra_dependencies, None, &compat_map)
+            .map_err(SourceBuildError::from)?;
+
     let editable =
         matches!(spec.build_profile, BuildProfile::Development) && spec.record.has_mutable_source();
     let built = ctx
@@ -400,6 +407,7 @@ async fn compute_inner(
             method: BackendSourceBuildMethod::BuildV1(BackendSourceBuildV1Method {
                 editable,
                 dependencies: run_dependencies,
+                extra_dependencies,
                 run_exports,
                 build_prefix: BackendSourceBuildPrefix {
                     platform: spec.build_environment.build_platform,

--- a/crates/pixi_command_dispatcher/src/reporter.rs
+++ b/crates/pixi_command_dispatcher/src/reporter.rs
@@ -171,9 +171,7 @@ pub trait BackendSourceBuildReporter: Send + Sync {
 pub(crate) fn has_direct_conda_dependency(
     dependencies: &pixi_spec_containers::DependencyMap<rattler_conda_types::PackageName, PixiSpec>,
 ) -> bool {
-    dependencies.iter_specs().any(|(_, spec)| match spec {
-        PixiSpec::Url(url) => url.is_binary(),
-        PixiSpec::Path(path) => path.is_binary(),
-        _ => false,
-    })
+    dependencies
+        .iter_specs()
+        .any(|(_, spec)| matches!(spec, PixiSpec::UrlBinary(_) | PixiSpec::PathBinary(_)))
 }

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -187,7 +187,7 @@ fn default_build_environment() -> BuildEnvironment {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
+#[ignore]
 pub async fn simple_test() {
     use pixi_test_utils::GitRepoFixture;
 

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -26,7 +26,7 @@ use pixi_spec_containers::DependencyMap;
 use pixi_test_utils::format_diagnostic;
 use pixi_utils::variants::VariantConfig;
 use rattler_conda_types::{
-    ChannelUrl, GenericVirtualPackage, PackageName, Platform, VersionSpec, prefix::Prefix,
+    ChannelUrl, GenericVirtualPackage, PackageName, Platform, prefix::Prefix,
 };
 use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
 use url::Url;
@@ -225,11 +225,11 @@ pub async fn simple_test() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "foobar-desktop".parse().unwrap(),
-                GitSpec {
-                    git: git_repo.url.parse().unwrap(),
-                    rev: Some(GitReference::Rev(git_repo.commits[0].clone())),
-                    subdirectory: Subdirectory::try_from("recipe").unwrap(),
-                }
+                GitSpec::new(
+                    git_repo.url.parse().unwrap(),
+                    Some(GitReference::Rev(git_repo.commits[0].clone())),
+                    Subdirectory::try_from("recipe").unwrap(),
+                )
                 .into(),
             )]),
             env_ref: env_ref_of(vec![channel_url.clone()], build_env.clone()),
@@ -305,7 +305,7 @@ pub async fn instantiate_backend_with_compatible_api_version() {
     dispatcher
         .instantiate_tool_environment(InstantiateToolEnvironmentSpec::new(
             backend_name,
-            PixiSpec::Version(VersionSpec::Any),
+            PixiSpec::any(),
             Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
         ))
         .await
@@ -330,7 +330,7 @@ pub async fn instantiate_backend_without_compatible_api_version() {
     let err = dispatcher
         .instantiate_tool_environment(InstantiateToolEnvironmentSpec::new(
             backend_name,
-            PixiSpec::Version(VersionSpec::Any),
+            PixiSpec::any(),
             Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
         ))
         .await
@@ -357,7 +357,7 @@ pub async fn instantiate_backend_with_compatible_api_version_respects_exclude_ne
     dispatcher
         .instantiate_tool_environment(InstantiateToolEnvironmentSpec::new(
             backend_name.clone(),
-            PixiSpec::Version(VersionSpec::Any),
+            PixiSpec::any(),
             Vec::from([Url::from_directory_path(channel_dir.clone())
                 .unwrap()
                 .into()]),
@@ -372,7 +372,7 @@ pub async fn instantiate_backend_with_compatible_api_version_respects_exclude_ne
             )),
             ..InstantiateToolEnvironmentSpec::new(
                 backend_name,
-                PixiSpec::Version(VersionSpec::Any),
+                PixiSpec::any(),
                 Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
             )
         })
@@ -412,7 +412,7 @@ pub async fn instantiate_backend_with_compatible_api_version_honors_exclude_newe
             ),
             ..InstantiateToolEnvironmentSpec::new(
                 backend_name,
-                PixiSpec::Version(VersionSpec::Any),
+                PixiSpec::any(),
                 Vec::from([channel_url]),
             )
         })
@@ -443,7 +443,7 @@ pub async fn instantiate_backend_without_compatible_api_version_cancels_duplicat
     // Build the spec once and issue two identical concurrent requests.
     let spec = InstantiateToolEnvironmentSpec::new(
         backend_name,
-        PixiSpec::Version(VersionSpec::Any),
+        PixiSpec::any(),
         Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
     );
 
@@ -511,7 +511,7 @@ pub async fn dropping_future_cancels_background_task() {
     // and the task would progress to installation if not cancelled.
     let spec = InstantiateToolEnvironmentSpec::new(
         PackageName::new_unchecked("backend-with-compatible-api-version"),
-        PixiSpec::Version(VersionSpec::Any),
+        PixiSpec::any(),
         Vec::from([Url::from_directory_path(channel_dir).unwrap().into()]),
     );
 
@@ -2052,7 +2052,7 @@ pub async fn test_installed_pins_binary_version() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version(version),
+                PixiSpec::from(version),
             )]),
             installed: std::sync::Arc::from(installed),
             env_ref: env_ref.clone(),
@@ -2182,7 +2182,7 @@ pub async fn test_installed_host_packages_pin_nested_solve() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2337,7 +2337,7 @@ pub async fn test_installed_hint_reused_across_variants() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: binary_env_ref,
@@ -2448,7 +2448,7 @@ pub async fn test_duplicate_installed_source_hints_are_order_independent() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2466,7 +2466,7 @@ pub async fn test_duplicate_installed_source_hints_are_order_independent() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.2.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.2.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2632,7 +2632,7 @@ foo = { path = "../foo" }
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.1.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.1.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),
@@ -2650,7 +2650,7 @@ foo = { path = "../foo" }
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package".parse().unwrap(),
-                PixiSpec::Version("==0.2.0".parse::<VersionSpec>().unwrap()),
+                PixiSpec::from("==0.2.0".parse::<VersionSpec>().unwrap()),
             )]),
             installed: std::sync::Arc::from([]),
             env_ref: env_ref.clone(),

--- a/crates/pixi_compute_sources/src/ext.rs
+++ b/crates/pixi_compute_sources/src/ext.rs
@@ -5,7 +5,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use pixi_compute_engine::ComputeCtx;
 use pixi_record::{PinnedPathSpec, PinnedSourceSpec};
-use pixi_spec::{SourceLocationSpec, UrlSpec};
+use pixi_spec::SourceLocationSpec;
 
 use crate::path::RootDirExt;
 use crate::{GitSourceCheckoutExt, SourceCheckout, SourceCheckoutError, UrlSourceCheckoutExt};
@@ -13,7 +13,7 @@ use crate::{GitSourceCheckoutExt, SourceCheckout, SourceCheckoutError, UrlSource
 /// Dispatch a checkout based on a [`SourceLocationSpec`] or a fully
 /// pinned [`PinnedSourceSpec`].
 pub trait SourceCheckoutExt {
-    /// Resolve a source-location spec into a [`SourceCheckout`].
+    /// Resolve a source location into a [`SourceCheckout`].
     ///
     /// - **Path** specs resolve against the workspace root, with `~/`
     ///   expansion and absolute-path passthrough.
@@ -40,14 +40,7 @@ impl SourceCheckoutExt for ComputeCtx {
     ) -> impl Future<Output = Result<SourceCheckout, SourceCheckoutError>> + Send + use<> {
         let fut: BoxFuture<'static, Result<SourceCheckout, SourceCheckoutError>> =
             match source_location_spec {
-                SourceLocationSpec::Url(url) => self
-                    .pin_and_checkout_url(UrlSpec {
-                        url: url.url,
-                        md5: url.md5,
-                        sha256: url.sha256,
-                        subdirectory: url.subdirectory,
-                    })
-                    .boxed(),
+                SourceLocationSpec::Url(url) => self.pin_and_checkout_url(url).boxed(),
                 SourceLocationSpec::Path(path) => {
                     let result = self.resolve_typed_path(path.path.to_path());
                     async move {

--- a/crates/pixi_compute_sources/src/git.rs
+++ b/crates/pixi_compute_sources/src/git.rs
@@ -15,7 +15,7 @@ use pixi_git::resolver::RepositoryReference;
 use pixi_git::source::Fetch as GitFetch;
 use pixi_git::{GitError, GitUrl};
 use pixi_record::{PinnedGitCheckout, PinnedGitSpec};
-use pixi_spec::GitSpec;
+use pixi_spec::GitLocationSpec;
 use tokio::sync::Semaphore;
 
 use crate::data::HasGitResolver;
@@ -152,7 +152,7 @@ pub trait GitSourceCheckoutExt {
     /// Check out the git repository associated with the given spec.
     fn pin_and_checkout_git(
         &mut self,
-        git_spec: GitSpec,
+        git_spec: GitLocationSpec,
     ) -> impl Future<Output = Result<SourceCheckout, SourceCheckoutError>> + Send + use<Self>;
 
     /// Check out a pinned git repository at the given commit.
@@ -165,7 +165,7 @@ pub trait GitSourceCheckoutExt {
 impl GitSourceCheckoutExt for ComputeCtx {
     fn pin_and_checkout_git(
         &mut self,
-        git_spec: GitSpec,
+        git_spec: GitLocationSpec,
     ) -> impl Future<Output = Result<SourceCheckout, SourceCheckoutError>> + Send + use<> {
         let git_reference = git_spec
             .rev

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -9,7 +9,7 @@ mod common;
 use common::{EngineConfig, LifecycleReporter, build_test_engine};
 use pixi_compute_sources::GitSourceCheckoutExt;
 use pixi_record::PinnedSourceSpec;
-use pixi_spec::{GitSpec, Subdirectory};
+use pixi_spec::{GitLocationSpec, Subdirectory};
 use pixi_test_utils::GitRepoFixture;
 
 /// `pin_and_checkout_git` against a fresh fixture clones the repo,
@@ -25,11 +25,7 @@ async fn pin_and_checkout_git_default_branch() {
         ..Default::default()
     });
 
-    let spec = GitSpec {
-        git: repo.base_url.clone(),
-        rev: None,
-        subdirectory: Subdirectory::default(),
-    };
+    let spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default());
 
     let checkout = engine
         .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
@@ -72,11 +68,11 @@ async fn git_checkout_fires_full_reporter_lifecycle() {
 
     engine
         .with_ctx(async |ctx| {
-            ctx.pin_and_checkout_git(GitSpec {
-                git: repo.base_url.clone(),
-                rev: None,
-                subdirectory: Subdirectory::default(),
-            })
+            ctx.pin_and_checkout_git(GitLocationSpec::new(
+                repo.base_url.clone(),
+                None,
+                Subdirectory::default(),
+            ))
             .await
         })
         .await

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -465,7 +465,7 @@ pub fn extract_git_requirements_from_workspace(project: &Workspace) -> Vec<GitSp
             for (_, dep_spec) in dependencies {
                 for spec in dep_spec {
                     if let PixiSpec::Git(spec) = spec {
-                        requirements.push(spec.clone());
+                        requirements.push(*spec);
                     }
                 }
             }

--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -634,6 +634,22 @@ pub enum PlatformUnsat {
     },
 
     #[error(
+        "the resolved extra group '{group}' of source package '{package}' no longer matches what the backend would re-derive from the manifest{added_msg}{removed_msg}",
+        added_msg = if added.is_empty() { String::new() } else { format!("; added: {}", added.join(", ")) },
+        removed_msg = if removed.is_empty() { String::new() } else { format!("; removed: {}", removed.join(", ")) },
+    )]
+    SourceExtraDependenciesChanged {
+        /// The source package whose extra group drifted.
+        package: String,
+        /// The extra group name.
+        group: String,
+        /// Specs the backend now declares that the locked group is missing.
+        added: Vec<String>,
+        /// Specs the locked group carries that the backend no longer declares.
+        removed: Vec<String>,
+    },
+
+    #[error(
         "the locked package build source for '{0}' does not match the requested build source, {1}"
     )]
     PackageBuildSourceMismatch(String, SourceMismatchError),

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -421,7 +421,7 @@ pub struct VerifiedIndividualEnvironment {
 
 /// Resolve dev dependencies and get all their dependencies
 pub async fn resolve_dev_dependencies(
-    dev_dependencies: Vec<(PackageName, SourceSpec)>,
+    dev_dependencies: Vec<(PackageName, SourceLocationSpec)>,
     command_dispatcher: &CommandDispatcher,
     channel_config: &rattler_conda_types::ChannelConfig,
     workspace_env_ref: WorkspaceEnvRef,
@@ -465,7 +465,7 @@ pub async fn resolve_dev_dependencies(
 /// Resolves all dependencies of a single dev dependency
 async fn resolve_single_dev_dependency(
     package_name: PackageName,
-    source_spec: SourceSpec,
+    source_spec: SourceLocationSpec,
     command_dispatcher: CommandDispatcher,
     channel_config: rattler_conda_types::ChannelConfig,
     workspace_env_ref: WorkspaceEnvRef,
@@ -473,7 +473,7 @@ async fn resolve_single_dev_dependency(
 ) -> Result<Vec<Dependency>, CommandDispatcherError<PlatformUnsat>> {
     let pinned_source = command_dispatcher
         .engine()
-        .with_ctx(async |ctx| ctx.pin_and_checkout(source_spec.location).await)
+        .with_ctx(async |ctx| ctx.pin_and_checkout(source_spec).await)
         .await
         .map_err_into_dispatcher(PlatformUnsat::from)?;
 
@@ -796,7 +796,7 @@ async fn verify_package_platform_satisfiability(
                 let (found_package, extras) = match spec.into_source_or_binary() {
                     Either::Left(source_spec) => {
                         expected_conda_source_dependencies.insert(name.clone());
-                        let extras = source_spec.extras.clone().unwrap_or_default();
+                        let extras = source_spec.matchspec.extras.clone().unwrap_or_default();
                         let found_package = find_matching_source_package(
                             locked_pixi_records,
                             name,
@@ -849,7 +849,7 @@ async fn verify_package_platform_satisfiability(
             }
             Dependency::CondaSource(name, source_spec, source) => {
                 expected_conda_source_dependencies.insert(name.clone());
-                let extras = source_spec.extras.clone().unwrap_or_default();
+                let extras = source_spec.matchspec.extras.clone().unwrap_or_default();
                 FoundPackage::Conda(
                     find_matching_source_package(locked_pixi_records, name, source_spec, source)
                         .map_err(CommandDispatcherError::Failed)?,
@@ -1029,8 +1029,9 @@ async fn verify_package_platform_satisfiability(
                             package_name,
                         ))
                     }) {
-                        let anchored_location = anchor.resolve(source.clone());
-                        let source_spec = SourceSpec::new(anchored_location, spec);
+                        let source_spec = anchor.resolve_location(source.clone()).with_matchspec(
+                            pixi_spec::MatchspecFields::from_nameless_match_spec(&spec),
+                        );
                         conda_stack.push(Dependency::CondaSource(
                             package_name.clone(),
                             source_spec,
@@ -1348,7 +1349,7 @@ fn find_matching_source_package(
 
     source_package
         .manifest_source
-        .satisfies(&source_spec.location)
+        .satisfies(&source_spec)
         .map_err(|e| PlatformUnsat::SourcePackageMismatch(name.as_source().to_string(), e))?;
 
     let match_spec = source_spec.to_nameless_match_spec();

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -28,8 +28,8 @@ use pixi_uv_conversions::{
 };
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
 use rattler_conda_types::{
-    GenericVirtualPackage, MatchSpec, Matches, PackageName, ParseChannelError, ParseMatchSpecError,
-    ParseMatchSpecOptions, RepodataRevision,
+    GenericVirtualPackage, MatchSpec, MatchSpecCondition, Matches, PackageName, ParseChannelError,
+    ParseMatchSpecError, ParseMatchSpecOptions, RepodataRevision,
 };
 use rattler_lock::{LockedPackage, UrlOrPath};
 use uv_distribution_types::{RequirementSource, RequiresPython};
@@ -1003,6 +1003,18 @@ async fn verify_package_platform_satisfiability(
                             PlatformUnsat::FailedToParseMatchSpec(depends.clone(), e),
                         ))
                     })?;
+
+                    // Skip a conditional dependency whose `when` condition the
+                    // environment does not satisfy; the solver would not have
+                    // installed it either, so requiring it here would spuriously
+                    // fail (e.g. `bat *[when="python>=3.10"]` in an environment
+                    // that pins `python <3.10`).
+                    if let Some(condition) = &spec.condition
+                        && !condition_is_met(condition, locked_pixi_records)
+                    {
+                        continue;
+                    }
+
                     let (name, spec) = spec.into_nameless();
 
                     let (origin, anchor) = match record {
@@ -1251,6 +1263,27 @@ pub struct CondaPackageIdx(usize);
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct PypiPackageIdx(usize);
+
+/// Returns `true` when a matchspec `when=` condition is satisfied by some
+/// locked conda record, mirroring the decision the solver made when it
+/// produced the lock file. `And` / `Or` recurse over their operands.
+fn condition_is_met(
+    condition: &MatchSpecCondition,
+    locked_pixi_records: &PixiRecordsByName,
+) -> bool {
+    match condition {
+        MatchSpecCondition::MatchSpec(spec) => locked_pixi_records
+            .records
+            .iter()
+            .any(|record| spec.matches(record)),
+        MatchSpecCondition::And(lhs, rhs) => {
+            condition_is_met(lhs, locked_pixi_records) && condition_is_met(rhs, locked_pixi_records)
+        }
+        MatchSpecCondition::Or(lhs, rhs) => {
+            condition_is_met(lhs, locked_pixi_records) || condition_is_met(rhs, locked_pixi_records)
+        }
+    }
+}
 
 fn find_matching_package(
     locked_pixi_records: &PixiRecordsByName,

--- a/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@source-extra-dependency-added.snap
+++ b/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@source-extra-dependency-added.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/tests.rs
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project for platform 'win-64'
+    Diagnostic severity: error
+    Caused by: the resolved extra group 'test' of source package 'source' no longer matches what the backend would re-derive from the manifest; added: extra-pkg >=1

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -637,7 +637,7 @@ fn verify_locked_against_backend_specs(
                         package: package.as_source().to_string(),
                         env,
                         name: dep_name.as_source().to_string(),
-                        location: resolved.location.to_string(),
+                        location: resolved.to_string(),
                     }));
                 }
             }
@@ -821,7 +821,7 @@ mod tests {
         PartialSourceRecordData, PinnedPathSpec, PinnedSourceSpec, SourceRecordData,
         UnresolvedPixiRecord, UnresolvedSourceRecord,
     };
-    use pixi_spec::{SourceAnchor, SourceLocationSpec};
+    use pixi_spec::{SourceAnchor, SourceSpec};
     use rattler_conda_types::{
         ChannelConfig, NoArchType, PackageName, PackageRecord, Platform, RepoDataRecord,
         VersionSpec, VersionWithSource, package::DistArchiveIdentifier,
@@ -1001,11 +1001,9 @@ mod tests {
             depends: vec![binary_dep("numpy", ">=1")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let result = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1030,11 +1028,9 @@ mod tests {
             depends: vec![binary_dep("numpy", ">=2")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let err = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1072,11 +1068,9 @@ mod tests {
             depends: vec![binary_dep("bar", "")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let err = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1106,11 +1100,9 @@ mod tests {
             depends: vec![binary_dep("cmake", "")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
         let err = verify_locked_against_backend_specs(
             &deps,
             &locked,
@@ -1172,11 +1164,9 @@ mod tests {
             depends: vec![pin_compatible_dep("numpy")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
 
         let err = verify_locked_against_backend_specs(
             &host_deps,
@@ -1216,11 +1206,9 @@ mod tests {
             depends: vec![pin_compatible_dep("numpy")],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
 
         let result = verify_locked_against_backend_specs(
             &host_deps,
@@ -1262,11 +1250,9 @@ mod tests {
             )],
             constraints: Vec::new(),
         };
-        let anchor = SourceAnchor::from(SourceLocationSpec::from(PinnedSourceSpec::Path(
-            PinnedPathSpec {
-                path: "./pkg".into(),
-            },
-        )));
+        let anchor = SourceAnchor::from(SourceSpec::from(PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        })));
 
         let err = verify_locked_against_backend_specs(
             &host_deps,

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use pixi_command_dispatcher::{
     CommandDispatcherError,
     build::{
-        Dependencies, PixiRunExports, dependencies::filter_match_specs,
+        Dependencies, PixiRunExports, convert_extra_dependencies, dependencies::filter_match_specs,
         pin_compatible::PinCompatibilityMap,
     },
 };
@@ -322,6 +322,53 @@ fn verify_locked_run_deps_against_backend(
         .collect::<Result<Vec<_>, _>>()?;
     diff_dep_sequences(record.constrains(), &expected_constrains)
         .map_err(|diff| diff.into_unsat(record.name(), SourceRunDepKind::RunConstrains))?;
+
+    // Verify the extra groups the backend declares still match what the lock
+    // file carries. Mirror the solve-path
+    // stringification in `resolve_source_record` exactly (resolve against the
+    // same pin-compatibility map, then `to_match_spec`) so the comparison is
+    // byte-for-byte. Without this, a manifest edit to an extra group goes
+    // unnoticed and the stale lock is treated as satisfied.
+    let expected_extras: std::collections::BTreeMap<String, Vec<String>> =
+        convert_extra_dependencies(&matching_output.extra_dependencies, None, &compat_map)
+            .map_err(|err| {
+                Box::new(PlatformUnsat::SourcePackageMetadataChanged(
+                    record.name().as_source().to_string(),
+                    err.to_string(),
+                ))
+            })?
+            .into_iter()
+            .map(|(group, specs)| {
+                let strings = specs
+                    .into_specs()
+                    .map(|(name, spec)| {
+                        spec.to_match_spec(&name, channel_config)
+                            .map(|m| m.to_string())
+                            .map_err(|err| spec_unsat(&name, &err))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((group.into_inner(), strings))
+            })
+            .collect::<Result<std::collections::BTreeMap<String, Vec<String>>, Box<PlatformUnsat>>>(
+            )?;
+
+    // Compare every group present on either side. A group missing from one
+    // side compares against the empty list, so an added group surfaces as
+    // `added` and a dropped group as `removed`.
+    let locked_extras = record.experimental_extra_depends();
+    let empty: Vec<String> = Vec::new();
+    for group in locked_extras.keys().chain(expected_extras.keys()) {
+        let locked = locked_extras.get(group).unwrap_or(&empty);
+        let expected = expected_extras.get(group).unwrap_or(&empty);
+        diff_dep_sequences(locked, expected).map_err(|diff| {
+            Box::new(PlatformUnsat::SourceExtraDependenciesChanged {
+                package: record.name().as_source().to_string(),
+                group: group.clone(),
+                added: diff.added,
+                removed: diff.removed,
+            })
+        })?;
+    }
 
     Ok(())
 }
@@ -810,8 +857,8 @@ mod tests {
         verify_locked_against_backend_specs,
     };
     use pixi_build_types::{
-        BinaryPackageSpec, NamedSpec, PackageSpec, PinCompatibleSpec, SourcePackageName,
-        VariantValue,
+        BinaryPackageSpec, ExtraGroupName, NamedSpec, PackageSpec, PinCompatibleSpec,
+        SourcePackageName, VariantValue,
         procedures::conda_outputs::{
             CondaOutput, CondaOutputDependencies, CondaOutputIgnoreRunExports, CondaOutputMetadata,
             CondaOutputRunExports,
@@ -1490,6 +1537,116 @@ mod tests {
                 assert_eq!(removed, vec!["bar <2".to_string()]);
             }
             other => panic!("expected RunConstrains drift, got: {other}"),
+        }
+    }
+
+    /// Build an `extra_dependencies` map carrying a single group.
+    fn extra_group(
+        group: &str,
+        deps: Vec<NamedSpec<PackageSpec>>,
+    ) -> BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> {
+        let mut map = BTreeMap::new();
+        map.insert(ExtraGroupName::new(group.to_string()).unwrap(), deps);
+        map
+    }
+
+    /// A locked record whose extras match what the backend re-derives
+    /// must verify clean.
+    #[test]
+    fn verify_locked_run_deps_passes_when_extras_match() {
+        let mut record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        if let SourceRecordData::Full(full) = &mut record.data {
+            full.package_record.experimental_extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["extra-pkg >=1".to_string()])]);
+        }
+        let mut output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+        output.extra_dependencies = extra_group("test", vec![binary_dep("extra-pkg", ">=1")]);
+
+        let result = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG);
+        assert!(result.is_ok(), "matching extras must not drift: {result:?}");
+    }
+
+    /// The backend declares an extra group the locked record never
+    /// captured. Editing `[package.run-dependencies.<group>]` in the
+    /// manifest must invalidate the lock, surfacing the new spec.
+    #[test]
+    fn verify_locked_run_deps_detects_extra_group_addition() {
+        let record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        let mut output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+        output.extra_dependencies = extra_group("test", vec![binary_dep("extra-pkg", ">=1")]);
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("backend added an extra group the lock file lacks");
+        match *err {
+            super::super::PlatformUnsat::SourceExtraDependenciesChanged {
+                group,
+                added,
+                removed,
+                ..
+            } => {
+                assert_eq!(group, "test");
+                assert_eq!(added, vec!["extra-pkg >=1".to_string()]);
+                assert!(removed.is_empty());
+            }
+            other => panic!("expected SourceExtraDependenciesChanged, got: {other}"),
+        }
+    }
+
+    /// The locked record carries an extra group the backend no longer
+    /// declares. The stale spec must surface as a removal.
+    #[test]
+    fn verify_locked_run_deps_detects_extra_group_removal() {
+        let mut record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        if let SourceRecordData::Full(full) = &mut record.data {
+            full.package_record.experimental_extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["extra-pkg >=1".to_string()])]);
+        }
+        let output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("backend dropped an extra group that's still locked");
+        match *err {
+            super::super::PlatformUnsat::SourceExtraDependenciesChanged {
+                group,
+                added,
+                removed,
+                ..
+            } => {
+                assert_eq!(group, "test");
+                assert!(added.is_empty());
+                assert_eq!(removed, vec!["extra-pkg >=1".to_string()]);
+            }
+            other => panic!("expected SourceExtraDependenciesChanged, got: {other}"),
+        }
+    }
+
+    /// The group is present on both sides but its dependency spec
+    /// changed (e.g. the manifest bumped the version bound). The drift
+    /// must report both the new and the old spec.
+    #[test]
+    fn verify_locked_run_deps_detects_extra_spec_change() {
+        let mut record = make_full_source_record("pkg", Vec::new(), Vec::new());
+        if let SourceRecordData::Full(full) = &mut record.data {
+            full.package_record.experimental_extra_depends =
+                BTreeMap::from([("test".to_string(), vec!["extra-pkg >=1".to_string()])]);
+        }
+        let mut output = make_conda_output_with_run_deps("pkg", Vec::new(), Vec::new());
+        output.extra_dependencies = extra_group("test", vec![binary_dep("extra-pkg", ">=2")]);
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("the extra group's spec changed bound");
+        match *err {
+            super::super::PlatformUnsat::SourceExtraDependenciesChanged {
+                group,
+                added,
+                removed,
+                ..
+            } => {
+                assert_eq!(group, "test");
+                assert_eq!(added, vec!["extra-pkg >=2".to_string()]);
+                assert_eq!(removed, vec!["extra-pkg >=1".to_string()]);
+            }
+            other => panic!("expected SourceExtraDependenciesChanged, got: {other}"),
         }
     }
 }

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -372,6 +372,11 @@ impl Workspace {
             miette::bail!("lock file not up-to-date with the workspace");
         }
 
+        // The environments whose conda dependencies are about to be re-solved.
+        // Captured before `outdated` is moved so we can validate their requested
+        // extras against the freshly solved records.
+        let solved_conda_environments: Vec<_> = outdated.conda.keys().cloned().collect();
+
         let LockFileDerivedData {
             lock_file,
             package_cache,
@@ -391,6 +396,11 @@ impl Workspace {
             .await?
             .update()
             .await?;
+
+        warn_unknown_requested_extras(
+            &solved_conda_environments,
+            &lock_file_derived_data.lock_file,
+        );
 
         // Write the lock file to disk
 
@@ -1314,6 +1324,86 @@ fn locked_packages_to_unresolved_records(
         .into_iter()
         .filter_map(|pkg| resolver.get_for_package(pkg))
         .collect()
+}
+
+/// Warns for every conda extra requested in the manifest that the resolved
+/// package does not declare. The solver drops unknown extras silently,
+/// so this surfaces likely typos without changing the
+/// resolution outcome.
+///
+/// Only the environments that were just solved are inspected, and warnings are
+/// deduplicated to one per `(package, extra)` across the whole update.
+fn warn_unknown_requested_extras(
+    solved_environments: &[crate::workspace::Environment<'_>],
+    lock_file: &LockFile,
+) {
+    let mut warned: HashSet<(rattler_conda_types::PackageName, String)> = HashSet::new();
+    for environment in solved_environments {
+        let Some(locked_environment) = lock_file.environment(environment.name().as_str()) else {
+            continue;
+        };
+
+        // Union the extras each resolved package declares across every locked
+        // platform. An extra can in principle exist on one platform's build but
+        // not another's; treat it as existing if any platform declares it.
+        // Source packages are commonly stored with only partial metadata, where
+        // `record()` is `None` but the extras live on the partial metadata.
+        let mut declared_extras: HashMap<String, HashSet<String>> = HashMap::new();
+        for (_, packages) in locked_environment.conda_packages_by_platform() {
+            for package in packages {
+                let extra_keys: Vec<String> = if let Some(record) = package.record() {
+                    record.experimental_extra_depends.keys().cloned().collect()
+                } else if let Some(partial) = package
+                    .as_source()
+                    .and_then(|source| source.metadata.as_partial())
+                {
+                    partial.experimental_extra_depends.keys().cloned().collect()
+                } else {
+                    Vec::new()
+                };
+                declared_extras
+                    .entry(package.name().as_normalized().to_string())
+                    .or_default()
+                    .extend(extra_keys);
+            }
+        }
+
+        let dependencies = environment.combined_dependencies(None);
+        for (name, spec) in dependencies.iter_specs() {
+            let Some(requested_extras) = spec.extras() else {
+                continue;
+            };
+            let Some(available) = declared_extras.get(name.as_normalized()) else {
+                // The package was not resolved here; nothing to validate against.
+                continue;
+            };
+            for extra in requested_extras {
+                if available.contains(extra) {
+                    continue;
+                }
+                if !warned.insert((name.clone(), extra.clone())) {
+                    continue;
+                }
+                tracing::warn!(
+                    "{}",
+                    format_unknown_extra_warning(name.as_normalized(), extra, available)
+                );
+            }
+        }
+    }
+}
+
+/// Renders the warning shown when a requested extra does not exist, listing the
+/// extras the package actually declares (or `none` when it declares none).
+fn format_unknown_extra_warning(package: &str, extra: &str, available: &HashSet<String>) -> String {
+    let mut available: Vec<&str> = available.iter().map(String::as_str).collect();
+    available.sort_unstable();
+    let available = if available.is_empty() {
+        "no extras available".to_string()
+    } else {
+        format!("available extras: {}", available.join(", "))
+    };
+    format!("extra '{extra}' requested for '{package}' does not exist ({available})")
 }
 
 pub struct UpdateContext<'p> {
@@ -2945,10 +3035,7 @@ async fn spawn_extract_environment_task(
     let mut conda_package_names: Vec<PackageName> = Vec::new();
     for (name, spec) in combined_conda_dependencies.iter_specs() {
         conda_package_names.push(PackageName::Conda((name.clone(), None)));
-        if let Some(extras) = spec
-            .as_detailed()
-            .and_then(|detailed| detailed.extras.as_ref())
-        {
+        if let Some(extras) = spec.extras() {
             for extra in extras {
                 conda_package_names.push(PackageName::Conda((name.clone(), Some(extra.clone()))));
             }
@@ -3362,6 +3449,26 @@ mod tests {
     use super::*;
     use pixi_manifest::PyPiDependencies;
     use pixi_pypi_spec::PixiPypiSpec;
+
+    #[test]
+    fn test_format_unknown_extra_warning() {
+        let available = ["test".to_string(), "docs".to_string()]
+            .into_iter()
+            .collect();
+        insta::assert_snapshot!(
+            format_unknown_extra_warning("my-package", "nonexistent", &available),
+            @"extra 'nonexistent' requested for 'my-package' does not exist (available extras: docs, test)"
+        );
+    }
+
+    #[test]
+    fn test_format_unknown_extra_warning_no_available_extras() {
+        let available = HashSet::new();
+        insta::assert_snapshot!(
+            format_unknown_extra_warning("my-package", "nonexistent", &available),
+            @"extra 'nonexistent' requested for 'my-package' does not exist (no extras available)"
+        );
+    }
 
     #[test]
     fn test_editable_path_spec_with_registry_spec() {

--- a/crates/pixi_core/src/workspace/grouped_environment.rs
+++ b/crates/pixi_core/src/workspace/grouped_environment.rs
@@ -10,7 +10,7 @@ use pixi_manifest::{
     EnvironmentName, Feature, HasFeaturesIter, HasWorkspaceManifest, PixiPlatform,
     WorkspaceManifest,
 };
-use pixi_spec::SourceSpec;
+use pixi_spec::SourceLocationSpec;
 use pixi_utils::prefix::Prefix;
 use rattler_conda_types::{ChannelConfig, GenericVirtualPackage, PackageName};
 
@@ -125,7 +125,7 @@ impl<'p> GroupedEnvironment<'p> {
     pub fn combined_dev_dependencies(
         &self,
         platform: Option<&PixiPlatform>,
-    ) -> IndexMap<PackageName, OrderSet<SourceSpec>> {
+    ) -> IndexMap<PackageName, OrderSet<SourceLocationSpec>> {
         let mut result = IndexMap::new();
         for feature in self.features().rev() {
             if let Some(deps) = feature.dev_dependencies(platform) {

--- a/crates/pixi_global/src/project/global_spec.rs
+++ b/crates/pixi_global/src/project/global_spec.rs
@@ -49,7 +49,7 @@ impl GlobalSpec {
     }
 
     /// Converts a [`MatchSpec`] into a [`GlobalSpec`].
-    /// this can only result in a [`PixiSpec::Version`] or [`PixiSpec::DetailedVersion`] because
+    /// this can only result in a [`PixiSpec::DetailedVersion`] because
     /// a `MatchSpec` has no direct support for source specifications
     pub fn try_from_matchspec_with_name(
         match_spec: MatchSpec,

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -24,7 +24,7 @@ pub struct PackageBuild {
     /// channels from the containing workspace should be used.
     pub channels: Option<Vec<NamedChannelOrUrl>>,
 
-    /// Optional package source specification
+    /// Optional package source location
     pub source: Option<SourceLocationSpec>,
 
     /// Additional configuration for the build backend.

--- a/crates/pixi_manifest/src/dependencies.rs
+++ b/crates/pixi_manifest/src/dependencies.rs
@@ -1,9 +1,9 @@
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
-use pixi_spec::{PixiSpec, SourceSpec};
+use pixi_spec::{PixiSpec, SourceLocationSpec};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::PackageName;
 
 pub type PyPiDependencies = DependencyMap<PypiPackageName, PixiPypiSpec>;
 pub type CondaDependencies = DependencyMap<PackageName, PixiSpec>;
-pub type CondaDevDependencies = DependencyMap<PackageName, SourceSpec>;
+pub type CondaDevDependencies = DependencyMap<PackageName, SourceLocationSpec>;
 pub type CondaConstraints = DependencyMap<PackageName, PixiSpec>;

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -407,7 +407,7 @@ impl Feature {
     pub fn dev_dependencies<'a>(
         &'a self,
         platform: Option<&'a PixiPlatform>,
-    ) -> Option<Cow<'a, DependencyMap<PackageName, pixi_spec::SourceSpec>>> {
+    ) -> Option<Cow<'a, DependencyMap<PackageName, pixi_spec::SourceLocationSpec>>> {
         self.targets
             .resolve(platform)
             // Get the targets in reverse order, from least specific to most specific.

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -815,7 +815,7 @@ hTTPx = ">=0.28.1,<0.29" # Some comment.
         document
             .add_dependency(
                 &PackageName::from_str("HtTpX").unwrap(),
-                &PixiSpec::Version("0.1.*".parse().unwrap()),
+                &PixiSpec::from("0.1.*".parse::<rattler_conda_types::VersionSpec>().unwrap()),
                 SpecType::Run,
                 None,
                 &FeatureName::default(),

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -801,7 +801,7 @@ mod tests {
 
         // Add foo = "==2.0" with Overwrite behavior
         let foo = PackageName::from_str("foo").unwrap();
-        let spec = PixiSpec::Version(
+        let spec = PixiSpec::from(
             VersionSpec::from_str("==2.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
 
@@ -853,7 +853,7 @@ mod tests {
         let foo = PackageName::from_str("foo").unwrap();
 
         // Add foo = "==1.0"
-        let spec1 = PixiSpec::Version(
+        let spec1 = PixiSpec::from(
             VersionSpec::from_str("==1.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
         manifest_mut
@@ -868,7 +868,7 @@ mod tests {
             .unwrap();
 
         // Add foo = "==2.0" (should overwrite)
-        let spec2 = PixiSpec::Version(
+        let spec2 = PixiSpec::from(
             VersionSpec::from_str("==2.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
         manifest_mut
@@ -883,7 +883,7 @@ mod tests {
             .unwrap();
 
         // Add foo = "==3.0" (should overwrite again)
-        let spec3 = PixiSpec::Version(
+        let spec3 = PixiSpec::from(
             VersionSpec::from_str("==3.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
         manifest_mut
@@ -936,7 +936,7 @@ mod tests {
 
         // Try to add foo = "==2.0" with IgnoreDuplicate
         let foo = PackageName::from_str("foo").unwrap();
-        let spec = PixiSpec::Version(
+        let spec = PixiSpec::from(
             VersionSpec::from_str("==2.0", rattler_conda_types::ParseStrictness::Strict).unwrap(),
         );
 

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -1375,7 +1375,6 @@ mod test {
         let spec = &pkg.build.backend.spec;
         // The resolved backend spec must carry the workspace-declared version.
         match spec {
-            pixi_spec::PixiSpec::Version(v) => assert_eq!(v.to_string(), "==1.2.3"),
             pixi_spec::PixiSpec::DetailedVersion(detailed) => {
                 assert_eq!(detailed.version.as_ref().unwrap().to_string(), "==1.2.3")
             }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__config_parsing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 333
 expression: parsed.value
 ---
 PackageBuild {

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
-use pixi_spec::{PixiSpec, SourceSpec, TomlLocationSpec};
+use pixi_spec::{PixiSpec, TomlLocationSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_toml::{TomlHashMap, TomlIndexMap};
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
@@ -74,7 +74,7 @@ impl TomlTarget {
             }
         }
 
-        // Convert dev dependencies from TomlLocationSpec to SourceSpec
+        // Convert dev dependencies from TomlLocationSpec to SourceLocationSpec
         let dev_dependencies = self
             .dev_dependencies
             .map(|dev_map| {
@@ -83,7 +83,7 @@ impl TomlTarget {
                     .map(|(name, toml_loc)| {
                         toml_loc
                             .into_source_location_spec()
-                            .map(|location| (name, SourceSpec::from(location)))
+                            .map(|location| (name, location))
                     })
                     .collect::<Result<IndexMap<_, _>, _>>()
             })

--- a/crates/pixi_pypi_spec/src/lib.rs
+++ b/crates/pixi_pypi_spec/src/lib.rs
@@ -28,6 +28,7 @@ pub use version_or_star::VersionOrStar;
 /// - `Url`: From a direct URL to a package archive
 #[derive(Debug, Serialize, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged, rename_all = "kebab-case")]
+#[allow(clippy::large_enum_variant)]
 pub enum PixiPypiSource {
     /// From a package registry with version constraints.
     Registry {
@@ -349,11 +350,11 @@ mod tests {
     #[test]
     fn test_is_source_dependency_for_git() {
         let spec = PixiPypiSpec::new(PixiPypiSource::Git {
-            git: GitSpec {
-                git: Url::parse("https://github.com/example/repo").unwrap(),
-                rev: None,
-                subdirectory: Default::default(),
-            },
+            git: GitSpec::new(
+                Url::parse("https://github.com/example/repo").unwrap(),
+                None,
+                Default::default(),
+            ),
         });
         assert!(spec.is_source_dependency());
     }
@@ -395,11 +396,11 @@ mod tests {
         // Spec with extras
         let spec = PixiPypiSpec::with_extras_and_markers(
             PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/example/repo").unwrap(),
-                    rev: None,
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/example/repo").unwrap(),
+                    None,
+                    Default::default(),
+                ),
             },
             vec![extra.clone()],
             MarkerTree::default(),
@@ -420,11 +421,11 @@ mod tests {
         // Spec with markers
         let spec = PixiPypiSpec::with_extras_and_markers(
             PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/example/repo").unwrap(),
-                    rev: None,
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/example/repo").unwrap(),
+                    None,
+                    Default::default(),
+                ),
             },
             vec![],
             markers.clone(),
@@ -570,11 +571,11 @@ mod tests {
         assert_eq!(
             as_pypi_req,
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
-                    rev: Some(GitReference::DefaultBranch),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
+                    Some(GitReference::DefaultBranch),
+                    Default::default()
+                ),
             })
         );
 
@@ -583,13 +584,13 @@ mod tests {
         assert_eq!(
             as_pypi_req,
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
-                    rev: Some(GitReference::Rev(
+                git: GitSpec::new(
+                    Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
+                    Some(GitReference::Rev(
                         "b283011c6df4a9e034baca9aea19aa8e5a70e3ab".to_string()
                     )),
-                    subdirectory: Default::default(),
-                },
+                    Default::default()
+                ),
             })
         );
 
@@ -678,11 +679,11 @@ mod tests {
         assert_eq!(
             PixiPypiSpec::try_from(parsed).unwrap(),
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
-                    rev: Some(GitReference::Rev("main".to_string())),
-                    subdirectory: Default::default()
-                },
+                git: GitSpec::new(
+                    Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
+                    Some(GitReference::Rev("main".to_string())),
+                    Default::default()
+                ),
             })
         );
 
@@ -694,11 +695,11 @@ mod tests {
         assert_eq!(
             PixiPypiSpec::try_from(parsed).unwrap(),
             PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
-                    rev: Some(GitReference::DefaultBranch),
-                    subdirectory: Subdirectory::try_from("python/ribasim").unwrap(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
+                    Some(GitReference::DefaultBranch),
+                    Subdirectory::try_from("python/ribasim").unwrap()
+                ),
             })
         );
     }

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -27,11 +27,11 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             "git" => {
                                 let subdirectory = extract_directory_from_url(&url);
                                 let git_url = GitUrl::try_from(url).unwrap();
-                                let git_spec = GitSpec {
-                                    git: git_url.repository().clone(),
-                                    rev: Some(git_url.reference().clone().into()),
+                                let git_spec = GitSpec::new(
+                                    git_url.repository().clone(),
+                                    Some(git_url.reference().clone().into()),
                                     subdirectory,
-                                };
+                                );
 
                                 PixiPypiSpec::with_extras_and_markers(
                                     PixiPypiSource::Git { git: git_spec },
@@ -74,11 +74,11 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                     {
                         let git_url = GitUrl::try_from(url).unwrap();
                         let subdirectory = extract_directory_from_url(git_url.repository());
-                        let git_spec = GitSpec {
-                            git: git_url.repository().clone(),
-                            rev: Some(git_url.reference().clone().into()),
+                        let git_spec = GitSpec::new(
+                            git_url.repository().clone(),
+                            Some(git_url.reference().clone().into()),
                             subdirectory,
-                        };
+                        );
                         PixiPypiSpec::with_extras_and_markers(
                             PixiPypiSource::Git { git: git_spec },
                             req.extras,

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -150,15 +150,14 @@ impl RawPyPiRequirement {
                 };
                 PixiPypiSpec::with_extras_and_markers(
                     PixiPypiSource::Git {
-                        git: GitSpec {
+                        git: GitSpec::new(
                             git,
                             rev,
-                            subdirectory: self
-                                .subdirectory
+                            self.subdirectory
                                 .map(pixi_spec::Subdirectory::try_from)
                                 .transpose()?
                                 .unwrap_or_default(),
-                        },
+                        ),
                     },
                     self.extras,
                     self.marker,
@@ -336,6 +335,7 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         git,
                         rev,
                         subdirectory,
+                        matchspec: _,
                     },
             } => {
                 let mut table = toml_edit::Table::new().into_inline_table();
@@ -678,11 +678,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: None,
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    None,
+                    Default::default()
+                ),
             })
         );
     }
@@ -697,11 +697,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: Some(GitReference::Branch("main".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    Some(GitReference::Branch("main".to_string())),
+                    Default::default()
+                ),
             })
         );
     }
@@ -716,11 +716,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: Some(GitReference::Tag("v.1.2.3".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    Some(GitReference::Tag("v.1.2.3".to_string())),
+                    Default::default()
+                ),
             })
         );
     }
@@ -735,11 +735,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://github.com/pallets/flask.git").unwrap(),
-                    rev: Some(GitReference::Tag("3.0.0".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://github.com/pallets/flask.git").unwrap(),
+                    Some(GitReference::Tag("3.0.0".to_string())),
+                    Default::default()
+                ),
             }),
         );
     }
@@ -754,11 +754,11 @@ mod test {
         assert_eq!(
             requirement.first().unwrap().1,
             &PixiPypiSpec::new(PixiPypiSource::Git {
-                git: GitSpec {
-                    git: Url::parse("https://test.url.git").unwrap(),
-                    rev: Some(GitReference::Rev("123456".to_string())),
-                    subdirectory: Default::default(),
-                },
+                git: GitSpec::new(
+                    Url::parse("https://test.url.git").unwrap(),
+                    Some(GitReference::Rev("123456".to_string())),
+                    Default::default()
+                ),
             })
         );
     }

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -7,7 +7,8 @@ use pixi_git::{
 };
 use pixi_path::normalize::normalize_typed;
 use pixi_spec::{
-    GitReference, GitSpec, PathSourceSpec, SourceLocationSpec, Subdirectory, UrlSourceSpec,
+    GitLocationSpec, GitReference, GitSpec, PathSourceSpec, PathSpec, SourceLocationSpec,
+    SourceSpec, Subdirectory, UrlSourceSpec, UrlSpec,
 };
 use rattler_digest::{Md5Hash, Sha256Hash};
 use rattler_lock::UrlOrPath;
@@ -148,7 +149,7 @@ impl PinnedSourceSpec {
     ///
     /// ```
     /// use pixi_record::{PinnedSourceSpec, PinnedGitSpec, PinnedGitCheckout};
-    /// use pixi_spec::{SourceSpec, SourceLocationSpec, GitSpec, GitReference};
+    /// use pixi_spec::{GitReference, GitSpec, SourceSpec};
     /// use pixi_git::sha::GitSha;
     /// use url::Url;
     /// use std::str::FromStr;
@@ -164,18 +165,18 @@ impl PinnedSourceSpec {
     ///     },
     /// });
     ///
-    /// let source_spec = SourceLocationSpec::Git(GitSpec {
-    ///     git: Url::parse("https://github.com/user/repo.git")?,
-    ///     rev: None,
-    ///     subdirectory: Default::default(),
-    /// });
+    /// let source_spec = SourceSpec::from(GitSpec::new(
+    ///     Url::parse("https://github.com/user/repo.git")?,
+    ///     None,
+    ///     Default::default(),
+    /// ));
     ///
-    /// assert!(pinned_git.matches_source_spec(&source_spec));
+    /// assert!(pinned_git.matches_source_spec(&source_spec.location));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn matches_source_spec(&self, source_spec: &SourceLocationSpec) -> bool {
-        match (self, &source_spec) {
+    pub fn matches_source_spec(&self, location: &SourceLocationSpec) -> bool {
+        match (self, location) {
             // Path sources: paths must be exactly equal
             (PinnedSourceSpec::Path(pinned_path), SourceLocationSpec::Path(source_path)) => {
                 pinned_path.path == source_path.path
@@ -768,7 +769,7 @@ pub enum SourceMismatchError {
 impl PinnedPathSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked path satisfies the requested path.
-    pub fn satisfies(&self, spec: &PathSourceSpec) -> Result<(), SourceMismatchError> {
+    pub fn satisfies(&self, spec: &PathSpec) -> Result<(), SourceMismatchError> {
         if spec.path.normalize() != self.path.normalize() {
             return Err(SourceMismatchError::PathMismatch {
                 locked: self.path.clone(),
@@ -782,7 +783,7 @@ impl PinnedPathSpec {
 impl PinnedUrlSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked url satisfies the requested url.
-    pub fn satisfies(&self, spec: &UrlSourceSpec) -> Result<(), SourceMismatchError> {
+    pub fn satisfies(&self, spec: &UrlSpec) -> Result<(), SourceMismatchError> {
         if spec.url != self.url {
             return Err(SourceMismatchError::UrlMismatch {
                 locked: self.url.clone(),
@@ -834,7 +835,7 @@ impl PinnedUrlSpec {
 impl PinnedGitSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked git url satisfies the requested git url.
-    pub fn satisfies(&self, spec: &GitSpec) -> Result<(), SourceMismatchError> {
+    pub fn satisfies(&self, spec: &GitLocationSpec) -> Result<(), SourceMismatchError> {
         let mut to_be_redacted = spec.git.clone();
         redact_credentials(&mut to_be_redacted);
 
@@ -873,8 +874,8 @@ impl PinnedGitSpec {
 impl PinnedSourceSpec {
     #[allow(clippy::result_large_err)]
     /// Verifies if the locked source satisfies the requested source.
-    pub fn satisfies(&self, spec: &SourceLocationSpec) -> Result<(), SourceMismatchError> {
-        match (self, &spec) {
+    pub fn satisfies(&self, spec: &SourceSpec) -> Result<(), SourceMismatchError> {
+        match (self, &spec.location) {
             (PinnedSourceSpec::Path(locked), SourceLocationSpec::Path(spec)) => {
                 locked.satisfies(spec)
             }
@@ -917,41 +918,41 @@ impl Display for PinnedGitSpec {
     }
 }
 
-impl From<PinnedSourceSpec> for SourceLocationSpec {
+impl From<PinnedSourceSpec> for SourceSpec {
     fn from(value: PinnedSourceSpec) -> Self {
         match value {
-            PinnedSourceSpec::Url(url) => SourceLocationSpec::Url(url.into()),
-            PinnedSourceSpec::Git(git) => SourceLocationSpec::Git(git.into()),
-
-            PinnedSourceSpec::Path(path) => SourceLocationSpec::Path(path.into()),
+            PinnedSourceSpec::Url(url) => UrlSourceSpec::from(url).into(),
+            PinnedSourceSpec::Git(git) => GitSpec::from(git).into(),
+            PinnedSourceSpec::Path(path) => PathSourceSpec::from(path).into(),
         }
+    }
+}
+
+impl From<PinnedSourceSpec> for SourceLocationSpec {
+    fn from(value: PinnedSourceSpec) -> Self {
+        SourceSpec::from(value).location
     }
 }
 
 impl From<PinnedPathSpec> for PathSourceSpec {
     fn from(value: PinnedPathSpec) -> Self {
-        Self { path: value.path }
+        Self::new(value.path)
     }
 }
 
 impl From<PinnedUrlSpec> for UrlSourceSpec {
     fn from(value: PinnedUrlSpec) -> Self {
-        Self {
-            url: value.url,
-            sha256: Some(value.sha256),
-            md5: value.md5,
-            subdirectory: value.subdirectory,
-        }
+        Self::new(value.url, value.md5, Some(value.sha256), value.subdirectory)
     }
 }
 
 impl From<PinnedGitSpec> for GitSpec {
     fn from(value: PinnedGitSpec) -> Self {
-        Self {
-            git: value.git,
-            subdirectory: value.source.subdirectory,
-            rev: Some(value.source.reference),
-        }
+        Self::new(
+            value.git,
+            Some(value.source.reference),
+            value.source.subdirectory,
+        )
     }
 }
 
@@ -982,9 +983,10 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec);
+        let result = locked_git_spec.satisfies(&requested_git_spec.location());
 
         assert!(result.is_ok());
 
@@ -1001,9 +1003,10 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec);
+        let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec.location());
 
         assert!(result.is_ok());
 
@@ -1020,9 +1023,10 @@ mod tests {
             git: Url::parse("https://github.com/example/repo").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix);
+        let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix.location());
 
         assert!(result.is_ok());
 
@@ -1039,9 +1043,10 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec);
+        let result = locked_git_spec.satisfies(&requested_git_spec.location());
 
         assert!(result.is_ok());
 
@@ -1058,9 +1063,10 @@ mod tests {
             git: Url::parse("git+https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix);
+        let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix.location());
 
         result.unwrap();
 
@@ -1082,9 +1088,12 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("d2e32".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
+        let result = locked_git_spec
+            .satisfies(&requested_git_spec.location())
+            .unwrap_err();
         assert!(matches!(result, SourceMismatchError::GitRevMismatch { .. }));
     }
 
@@ -1103,9 +1112,12 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
+        let result = locked_git_spec
+            .satisfies(&requested_git_spec.location())
+            .unwrap_err();
         assert!(matches!(result, SourceMismatchError::UrlMismatch { .. }));
     }
 
@@ -1126,9 +1138,10 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec);
+        let result = locked_git_spec.satisfies(&requested_git_spec.location());
         assert!(result.is_ok());
     }
 
@@ -1149,9 +1162,12 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
+        let result = locked_git_spec
+            .satisfies(&requested_git_spec.location())
+            .unwrap_err();
         assert!(matches!(
             result,
             SourceMismatchError::GitSubdirectoryMismatch { .. }
@@ -1173,16 +1189,19 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            matchspec: pixi_spec::MatchspecFields::default(),
         };
 
-        let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
+        let result = locked_git_spec
+            .satisfies(&requested_git_spec.location())
+            .unwrap_err();
         assert!(matches!(
             result,
             SourceMismatchError::GitSubdirectoryMismatch { .. }
         ));
     }
 
-    use pixi_spec::{PathSourceSpec, SourceLocationSpec, UrlSourceSpec};
+    use pixi_spec::{PathSourceSpec, SourceSpec, UrlSourceSpec};
     use typed_path::Utf8TypedPathBuf;
 
     #[test]
@@ -1191,11 +1210,12 @@ mod tests {
             path: Utf8TypedPathBuf::from("/path/to/source"),
         });
 
-        let spec = SourceLocationSpec::Path(PathSourceSpec {
+        let spec = SourceSpec::from(PathSourceSpec {
             path: Utf8TypedPathBuf::from("/path/to/source"),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1204,11 +1224,12 @@ mod tests {
             path: Utf8TypedPathBuf::from("/path/to/source"),
         });
 
-        let spec = SourceLocationSpec::Path(PathSourceSpec {
+        let spec = SourceSpec::from(PathSourceSpec {
             path: Utf8TypedPathBuf::from("/different/path"),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1222,14 +1243,15 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo.git").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match despite .git suffix difference
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1243,14 +1265,15 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match despite .git suffix difference
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1264,13 +1287,14 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo2").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1284,14 +1308,15 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match - spec doesn't care about subdirectory
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1305,13 +1330,14 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1325,13 +1351,14 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir2").unwrap(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1345,14 +1372,15 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should not match - spec requires a subdirectory that pinned doesn't have
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1367,14 +1395,15 @@ mod tests {
             subdirectory: Default::default(),
         });
 
-        let spec = SourceLocationSpec::Url(UrlSourceSpec {
+        let spec = SourceSpec::from(UrlSourceSpec {
             url: Url::parse("https://example.com/archive.tar.gz").unwrap(),
             sha256: None,
             md5: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1389,14 +1418,15 @@ mod tests {
             subdirectory: Default::default(),
         });
 
-        let spec = SourceLocationSpec::Url(UrlSourceSpec {
+        let spec = SourceSpec::from(UrlSourceSpec {
             url: Url::parse("https://example.com/different.tar.gz").unwrap(),
             sha256: None,
             md5: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1405,13 +1435,14 @@ mod tests {
             path: Utf8TypedPathBuf::from("/path/to/source"),
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1425,14 +1456,15 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Url(UrlSourceSpec {
+        let spec = SourceSpec::from(UrlSourceSpec {
             url: Url::parse("https://example.com/archive.tar.gz").unwrap(),
             sha256: None,
             md5: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1447,11 +1479,12 @@ mod tests {
             subdirectory: Default::default(),
         });
 
-        let spec = SourceLocationSpec::Path(PathSourceSpec {
+        let spec = SourceSpec::from(PathSourceSpec {
             path: Utf8TypedPathBuf::from("/path/to/source"),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1469,13 +1502,14 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Rev("v2.0.0".to_string())),
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(!pinned.matches_source_spec(&spec));
+        assert!(!pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1491,13 +1525,14 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Branch("main".to_string())),
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]
@@ -1511,14 +1546,15 @@ mod tests {
             },
         });
 
-        let spec = SourceLocationSpec::Git(GitSpec {
+        let spec = SourceSpec::from(GitSpec {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            matchspec: pixi_spec::MatchspecFields::default(),
         });
 
         // Should match - GitHub URLs are case-insensitive
-        assert!(pinned.matches_source_spec(&spec));
+        assert!(pinned.matches_source_spec(&spec.location));
     }
 
     #[test]

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -686,6 +686,14 @@ impl SourceRecord<SourceRecordData> {
         }
     }
 
+    /// Extra groups, keyed by group name.
+    pub fn experimental_extra_depends(&self) -> &BTreeMap<String, Vec<String>> {
+        match &self.data {
+            SourceRecordData::Full(full) => &full.package_record.experimental_extra_depends,
+            SourceRecordData::Partial(partial) => &partial.experimental_extra_depends,
+        }
+    }
+
     /// Source dependency locations.
     pub fn sources(&self) -> &BTreeMap<String, SourceLocationSpec> {
         match &self.data {

--- a/crates/pixi_spec/src/dev_source.rs
+++ b/crates/pixi_spec/src/dev_source.rs
@@ -4,7 +4,7 @@
 //! Development sources are source packages whose dependencies should be installed
 //! without building the package itself - useful for development environments.
 
-use crate::SourceSpec;
+use crate::SourceLocationSpec;
 
 /// A development source specification as provided by the user (e.g., from pixi.toml).
 ///
@@ -25,11 +25,11 @@ use crate::SourceSpec;
 /// This would be represented as:
 /// ```ignore
 /// DevSourceSpec {
-///     source: SourceSpec::Path(PathSourceSpec { path: "../my-package" }),
+///     source: SourceLocationSpec::Path(PathSpec { path: "../my-package" }),
 /// }
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Serialize)]
 pub struct DevSourceSpec {
-    /// The source specification (path/git/url)
-    pub source: SourceSpec,
+    /// The source location (path/git/url)
+    pub source: SourceLocationSpec,
 }

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -5,9 +5,10 @@ use serde::{Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
 
-use crate::Subdirectory;
+use crate::{MatchspecFields, Subdirectory};
 
-/// A specification of a package from a git repository.
+/// A specification of a package from a git repository, optionally
+/// constrained by match-spec selectors (`version`, `build`, `extras`, …).
 #[derive(Debug, Clone, Hash, Eq, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct GitSpec {
@@ -21,9 +22,90 @@ pub struct GitSpec {
     /// The git subdirectory of the package
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Match-spec selectors applied to the built output (flattened).
+    #[serde(flatten)]
+    pub matchspec: MatchspecFields,
+}
+
+impl GitSpec {
+    /// Constructs a new [`GitSpec`] with no matchspec selectors.
+    pub fn new(git: Url, rev: Option<GitReference>, subdirectory: Subdirectory) -> Self {
+        Self {
+            git,
+            rev,
+            subdirectory,
+            matchspec: MatchspecFields::default(),
+        }
+    }
+
+    /// Returns the git location without any match-spec selectors.
+    pub fn location(&self) -> GitLocationSpec {
+        GitLocationSpec {
+            git: self.git.clone(),
+            rev: self.rev.clone(),
+            subdirectory: self.subdirectory.clone(),
+        }
+    }
+
+    /// Splits this spec into its location and its match-spec selectors.
+    pub fn into_location(self) -> GitLocationSpec {
+        GitLocationSpec {
+            git: self.git,
+            rev: self.rev,
+            subdirectory: self.subdirectory,
+        }
+    }
 }
 
 impl Display for GitSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.location().fmt(f)
+    }
+}
+
+/// A git repository location, without any match-spec selectors.
+///
+/// This is the locating half of a [`GitSpec`]: it is enough to check out
+/// the source, but carries none of the constraints used to pick a built
+/// output.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GitLocationSpec {
+    /// The git url of the package which can contain git+ prefixes.
+    pub git: Url,
+
+    /// The git revision of the package
+    #[serde(skip_serializing_if = "GitReference::is_default_branch", flatten)]
+    pub rev: Option<GitReference>,
+
+    /// The git subdirectory of the package
+    #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
+    pub subdirectory: Subdirectory,
+}
+
+impl GitLocationSpec {
+    /// Constructs a new [`GitLocationSpec`].
+    pub fn new(git: Url, rev: Option<GitReference>, subdirectory: Subdirectory) -> Self {
+        Self {
+            git,
+            rev,
+            subdirectory,
+        }
+    }
+
+    /// Attaches match-spec selectors to this location, producing a [`GitSpec`].
+    pub fn with_matchspec(self, matchspec: MatchspecFields) -> GitSpec {
+        GitSpec {
+            git: self.git,
+            rev: self.rev,
+            subdirectory: self.subdirectory,
+            matchspec,
+        }
+    }
+}
+
+impl Display for GitLocationSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.git)?;
         if let Some(rev) = &self.rev {

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -12,6 +12,7 @@ mod detailed;
 mod dev_source;
 mod exclude_newer;
 mod git;
+mod matchspec_fields;
 mod path;
 mod pin;
 mod source_anchor;
@@ -24,13 +25,14 @@ use std::{fmt::Display, path::PathBuf, str::FromStr};
 pub use detailed::DetailedSpec;
 pub use dev_source::DevSourceSpec;
 pub use exclude_newer::{ExcludeNewer, ResolvedExcludeNewer};
-pub use git::{GitReference, GitReferenceError, GitSpec};
+pub use git::{GitLocationSpec, GitReference, GitReferenceError, GitSpec};
 use itertools::Either;
+pub use matchspec_fields::MatchspecFields;
 pub use path::{PathBinarySpec, PathSourceSpec, PathSpec};
 pub use pin::{Pin, PinBound, PinError, PinExpression};
 use rattler_conda_types::{
-    BuildNumberSpec, ChannelConfig, MatchSpec, MatchSpecCondition, NamedChannelOrUrl,
-    NamelessMatchSpec, PackageName, ParseChannelError, StringMatcher, VersionSpec,
+    ChannelConfig, MatchSpec, NamedChannelOrUrl, NamelessMatchSpec, PackageName, ParseChannelError,
+    VersionSpec, package::CondaArchiveType,
 };
 #[cfg(feature = "rattler_lock")]
 pub use rattler_lock::Verbatim;
@@ -38,6 +40,7 @@ pub use source_anchor::SourceAnchor;
 pub use subdirectory::{Subdirectory, SubdirectoryError};
 use thiserror::Error;
 pub use toml::{TomlLocationSpec, TomlSpec, TomlVersionSpecStr};
+use url::url_is_binary;
 pub use url::{UrlBinarySpec, UrlSourceSpec, UrlSpec};
 
 /// An error that is returned when a spec cannot be converted into another spec
@@ -70,6 +73,18 @@ pub enum SpecConversionError {
 /// This type can represent both source and binary packages. Use the
 /// [`Self::try_into_nameless_match_spec`] method to convert this type into a
 /// type that only represents binary packages.
+///
+/// The variants encode the binary-vs-source distinction at the type level
+/// rather than via runtime URL/path inspection; see the individual variant
+/// docs for the meaning of each.
+///
+/// `Version` and `DetailedVersion` are kept separate so the on-disk distinction
+/// between the bare string form `"*"` and the table form `{ version = "*" }`
+/// survives a serialization round-trip.
+///
+/// The binary variants do not carry matchspec selectors: a `.conda` archive
+/// is already a fully-specified package, so `version`, `build`, etc. would be
+/// meaningless.
 #[derive(Debug, Clone, Hash, ::serde::Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum PixiSpec {
@@ -84,25 +99,26 @@ pub enum PixiSpec {
     /// be retrieved from a channel.
     DetailedVersion(Box<DetailedSpec>),
 
-    /// The spec is represented as an archive that can be downloaded from the
-    /// specified URL. The package should be retrieved from the URL and can
-    /// either represent a source or binary package depending on the archive
-    /// type.
-    Url(UrlSpec),
+    /// URL pointing at a binary conda archive (`.conda` / `.tar.bz2`).
+    UrlBinary(UrlBinarySpec),
 
-    /// The spec is represented as a git repository. The package represents a
-    /// source distribution of some kind.
-    Git(GitSpec),
+    /// Local path pointing at a binary conda archive (`.conda` / `.tar.bz2`).
+    PathBinary(PathBinarySpec),
 
-    /// The spec is represented as a local path. The package should be retrieved
-    /// from the local filesystem. The package can be either a source or binary
-    /// package.
-    Path(PathSpec),
+    /// URL pointing at a source archive (e.g. `.zip`, `.tar.gz`), with
+    /// optional matchspec selectors used to pick which built output to use.
+    UrlSource(Box<UrlSourceSpec>),
+
+    /// Local directory or source path, with optional matchspec selectors.
+    PathSource(Box<PathSourceSpec>),
+
+    /// Git repository, with optional matchspec selectors.
+    Git(Box<GitSpec>),
 }
 
 impl Default for PixiSpec {
     fn default() -> Self {
-        PixiSpec::Version(VersionSpec::Any)
+        PixiSpec::any()
     }
 }
 
@@ -111,9 +127,11 @@ impl Display for PixiSpec {
         match self {
             PixiSpec::Version(version) => write!(f, "{version}"),
             PixiSpec::DetailedVersion(detailed) => write!(f, "{detailed}"),
-            PixiSpec::Url(url) => write!(f, "{url}"),
+            PixiSpec::UrlBinary(url) => write!(f, "{url}"),
+            PixiSpec::PathBinary(path) => write!(f, "{path}"),
+            PixiSpec::UrlSource(url) => write!(f, "{url}"),
+            PixiSpec::PathSource(path) => write!(f, "{path}"),
             PixiSpec::Git(git) => write!(f, "{git}"),
-            PixiSpec::Path(path) => write!(f, "{path}"),
         }
     }
 }
@@ -136,30 +154,52 @@ impl PixiSpec {
         channel_config: &ChannelConfig,
     ) -> Self {
         if let Some(url) = spec.url {
-            Self::Url(UrlSpec {
-                url,
-                md5: spec.md5,
-                sha256: spec.sha256,
-                // A nameless matchspec always describes a binary spec which cannot have a
-                // subdirectory
-                subdirectory: Subdirectory::default(),
-            })
-        } else if spec.build.is_none()
-            && spec.build_number.is_none()
-            && spec.file_name.is_none()
-            && spec.extras.is_none()
-            && spec.flags.is_none()
-            && spec.channel.is_none()
-            && spec.subdir.is_none()
-            && spec.md5.is_none()
-            && spec.sha256.is_none()
-            && spec.license.is_none()
-            && spec.license_family.is_none()
-            && spec.condition.is_none()
-            && spec.track_features.is_none()
-        {
-            Self::Version(spec.version.unwrap_or(VersionSpec::Any))
+            // Detect whether the URL points to a binary archive.
+            if url_is_binary(&url) {
+                Self::UrlBinary(UrlBinarySpec {
+                    url,
+                    md5: spec.md5,
+                    sha256: spec.sha256,
+                })
+            } else {
+                Self::UrlSource(Box::new(UrlSourceSpec {
+                    url,
+                    md5: spec.md5,
+                    sha256: spec.sha256,
+                    subdirectory: Subdirectory::default(),
+                    matchspec: MatchspecFields {
+                        version: spec.version,
+                        build: spec.build,
+                        build_number: spec.build_number,
+                        extras: spec.extras,
+                        flags: spec.flags,
+                        subdir: spec.subdir,
+                        license: spec.license,
+                        condition: spec.condition,
+                        track_features: spec.track_features,
+                    },
+                }))
+            }
         } else {
+            // A bare nameless spec (no fields other than possibly `version`)
+            // round-trips to a `PixiSpec::Version`, so it serializes as the
+            // bare string `"*"` (or `">=1"`, ...) instead of a table.
+            let is_bare = spec.build.is_none()
+                && spec.build_number.is_none()
+                && spec.file_name.is_none()
+                && spec.extras.is_none()
+                && spec.flags.is_none()
+                && spec.channel.is_none()
+                && spec.subdir.is_none()
+                && spec.md5.is_none()
+                && spec.sha256.is_none()
+                && spec.license.is_none()
+                && spec.license_family.is_none()
+                && spec.condition.is_none()
+                && spec.track_features.is_none();
+            if is_bare {
+                return Self::Version(spec.version.unwrap_or(VersionSpec::Any));
+            }
             Self::DetailedVersion(Box::new(DetailedSpec {
                 version: spec.version,
                 build: spec.build,
@@ -188,21 +228,38 @@ impl PixiSpec {
         match self {
             Self::Version(v) => v != &VersionSpec::Any,
             Self::DetailedVersion(v) => v.version.as_ref().is_some_and(|v| v != &VersionSpec::Any),
+            Self::UrlSource(u) => u
+                .matchspec
+                .version
+                .as_ref()
+                .is_some_and(|v| v != &VersionSpec::Any),
+            Self::PathSource(p) => p
+                .matchspec
+                .version
+                .as_ref()
+                .is_some_and(|v| v != &VersionSpec::Any),
+            Self::Git(g) => g
+                .matchspec
+                .version
+                .as_ref()
+                .is_some_and(|v| v != &VersionSpec::Any),
             _ => false,
         }
     }
 
-    /// Returns a [`VersionSpec`] if this instance is a version spec.
+    /// Returns a [`VersionSpec`] if this instance carries one.
     pub fn as_version_spec(&self) -> Option<&VersionSpec> {
         match self {
             Self::Version(v) => Some(v),
             Self::DetailedVersion(v) => v.version.as_ref(),
+            Self::UrlSource(u) => u.matchspec.version.as_ref(),
+            Self::PathSource(p) => p.matchspec.version.as_ref(),
+            Self::Git(g) => g.matchspec.version.as_ref(),
             _ => None,
         }
     }
 
-    /// Returns a [`DetailedSpec`] if this instance is a detailed version
-    /// spec.
+    /// Returns a [`DetailedSpec`] if this instance is a detailed spec.
     pub fn as_detailed(&self) -> Option<&DetailedSpec> {
         match self {
             Self::DetailedVersion(v) => Some(v),
@@ -210,10 +267,50 @@ impl PixiSpec {
         }
     }
 
-    /// Returns a [`UrlSpec`] if this instance is a detailed version spec.
-    pub fn as_url(&self) -> Option<&UrlSpec> {
+    /// Returns the requested extras for this spec, if any are declared.
+    ///
+    /// Extras can be declared on a detailed version spec as well as on the
+    /// source spec variants (URL, path, git) through their matchspec
+    /// selectors.
+    pub fn extras(&self) -> Option<&[String]> {
+        let extras = match self {
+            Self::DetailedVersion(v) => v.extras.as_ref(),
+            Self::UrlSource(u) => u.matchspec.extras.as_ref(),
+            Self::PathSource(p) => p.matchspec.extras.as_ref(),
+            Self::Git(g) => g.matchspec.extras.as_ref(),
+            Self::Version(_) | Self::UrlBinary(_) | Self::PathBinary(_) => None,
+        };
+        extras.map(Vec::as_slice)
+    }
+
+    /// Returns a [`UrlSourceSpec`] if this instance is a URL source spec.
+    pub fn as_url_source(&self) -> Option<&UrlSourceSpec> {
         match self {
-            Self::Url(v) => Some(v),
+            Self::UrlSource(u) => Some(u),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`UrlBinarySpec`] if this instance is a URL binary spec.
+    pub fn as_url_binary(&self) -> Option<&UrlBinarySpec> {
+        match self {
+            Self::UrlBinary(u) => Some(u),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`PathSourceSpec`] if this instance is a path source spec.
+    pub fn as_path_source(&self) -> Option<&PathSourceSpec> {
+        match self {
+            Self::PathSource(p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`PathBinarySpec`] if this instance is a path binary spec.
+    pub fn as_path_binary(&self) -> Option<&PathBinarySpec> {
+        match self {
+            Self::PathBinary(p) => Some(p),
             _ => None,
         }
     }
@@ -221,15 +318,39 @@ impl PixiSpec {
     /// Returns a [`GitSpec`] if this instance is a git spec.
     pub fn as_git(&self) -> Option<&GitSpec> {
         match self {
-            Self::Git(v) => Some(v),
+            Self::Git(g) => Some(g),
             _ => None,
         }
     }
 
-    /// Returns a [`PathSpec`] if this instance is a path spec.
-    pub fn as_path(&self) -> Option<&PathSpec> {
+    /// Returns a [`UrlSpec`] reconstructed from a URL-typed variant.
+    pub fn as_url(&self) -> Option<UrlSpec> {
         match self {
-            Self::Path(v) => Some(v),
+            Self::UrlBinary(u) => Some(UrlSpec {
+                url: u.url.clone(),
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: Subdirectory::default(),
+            }),
+            Self::UrlSource(u) => Some(UrlSpec {
+                url: u.url.clone(),
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: u.subdirectory.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// Returns a [`PathSpec`] reconstructed from a path-typed variant.
+    pub fn as_path(&self) -> Option<PathSpec> {
+        match self {
+            Self::PathBinary(p) => Some(PathSpec {
+                path: p.path.clone(),
+            }),
+            Self::PathSource(p) => Some(PathSpec {
+                path: p.path.clone(),
+            }),
             _ => None,
         }
     }
@@ -239,6 +360,9 @@ impl PixiSpec {
         match self {
             Self::Version(v) => Some(v),
             Self::DetailedVersion(v) => v.version,
+            Self::UrlSource(u) => u.matchspec.version,
+            Self::PathSource(p) => p.matchspec.version,
+            Self::Git(g) => g.matchspec.version,
             _ => None,
         }
     }
@@ -258,7 +382,18 @@ impl PixiSpec {
     /// Converts this instance into a [`UrlSpec`] if possible.
     pub fn into_url(self) -> Option<UrlSpec> {
         match self {
-            Self::Url(v) => Some(v),
+            Self::UrlBinary(u) => Some(UrlSpec {
+                url: u.url,
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: Subdirectory::default(),
+            }),
+            Self::UrlSource(u) => Some(UrlSpec {
+                url: u.url,
+                md5: u.md5,
+                sha256: u.sha256,
+                subdirectory: u.subdirectory,
+            }),
             _ => None,
         }
     }
@@ -266,7 +401,7 @@ impl PixiSpec {
     /// Converts this instance into a [`GitSpec`] if possible.
     pub fn into_git(self) -> Option<GitSpec> {
         match self {
-            Self::Git(v) => Some(v),
+            Self::Git(g) => Some(*g),
             _ => None,
         }
     }
@@ -274,7 +409,8 @@ impl PixiSpec {
     /// Converts this instance into a [`PathSpec`] if possible.
     pub fn into_path(self) -> Option<PathSpec> {
         match self {
-            Self::Path(v) => Some(v),
+            Self::PathBinary(p) => Some(PathSpec { path: p.path }),
+            Self::PathSource(p) => Some(PathSpec { path: p.path }),
             _ => None,
         }
     }
@@ -294,30 +430,28 @@ impl PixiSpec {
             PixiSpec::DetailedVersion(spec) => {
                 Some(spec.try_into_nameless_match_spec(channel_config)?)
             }
-            PixiSpec::Url(url) => url.try_into_nameless_match_spec().ok(),
-            PixiSpec::Git(_) => None,
-            PixiSpec::Path(path) => path.try_into_nameless_match_spec(&channel_config.root_dir)?,
+            PixiSpec::UrlBinary(url) => Some(url.into()),
+            PixiSpec::PathBinary(path) => {
+                Some(path.try_into_nameless_match_spec(&channel_config.root_dir)?)
+            }
+            PixiSpec::UrlSource(_) | PixiSpec::PathSource(_) | PixiSpec::Git(_) => None,
         };
 
         Ok(spec)
     }
 
-    /// Converts this instance in a source or binary spec.
+    /// Converts this instance into a source or binary spec.
     pub fn into_source_or_binary(self) -> Either<SourceSpec, BinarySpec> {
         match self {
             PixiSpec::Version(version) => Either::Right(BinarySpec::Version(version)),
             PixiSpec::DetailedVersion(detailed) => {
                 Either::Right(BinarySpec::DetailedVersion(detailed))
             }
-            PixiSpec::Url(url) => url
-                .into_source_or_binary()
-                .map_left(|url| SourceLocationSpec::Url(url).into())
-                .map_right(BinarySpec::Url),
-            PixiSpec::Git(git) => Either::Left(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .into_source_or_binary()
-                .map_left(|path| SourceLocationSpec::Path(path).into())
-                .map_right(BinarySpec::Path),
+            PixiSpec::UrlBinary(url) => Either::Right(BinarySpec::Url(url)),
+            PixiSpec::PathBinary(path) => Either::Right(BinarySpec::Path(path)),
+            PixiSpec::UrlSource(url) => Either::Left(SourceSpec::from(*url)),
+            PixiSpec::PathSource(path) => Either::Left(SourceSpec::from(*path)),
+            PixiSpec::Git(git) => Either::Left(SourceSpec::from(*git)),
         }
     }
 
@@ -326,28 +460,19 @@ impl PixiSpec {
     #[allow(clippy::result_large_err)]
     pub fn try_into_source_spec(self) -> Result<SourceSpec, Self> {
         match self {
-            PixiSpec::Url(url) => url
-                .try_into_source_url()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
-            PixiSpec::Git(git) => Ok(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .try_into_source_path()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
+            PixiSpec::UrlSource(url) => Ok(SourceSpec::from(*url)),
+            PixiSpec::PathSource(path) => Ok(SourceSpec::from(*path)),
+            PixiSpec::Git(git) => Ok(SourceSpec::from(*git)),
             _ => Err(self),
         }
     }
 
     /// Returns true if this spec represents a binary package.
     pub fn is_binary(&self) -> bool {
-        match self {
-            Self::Version(_) => true,
-            Self::DetailedVersion(_) => true,
-            Self::Url(url) => url.is_binary(),
-            Self::Git(_) => false,
-            Self::Path(path) => path.is_binary(),
-        }
+        matches!(
+            self,
+            Self::Version(_) | Self::DetailedVersion(_) | Self::UrlBinary(_) | Self::PathBinary(_)
+        )
     }
 
     /// Returns true if this spec represents a source package.
@@ -359,13 +484,7 @@ impl PixiSpec {
     /// A spec is mutable if it points to a local path-based source
     /// (non-binary).
     pub fn is_mutable(&self) -> bool {
-        match self {
-            Self::Version(_) => false,
-            Self::DetailedVersion(_) => false,
-            Self::Url(_) => false,
-            Self::Git(_) => false,
-            Self::Path(path) => !path.is_binary(),
-        }
+        matches!(self, Self::PathSource(_))
     }
 
     /// Converts this instance into a [`toml_edit::Value`].
@@ -381,16 +500,13 @@ impl PixiSpec {
         channel_config: &ChannelConfig,
     ) -> Result<NamelessMatchSpec, SpecConversionError> {
         match self.into_source_or_binary() {
-            Either::Left(_source) => Ok(NamelessMatchSpec::default()),
+            Either::Left(source) => Ok(source.to_nameless_match_spec()),
             Either::Right(binary) => binary.try_into_nameless_match_spec(channel_config),
         }
     }
 
     /// Convert this spec into a fully-named [`MatchSpec`] for the given
-    /// package `name`. Source-typed specs round-trip through
-    /// [`SourceSpec::to_nameless_match_spec`], binary-typed specs through
-    /// [`BinarySpec::try_into_nameless_match_spec`]; the result is wrapped
-    /// in a `MatchSpec` carrying `name`.
+    /// package `name`.
     pub fn to_match_spec(
         self,
         name: &PackageName,
@@ -404,87 +520,30 @@ impl PixiSpec {
     }
 }
 
-/// A specification for a source package.
+/// A source location, without any match-spec selectors.
 ///
-/// This type only represents source packages. Use [`PixiSpec`] to represent
-/// both binary and source packages.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize)]
-pub struct SourceSpec {
-    /// The location of the source.
-    #[serde(flatten)]
-    pub location: SourceLocationSpec,
-
-    /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
-    pub version: Option<VersionSpec>,
-
-    /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
-    pub build: Option<StringMatcher>,
-
-    /// The build number of the package
-    pub build_number: Option<BuildNumberSpec>,
-
-    /// Optional extra dependencies to select for the package
-    pub extras: Option<Vec<String>>,
-
-    /// Plain string flags used to select package variants.
-    pub flags: Option<Vec<StringMatcher>>,
-
-    /// The subdir of the channel
-    pub subdir: Option<String>,
-
-    /// The namespace of the package (currently not used)
-    pub namespace: Option<String>,
-
-    /// The license of the package
-    pub license: Option<String>,
-
-    /// The license family of the package
-    pub license_family: Option<String>,
-
-    /// The condition under which this match spec applies.
-    pub condition: Option<MatchSpecCondition>,
-
-    /// The track features of the package
-    pub track_features: Option<Vec<String>>,
-}
-
-impl From<SourceLocationSpec> for SourceSpec {
-    fn from(value: SourceLocationSpec) -> Self {
-        Self {
-            location: value,
-            version: None,
-            build: None,
-            build_number: None,
-            extras: None,
-            flags: None,
-            subdir: None,
-            namespace: None,
-            license: None,
-            license_family: None,
-            condition: None,
-            track_features: None,
-        }
-    }
-}
-
-/// A specification for a source location.
+/// This is enough to locate and check out the source. It deliberately does
+/// not carry [`MatchspecFields`]: where only the location matters (checking
+/// out source, referring to a manifest), use this type. To also constrain
+/// which built output is selected, pair it with [`MatchspecFields`] in a
+/// [`SourceSpec`].
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum SourceLocationSpec {
     /// The spec is represented as an archive that can be downloaded from the
     /// specified URL.
-    Url(UrlSourceSpec),
+    Url(UrlSpec),
 
     /// The spec is represented as a git repository.
-    Git(GitSpec),
+    Git(GitLocationSpec),
 
     /// The spec is represented as a local directory or local file archive.
-    Path(PathSourceSpec),
+    Path(PathSpec),
 }
 
 impl Display for SourceLocationSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self {
+        match self {
             SourceLocationSpec::Url(url) => write!(f, "{url}"),
             SourceLocationSpec::Git(git) => write!(f, "{git}"),
             SourceLocationSpec::Path(path) => write!(f, "{path}"),
@@ -492,109 +551,190 @@ impl Display for SourceLocationSpec {
     }
 }
 
-impl Display for SourceSpec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.location.fmt(f)
-    }
-}
-
-impl SourceSpec {
-    /// Constructs a new instance from a location and a nameless match spec.
-    pub fn new(location: SourceLocationSpec, spec: NamelessMatchSpec) -> Self {
-        let NamelessMatchSpec {
-            version,
-            build,
-            build_number,
-            file_name: _,
-            extras,
-            flags,
-            channel: _,
-            subdir,
-            namespace,
-            md5: _,
-            sha256: _,
-            url: _,
-            license,
-            condition,
-            track_features,
-            license_family,
-        } = spec;
-        Self {
-            location,
-            version,
-            build,
-            build_number,
-            extras,
-            flags,
-            subdir,
-            namespace,
-            license,
-            license_family,
-            condition,
-            track_features,
-        }
+impl SourceLocationSpec {
+    /// Returns true if this location is a git repository.
+    pub fn is_git(&self) -> bool {
+        matches!(self, SourceLocationSpec::Git(_))
     }
 
-    /// Convert this instance into a nameless match spec.
-    pub fn to_nameless_match_spec(&self) -> NamelessMatchSpec {
-        let Self {
-            location: _,
-            version,
-            build,
-            build_number,
-            extras,
-            flags,
-            subdir,
-            namespace,
-            license,
-            license_family,
-            condition,
-            track_features,
-        } = self;
-        NamelessMatchSpec {
-            version: version.clone(),
-            build: build.clone(),
-            build_number: build_number.clone(),
-            extras: extras.clone(),
-            flags: flags.clone(),
-            subdir: subdir.clone(),
-            namespace: namespace.clone(),
-            license: license.clone(),
-            license_family: license_family.clone(),
-            condition: condition.clone(),
-            track_features: track_features.clone(),
-            ..NamelessMatchSpec::default()
+    /// Returns true if this location is a local path.
+    pub fn is_path(&self) -> bool {
+        matches!(self, SourceLocationSpec::Path(_))
+    }
+
+    /// Returns true if this location is a URL archive.
+    pub fn is_url(&self) -> bool {
+        matches!(self, SourceLocationSpec::Url(_))
+    }
+
+    /// Attaches match-spec selectors to this location.
+    pub fn with_matchspec(self, matchspec: MatchspecFields) -> SourceSpec {
+        SourceSpec {
+            location: self,
+            matchspec,
         }
     }
 
     /// Converts this instance into a [`toml_edit::Value`].
     pub fn to_toml_value(&self) -> toml_edit::Value {
-        ::serde::Serialize::serialize(&self.location, toml_edit::ser::ValueSerializer::new())
+        ::serde::Serialize::serialize(self, toml_edit::ser::ValueSerializer::new())
             .expect("conversion to toml cannot fail")
     }
 
     /// Resolves the source location using the provided source anchor.
     pub fn resolve(self, source_anchor: &SourceAnchor) -> Self {
-        Self {
-            location: source_anchor.resolve(self.location),
-            ..self
+        source_anchor.resolve_location(self)
+    }
+}
+
+impl From<UrlSpec> for SourceLocationSpec {
+    fn from(value: UrlSpec) -> Self {
+        SourceLocationSpec::Url(value)
+    }
+}
+
+impl From<PathSpec> for SourceLocationSpec {
+    fn from(value: PathSpec) -> Self {
+        SourceLocationSpec::Path(value)
+    }
+}
+
+impl From<GitLocationSpec> for SourceLocationSpec {
+    fn from(value: GitLocationSpec) -> Self {
+        SourceLocationSpec::Git(value)
+    }
+}
+
+/// A specification for a source package: a [`SourceLocationSpec`] together
+/// with the [`MatchspecFields`] selectors that pick which built output of
+/// that source to use.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SourceSpec {
+    /// Where the source is located.
+    #[serde(flatten)]
+    pub location: SourceLocationSpec,
+
+    /// Match-spec selectors applied to the built output.
+    #[serde(flatten)]
+    pub matchspec: MatchspecFields,
+}
+
+impl Display for SourceSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.location)
+    }
+}
+
+impl SourceSpec {
+    /// Returns true if this spec represents a git repository.
+    pub fn is_git(&self) -> bool {
+        self.location.is_git()
+    }
+
+    /// Returns true if this spec represents a local path.
+    pub fn is_path(&self) -> bool {
+        self.location.is_path()
+    }
+
+    /// Returns true if this spec represents a URL archive.
+    pub fn is_url(&self) -> bool {
+        self.location.is_url()
+    }
+
+    /// Convert this source location into a [`NamelessMatchSpec`] containing
+    /// only the matchspec selectors (the location itself is not encoded).
+    pub fn to_nameless_match_spec(&self) -> NamelessMatchSpec {
+        self.matchspec.to_nameless_match_spec()
+    }
+
+    /// Converts this instance into a [`toml_edit::Value`].
+    pub fn to_toml_value(&self) -> toml_edit::Value {
+        ::serde::Serialize::serialize(self, toml_edit::ser::ValueSerializer::new())
+            .expect("conversion to toml cannot fail")
+    }
+
+    /// Resolves the source location using the provided source anchor.
+    pub fn resolve(self, source_anchor: &SourceAnchor) -> Self {
+        source_anchor.resolve(self)
+    }
+}
+
+impl From<UrlSourceSpec> for SourceSpec {
+    fn from(value: UrlSourceSpec) -> Self {
+        let UrlSourceSpec {
+            url,
+            md5,
+            sha256,
+            subdirectory,
+            matchspec,
+        } = value;
+        SourceSpec {
+            location: SourceLocationSpec::Url(UrlSpec {
+                url,
+                md5,
+                sha256,
+                subdirectory,
+            }),
+            matchspec,
         }
     }
 }
 
-impl SourceLocationSpec {
-    /// Returns true if this spec represents a git repository.
-    pub fn is_git(&self) -> bool {
-        matches!(self, SourceLocationSpec::Git(_))
+impl From<PathSourceSpec> for SourceSpec {
+    fn from(value: PathSourceSpec) -> Self {
+        SourceSpec {
+            location: SourceLocationSpec::Path(PathSpec { path: value.path }),
+            matchspec: value.matchspec,
+        }
+    }
+}
+
+impl From<GitSpec> for SourceSpec {
+    fn from(value: GitSpec) -> Self {
+        let matchspec = value.matchspec;
+        SourceSpec {
+            location: SourceLocationSpec::Git(GitLocationSpec {
+                git: value.git,
+                rev: value.rev,
+                subdirectory: value.subdirectory,
+            }),
+            matchspec,
+        }
+    }
+}
+
+impl From<SourceLocationSpec> for SourceSpec {
+    fn from(location: SourceLocationSpec) -> Self {
+        SourceSpec {
+            location,
+            matchspec: MatchspecFields::default(),
+        }
     }
 }
 
 impl From<SourceSpec> for PixiSpec {
     fn from(value: SourceSpec) -> Self {
-        match value.location {
-            SourceLocationSpec::Url(url) => Self::Url(url.into()),
-            SourceLocationSpec::Git(git) => Self::Git(git),
-            SourceLocationSpec::Path(path) => Self::Path(path.into()),
+        let SourceSpec {
+            location,
+            matchspec,
+        } = value;
+        match location {
+            SourceLocationSpec::Url(UrlSpec {
+                url,
+                md5,
+                sha256,
+                subdirectory,
+            }) => Self::UrlSource(Box::new(UrlSourceSpec {
+                url,
+                md5,
+                sha256,
+                subdirectory,
+                matchspec,
+            })),
+            SourceLocationSpec::Git(git) => Self::Git(Box::new(git.with_matchspec(matchspec))),
+            SourceLocationSpec::Path(PathSpec { path }) => {
+                Self::PathSource(Box::new(PathSourceSpec { path, matchspec }))
+            }
         }
     }
 }
@@ -607,31 +747,67 @@ impl From<DetailedSpec> for PixiSpec {
 
 impl From<UrlSpec> for PixiSpec {
     fn from(value: UrlSpec) -> Self {
-        Self::Url(value)
+        // A bare `UrlSpec` doesn't pre-commit to source-or-binary, so we
+        // inspect the URL to decide which typed variant to produce.
+        if url_is_binary(&value.url) {
+            Self::UrlBinary(UrlBinarySpec {
+                url: value.url,
+                md5: value.md5,
+                sha256: value.sha256,
+            })
+        } else {
+            Self::UrlSource(Box::new(UrlSourceSpec {
+                url: value.url,
+                md5: value.md5,
+                sha256: value.sha256,
+                subdirectory: value.subdirectory,
+                matchspec: MatchspecFields::default(),
+            }))
+        }
     }
 }
 
-impl From<UrlSourceSpec> for SourceSpec {
+impl From<UrlSourceSpec> for PixiSpec {
     fn from(value: UrlSourceSpec) -> Self {
-        SourceLocationSpec::Url(value).into()
+        Self::UrlSource(Box::new(value))
+    }
+}
+
+impl From<UrlBinarySpec> for PixiSpec {
+    fn from(value: UrlBinarySpec) -> Self {
+        Self::UrlBinary(value)
     }
 }
 
 impl From<GitSpec> for PixiSpec {
     fn from(value: GitSpec) -> Self {
-        Self::Git(value)
+        Self::Git(Box::new(value))
     }
 }
 
 impl From<PathSpec> for PixiSpec {
     fn from(value: PathSpec) -> Self {
-        Self::Path(value)
+        // Inspect the path extension to decide source-or-binary.
+        if CondaArchiveType::try_from(std::path::Path::new(value.path.as_str())).is_some() {
+            Self::PathBinary(PathBinarySpec { path: value.path })
+        } else {
+            Self::PathSource(Box::new(PathSourceSpec {
+                path: value.path,
+                matchspec: MatchspecFields::default(),
+            }))
+        }
     }
 }
 
-impl From<PathSourceSpec> for SourceSpec {
+impl From<PathSourceSpec> for PixiSpec {
     fn from(value: PathSourceSpec) -> Self {
-        SourceLocationSpec::Path(value).into()
+        Self::PathSource(Box::new(value))
+    }
+}
+
+impl From<PathBinarySpec> for PixiSpec {
+    fn from(value: PathBinarySpec) -> Self {
+        Self::PathBinary(value)
     }
 }
 
@@ -642,7 +818,7 @@ impl From<PixiSpec> for toml_edit::Value {
     }
 }
 
-/// A specification for a source package.
+/// A specification for a binary package.
 ///
 /// This type only represents binary packages. Use [`PixiSpec`] to represent
 /// both binary and source packages.
@@ -651,9 +827,6 @@ impl From<PixiSpec> for toml_edit::Value {
 pub enum BinarySpec {
     /// The spec is represented solely by a version string. The package should
     /// be retrieved from a channel.
-    ///
-    /// This is similar to the `DetailedVersion` variant but with a simplified
-    /// version spec.
     Version(VersionSpec),
 
     /// The spec is represented by a detailed version spec. The package should
@@ -661,12 +834,11 @@ pub enum BinarySpec {
     DetailedVersion(Box<DetailedSpec>),
 
     /// The spec is represented as an archive that can be downloaded from the
-    /// specified URL. The package should be retrieved from the URL and can
-    /// only represent an archive.
+    /// specified URL.
     Url(UrlBinarySpec),
 
     /// The spec is represented as a local path. The package should be retrieved
-    /// from the local filesystem. The package can only be a binary package.
+    /// from the local filesystem.
     Path(PathBinarySpec),
 }
 
@@ -711,8 +883,8 @@ impl From<BinarySpec> for PixiSpec {
         match value {
             BinarySpec::Version(version) => Self::Version(version),
             BinarySpec::DetailedVersion(detailed) => Self::DetailedVersion(detailed),
-            BinarySpec::Url(url) => Self::Url(url.into()),
-            BinarySpec::Path(path) => Self::Path(path.into()),
+            BinarySpec::Url(url) => Self::UrlBinary(url),
+            BinarySpec::Path(path) => Self::PathBinary(path),
         }
     }
 }
@@ -727,10 +899,19 @@ impl From<VersionSpec> for BinarySpec {
 impl From<rattler_lock::source::SourceLocation> for SourceLocationSpec {
     fn from(value: rattler_lock::source::SourceLocation) -> Self {
         match value {
-            rattler_lock::source::SourceLocation::Url(url) => Self::Url(url.into()),
-            rattler_lock::source::SourceLocation::Git(git) => Self::Git(git.into()),
-            rattler_lock::source::SourceLocation::Path(path) => Self::Path(path.into()),
+            rattler_lock::source::SourceLocation::Url(url) => SourceLocationSpec::Url(url.into()),
+            rattler_lock::source::SourceLocation::Git(git) => SourceLocationSpec::Git(git.into()),
+            rattler_lock::source::SourceLocation::Path(path) => {
+                SourceLocationSpec::Path(path.into())
+            }
         }
+    }
+}
+
+#[cfg(feature = "rattler_lock")]
+impl From<rattler_lock::source::SourceLocation> for SourceSpec {
+    fn from(value: rattler_lock::source::SourceLocation) -> Self {
+        SourceLocationSpec::from(value).into()
     }
 }
 
@@ -746,7 +927,14 @@ impl From<SourceLocationSpec> for rattler_lock::source::SourceLocation {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<rattler_lock::source::UrlSourceLocation> for UrlSourceSpec {
+impl From<SourceSpec> for rattler_lock::source::SourceLocation {
+    fn from(value: SourceSpec) -> Self {
+        value.location.into()
+    }
+}
+
+#[cfg(feature = "rattler_lock")]
+impl From<rattler_lock::source::UrlSourceLocation> for UrlSpec {
     fn from(value: rattler_lock::source::UrlSourceLocation) -> Self {
         let rattler_lock::source::UrlSourceLocation {
             url,
@@ -767,8 +955,8 @@ impl From<rattler_lock::source::UrlSourceLocation> for UrlSourceSpec {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<UrlSourceSpec> for rattler_lock::source::UrlSourceLocation {
-    fn from(value: UrlSourceSpec) -> Self {
+impl From<UrlSpec> for rattler_lock::source::UrlSourceLocation {
+    fn from(value: UrlSpec) -> Self {
         Self {
             url: value.url,
             md5: value.md5,
@@ -779,7 +967,7 @@ impl From<UrlSourceSpec> for rattler_lock::source::UrlSourceLocation {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<rattler_lock::source::GitSourceLocation> for GitSpec {
+impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
     fn from(value: rattler_lock::source::GitSourceLocation) -> Self {
         Self {
             git: value.git,
@@ -800,8 +988,8 @@ impl From<rattler_lock::source::GitSourceLocation> for GitSpec {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<GitSpec> for rattler_lock::source::GitSourceLocation {
-    fn from(value: GitSpec) -> Self {
+impl From<GitLocationSpec> for rattler_lock::source::GitSourceLocation {
+    fn from(value: GitLocationSpec) -> Self {
         Self {
             git: value.git,
             rev: match value.rev {
@@ -818,15 +1006,15 @@ impl From<GitSpec> for rattler_lock::source::GitSourceLocation {
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<rattler_lock::source::PathSourceLocation> for PathSourceSpec {
+impl From<rattler_lock::source::PathSourceLocation> for PathSpec {
     fn from(value: rattler_lock::source::PathSourceLocation) -> Self {
         Self { path: value.path }
     }
 }
 
 #[cfg(feature = "rattler_lock")]
-impl From<PathSourceSpec> for rattler_lock::source::PathSourceLocation {
-    fn from(value: PathSourceSpec) -> Self {
+impl From<PathSpec> for rattler_lock::source::PathSourceLocation {
+    fn from(value: PathSpec) -> Self {
         Self { path: value.path }
     }
 }
@@ -844,7 +1032,7 @@ mod test {
     use serde_json::{Value, json};
     use url::Url;
 
-    use crate::{BinarySpec, PixiSpec};
+    use crate::{BinarySpec, MatchspecFields, PixiSpec};
 
     #[test]
     fn test_is_binary() {
@@ -1014,5 +1202,122 @@ mod test {
         let name = PackageName::new_unchecked("openssl");
         let match_spec = spec.to_match_spec(&name, &channel_config).unwrap();
         assert_eq!(match_spec.to_string(), "openssl >=2.0");
+    }
+
+    /// A path source spec carrying matchspec selectors should turn into a
+    /// `MatchSpec` carrying those same selectors (the location itself
+    /// is dropped — `to_match_spec` returns a *binary-shaped* matchspec
+    /// that the solver uses to pick which built output of the source
+    /// satisfies the constraint).
+    #[test]
+    fn test_path_source_with_matchspec_to_match_spec() {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "path": "../my-pkg",
+            "version": ">=1.0",
+            "build": "py310_*",
+            "subdir": "linux-64",
+        }))
+        .unwrap();
+
+        let name = PackageName::new_unchecked("my-pkg");
+        let match_spec = spec.to_match_spec(&name, &channel_config).unwrap();
+
+        assert_eq!(
+            match_spec.name.as_exact().map(PackageName::as_normalized),
+            Some("my-pkg")
+        );
+        assert_eq!(match_spec.version.unwrap().to_string(), ">=1.0");
+        assert_eq!(match_spec.subdir.as_deref(), Some("linux-64"));
+        assert!(match_spec.build.is_some());
+    }
+
+    /// `try_into_nameless_match_spec` on a source variant returns `None`
+    /// (sources don't have a fully-resolved nameless matchspec); use
+    /// `to_match_spec` or read `matchspec()` instead.
+    #[test]
+    fn test_try_into_nameless_match_spec_source_returns_none() {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "git": "https://example.com/foo.git",
+            "version": ">=1.0",
+        }))
+        .unwrap();
+        assert!(matches!(spec, PixiSpec::Git(_)));
+        let result = spec.try_into_nameless_match_spec(&channel_config).unwrap();
+        assert!(result.is_none());
+    }
+
+    /// `MatchspecFields::from_nameless_match_spec` extracts only the
+    /// matchspec subset; binary-only fields (`url`, `md5`, `sha256`,
+    /// `file_name`, `channel`, `namespace`) are dropped.
+    #[test]
+    fn test_matchspec_fields_extraction_drops_binary_fields() {
+        use rattler_conda_types::NamelessMatchSpec;
+        let nameless = NamelessMatchSpec {
+            version: Some(VersionSpec::from_str(">=1.0", Lenient).unwrap()),
+            build_number: Some(">=3".parse().unwrap()),
+            file_name: Some("foo.conda".to_string()),
+            md5: Some(Default::default()),
+            ..NamelessMatchSpec::default()
+        };
+        let fields = MatchspecFields::from_nameless_match_spec(&nameless);
+        assert_eq!(fields.version.as_ref().unwrap().to_string(), ">=1.0");
+        assert!(fields.build_number.is_some());
+        // Re-encoding to NamelessMatchSpec must NOT carry the binary-only
+        // fields back.
+        let round_tripped = fields.to_nameless_match_spec();
+        assert!(round_tripped.file_name.is_none());
+        assert!(round_tripped.md5.is_none());
+        assert!(round_tripped.url.is_none());
+    }
+
+    /// A bare version string round-trips to a `PixiSpec::Version` and
+    /// serializes back to a string, while the table form `{ version = "X" }`
+    /// stays a table - the two on-disk shapes are preserved by the type.
+    #[test]
+    fn test_bare_version_vs_table_form_preserved() {
+        let from_string: PixiSpec = serde_json::from_value(json!("1.2.3")).unwrap();
+        assert!(matches!(from_string, PixiSpec::Version(_)));
+        let json = serde_json::to_value(&from_string).unwrap();
+        assert_eq!(json, json!("==1.2.3"));
+        assert_eq!(from_string.to_string(), "==1.2.3");
+
+        let from_table: PixiSpec = serde_json::from_value(json!({ "version": "1.2.3" })).unwrap();
+        assert!(matches!(from_table, PixiSpec::DetailedVersion(_)));
+        let json = serde_json::to_value(&from_table).unwrap();
+        assert!(json.is_object(), "expected a JSON object, got {json}");
+    }
+
+    /// `from_nameless_matchspec` on a bare nameless spec (no fields other
+    /// than possibly `version`) produces a `PixiSpec::Version`, which
+    /// serializes as the bare string form.
+    #[test]
+    fn test_bare_nameless_becomes_version() {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
+        let nameless = MatchSpec::from_str("any-spec", ParseMatchSpecOptions::lenient())
+            .unwrap()
+            .into_nameless()
+            .1;
+        let spec = PixiSpec::from_nameless_matchspec(nameless, &channel_config);
+        assert!(matches!(spec, PixiSpec::Version(_)));
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json, json!("*"));
+        assert_eq!(spec.to_string(), "*");
+    }
+
+    /// A `Detailed` spec with *any* extra field present must serialize
+    /// as a table — the bare-string collapse only applies when only
+    /// `version` is set.
+    #[test]
+    fn test_detailed_with_extra_field_serializes_as_table() {
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "version": "1.2.3",
+            "build": "py37_*",
+        }))
+        .unwrap();
+        let value = serde_json::to_value(&spec).unwrap();
+        assert!(value.is_object(), "expected a JSON object, got {value}");
     }
 }

--- a/crates/pixi_spec/src/matchspec_fields.rs
+++ b/crates/pixi_spec/src/matchspec_fields.rs
@@ -1,0 +1,107 @@
+//! Match-spec selector fields that can decorate a source-side spec
+//! (URL source archive, path source, or git checkout).
+//!
+//! These mirror the subset of `NamelessMatchSpec` that makes sense for
+//! source packages once the source has been resolved into a concrete
+//! built output: `version`, `build`, `build-number`, `extras`, `flags`,
+//! `subdir`, `license`, `when` (parsed into `condition`), and
+//! `track-features`. Binary-only fields like `file-name`, `channel`,
+//! `md5`, `sha256` deliberately stay on `DetailedSpec` / `UrlBinarySpec` /
+//! `PathBinarySpec`. `license-family` is deprecated, so it is not carried
+//! here.
+
+use rattler_conda_types::{
+    BuildNumberSpec, MatchSpecCondition, NamelessMatchSpec, StringMatcher, VersionSpec,
+};
+use serde_with::{serde_as, skip_serializing_none};
+
+/// Optional match-spec selectors carried alongside a source location.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq, ::serde::Serialize, ::serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MatchspecFields {
+    /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`).
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub version: Option<VersionSpec>,
+
+    /// The build string of the package (e.g. `py37_0`, `py*`).
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub build: Option<StringMatcher>,
+
+    /// The build number of the package.
+    #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
+    pub build_number: Option<BuildNumberSpec>,
+
+    /// Optional extra dependencies to select for the package.
+    pub extras: Option<Vec<String>>,
+
+    /// Plain string flags used to select package variants.
+    #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
+    pub flags: Option<Vec<StringMatcher>>,
+
+    /// The subdir of the channel.
+    pub subdir: Option<String>,
+
+    /// The license of the package.
+    pub license: Option<String>,
+
+    /// The condition (`when` in TOML) under which this spec applies.
+    pub condition: Option<MatchSpecCondition>,
+
+    /// The track features of the package.
+    pub track_features: Option<Vec<String>>,
+}
+
+impl MatchspecFields {
+    /// Returns `true` if every field is `None`.
+    pub fn is_empty(&self) -> bool {
+        self.version.is_none()
+            && self.build.is_none()
+            && self.build_number.is_none()
+            && self.extras.is_none()
+            && self.flags.is_none()
+            && self.subdir.is_none()
+            && self.license.is_none()
+            && self.condition.is_none()
+            && self.track_features.is_none()
+    }
+
+    /// Extract the matchspec subset of a [`NamelessMatchSpec`], ignoring
+    /// binary-only fields (`file_name`, `channel`, `md5`, `sha256`, `url`,
+    /// `namespace`).
+    pub fn from_nameless_match_spec(spec: &NamelessMatchSpec) -> Self {
+        Self {
+            version: spec.version.clone(),
+            build: spec.build.clone(),
+            build_number: spec.build_number.clone(),
+            extras: spec.extras.clone(),
+            flags: spec.flags.clone(),
+            subdir: spec.subdir.clone(),
+            license: spec.license.clone(),
+            condition: spec.condition.clone(),
+            track_features: spec.track_features.clone(),
+        }
+    }
+
+    /// Stamp these fields into a [`NamelessMatchSpec`], leaving the
+    /// binary-only fields untouched.
+    pub fn write_into_nameless_match_spec(&self, spec: &mut NamelessMatchSpec) {
+        spec.version = self.version.clone();
+        spec.build = self.build.clone();
+        spec.build_number = self.build_number.clone();
+        spec.extras = self.extras.clone();
+        spec.flags = self.flags.clone();
+        spec.subdir = self.subdir.clone();
+        spec.license = self.license.clone();
+        spec.condition = self.condition.clone();
+        spec.track_features = self.track_features.clone();
+    }
+
+    /// Build a [`NamelessMatchSpec`] populated from these fields only.
+    pub fn to_nameless_match_spec(&self) -> NamelessMatchSpec {
+        let mut spec = NamelessMatchSpec::default();
+        self.write_into_nameless_match_spec(&mut spec);
+        spec
+    }
+}

--- a/crates/pixi_spec/src/path.rs
+++ b/crates/pixi_spec/src/path.rs
@@ -8,7 +8,7 @@ use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveType};
 use serde_with::serde_as;
 use typed_path::{Utf8NativePathBuf, Utf8TypedPathBuf};
 
-use crate::{BinarySpec, SpecConversionError};
+use crate::{BinarySpec, MatchspecFields, SpecConversionError};
 
 /// A specification of a package from a path.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -51,7 +51,10 @@ impl PathSpec {
         if self.is_binary() {
             Err(self)
         } else {
-            Ok(PathSourceSpec { path: self.path })
+            Ok(PathSourceSpec {
+                path: self.path,
+                matchspec: MatchspecFields::default(),
+            })
         }
     }
 
@@ -69,7 +72,10 @@ impl PathSpec {
         if self.is_binary() {
             Either::Right(PathBinarySpec { path: self.path })
         } else {
-            Either::Left(PathSourceSpec { path: self.path })
+            Either::Left(PathSourceSpec {
+                path: self.path,
+                matchspec: MatchspecFields::default(),
+            })
         }
     }
 }
@@ -85,12 +91,26 @@ impl Display for PathSpec {
 // serialization and deserialization below. See git blame history
 // right before this line was added.
 
-/// Path to a source package. Different from [`PathSpec`] in that this type only
+/// Path to a source package, optionally constrained by match-spec
+/// selectors. Different from [`PathSpec`] in that this type only
 /// refers to source packages.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct PathSourceSpec {
     /// The path to the package. Either a directory or an archive.
     pub path: Utf8TypedPathBuf,
+
+    /// Match-spec selectors applied to the built output.
+    pub matchspec: MatchspecFields,
+}
+
+impl PathSourceSpec {
+    /// Constructs a new [`PathSourceSpec`] with no matchspec selectors.
+    pub fn new(path: impl Into<Utf8TypedPathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            matchspec: MatchspecFields::default(),
+        }
+    }
 }
 
 impl Display for PathSourceSpec {
@@ -105,12 +125,15 @@ impl serde::Serialize for PathSourceSpec {
         S: serde::Serializer,
     {
         #[derive(serde::Serialize)]
-        struct Raw {
+        struct Raw<'a> {
             path: String,
+            #[serde(flatten)]
+            matchspec: &'a MatchspecFields,
         }
 
         Raw {
             path: self.path.to_string(),
+            matchspec: &self.matchspec,
         }
         .serialize(serializer)
     }
@@ -124,10 +147,13 @@ impl<'de> serde::Deserialize<'de> for PathSourceSpec {
         #[derive(serde::Deserialize)]
         struct Raw {
             path: String,
+            #[serde(flatten)]
+            matchspec: MatchspecFields,
         }
 
         Raw::deserialize(deserializer).map(|raw| PathSourceSpec {
             path: raw.path.into(),
+            matchspec: raw.matchspec,
         })
     }
 }
@@ -149,14 +175,20 @@ impl PathSourceSpec {
     }
 }
 
-/// Path to a source package. Different from [`PathSpec`] in that this type only
-/// refers to source packages.
+/// Path to a binary conda archive. Different from [`PathSpec`] in that
+/// this type only refers to binary packages.
 #[serde_as]
 #[derive(Debug, Clone, Hash, Eq, PartialEq, ::serde::Serialize)]
 pub struct PathBinarySpec {
     /// The path to the package. Either a directory or an archive.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub path: Utf8TypedPathBuf,
+}
+
+impl Display for PathBinarySpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.path)
+    }
 }
 
 impl From<PathBinarySpec> for PathSpec {

--- a/crates/pixi_spec/src/pin.rs
+++ b/crates/pixi_spec/src/pin.rs
@@ -331,7 +331,7 @@ mod tests {
         let v = Version::from_str("3.11.5").unwrap();
         let spec = pin.resolve(&v, "h12345").unwrap();
         let PixiSpec::DetailedVersion(detailed) = spec else {
-            panic!("expected DetailedVersion");
+            panic!("expected Detailed");
         };
         assert_eq!(detailed.version.unwrap().to_string(), "==3.11.5");
         assert!(detailed.build.is_some());

--- a/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
+++ b/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_spec/src/toml.rs
+assertion_line: 1677
 expression: snapshot
 ---
 - input: 1.2.3
@@ -71,14 +72,71 @@ expression: snapshot
     git: "https://github.com/conda-forge/21cmfast-feedstock"
     branch: main
 - input:
+    path: "../mypkg"
+    version: 1.2.3
+  result:
+    path: "../mypkg"
+    version: "==1.2.3"
+- input:
+    path: "../mypkg"
+    version: ">=1.2"
+    build: py37_*
+  result:
+    path: "../mypkg"
+    version: ">=1.2"
+    build: py37_*
+- input:
+    path: "../mypkg"
+    subdir: linux-64
+    track-features:
+      - legacy
+  result:
+    path: "../mypkg"
+    subdir: linux-64
+    track-features:
+      - legacy
+- input:
+    git: "https://github.com/foo/bar"
+    branch: main
+    version: ">=1.0"
+    extras:
+      - cuda
+  result:
+    git: "https://github.com/foo/bar"
+    branch: main
+    version: ">=1.0"
+    extras:
+      - cuda
+- input:
+    url: "https://example.com/foo.tar.gz"
+    version: 1.2.3
+    build-number: ">=3"
+  result:
+    url: "https://example.com/foo.tar.gz"
+    version: "==1.2.3"
+    build-number: ">=3"
+- input:
+    url: "https://example.com/foo.tar.gz"
+    flags:
+      - cuda
+      - "blas:*"
+  result:
+    url: "https://example.com/foo.tar.gz"
+    flags:
+      - cuda
+      - "blas:*"
+- input:
+    path: "../mypkg"
+    version: 1.2.3
+    license: MIT
+  result:
+    path: "../mypkg"
+    version: "==1.2.3"
+    license: MIT
+- input:
     ver: 1.2.3
   result:
     error: "ERROR: unknown field `ver`"
-- input:
-    path: foobar
-    version: 1.2.3
-  result:
-    error: "ERROR: `version` cannot be used with `path`"
 - input:
     version: //
   result:
@@ -104,6 +162,21 @@ expression: snapshot
     sha256: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
   result:
     error: "ERROR: `sha256` cannot be used with `git`"
+- input:
+    url: "https://example.com/foo.conda"
+    version: 1.2.3
+  result:
+    error: "ERROR: `version` cannot be used with `url`"
+- input:
+    path: foo.conda
+    version: 1.2.3
+  result:
+    error: "ERROR: `version` cannot be used with `path`"
+- input:
+    url: "https://example.com/foo.conda"
+    license: MIT
+  result:
+    error: "ERROR: `license` cannot be used with `url`"
 - input: /path/style
   result:
     error: "ERROR: it seems you're trying to add a path dependency, please specify as a table with a `path` key: '{ path = \"/path/style\" }'"

--- a/crates/pixi_spec/src/source_anchor.rs
+++ b/crates/pixi_spec/src/source_anchor.rs
@@ -1,11 +1,14 @@
-use crate::{GitSpec, PathSourceSpec, SourceLocationSpec, SourceSpec, Subdirectory, UrlSourceSpec};
+use crate::{GitLocationSpec, PathSpec, SourceLocationSpec, SourceSpec, Subdirectory};
 use pixi_consts::consts::KNOWN_MANIFEST_FILES;
 use pixi_path::normalize;
 use typed_path::Utf8TypedPath;
 
-/// `SourceAnchor` represents the resolved base location of a `SourceSpec`.
+/// `SourceAnchor` represents the resolved base location of a source spec.
 /// It serves as a reference point for interpreting relative or recursive
 /// source specifications, enabling consistent resolution of nested sources.
+///
+/// Only the location matters for anchoring, so this holds a
+/// [`SourceLocationSpec`] rather than a full [`SourceSpec`].
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum SourceAnchor {
     /// The source is relative to the workspace root.
@@ -15,29 +18,44 @@ pub enum SourceAnchor {
     Source(SourceLocationSpec),
 }
 
-impl From<SourceSpec> for SourceAnchor {
-    fn from(value: SourceSpec) -> Self {
-        SourceAnchor::Source(value.location)
-    }
-}
-
 impl From<SourceLocationSpec> for SourceAnchor {
     fn from(value: SourceLocationSpec) -> Self {
         SourceAnchor::Source(value)
     }
 }
 
+impl From<SourceSpec> for SourceAnchor {
+    fn from(value: SourceSpec) -> Self {
+        SourceAnchor::Source(value.location)
+    }
+}
+
 impl SourceAnchor {
-    /// Resolve a source location spec relative to this anchor.
-    pub fn resolve(&self, spec: SourceLocationSpec) -> SourceLocationSpec {
+    /// Resolve a source spec relative to this anchor. Only the location is
+    /// resolved; the spec's matchspec selectors ride along unchanged, since
+    /// the base's selectors apply to the base, not to its nested children.
+    pub fn resolve(&self, spec: SourceSpec) -> SourceSpec {
+        let SourceSpec {
+            location,
+            matchspec,
+        } = spec;
+        let location = self.resolve_location(location);
+        SourceSpec {
+            location,
+            matchspec,
+        }
+    }
+
+    /// Resolve a source location relative to this anchor.
+    pub fn resolve_location(&self, location: SourceLocationSpec) -> SourceLocationSpec {
         // If this instance is already anchored to the workspace we can simply return
         // immediately.
         let SourceAnchor::Source(base) = self else {
-            return match spec {
+            return match location {
                 SourceLocationSpec::Url(url) => SourceLocationSpec::Url(url),
                 SourceLocationSpec::Git(git) => SourceLocationSpec::Git(git),
-                SourceLocationSpec::Path(PathSourceSpec { path }) => {
-                    SourceLocationSpec::Path(PathSourceSpec {
+                SourceLocationSpec::Path(PathSpec { path }) => {
+                    SourceLocationSpec::Path(PathSpec {
                         // Normalize the input path.
                         path: normalize::normalize_typed(path.to_path()),
                     })
@@ -46,17 +64,17 @@ impl SourceAnchor {
         };
 
         // Only path specs can be relative.
-        let SourceLocationSpec::Path(PathSourceSpec { path }) = spec else {
-            return spec;
+        let SourceLocationSpec::Path(PathSpec { path }) = location else {
+            return location;
         };
 
         // If the path is absolute we can just return it.
         if path.is_absolute() || path.starts_with("~") {
-            return SourceLocationSpec::Path(PathSourceSpec { path });
+            return SourceLocationSpec::Path(PathSpec { path });
         }
 
         match base {
-            SourceLocationSpec::Path(PathSourceSpec { path: base }) => {
+            SourceLocationSpec::Path(PathSpec { path: base }) => {
                 // Use the parent directory as the base when the base path points to
                 // a manifest file (e.g., `package-a/pixi.toml` -> `package-a`).
                 // This ensures relative paths like `../package-b` resolve correctly.
@@ -71,14 +89,14 @@ impl SourceAnchor {
                 };
 
                 let relative_path = normalize::normalize_typed(base_dir.join(path).to_path());
-                SourceLocationSpec::Path(PathSourceSpec {
+                SourceLocationSpec::Path(PathSpec {
                     path: relative_path,
                 })
             }
-            SourceLocationSpec::Url(UrlSourceSpec { .. }) => {
+            SourceLocationSpec::Url(_) => {
                 unimplemented!("Cannot resolve relative paths for URL sources")
             }
-            SourceLocationSpec::Git(GitSpec {
+            SourceLocationSpec::Git(GitLocationSpec {
                 git,
                 rev,
                 subdirectory,
@@ -96,7 +114,7 @@ impl SourceAnchor {
                 } else {
                     Subdirectory::try_from(subdir_str).unwrap_or_default()
                 };
-                SourceLocationSpec::Git(GitSpec {
+                SourceLocationSpec::Git(GitLocationSpec {
                     git: git.clone(),
                     rev: rev.clone(),
                     subdirectory,

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -4,13 +4,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use itertools::Either;
 use pixi_toml::{TomlDigest, TomlFromStr, TomlWith, custom_error_message_with_help};
 use rattler_conda_types::{
     BuildNumberSpec, ChannelConfig, MatchSpec, MatchSpecCondition, NamedChannelOrUrl,
     NamelessMatchSpec, PackageName, PackageNameMatcher, ParseMatchSpecOptions,
     ParseStrictness::{Lenient, Strict},
     RepodataRevision, StringMatcher, VersionSpec,
+    package::CondaArchiveType,
     version_spec::{ParseConstraintError, ParseVersionSpecError},
 };
 use rattler_digest::{Md5Hash, Sha256Hash};
@@ -25,8 +25,9 @@ use toml_span::{
 use url::Url;
 
 use crate::{
-    BinarySpec, DetailedSpec, GitReference, GitSpec, PathSourceSpec, PathSpec, PixiSpec,
-    SourceLocationSpec, Subdirectory, SubdirectoryError, UrlSourceSpec, UrlSpec,
+    BinarySpec, DetailedSpec, GitLocationSpec, GitReference, GitSpec, MatchspecFields,
+    PathBinarySpec, PathSourceSpec, PathSpec, PixiSpec, SourceLocationSpec, Subdirectory,
+    SubdirectoryError, UrlBinarySpec, UrlSourceSpec, UrlSpec,
 };
 
 /// A TOML representation of a package specification.
@@ -397,7 +398,7 @@ impl SpecError {
 }
 
 #[derive(Error, Debug)]
-pub enum SourceLocationSpecError {
+pub enum SourceSpecError {
     #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
     NotAGitSpec,
 
@@ -428,6 +429,25 @@ pub enum NotBinary {
     #[error(
         "`git` can only refer to a source distributions but a binary distribution was expected"
     )]
+    Git,
+}
+
+/// Internal tag identifying which kind of `PixiSpec` variant a [`TomlSpec`]
+/// resolves to, after inspecting the URL/path extension at parse time.
+#[derive(Copy, Clone, Debug)]
+enum LocationKind {
+    /// No `url` / `path` / `git`.
+    None,
+    /// A `url = ...` that points at a binary conda archive.
+    UrlBinary,
+    /// A `url = ...` that points at a non-binary archive (`.zip`, `.tar.gz`,
+    /// ...).
+    UrlSource,
+    /// A `path = ...` that points at a binary conda archive.
+    PathBinary,
+    /// A `path = ...` that points at a directory or non-binary archive.
+    PathSource,
+    /// A `git = ...`.
     Git,
 }
 
@@ -535,56 +555,110 @@ impl TomlSpec {
         }
     }
 
-    fn validate_field_combinations(&self) -> Result<(), SpecError> {
-        let (is_git, is_path, is_url) = if let Some(loc) = &self.location {
+    /// Validate combinations of fields once the binary-vs-source nature of
+    /// the location has been decided.
+    ///
+    /// Rules:
+    /// * `branch` / `rev` / `tag` only with `git`.
+    /// * `sha256` / `md5` only with `url`.
+    /// * Only one of `url` / `path` / `git`.
+    /// * `channel` / `file-name` / `license-family` are forbidden with any
+    ///   location; they only apply to a plain channel dependency.
+    /// * Matchspec fields (`version`, `build`, `license`, ...) are forbidden
+    ///   when the URL or path resolves to a *binary* archive - the resulting
+    ///   package is already fully specified - but allowed with source
+    ///   locations.
+    fn validate_field_combinations(&self) -> Result<LocationKind, SpecError> {
+        let location_kind = if let Some(loc) = &self.location {
             if loc.git.is_none() && (loc.branch.is_some() || loc.rev.is_some() || loc.tag.is_some())
             {
                 return Err(SpecError::NotAGitSpec);
             }
-            (loc.git.is_some(), loc.path.is_some(), loc.url.is_some())
+            match (loc.url.as_ref(), loc.path.as_ref(), loc.git.as_ref()) {
+                (Some(url), None, None) => {
+                    if url
+                        .path_segments()
+                        .and_then(Iterator::last)
+                        .and_then(|seg| CondaArchiveType::try_from(Path::new(seg)))
+                        .is_some()
+                    {
+                        LocationKind::UrlBinary
+                    } else {
+                        LocationKind::UrlSource
+                    }
+                }
+                (None, Some(path), None) => {
+                    if CondaArchiveType::try_from(Path::new(path.as_str())).is_some() {
+                        LocationKind::PathBinary
+                    } else {
+                        LocationKind::PathSource
+                    }
+                }
+                (None, None, Some(_)) => LocationKind::Git,
+                (None, None, None) => LocationKind::None,
+                _ => return Err(SpecError::MultipleIdentifiers),
+            }
         } else {
-            (false, false, false)
+            LocationKind::None
         };
 
-        let non_detailed_keys = [
-            is_git.then_some("`git`"),
-            is_path.then_some("`path`"),
-            is_url.then_some("`url`"),
-        ]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-        .join(", ");
-
-        // Common field checks
-        if !non_detailed_keys.is_empty() {
+        // `channel`, `file-name` and `license-family` are always forbidden
+        // with a location: they only apply to a plain channel dependency.
+        // `license-family` is additionally deprecated.
+        let source_or_binary_keys = match location_kind {
+            LocationKind::Git => "`git`",
+            LocationKind::UrlSource | LocationKind::UrlBinary => "`url`",
+            LocationKind::PathSource | LocationKind::PathBinary => "`path`",
+            LocationKind::None => "",
+        };
+        if !source_or_binary_keys.is_empty() {
             for (field_name, is_some) in [
-                ("`version`", self.version.is_some()),
-                ("`build`", self.build.is_some()),
-                ("`build-number`", self.build_number.is_some()),
-                ("`file-name`", self.file_name.is_some()),
-                ("`extras`", self.extras.is_some()),
-                ("`flags`", self.flags.is_some()),
                 ("`channel`", self.channel.is_some()),
-                ("`subdir`", self.subdir.is_some()),
-                ("`when`", self.when.is_some()),
-                ("`track-features`", self.track_features.is_some()),
+                ("`file-name`", self.file_name.is_some()),
+                ("`license-family`", self.license_family.is_some()),
             ] {
                 if is_some {
                     return Err(SpecError::InvalidCombination(
                         field_name.into(),
-                        non_detailed_keys.into(),
+                        source_or_binary_keys.into(),
                     ));
                 }
             }
         }
 
+        // Matchspec fields are rejected when the location resolves to a
+        // binary archive: a `.conda` archive is already a fully-specified
+        // package, so `version` etc. would be meaningless.
+        let binary_location_key = match location_kind {
+            LocationKind::UrlBinary => Some("`url`"),
+            LocationKind::PathBinary => Some("`path`"),
+            _ => None,
+        };
+        if let Some(key) = binary_location_key {
+            for (field_name, is_some) in [
+                ("`version`", self.version.is_some()),
+                ("`build`", self.build.is_some()),
+                ("`build-number`", self.build_number.is_some()),
+                ("`extras`", self.extras.is_some()),
+                ("`flags`", self.flags.is_some()),
+                ("`subdir`", self.subdir.is_some()),
+                ("`license`", self.license.is_some()),
+                ("`when`", self.when.is_some()),
+                ("`track-features`", self.track_features.is_some()),
+            ] {
+                if is_some {
+                    return Err(SpecError::InvalidCombination(field_name.into(), key.into()));
+                }
+            }
+        }
+
+        // `sha256` / `md5` only apply to URL specs (binary or source archive).
         if let Some(loc) = &self.location {
-            let non_url_keys = [is_git.then_some("`git`"), is_path.then_some("`path`")]
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
-                .join(", ");
+            let non_url_keys = match location_kind {
+                LocationKind::Git => "`git`",
+                LocationKind::PathSource | LocationKind::PathBinary => "`path`",
+                _ => "",
+            };
 
             if !non_url_keys.is_empty() {
                 for (field_name, is_some) in [
@@ -601,232 +675,165 @@ impl TomlSpec {
             }
         }
 
-        Ok(())
+        Ok(location_kind)
     }
 
     /// Convert the TOML representation into an actual [`PixiSpec`].
     pub fn into_spec(self) -> Result<PixiSpec, SpecError> {
-        self.validate_field_combinations()?;
+        let kind = self.validate_field_combinations()?;
+        let condition = self.when.map(TomlWhen::into_condition).transpose()?;
+        let matchspec = MatchspecFields {
+            version: self.version,
+            build: self.build,
+            build_number: self.build_number,
+            extras: self.extras,
+            flags: self.flags,
+            subdir: self.subdir,
+            license: self.license,
+            condition,
+            track_features: self.track_features,
+        };
 
-        let spec: PixiSpec;
-        if let Some(loc) = self.location {
-            spec = match (loc.url, loc.path, loc.git) {
-                (Some(url), None, None) => PixiSpec::Url(UrlSpec {
+        match kind {
+            LocationKind::None => {
+                let (md5, sha256) = match &self.location {
+                    Some(loc) => (loc.md5, loc.sha256),
+                    None => (None, None),
+                };
+                let any_field = !matchspec.is_empty()
+                    || self.file_name.is_some()
+                    || self.channel.is_some()
+                    || md5.is_some()
+                    || sha256.is_some();
+                if !any_field {
+                    return Err(SpecError::MissingDetailedIdentifier);
+                }
+                Ok(PixiSpec::DetailedVersion(Box::new(DetailedSpec {
+                    version: matchspec.version,
+                    build: matchspec.build,
+                    build_number: matchspec.build_number,
+                    file_name: self.file_name,
+                    extras: matchspec.extras,
+                    flags: matchspec.flags,
+                    channel: self.channel,
+                    subdir: matchspec.subdir,
+                    md5,
+                    sha256,
+                    license: matchspec.license,
+                    license_family: self.license_family,
+                    condition: matchspec.condition,
+                    track_features: matchspec.track_features,
+                })))
+            }
+            LocationKind::UrlBinary => {
+                let loc = self.location.expect("location set when kind != None");
+                let url = loc.url.expect("url set for UrlBinary kind");
+                Ok(PixiSpec::UrlBinary(UrlBinarySpec {
                     url,
                     md5: loc.md5,
                     sha256: loc.sha256,
-                    subdirectory: loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default(),
-                }),
-                (None, Some(path), None) => PixiSpec::Path(PathSpec { path: path.into() }),
-                (None, None, Some(git)) => {
-                    let rev = match (loc.branch, loc.rev, loc.tag) {
-                        (Some(branch), None, None) => Some(GitReference::Branch(branch)),
-                        (None, Some(rev), None) => Some(GitReference::Rev(rev)),
-                        (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
-                        (None, None, None) => None,
-                        _ => {
-                            return Err(SpecError::MultipleGitRefs);
-                        }
-                    };
-                    let subdirectory = loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default();
-                    PixiSpec::Git(GitSpec {
-                        git,
-                        rev,
-                        subdirectory,
-                    })
-                }
-                (None, None, None) => {
-                    let is_detailed = self.version.is_some()
-                        || self.build.is_some()
-                        || self.build_number.is_some()
-                        || self.file_name.is_some()
-                        || self.extras.is_some()
-                        || self.flags.is_some()
-                        || self.channel.is_some()
-                        || self.subdir.is_some()
-                        || loc.md5.is_some()
-                        || loc.sha256.is_some()
-                        || self.license.is_some()
-                        || self.license_family.is_some()
-                        || self.when.is_some()
-                        || self.track_features.is_some();
-                    if !is_detailed {
-                        return Err(SpecError::MissingDetailedIdentifier);
-                    }
-
-                    PixiSpec::DetailedVersion(Box::new(DetailedSpec {
-                        version: self.version,
-                        build: self.build,
-                        build_number: self.build_number,
-                        file_name: self.file_name,
-                        extras: self.extras,
-                        flags: self.flags,
-                        channel: self.channel,
-                        subdir: self.subdir,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        license: self.license,
-                        license_family: self.license_family,
-                        condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                        track_features: self.track_features,
-                    }))
-                }
-                (_, _, _) => return Err(SpecError::MultipleIdentifiers),
-            };
-        } else {
-            let is_detailed = self.version.is_some()
-                || self.build.is_some()
-                || self.build_number.is_some()
-                || self.file_name.is_some()
-                || self.extras.is_some()
-                || self.flags.is_some()
-                || self.channel.is_some()
-                || self.subdir.is_some()
-                || self.license.is_some()
-                || self.license_family.is_some()
-                || self.when.is_some()
-                || self.track_features.is_some();
-            if !is_detailed {
-                return Err(SpecError::MissingDetailedIdentifier);
+                }))
             }
-
-            spec = PixiSpec::DetailedVersion(Box::new(DetailedSpec {
-                version: self.version,
-                build: self.build,
-                build_number: self.build_number,
-                file_name: self.file_name,
-                extras: self.extras,
-                flags: self.flags,
-                channel: self.channel,
-                subdir: self.subdir,
-                md5: None,
-                sha256: None,
-                license: self.license,
-                license_family: self.license_family,
-                condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                track_features: self.track_features,
-            }));
+            LocationKind::UrlSource => {
+                let loc = self.location.expect("location set when kind != None");
+                let url = loc.url.expect("url set for UrlSource kind");
+                let subdirectory = loc
+                    .subdirectory
+                    .map(Subdirectory::try_from)
+                    .transpose()?
+                    .unwrap_or_default();
+                Ok(PixiSpec::UrlSource(Box::new(UrlSourceSpec {
+                    url,
+                    md5: loc.md5,
+                    sha256: loc.sha256,
+                    subdirectory,
+                    matchspec,
+                })))
+            }
+            LocationKind::PathBinary => {
+                let loc = self.location.expect("location set when kind != None");
+                let path = loc.path.expect("path set for PathBinary kind");
+                Ok(PixiSpec::PathBinary(PathBinarySpec { path: path.into() }))
+            }
+            LocationKind::PathSource => {
+                let loc = self.location.expect("location set when kind != None");
+                let path = loc.path.expect("path set for PathSource kind");
+                Ok(PixiSpec::PathSource(Box::new(PathSourceSpec {
+                    path: path.into(),
+                    matchspec,
+                })))
+            }
+            LocationKind::Git => {
+                let loc = self.location.expect("location set when kind != None");
+                let git = loc.git.expect("git set for Git kind");
+                let rev = match (loc.branch, loc.rev, loc.tag) {
+                    (Some(branch), None, None) => Some(GitReference::Branch(branch)),
+                    (None, Some(rev), None) => Some(GitReference::Rev(rev)),
+                    (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
+                    (None, None, None) => None,
+                    _ => return Err(SpecError::MultipleGitRefs),
+                };
+                let subdirectory = loc
+                    .subdirectory
+                    .map(Subdirectory::try_from)
+                    .transpose()?
+                    .unwrap_or_default();
+                Ok(PixiSpec::Git(Box::new(GitSpec {
+                    git,
+                    rev,
+                    subdirectory,
+                    matchspec,
+                })))
+            }
         }
-
-        Ok(spec)
     }
 
-    /// Convert the TOML representation into an actual [`PixiSpec`].
+    /// Convert the TOML representation into a [`BinarySpec`].
     pub fn into_binary_spec(self) -> Result<BinarySpec, SpecError> {
-        self.validate_field_combinations()?;
+        let kind = self.validate_field_combinations()?;
+        let condition = self.when.map(TomlWhen::into_condition).transpose()?;
 
-        let spec: BinarySpec;
-        if let Some(loc) = self.location {
-            spec = match (loc.url, loc.path, loc.git) {
-                (Some(url), None, None) => {
-                    let url_spec = UrlSpec {
-                        url,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        subdirectory: loc
-                            .subdirectory
-                            .map(Subdirectory::try_from)
-                            .transpose()?
-                            .unwrap_or_default(),
-                    };
-                    if let Either::Right(binary) = url_spec.into_source_or_binary() {
-                        BinarySpec::Url(binary)
-                    } else {
-                        return Err(SpecError::NotABinary(NotBinary::Url));
-                    }
-                }
-                (None, Some(path), None) => {
-                    let path_spec = PathSpec { path: path.into() };
-                    if let Either::Right(binary) = path_spec.into_source_or_binary() {
-                        BinarySpec::Path(binary)
-                    } else {
-                        return Err(SpecError::NotABinary(NotBinary::Path));
-                    }
-                }
-                (None, None, Some(_git)) => {
-                    return Err(SpecError::NotABinary(NotBinary::Git));
-                }
-                (None, None, None) => {
-                    let is_detailed = self.version.is_some()
-                        || self.build.is_some()
-                        || self.build_number.is_some()
-                        || self.file_name.is_some()
-                        || self.extras.is_some()
-                        || self.flags.is_some()
-                        || self.channel.is_some()
-                        || self.subdir.is_some()
-                        || loc.md5.is_some()
-                        || loc.sha256.is_some()
-                        || self.license.is_some()
-                        || self.license_family.is_some()
-                        || self.when.is_some()
-                        || self.track_features.is_some();
-                    if !is_detailed {
-                        return Err(SpecError::MissingDetailedIdentifier);
-                    }
-
-                    BinarySpec::DetailedVersion(Box::new(DetailedSpec {
-                        version: self.version,
-                        build: self.build,
-                        build_number: self.build_number,
-                        file_name: self.file_name,
-                        extras: self.extras,
-                        flags: self.flags,
-                        channel: self.channel,
-                        subdir: self.subdir,
-                        md5: loc.md5,
-                        sha256: loc.sha256,
-                        license: self.license,
-                        license_family: self.license_family,
-                        condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                        track_features: self.track_features,
-                    }))
-                }
-                (_, _, _) => return Err(SpecError::MultipleIdentifiers),
-            };
-        } else {
-            let is_detailed = self.version.is_some()
-                || self.build.is_some()
-                || self.build_number.is_some()
-                || self.file_name.is_some()
-                || self.extras.is_some()
-                || self.flags.is_some()
-                || self.channel.is_some()
-                || self.subdir.is_some()
-                || self.license.is_some()
-                || self.license_family.is_some()
-                || self.when.is_some()
-                || self.track_features.is_some();
-            if !is_detailed {
-                return Err(SpecError::MissingDetailedIdentifier);
+        match kind {
+            LocationKind::None => {
+                let (md5, sha256) = match &self.location {
+                    Some(loc) => (loc.md5, loc.sha256),
+                    None => (None, None),
+                };
+                Ok(BinarySpec::DetailedVersion(Box::new(DetailedSpec {
+                    version: self.version,
+                    build: self.build,
+                    build_number: self.build_number,
+                    file_name: self.file_name,
+                    extras: self.extras,
+                    flags: self.flags,
+                    channel: self.channel,
+                    subdir: self.subdir,
+                    md5,
+                    sha256,
+                    license: self.license,
+                    license_family: self.license_family,
+                    condition,
+                    track_features: self.track_features,
+                })))
             }
-
-            spec = BinarySpec::DetailedVersion(Box::new(DetailedSpec {
-                version: self.version,
-                build: self.build,
-                build_number: self.build_number,
-                file_name: self.file_name,
-                extras: self.extras,
-                flags: self.flags,
-                channel: self.channel,
-                subdir: self.subdir,
-                md5: None,
-                sha256: None,
-                license: self.license,
-                license_family: self.license_family,
-                condition: self.when.map(TomlWhen::into_condition).transpose()?,
-                track_features: self.track_features,
-            }));
-        };
-        Ok(spec)
+            LocationKind::UrlBinary => {
+                let loc = self.location.expect("location set");
+                let url = loc.url.expect("url set");
+                Ok(BinarySpec::Url(UrlBinarySpec {
+                    url,
+                    md5: loc.md5,
+                    sha256: loc.sha256,
+                }))
+            }
+            LocationKind::PathBinary => {
+                let loc = self.location.expect("location set");
+                let path = loc.path.expect("path set");
+                Ok(BinarySpec::Path(PathBinarySpec { path: path.into() }))
+            }
+            LocationKind::UrlSource => Err(SpecError::NotABinary(NotBinary::Url)),
+            LocationKind::PathSource => Err(SpecError::NotABinary(NotBinary::Path)),
+            LocationKind::Git => Err(SpecError::NotABinary(NotBinary::Git)),
+        }
     }
 }
 
@@ -1082,18 +1089,18 @@ fn fold_when_conditions(
 }
 
 impl TomlLocationSpec {
-    fn validate_field_combinations(&self) -> Result<(), SourceLocationSpecError> {
+    fn validate_field_combinations(&self) -> Result<(), SourceSpecError> {
         let (is_git, is_path, is_url) = {
             if self.git.is_none()
                 && (self.branch.is_some() || self.rev.is_some() || self.tag.is_some())
             {
-                return Err(SourceLocationSpecError::NotAGitSpec);
+                return Err(SourceSpecError::NotAGitSpec);
             }
             (self.git.is_some(), self.path.is_some(), self.url.is_some())
         };
 
         if !is_git && !is_path && !is_url {
-            return Err(SourceLocationSpecError::NoSourceType);
+            return Err(SourceSpecError::NoSourceType);
         }
 
         let non_url_keys = [is_git.then_some("`git`"), is_path.then_some("`path`")]
@@ -1108,7 +1115,7 @@ impl TomlLocationSpec {
                 ("`md5`", self.md5.is_some()),
             ] {
                 if is_some {
-                    return Err(SourceLocationSpecError::InvalidCombination(
+                    return Err(SourceSpecError::InvalidCombination(
                         field_name.into(),
                         non_url_keys.into(),
                     ));
@@ -1119,12 +1126,15 @@ impl TomlLocationSpec {
         Ok(())
     }
 
-    /// Convert the TOML representation into a `SourceLocationSpec`.
-    pub fn into_source_location_spec(self) -> Result<SourceLocationSpec, SourceLocationSpecError> {
+    /// Convert the TOML representation into a [`SourceLocationSpec`].
+    ///
+    /// A [`TomlLocationSpec`] only ever describes a location, never any
+    /// match-spec selectors, so the result carries no selectors.
+    pub fn into_source_location_spec(self) -> Result<SourceLocationSpec, SourceSpecError> {
         self.validate_field_combinations()?;
 
-        let spec = match (self.url, self.path, self.git) {
-            (Some(url), None, None) => SourceLocationSpec::Url(UrlSourceSpec {
+        let location = match (self.url, self.path, self.git) {
+            (Some(url), None, None) => SourceLocationSpec::Url(UrlSpec {
                 url,
                 md5: self.md5,
                 sha256: self.sha256,
@@ -1134,9 +1144,7 @@ impl TomlLocationSpec {
                     .transpose()?
                     .unwrap_or_default(),
             }),
-            (None, Some(path), None) => {
-                SourceLocationSpec::Path(PathSourceSpec { path: path.into() })
-            }
+            (None, Some(path), None) => SourceLocationSpec::Path(PathSpec { path: path.into() }),
             (None, None, Some(git)) => {
                 let rev = match (self.branch, self.rev, self.tag) {
                     (Some(branch), None, None) => Some(GitReference::Branch(branch)),
@@ -1144,7 +1152,7 @@ impl TomlLocationSpec {
                     (None, None, Some(tag)) => Some(GitReference::Tag(tag)),
                     (None, None, None) => None,
                     _ => {
-                        return Err(SourceLocationSpecError::MultipleGitRefs);
+                        return Err(SourceSpecError::MultipleGitRefs);
                     }
                 };
                 let subdirectory = self
@@ -1152,15 +1160,15 @@ impl TomlLocationSpec {
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default();
-                SourceLocationSpec::Git(GitSpec {
+                SourceLocationSpec::Git(GitLocationSpec {
                     git,
                     rev,
                     subdirectory,
                 })
             }
-            (_, _, _) => return Err(SourceLocationSpecError::MultipleIdentifiers),
+            (_, _, _) => return Err(SourceSpecError::MultipleIdentifiers),
         };
-        Ok(spec)
+        Ok(location)
     }
 }
 
@@ -1415,7 +1423,7 @@ impl<'de> toml_span::Deserialize<'de> for PixiSpec {
         match value.take() {
             ValueInner::String(str) => {
                 parse_version_string(&str)
-                    .map(PixiSpec::Version)
+                    .map(PixiSpec::from)
                     .map_err(|msg| {
                         DeserError::from(toml_span::Error {
                             kind: ErrorKind::Custom(msg.into()),
@@ -1481,7 +1489,7 @@ impl<'de> Deserialize<'de> for PixiSpec {
             )
             .string(|str| {
                 parse_version_string(str)
-                    .map(PixiSpec::Version)
+                    .map(PixiSpec::from)
                     .map_err(serde_untagged::de::Error::custom)
             })
             .map(|map| {
@@ -1574,6 +1582,18 @@ mod test {
         format_parse_error(trimmed, TomlDiagnostic(first))
     }
 
+    /// Parse a TOML pixi spec successfully.
+    fn parse_toml_ok(input: &str) -> PixiSpec {
+        let mut value = toml_span::parse(input.trim()).expect("expected valid TOML");
+        <PixiSpec as toml_span::Deserialize>::deserialize(&mut value)
+            .expect("expected parse to succeed")
+    }
+
+    /// Parse a JSON pixi spec successfully.
+    fn parse_json_ok(input: Value) -> PixiSpec {
+        serde_json::from_value::<PixiSpec>(input).expect("expected parse to succeed")
+    }
+
     /// JSON parse failures don't carry source spans, so we just stringify.
     fn parse_json_error(input: Value) -> String {
         serde_json::from_value::<PixiSpec>(input)
@@ -1599,14 +1619,27 @@ mod test {
             json!({ "url": "https://conda.anaconda.org/conda-forge/linux-64/21cmfast-3.3.1-py38h0db86a8_1.conda", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main" }),
+            // Source specs with matchspec selectors:
+            json!({ "path": "../mypkg", "version": "1.2.3" }),
+            json!({ "path": "../mypkg", "version": ">=1.2", "build": "py37_*" }),
+            json!({ "path": "../mypkg", "subdir": "linux-64", "track-features": ["legacy"] }),
+            json!({ "git": "https://github.com/foo/bar", "branch": "main", "version": ">=1.0", "extras": ["cuda"] }),
+            json!({ "url": "https://example.com/foo.tar.gz", "version": "1.2.3", "build-number": ">=3" }),
+            json!({ "url": "https://example.com/foo.tar.gz", "flags": ["cuda", "blas:*"] }),
+            json!({ "path": "../mypkg", "version": "1.2.3", "license": "MIT" }),
             // Errors:
             json!({ "ver": "1.2.3" }),
-            json!({ "path": "foobar" , "version": "1.2.3" }),
             json!({ "version": "//" }),
             json!({ "path": "foobar", "version": "//" }),
             json!({ "path": "foobar", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main", "tag": "v1" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
+            // A `.conda` URL is binary; matchspec selectors must be rejected.
+            json!({ "url": "https://example.com/foo.conda", "version": "1.2.3" }),
+            // A `.conda` path is binary; matchspec selectors must be rejected.
+            json!({ "path": "foo.conda", "version": "1.2.3" }),
+            // `license` is a matchspec selector, so it is rejected on a binary archive.
+            json!({ "url": "https://example.com/foo.conda", "license": "MIT" }),
             json! { "/path/style"},
             json! { "./path/style"},
             json! { "\\path\\style"},
@@ -1642,6 +1675,28 @@ mod test {
         }
 
         insta::assert_yaml_snapshot!(snapshot);
+    }
+
+    #[test]
+    fn test_license_on_source_spec() {
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "path": "../mypkg",
+            "version": ">=1.0",
+            "license": "MIT",
+        }))
+        .unwrap();
+        let source = spec
+            .into_source_or_binary()
+            .left()
+            .expect("a path spec is a source spec");
+        assert_eq!(source.matchspec.license.as_deref(), Some("MIT"));
+
+        // `license` is a matchspec selector, so it is forbidden on a binary archive.
+        let err = serde_json::from_value::<PixiSpec>(
+            json!({ "url": "https://example.com/foo.conda", "license": "MIT" }),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("license"));
     }
 
     #[test]
@@ -2032,8 +2087,20 @@ when = { package = "python", track-features = ["legacy"] }"#;
     }
 
     #[test]
-    fn test_when_reject_combined_with_path_json() {
+    fn test_when_accept_combined_with_path_json() {
+        // Matchspec fields including `when` are allowed alongside a path
+        // source (a directory or non-binary archive).
         let input = json!({ "path": "../foo", "when": "__unix" });
+        let spec = parse_json_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert!(path.matchspec.condition.is_some());
+    }
+
+    #[test]
+    fn test_matchspec_reject_with_binary_path_json() {
+        // A path pointing at a `.conda` archive is binary; matchspec
+        // selectors are meaningless there and must be rejected.
+        let input = json!({ "path": "foo.conda", "when": "__unix" });
         assert_snapshot!(parse_json_error(input), @"`when` cannot be used with `path`");
     }
 
@@ -2236,16 +2303,14 @@ when = { all = ["__unix", "python[version='>=3.10']"] }"#;
     }
 
     #[test]
-    fn test_when_reject_combined_with_path_toml() {
+    fn test_when_accept_combined_with_path_toml() {
+        // A `path = ../foo` is a non-binary source location, so matchspec
+        // selectors including `when` are accepted.
         let input = r#"path = "../foo"
 when = "__unix""#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `when` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ when = "__unix"
-          ╰────
-        "###);
+        let spec = parse_toml_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert!(path.matchspec.condition.is_some());
     }
 
     #[test]
@@ -2267,24 +2332,48 @@ when = "__unix""#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_json() {
+    fn test_v3_accept_extras_with_path_json() {
         let input = json!({ "path": "../foo", "extras": ["dev"] });
-        assert_snapshot!(parse_json_error(input), @"`extras` cannot be used with `path`");
+        let spec = parse_json_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert_eq!(
+            path.matchspec.extras.as_deref(),
+            Some(&["dev".to_string()][..])
+        );
     }
 
     #[test]
-    fn test_v3_reject_flags_with_git_json() {
+    fn test_v3_accept_flags_with_git_json() {
         let input = json!({ "git": "https://example.com/foo.git", "flags": ["cuda"] });
-        assert_snapshot!(parse_json_error(input), @"`flags` cannot be used with `git`");
+        let spec = parse_json_ok(input);
+        let git = spec.as_git().expect("expected a git spec");
+        assert!(git.matchspec.flags.is_some());
     }
 
     #[test]
     fn test_v3_reject_track_features_with_url_json() {
+        // `.conda` extension makes this a binary URL; matchspec selectors
+        // are rejected.
         let input = json!({
             "url": "https://example.com/foo.conda",
             "track-features": ["legacy"],
         });
         assert_snapshot!(parse_json_error(input), @"`track-features` cannot be used with `url`");
+    }
+
+    #[test]
+    fn test_v3_accept_track_features_with_source_url_json() {
+        // Non-binary URL extension: matchspec selectors are accepted.
+        let input = json!({
+            "url": "https://example.com/foo.tar.gz",
+            "track-features": ["legacy"],
+        });
+        let spec = parse_json_ok(input);
+        let url = spec.as_url_source().expect("expected a url source spec");
+        assert_eq!(
+            url.matchspec.track_features.as_deref(),
+            Some(&["legacy".to_string()][..])
+        );
     }
 
     #[test]
@@ -2344,20 +2433,20 @@ flags = ["*[unclosed"]"#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_toml() {
+    fn test_v3_accept_extras_with_path_toml() {
         let input = r#"path = "../foo"
 extras = ["dev"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `extras` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ extras = ["dev"]
-          ╰────
-        "###);
+        let spec = parse_toml_ok(input);
+        let path = spec.as_path_source().expect("expected a path source spec");
+        assert_eq!(
+            path.matchspec.extras.as_deref(),
+            Some(&["dev".to_string()][..])
+        );
     }
 
     #[test]
-    fn test_v3_reject_flags_with_url_toml() {
+    fn test_v3_reject_flags_with_binary_url_toml() {
+        // `.conda` extension marks this as a binary URL: matchspec rejected.
         let input = r#"url = "https://example.com/foo.conda"
 flags = ["cuda"]"#;
         assert_snapshot!(parse_toml_error(input), @r###"
@@ -2370,15 +2459,113 @@ flags = ["cuda"]"#;
     }
 
     #[test]
-    fn test_v3_reject_track_features_with_git_toml() {
+    fn test_v3_accept_flags_with_source_url_toml() {
+        // `.tar.gz` is not a binary conda archive: matchspec accepted.
+        let input = r#"url = "https://example.com/foo.tar.gz"
+flags = ["cuda"]"#;
+        let spec = parse_toml_ok(input);
+        let url = spec.as_url_source().expect("expected a url source spec");
+        assert!(url.matchspec.flags.is_some());
+    }
+
+    #[test]
+    fn test_v3_accept_track_features_with_git_toml() {
         let input = r#"git = "https://example.com/foo.git"
 track-features = ["legacy"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `track-features` cannot be used with `git`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ git = "https://example.com/foo.git"
-        2 │ ╰─▶ track-features = ["legacy"]
-          ╰────
-        "###);
+        let spec = parse_toml_ok(input);
+        let git = spec.as_git().expect("expected a git spec");
+        assert_eq!(
+            git.matchspec.track_features.as_deref(),
+            Some(&["legacy".to_string()][..])
+        );
+    }
+
+    /// Source-side matchspec round-trips through JSON serialization:
+    /// a spec mixing a source location with several matchspec selectors
+    /// must parse, serialize, and re-parse to an equal `PixiSpec`.
+    #[test]
+    fn test_source_matchspec_roundtrip_full() {
+        let inputs: Vec<Value> = vec![
+            // path + multiple matchspec fields
+            json!({
+                "path": "../my-pkg",
+                "version": "1.2.3",
+                "build": "py37_*",
+                "build-number": ">=3",
+                "extras": ["cuda", "mkl"],
+                "subdir": "linux-64",
+                "track-features": ["legacy"],
+            }),
+            // git + matchspec
+            json!({
+                "git": "https://github.com/foo/bar",
+                "branch": "main",
+                "version": ">=1.0",
+                "extras": ["dev"],
+            }),
+            // non-binary url + matchspec
+            json!({
+                "url": "https://example.com/foo.tar.gz",
+                "version": "1.2.3",
+                "build-number": ">=3",
+                "flags": ["cuda"],
+            }),
+        ];
+
+        for input in inputs {
+            let first: PixiSpec =
+                serde_json::from_value(input.clone()).expect("expected initial parse to succeed");
+            let serialized = serde_json::to_value(&first).expect("serialize should succeed");
+            let second: PixiSpec = serde_json::from_value(serialized.clone())
+                .expect("round-trip parse should succeed");
+            assert_eq!(
+                first, second,
+                "round-trip mismatch for input:\n{input}\n\nrendered as: {serialized}"
+            );
+        }
+    }
+
+    /// A path source carrying matchspec selectors round-trips through
+    /// `PixiSpec::try_into_source_spec` and back into a `PixiSpec`, and
+    /// the matchspec fields survive intact via the accessor.
+    #[test]
+    fn test_source_location_spec_matchspec_accessor() {
+        let spec = parse_toml_ok(
+            r#"path = "../my-pkg"
+version = ">=2.0"
+build = "py310_*"
+extras = ["test"]"#,
+        );
+
+        // Routing into a SourceSpec preserves matchspec.
+        let source = spec
+            .clone()
+            .try_into_source_spec()
+            .expect("expected a source spec");
+        assert!(source.is_path());
+        let matchspec = &source.matchspec;
+        assert_eq!(matchspec.version.as_ref().unwrap().to_string(), ">=2.0");
+        assert!(matchspec.build.is_some());
+        assert_eq!(matchspec.extras.as_deref(), Some(&["test".to_string()][..]));
+
+        // Lifting it back through `From<SourceSpec>` returns the
+        // same `PixiSpec`.
+        let round_tripped = PixiSpec::from(source);
+        assert_eq!(spec, round_tripped);
+    }
+
+    /// `try_into_source_spec` returns the original `PixiSpec` (via `Err`)
+    /// when invoked on a binary variant.
+    #[test]
+    fn test_try_into_source_spec_rejects_binary() {
+        let detailed: PixiSpec = parse_json_ok(json!({ "version": "1.2.3" }));
+        let err = detailed.try_into_source_spec().unwrap_err();
+        assert!(matches!(err, PixiSpec::DetailedVersion(_)));
+
+        let url_binary = parse_json_ok(json!({
+            "url": "https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py.conda",
+        }));
+        let err = url_binary.try_into_source_spec().unwrap_err();
+        assert!(matches!(err, PixiSpec::UrlBinary(_)));
     }
 }

--- a/crates/pixi_spec/src/url.rs
+++ b/crates/pixi_spec/src/url.rs
@@ -1,10 +1,10 @@
-use crate::{BinarySpec, Subdirectory};
+use crate::{BinarySpec, MatchspecFields, Subdirectory};
 use itertools::Either;
-use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveIdentifier};
+use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveType};
 use rattler_digest::{Md5Hash, Sha256Hash};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::fmt::Display;
+use std::{fmt::Display, path::Path};
 use url::Url;
 
 /// A specification of a package from a URL. This is used to represent both
@@ -59,6 +59,7 @@ impl UrlSpec {
                 md5: self.md5,
                 sha256: self.sha256,
                 subdirectory: self.subdirectory,
+                matchspec: MatchspecFields::default(),
             })
         }
     }
@@ -78,14 +79,29 @@ impl UrlSpec {
                 md5: self.md5,
                 sha256: self.sha256,
                 subdirectory: self.subdirectory,
+                matchspec: MatchspecFields::default(),
             })
         }
     }
 
     /// Returns true if the URL points to a binary package.
+    ///
+    /// Detection is purely by file extension (`.conda` or `.tar.bz2`):
+    /// any URL whose last path segment ends in one of these is treated as
+    /// a binary archive at parse time, even if the filename doesn't follow
+    /// the `name-version-build` convention.
     pub fn is_binary(&self) -> bool {
-        CondaArchiveIdentifier::try_from_url(&self.url).is_some()
+        url_is_binary(&self.url)
     }
+}
+
+/// Returns true if `url` looks like a binary conda archive based on its
+/// path extension (`.conda` or `.tar.bz2`).
+pub(crate) fn url_is_binary(url: &Url) -> bool {
+    url.path_segments()
+        .and_then(Iterator::last)
+        .and_then(|seg| CondaArchiveType::try_from(Path::new(seg)))
+        .is_some()
 }
 
 impl Display for UrlSpec {
@@ -101,7 +117,8 @@ impl Display for UrlSpec {
     }
 }
 
-/// A specification of a source archive from a URL.
+/// A specification of a source archive from a URL, optionally constrained
+/// by match-spec selectors (version, build, extras, …).
 #[serde_as]
 #[derive(Debug, Clone, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct UrlSourceSpec {
@@ -121,6 +138,28 @@ pub struct UrlSourceSpec {
     /// The subdirectory of the package inside the archive
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Match-spec selectors applied to the built output (flattened).
+    #[serde(flatten)]
+    pub matchspec: MatchspecFields,
+}
+
+impl UrlSourceSpec {
+    /// Constructs a new [`UrlSourceSpec`] with no matchspec selectors.
+    pub fn new(
+        url: Url,
+        md5: Option<Md5Hash>,
+        sha256: Option<Sha256Hash>,
+        subdirectory: Subdirectory,
+    ) -> Self {
+        Self {
+            url,
+            md5,
+            sha256,
+            subdirectory,
+            matchspec: MatchspecFields::default(),
+        }
+    }
 }
 
 impl Display for UrlSourceSpec {
@@ -150,17 +189,35 @@ impl From<UrlSourceSpec> for UrlSpec {
     }
 }
 
-/// A specification of a source archive from a URL.
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize)]
+/// A specification of a binary conda archive from a URL.
+#[serde_as]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UrlBinarySpec {
     /// The URL of the package
     pub url: Url,
 
     /// The md5 hash of the archive
+    #[serde_as(as = "Option<rattler_digest::serde::SerializableHash<rattler_digest::Md5>>")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub md5: Option<Md5Hash>,
 
     /// The sha256 hash of the archive
+    #[serde_as(as = "Option<rattler_digest::serde::SerializableHash<rattler_digest::Sha256>>")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub sha256: Option<Sha256Hash>,
+}
+
+impl Display for UrlBinarySpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.url)?;
+        if let Some(md5) = &self.md5 {
+            write!(f, " md5={md5:x}")?;
+        }
+        if let Some(sha256) = &self.sha256 {
+            write!(f, " sha256={sha256:x}")?;
+        }
+        Ok(())
+    }
 }
 
 impl From<UrlBinarySpec> for UrlSpec {

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -112,6 +112,7 @@ pub fn as_uv_req(
                     git,
                     rev,
                     subdirectory,
+                    matchspec: _,
                 },
         } => {
             let git_url = GitUrlWithPrefix::from(git);
@@ -357,13 +358,13 @@ mod tests {
     #[test]
     fn test_git_url() {
         let pypi_req = PixiPypiSpec::new(PixiPypiSource::Git {
-            git: GitSpec {
-                git: Url::parse("ssh://git@github.com/user/test.git").unwrap(),
-                rev: Some(GitReference::Rev(
+            git: GitSpec::new(
+                Url::parse("ssh://git@github.com/user/test.git").unwrap(),
+                Some(GitReference::Rev(
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
-                subdirectory: Default::default(),
-            },
+                Default::default(),
+            ),
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
 
@@ -385,13 +386,13 @@ mod tests {
 
         // With git+ prefix
         let pypi_req = PixiPypiSpec::new(PixiPypiSource::Git {
-            git: GitSpec {
-                git: Url::parse("git+https://github.com/user/test.git").unwrap(),
-                rev: Some(GitReference::Rev(
+            git: GitSpec::new(
+                Url::parse("git+https://github.com/user/test.git").unwrap(),
+                Some(GitReference::Rev(
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
-                subdirectory: Default::default(),
-            },
+                Default::default(),
+            ),
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
         let expected_uv_req = RequirementSource::Git {

--- a/docs/concepts/package_specifications.md
+++ b/docs/concepts/package_specifications.md
@@ -72,8 +72,9 @@ This syntax allows you to specify:
 - **build**: Build string pattern (see [build strings](#build-strings))
 - **build-number**: Build number constraint (e.g., `">=1"`, `"0"`) (see [build number](#build-number))
 - **channel**: Specific channel name or full URL (see [channel](#channel))
-- **extras**: Optional extra dependencies exposed by the package metadata
-- **flags**: Variant-selection flags exposed by package metadata
+- **extras**: Optional extra dependencies exposed by the package metadata (see [extras and flags](#extras-and-flags))
+- **flags**: Variant-selection flags exposed by package metadata (see [extras and flags](#extras-and-flags))
+- **when**: Condition under which the dependency applies (see [conditional dependencies](#conditional-dependencies))
 - **sha256/md5**: Package checksums for verification (see [checksums](#checksums-sha256md5))
 - **license**: Expected license type (see [license](#license))
 - **file-name**: Specific package file name (see [file name](#file-name))
@@ -83,12 +84,38 @@ This syntax allows you to specify:
 Some conda packages expose extra dependency groups or variant flags in their package metadata.
 Use `extras` to request optional dependencies and `flags` to select variants that are represented as package metadata instead of a separate package name.
 
+- `extras` pulls in the listed optional dependency groups of the dependency. It is equivalent to writing `name[group1,group2]` in a MatchSpec.
+- `flags` requires the dependency to have been built with the listed build flags.
+
 ```toml title="pixi.toml"
 [dependencies.v3-package]
 version = ">=1.0"
 extras = ["test"]
 flags = ["cuda", "blas:*"]
 ```
+
+These fields work on both channel and source dependencies:
+
+```toml title="pixi.toml"
+[dependencies]
+# Channel dependency: pull in the `tests` extras group of `mypackage`.
+mypackage = { version = ">=1.2", extras = ["tests"] }
+# Local source dependency: pull in `tests` and require it to be built with `cuda`.
+otherpackage = { path = "./otherpackage", extras = ["tests"], flags = ["cuda"] }
+```
+
+### Conditional Dependencies
+
+Use `when` to only apply a dependency when a condition is satisfied.
+The condition is a table with a `package` field naming another dependency to check, plus the version constraint it must meet.
+
+```toml title="pixi.toml"
+[dependencies]
+# Only install `numpy` when `python` is at least 3.12.
+numpy = { version = "*", when = { package = "python", version = ">=3.12" } }
+```
+
+Like `extras` and `flags`, `when` works on both channel and source dependencies.
 
 ### Version Operators
 

--- a/tests/data/non-satisfiability/source-extra-dependency-added/pixi.lock
+++ b/tests/data/non-satisfiability/source-extra-dependency-added/pixi.lock
@@ -1,0 +1,17 @@
+version: 6
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+        - conda: source
+packages:
+  - conda: source
+    name: source
+    version: 0.1.0
+    build: ""
+    subdir: noarch
+    noarch: false
+    variants:
+      target_platform: noarch

--- a/tests/data/non-satisfiability/source-extra-dependency-added/pixi.toml
+++ b/tests/data/non-satisfiability/source-extra-dependency-added/pixi.toml
@@ -1,0 +1,9 @@
+[workspace]
+channels = ["conda-forge"]
+name = "source-extra-dependency"
+platforms = ["win-64"]
+preview = ["pixi-build"]
+version = "0.1.0"
+
+[dependencies]
+source = { path = "source" }

--- a/tests/data/non-satisfiability/source-extra-dependency-added/source/pixi.toml
+++ b/tests/data/non-satisfiability/source-extra-dependency-added/source/pixi.toml
@@ -1,0 +1,11 @@
+[package]
+name = "source"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+# The backend re-derives this extra group, but the locked record below
+# carries no extras at all, so the lock must be reported as drifted.
+[package.extra-dependencies.test]
+extra-pkg = ">=1"


### PR DESCRIPTION
### Description

Compare the extra-dependency groups recorded in the lock file against what the backend re-derives from a source package manifest, and report a SourceExtraDependenciesChanged error when they diverge. The error lists the specs added and removed per extra group so the drift is actionable.

Based on https://github.com/prefix-dev/pixi/pull/6262

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

