### PR TITLE
chore: strip debug info from dependencies in dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,6 +289,12 @@ rattler_build_yaml_parser = { git = "https://github.com/prefix-dev/rattler-build
 [patch."https://github.com/prefix-dev/rattler-build"]
 #rattler-build = { path = "/var/home/tobias/src/rattler-build" }
 
+# Strip debug info from dependencies: faster links, much smaller `target/`,
+# while keeping full debuggability for our own crates.
+# See https://matklad.github.io/2021/09/04/fast-rust-builds.html
+[profile.dev.package."*"]
+debug = false
+
 [profile.ci]
 codegen-units = 16
 inherits = "release"


### PR DESCRIPTION
### Description

Speeds up the Rust build by stripping debug information from third-party dependencies in dev builds. Our own crates keep full debug info, so debugging is unaffected, but clean builds are noticeably faster and the `target/` directory shrinks by roughly 40%. 

This only affects dev builds, so the release, CI, and dist profiles used for the published binaries are untouched.

Inspired by the techniques in [Fast Rust Builds](https://matklad.github.io/2021/09/04/fast-rust-builds.html).

### How Has This Been Tested?

Ran clean builds before and after the change and confirmed the build time and `target/` size both dropped, that our own crates still carry full debug info, and that the final binary remains debuggable.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas