### PR TITLE
test: skip example satisfiability checks on unsupported platforms

### DIFF
--- a/tests/integration_python/pixi_build/test_examples_satisfiability.py
+++ b/tests/integration_python/pixi_build/test_examples_satisfiability.py
@@ -1,9 +1,32 @@
 import tomllib
 from pathlib import Path
+from typing import TypeAlias, cast
 
 import pytest
 
-from .common import repo_root, verify_cli_command
+from .common import current_platform, repo_root, verify_cli_command
+
+Workspace: TypeAlias = dict[str, object]
+
+
+def workspace_from_manifest(manifest_path: Path) -> Workspace | None:
+    manifest = cast(dict[str, object], tomllib.loads(manifest_path.read_text()))
+    if manifest_path.name == "pyproject.toml":
+        # Only consider pyproject.toml files that configure a pixi workspace
+        # to avoid testing non-pixi files.
+        tool = cast(dict[str, object], manifest.get("tool", {}))
+        pixi = cast(dict[str, object], tool.get("pixi", {}))
+        workspace = pixi.get("workspace")
+    elif manifest_path.name == "pixi.toml":
+        # Only consider pixi.toml files with a workspace section to avoid
+        # testing non-workspace member manifests.
+        workspace = manifest.get("workspace")
+    else:
+        return None
+
+    if isinstance(workspace, dict):
+        return cast(Workspace, workspace)
+    return None
 
 
 def workspace_example_manifests() -> list[Path]:
@@ -14,23 +37,30 @@ def workspace_example_manifests() -> list[Path]:
     """
     manifests: list[Path] = []
     for manifest_path in sorted(repo_root().joinpath("examples").glob("**/p*.toml")):
-        manifest = tomllib.loads(manifest_path.read_text())
-        if manifest_path.name == "pyproject.toml":
-            # Only consider pyproject.toml files that configure a pixi workspace
-            # to avoid testing non-pixi files.
-            workspace = manifest.get("tool", {}).get("pixi", {}).get("workspace")
-        elif manifest_path.name == "pixi.toml":
-            # Only consider pixi.toml files with a workspace section to avoid
-            # testing non-workspace member manifests.
-            workspace = manifest.get("workspace")
-        else:
-            continue
-        if workspace is not None:
+        if workspace_from_manifest(manifest_path) is not None:
             manifests.append(manifest_path)
     return manifests
 
 
 WORKSPACE_EXAMPLE_MANIFESTS = workspace_example_manifests()
+
+
+def supports_current_platform(workspace: Workspace) -> bool:
+    """Return whether the workspace supports the current runner platform."""
+    platforms = workspace.get("platforms")
+    if not isinstance(platforms, list):
+        return False
+
+    current = current_platform()
+    for platform in cast(list[object], platforms):
+        if platform == current:
+            return True
+        if isinstance(platform, dict):
+            rich_platform = cast(dict[str, object], platform)
+            if rich_platform.get("name") == current or rich_platform.get("platform") == current:
+                return True
+
+    return False
 
 
 @pytest.mark.slow
@@ -47,6 +77,13 @@ def test_example_lock_file_satisfiability(pixi: Path, manifest_path: Path) -> No
     `PIXI_BUILD_BACKEND_OVERRIDE` that is set by the session fixture in
     `conftest.py`.
     """
+    workspace = workspace_from_manifest(manifest_path)
+    if workspace is None:
+        pytest.fail(f"{manifest_path} does not contain a pixi workspace")
+
+    if not supports_current_platform(workspace):
+        pytest.skip(f"example does not support current platform {current_platform()}")
+
     verify_cli_command(
         [
             pixi,


### PR DESCRIPTION
### Description

Because the new pytest runs every example workspace on every CI runner, but pixi tree defaults to the current platform.

 ```sh
   pixi tree --locked --no-install --manifest-path <example>
 ```
 Some examples are intentionally platform-specific. For example:

 ```toml
   # examples/tasks/pixi.toml
   platforms = ["osx-arm64"]
 ```

 So on Linux CI, the test runs:

 ```sh
   pixi tree --locked --no-install --manifest-path examples/tasks/pixi.toml
 ```

 and pixi tree tries to use Linux by default. But the example only supports osx-arm64, so it fails with:

 ```text
   no platform supported by environment 'default' matches the current system
 ```

Hopefully fixes CI failure found in: https://github.com/prefix-dev/pixi/pull/6301 and https://github.com/prefix-dev/pixi/pull/6302 and maybe other PR's

Tool used: Codex with Pi

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
