### PR TITLE
fix(spec): allow extras and flags on source dependency specs

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,6 +4,9 @@
 ignore-interior-mutability = [
   "pixi_core::workspace::environment::Environment",
   "pixi_core::workspace::solve_group::SolveGroup",
+  # StringMatcher's Hash/Eq are derived from the pattern string; the interior
+  # mutability is only a lazily-built regex cache and cannot destabilize keys.
+  "rattler_conda_types::StringMatcher",
 ]
 
 disallowed-methods = [

--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -1235,6 +1235,255 @@ dep-a = ">=1.0"
     );
 }
 
+/// Writes the source package manifest used by the extras tests: regular
+/// run-dependency `dep-a` plus a `training` extra group containing
+/// `extra-dep`.
+fn write_extras_source_manifest(source_dir: &std::path::Path) {
+    let source_manifest = r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "passthrough", version = "*" }
+
+[package.run-dependencies]
+dep-a = ">=1.0"
+
+[package.extra-dependencies.training]
+extra-dep = ">=1.0"
+"#;
+    fs::write(source_dir.join("pixi.toml"), source_manifest).unwrap();
+}
+
+/// Builds the channel for the extras tests: `dep-a` (regular run-dep)
+/// and `extra-dep` (only reachable through the `training` extra group).
+async fn extras_test_channel() -> pixi_test_utils::LocalChannel {
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("dep-a", "1.0.0").finish());
+    package_database.add_package(Package::build("extra-dep", "1.0.0").finish());
+    package_database.into_channel().await.unwrap()
+}
+
+/// A path dependency requesting an extra group must pull that group's
+/// dependencies into the environment, and the resulting lock file must be
+/// stable: an immediate re-check may not trigger another solve.
+#[tokio::test]
+async fn test_source_dependency_with_extras_locks_extra_deps() {
+    setup_tracing();
+
+    let channel = extras_test_channel().await;
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    write_extras_source_manifest(&source_dir);
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package", extras = ["training"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let workspace = pixi.workspace().unwrap();
+    let (lock_file_data, was_updated) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("initial lock file generation should succeed");
+    assert!(was_updated, "initial solve must create the lock file");
+
+    let lock_file = lock_file_data.into_lock_file();
+    for package in ["my-package", "dep-a", "extra-dep"] {
+        assert!(
+            lock_file.contains_conda_package(
+                consts::DEFAULT_ENVIRONMENT_NAME,
+                Platform::current(),
+                package,
+            ),
+            "expected '{package}' to be locked",
+        );
+    }
+
+    // Re-checking the fresh lock file must not trigger another solve. This
+    // exercises the satisfiability walk over `experimental_extra_depends`:
+    // without it, `extra-dep` is unreachable and the verifier rejects the
+    // lock file as carrying too many packages.
+    let workspace = pixi.workspace().unwrap();
+    let (_, was_updated_again) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("re-checking the lock file should succeed");
+    assert!(
+        !was_updated_again,
+        "a lock file with extras must be stable across satisfiability checks",
+    );
+}
+
+/// Adding or removing `extras` on a path dependency must invalidate the
+/// lock file in both directions.
+#[tokio::test]
+async fn test_changing_extras_on_source_dependency_invalidates_lock_file() {
+    setup_tracing();
+
+    let channel = extras_test_channel().await;
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    write_extras_source_manifest(&source_dir);
+
+    let manifest_without_extras = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    let manifest_with_extras = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package", extras = ["training"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+
+    fs::write(pixi.manifest_path(), &manifest_without_extras).unwrap();
+    let workspace = pixi.workspace().unwrap();
+    let (lock_file_data, _) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("initial lock file generation should succeed");
+    assert!(
+        !lock_file_data.into_lock_file().contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-dep",
+        ),
+        "without extras the extra group's dependency must not be locked",
+    );
+
+    // Requesting the extra must invalidate the lock file and pull the
+    // group's dependency in.
+    fs::write(pixi.manifest_path(), &manifest_with_extras).unwrap();
+    let workspace = pixi.workspace().unwrap();
+    let (lock_file_data, was_updated) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("lock file update after adding extras should succeed");
+    assert!(
+        was_updated,
+        "adding extras to a path dependency must invalidate the lock file",
+    );
+    assert!(
+        lock_file_data.into_lock_file().contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-dep",
+        ),
+        "the requested extra group's dependency must be locked",
+    );
+
+    // Dropping the extra must invalidate the lock file again and remove
+    // the group's dependency.
+    fs::write(pixi.manifest_path(), &manifest_without_extras).unwrap();
+    let workspace = pixi.workspace().unwrap();
+    let (lock_file_data, was_updated) = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await
+        .expect("lock file update after removing extras should succeed");
+    assert!(
+        was_updated,
+        "removing extras from a path dependency must invalidate the lock file",
+    );
+    assert!(
+        !lock_file_data.into_lock_file().contains_conda_package(
+            consts::DEFAULT_ENVIRONMENT_NAME,
+            Platform::current(),
+            "extra-dep",
+        ),
+        "after dropping the extra its dependency must be gone from the lock file",
+    );
+}
+
+/// Requesting an extra group the source package does not declare must
+/// fail the solve instead of being silently ignored.
+#[tokio::test]
+async fn test_unknown_extra_on_source_dependency_fails() {
+    setup_tracing();
+
+    let channel = extras_test_channel().await;
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    write_extras_source_manifest(&source_dir);
+
+    let manifest = format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./my-package", extras = ["does-not-exist"] }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    );
+    fs::write(pixi.manifest_path(), manifest).unwrap();
+
+    let workspace = pixi.workspace().unwrap();
+    let result = workspace
+        .update_lock_file(None, pixi_core::UpdateLockFileOptions::default())
+        .await;
+    let error = result
+        .err()
+        .expect("requesting an undeclared extra must fail the solve")
+        .chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        error.contains("'my-package' does not provide the requested extra 'does-not-exist'"),
+        "error must name the package and the missing extra, got: {error}",
+    );
+    assert!(
+        error.contains("available extras: training"),
+        "error must list the available extras, got: {error}",
+    );
+}
+
 /// Removing a host-dependency that contributes a `weak_constrains`
 /// run-export must invalidate the lock file, even though pixi's manifest
 /// schema doesn't currently expose `[package.run-constraints]` directly.

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -66,6 +66,8 @@ pub async fn add_conda_dep(
                     git: git.clone(),
                     rev: Some(git_options.reference.clone()),
                     subdirectory: subdirectory.clone(),
+                    extras: None,
+                    flags: None,
                 };
                 (
                     name.clone(),

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -588,7 +588,18 @@ fn create_output(
         )),
         host_dependencies: Some(host_deps),
         run_dependencies,
-        extra_dependencies: convert_extra_depends(&index_json.experimental_extra_depends),
+        extra_dependencies: {
+            // Groups declared in the source manifest's
+            // `[package.extra-dependencies]` extend (and shadow per group)
+            // whatever a pre-built package recorded in its repodata.
+            let mut extra_dependencies =
+                convert_extra_depends(&index_json.experimental_extra_depends);
+            extra_dependencies.extend(extract_extra_dependencies(
+                &project_model.targets,
+                params.host_platform,
+            ));
+            extra_dependencies
+        },
         metadata: CondaOutputMetadata {
             name: project_model
                 .name
@@ -731,6 +742,42 @@ fn resolve_run_export_spec(
         }
         .into(),
     })
