### PR TITLE
fix: accept find-links URLs during lock file satisfiability

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -490,25 +490,19 @@ async fn resolve_single_dev_dependency(
     Ok(dependencies)
 }
 
-/// Collect the set of PyPI indexes a locked package URL may belong to in
-/// order to satisfy a requirement that has no per-package `index`.
-///
-/// This is the union of the regular `indexes` (index-url + extra-index-urls)
-/// and the URL-based `find-links` entries. Packages resolved from a
-/// `find-links` flat index record the find-links URL as their `index_url`,
-/// so those URLs must be considered acceptable as well (issue #6265).
-/// Path-based find-links entries carry no URL and are skipped.
-///
-/// Returns an empty vector for pre-v7 lock files (no recorded indexes).
+/// Indexes a locked package URL may belong to: the regular `indexes` plus
+/// the URL-based `find-links` entries. Packages from a `find-links` flat
+/// index record the find-links URL as their `index_url` (issue #6265).
+/// Path-based find-links carry no URL and are skipped. Empty for pre-v7
+/// lock files.
 fn collect_locked_indexes(
     locked_pypi_indexes: Option<&rattler_lock::PypiIndexes>,
-) -> Vec<url::Url> {
+) -> Vec<&url::Url> {
     locked_pypi_indexes
         .map(|i| {
             i.indexes
                 .iter()
-                .cloned()
-                .chain(i.find_links.iter().filter_map(|fl| fl.as_url().cloned()))
+                .chain(i.find_links.iter().filter_map(|fl| fl.as_url()))
                 .collect()
         })
         .unwrap_or_default()
@@ -1391,6 +1385,6 @@ mod tests {
         };
 
         let collected = collect_locked_indexes(Some(&indexes));
-        assert_eq!(collected, vec![pypi_index, find_links_url]);
+        assert_eq!(collected, vec![&pypi_index, &find_links_url]);
     }
 }

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -490,6 +490,30 @@ async fn resolve_single_dev_dependency(
     Ok(dependencies)
 }
 
