### PR TITLE
fix: keep conda-env build discriminator out of PEP 517 config_settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6956,6 +6956,7 @@ dependencies = [
  "uv-distribution-filename",
  "uv-distribution-types",
  "uv-flags",
+ "uv-git",
  "uv-install-wheel",
  "uv-installer",
  "uv-normalize",
@@ -6967,6 +6968,7 @@ dependencies = [
  "uv-redacted",
  "uv-resolver",
  "uv-types",
+ "uv-workspace",
 ]
 
 [[package]]

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -30,9 +30,9 @@ use pixi_reporters::{UvReporter, UvReporterOptions};
 use pixi_uv_conversions::{
     ConversionError, as_uv_req, configure_insecure_hosts_for_tls_bypass,
     convert_uv_requirements_to_pep508, into_pinned_git_spec, into_uv_git_reference,
-    into_uv_git_sha, pypi_build_config_settings, pypi_options_to_build_options,
-    pypi_options_to_index_locations, to_index_strategy, to_prerelease_mode, to_requirements,
-    to_uv_normalize, to_uv_version, to_version_specifiers,
+    into_uv_git_sha, pypi_options_to_build_options, pypi_options_to_index_locations,
+    to_index_strategy, to_prerelease_mode, to_requirements, to_uv_normalize, to_uv_version,
+    to_version_specifiers,
 };
 use pypi_modifiers::{
     pypi_marker_env::determine_marker_environment,
@@ -554,11 +554,11 @@ pub async fn resolve_pypi(
 
     let dependency_metadata = DependencyMetadata::default();
 
-    // Scope source builds to the conda environment. See issue #6226.
-    let config_settings = match repodata_building_records.as_ref() {
-        Ok(records) => pypi_build_config_settings(&records.records),
-        Err(_) => ConfigSettings::default(),
-    };
+    // Metadata extraction is env-independent, so no scoping here; the build cache
+    // is scoped per environment at install time (see `CacheScopedBuildContext` in
+    // pixi_install_pypi). Keeping the fingerprint out of `config_settings` also
+    // avoids breaking strict PEP 517 backends like meson-python. See #6271 and #6226.
+    let config_settings = ConfigSettings::default();
     let build_params = UvBuildDispatchParams::new(
         &registry_client,
         &context.cache,

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -19,9 +19,8 @@ use pixi_record::{LockedGitUrl, PixiRecord};
 use pixi_spec::Subdirectory;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
-    configure_insecure_hosts_for_tls_bypass, into_pixi_reference, pypi_build_config_settings,
-    pypi_options_to_build_options, pypi_options_to_index_locations, to_index_strategy,
-    to_requirements,
+    configure_insecure_hosts_for_tls_bypass, into_pixi_reference, pypi_options_to_build_options,
+    pypi_options_to_index_locations, to_index_strategy, to_requirements,
 };
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
 use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record};
@@ -634,11 +633,11 @@ async fn read_local_package_metadata(
         )
     };
 
-    // Scope source builds to the conda environment. See issue #6226.
-    let config_settings = match ctx.building_pixi_records.as_ref() {
-        Ok(records) => pypi_build_config_settings(&records.records),
-        Err(_) => ConfigSettings::default(),
-    };
+    // Metadata extraction is env-independent, so no scoping here; the build cache
+    // is scoped per environment at install time (see `CacheScopedBuildContext` in
+    // pixi_install_pypi). Keeping the fingerprint out of `config_settings` also
+    // avoids breaking strict PEP 517 backends like meson-python. See #6271 and #6226.
+    let config_settings = ConfigSettings::default();
     let build_params = UvBuildDispatchParams::new(
         &registry_client,
         &ctx.uv_context.cache,

--- a/crates/pixi_install_pypi/Cargo.toml
+++ b/crates/pixi_install_pypi/Cargo.toml
@@ -50,6 +50,7 @@ uv-distribution = { workspace = true }
 uv-distribution-filename = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-flags = { workspace = true }
+uv-git = { workspace = true }
 uv-install-wheel = { workspace = true }
 uv-installer = { workspace = true }
 uv-normalize = { workspace = true }
@@ -61,6 +62,7 @@ uv-python = { workspace = true }
 uv-redacted = { workspace = true }
 uv-resolver = { workspace = true }
 uv-types = { workspace = true }
+uv-workspace = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/pixi_install_pypi/src/cache_scoped_build_context.rs
+++ b/crates/pixi_install_pypi/src/cache_scoped_build_context.rs
@@ -1,0 +1,169 @@
+//! A [`BuildContext`] that scopes uv's source-build cache to the conda
+//! environment without leaking the discriminator to the PEP 517 backend.
+//!
+//! uv computes the built-wheel cache shard from [`BuildContext::config_settings`],
+//! but the backend receives its config settings from the inner [`BuildDispatch`]'s
+//! own field (read directly inside `BuildDispatch::setup_build`). By returning a
+//! fingerprinted [`ConfigSettings`] here while the wrapped dispatch is built with
+//! clean settings, source builds are cached per environment (issue #6226) yet no
+//! synthetic option reaches strict backends like meson-python (issue #6271).
+
+use std::path::Path;
+
+use uv_configuration::{BuildKind, BuildOutput, NoSources};
+use uv_dispatch::BuildDispatch;
+use uv_distribution_filename::DistFilename;
+use uv_distribution_types::{
+    CachedDist, ConfigSettings, IsBuildBackendError, Requirement, SourceDist,
+};
+use uv_python::PythonEnvironment;
+use uv_types::{BuildArena, BuildContext, BuildStack, ResolvedRequirements};
+
+/// Wraps a [`BuildDispatch`], overriding only the config settings uv uses for the
+/// build cache key. See the module docs.
+pub(crate) struct CacheScopedBuildContext<'a> {
+    inner: BuildDispatch<'a>,
+    cache_config_settings: ConfigSettings,
+}
+
+impl<'a> CacheScopedBuildContext<'a> {
+    pub(crate) fn new(inner: BuildDispatch<'a>, cache_config_settings: ConfigSettings) -> Self {
+        Self {
+            inner,
+            cache_config_settings,
+        }
+    }
+}
+
+impl<'ctx> BuildContext for CacheScopedBuildContext<'ctx> {
+    type SourceDistBuilder = <BuildDispatch<'ctx> as BuildContext>::SourceDistBuilder;
+
+    /// The whole point of the wrapper: the cache shard is keyed by the
+    /// fingerprinted settings, while the inner dispatch builds with its own
+    /// (clean) ones.
+    fn config_settings(&self) -> &ConfigSettings {
+        &self.cache_config_settings
+    }
+
+    async fn interpreter(&self) -> &uv_python::Interpreter {
+        self.inner.interpreter().await
+    }
+
+    fn cache(&self) -> &uv_cache::Cache {
+        self.inner.cache()
+    }
+
+    fn git(&self) -> &uv_git::GitResolver {
+        self.inner.git()
+    }
+
+    fn capabilities(&self) -> &uv_distribution_types::IndexCapabilities {
+        self.inner.capabilities()
+    }
+
+    fn dependency_metadata(&self) -> &uv_distribution_types::DependencyMetadata {
+        self.inner.dependency_metadata()
+    }
+
+    fn build_options(&self) -> &uv_configuration::BuildOptions {
+        self.inner.build_options()
+    }
+
+    fn sources(&self) -> &NoSources {
+        self.inner.sources()
+    }
+
+    fn locations(&self) -> &uv_distribution_types::IndexLocations {
+        self.inner.locations()
+    }
+
+    async fn resolve<'a>(
+        &'a self,
+        requirements: &'a [Requirement],
+        build_stack: &'a BuildStack,
+    ) -> Result<ResolvedRequirements, impl IsBuildBackendError> {
+        self.inner.resolve(requirements, build_stack).await
+    }
+
+    async fn install<'a>(
+        &'a self,
+        resolution: &'a ResolvedRequirements,
+        venv: &'a PythonEnvironment,
+        build_stack: &'a BuildStack,
+    ) -> Result<Vec<CachedDist>, impl IsBuildBackendError> {
+        self.inner.install(resolution, venv, build_stack).await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn setup_build<'a>(
+        &'a self,
+        source: &'a Path,
+        subdirectory: Option<&'a Path>,
+        install_path: &'a Path,
+        version_id: Option<&'a str>,
+        dist: Option<&'a SourceDist>,
+        sources: &'a NoSources,
+        build_kind: BuildKind,
+        build_output: BuildOutput,
+        build_stack: BuildStack,
+    ) -> Result<Self::SourceDistBuilder, impl IsBuildBackendError> {
+        self.inner
+            .setup_build(
+                source,
+                subdirectory,
+                install_path,
+                version_id,
+                dist,
+                sources,
+                build_kind,
+                build_output,
+                build_stack,
+            )
+            .await
+    }
+
+    async fn direct_build<'a>(
+        &'a self,
+        source: &'a Path,
+        subdirectory: Option<&'a Path>,
+        output_dir: &'a Path,
+        sources: NoSources,
+        build_kind: BuildKind,
+        version_id: Option<&'a str>,
+    ) -> Result<Option<DistFilename>, impl IsBuildBackendError> {
+        self.inner
+            .direct_build(
+                source,
+                subdirectory,
+                output_dir,
+                sources,
+                build_kind,
+                version_id,
+            )
+            .await
+    }
+
+    fn workspace_cache(&self) -> &uv_workspace::WorkspaceCache {
+        self.inner.workspace_cache()
+    }
+
+    fn build_arena(&self) -> &BuildArena<Self::SourceDistBuilder> {
+        self.inner.build_arena()
+    }
+
+    fn config_settings_package(&self) -> &uv_distribution_types::PackageConfigSettings {
+        self.inner.config_settings_package()
+    }
+
+    fn extra_build_requires(&self) -> &uv_distribution_types::ExtraBuildRequires {
+        self.inner.extra_build_requires()
+    }
+
+    fn build_isolation(&self) -> uv_types::BuildIsolation<'_> {
+        self.inner.build_isolation()
+    }
+
+    fn extra_build_variables(&self) -> &uv_distribution_types::ExtraBuildVariables {
+        self.inner.extra_build_variables()
+    }
+}

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -24,7 +24,7 @@ use pixi_utils::prefix::Prefix;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
     BuildIsolation, configure_insecure_hosts_for_tls_bypass, locked_indexes_to_index_locations,
