### PR TITLE
fix: stop source builds rebuilding from scratch on every run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7021,6 +7021,7 @@ version = "0.1.0"
 dependencies = [
  "fs-err",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "typed-path",

--- a/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
+++ b/crates/pixi_command_dispatcher/src/backend_source_build/mod.rs
@@ -4,12 +4,7 @@ mod ext;
 
 pub use ext::BackendSourceBuildExt;
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Display,
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, fmt::Display, path::PathBuf, sync::Arc};
 
 use crate::BackendHandle;
 use futures::{SinkExt, channel::mpsc::UnboundedSender};
@@ -17,14 +12,13 @@ use itertools::{Either, Itertools};
 use miette::Diagnostic;
 use pixi_build_frontend::json_rpc::CommunicationError;
 use pixi_build_types::{
-    VariantValue,
+    InputGlobSet, VariantValue,
     procedures::conda_build_v1::{
         CondaBuildV1Dependency, CondaBuildV1DependencyRunExportSource,
         CondaBuildV1DependencySource, CondaBuildV1Output, CondaBuildV1Params, CondaBuildV1Prefix,
         CondaBuildV1PrefixPackage, CondaBuildV1RunExports, CondaPackageFormat,
     },
 };
-use pixi_glob::GlobSet;
 use pixi_spec::{BinarySpec, PixiSpec, SpecConversionError};
 use rattler_conda_types::{
     ChannelConfig, ChannelUrl, MatchSpec, PackageName, Platform, RepoDataRecord, VersionWithSource,
@@ -60,10 +54,6 @@ pub struct BackendSourceBuildSpec {
 
     /// The subdirectory (platform) of the package.
     pub subdir: String,
-
-    /// The directory where the source code is located on disk.
-    #[serde(skip)]
-    pub source_dir: PathBuf,
 
     /// The method to use for building the source package.
     pub method: BackendSourceBuildMethod,
@@ -130,17 +120,10 @@ pub struct BackendBuiltSource {
     #[serde(skip)]
     pub output_file: PathBuf,
 
-    /// The globs that were used as input to the build. Use these for
-    /// re-verifying the build.
-    ///
-    /// Order is preserved: pixi's `GlobSet` is gitignore last-match-wins, so
-    /// inclusion patterns must precede any negated exclusions that should
-    /// override them.
-    pub input_globs: Vec<String>,
-
-    /// The actual files that matched the globs at build time. This allows
-    /// detecting file deletions and additions.
-    pub input_files: BTreeSet<PathBuf>,
+    /// The inputs the build read, as structured glob groups (patterns plus
+    /// marker / hidden-file / root config). The backend's flat `input_globs`
+    /// are folded into a group here so there's a single representation.
+    pub input_glob_sets: Vec<InputGlobSet>,
 }
 
 impl BackendSourceBuildSpec {
@@ -158,7 +141,6 @@ impl BackendSourceBuildSpec {
                     self.build,
                     self.subdir,
                     params,
-                    self.source_dir,
                     self.work_directory,
                     self.channels,
                     channel_config,
@@ -177,7 +159,6 @@ impl BackendSourceBuildSpec {
         build: String,
         subdir: String,
         params: BackendSourceBuildV1Method,
-        source_dir: PathBuf,
         work_directory: PathBuf,
         channels: Vec<ChannelUrl>,
         channel_config: Arc<ChannelConfig>,
@@ -324,25 +305,11 @@ impl BackendSourceBuildSpec {
             ));
         };
 
-        // Compute the files that match the input globs.
-        let glob_set = GlobSet::create(built_package.input_globs.iter().map(String::as_str));
-        let input_files = glob_set
-            .collect_matching(&source_dir)
-            .map_err(BackendSourceBuildError::from)
-            .map_err(CommandDispatcherError::Failed)?
-            .into_iter()
-            .filter_map(|entry| {
-                entry
-                    .into_path()
-                    .strip_prefix(&source_dir)
-                    .ok()
-                    .map(|p| p.to_path_buf())
-            })
-            .collect();
-
         Ok(BackendBuiltSource {
-            input_globs: built_package.input_globs.into_iter().collect(),
-            input_files,
+            input_glob_sets: crate::input_globs::fold_input_globs(
+                built_package.input_globs,
+                built_package.input_glob_sets,
+            ),
             output_file: built_package.output_file,
         })
     }

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -366,7 +366,7 @@ impl BuildBackendMetadataInner {
         for source_file_path in cache_entry
             .input_files
             .iter()
-            .map(|path| build_source_dir.join(path).into_std_path_buf())
+            .map(|path| path.as_std_path().to_path_buf())
             .chain(cache_entry.build_variant_files.iter().cloned())
         {
             match source_file_path.metadata().and_then(|m| m.modified()) {
@@ -400,33 +400,22 @@ impl BuildBackendMetadataInner {
         // Invalidate when the walk picks up a file the cache entry never
         // recorded (i.e. one that was added since the last run). The
         // existing entries in `input_files` were freshness-checked above;
-        // this second pass only catches newcomers.
-        //
-        // `input_files` stores paths relative to `build_source_dir` (see
-        // the `strip_prefix` at the write site), so the absolute paths
-        // returned by the walker must be relativized before the membership
-        // check or every path looks "new".  When the cache entry carries
-        // the structured `input_glob_sets` we use that instead of the flat
-        // `input_globs`; this is what unlocks the marker-driven workspace
-        // walk for ROS-style backends.
-        let globs_root = build_source_dir.as_std_path();
-        let new_file_candidates = crate::input_globs::collect_input_files_via_engine(
+        // this second pass only catches newcomers. Both the walk and the
+        // stored `input_files` are absolute, so they compare directly. The
+        // structured `input_glob_sets` can express the marker-driven
+        // workspace walk for ROS-style backends.
+        let new_file_candidates = crate::input_globs::collect_input_files(
             ctx,
-            &cache_entry.input_globs,
-            cache_entry.input_glob_sets.as_deref(),
-            globs_root,
+            &cache_entry.input_glob_sets,
+            build_source_dir,
         )
         .await
         .map_err(BuildBackendMetadataError::GlobSet)?;
         for abs_path in new_file_candidates {
-            let key_path = abs_path
-                .strip_prefix(globs_root)
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|_| abs_path.clone());
-            if !cache_entry.input_files.contains(&key_path) {
+            if !cache_entry.input_files.contains(&abs_path) {
                 tracing::info!(
                     "found cached outputs but a new matching file at '{}' has been detected, invalidating cache.",
-                    abs_path.display()
+                    abs_path.as_std_path().display()
                 );
                 return Ok(Err(Some(cache_entry)));
             }
@@ -565,30 +554,21 @@ impl BuildBackendMetadataInner {
             );
         }
 
-        // Determine the files that match the input globs.
+        // Normalize the backend's flat + structured globs into a single list,
+        // then determine the (absolute) files that match them.
+        let input_glob_sets =
+            crate::input_globs::fold_input_globs(outputs.input_globs, outputs.input_glob_sets);
         let globs_root = build_source_checkout.path.as_dir_or_file_parent();
-        let globs_root_path = globs_root.as_std_path();
-        let input_glob_files = crate::input_globs::collect_input_files_via_engine(
-            ctx,
-            &outputs.input_globs,
-            outputs.input_glob_sets.as_deref(),
-            globs_root_path,
-        )
-        .await
-        .map_err(BuildBackendMetadataError::GlobSet)?
-        .into_iter()
-        .map(|path| {
-            path.strip_prefix(globs_root_path)
-                .ok()
-                .unwrap_or(&path)
-                .to_path_buf()
-        })
-        .collect();
+        let input_glob_files =
+            crate::input_globs::collect_input_files(ctx, &input_glob_sets, globs_root)
+                .await
+                .map_err(BuildBackendMetadataError::GlobSet)?
+                .into_iter()
+                .collect();
 
         Ok(RawCondaOutputs {
             outputs: outputs.outputs,
-            input_globs: outputs.input_globs.into_iter().collect(),
-            input_glob_sets: outputs.input_glob_sets,
+            input_glob_sets,
             input_files: input_glob_files,
             timestamp,
         })
@@ -1040,7 +1020,6 @@ impl BuildBackendMetadataInner {
             outputs: raw.outputs,
             build_variants: self.variant_configuration.clone(),
             build_variant_files: self.variant_files.iter().cloned().collect(),
-            input_globs: raw.input_globs,
             input_glob_sets: raw.input_glob_sets,
             input_files: raw.input_files,
             source: canonical_source,
@@ -1086,14 +1065,12 @@ impl BuildBackendMetadataInner {
 struct RawCondaOutputs {
     /// The outputs as reported by the build backend.
     outputs: Vec<pixi_build_types::procedures::conda_outputs::CondaOutput>,
-    /// Globs of files from which the metadata was derived. Order matters:
+    /// Structured glob groups of files from which the metadata was derived
+    /// (the backend's flat globs folded in). Order within a group matters:
     /// pixi's `GlobSet` is gitignore last-match-wins.
-    input_globs: Vec<String>,
-    /// Structured form of [`Self::input_globs`].  Some only when the
-    /// backend's response carried `inputGlobSets`.
-    input_glob_sets: Option<Vec<pixi_build_types::InputGlobSet>>,
-    /// Paths of files that match the input globs.
-    input_files: std::collections::BTreeSet<PathBuf>,
+    input_glob_sets: Vec<pixi_build_types::InputGlobSet>,
+    /// Absolute paths of the files that matched the input globs.
+    input_files: std::collections::BTreeSet<pixi_path::AbsPathBuf>,
     /// The timestamp of when the metadata was computed.
     timestamp: SystemTime,
 }

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -31,7 +31,9 @@ use std::{
 use async_fd_lock::{LockRead, LockWrite};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
-use pixi_glob::GlobSet;
+use pixi_build_types::InputGlobSet;
+use pixi_compute_engine::ComputeCtx;
+use pixi_path::{AbsPath, AbsPathBuf};
 use pixi_record::{UnresolvedPixiRecord, UnresolvedSourceRecord};
 use rattler_conda_types::{PackageName, Platform, RepoDataRecord};
 use rattler_digest::Sha256Hash;
@@ -136,19 +138,17 @@ pub fn compute_artifact_cache_key(
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArtifactSidecar {
-    /// Glob patterns that match the set of files the build reads. Used at
+    /// Structured glob groups describing the files the build reads (the flat
+    /// globs a backend reports are folded into a group upstream). Walked at
     /// lookup time to detect newly-added matching files.
-    ///
-    /// Order is preserved: pixi's `GlobSet` is gitignore last-match-wins, so
-    /// inclusion patterns must precede any negated exclusions that should
-    /// override them.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub input_globs: Vec<String>,
+    pub input_glob_sets: Vec<InputGlobSet>,
 
-    /// Paths of the files actually read by the build, relative to the source
-    /// directory, paired with their mtime at build time.
+    /// Files that matched the input globs, paired with their mtime at build
+    /// time. Keyed by absolute path (the walk roots are absolute), so the keys
+    /// round-trip directly against the engine walk at lookup time.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub input_files: BTreeMap<PathBuf, DateTime<Utc>>,
+    pub input_files: BTreeMap<AbsPathBuf, DateTime<Utc>>,
 
     /// sha256 of the cached `.conda`. Callers rely on this for transitive
     /// invalidation of dependents.
@@ -259,9 +259,10 @@ impl ArtifactCache {
     /// files outside the cache entry and don't race with writers.
     pub async fn lookup(
         &self,
+        ctx: &mut ComputeCtx,
         package: &PackageName,
         key: &ArtifactCacheKey,
-        source_dir: &Path,
+        source_dir: &AbsPath,
     ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
         let sidecar_path = self.sidecar_path(package, key);
         // Fast-path the common "no entry yet" case: skip creating the
@@ -293,9 +294,8 @@ impl ArtifactCache {
         drop(_guard);
 
         // Check every recorded file still matches its mtime.
-        for (rel, expected_mtime) in &sidecar.input_files {
-            let full = source_dir.join(rel);
-            let modified = match fs_err::metadata(&full).and_then(|m| m.modified()) {
+        for (path, expected_mtime) in &sidecar.input_files {
+            let modified = match fs_err::metadata(path).and_then(|m| m.modified()) {
                 Ok(m) => DateTime::<Utc>::from(m),
                 Err(_) => return Ok(None),
             };
@@ -305,18 +305,15 @@ impl ArtifactCache {
         }
 
         // Detect newly-added files that match the stored globs. This catches
-        // sources added after the cache entry was written.
-        if !sidecar.input_globs.is_empty() {
-            let glob_set = GlobSet::create(sidecar.input_globs.iter().map(String::as_str));
-            let matches = glob_set
-                .collect_matching(source_dir)
-                .map_err(ArtifactCacheError::from)?;
-            for matched in matches {
-                let path = matched.into_path();
-                let rel = path.strip_prefix(source_dir).unwrap_or(&path).to_path_buf();
-                if !sidecar.input_files.contains_key(&rel) {
-                    return Ok(None);
-                }
+        // sources added after the cache entry was written. Uses the same
+        // engine-deduped walk as `build_backend_metadata`.
+        let current =
+            crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir)
+                .await
+                .map_err(ArtifactCacheError::Glob)?;
+        for matched in current {
+            if !sidecar.input_files.contains_key(&matched) {
+                return Ok(None);
             }
         }
 
@@ -336,10 +333,10 @@ impl ArtifactCache {
 
     /// Place `artifact_source` into the cache and write its sidecar.
     ///
-    /// `input_files` are paths relative to `source_dir`; their mtimes are
-    /// captured at store time. `record` is the synthesized `RepoDataRecord`
-    /// for the artifact; it is persisted in the sidecar so cache hits can
-    /// skip re-reading index.json.
+    /// `input_files` are absolute paths; their mtimes are captured at store
+    /// time. `record` is the synthesized `RepoDataRecord` for the artifact; it
+    /// is persisted in the sidecar so cache hits can skip re-reading
+    /// index.json.
     ///
     /// Holds an exclusive write lock on the entry's `.lock` file for
     /// the artifact copy + sidecar write, so a concurrent
@@ -351,9 +348,8 @@ impl ArtifactCache {
         package: &PackageName,
         key: &ArtifactCacheKey,
         artifact_source: &Path,
-        input_globs: impl IntoIterator<Item = String>,
-        input_files: impl IntoIterator<Item = PathBuf>,
-        source_dir: &Path,
+        input_glob_sets: Vec<InputGlobSet>,
+        input_files: impl IntoIterator<Item = AbsPathBuf>,
         record: RepoDataRecord,
     ) -> Result<CachedArtifact, ArtifactCacheError> {
         let entry_dir = self.entry_dir(package, key);
@@ -393,16 +389,17 @@ impl ArtifactCache {
         };
 
         let mut input_files_mtimes = BTreeMap::new();
-        for rel in input_files {
-            let full = source_dir.join(&rel);
-            let modified = fs_err::metadata(&full)
+        for path in input_files {
+            let modified = fs_err::metadata(&path)
                 .and_then(|m| m.modified())
-                .map_err(|err| ArtifactCacheError::io("stat input file", full.clone(), err))?;
-            input_files_mtimes.insert(rel, DateTime::<Utc>::from(modified));
+                .map_err(|err| {
+                    ArtifactCacheError::io("stat input file", path.clone().into(), err)
+                })?;
+            input_files_mtimes.insert(path, DateTime::<Utc>::from(modified));
         }
 
         let sidecar = ArtifactSidecar {
-            input_globs: input_globs.into_iter().collect(),
+            input_glob_sets,
             input_files: input_files_mtimes,
             artifact_sha256: sha256,
             artifact_filename: filename,
@@ -459,6 +456,7 @@ impl From<pixi_glob::GlobSetError> for ArtifactCacheError {
 mod tests {
     use std::str::FromStr;
 
+    use pixi_compute_engine::ComputeEngine;
     use rattler_conda_types::{PackageName, PackageRecord};
     use tempfile::TempDir;
 
@@ -470,6 +468,36 @@ mod tests {
 
     fn pkg(name: &str) -> PackageName {
         PackageName::from_str(name).unwrap()
+    }
+
+    /// A single glob group with default (markers-free, hidden-excluding) config.
+    fn glob_group(patterns: &[&str]) -> InputGlobSet {
+        InputGlobSet {
+            patterns: patterns.iter().map(|p| p.to_string()).collect(),
+            markers: Vec::new(),
+            exclude_hidden: true,
+            root: None,
+        }
+    }
+
+    fn abs(path: impl Into<PathBuf>) -> AbsPathBuf {
+        AbsPathBuf::new(path).unwrap()
+    }
+
+    /// Drive [`ArtifactCache::lookup`] (which needs a `ComputeCtx`) through the
+    /// provided engine. The test source dirs are absolute tempdirs.
+    async fn lookup(
+        engine: &ComputeEngine,
+        cache: &ArtifactCache,
+        package: &PackageName,
+        key: &ArtifactCacheKey,
+        source: &Path,
+    ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
+        let source = AbsPath::new(source).unwrap();
+        engine
+            .with_ctx(async |ctx| cache.lookup(ctx, package, key, source).await)
+            .await
+            .expect("compute engine cycle")
     }
 
     fn dummy_record(name: &str) -> RepoDataRecord {
@@ -496,10 +524,10 @@ mod tests {
     async fn lookup_missing_entry_returns_none() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
-        let got = cache
-            .lookup(&pkg("foo"), &key("linux-64-abc"), &source)
+        let got = lookup(&engine, &cache, &pkg("foo"), &key("linux-64-abc"), &source)
             .await
             .unwrap();
         assert!(got.is_none());
@@ -510,6 +538,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let cache_root = tmp.path().join("artifacts");
         let cache = ArtifactCache::new(&cache_root);
+        let engine = ComputeEngine::new();
 
         // A fake source tree with one input file.
         let source = tmp.path().join("src");
@@ -529,15 +558,16 @@ mod tests {
                 &pkg("foo"),
                 &key,
                 &artifact,
-                vec!["**/*.py".to_string()],
-                vec![PathBuf::from("main.py")],
-                &source,
+                vec![glob_group(&["**/*.py"])],
+                vec![abs(input.clone())],
                 dummy_record("foo"),
             )
             .await
             .unwrap();
 
-        let hit = cache.lookup(&pkg("foo"), &key, &source).await.unwrap();
+        let hit = lookup(&engine, &cache, &pkg("foo"), &key, &source)
+            .await
+            .unwrap();
         let hit = hit.expect("cache hit after store");
         assert_eq!(hit.sha256, stored.sha256);
         assert_eq!(hit.artifact, stored.artifact);
@@ -551,6 +581,7 @@ mod tests {
     async fn lookup_stale_when_source_file_changes() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
 
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
@@ -568,9 +599,8 @@ mod tests {
                 &pkg("foo"),
                 &key,
                 &artifact,
-                Vec::<String>::new(),
-                vec![PathBuf::from("main.py")],
-                &source,
+                Vec::new(),
+                vec![abs(input.clone())],
                 dummy_record("foo"),
             )
             .await
@@ -580,7 +610,9 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(20));
         fs_err::write(&input, b"new").unwrap();
 
-        let got = cache.lookup(&pkg("foo"), &key, &source).await.unwrap();
+        let got = lookup(&engine, &cache, &pkg("foo"), &key, &source)
+            .await
+            .unwrap();
         assert!(got.is_none(), "mtime change should invalidate the entry");
     }
 
@@ -588,10 +620,12 @@ mod tests {
     async fn lookup_stale_when_new_file_matches_glob() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
 
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
-        fs_err::write(source.join("main.py"), b"body").unwrap();
+        let input = source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
 
         let scratch = tmp.path().join("scratch");
         fs_err::create_dir_all(&scratch).unwrap();
@@ -604,9 +638,8 @@ mod tests {
                 &pkg("foo"),
                 &key,
                 &artifact,
-                vec!["**/*.py".to_string()],
-                vec![PathBuf::from("main.py")],
-                &source,
+                vec![glob_group(&["**/*.py"])],
+                vec![abs(input.clone())],
                 dummy_record("foo"),
             )
             .await
@@ -615,7 +648,9 @@ mod tests {
         // Introduce a new file that matches the stored glob.
         fs_err::write(source.join("extra.py"), b"new module").unwrap();
 
-        let got = cache.lookup(&pkg("foo"), &key, &source).await.unwrap();
+        let got = lookup(&engine, &cache, &pkg("foo"), &key, &source)
+            .await
+            .unwrap();
         assert!(
             got.is_none(),
             "a newly-added matching file should invalidate the entry"
@@ -630,6 +665,7 @@ mod tests {
         // that accidentally drops a field will fail this test.
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
 
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
@@ -649,16 +685,14 @@ mod tests {
                 &pkg("foo"),
                 &key,
                 &artifact,
-                Vec::<String>::new(),
-                Vec::<PathBuf>::new(),
-                &source,
+                Vec::new(),
+                Vec::<AbsPathBuf>::new(),
                 record.clone(),
             )
             .await
             .unwrap();
 
-        let hit = cache
-            .lookup(&pkg("foo"), &key, &source)
+        let hit = lookup(&engine, &cache, &pkg("foo"), &key, &source)
             .await
             .unwrap()
             .expect("cache should hit");
@@ -695,9 +729,11 @@ mod tests {
     async fn concurrent_store_and_lookup_do_not_error() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
-        fs_err::write(source.join("main.py"), b"body").unwrap();
+        let input = source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
         let scratch = tmp.path().join("scratch");
         fs_err::create_dir_all(&scratch).unwrap();
         let artifact = scratch.join("foo-1.0.0-h0.conda");
@@ -709,7 +745,7 @@ mod tests {
         let mut handles = Vec::new();
         for _ in 0..4 {
             let cache = cache.clone();
-            let source = source.clone();
+            let input = input.clone();
             let artifact = artifact.clone();
             let pkg = pkg.clone();
             let key = key.clone();
@@ -719,9 +755,8 @@ mod tests {
                         &pkg,
                         &key,
                         &artifact,
-                        Vec::<String>::new(),
-                        vec![PathBuf::from("main.py")],
-                        &source,
+                        Vec::new(),
+                        vec![abs(input)],
                         dummy_record("foo"),
                     )
                     .await
@@ -730,6 +765,7 @@ mod tests {
         }
         for _ in 0..8 {
             let cache = cache.clone();
+            let engine = engine.clone();
             let source = source.clone();
             let pkg = pkg.clone();
             let key = key.clone();
@@ -737,7 +773,7 @@ mod tests {
                 // Ignore whether it's a hit or miss; racing with stores
                 // the lookup may see either. The contract under test is
                 // that it never errors out.
-                let _ = cache.lookup(&pkg, &key, &source).await.unwrap();
+                let _ = lookup(&engine, &cache, &pkg, &key, &source).await.unwrap();
             }));
         }
         for h in handles {
@@ -749,6 +785,7 @@ mod tests {
     async fn corrupt_sidecar_is_a_miss() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
 
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
@@ -757,11 +794,79 @@ mod tests {
         fs_err::create_dir_all(&entry).unwrap();
         fs_err::write(entry.join("sidecar.json"), b"{ this is not valid").unwrap();
 
-        let got = cache
-            .lookup(&pkg("foo"), &key("linux-64-abc"), &source)
+        let got = lookup(&engine, &cache, &pkg("foo"), &key("linux-64-abc"), &source)
             .await
             .unwrap();
         assert!(got.is_none());
+    }
+
+    /// Regression for prefix-dev/pixi#6232: a thin package whose manifest
+    /// points at `../recipe.yaml` makes the build report a `../**` input
+    /// glob. The walker rebases that onto the parent directory, so it matches
+    /// files outside the package's own source dir (the recipe, the build
+    /// script, sibling variant dirs). Those must round-trip through store +
+    /// lookup so the second run is a cache hit instead of rebuilding from
+    /// scratch.
+    #[tokio::test]
+    async fn issue_6232_parent_recipe_glob_does_not_force_rebuild() {
+        let tmp = TempDir::new().unwrap();
+        // Layout: <root>/llama-cpp/{recipe.yaml, build.sh, vulkan/{pixi.toml, variants.yaml}}
+        let parent = tmp.path().join("llama-cpp");
+        let source = parent.join("vulkan");
+        fs_err::create_dir_all(&source).unwrap();
+        fs_err::write(parent.join("recipe.yaml"), b"recipe").unwrap();
+        fs_err::write(parent.join("build.sh"), b"script").unwrap();
+        fs_err::write(source.join("pixi.toml"), b"manifest").unwrap();
+        fs_err::write(source.join("variants.yaml"), b"backend:\n  - vulkan\n").unwrap();
+        let source_abs = AbsPath::new(&source).unwrap();
+
+        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
+        let scratch = tmp.path().join("scratch");
+        fs_err::create_dir_all(&scratch).unwrap();
+        let artifact = scratch.join("foo-1.0.0-h0.conda");
+        fs_err::write(&artifact, b"artifact").unwrap();
+
+        // The build reports `../**` because the recipe lives in the parent dir.
+        let groups = vec![glob_group(&["../**"])];
+
+        // Resolve the matched files exactly as the source-build pipeline does.
+        let input_files = engine
+            .with_ctx(async |ctx| {
+                crate::input_globs::collect_input_files(ctx, &groups, source_abs).await
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        // Sanity: the `../**` glob really did reach the parent recipe.
+        assert!(
+            input_files
+                .iter()
+                .any(|p| p.as_std_path().ends_with("llama-cpp/recipe.yaml")),
+            "expected `../**` to match the parent recipe, got {input_files:?}",
+        );
+
+        let key = key("linux-64-abc");
+        cache
+            .store(
+                &pkg("foo"),
+                &key,
+                &artifact,
+                groups,
+                input_files,
+                dummy_record("foo"),
+            )
+            .await
+            .unwrap();
+
+        // Second run with nothing changed: must hit, not rebuild.
+        let hit = lookup(&engine, &cache, &pkg("foo"), &key, &source)
+            .await
+            .unwrap();
+        assert!(
+            hit.is_some(),
+            "issue #6232: a `../`-recipe glob must not force a rebuild on the next run",
+        );
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -195,29 +195,21 @@ pub struct BuildBackendMetadataCacheEntry {
     #[serde(default, skip_serializing_if = "BinaryHeap::is_empty")]
     pub build_variant_files: BinaryHeap<PathBuf>,
 
-    /// Globs of files from which the metadata was derived. Globs require
+    /// Structured glob groups of files from which the metadata was derived
+    /// (patterns plus marker / hidden-file / root config). Globs require
     /// recursively iterating the filesystem which can be particularly slow so
-    /// we prefer to store direct file paths instead. However, this does not
-    /// work for all backends so we also support globs.
-    ///
-    /// Order is preserved: pixi's `GlobSet` is gitignore last-match-wins, so
-    /// inclusion patterns must precede any negated exclusions that should
-    /// override them. If the source itself is immutable this is empty.
+    /// we prefer to store direct file paths (`input_files`) instead. However,
+    /// that does not work for all backends so we also keep the groups. The
+    /// flat `input_globs` a backend reports are folded into a group here so
+    /// there's a single representation. If the source itself is immutable this
+    /// is empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub input_globs: Vec<String>,
+    pub input_glob_sets: Vec<pixi_build_types::InputGlobSet>,
 
-    /// Structured form of [`Self::input_globs`].  Populated when the
-    /// backend response carried `input_glob_sets`; pixi prefers this when
-    /// re-walking for new-file detection because it can express
-    /// marker-driven pruning that the flat list cannot.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub input_glob_sets: Option<Vec<pixi_build_types::InputGlobSet>>,
-
-    /// Paths relative to the source checkout of files that were used to
-    /// determine the metadata. This is the result of the matching the globs
-    /// against the filesystem.
+    /// Absolute paths of files that were used to determine the metadata. This
+    /// is the result of matching the globs against the filesystem.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub input_files: BTreeSet<PathBuf>,
+    pub input_files: BTreeSet<pixi_path::AbsPathBuf>,
 
     /// The timestamp of when the metadata was computed.
     pub timestamp: std::time::SystemTime,

--- a/crates/pixi_command_dispatcher/src/input_globs.rs
+++ b/crates/pixi_command_dispatcher/src/input_globs.rs
@@ -1,58 +1,185 @@
-//! Compute-engine-driven helper for walking the input globs a backend
-//! reported.  Both the flat `input_globs: Vec<String>` and the
-//! structured `input_glob_sets: Option<Vec<InputGlobSet>>` are consumed:
-//! the flat form is folded into a synthetic [`InputGlobSet`] (no
-//! markers, default hidden handling, caller's root) and walked
-//! alongside any structured groups via [`InputGlobSetWalkKey`], so two
-//! consumers that arrive at the same `(absolute_root, patterns,
-//! markers, exclude_hidden)` tuple share a single walk for the engine's
-//! lifetime.
+//! Compute-engine-driven helper for walking the input glob groups a
+//! backend reported.  Each [`InputGlobSet`] is walked via
+//! [`InputGlobSetWalkKey`], so two consumers that arrive at the same
+//! `(absolute_root, patterns, markers, exclude_hidden)` tuple share a
+//! single walk for the engine's lifetime.
+//!
+//! Backends report inputs as a flat `input_globs: Vec<String>` plus an
+//! optional structured `input_glob_sets`. [`fold_input_globs`] normalizes
+//! the two into a single `Vec<InputGlobSet>` (the flat list becomes one
+//! marker-free, hidden-excluding group) so the rest of the pipeline only
+//! ever deals with groups.
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use pixi_build_types::InputGlobSet;
 use pixi_compute_engine::ComputeCtx;
 use pixi_glob::GlobSetError;
+use pixi_path::{AbsPath, AbsPathBuf};
 
 use crate::keys::InputGlobSetWalkKey;
 
-/// Walk every group implied by the input declaration, deduping the
-/// resulting paths.  See module docs for the consumption rules.
-pub async fn collect_input_files_via_engine(
-    ctx: &mut ComputeCtx,
-    input_globs: &[String],
-    input_glob_sets: Option<&[InputGlobSet]>,
-    caller_root: &Path,
-) -> Result<Vec<PathBuf>, Arc<GlobSetError>> {
-    let mut all: Vec<PathBuf> = Vec::new();
-
+/// Normalize a backend's `(input_globs, input_glob_sets)` pair into a
+/// single list of groups. The flat globs (if any) are folded into one
+/// group with default config (no markers, hidden excluded, caller's root).
+pub fn fold_input_globs(
+    input_globs: Vec<String>,
+    input_glob_sets: Option<Vec<InputGlobSet>>,
+) -> Vec<InputGlobSet> {
+    let mut groups = input_glob_sets.unwrap_or_default();
     if !input_globs.is_empty() {
-        let flat_as_group = InputGlobSet {
-            patterns: input_globs.to_vec(),
+        groups.push(InputGlobSet {
+            patterns: input_globs,
             markers: Vec::new(),
             exclude_hidden: true,
             root: None,
-        };
-        let key = InputGlobSetWalkKey::from_group(&flat_as_group, caller_root);
-        let paths = ctx.compute(&key).await?;
-        all.extend(paths.iter().cloned());
+        });
     }
+    groups
+}
 
-    if let Some(groups) = input_glob_sets {
-        for group in groups {
-            let key = InputGlobSetWalkKey::from_group(group, caller_root);
-            let paths = ctx.compute(&key).await?;
-            all.extend(paths.iter().cloned());
-        }
-    }
+/// Walk every group from the absolute `caller_root`, deduping the resulting
+/// (absolute) paths. Groups are independent walks and run concurrently.
+/// Overlapping matches across groups (e.g. a flat group folded alongside a
+/// structured one) are collapsed.
+pub async fn collect_input_files(
+    ctx: &mut ComputeCtx,
+    groups: &[InputGlobSet],
+    caller_root: &AbsPath,
+) -> Result<Vec<AbsPathBuf>, Arc<GlobSetError>> {
+    let caller_root = caller_root.to_path_buf();
+    let per_group = ctx
+        .try_compute_join(
+            groups.to_vec(),
+            async move |sub_ctx: &mut ComputeCtx,
+                        group: InputGlobSet|
+                        -> Result<Vec<AbsPathBuf>, Arc<GlobSetError>> {
+                let key = InputGlobSetWalkKey::from_group(&group, caller_root.as_std_path());
+                let paths = sub_ctx.compute(&key).await?;
+                Ok(paths
+                    .iter()
+                    .map(|path| {
+                        // The walk root is absolute, so every match is too.
+                        AbsPathBuf::new(path.clone())
+                            .expect("glob walk of an absolute root yields absolute paths")
+                    })
+                    .collect())
+            },
+        )
+        .await?;
 
-    // Dedupe; a backend transitioning to `input_glob_sets` emits both
-    // forms for back-compat and we'd otherwise count overlapping matches
-    // twice.
+    let mut all: Vec<AbsPathBuf> = per_group.into_iter().flatten().collect();
     all.sort();
     all.dedup();
     Ok(all)
+}
+
+#[cfg(test)]
+mod tests {
+    use pixi_compute_engine::ComputeEngine;
+    use pixi_path::AbsPath;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn group(patterns: &[&str], exclude_hidden: bool) -> InputGlobSet {
+        InputGlobSet {
+            patterns: patterns.iter().map(|p| p.to_string()).collect(),
+            markers: Vec::new(),
+            exclude_hidden,
+            root: None,
+        }
+    }
+
+    /// Drive `collect_input_files` (needs a `ComputeCtx`) through a throwaway
+    /// engine and return the matched paths.
+    async fn collect(groups: &[InputGlobSet], root: &AbsPath) -> Vec<AbsPathBuf> {
+        ComputeEngine::new()
+            .with_ctx(async |ctx| collect_input_files(ctx, groups, root).await)
+            .await
+            .expect("no cycle")
+            .expect("walk succeeds")
+    }
+
+    #[test]
+    fn fold_normalizes_flat_and_structured_into_groups() {
+        // Empty in, empty out.
+        assert!(fold_input_globs(Vec::new(), None).is_empty());
+
+        // Flat globs become one default group (no markers, hidden excluded,
+        // caller's root).
+        let folded = fold_input_globs(vec!["a".into(), "b".into()], None);
+        assert_eq!(folded.len(), 1);
+        assert_eq!(folded[0].patterns, vec!["a".to_string(), "b".to_string()]);
+        assert!(folded[0].markers.is_empty());
+        assert!(folded[0].exclude_hidden);
+        assert!(folded[0].root.is_none());
+
+        // Structured groups pass through unchanged.
+        let structured = vec![group(&["x"], false)];
+        assert_eq!(
+            fold_input_globs(Vec::new(), Some(structured.clone())),
+            structured
+        );
+
+        // Both: structured first, the folded flat group appended.
+        let folded = fold_input_globs(vec!["flat".into()], Some(vec![group(&["x"], true)]));
+        assert_eq!(folded.len(), 2);
+        assert_eq!(folded[0].patterns, vec!["x".to_string()]);
+        assert_eq!(folded[1].patterns, vec!["flat".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn collect_returns_absolute_matches() {
+        let tmp = TempDir::new().unwrap();
+        fs_err::write(tmp.path().join("a.txt"), b"x").unwrap();
+        let root = AbsPath::new(tmp.path()).unwrap();
+
+        let files = collect(&[group(&["**"], true)], root).await;
+        assert!(files.iter().all(|p| p.as_std_path().is_absolute()));
+        assert!(files.iter().any(|p| p.as_std_path().ends_with("a.txt")));
+    }
+
+    #[tokio::test]
+    async fn collect_honors_structured_group_config() {
+        // Proves the per-group config (here `exclude_hidden`) is threaded
+        // through to the walk rather than ignored.
+        let tmp = TempDir::new().unwrap();
+        fs_err::write(tmp.path().join(".hidden"), b"x").unwrap();
+        let root = AbsPath::new(tmp.path()).unwrap();
+
+        let excluded = collect(&[group(&["**"], true)], root).await;
+        assert!(
+            !excluded
+                .iter()
+                .any(|p| p.as_std_path().ends_with(".hidden"))
+        );
+
+        let included = collect(&[group(&["**"], false)], root).await;
+        assert!(
+            included
+                .iter()
+                .any(|p| p.as_std_path().ends_with(".hidden"))
+        );
+    }
+
+    #[tokio::test]
+    async fn collect_unions_and_dedups_multiple_groups() {
+        let tmp = TempDir::new().unwrap();
+        fs_err::write(tmp.path().join("a.txt"), b"x").unwrap();
+        fs_err::write(tmp.path().join("b.log"), b"x").unwrap();
+        let root = AbsPath::new(tmp.path()).unwrap();
+
+        // Two overlapping groups; `a.txt` is matched by both and must appear once.
+        let files = collect(&[group(&["**/*.txt"], true), group(&["**"], true)], root).await;
+        assert_eq!(
+            files
+                .iter()
+                .filter(|p| p.as_std_path().ends_with("a.txt"))
+                .count(),
+            1,
+            "overlapping matches across groups must be deduped",
+        );
+        assert!(files.iter().any(|p| p.as_std_path().ends_with("b.log")));
+    }
 }

--- a/crates/pixi_command_dispatcher/src/keys/input_glob_set_walk.rs
+++ b/crates/pixi_command_dispatcher/src/keys/input_glob_set_walk.rs
@@ -40,7 +40,7 @@ pub struct InputGlobSetWalkSpec {
 impl InputGlobSetWalkSpec {
     /// Build a spec from an [`InputGlobSet`] resolved against
     /// `caller_root`.  Mirrors the resolution rule used by
-    /// `crate::input_globs::collect_input_files_via_engine`: absolute
+    /// `crate::input_globs::collect_input_files`: absolute
     /// `root` overrides, relative `root` joins, `None` falls back to
     /// `caller_root`.
     pub fn from_group(group: &InputGlobSet, caller_root: &Path) -> Self {

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -205,10 +205,9 @@ async fn compute_inner(
     let source_dir = build_source_checkout
         .path
         .as_dir_or_file_parent()
-        .as_std_path()
         .to_path_buf();
     if let Some(hit) = artifact_cache
-        .lookup(spec.record.name(), &cache_key, &source_dir)
+        .lookup(ctx, spec.record.name(), &cache_key, &source_dir)
         .await
         .map_err(map_cache_err)?
     {
@@ -423,7 +422,6 @@ async fn compute_inner(
             version: output.metadata.version.clone(),
             build: output.metadata.build.clone(),
             subdir: output.metadata.subdir.to_string(),
-            source_dir: source_dir.clone(),
             work_directory,
             channels: spec.channels.clone(),
         })
@@ -435,14 +433,20 @@ async fn compute_inner(
     // can persist it alongside the artifact.
     let record = synthesize_repodata(&built.output_file).await?;
 
+    // Resolve the files matching the build's reported globs through the
+    // compute engine (same deduped walk as `build_backend_metadata`).
+    let input_files =
+        crate::input_globs::collect_input_files(ctx, &built.input_glob_sets, &source_dir)
+            .await
+            .map_err(SourceBuildError::GlobSet)?;
+
     let stored = artifact_cache
         .store(
             spec.record.name(),
             &cache_key,
             &built.output_file,
-            built.input_globs,
-            built.input_files,
-            &source_dir,
+            built.input_glob_sets,
+            input_files,
             record,
         )
         .await

--- a/crates/pixi_path/Cargo.toml
+++ b/crates/pixi_path/Cargo.toml
@@ -16,4 +16,5 @@ thiserror = { workspace = true }
 typed-path = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/pixi_path/src/lib.rs
+++ b/crates/pixi_path/src/lib.rs
@@ -401,9 +401,22 @@ impl ToOwned for AbsPath {
 ///
 /// An `AbsPathBuf` always contains an absolute path. This is enforced at
 /// construction time.
-#[derive(Clone, Hash, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, serde::Serialize)]
 #[serde(transparent)]
 pub struct AbsPathBuf(PathBuf);
+
+impl<'de> serde::Deserialize<'de> for AbsPathBuf {
+    /// Validates the absolute-path invariant on the way in, so a serialized
+    /// relative path is rejected rather than silently producing a malformed
+    /// `AbsPathBuf`.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let path = <PathBuf as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(path).map_err(serde::de::Error::custom)
+    }
+}
 
 impl AbsPathBuf {
     /// Creates a new `AbsPathBuf` from a path.
@@ -1163,6 +1176,18 @@ mod tests {
     fn test_abs_path_buf_new_with_relative() {
         let result = AbsPathBuf::new("relative/path");
         assert!(matches!(result, Err(PathError::NotAbsolute(_))));
+    }
+
+    #[test]
+    fn test_abs_path_buf_deserialize_validates_absoluteness() {
+        // An absolute path round-trips.
+        let abs = AbsPathBuf::new(get_absolute_path()).unwrap();
+        let json = serde_json::to_string(&abs).unwrap();
+        assert_eq!(serde_json::from_str::<AbsPathBuf>(&json).unwrap(), abs);
+
+        // A relative path is rejected rather than producing a malformed value.
+        let relative = serde_json::to_string(&PathBuf::from("relative/path")).unwrap();
+        assert!(serde_json::from_str::<AbsPathBuf>(&relative).is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Description

Source packages that keep their build variants in a separate `variants.yaml`, with the recipe shared from a parent directory, were rebuilt from scratch on every command even when nothing had changed.

The build cache decides whether a package needs rebuilding by checking the files that went into the previous build. It was not tracking the files that live outside the package's own directory (such as the shared recipe and build script), so on every run it saw them as newly added and threw the cached build away.

This change makes the cache record and re-check those files correctly, so a build is reused until its inputs actually change. The same handling is applied to both the source build cache and the build backend metadata cache, so the two stay consistent. The result matches the behaviour you already get when variants are declared inline with `[workspace.build-variants]`.

Fixes #6232

### How Has This Been Tested?

Added a regression test that reproduces the issue's project layout (a package whose recipe lives in a parent directory) and confirms the build is reused on the second run instead of rebuilt, plus unit tests for the file matching that the caches rely on. The full `pixi_command_dispatcher` test suite passes and the project builds cleanly.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.