+/// Collect the set of PyPI indexes a locked package URL may belong to in
+/// order to satisfy a requirement that has no per-package `index`.
+///
+/// This is the union of the regular `indexes` (index-url + extra-index-urls)
+/// and the URL-based `find-links` entries. Packages resolved from a
+/// `find-links` flat index record the find-links URL as their `index_url`,
+/// so those URLs must be considered acceptable as well (issue #6265).
+/// Path-based find-links entries carry no URL and are skipped.
+///
+/// Returns an empty vector for pre-v7 lock files (no recorded indexes).
+fn collect_locked_indexes(
+    locked_pypi_indexes: Option<&rattler_lock::PypiIndexes>,
+) -> Vec<url::Url> {
+    locked_pypi_indexes
+        .map(|i| {
+            i.indexes
+                .iter()
+                .cloned()
+                .chain(i.find_links.iter().filter_map(|fl| fl.as_url().cloned()))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 async fn verify_package_platform_satisfiability(
     ctx: &VerifySatisfiabilityContext<'_>,
     platform_setup: &crate::lock_file::platform_setup::PlatformSetup,
@@ -519,10 +543,8 @@ async fn verify_package_platform_satisfiability(
     // Indexes the lock file was resolved against. Authoritative because
     // `verify_pypi_indexes` already confirmed they match the manifest. A
     // locked package URL must be one of these to satisfy a requirement
-    // with no per-package `index`. None for pre-v7 lock files.
-    let locked_indexes: &[url::Url] = locked_pypi_indexes
-        .map(|i| i.indexes.as_slice())
-        .unwrap_or(&[]);
+    // with no per-package `index`. Empty for pre-v7 lock files.
+    let locked_indexes = collect_locked_indexes(locked_pypi_indexes);
 
     // retrieve dependency-overrides
     // map it to (name => requirement) for later matching
@@ -848,7 +870,7 @@ async fn verify_package_platform_satisfiability(
                                     record,
                                     ctx.project_root,
                                     origin,
-                                    locked_indexes,
+                                    &locked_indexes,
                                 ) {
                                     delayed_pypi_error.get_or_insert(err);
                                 }
@@ -1334,4 +1356,41 @@ pub fn verify_solve_group_satisfiability(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_lock::{FindLinksUrlOrPath, PypiIndexes};
+    use url::Url;
+
+    use super::collect_locked_indexes;
+
+    /// Pre-v7 lock files don't record indexes; the set is empty.
+    #[test]
+    fn test_collect_locked_indexes_none() {
+        assert!(collect_locked_indexes(None).is_empty());
+    }
+
+    /// Regression for issue #6265: URL-based `find-links` entries must be
+    /// included in the set of acceptable indexes, alongside the regular
+    /// `indexes`. A package resolved from a flat index records the
+    /// find-links URL as its `index_url`, so satisfiability must accept it.
+    #[test]
+    fn test_collect_locked_indexes_includes_find_links() {
+        let pypi_index = Url::parse("https://pypi.org/simple").unwrap();
+        let find_links_url =
+            Url::parse("https://data.pyg.org/whl/torch-2.8.0+cpu.html").unwrap();
+
+        let indexes = PypiIndexes {
+            indexes: vec![pypi_index.clone()],
+            find_links: vec![
+                FindLinksUrlOrPath::Url(find_links_url.clone()),
+                // Path-based find-links carry no URL and must be skipped.
+                FindLinksUrlOrPath::Path("./local-wheels".into()),
+            ],
+        };
+
+        let collected = collect_locked_indexes(Some(&indexes));
+        assert_eq!(collected, vec![pypi_index, find_links_url]);
+    }
 }

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -1372,8 +1372,7 @@ mod tests {
     #[test]
     fn test_collect_locked_indexes_includes_find_links() {
         let pypi_index = Url::parse("https://pypi.org/simple").unwrap();
-        let find_links_url =
-            Url::parse("https://data.pyg.org/whl/torch-2.8.0+cpu.html").unwrap();
+        let find_links_url = Url::parse("https://data.pyg.org/whl/torch-2.8.0+cpu.html").unwrap();
 
         let indexes = PypiIndexes {
             indexes: vec![pypi_index.clone()],

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -130,7 +130,7 @@ pub(crate) fn pypi_satisfies_requirement(
     locked_record: &LockedPypiRecord,
     project_root: &Path,
     origin: RequirementOrigin,
-    locked_indexes: &[Url],
+    locked_indexes: &[&Url],
 ) -> Result<(), Box<PlatformUnsat>> {
     let locked_data = &locked_record.data;
     if spec.name.to_string() != locked_data.name().to_string() {
@@ -195,8 +195,9 @@ pub(crate) fn pypi_satisfies_requirement(
                 (None, Some(locked_url)) if origin == RequirementOrigin::Manifest => {
                     // Issue #6060: accept the locked URL if it matches any
                     // env-level configured index; fall back to PyPI default.
-                    let effective_indexes: &[Url] = if locked_indexes.is_empty() {
-                        std::slice::from_ref(&*pixi_consts::consts::DEFAULT_PYPI_INDEX_URL)
+                    let default_index = &*pixi_consts::consts::DEFAULT_PYPI_INDEX_URL;
+                    let effective_indexes: &[&Url] = if locked_indexes.is_empty() {
+                        std::slice::from_ref(&default_index)
                     } else {
                         locked_indexes
                     };
@@ -1457,7 +1458,7 @@ mod tests {
             &locked_data,
             &project_root,
             RequirementOrigin::Manifest,
-            &[Url::parse(custom_index).unwrap()],
+            &[&Url::parse(custom_index).unwrap()],
         );
         assert!(result.is_ok(), "{:?}", result.unwrap_err());
 
@@ -1467,7 +1468,7 @@ mod tests {
             &locked_data,
             &project_root,
             RequirementOrigin::Manifest,
-            &[Url::parse(&format!("{custom_index}/")).unwrap()],
+            &[&Url::parse(&format!("{custom_index}/")).unwrap()],
         );
         assert!(result_with_trailing_slash.is_ok());
 
@@ -1477,7 +1478,7 @@ mod tests {
             &locked_data,
             &project_root,
             RequirementOrigin::Manifest,
-            &[Url::parse("https://unrelated.example.com/simple").unwrap()],
+            &[&Url::parse("https://unrelated.example.com/simple").unwrap()],
         );
         assert!(result_unrelated.is_err());
     }
@@ -1512,8 +1513,8 @@ mod tests {
             &project_root,
             RequirementOrigin::Manifest,
             &[
-                pixi_consts::consts::DEFAULT_PYPI_INDEX_URL.clone(),
-                Url::parse(extra_index).unwrap(),
+                &*pixi_consts::consts::DEFAULT_PYPI_INDEX_URL,
+                &Url::parse(extra_index).unwrap(),
             ],
         );
         assert!(result.is_ok(), "{:?}", result.unwrap_err());

--- a/tests/data/satisfiability/pypi-find-links-index/pixi.lock
+++ b/tests/data/satisfiability/pypi-find-links-index/pixi.lock
@@ -1,0 +1,33 @@
+#
+# This lock file should satisfy the accompanying pixi.toml file.
+#
+# Regression for issue #6265: my-dep is resolved from the find-links flat
+# index, so its `index` is the find-links URL rather than a regular index.
+# A requirement with no per-package index must still accept it.
+
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+      - https://pypi.org/simple
+    find-links:
+      - url: https://data.pyg.org/whl/torch-2.8.0+cpu.html
+    packages:
+      win-64:
+        - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+        - pypi: https://data.pyg.org/whl/my_dep-1.0.0-py3-none-any.whl
+packages:
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+    sha256: 1a95494abe572a8819c933f978df89f00bde72ea9432d46a70632599e8029ea4
+    md5: f07c8c5dd98767f9a652de5d039b284e
+    # Faked to be empty to reduce the size of the example
+    depends: []
+  - pypi: https://data.pyg.org/whl/my_dep-1.0.0-py3-none-any.whl
+    name: my-dep
+    version: 1.0.0
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    index: https://data.pyg.org/whl/torch-2.8.0+cpu.html

--- a/tests/data/satisfiability/pypi-find-links-index/pixi.toml
+++ b/tests/data/satisfiability/pypi-find-links-index/pixi.toml
@@ -1,0 +1,13 @@
+[workspace]
+channels = ["conda-forge"]
+name = "pypi-find-links-index"
+platforms = ["win-64"]
+
+[workspace.pypi-options]
+find-links = [{ url = "https://data.pyg.org/whl/torch-2.8.0+cpu.html" }]
+
+[dependencies]
+python = "3.12.*"
+
+[pypi-dependencies]
+my-dep = "*"


### PR DESCRIPTION
### Description

`pixi install --locked` failed when a workspace used `find-links`. After a successful `pixi lock`, packages resolved from a `find-links` index were incorrectly treated as out of date, so the locked install was rejected even though the lock file was current. This worked in 0.67.2 and regressed in 0.70.0.

This change makes `find-links` packages satisfy the lock file again, so `pixi lock` followed by `pixi install --locked` succeeds.

Fixes #6265

### How Has This Been Tested?

- Reproduced the original issue with the workspace from the report (lightning and the torch/PyG stack with a `find-links` URL): `pixi install --locked` failed before the change and succeeds after it.
- Added a satisfiability regression fixture covering a package locked from a `find-links` index.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.