+}
+
+/// Collects the `[package.extra-dependencies]` groups declared in the source
+/// manifest's project model for the given platform, mirroring how
+/// `extract_dependencies` resolves the regular dependency tables.
+fn extract_extra_dependencies(
+    targets: &Option<Targets>,
+    platform: Platform,
+) -> BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> {
+    let mut result: BTreeMap<ExtraGroupName, Vec<NamedSpec<PackageSpec>>> = BTreeMap::new();
+    let matching_targets = targets.iter().flat_map(|targets| {
+        targets
+            .default_target
+            .iter()
+            .chain(
+                targets
+                    .targets
+                    .iter()
+                    .flatten()
+                    .flat_map(|(selector, target)| {
+                        matches_target_selector(selector, platform).then_some(target)
+                    }),
+            )
+    });
+    for target in matching_targets {
+        for (group, deps) in target.extra_dependencies.iter().flatten() {
+            result
+                .entry(group.clone())
+                .or_default()
+                .extend(deps.iter().map(|(name, spec)| NamedSpec {
+                    name: name.clone(),
+                    spec: spec.clone(),
+                }));
+        }
+    }
+    result
 }
 
 /// Converts a finished package's `experimental_extra_depends` (group name to a

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -64,6 +64,8 @@ fn to_pixi_spec_v1(
                         git,
                         rev,
                         subdirectory,
+                        extras: _,
+                        flags: _,
                     } = git_spec;
                     pbt::SourcePackageLocationSpec::Git(pbt::GitSpec {
                         git,

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -104,6 +104,8 @@ impl GlobalSpecs {
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
+                extras: None,
+                flags: None,
             };
             Some(PixiSpec::Git(git_spec))
         } else if let Some(path) = &self.path {
@@ -159,10 +161,10 @@ impl GlobalSpecs {
                         manifest_root.to_string_lossy().to_string(),
                     )
                 })?;
-            Some(PixiSpec::Path(pixi_spec::PathSpec {
-                path: Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
+            Some(PixiSpec::Path(pixi_spec::PathSpec::new(
+                Utf8NativePathBuf::from(relative_path.to_string_lossy().to_string())
                     .to_typed_path_buf(),
-            }))
+            )))
         } else {
             fn pathlike(s: &str) -> bool {
                 s.contains(".conda") || s.contains('/') || s.contains('\\')

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -66,6 +66,8 @@ pub fn from_source_package_location_spec(
                     .subdirectory
                     .and_then(|s| pixi_spec::Subdirectory::try_from(s).ok())
                     .unwrap_or_default(),
+                extras: None,
+                flags: None,
             })
         }
 

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -235,6 +235,9 @@ pub enum SolvePixiEnvironmentError {
     #[error(transparent)]
     SpecConversionError(Arc<SpecConversionError>),
 
+    #[error(transparent)]
+    ExtraNotProvided(Arc<crate::solve_conda::SolveCondaEnvironmentError>),
+
     #[error("detected a cyclic dependency:\n\n{0}")]
     Cycle(Cycle),
 
@@ -326,6 +329,9 @@ impl From<SolveCondaEnvironmentError> for SolvePixiEnvironmentError {
             }
             SolveCondaEnvironmentError::Gateway(err) => {
                 SolvePixiEnvironmentError::QueryError(Arc::new(err))
+            }
+            err @ SolveCondaEnvironmentError::ExtraNotProvided { .. } => {
+                SolvePixiEnvironmentError::ExtraNotProvided(Arc::new(err))
             }
         }
     }

--- a/crates/pixi_command_dispatcher/src/installed_source_hints.rs
+++ b/crates/pixi_command_dispatcher/src/installed_source_hints.rs
@@ -388,6 +388,8 @@ mod tests {
             git: url::Url::parse(url).expect("valid git url"),
             rev: Some(GitReference::Branch("main".into())),
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         })
     }
 

--- a/crates/pixi_command_dispatcher/src/keys/solve_conda.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_conda.rs
@@ -180,6 +180,9 @@ pub enum SolveCondaKeyError {
 
     #[error(transparent)]
     Gateway(Arc<GatewayError>),
+
+    #[error(transparent)]
+    ExtraNotProvided(Arc<SolveCondaEnvironmentError>),
 }
 
 impl From<SolveCondaEnvironmentError> for SolveCondaKeyError {
@@ -190,6 +193,9 @@ impl From<SolveCondaEnvironmentError> for SolveCondaKeyError {
                 SolveCondaKeyError::SpecConversion(Arc::new(e))
             }
             SolveCondaEnvironmentError::Gateway(e) => SolveCondaKeyError::Gateway(Arc::new(e)),
+            err @ SolveCondaEnvironmentError::ExtraNotProvided { .. } => {
+                SolveCondaKeyError::ExtraNotProvided(Arc::new(err))
+            }
         }
     }
 }

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -406,6 +406,9 @@ async fn compute_inner(
                 SolvePixiEnvironmentError::SpecConversionError(a)
             }
             SolveCondaKeyError::Gateway(a) => SolvePixiEnvironmentError::QueryError(a),
