### PR TITLE
feat(manifest): support wildcard platform target selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,6 +6984,7 @@ dependencies = [
  "dunce",
  "fancy_display",
  "fs-err",
+ "glob",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ flate2 = "1.1.0"
 fs-err = { version = "3.1.0" }
 fs_extra = "1.3.0"
 futures = "0.3.31"
+glob = "0.3.3"
 hex = "0.4.3"
 http = "1.3.1"
 http-cache-reqwest = "1.0.0-alpha.6"

--- a/crates/pixi_build_discovery/src/discovery.rs
+++ b/crates/pixi_build_discovery/src/discovery.rs
@@ -277,6 +277,22 @@ impl DiscoveredBackend {
             })
             .collect::<Result<_, _>>()?;
 
+        let target_configuration = build_system
+            .target_config
+            .map(|c| {
+                c.into_iter()
+                    .map(|(selector, config)| {
+                        Ok((
+                            to_target_selector_v1(&selector)?,
+                            config.deserialize_into().expect(
+                                "Configuration dictionary needs to be serializable to JSON",
+                            ),
+                        ))
+                    })
+                    .collect::<Result<_, SpecConversionError>>()
+            })
+            .transpose()?;
+
         Ok(Self {
             backend_spec: BackendSpec::JsonRpc(JsonRpcBackendSpec {
                 name: build_system.backend.name.as_normalized().to_string(),
@@ -303,18 +319,7 @@ impl DiscoveredBackend {
                         .deserialize_into()
                         .expect("Configuration dictionary needs to be serializable to JSON")
                 }),
-                target_configuration: build_system.target_config.map(|c| {
-                    c.into_iter()
-                        .map(|(selector, config)| {
-                            (
-                                to_target_selector_v1(&selector),
-                                config.deserialize_into().expect(
-                                    "Configuration dictionary needs to be serializable to JSON",
-                                ),
-                            )
-                        })
-                        .collect()
-                }),
+                target_configuration,
             },
         })
     }

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -200,15 +200,25 @@ fn to_target_v1(
 /// Converts a manifest [`TargetSelector`] to its wire form. Only used for the
 /// per-target backend configuration (`[package.build.target.<selector>]`);
 /// dependencies carry conditional expressions instead.
-pub fn to_target_selector_v1(selector: &TargetSelector) -> pbt::TargetSelector {
-    match selector {
+pub fn to_target_selector_v1(
+    selector: &TargetSelector,
+) -> Result<pbt::TargetSelector, SpecConversionError> {
+    Ok(match selector {
         TargetSelector::Platform(platform) => pbt::TargetSelector::Platform(platform.to_string()),
         TargetSelector::Subdir(subdir) => pbt::TargetSelector::Subdir(subdir.to_string()),
         TargetSelector::Unix => pbt::TargetSelector::Unix,
         TargetSelector::Linux => pbt::TargetSelector::Linux,
         TargetSelector::Win => pbt::TargetSelector::Win,
         TargetSelector::MacOs => pbt::TargetSelector::MacOs,
-    }
+        // Package targets resolve by subdir through the build-types protocol,
+        // which has no wildcard concept; glob keys are rejected upstream while
+        // parsing the manifest, so this is an unreachable backstop.
+        TargetSelector::PlatformGlob(glob) => {
+            return Err(SpecConversionError::WildcardTargetSelector(
+                glob.as_str().to_string(),
+            ));
+        }
+    })
 }
 
 fn to_targets_v1(

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -1413,6 +1413,9 @@ pub(super) fn spec_conversion_to_match_spec_error(e: SpecConversionError) -> Par
         SpecConversionError::InvalidPath(p) => ParseChannelError::InvalidPath(p).into(),
         SpecConversionError::InvalidChannel(_name, p) => p.into(),
         SpecConversionError::MissingName => ParseMatchSpecError::MissingPackageName,
+        SpecConversionError::WildcardTargetSelector(_) => {
+            unreachable!("target selectors are never converted while parsing match specs")
+        }
     }
 }
 

--- a/crates/pixi_manifest/Cargo.toml
+++ b/crates/pixi_manifest/Cargo.toml
@@ -14,6 +14,7 @@ console = { workspace = true }
 dunce = { workspace = true }
 fancy_display = { workspace = true }
 fs-err = { workspace = true }
+glob = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -51,7 +51,7 @@ use miette::Diagnostic;
 pub use package::Package;
 pub use platform::{
     PixiPlatform, PixiPlatformError, PixiPlatformName, PixiPlatformNameError, PlatformEdit,
-    PlatformMove,
+    PlatformGlob, PlatformGlobError, PlatformMove,
 };
 pub use preview::{KnownPreviewFeature, Preview};
 pub use s3::S3Options;

--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__glob_target_no_match_warns.snap
+++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__glob_target_no_match_warns.snap
@@ -1,0 +1,17 @@
+---
+source: crates/pixi_manifest/src/manifests/workspace.rs
+expression: "expect_parse_warnings(r#\"\n[workspace]\nname = \"foo\"\nversion = \"0.1.0\"\nchannels = []\nplatforms = ['win-64', 'osx-64', 'linux-64']\n\n[target.\"cuda-*\".dependencies]\nfoo = \"1.0\"\n\"#)"
+---
+  ⚠ The target selector 'cuda-*' does not match any of the platforms supported by the workspace
+   ╭─[pixi.toml:8:10]
+ 5 │ channels = []
+ 6 │ platforms = ['win-64', 'osx-64', 'linux-64']
+   ·             ────────────────┬───────────────
+   ·                             ╰── the platforms supported by the workspace are defined here
+ 7 │
+ 8 │ [target."cuda-*".dependencies]
+   ·          ───┬──
+   ·             ╰── target selector specified here
+ 9 │ foo = "1.0"
+   ╰────
+  help: Declare a platform whose name matches 'cuda-*', using `pixi workspace platform add <name>`

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -1925,6 +1925,26 @@ start = "python -m flask run --port=5050"
     }
 
     #[test]