-    pypi_build_config_settings, pypi_options_to_build_options, to_exclude_newer, to_index_strategy,
+    pypi_cache_config_settings, pypi_options_to_build_options, to_exclude_newer, to_index_strategy,
 };
 use plan::{InstallPlanner, InstallReason, NeedReinstall, PyPIInstallationPlan};
 use pypi_modifiers::{
@@ -135,11 +135,14 @@ impl InstallablePypiRecord {
     }
 }
 
+pub(crate) mod cache_scoped_build_context;
 pub(crate) mod conda_pypi_clobber;
 pub(crate) mod conversions;
 pub(crate) mod install_wheel;
 pub(crate) mod plan;
 pub(crate) mod utils;
+
+use cache_scoped_build_context::CacheScopedBuildContext;
 
 /// Continue or skip a PyPI prefix update based on the interpreter state.
 pub enum ContinuePyPIPrefixUpdate<'a> {
@@ -349,7 +352,12 @@ struct UvInstallerPlannerConfig {
     tags: Tags,
     index_locations: IndexLocations,
     build_options: BuildOptions,
+    /// Settings passed to the PEP 517 backend (kept clean of pixi internals).
     config_settings: ConfigSettings,
+    /// Fingerprint-bearing settings used *only* as the build context's cache key,
+    /// never handed to the backend. See [`pypi_cache_config_settings`] and
+    /// [`CacheScopedBuildContext`].
+    cache_config_settings: ConfigSettings,
     venv: PythonEnvironment,
 }
 