+            SolveCondaKeyError::ExtraNotProvided(a) => {
+                SolvePixiEnvironmentError::ExtraNotProvided(a)
+            }
         })?;
     tracing::debug!(
         elapsed_ms = compute_started.elapsed().as_millis() as u64,

--- a/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
+++ b/crates/pixi_command_dispatcher/src/solve_conda/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use itertools::Itertools;
 use pixi_record::{PixiRecord, SourceRecord};
-use pixi_spec::{BinarySpec, ResolvedExcludeNewer, SourceSpec};
+use pixi_spec::{BinarySpec, PixiSpec, ResolvedExcludeNewer, SourceSpec};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::{
     ChannelUrl, GenericVirtualPackage, MatchSpec, Platform, RepoDataRecord, Version,
@@ -119,6 +119,32 @@ impl SolveCondaEnvironmentSpec {
         // for more concurrency.
         let solve_result = tokio::task::spawn_blocking(move || {
             let exclude_newer = self.exclude_newer.clone().map(Into::into);
+
+            // Remember which extras each direct or dev-source dependency
+            // requested. The solver treats extras as conditional activation:
+            // a record that does not provide a requested extra still solves,
+            // silently ignoring the request. Collect the requests up front
+            // (the spec maps are consumed below) and verify them against the
+            // solved records afterwards.
+            let requested_extras = self
+                .source_specs
+                .iter_specs()
+                .filter_map(|(name, spec)| spec.extras.clone().map(|extras| (name.clone(), extras)))
+                .chain(self.binary_specs.iter_specs().filter_map(|(name, spec)| {
+                    let BinarySpec::DetailedVersion(detailed) = spec else {
+                        return None;
+                    };
+                    detailed.extras.clone().map(|extras| (name.clone(), extras))
+                }))
+                .chain(
+                    self.dev_source_records
+                        .iter()
+                        .flat_map(|dev_source| dev_source.dependencies.iter_specs())
+                        .filter_map(|(name, spec)| {
+                            pixi_spec_extras(spec).map(|extras| (name.clone(), extras.to_vec()))
+                        }),
+                )
+                .collect_vec();
 
             // Determine for which records we have source records because those records should only
             //  be installed as source records.
@@ -310,24 +336,67 @@ impl SolveCondaEnvironmentSpec {
             let solver_result = rattler_solve::resolvo::Solver.solve(task)?;
 
             // Convert the results back into pixi records.
-            Ok::<_, SolveCondaEnvironmentError>(
-                solver_result
-                    .records
-                    .into_iter()
-                    .filter_map(|record| {
-                        if let Some(source_record) = url_to_source_package.remove(&record.url) {
-                            // This is a source package, we want to return the source record
-                            // instead of the binary record.
-                            return Some(PixiRecord::Source(Arc::new(source_record.0)));
-                        } else if let Some(_dev_source) = url_to_dev_source.remove(&record.url) {
-                            // This is a dev source, we don't want to return it.
-                            return None;
-                        }
+            let records = solver_result
+                .records
+                .into_iter()
+                .filter_map(|record| {
+                    if let Some(source_record) = url_to_source_package.remove(&record.url) {
+                        // This is a source package, we want to return the source record
+                        // instead of the binary record.
+                        return Some(PixiRecord::Source(Arc::new(source_record.0)));
+                    } else if let Some(_dev_source) = url_to_dev_source.remove(&record.url) {
+                        // This is a dev source, we don't want to return it.
+                        return None;
+                    }
 
-                        Some(PixiRecord::Binary(Arc::new(record)))
+                    Some(PixiRecord::Binary(Arc::new(record)))
+                })
+                .collect_vec();
+
+            // Reject requested extras that the solved records do not provide;
+            // the solver itself silently ignores them. Besides the direct
+            // requests collected above, also mirror the lock-file
+            // satisfiability walk by checking extras requested through the
+            // solved records' own `depends` strings (`pkg[extras=[...]]`),
+            // so a lock file produced here always verifies.
+            let records_by_name: HashMap<&rattler_conda_types::PackageName, &PixiRecord> = records
+                .iter()
+                .map(|record| (&record.package_record().name, record))
+                .collect();
+            let transitive_extras = records.iter().flat_map(|record| {
+                record
+                    .package_record()
+                    .depends
+                    .iter()
+                    .filter(|depend| depend.contains("extras="))
+                    .filter_map(|depend| {
+                        let spec = MatchSpec::from_str(
+                            depend,
+                            rattler_conda_types::ParseMatchSpecOptions::lenient()
+                                .with_repodata_revision(rattler_conda_types::RepodataRevision::V3),
+                        )
+                        .ok()?;
+                        let name = spec.name.as_exact()?.clone();
+                        Some((name, spec.extras?))
                     })
-                    .collect_vec(),
-            )
+            });
+            for (name, extras) in requested_extras.into_iter().chain(transitive_extras) {
+                let Some(record) = records_by_name.get(&name) else {
+                    continue;
+                };
+                let provided = &record.package_record().experimental_extra_depends;
+                for extra in extras {
+                    if !provided.contains_key(&extra) {
+                        return Err(SolveCondaEnvironmentError::ExtraNotProvided {
+                            package: name.as_source().to_string(),
+                            extra,
+                            available: provided.keys().cloned().collect(),
+                        });
+                    }
+                }
+            }
+
+            Ok::<_, SolveCondaEnvironmentError>(records)
         })
         .await;
 
@@ -354,6 +423,17 @@ pub enum SolveCondaBlockingError {
     /// The blocking task panicked; payload is passed through so callers
     /// can decide whether to resume the unwind.
     Panic(Box<dyn std::any::Any + Send + 'static>),
+}
+
+/// Returns the extras requested by a [`PixiSpec`], if any.
+fn pixi_spec_extras(spec: &PixiSpec) -> Option<&[String]> {
+    match spec {
+        PixiSpec::DetailedVersion(detailed) => detailed.extras.as_deref(),
+        PixiSpec::Url(url) => url.extras.as_deref(),
+        PixiSpec::Git(git) => git.extras.as_deref(),
+        PixiSpec::Path(path) => path.extras.as_deref(),
+        PixiSpec::Version(_) => None,
+    }
 }
 
 /// Generates a unique URL for a source record.
@@ -404,6 +484,24 @@ fn dev_source_build_string(dev_source: &pixi_record::DevSourceRecord) -> String 
 pub enum SolveCondaEnvironmentError {
     #[error(transparent)]
     SolveError(#[from] rattler_solve::SolveError),
+
+    /// A dependency requested an extra group that none of the candidate
+    /// records of the package provide. The solver itself treats extras as
+    /// conditional activation and would silently ignore the request, so this
+    /// is validated eagerly to surface typos.
+    #[error(
+        "the package '{package}' does not provide the requested extra '{extra}'{}",
+        if .available.is_empty() {
+            String::new()
+        } else {
+            format!("; available extras: {}", .available.join(", "))
+        }
+    )]
+    ExtraNotProvided {
+        package: String,
+        extra: String,
+        available: Vec<String>,
+    },
 
     #[error(transparent)]
     SpecConversionError(#[from] pixi_spec::SpecConversionError),

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -229,6 +229,8 @@ pub async fn simple_test() {
                     git: git_repo.url.parse().unwrap(),
                     rev: Some(GitReference::Rev(git_repo.commits[0].clone())),
                     subdirectory: Subdirectory::try_from("recipe").unwrap(),
+                    extras: None,
+                    flags: None,
                 }
                 .into(),
             )]),
@@ -592,10 +594,7 @@ pub async fn test_cycle() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package_a".parse().unwrap(),
-                PathSpec {
-                    path: "package_a".into(),
-                }
-                .into(),
+                PathSpec::new("package_a").into(),
             )]),
             env_ref: env_ref_of(vec![], BuildEnvironment::simple(Platform::Linux64, vec![])),
             ..empty_pixi_env_spec()
@@ -643,10 +642,7 @@ pub async fn test_cycle_three_packages() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "package_a".parse().unwrap(),
-                PathSpec {
-                    path: "package_a".into(),
-                }
-                .into(),
+                PathSpec::new("package_a").into(),
             )]),
             env_ref: env_ref_of(vec![], BuildEnvironment::simple(Platform::Linux64, vec![])),
             ..empty_pixi_env_spec()
@@ -2135,7 +2131,7 @@ pub async fn test_installed_host_packages_pin_nested_solve() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "foo".parse().unwrap(),
-                PathSpec { path: "foo".into() }.into(),
+                PathSpec::new("foo").into(),
             )]),
             installed,
             installed_source_hints,
@@ -2294,7 +2290,7 @@ pub async fn test_installed_hint_reused_across_variants() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "foo".parse().unwrap(),
-                PathSpec { path: "foo".into() }.into(),
+                PathSpec::new("foo").into(),
             )]),
             installed,
             installed_source_hints,