+    fn test_glob_target_no_match_warns() {
+        // A wildcard target selector that matches no declared platform parses
+        // with a glob-aware warning that does not suggest `platform add cuda-*`.
+        // Use a `[workspace]` manifest so the `[project]` deprecation warning
+        // doesn't pollute the snapshot.
+        assert_snapshot!(expect_parse_warnings(
+            r#"
+[workspace]
+name = "foo"
+version = "0.1.0"
+channels = []
+platforms = ['win-64', 'osx-64', 'linux-64']
+
+[target."cuda-*".dependencies]
+foo = "1.0"
+"#
+        ));
+    }
+
+    #[test]
     fn test_invalid_key() {
         insta::with_settings!({snapshot_suffix => "foobar"}, {
             assert_snapshot!(expect_parse_failure(&format!("{PROJECT_BOILERPLATE}\n[foobar]")))

--- a/crates/pixi_manifest/src/platform.rs
+++ b/crates/pixi_manifest/src/platform.rs
@@ -30,6 +30,12 @@ pub enum PixiPlatformNameError {
 /// custom names like `gpu-linux-cuda12-glibc228`.
 const MAX_PLATFORM_NAME_BYTES: usize = 64;
 
+/// Bytes allowed in the body of a platform name and as the literal parts of a
+/// [`PlatformGlob`]: ASCII alphanumerics and `-`.
+fn is_platform_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'-'
+}
+
 // `Deserialize` is implemented by hand (below) to route through `TryFrom` so
 // the name validation can't be bypassed; the derive would accept any string.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, serde::Serialize)]
@@ -78,7 +84,7 @@ impl PixiPlatformName {
                 // Trailing `-` is not allowed.
                 c.is_ascii_alphanumeric()
             } else {
-                c.is_ascii_alphanumeric() || *c == b'-'
+                is_platform_name_byte(*c)
             };
 
             if !ok {
@@ -126,6 +132,128 @@ impl Deref for PixiPlatformName {
     fn deref(&self) -> &Self::Target {
         &self.0
     }
+}
+
+#[derive(thiserror::Error, Clone, Debug)]
+pub enum PlatformGlobError {
+    #[error("a platform glob can not be empty")]
+    Empty,
+    #[error("a platform glob must contain at least one `*` wildcard")]
+    NoWildcard,
+    #[error(
+        "a platform glob can not contain '{character}' at position {position} (`*` is the only supported wildcard)"
+    )]
+    InvalidCharacter { character: char, position: usize },
+    #[error("a platform glob can not be longer than {max} bytes (got {actual})")]
+    TooLong { max: usize, actual: usize },
+    #[error("'{glob}' is not a valid glob: {message}")]
+    InvalidPattern { glob: String, message: String },
+}
+
+/// Characters the [`glob`] crate treats as the start of a wildcard construct.
+/// `PlatformGlob` only *supports* `*`, but a target key containing any of
+/// these is routed through glob validation -- see [`PlatformGlob::looks_like_glob`].
+const GLOB_METACHARACTERS: [char; 3] = ['*', '?', '['];
+
+/// A glob pattern matched against workspace platform names in a target
+/// selector, e.g. `cuda-*`. The only metacharacter is `*`, which matches zero
+/// or more name-legal characters. Matching is anchored and case-sensitive.
+///
+/// Matching is delegated to the [`glob`] crate to stay consistent with the
+/// rest of the ecosystem. The input is validated to contain only `*` and
+/// name-legal bytes *before* it reaches the glob engine, so the crate's other
+/// metacharacters (`?`, `[...]`, `**`) can never change how a pattern matches.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PlatformGlob(glob::Pattern);
+
+impl PlatformGlob {
+    /// Returns true if `name` matches this pattern in full.
+    pub fn matches(&self, name: &str) -> bool {
+        self.0.matches(name)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns true if `input` should be parsed as a glob rather than an exact
+    /// platform name. Any of the [`glob`] crate's metacharacters counts, even
+    /// the ones `PlatformGlob` rejects, so that e.g. `cuda?` reports a
+    /// glob-specific error instead of being mistaken for a malformed platform
+    /// name.
+    pub fn looks_like_glob(input: &str) -> bool {
+        input.contains(GLOB_METACHARACTERS)
+    }
+}
+
+impl TryFrom<&str> for PlatformGlob {
+    type Error = PlatformGlobError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        let bytes = input.as_bytes();
+        if bytes.is_empty() {
+            return Err(PlatformGlobError::Empty);
+        }
+        if bytes.len() > MAX_PLATFORM_NAME_BYTES {
+            return Err(PlatformGlobError::TooLong {
+                max: MAX_PLATFORM_NAME_BYTES,
+                actual: bytes.len(),
+            });
+        }
+        // Restrict the input to `*` and name-legal bytes so the glob engine
+        // below only ever interprets `*` as a wildcard; `?`, `[`, `]` and any
+        // other metacharacter is reported as an invalid character.
+        for (position, byte) in bytes.iter().enumerate() {
+            if *byte != b'*' && !is_platform_name_byte(*byte) {
+                let character = if !byte.is_ascii_control() && *byte < 128 {
+                    *byte as char
+                } else {
+                    '\u{fffd}'
+                };
+                return Err(PlatformGlobError::InvalidCharacter {
+                    character,
+                    position,
+                });
+            }
+        }
+        if !bytes.contains(&b'*') {
+            return Err(PlatformGlobError::NoWildcard);
+        }
+        // Collapse runs of `*` into a single `*`. `*` stays the only wildcard,
+        // and the glob engine never sees its recursive `**` form, which is
+        // meaningless for separator-free platform names and would otherwise be
+        // rejected mid-pattern.
+        let collapsed = collapse_consecutive_stars(input);
+        // The validation above guarantees a valid pattern, but the glob engine
+        // is the final authority; surface any error rather than panicking.
+        let pattern =
+            glob::Pattern::new(&collapsed).map_err(|error| PlatformGlobError::InvalidPattern {
+                glob: input.to_string(),
+                message: error.to_string(),
+            })?;
+        Ok(PlatformGlob(pattern))
+    }
+}
+
+impl Display for PlatformGlob {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Collapse runs of `*` into a single `*`, leaving every other character
+/// untouched.
+fn collapse_consecutive_stars(input: &str) -> String {
+    let mut collapsed = String::with_capacity(input.len());
+    let mut previous_was_star = false;
+    for character in input.chars() {
+        let is_star = character == '*';
+        if !(is_star && previous_was_star) {
+            collapsed.push(character);
+        }
+        previous_was_star = is_star;
+    }
+    collapsed
 }
 
 #[derive(thiserror::Error, Clone, Debug)]
@@ -1293,5 +1421,120 @@ mod tests {
             .collect();
         assert!(names.iter().any(|n| n == "__musl"), "got {names:?}");
         assert!(!names.iter().any(|n| n == "__glibc"), "got {names:?}");
+    }
+
+    fn glob(pattern: &str) -> PlatformGlob {
+        PlatformGlob::try_from(pattern).expect("valid glob")
+    }
+
+    #[test]
+    fn glob_matches_prefix_suffix_and_infix() {
+        // Trailing `*` (literal prefix).
+        assert!(glob("cuda-*").matches("cuda-win-64"));
+        assert!(glob("cuda-*").matches("cuda-linux-64"));
+        assert!(!glob("cuda-*").matches("win-64"));
+        // Leading `*` (literal suffix).
+        assert!(glob("*-64").matches("linux-64"));
+        assert!(glob("*-64").matches("cuda-win-64"));
+        assert!(!glob("*-64").matches("linux-aarch64"));
+        // `*` between two literals (`foo*bar`).
+        assert!(glob("cuda-*-64").matches("cuda-win-64"));
+        // The inner `*` may match the empty span.
+        assert!(glob("cuda-*-64").matches("cuda--64"));
+        // A wrong prefix, a wrong suffix, and a name missing the trailing
+        // literal each fail the infix pattern.
+        assert!(!glob("cuda-*-64").matches("rocm-win-64"));
+        assert!(!glob("cuda-*-64").matches("cuda-win-65"));
+        assert!(!glob("cuda-*-64").matches("cuda-64"));
+        // Literal surrounded by `*` on both sides.
+        assert!(glob("*cuda*").matches("my-cuda-build"));
+        assert!(glob("*cuda*").matches("cuda"));
+        assert!(!glob("*cuda*").matches("rocm-64"));
+    }
+
+    #[test]
+    fn glob_star_matches_everything() {
+        assert!(glob("*").matches("linux-64"));
+        assert!(glob("*").matches("cuda-win-64"));
+        assert!(glob("*").matches(""));
+    }
+
+    #[test]
+    fn glob_handles_tricky_wildcard_placements() {
+        // Adjacent stars behave like a single star.
+        assert!(glob("cuda**").matches("cuda-12"));
+        // Empty span between two stars.
+        assert!(glob("a**b").matches("ab"));
+        assert!(glob("a**b").matches("axyzb"));
+        // Backtracking with repeated literals.
+        assert!(glob("*a*a").matches("xaya"));
+        assert!(!glob("*a*a").matches("xayb"));
+        assert!(glob("*a*a").matches("aa"));
+        // Leading and trailing stars around a literal.
+        assert!(glob("*mid*").matches("mid"));
+        assert!(glob("*mid*").matches("xmidy"));
+    }
+
+    #[test]
+    fn glob_matching_is_case_sensitive() {
+        assert!(!glob("CUDA-*").matches("cuda-win-64"));
+        assert!(glob("CUDA-*").matches("CUDA-win-64"));
+    }
+
+    #[test]
+    fn glob_rejects_invalid_patterns() {
+        assert!(matches!(
+            PlatformGlob::try_from(""),
+            Err(PlatformGlobError::Empty)
+        ));
+        // A pattern without a wildcard is not a glob.
+        assert!(matches!(
+            PlatformGlob::try_from("cuda-win-64"),
+            Err(PlatformGlobError::NoWildcard)
+        ));
+        assert!(matches!(
+            PlatformGlob::try_from("cuda-*!"),
+            Err(PlatformGlobError::InvalidCharacter { character: '!', .. })
+        ));
+        assert!(matches!(
+            PlatformGlob::try_from("cuda *"),
+            Err(PlatformGlobError::InvalidCharacter { character: ' ', .. })
+        ));
+    }
+
+    /// `*` is the only supported metacharacter, so the glob crate's other
+    /// wildcards are rejected as invalid characters rather than silently
+    /// interpreted.
+    #[test]
+    fn glob_rejects_other_glob_metacharacters() {
+        for (input, expected) in [("cuda-?", '?'), ("cuda-[abc]*", '[')] {
+            assert!(
+                matches!(
+                    PlatformGlob::try_from(input),
+                    Err(PlatformGlobError::InvalidCharacter { character, .. }) if character == expected
+                ),
+                "expected InvalidCharacter({expected:?}) for {input:?}",
+            );
+        }
+    }
+
+    /// Detection of glob keys must recognise every metacharacter the glob crate
+    /// treats specially, even the ones `PlatformGlob` rejects, so they are
+    /// routed to glob validation instead of exact-platform parsing.
+    #[test]
+    fn looks_like_glob_spots_every_metacharacter() {
+        assert!(PlatformGlob::looks_like_glob("cuda-*"));
+        assert!(PlatformGlob::looks_like_glob("cuda-?"));
+        assert!(PlatformGlob::looks_like_glob("cuda-[abc]"));
+        assert!(!PlatformGlob::looks_like_glob("cuda-win-64"));
+    }
+
+    /// Runs of `*` collapse to a single wildcard so the glob crate never sees
+    /// its recursive `**` form; matching still behaves like a single `*`.
+    #[test]
+    fn glob_collapses_consecutive_stars() {
+        let collapsed = glob("cuda**-*");
+        assert_eq!(collapsed.as_str(), "cuda*-*");
+        assert!(collapsed.matches("cuda-12-64"));
     }
 }

--- a/crates/pixi_manifest/src/platform.rs
+++ b/crates/pixi_manifest/src/platform.rs
@@ -36,6 +36,16 @@ fn is_platform_name_byte(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'-'
 }
 
+/// Render `byte` for an `InvalidCharacter` error, substituting U+FFFD for
+/// control or non-ASCII bytes so the message stays printable.
+fn byte_for_error_display(byte: u8) -> char {
+    if byte.is_ascii() && !byte.is_ascii_control() {
+        byte as char
+    } else {
+        char::REPLACEMENT_CHARACTER
+    }
+}
+
 // `Deserialize` is implemented by hand (below) to route through `TryFrom` so
 // the name validation can't be bypassed; the derive would accept any string.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, serde::Serialize)]
@@ -69,11 +79,7 @@ impl PixiPlatformName {
             });
         }
         for (pos, c) in bytes.iter().enumerate() {
-            let character = if !c.is_ascii_control() && *c < 128 {
-                *c as char
-            } else {
-                '�'
-            };
+            let character = byte_for_error_display(*c);
             let is_first = pos == 0;
             let is_last = pos + 1 == input_len;
 
@@ -205,13 +211,8 @@ impl TryFrom<&str> for PlatformGlob {
         // other metacharacter is reported as an invalid character.
         for (position, byte) in bytes.iter().enumerate() {
             if *byte != b'*' && !is_platform_name_byte(*byte) {
-                let character = if !byte.is_ascii_control() && *byte < 128 {
-                    *byte as char
-                } else {
-                    '\u{fffd}'
-                };
                 return Err(PlatformGlobError::InvalidCharacter {
-                    character,
+                    character: byte_for_error_display(*byte),
                     position,
                 });
             }

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -10,7 +10,7 @@ use rattler_conda_types::{PackageName, ParsePlatformError, Platform};
 use super::error::DependencyError;
 use crate::{
     CondaDependencies, DependencyOverwriteBehavior, InternalDependencyBehavior, PixiPlatform,
-    PixiPlatformName, PyPiDependencies, SpecType,
+    PixiPlatformName, PlatformGlob, PyPiDependencies, SpecType,
     activation::Activation,
     dependencies::{CondaConstraints, CondaDevDependencies},
     task::{Task, TaskName},
@@ -456,6 +456,7 @@ impl PackageTarget {
 pub enum TargetSelector {
     // Platform specific configuration
     Platform(PixiPlatformName),
+    PlatformGlob(PlatformGlob),
     Subdir(Platform),
     Unix,
     Linux,
@@ -468,6 +469,7 @@ impl TargetSelector {
     pub fn matches(&self, platform: &PixiPlatform) -> bool {
         match self {
             TargetSelector::Platform(p) => p == platform.name(),
+            TargetSelector::PlatformGlob(glob) => glob.matches(platform.name().as_str()),
             TargetSelector::Subdir(subdir) => *subdir == platform.subdir(),
             TargetSelector::Linux => platform.subdir().is_linux(),
             TargetSelector::Unix => platform.subdir().is_unix(),
@@ -476,9 +478,15 @@ impl TargetSelector {
         }
     }
 
+    /// Returns true if this selector is a wildcard platform glob.
+    pub fn is_glob(&self) -> bool {
+        matches!(self, TargetSelector::PlatformGlob(_))
+    }
+
     pub fn as_str(&self) -> &str {
         match self {
             TargetSelector::Platform(p) => p.as_str(),
+            TargetSelector::PlatformGlob(glob) => glob.as_str(),
             TargetSelector::Subdir(subdir) => subdir.as_str(),
             TargetSelector::Linux => "linux",
             TargetSelector::Unix => "unix",
@@ -540,6 +548,12 @@ impl FromStr for TargetSelector {
         }
         if let Ok(platform) = Platform::from_str(s) {
             return Ok(TargetSelector::Subdir(platform));
+        }
+        if PlatformGlob::looks_like_glob(s) {
+            let glob = PlatformGlob::try_from(s).map_err(|_| ParsePlatformError {
+                string: s.to_string(),
+            })?;
+            return Ok(TargetSelector::PlatformGlob(glob));
         }
         let Ok(platform) = PixiPlatformName::try_from(s) else {
             return Err(ParsePlatformError {
@@ -767,7 +781,8 @@ mod tests {
     use std::{path::Path, str::FromStr};
 
     use crate::{
-        DependencyOverwriteBehavior, FeatureName, PixiPlatform, SpecType, WorkspaceManifest,
+        DependencyOverwriteBehavior, FeatureName, PixiPlatform, PixiPlatformName, SpecType,
+        TargetSelector, WorkspaceManifest,
     };
 
     #[test]
@@ -1071,6 +1086,98 @@ mod tests {
             osx_specs[0].as_version_spec().unwrap().to_string(),
             "==1.0",
             "Expected foo=1.0 on osx-arm64"
+        );
+    }
+
+    #[test]
+    fn glob_selector_parses_and_round_trips() {
+        let selector = TargetSelector::from_str("cuda-*").expect("valid glob selector");
+        assert!(selector.is_glob());
+        assert_eq!(selector.as_str(), "cuda-*");
+        assert_eq!(selector.to_string(), "cuda-*");
+
+        // A name without a wildcard stays an exact platform selector.
+        assert!(matches!(
+            TargetSelector::from_str("cuda-win-64"),
+            Ok(TargetSelector::Platform(_))
+        ));
+    }
+
+    #[test]
+    fn glob_selector_matches_platform_names() {
+        let selector = TargetSelector::from_str("cuda-*").unwrap();
+        let cuda_win = PixiPlatform::new(
+            PixiPlatformName::try_from("cuda-win-64").unwrap(),
+            Platform::Win64,
+            vec![],
+        )
+        .unwrap();
+        assert!(selector.matches(&cuda_win));
+        // A bare subdir platform is not matched by `cuda-*`.
+        assert!(!selector.matches(&PixiPlatform::from_subdir(Platform::Win64)));
+    }
+
+    /// A glob target applies to every matching rich platform, and a more
+    /// specific exact selector defined *after* it wins by insertion order.
+    #[test]
+    fn glob_target_applies_with_insertion_order_precedence() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [project]
+        name = "test"
+        channels = []
+        platforms = [
+            { name = "cuda-win-64", platform = "win-64", cuda = "12" },
+            { name = "cuda-linux-64", platform = "linux-64", cuda = "12" },
+            "linux-64",
+        ]
+
+        [dependencies]
+        foo = "1.0"
+
+        [target."cuda-*".dependencies]
+        foo = "2.0"
+
+        [target.cuda-win-64.dependencies]
+        foo = "3.0"
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        let feature = manifest.default_feature();
+        let foo = PackageName::from_str("foo").unwrap();
+        let resolved = |name: &str, subdir: Platform| {
+            let platform = if name == subdir.as_str() {
+                PixiPlatform::from_subdir(subdir)
+            } else {
+                PixiPlatform::new(PixiPlatformName::try_from(name).unwrap(), subdir, vec![])
+                    .unwrap()
+            };
+            let deps = feature.run_dependencies(Some(&platform))?;
+            let spec = deps
+                .get(&foo)?
+                .iter()
+                .next()?
+                .as_version_spec()?
+                .to_string();
+            Some(spec)
+        };
+
+        // `cuda-linux-64` only matches the glob → foo=2.0.
+        assert_eq!(
+            resolved("cuda-linux-64", Platform::Linux64).as_deref(),
+            Some("==2.0")
+        );
+        // `cuda-win-64` matches both; the later exact selector wins → foo=3.0.
+        assert_eq!(
+            resolved("cuda-win-64", Platform::Win64).as_deref(),
+            Some("==3.0")
+        );
+        // The bare `linux-64` matches neither glob nor exact → default foo=1.0.
+        assert_eq!(
+            resolved("linux-64", Platform::Linux64).as_deref(),
+            Some("==1.0")
         );
     }
 }

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -15,7 +15,7 @@ use crate::{
     PackageBuild, TargetSelector, TomlError, WithWarnings,
     build_system::BuildBackend,
     error::GenericError,
-    toml::build_target::TomlPackageBuildTarget,
+    toml::{build_target::TomlPackageBuildTarget, reject_glob_in_package_target},
     utils::{PixiSpanned, package_map::UniquePackageMap},
     warning::Deprecation,
 };
@@ -118,13 +118,13 @@ impl TomlPackageBuild {
         };
 
         // Convert target-specific build config
-        let target_config = self
-            .target
-            .into_iter()
-            .flat_map(|(selector, target)| {
-                target.config.map(|config| (selector.into_inner(), config))
-            })
-            .collect::<IndexMap<_, _>>();
+        let mut target_config = IndexMap::new();
+        for (selector, target) in self.target {
+            reject_glob_in_package_target(&selector)?;
+            if let Some(config) = target.config {
+                target_config.insert(selector.into_inner(), config);
+            }
+        }
 
         Ok(WithWarnings {
             value: PackageBuild {
@@ -375,6 +375,21 @@ mod test {
             .expect_err("parsing should fail");
 
         format_parse_error(pixi_toml, parse_error)
+    }
+
+    #[test]
+    fn test_glob_target_rejected_in_build_target() {
+        let toml = r#"
+            backend = { name = "foobar", version = "*" }
+            [target."cuda-*"]
+            config = { key = "value" }
+        "#;
+        let error = expect_parse_failure(toml);
+        assert!(
+            error.contains("wildcard target selector")
+                && error.contains("not supported in package targets"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/mod.rs
+++ b/crates/pixi_manifest/src/toml/mod.rs
@@ -56,6 +56,29 @@ impl<T: for<'de> toml_span::Deserialize<'de>> FromTomlStr for T {
     }
 }
 
+/// Rejects wildcard platform globs in package target selectors. Package
+/// targets resolve by subdir through the build-types protocol, which has no
+/// wildcard concept, so globs are only allowed on workspace and feature
+/// targets.
+pub(crate) fn reject_glob_in_package_target(
+    selector: &PixiSpanned<TargetSelector>,
+) -> Result<(), TomlError> {
+    if !selector.value.is_glob() {
+        return Ok(());
+    }
+    let mut error = GenericError::new(format!(
+        "the wildcard target selector '{}' is not supported in package targets",
+        selector.value
+    ))
+    .with_help("Use a concrete platform name, such as `linux-64`, instead of a wildcard.");
+    if let Some(span) = &selector.span {
+        error = error
+            .with_opt_span(Some(span.clone()))
+            .with_span_label("wildcard target selector specified here");
+    }
+    Err(error.into())
+}
+
 /// An enum that contains a span to a `platforms =` section. Either from a
 /// feature or a workspace.
 enum PlatformSpan {
@@ -95,9 +118,31 @@ fn create_unsupported_selector_warning(
             }
         }
     }
-    if suggestions.is_empty() {
+    if suggestions.is_empty() && !selector.value.is_glob() {
         suggestions.push(selector.value.to_string());
     }
+
+    // A glob can't be passed to `platform add`, so point at declaring a
+    // platform whose name matches the pattern instead of suggesting the
+    // pattern itself as a platform name.
+    let help = if selector.value.is_glob() {
+        format!(
+            "Declare a platform whose name matches '{}', using `pixi workspace platform add <name>`",
+            selector.value
+        )
+    } else {
+        match suggestions.as_slice() {
+            [single] => format!(
+                "Add '{single}' to the supported platforms, using `pixi workspace platform add {single}`",
+            ),
+            many => format!(
+                "Add one of {0} to the supported platforms, using `pixi workspace platform add {1}`",
+                many.iter()
+                    .format_with(", ", |p, f| f(&format_args!("'{p}'"))),
+                many[0],
+            ),
+        }
+    };
 
     GenericError::new(format!(
         "The target selector '{}' does not match any of the platforms supported by the {}",
@@ -111,15 +156,5 @@ fn create_unsupported_selector_warning(
         )),
         Range::<usize>::from(span),
     ))
-    .with_help(match suggestions.as_slice() {
-        [single] => format!(
-            "Add '{single}' to the supported platforms, using `pixi workspace platform add {single}`",
-        ),
-        many => format!(
-            "Add one of {0} to the supported platforms, using `pixi workspace platform add {1}`",
-            many.iter()
-                .format_with(", ", |p, f| f(&format_args!("'{p}'"))),
-            many[0],
-        ),
-    })
+    .with_help(help)
 }

--- a/crates/pixi_manifest/src/toml/package.rs
+++ b/crates/pixi_manifest/src/toml/package.rs
@@ -17,6 +17,7 @@ use crate::{
     target::PackageTarget,
     toml::{
         TomlPackageBuild, manifest::ExternalWorkspaceProperties, package_target::TomlPackageTarget,
+        reject_glob_in_package_target,
     },
     utils::{
         PixiSpanned,
@@ -449,6 +450,7 @@ impl TomlPackage {
         // the equivalent expression. Emit a deprecation warning that spells out
         // that replacement.
         for (selector, toml_target) in self.target {
+            reject_glob_in_package_target(&selector)?;
             let expression = target_selector_expression(&selector.value);
             warnings.push(
                 Deprecation::package_target(
@@ -952,6 +954,34 @@ mod test {
         assert!(win_target.extra_dependencies.contains_key("bench"));
         // Default target should NOT have the per-target extras.
         assert!(manifest.dependencies.extra_dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_glob_target_rejected_in_package() {
+        // Wildcard target selectors are only allowed on workspace and feature
+        // targets; package targets resolve by subdir and must reject them.
+        let input = r#"
+        name = "bla"
+        version = "1.0"
+
+        [build]
+        backend = { name = "bla", version = "1.0" }
+
+        [target."cuda-*".host-dependencies]
+        cuda = "12"
+        "#;
+
+        let parse_error = TomlPackage::from_toml_str(input)
+            .and_then(|package| {
+                package.into_manifest(
+                    WorkspacePackageProperties::default(),
+                    PackageDefaults::default(),
+                    &Preview::default(),
+                    Path::new(""),
+                )
+            })
+            .expect_err("glob target selector should be rejected in a package");
+        assert_snapshot!(format_parse_error(input, parse_error));
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__package__test__glob_target_rejected_in_package.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__package__test__glob_target_rejected_in_package.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pixi_manifest/src/toml/package.rs
+expression: "format_parse_error(input, parse_error)"
+---
+  × the wildcard target selector 'cuda-*' is not supported in package targets
+   ╭─[pixi.toml:8:18]
+ 7 │
+ 8 │         [target."cuda-*".host-dependencies]
+   ·                  ───┬──
+   ·                     ╰── wildcard target selector specified here
+ 9 │         cuda = "12"
+   ╰────
+  help: Use a concrete platform name, such as `linux-64`, instead of a wildcard.

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -66,6 +66,10 @@ pub enum SpecConversionError {
     /// The `name` field is missing in the spec.
     #[error("the `package.name` must be provided in versions of pixi-build-api-version <2")]
     MissingName,
+
+    /// A wildcard platform glob was used in a package target selector.
+    #[error("wildcard target selector '{0}' is not supported in package targets")]
+    WildcardTargetSelector(String),
 }
 
 /// A package specification for pixi.

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -203,3 +203,30 @@ scripts = ["setup.sh", "local_setup.bash"]
 scripts = ["setup.bat", "local_setup.bat"]
 ```
 When this workspace is used on `win-64` it will only execute the target scripts not the scripts specified in the default `activation.scripts`
+
+### Wildcard platform selectors
+
+When several [workspace platforms](#declaring-virtual-packages-per-platform) share configuration, you can match them with a `*` wildcard in the target selector instead of repeating each block.
+The pattern is matched against the platform *name*, so it is most useful together with custom platform names:
+
+```toml title="pixi.toml"
+[workspace]
+platforms = [
+  { name = "cuda-win-64", platform = "win-64", cuda = "12" },
+  { name = "cuda-linux-64", platform = "linux-64", cuda = "12" },
+  "win-64",
+  "linux-64",
+]
+
+[target."cuda-*".tasks]
+test = "python test.py --cuda"
+train = "python train.py --cuda"
+```
+
+Here both `cuda-win-64` and `cuda-linux-64` pick up the `test` and `train` tasks, while the bare `win-64` and `linux-64` platforms do not.
+
+A few details:
+
+- `*` is the only metacharacter and matches any run of characters. Patterns are matched in full and are case-sensitive (`cuda-*`, `*-64`, `*cuda*`).
+- When more than one selector matches a platform, the one defined **later** in the manifest wins, the same way `[target.linux]` and `[target.linux-64]` already combine. Place a specific `[target.cuda-win-64]` override *after* the `[target."cuda-*"]` block.
+- Wildcards are only allowed on workspace and feature targets. They are rejected in `[package.target]` and `[package.build.target]`, which resolve by subdir.

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -91,6 +91,46 @@ def test_run_platform_not_in_environment_errors(pixi: Path, tmp_pixi_workspace: 
     )
 
 
+def test_run_wildcard_target_selector_resolves_per_platform(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """A `[target."<glob>".tasks]` block applies to every workspace platform
+    whose name matches the glob, and not to the others. Two platforms share
+    the host subdir -- one named `gpu-<host>` (matched by `gpu-*`) and the bare
+    `<host>` (not matched) -- so both are runnable on this machine and the
+    resolved task body differs by `--platform`."""
+    rich = f"gpu-{CURRENT_PLATFORM}"
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    manifest.write_text(
+        f"""
+[workspace]
+name = "glob-target-test"
+channels = []
+platforms = ["{CURRENT_PLATFORM}", {{ name = "{rich}", platform = "{CURRENT_PLATFORM}" }}]
+
+[tasks]
+hello = "echo default-task"
+
+[target."gpu-*".tasks]
+hello = "echo glob-task"
+"""
+    )
+
+    # The glob matches `gpu-<host>` -> the wildcard target's body wins.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--platform", rich, "hello"],
+        stdout_contains="glob-task",
+        stdout_excludes="default-task",
+    )
+
+    # The bare `<host>` name is not matched by `gpu-*` -> only the default body.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--platform", CURRENT_PLATFORM, "hello"],
+        stdout_contains="default-task",
+        stdout_excludes="glob-task",
+    )
+
+
 def test_run_in_shell_project(pixi: Path) -> None:
     # We don't want a `pixi.toml` in our parent directory
     # so let's use tempfile here


### PR DESCRIPTION
### Description

Allow a `*` wildcard in target table keys, matched against the workspace
platform name, e.g. `[target."cuda-*".tasks]`. This lets configuration be
shared across several named platforms (such as `cuda-win-64` and
`cuda-linux-64`) instead of duplicating a block per platform.

The glob matches the full platform name, is case-sensitive, and uses `*`
as the only metacharacter. When several selectors match a platform they
combine in manifest order, the same as the existing family/subdir
selectors. Wildcards are rejected in `[package.target]` and
`[package.build.target]`, which resolve by subdir through the build-types
protocol.

Closes #6236.

### How Has This Been Tested?

New test

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
