### PR TITLE
test: move examples satisfiability tests to Python

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/tests.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/tests.rs
@@ -208,44 +208,6 @@ async fn test_good_satisfiability(
 #[rstest]
 #[tokio::test]
 #[traced_test]
-async fn q(#[files("../../examples/**/p*.toml")] manifest_path: PathBuf) {
-    // If a pyproject.toml is present check for `tool.pixi` in the file to avoid
-    // testing of non-pixi files
-    if manifest_path.file_name().unwrap() == "pyproject.toml" {
-        let manifest_str = fs_err::read_to_string(&manifest_path).unwrap();
-        if !manifest_str.contains("tool.pixi.workspace") {
-            return;
-        }
-    }
-
-    // If a pixi.toml is present check for a `[workspace]` section header in
-    // the file to avoid testing non-workspace member manifests. A bare
-    // substring match on "workspace" would false-match on members that use
-    // `{ workspace = true }` inheritance markers.
-    if manifest_path.file_name().unwrap() == "pixi.toml" {
-        let manifest_str = fs_err::read_to_string(&manifest_path).unwrap();
-        if !manifest_str
-            .lines()
-            .any(|line| line.trim_start().starts_with("[workspace"))
-        {
-            return;
-        }
-    }
-
-    let project = Workspace::from_path(&manifest_path).unwrap();
-    let lock_file = LockFile::from_path(&project.lock_file_path()).unwrap();
-    match verify_lock_file_satisfiability(&project, &lock_file, None)
-        .await
-        .into_diagnostic()
-    {
-        Ok(()) => {}
-        Err(e) => panic!("{e:?}"),
-    }
-}
-
-#[rstest]
-#[tokio::test]
-#[traced_test]
 async fn test_failing_satisfiability(
     #[files("../../tests/data/non-satisfiability/*/pixi.toml")] manifest_path: PathBuf,
 ) {

--- a/tests/integration_python/pixi_build/test_examples_satisfiability.py
+++ b/tests/integration_python/pixi_build/test_examples_satisfiability.py
@@ -1,0 +1,59 @@
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from .common import repo_root, verify_cli_command
+
+
+def workspace_example_manifests() -> list[Path]:
+    """Collect the workspace manifests of all examples.
+
+    Globs for `pixi.toml` and `pyproject.toml` files in `examples/` and keeps
+    only the ones that describe an actual pixi workspace.
+    """
+    manifests: list[Path] = []
+    for manifest_path in sorted(repo_root().joinpath("examples").glob("**/p*.toml")):
+        manifest = tomllib.loads(manifest_path.read_text())
+        if manifest_path.name == "pyproject.toml":
+            # Only consider pyproject.toml files that configure a pixi workspace
+            # to avoid testing non-pixi files.
+            workspace = manifest.get("tool", {}).get("pixi", {}).get("workspace")
+        elif manifest_path.name == "pixi.toml":
+            # Only consider pixi.toml files with a workspace section to avoid
+            # testing non-workspace member manifests.
+            workspace = manifest.get("workspace")
+        else:
+            continue
+        if workspace is not None:
+            manifests.append(manifest_path)
+    return manifests
+
+
+WORKSPACE_EXAMPLE_MANIFESTS = workspace_example_manifests()
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "manifest_path",
+    WORKSPACE_EXAMPLE_MANIFESTS,
+    ids=[str(p.relative_to(repo_root())) for p in WORKSPACE_EXAMPLE_MANIFESTS],
+)
+def test_example_lock_file_satisfiability(pixi: Path, manifest_path: Path) -> None:
+    """Verify that the committed lock file of each example satisfies its manifest.
+
+    `pixi tree --locked` performs the satisfiability check without re-solving or
+    installing the environment. The build backends are provided through the
+    `PIXI_BUILD_BACKEND_OVERRIDE` that is set by the session fixture in
+    `conftest.py`.
+    """
+    verify_cli_command(
+        [
+            pixi,
+            "tree",
+            "--locked",
+            "--no-install",
+            "--manifest-path",
+            manifest_path,
+        ],
+    )


### PR DESCRIPTION
Our satisfiability checks on examples don't work on PRs that have dependant build-backend changes. 

Moving them to Python fixes that since we override changes there. 