@@ -2409,7 +2405,7 @@ pub async fn test_duplicate_installed_source_hints_are_order_independent() {
         SolvePixiEnvironmentSpec {
             dependencies: DependencyMap::from_iter([(
                 "foo".parse().unwrap(),
-                PathSpec { path: "foo".into() }.into(),
+                PathSpec::new("foo").into(),
             )]),
             installed,
             installed_source_hints,
@@ -2587,14 +2583,8 @@ foo = { path = "../foo" }
 
     let make_spec = |installed: Vec<pixi_record::UnresolvedPixiRecord>| SolvePixiEnvironmentSpec {
         dependencies: DependencyMap::from_iter([
-            (
-                "foo".parse().unwrap(),
-                PathSpec { path: "foo".into() }.into(),
-            ),
-            (
-                "bar".parse().unwrap(),
-                PathSpec { path: "bar".into() }.into(),
-            ),
+            ("foo".parse().unwrap(), PathSpec::new("foo").into()),
+            ("bar".parse().unwrap(), PathSpec::new("bar").into()),
         ]),
         installed: std::sync::Arc::from(installed),
         env_ref: env_ref.clone(),

--- a/crates/pixi_compute_sources/src/ext.rs
+++ b/crates/pixi_compute_sources/src/ext.rs
@@ -46,6 +46,8 @@ impl SourceCheckoutExt for ComputeCtx {
                         md5: url.md5,
                         sha256: url.sha256,
                         subdirectory: url.subdirectory,
+                        extras: None,
+                        flags: None,
                     })
                     .boxed(),
                 SourceLocationSpec::Path(path) => {

--- a/crates/pixi_compute_sources/src/url.rs
+++ b/crates/pixi_compute_sources/src/url.rs
@@ -198,6 +198,8 @@ impl UrlSourceCheckoutExt for ComputeCtx {
             md5: pinned_url_spec.md5,
             sha256: Some(pinned_url_spec.sha256),
             subdirectory: pinned_url_spec.subdirectory.clone(),
+            extras: None,
+            flags: None,
         };
         let fut = self.compute(&CheckoutUrl(url_spec));
         async move {

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -29,6 +29,8 @@ async fn pin_and_checkout_git_default_branch() {
         git: repo.base_url.clone(),
         rev: None,
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let checkout = engine
@@ -76,6 +78,8 @@ async fn git_checkout_fires_full_reporter_lifecycle() {
                 git: repo.base_url.clone(),
                 rev: None,
                 subdirectory: Subdirectory::default(),
+                extras: None,
+                flags: None,
             })
             .await
         })

--- a/crates/pixi_compute_sources/tests/url_checkout.rs
+++ b/crates/pixi_compute_sources/tests/url_checkout.rs
@@ -39,6 +39,8 @@ async fn pin_and_checkout_url_reuses_cached_checkout() {
         md5: None,
         sha256: Some(sha),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let spec_for_engine = spec.clone();
@@ -78,12 +80,16 @@ async fn pin_and_checkout_url_reports_sha_mismatch_from_concurrent_request() {
         md5: None,
         sha256: None,
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
     let bad_spec = UrlSpec {
         url,
         md5: None,
         sha256: Some(Sha256::digest(b"pixi-url-bad-sha")),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let (good, bad) = tokio::join!(
@@ -121,6 +127,8 @@ async fn pin_and_checkout_url_validates_cached_results() {
         md5: None,
         sha256: None,
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     engine
@@ -134,6 +142,8 @@ async fn pin_and_checkout_url_validates_cached_results() {
         md5: None,
         sha256: Some(Sha256::digest(b"pixi-url-bad-cache")),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let err = engine
@@ -172,6 +182,8 @@ async fn url_checkout_fires_full_reporter_lifecycle() {
                 md5: None,
                 sha256: None,
                 subdirectory: Subdirectory::default(),
+                extras: None,
+                flags: None,
             })
             .await
         })
@@ -207,6 +219,8 @@ async fn url_checkout_semaphore_limits_inflight_count() {
         md5: None,
         sha256: None,
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let (a, b, c) = tokio::join!(

--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -339,6 +339,9 @@ pub enum PlatformUnsat {
     #[error("the locked source package '{0}' does not match the requested source package, {1}")]
     SourcePackageMismatch(String, SourceMismatchError),
 
+    #[error("the locked package '{0}' does not provide the requested extra '{1}'")]
+    ExtraNotProvided(String, String),
+
     #[error("failed to convert the requirement for '{0}'")]
     FailedToConvertRequirement(pep508_rs::PackageName, #[source] Box<ParsedUrlError>),
 

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -833,6 +833,7 @@ async fn verify_package_platform_satisfiability(
                     let pkg_idx = CondaPackageIdx(*repodata_idx);
                     conda_packages_used_by_pypi
                         .insert(locked_pixi_records.records[pkg_idx.0].name().clone());
+                    // PyPI extras do not map onto conda extras.
                     FoundPackage::Conda(pkg_idx, Vec::new())
                 } else {
                     match to_normalize(&requirement.name)
@@ -899,7 +900,9 @@ async fn verify_package_platform_satisfiability(
                 let record = &locked_pixi_records.records[idx.0];
 
                 // Regular deps on first visit, plus deps of any newly requested
-                // extra (else extra-only packages look unused).
+                // extra (else extra-only packages look unused). A requested
+                // extra the locked package does not provide makes the lock
+                // file unsatisfiable.
                 let mut depends_to_walk: Vec<&String> = Vec::new();
                 if newly_visited {
                     depends_to_walk.extend(record.package_record().depends.iter());
@@ -907,12 +910,19 @@ async fn verify_package_platform_satisfiability(
                 {
                     let followed = conda_extras_followed.entry(idx).or_default();
                     for extra in &extras {
-                        if followed.insert(extra.clone())
-                            && let Some(extra_depends) = record
-                                .package_record()
-                                .experimental_extra_depends
-                                .get(extra)
-                        {
+                        let Some(extra_depends) = record
+                            .package_record()
+                            .experimental_extra_depends
+                            .get(extra)
+                        else {
+                            return Err(CommandDispatcherError::Failed(Box::new(
+                                PlatformUnsat::ExtraNotProvided(
+                                    record.name().as_source().to_string(),
+                                    extra.clone(),
+                                ),
+                            )));
+                        };
+                        if followed.insert(extra.clone()) {
                             depends_to_walk.extend(extra_depends.iter());
                         }
                     }

--- a/crates/pixi_pypi_spec/src/lib.rs
+++ b/crates/pixi_pypi_spec/src/lib.rs
@@ -353,6 +353,8 @@ mod tests {
                 git: Url::parse("https://github.com/example/repo").unwrap(),
                 rev: None,
                 subdirectory: Default::default(),
+                extras: None,
+                flags: None,
             },
         });
         assert!(spec.is_source_dependency());
@@ -399,6 +401,8 @@ mod tests {
                     git: Url::parse("https://github.com/example/repo").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             },
             vec![extra.clone()],
@@ -424,6 +428,8 @@ mod tests {
                     git: Url::parse("https://github.com/example/repo").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             },
             vec![],
@@ -574,6 +580,8 @@ mod tests {
                     git: Url::parse("https://github.com/ecederstrand/exchangelib").unwrap(),
                     rev: Some(GitReference::DefaultBranch),
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );
@@ -589,6 +597,8 @@ mod tests {
                         "b283011c6df4a9e034baca9aea19aa8e5a70e3ab".to_string()
                     )),
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );
@@ -681,7 +691,9 @@ mod tests {
                 git: GitSpec {
                     git: Url::parse("ssh://git@github.com/python-attrs/attrs.git").unwrap(),
                     rev: Some(GitReference::Rev("main".to_string())),
-                    subdirectory: Default::default()
+                    subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );
@@ -698,6 +710,8 @@ mod tests {
                     git: Url::parse("https://github.com/Deltares/Ribasim.git").unwrap(),
                     rev: Some(GitReference::DefaultBranch),
                     subdirectory: Subdirectory::try_from("python/ribasim").unwrap(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );

--- a/crates/pixi_pypi_spec/src/pep508.rs
+++ b/crates/pixi_pypi_spec/src/pep508.rs
@@ -31,6 +31,8 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                                     git: git_url.repository().clone(),
                                     rev: Some(git_url.reference().clone().into()),
                                     subdirectory,
+                                    extras: None,
+                                    flags: None,
                                 };
 
                                 PixiPypiSpec::with_extras_and_markers(
@@ -78,6 +80,8 @@ impl TryFrom<pep508_rs::Requirement> for PixiPypiSpec {
                             git: git_url.repository().clone(),
                             rev: Some(git_url.reference().clone().into()),
                             subdirectory,
+                            extras: None,
+                            flags: None,
                         };
                         PixiPypiSpec::with_extras_and_markers(
                             PixiPypiSource::Git { git: git_spec },

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -158,6 +158,8 @@ impl RawPyPiRequirement {
                                 .map(pixi_spec::Subdirectory::try_from)
                                 .transpose()?
                                 .unwrap_or_default(),
+                            extras: None,
+                            flags: None,
                         },
                     },
                     self.extras,
@@ -336,6 +338,8 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         git,
                         rev,
                         subdirectory,
+                        extras: _,
+                        flags: _,
                     },
             } => {
                 let mut table = toml_edit::Table::new().into_inline_table();
@@ -682,6 +686,8 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: None,
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );
@@ -701,6 +707,8 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Branch("main".to_string())),
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );
@@ -720,6 +728,8 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Tag("v.1.2.3".to_string())),
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );
@@ -739,6 +749,8 @@ mod test {
                     git: Url::parse("https://github.com/pallets/flask.git").unwrap(),
                     rev: Some(GitReference::Tag("3.0.0".to_string())),
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             }),
         );
@@ -758,6 +770,8 @@ mod test {
                     git: Url::parse("https://test.url.git").unwrap(),
                     rev: Some(GitReference::Rev("123456".to_string())),
                     subdirectory: Default::default(),
+                    extras: None,
+                    flags: None,
                 },
             })
         );

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -168,6 +168,8 @@ impl PinnedSourceSpec {
     ///     git: Url::parse("https://github.com/user/repo.git")?,
     ///     rev: None,
     ///     subdirectory: Default::default(),
+    ///     extras: None,
+    ///     flags: None,
     /// });
     ///
     /// assert!(pinned_git.matches_source_spec(&source_spec));
@@ -951,6 +953,8 @@ impl From<PinnedGitSpec> for GitSpec {
             git: value.git,
             subdirectory: value.source.subdirectory,
             rev: Some(value.source.reference),
+            extras: None,
+            flags: None,
         }
     }
 }
@@ -982,6 +986,8 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1001,6 +1007,8 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec);
@@ -1020,6 +1028,8 @@ mod tests {
             git: Url::parse("https://github.com/example/repo").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix);