@@ -360,7 +368,12 @@ struct UvInstallerConfig {
     build_options: BuildOptions,
     registry_client: Arc<RegistryClient>,
     flat_index: FlatIndex,
+    /// Settings passed to the PEP 517 backend (kept clean of pixi internals).
     config_settings: ConfigSettings,
+    /// Fingerprint-bearing settings used *only* as the build context's cache key,
+    /// never handed to the backend. See [`pypi_cache_config_settings`] and
+    /// [`CacheScopedBuildContext`].
+    cache_config_settings: ConfigSettings,
     venv: PythonEnvironment,
     build_isolation: BuildIsolation,
     constraints: Constraints,
@@ -517,9 +530,12 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             pypi_options_to_build_options(self.build_config.no_build, self.build_config.no_binary)
                 .into_diagnostic()?;
 
-        // Scope source builds to the conda environment, matching the key used
-        // during resolution. See issue #6226.
-        let config_settings = pypi_build_config_settings(pixi_records);
+        // The backend gets clean settings; the conda-environment fingerprint is
+        // applied only to the build cache key via `CacheScopedBuildContext`, so
+        // strict backends like meson-python aren't broken (#6271) while wheels
+        // stay scoped per environment (#6226).
+        let config_settings = ConfigSettings::default();
+        let cache_config_settings = pypi_cache_config_settings(&config_settings, pixi_records);
 
         // Setup the interpreter from the conda prefix
         let python_location = self.config.prefix.root().join(python_interpreter_path);
@@ -540,6 +556,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             index_locations,
             build_options,
             config_settings,
+            cache_config_settings,
             venv,
         })
     }
