### PR TITLE
docs: add AWS Lambda integration example

### DIFF
--- a/docs/integration/third_party/aws_lambda.md
+++ b/docs/integration/third_party/aws_lambda.md
@@ -1,6 +1,9 @@
-AWS Lambda is a serverless compute platform that lets you run code without managing servers. Pixi can be used to manage the Python environment and dependencies required for Lambda functions.
+# AWS Lambda
+
+`AWS Lambda` is a serverless compute platform that lets you run code without managing servers. Pixi can be used to manage the Python environment and dependencies required for Lambda functions.
 
 ## Create a project
+
 Create a new Pixi project:
 
 ```bash
@@ -9,24 +12,27 @@ pixi init my_lambda_project
 
 ## Add dependencies
 
-Add Python as a prerequisite:
+Add Python:
 
 ```bash
 pixi add python
 ```
+
 Add AWS Lambda Powertools:
 
 ```bash
 pixi add aws-lambda-powertools
 ```
-AWS Lambda Powertools is a utility toolkit for AWS Lambda functions that provides logging, tracing, metrics, and other operational features.
 
-Your pixi.toml should contain:
+Your `pixi.toml` should contain:
+
 ```toml title="pixi.toml"
 [dependencies]
-python = ">=3.14.5,<3.15"
+python = ">=3.13,<3.14"
 aws-lambda-powertools = ">=3.29.0,<4"
 ```
+
+## Create a Lambda handler
 
 Create a `main.py` file:
 
@@ -47,16 +53,78 @@ if __name__ == "__main__":
     print(handler({}, None))
 ```
 
-Run the example:
+## Run locally
 
-```bash 
+```bash
 pixi run python main.py
 ```
 
-Expected output:
+Output:
 
-```bash 
+```bash
 {'statusCode': 200, 'body': 'Hello from AWS Lambda using Pixi'}
 ```
 
 The output is the dictionary returned by the Lambda handler when invoked locally with a dummy event (`{}`) and no execution context (`None`).
+
+## Deployment
+
+### Build a container image
+
+The following Dockerfile uses Pixi to create the Python environment in a build stage and copies it into an AWS Lambda Python runtime image.
+
+```dockerfile title="Dockerfile"
+FROM ghcr.io/prefix-dev/pixi:latest AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN pixi install --locked
+
+## Create an AWS-runtime Lambda image
+FROM public.ecr.aws/lambda/python:3.13
+
+# Copy the runtime dependencies from the builder stage.
+COPY --from=build /app/.pixi/envs/default /opt/pixi-env
+
+# Copy the application code.
+COPY app/ ${LAMBDA_TASK_ROOT}/app
+
+ENV PATH="/opt/pixi-env/bin:${PATH}"
+ENV PYTHONPATH="/opt/pixi-env/lib/python3.13/site-packages:${PYTHONPATH}"
+
+# Set the AWS Lambda handler.
+CMD ["app.main.handler"]
+```
+
+Build the image:
+
+```bash
+docker build -t pixi-lambda .
+```
+
+### Test the image
+
+Enter the container:
+
+```bash
+docker run -it --entrypoint /bin/sh pixi-lambda
+```
+
+Run the handler:
+
+```bash
+python /var/task/app/main.py
+```
+
+Output:
+
+```bash
+{'statusCode': 200, 'body': 'Hello from AWS Lambda using Pixi'}
+```
+
+## Further reading
+
+* Deploying Pixi projects to production: https://tech.quantco.com/blog/pixi-production
+* AWS Lambda documentation: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html

--- a/docs/integration/third_party/aws_lambda.md
+++ b/docs/integration/third_party/aws_lambda.md
@@ -1,0 +1,62 @@
+AWS Lambda is a serverless compute platform that lets you run code without managing servers. Pixi can be used to manage the Python environment and dependencies required for Lambda functions.
+
+## Create a project
+Create a new Pixi project:
+
+```bash
+pixi init my_lambda_project
+```
+
+## Add dependencies
+
+Add Python as a prerequisite:
+
+```bash
+pixi add python
+```
+Add AWS Lambda Powertools:
+
+```bash
+pixi add aws-lambda-powertools
+```
+AWS Lambda Powertools is a utility toolkit for AWS Lambda functions that provides logging, tracing, metrics, and other operational features.
+
+Your pixi.toml should contain:
+```toml title="pixi.toml"
+[dependencies]
+python = ">=3.14.5,<3.15"
+aws-lambda-powertools = ">=3.29.0,<4"
+```
+
+Create a `main.py` file:
+
+```python title="main.py"
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+
+def handler(event, context):
+    logger.info("Request received")
+
+    return {
+        "statusCode": 200,
+        "body": "Hello from AWS Lambda using Pixi"
+    }
+
+if __name__ == "__main__":
+    print(handler({}, None))
+```
+
+Run the example:
+
+```bash 
+pixi run python main.py
+```
+
+Expected output:
+
+```bash 
+{'statusCode': 200, 'body': 'Hello from AWS Lambda using Pixi'}
+```
+
+The output is the dictionary returned by the Lambda handler when invoked locally with a dummy event (`{}`) and no execution context (`None`).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,6 +192,7 @@ nav:
           - Conda Deny: integration/third_party/conda_deny.md
           - Direnv: integration/third_party/direnv.md
           - Starship: integration/third_party/starship.md
+          - AWS Lambda: integration/third_party/aws_lambda.md
   - Advanced:
       - Security: security.md
       - Channel Logic: advanced/channel_logic.md


### PR DESCRIPTION
### Description

Adds an AWS Lambda integration example to the third-party integrations documentation.

The example demonstrates:

Creating a Pixi project
Adding Python
Installing aws-lambda-powertools
Creating a simple Lambda handler
Running the handler locally with Pixi

I have decided to put this page in the thirsd-party integrations as suggested by the issue author.

Fixes #3738

### How Has This Been Tested?

Tested locally with:

pixi init my_lambda_project
pixi add python
pixi add aws-lambda-powertools
pixi run python main.py

The example successfully executes and returns the expected response.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ✔] This PR contains AI-generated content.
  - [✔ ] I have tested any AI-generated content in my PR.
  - [ ✔] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
I have taken help of ChatGpt to write the example python script.

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [ ✔] I have performed a self-review of my own code
- [✔ ] I have made corresponding changes to the documentation
- [ ✔] I have added sufficient tests to cover my changes.

