### PR TITLE
fix(ci): Attest the tarballs and the binary inside separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,11 @@ jobs:
         id: attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}"
+          subject-path: |
+            target/distrib/pixi-${{ join(matrix.targets, ', ') }}
+            target/distrib/pixi-${{ join(matrix.targets, ', ') }}.tar.gz
+            target/distrib/pixi-${{ join(matrix.targets, ', ') }}.zip
+            target/distrib/pixi-${{ join(matrix.targets, ', ') }}.msi
       - run: cp ${{ steps.attest.outputs.bundle-path }} target/distrib/attestations-${{ join(matrix.targets, ', ') }}.intoto.jsonl
       - id: cargo-dist
         name: Post-build


### PR DESCRIPTION
### Description

Attest more of our release artifacts.

Fixes #6133

### How Has This Been Tested?

Not at all yet. I want to do a release job dry-run once somebody else took a look at it and agrees that a dry-run should be save :-)

Actionlint is clean for release.yml, so that's a good sign.

### AI Disclosure

No AI generated changes at all

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