@@ -607,6 +624,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             registry_client,
             flat_index,
             config_settings: planner_config.config_settings,
+            cache_config_settings: planner_config.cache_config_settings,
             venv: planner_config.venv,
             build_isolation,
             constraints: Constraints::default(),
@@ -639,8 +657,12 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
 
         let extra_build_requires = ExtraBuildRequires::default();
         let package_settings = PackageConfigSettings::default();
-
         let extra_build_variables = ExtraBuildVariables::default();
+
+        // The cache lookup must use the fingerprinted settings, the same ones the
+        // build dispatch exposes via `CacheScopedBuildContext`, or the
+        // per-environment shard a wheel is built into would never be found again.
+        let cache_config_settings = &planner_config.cache_config_settings;
 
         // This is used to find wheels that are available from the registry
         let registry_index = RegistryWheelIndex::new(
@@ -648,7 +670,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             &planner_config.tags,
             &planner_config.index_locations,
             &self.context_config.uv_context.hash_strategy,
-            &planner_config.config_settings,
+            cache_config_settings,
             &package_settings,
             &extra_build_requires,
             &extra_build_variables,
@@ -659,7 +681,7 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             &self.context_config.uv_context.cache,
             &planner_config.tags,
             &self.context_config.uv_context.hash_strategy,
-            &planner_config.config_settings,
+            cache_config_settings,
             &package_settings,
             &extra_build_requires,
             &extra_build_variables,
@@ -932,7 +954,13 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         } else {
             HashMap::new()
         };