@@ -1039,6 +1049,8 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1058,6 +1070,8 @@ mod tests {
             git: Url::parse("git+https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix);
@@ -1082,6 +1096,8 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("d2e32".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1103,6 +1119,8 @@ mod tests {
             git: Url::parse("https://github.com/example/repo.git").unwrap(),
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1126,6 +1144,8 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec);
@@ -1149,6 +1169,8 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1173,6 +1195,8 @@ mod tests {
             // we are not specifying the rev
             // and request the default branch
             rev: None,
+            extras: None,
+            flags: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec).unwrap_err();
@@ -1226,6 +1250,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo.git").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         // Should match despite .git suffix difference
@@ -1247,6 +1273,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         // Should match despite .git suffix difference
@@ -1268,6 +1296,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo2").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1288,6 +1318,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         // Should match - spec doesn't care about subdirectory
@@ -1309,6 +1341,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            extras: None,
+            flags: None,
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1329,6 +1363,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir2").unwrap(),
+            extras: None,
+            flags: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1349,6 +1385,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
+            extras: None,
+            flags: None,
         });
 
         // Should not match - spec requires a subdirectory that pinned doesn't have
@@ -1409,6 +1447,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1473,6 +1513,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Rev("v2.0.0".to_string())),
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec));
@@ -1495,6 +1537,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: Some(GitReference::Branch("main".to_string())),
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         assert!(pinned.matches_source_spec(&spec));
@@ -1515,6 +1559,8 @@ mod tests {
             git: Url::parse("https://github.com/user/repo").unwrap(),
             rev: None,
             subdirectory: Default::default(),
+            extras: None,
+            flags: None,
         });
 
         // Should match - GitHub URLs are case-insensitive

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -1,13 +1,16 @@
 use std::fmt::Display;
 
 use pixi_git::git;
+use rattler_conda_types::StringMatcher;
 use serde::{Serialize, Serializer};
+use serde_with::serde_as;
 use thiserror::Error;
 use url::Url;
 
 use crate::Subdirectory;
 
 /// A specification of a package from a git repository.
+#[serde_as]
 #[derive(Debug, Clone, Hash, Eq, PartialEq, ::serde::Serialize, ::serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct GitSpec {
@@ -21,6 +24,18 @@ pub struct GitSpec {
     /// The git subdirectory of the package
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Extra dependency groups to enable for the package. Only meaningful on
+    /// manifest-side specs; hoisted into [`crate::SourceSpec::extras`] when
+    /// the spec is converted, so location copies always carry `None`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub extras: Option<Vec<String>>,
+
+    /// Variant flags to select for the package. Hoisted into
+    /// [`crate::SourceSpec::flags`] on conversion, like `extras`.
+    #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub flags: Option<Vec<StringMatcher>>,
 }
 
 impl Display for GitSpec {

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -143,6 +143,8 @@ impl PixiSpec {
                 // A nameless matchspec always describes a binary spec which cannot have a
                 // subdirectory
                 subdirectory: Subdirectory::default(),
+                extras: spec.extras,
+                flags: spec.flags,
             })
         } else if spec.build.is_none()
             && spec.build_number.is_none()
@@ -303,38 +305,99 @@ impl PixiSpec {
     }
 
     /// Converts this instance in a source or binary spec.
+    ///
+    /// `extras` and `flags` are hoisted from the location-carrying spec into
+    /// [`SourceSpec`] for source packages. For binary archives they are
+    /// dropped; parsing already rejects that combination.
     pub fn into_source_or_binary(self) -> Either<SourceSpec, BinarySpec> {
         match self {
             PixiSpec::Version(version) => Either::Right(BinarySpec::Version(version)),
             PixiSpec::DetailedVersion(detailed) => {
                 Either::Right(BinarySpec::DetailedVersion(detailed))
             }
-            PixiSpec::Url(url) => url
-                .into_source_or_binary()
-                .map_left(|url| SourceLocationSpec::Url(url).into())
-                .map_right(BinarySpec::Url),
-            PixiSpec::Git(git) => Either::Left(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .into_source_or_binary()
-                .map_left(|path| SourceLocationSpec::Path(path).into())
-                .map_right(BinarySpec::Path),
+            PixiSpec::Url(mut url) => {
+                let extras = url.extras.take();
+                let flags = url.flags.take();
+                url.into_source_or_binary()
+                    .map_left(|url| SourceSpec {
+                        extras,
+                        flags,
+                        ..SourceLocationSpec::Url(url).into()
+                    })
+                    .map_right(BinarySpec::Url)
+            }
+            PixiSpec::Git(mut git) => {
+                let extras = git.extras.take();
+                let flags = git.flags.take();
+                Either::Left(SourceSpec {
+                    extras,
+                    flags,
+                    ..SourceLocationSpec::Git(git).into()
+                })
+            }
+            PixiSpec::Path(mut path) => {
+                let extras = path.extras.take();
+                let flags = path.flags.take();
+                path.into_source_or_binary()
+                    .map_left(|path| SourceSpec {
+                        extras,
+                        flags,
+                        ..SourceLocationSpec::Path(path).into()
+                    })
+                    .map_right(BinarySpec::Path)
+            }
         }
     }
 
     /// Converts this instance into a source spec if this instance represents a
     /// source package.
+    ///
+    /// `extras` and `flags` are hoisted into [`SourceSpec`], mirroring
+    /// [`Self::into_source_or_binary`].
     #[allow(clippy::result_large_err)]
     pub fn try_into_source_spec(self) -> Result<SourceSpec, Self> {
         match self {
-            PixiSpec::Url(url) => url
-                .try_into_source_url()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
-            PixiSpec::Git(git) => Ok(SourceLocationSpec::Git(git).into()),
-            PixiSpec::Path(path) => path
-                .try_into_source_path()
-                .map(SourceSpec::from)
-                .map_err(PixiSpec::from),
+            PixiSpec::Url(mut url) => {
+                let extras = url.extras.take();
+                let flags = url.flags.take();
+                match url.try_into_source_url() {
+                    Ok(url) => Ok(SourceSpec {
+                        extras,
+                        flags,
+                        ..SourceLocationSpec::Url(url).into()
+                    }),
+                    Err(mut url) => {
+                        url.extras = extras;
+                        url.flags = flags;
+                        Err(PixiSpec::from(url))
+                    }
+                }
+            }
+            PixiSpec::Git(mut git) => {
+                let extras = git.extras.take();
+                let flags = git.flags.take();
+                Ok(SourceSpec {
+                    extras,
+                    flags,
+                    ..SourceLocationSpec::Git(git).into()
+                })
+            }
+            PixiSpec::Path(mut path) => {
+                let extras = path.extras.take();
+                let flags = path.flags.take();
+                match path.try_into_source_path() {
+                    Ok(path) => Ok(SourceSpec {
+                        extras,
+                        flags,
+                        ..SourceLocationSpec::Path(path).into()
+                    }),
+                    Err(mut path) => {
+                        path.extras = extras;
+                        path.flags = flags;
+                        Err(PixiSpec::from(path))
+                    }
+                }
+            }
             _ => Err(self),
         }
     }
@@ -591,10 +654,30 @@ impl SourceLocationSpec {
 
 impl From<SourceSpec> for PixiSpec {
     fn from(value: SourceSpec) -> Self {
-        match value.location {
-            SourceLocationSpec::Url(url) => Self::Url(url.into()),
-            SourceLocationSpec::Git(git) => Self::Git(git),
-            SourceLocationSpec::Path(path) => Self::Path(path.into()),
+        let SourceSpec {
+            location,
+            extras,
+            flags,
+            ..
+        } = value;
+        match location {
+            SourceLocationSpec::Url(url) => {
+                let mut url = UrlSpec::from(url);
+                url.extras = extras;
+                url.flags = flags;
+                Self::Url(url)
+            }
+            SourceLocationSpec::Git(mut git) => {
+                git.extras = extras;
+                git.flags = flags;
+                Self::Git(git)
+            }
+            SourceLocationSpec::Path(path) => {
+                let mut path = PathSpec::from(path);
+                path.extras = extras;
+                path.flags = flags;
+                Self::Path(path)
+            }
         }
     }
 }
@@ -795,6 +878,9 @@ impl From<rattler_lock::source::GitSourceLocation> for GitSpec {
                 .subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
+            // Lock-file locations never carry extras/flags.
+            extras: None,
+            flags: None,
         }
     }
 }
@@ -989,6 +1075,28 @@ mod test {
         assert_eq!(roundtrip.license_family, spec.license_family);
         assert_eq!(roundtrip.condition, spec.condition);
         assert_eq!(roundtrip.track_features, spec.track_features);
+    }
+
+    #[test]
+    fn test_source_spec_pixi_spec_roundtrip_preserves_extras() {
+        // `extras`/`flags` are hoisted into `SourceSpec` on conversion and
+        // must be restored into the variant struct on the way back.
+        let spec: PixiSpec = serde_json::from_value(json!({
+            "git": "https://example.com/foo.git",
+            "extras": ["dev"],
+            "flags": ["cuda"],
+        }))
+        .unwrap();
+
+        let source = spec.clone().try_into_source_spec().unwrap();
+        assert_eq!(source.extras, Some(vec!["dev".to_string()]));
+        assert_eq!(
+            source.flags,
+            Some(vec![StringMatcher::from_str("cuda").unwrap()])
+        );
+
+        let roundtrip = PixiSpec::from(source);
+        assert_eq!(roundtrip, spec);
     }
 
     #[test]

--- a/crates/pixi_spec/src/path.rs
+++ b/crates/pixi_spec/src/path.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use itertools::Either;
-use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveType};
+use rattler_conda_types::{NamelessMatchSpec, StringMatcher, package::CondaArchiveType};
 use serde_with::serde_as;
 use typed_path::{Utf8NativePathBuf, Utf8TypedPathBuf};
 