-        let build_dispatch = self.create_build_dispatch(setup, &env_vars);
+        // Wrap the dispatch so the conda-environment fingerprint scopes the build
+        // cache key without reaching the PEP 517 backend (see
+        // `CacheScopedBuildContext`).
+        let build_dispatch = CacheScopedBuildContext::new(
+            self.create_build_dispatch(setup, &env_vars),
+            setup.cache_config_settings.clone(),
+        );
 
         let distribution_database = DistributionDatabase::new(
             setup.registry_client.as_ref(),

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -32,22 +32,32 @@ use uv_redacted::DisplaySafeUrl;
 
 use crate::{ConversionError, VersionError};
 
-/// The `config_settings` key under which the conda-environment fingerprint is
-/// injected.
+/// `config_settings` key carrying the conda-environment fingerprint.
 const CONDA_ENVIRONMENT_CONFIG_SETTING: &str = "pixi-conda-environment";
 
-/// Builds the [`ConfigSettings`] for PyPI resolution and installation, seeded
-/// with a fingerprint of the conda environment.
+/// Builds the [`ConfigSettings`] used to scope the PyPI source-build cache to the
+/// conda environment: a wheel built against one set of conda dependencies is not
+/// reused in an environment that resolves different ones (issue #6226).
 ///
-/// uv folds `config_settings` into the cache key of wheels it builds from
-/// source, so this scopes source builds per environment. Prebuilt registry
-/// wheels are unaffected. See <https://github.com/prefix-dev/pixi/issues/6226>.
-pub fn pypi_build_config_settings(conda_records: &[PixiRecord]) -> ConfigSettings {
+/// The result is `config_settings` (the settings handed to the PEP 517 backend)
+/// with the conda-environment fingerprint layered on top, so the cache key always
+/// reflects the real backend settings as well; should those stop being empty, the
+/// scoping keeps working.
+///
+/// uv folds `config_settings` into the built-wheel cache key, so this is applied
+/// globally. It must only be used as the build context's *cache* settings, never
+/// handed to the build dispatch that invokes the PEP 517 backend, since strict
+/// backends like meson-python reject unknown keys (issue #6271).
+pub fn pypi_cache_config_settings(
+    config_settings: &ConfigSettings,
+    conda_records: &[PixiRecord],
+) -> ConfigSettings {
     let fingerprint = CondaEnvironmentFingerprint::new(conda_records);
     let entry =
         ConfigSettingEntry::from_str(&format!("{CONDA_ENVIRONMENT_CONFIG_SETTING}={fingerprint}"))
             .expect("the fingerprint is always a valid `KEY=VALUE` config setting");
-    std::iter::once(entry).collect()
+    let fingerprint_settings: ConfigSettings = std::iter::once(entry).collect();
+    config_settings.clone().merge(fingerprint_settings)
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -927,5 +937,26 @@ mod tests {
         let pinned = into_pinned_git_spec(dist, None);
 
         assert_eq!(pinned.git.as_str(), original);
+    }
+
+    /// #6271/#6226: the cache settings carry the conda-environment fingerprint on
+    /// top of the given backend settings, so the cache key reflects both.
+    #[test]
+    fn pypi_cache_config_settings_layers_fingerprint_on_base() {
+        use pixi_record::CondaEnvironmentFingerprint;
+
+        let base: ConfigSettings =
+            std::iter::once(ConfigSettingEntry::from_str("backend-key=backend-value").unwrap())
+                .collect();
+        let settings = pypi_cache_config_settings(&base, &[]);
+
+        let rendered = settings.escape_for_python();
+        // The fingerprint of the (here empty) conda environment is present...
+        let expected = CondaEnvironmentFingerprint::new(&[]).to_string();
+        assert!(rendered.contains(CONDA_ENVIRONMENT_CONFIG_SETTING));
+        assert!(rendered.contains(&expected));
+        // ...and the base backend settings are preserved.
+        assert!(rendered.contains("backend-key"));
+        assert!(rendered.contains("backend-value"));
     }
 }


### PR DESCRIPTION
### Description

Fixes a regression in pixi 0.70.1 where PyPI packages using the meson-python build backend failed to build from git or other source dependencies, reporting `Unknown option 'pixi-conda-environment'`. This affected projects like numcodecs and broke downstream CI such as xarray's.

The 0.70.1 fix that scopes source builds per conda environment did so by passing an internal marker through a channel that pixi also forwards to the package's build backend. Strict backends like meson-python validate what they receive and rejected the unknown marker.

This change keeps the per-environment scoping but moves that marker so it only influences pixi's own build cache and is never handed to the build backend. As a result, a wheel built against one set of conda dependencies is still not reused in an environment that resolves different ones, and strict backends like meson-python build again.

Fixes #6271

### How Has This Been Tested?

Built pixi from this branch and ran `pixi install` against the reported case (a numcodecs git dependency with meson-python): the `Unknown option` error no longer occurs and the build proceeds normally. Also verified a meson-python git dependency builds and installs cleanly end to end.

Separately confirmed the per-environment cache scoping still holds: the same source package installed in two environments that differ in their conda dependencies produces two distinct cached builds rather than reusing one, while re-installing the same environment reuses its existing build. Added a unit test covering the scoping settings.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.