@@ -15,12 +15,25 @@ use crate::{BinarySpec, SpecConversionError};
 pub struct PathSpec {
     /// The path to the package
     pub path: Utf8TypedPathBuf,
+
+    /// Extra dependency groups to enable for the package. Only meaningful
+    /// when the path refers to a source package; hoisted into
+    /// [`crate::SourceSpec::extras`] when the spec is converted.
+    pub extras: Option<Vec<String>>,
+
+    /// Variant flags to select for the package. Hoisted into
+    /// [`crate::SourceSpec::flags`] on conversion, like `extras`.
+    pub flags: Option<Vec<StringMatcher>>,
 }
 
 impl PathSpec {
     /// Constructs a new [`PathSpec`] from the given path.
     pub fn new(path: impl Into<Utf8TypedPathBuf>) -> Self {
-        Self { path: path.into() }
+        Self {
+            path: path.into(),
+            extras: None,
+            flags: None,
+        }
     }
 
     /// Converts this instance into a [`NamelessMatchSpec`] if the path points
@@ -134,7 +147,7 @@ impl<'de> serde::Deserialize<'de> for PathSourceSpec {
 
 impl From<PathSourceSpec> for PathSpec {
     fn from(value: PathSourceSpec) -> Self {
-        Self { path: value.path }
+        Self::new(value.path)
     }
 }
 
@@ -161,7 +174,7 @@ pub struct PathBinarySpec {
 
 impl From<PathBinarySpec> for PathSpec {
     fn from(value: PathBinarySpec) -> Self {
-        Self { path: value.path }
+        Self::new(value.path)
     }
 }
 

--- a/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
+++ b/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/pixi_spec/src/toml.rs
+assertion_line: 1744
 expression: snapshot
 ---
 - input: 1.2.3
@@ -70,6 +71,40 @@ expression: snapshot
   result:
     git: "https://github.com/conda-forge/21cmfast-feedstock"
     branch: main
+- input:
+    path: foobar
+    extras:
+      - dev
+  result:
+    path: foobar
+    extras:
+      - dev
+- input:
+    path: foobar
+    extras:
+      - dev
+    flags:
+      - cuda
+  result:
+    path: foobar
+    extras:
+      - dev
+    flags:
+      - cuda
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    extras:
+      - dev
+  result:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    extras:
+      - dev
+- input:
+    path: foobar.conda
+    extras:
+      - dev
+  result:
+    error: "ERROR: `extras` cannot be used with `path` pointing to a binary archive; it is only supported for source packages"
 - input:
     ver: 1.2.3
   result:

--- a/crates/pixi_spec/src/source_anchor.rs
+++ b/crates/pixi_spec/src/source_anchor.rs
@@ -82,6 +82,8 @@ impl SourceAnchor {
                 git,
                 rev,
                 subdirectory,
+                extras,
+                flags,
             }) => {
                 let base_subdir = subdirectory.as_path().to_string_lossy();
                 let relative_subdir = normalize::normalize_typed(
@@ -100,6 +102,8 @@ impl SourceAnchor {
                     git: git.clone(),
                     rev: rev.clone(),
                     subdirectory,
+                    extras: extras.clone(),
+                    flags: flags.clone(),
                 })
             }
         }

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -356,6 +356,11 @@ pub enum SpecError {
     #[error("{0} cannot be used with {1}")]
     InvalidCombination(Cow<'static, str>, Cow<'static, str>),
 
+    #[error(
+        "{0} cannot be used with {1} pointing to a binary archive; it is only supported for source packages"
+    )]
+    SourceFieldOnBinaryArchive(Cow<'static, str>, Cow<'static, str>),
+
     #[error("{message}")]
     InvalidWhen {
         message: String,
@@ -556,15 +561,16 @@ impl TomlSpec {
         .collect::<Vec<_>>()
         .join(", ");
 
-        // Common field checks
+        // Common field checks. `extras` and `flags` are deliberately absent:
+        // they are valid on source specs (e.g. requesting an extra group of a
+        // path dependency) and are validated separately in `into_spec` /
+        // `into_binary_spec`.
         if !non_detailed_keys.is_empty() {
             for (field_name, is_some) in [
                 ("`version`", self.version.is_some()),
                 ("`build`", self.build.is_some()),
                 ("`build-number`", self.build_number.is_some()),
                 ("`file-name`", self.file_name.is_some()),
-                ("`extras`", self.extras.is_some()),
-                ("`flags`", self.flags.is_some()),
                 ("`channel`", self.channel.is_some()),
                 ("`subdir`", self.subdir.is_some()),
                 ("`when`", self.when.is_some()),
@@ -606,22 +612,71 @@ impl TomlSpec {
 
     /// Convert the TOML representation into an actual [`PixiSpec`].
     pub fn into_spec(self) -> Result<PixiSpec, SpecError> {
+        // `extras` and `flags` request behavior of a *source* package (extra
+        // dependency groups, variant selection), so a `path`/`url` that
+        // resolves to a binary archive cannot honor them.
+        fn reject_source_fields_on_binary_archive(
+            is_binary_archive: bool,
+            location: &'static str,
+            extras: &Option<Vec<String>>,
+            flags: &Option<Vec<StringMatcher>>,
+        ) -> Result<(), SpecError> {
+            if !is_binary_archive {
+                return Ok(());
+            }
+            for (field_name, is_some) in
+                [("`extras`", extras.is_some()), ("`flags`", flags.is_some())]
+            {
+                if is_some {
+                    return Err(SpecError::SourceFieldOnBinaryArchive(
+                        field_name.into(),
+                        location.into(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+
         self.validate_field_combinations()?;
 
         let spec: PixiSpec;
         if let Some(loc) = self.location {
             spec = match (loc.url, loc.path, loc.git) {
-                (Some(url), None, None) => PixiSpec::Url(UrlSpec {
-                    url,
-                    md5: loc.md5,
-                    sha256: loc.sha256,
-                    subdirectory: loc
-                        .subdirectory
-                        .map(Subdirectory::try_from)
-                        .transpose()?
-                        .unwrap_or_default(),
-                }),
-                (None, Some(path), None) => PixiSpec::Path(PathSpec { path: path.into() }),
+                (Some(url), None, None) => {
+                    let url_spec = UrlSpec {
+                        url,
+                        md5: loc.md5,
+                        sha256: loc.sha256,
+                        subdirectory: loc
+                            .subdirectory
+                            .map(Subdirectory::try_from)
+                            .transpose()?
+                            .unwrap_or_default(),
+                        extras: self.extras,
+                        flags: self.flags,
+                    };
+                    reject_source_fields_on_binary_archive(
+                        url_spec.is_binary(),
+                        "`url`",
+                        &url_spec.extras,
+                        &url_spec.flags,
+                    )?;
+                    PixiSpec::Url(url_spec)
+                }
+                (None, Some(path), None) => {
+                    let path_spec = PathSpec {
+                        path: path.into(),
+                        extras: self.extras,
+                        flags: self.flags,
+                    };
+                    reject_source_fields_on_binary_archive(
+                        path_spec.is_binary(),
+                        "`path`",
+                        &path_spec.extras,
+                        &path_spec.flags,
+                    )?;
+                    PixiSpec::Path(path_spec)
+                }
                 (None, None, Some(git)) => {
                     let rev = match (loc.branch, loc.rev, loc.tag) {
                         (Some(branch), None, None) => Some(GitReference::Branch(branch)),
@@ -641,6 +696,8 @@ impl TomlSpec {
                         git,
                         rev,
                         subdirectory,
+                        extras: self.extras,
+                        flags: self.flags,
                     })
                 }
                 (None, None, None) => {
@@ -725,6 +782,21 @@ impl TomlSpec {
 
         let spec: BinarySpec;
         if let Some(loc) = self.location {
+            // Binary specs cannot represent source packages, so the
+            // source-only fields are invalid with any location.
+            if loc.url.is_some() || loc.path.is_some() || loc.git.is_some() {
+                for (field_name, is_some) in [
+                    ("`extras`", self.extras.is_some()),
+                    ("`flags`", self.flags.is_some()),
+                ] {
+                    if is_some {
+                        return Err(SpecError::InvalidCombination(
+                            field_name.into(),
+                            "a binary package location".into(),
+                        ));
+                    }
+                }
+            }
             spec = match (loc.url, loc.path, loc.git) {
                 (Some(url), None, None) => {
                     let url_spec = UrlSpec {
@@ -736,6 +808,8 @@ impl TomlSpec {
                             .map(Subdirectory::try_from)
                             .transpose()?
                             .unwrap_or_default(),
+                        extras: None,
+                        flags: None,
                     };
                     if let Either::Right(binary) = url_spec.into_source_or_binary() {
                         BinarySpec::Url(binary)
@@ -744,7 +818,7 @@ impl TomlSpec {
                     }
                 }
                 (None, Some(path), None) => {
-                    let path_spec = PathSpec { path: path.into() };
+                    let path_spec = PathSpec::new(path);
                     if let Either::Right(binary) = path_spec.into_source_or_binary() {
                         BinarySpec::Path(binary)
                     } else {
@@ -1156,6 +1230,10 @@ impl TomlLocationSpec {
                     git,
                     rev,
                     subdirectory,
+                    // Locations never carry extras/flags; those live on the
+                    // surrounding `SourceSpec`.
+                    extras: None,
+                    flags: None,
                 })
             }
             (_, _, _) => return Err(SourceLocationSpecError::MultipleIdentifiers),
@@ -1498,13 +1576,21 @@ impl<'de> Deserialize<'de> for PathSpec {
     where
         D: Deserializer<'de>,
     {
+        #[serde_as]
         #[derive(Deserialize)]
         struct Raw {
             path: String,
+            #[serde(default)]
+            extras: Option<Vec<String>>,
+            #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
+            #[serde(default)]
+            flags: Option<Vec<StringMatcher>>,
         }
 
         Raw::deserialize(deserializer).map(|raw| PathSpec {
             path: raw.path.into(),
+            extras: raw.extras,
+            flags: raw.flags,
         })
     }
 }
@@ -1514,13 +1600,21 @@ impl Serialize for PathSpec {
     where
         S: Serializer,
     {
+        #[serde_as]
         #[derive(Serialize)]
-        struct Raw {
+        struct Raw<'a> {
             path: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            extras: &'a Option<Vec<String>>,
+            #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            flags: &'a Option<Vec<StringMatcher>>,
         }
 
         Raw {
             path: self.path.to_string(),
+            extras: &self.extras,
+            flags: &self.flags,
         }
         .serialize(serializer)
     }
@@ -1528,6 +1622,8 @@ impl Serialize for PathSpec {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use insta::assert_snapshot;
     use pixi_test_utils::format_parse_error;
     use pixi_toml::TomlDiagnostic;
@@ -1599,7 +1695,11 @@ mod test {
             json!({ "url": "https://conda.anaconda.org/conda-forge/linux-64/21cmfast-3.3.1-py38h0db86a8_1.conda", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main" }),
+            json!({ "path": "foobar", "extras": ["dev"] }),
+            json!({ "path": "foobar", "extras": ["dev"], "flags": ["cuda"] }),
+            json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "extras": ["dev"] }),
             // Errors:
+            json!({ "path": "foobar.conda", "extras": ["dev"] }),
             json!({ "ver": "1.2.3" }),
             json!({ "path": "foobar" , "version": "1.2.3" }),
             json!({ "version": "//" }),
@@ -2267,15 +2367,64 @@ when = "__unix""#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_json() {
+    fn test_v3_extras_with_path_json() {
         let input = json!({ "path": "../foo", "extras": ["dev"] });
-        assert_snapshot!(parse_json_error(input), @"`extras` cannot be used with `path`");
+        let spec: PixiSpec = serde_json::from_value(input).unwrap();
+        assert_eq!(
+            spec.as_path().unwrap().extras,
+            Some(vec!["dev".to_string()])
+        );
+
+        // Conversion hoists the extras out of the location into the source
+        // spec.
+        let source = spec.try_into_source_spec().unwrap();
+        assert_eq!(source.extras, Some(vec!["dev".to_string()]));
     }
 
     #[test]
-    fn test_v3_reject_flags_with_git_json() {
+    fn test_v3_flags_with_git_json() {
         let input = json!({ "git": "https://example.com/foo.git", "flags": ["cuda"] });
-        assert_snapshot!(parse_json_error(input), @"`flags` cannot be used with `git`");
+        let spec: PixiSpec = serde_json::from_value(input).unwrap();
+
+        let source = spec.try_into_source_spec().unwrap();
+        assert_eq!(
+            source.flags,
+            Some(vec![StringMatcher::from_str("cuda").unwrap()])
+        );
+
+        // The location copy must not retain the hoisted fields; it ends up in
+        // lock-file `sources` maps which never carry them.
+        let SourceLocationSpec::Git(git) = &source.location else {
+            panic!("expected a git location");
+        };
+        assert_eq!(git.extras, None);
+        assert_eq!(git.flags, None);
+    }
+
+    #[test]
+    fn test_v3_extras_with_url_source_json() {
+        let input = json!({ "url": "https://example.com/foo.tar.gz", "extras": ["dev"] });
+        let spec: PixiSpec = serde_json::from_value(input).unwrap();
+        let source = spec.try_into_source_spec().unwrap();
+        assert_eq!(source.extras, Some(vec!["dev".to_string()]));
+    }
+
+    #[test]
+    fn test_v3_reject_extras_with_binary_path_json() {
+        let input = json!({ "path": "../foo.conda", "extras": ["dev"] });
+        assert_snapshot!(
+            parse_json_error(input),
+            @"`extras` cannot be used with `path` pointing to a binary archive; it is only supported for source packages"
+        );
+    }
+
+    #[test]
+    fn test_v3_reject_flags_with_binary_url_json() {
+        let input = json!({ "url": "https://example.com/foo-1.0-h123_0.conda", "flags": ["cuda"] });
+        assert_snapshot!(
+            parse_json_error(input),
+            @"`flags` cannot be used with `url` pointing to a binary archive; it is only supported for source packages"
+        );
     }
 
     #[test]
@@ -2344,29 +2493,28 @@ flags = ["*[unclosed"]"#;
     }
 
     #[test]
-    fn test_v3_reject_extras_with_path_toml() {
+    fn test_v3_extras_with_path_toml() {
         let input = r#"path = "../foo"
 extras = ["dev"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `extras` cannot be used with `path`
-          ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ path = "../foo"
-        2 │ ╰─▶ extras = ["dev"]
-          ╰────
-        "###);
+        let mut value = toml_span::parse(input).unwrap();
+        let spec = <PixiSpec as toml_span::Deserialize>::deserialize(&mut value).unwrap();
+        assert_eq!(
+            spec.as_path().unwrap().extras,
+            Some(vec!["dev".to_string()])
+        );
     }
 
     #[test]
-    fn test_v3_reject_flags_with_url_toml() {
-        let input = r#"url = "https://example.com/foo.conda"
+    fn test_v3_reject_flags_with_binary_url_toml() {
+        let input = r#"url = "https://example.com/foo-1.0-h123_0.conda"
 flags = ["cuda"]"#;
-        assert_snapshot!(parse_toml_error(input), @r###"
-         × `flags` cannot be used with `url`
+        assert_snapshot!(parse_toml_error(input), @r#"
+         × `flags` cannot be used with `url` pointing to a binary archive; it is only supported for source packages
           ╭─[pixi.toml:1:1]
-        1 │ ╭─▶ url = "https://example.com/foo.conda"
+        1 │ ╭─▶ url = "https://example.com/foo-1.0-h123_0.conda"
         2 │ ╰─▶ flags = ["cuda"]
           ╰────
-        "###);
+        "#);
     }
 
     #[test]

--- a/crates/pixi_spec/src/url.rs
+++ b/crates/pixi_spec/src/url.rs
@@ -1,6 +1,6 @@
 use crate::{BinarySpec, Subdirectory};
 use itertools::Either;
-use rattler_conda_types::{NamelessMatchSpec, package::CondaArchiveIdentifier};
+use rattler_conda_types::{NamelessMatchSpec, StringMatcher, package::CondaArchiveIdentifier};
 use rattler_digest::{Md5Hash, Sha256Hash};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -28,6 +28,18 @@ pub struct UrlSpec {
     /// The subdirectory of the package inside the archive
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Extra dependency groups to enable for the package. Only meaningful
+    /// when the URL refers to a source package; hoisted into
+    /// [`crate::SourceSpec::extras`] when the spec is converted.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub extras: Option<Vec<String>>,
+
+    /// Variant flags to select for the package. Hoisted into
+    /// [`crate::SourceSpec::flags`] on conversion, like `extras`.
+    #[serde_as(as = "Option<Vec<serde_with::DisplayFromStr>>")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub flags: Option<Vec<StringMatcher>>,
 }
 
 impl UrlSpec {
@@ -146,6 +158,8 @@ impl From<UrlSourceSpec> for UrlSpec {
             md5: value.md5,
             sha256: value.sha256,
             subdirectory: value.subdirectory,
+            extras: None,
+            flags: None,
         }
     }
 }
@@ -171,6 +185,8 @@ impl From<UrlBinarySpec> for UrlSpec {
             sha256: value.sha256,
             // A binary url spec is already a conda package so it cannot have a subdirectory
             subdirectory: Subdirectory::default(),
+            extras: None,
+            flags: None,
         }
     }
 }

--- a/crates/pixi_url/tests/main.rs
+++ b/crates/pixi_url/tests/main.rs
@@ -108,6 +108,8 @@ async fn url_source_uses_existing_checkout_when_sha_and_files_present() {
         md5: None,
         sha256: Some(sha),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let fetch = UrlSource::new(spec, panic_client(), cache.path())
@@ -134,6 +136,8 @@ async fn resolver_reuses_cached_sha_without_downloading() {
         md5: None,
         sha256: None,
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let fetch = resolver
@@ -157,6 +161,8 @@ async fn url_source_downloads_and_reuses_checkout() {
         md5: None,
         sha256: None,
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let first = UrlSource::new(spec.clone(), client.clone(), cache.path())
@@ -184,6 +190,8 @@ async fn url_source_errors_on_sha_mismatch() {
         md5: None,
         sha256: Some(Sha256Hash::from([0u8; 32])),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let err = UrlSource::new(spec, LazyClient::default(), cache.path())
@@ -203,6 +211,8 @@ async fn url_source_errors_on_md5_mismatch() {
         md5: Some(bogus_md5()),
         sha256: Some(archive_sha()),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let err = UrlSource::new(spec, LazyClient::default(), cache.path())
@@ -221,6 +231,8 @@ async fn url_source_downloads_over_http_and_extracts_contents() {
         md5: None,
         sha256: Some(archive_sha()),
         subdirectory: Subdirectory::default(),
+        extras: None,
+        flags: None,
     };
 
     let fetch = UrlSource::new(spec, LazyClient::default(), cache.path())

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -112,6 +112,8 @@ pub fn as_uv_req(
                     git,
                     rev,
                     subdirectory,
+                    extras: _,
+                    flags: _,
                 },
         } => {
             let git_url = GitUrlWithPrefix::from(git);
@@ -363,6 +365,8 @@ mod tests {
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
                 subdirectory: Default::default(),
+                extras: None,
+                flags: None,
             },
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();
@@ -391,6 +395,8 @@ mod tests {
                     "d099af3b1028b00c232d8eda28a997984ae5848b".to_string(),
                 )),
                 subdirectory: Default::default(),
+                extras: None,
+                flags: None,
             },
         });
         let uv_req = as_uv_req(&pypi_req, "test", Path::new("")).unwrap();


### PR DESCRIPTION
The manifest reference promises requesting a source package's extra-dependencies group via 'pkg = { path = "...", extras = [...] }', but the TOML spec validation swept 'extras' and 'flags' into the blanket source-spec rejection list, so they only worked on binary specs.

Carry both fields on the manifest-side PathSpec, UrlSpec, and GitSpec and hoist them into SourceSpec on conversion; location copies (which end up in lock-file sources maps) always stay clean. Binary archives ('.conda', '.tar.bz2') reject the fields with a dedicated error since they cannot honor them.

Two consistency fixes ride along so the feature doesn't thrash the lock file:

- The satisfiability walker now traverses the experimental_extra_depends entries of requested extras (per package+extra pair) and rejects locked records that don't provide a requested group. Previously extras-activated packages were unreachable and every install re-solved.
- The conda solve validates requested extras (direct, dev-source, and transitive depends strings) against the solved records, because the solver itself treats extras as conditional activation and silently ignores unknown groups. Typos now fail loudly with the available groups.

The passthrough test backend forwards [package.extra-dependencies] from the project model so integration tests can exercise the full pipeline.

StringMatcher is added to clippy's ignore-interior-mutability list: its Hash/Eq derive from the pattern string, the interior mutability is only a lazily-built regex cache.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

More unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
