### PR TITLE
fix(core): key locked records by declared platform for rich platforms

### DIFF
--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -22,6 +22,7 @@ pub use records_by_name::{
     HasNameVersion, PixiRecordsByName, PypiRecordsByName, UnresolvedPixiRecordsByName,
 };
 pub use resolve::pypi::resolve_pypi;
+pub(crate) use satisfiability::resolve_lock_platform;
 pub use satisfiability::{
     Dependency, EnvironmentUnsat, PlatformUnsat, resolve_dev_dependencies,
     verify_environment_satisfiability, verify_platform_satisfiability,

--- a/crates/pixi_core/src/lock_file/satisfiability/mod.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/mod.rs
@@ -24,6 +24,7 @@ pub use errors::{
     PlatformUnsat, SolveGroupUnsat, SourceExcludeNewerMismatch, SourceRunDepKind,
     SourceTreeHashMismatch,
 };
+pub(crate) use platform::resolve_lock_platform;
 #[allow(unused_imports)]
 pub use platform::{
     CondaPackageIdx, Dependency, PlatformSatisfiabilityResult, PypiPackageIdx,

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -80,7 +80,7 @@ pub type PlatformSatisfiabilityResult = Result<
 /// `requested` declares. Lets pre-shim lockfiles still satisfy newly
 /// synthesised platforms whose VPs are present under the subdir; v5 and
 /// earlier lockfiles that don't track per-platform VPs are trusted.
-fn resolve_lock_platform<'lock>(
+pub(crate) fn resolve_lock_platform<'lock>(
     lock_file: &'lock rattler_lock::LockFile,
     requested: &PixiPlatformName,
     workspace_manifest: &pixi_manifest::WorkspaceManifest,

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -61,7 +61,8 @@ use uv_normalize::ExtraName;
 
 use super::{
     CondaPrefixUpdater, InstallSubset, PixiRecordsByName, PypiRecordsByName,
-    UnresolvedPixiRecordsByName, outdated::OutdatedEnvironments, utils::IoConcurrencyLimit,
+    UnresolvedPixiRecordsByName, outdated::OutdatedEnvironments, resolve_lock_platform,
+    utils::IoConcurrencyLimit,
 };
 use crate::{
     Workspace,
@@ -1730,9 +1731,8 @@ impl<'p> UpdateContextBuilder<'p> {
         };
         let lock_file = input.lock_file;
 
-        // Extract the current conda records from the lock file.
-
-        // Collect unresolved records per environment and platform.
+        // Key locked conda records by the env's declared (possibly rich) platform
+        // names so pre-rich, base-subdir-keyed lock files still feed rich lookups.
         #[allow(clippy::type_complexity)]
         let unresolved_by_env: Vec<(
             crate::workspace::Environment<'_>,
@@ -1742,14 +1742,16 @@ impl<'p> UpdateContextBuilder<'p> {
             .into_iter()
             .filter_map(|env| {
                 let locked_env = lock_file.environment(env.name().as_str())?;
-                let platforms: Vec<_> = locked_env
-                    .packages_by_platform()
-                    .filter_map(|(lock_platform, packages)| {
-                        // A name that isn't a valid pixi platform name has no
-                        // carryable records; dropping it re-solves that platform.
-                        let platform =
-                            PixiPlatformName::try_from(lock_platform.name().as_str()).ok()?;
-                        let unresolved = packages
+                let platforms: Vec<_> = env
+                    .platforms()
+                    .into_iter()
+                    .filter_map(|platform| {
+                        let lock_platform =
+                            resolve_lock_platform(&lock_file, &platform, env.workspace_manifest())?;
+                        let unresolved = locked_env
+                            .packages(lock_platform)
+                            .into_iter()
+                            .flatten()
                             .filter_map(|pkg| resolver.get_for_package(pkg))
                             .collect::<Vec<_>>();
                         Some((platform, unresolved))
@@ -1778,34 +1780,25 @@ impl<'p> UpdateContextBuilder<'p> {
             locked_repodata_records.insert(env, env_map);
         }
 
+        // Key pypi records by the declared platform names, mirroring conda above.
         let locked_pypi_records = project
             .environments()
             .into_iter()
-            .flat_map(|env| {
-                lock_file
-                    .environment(env.name().as_str())
+            .filter_map(|env| {
+                let locked_env = lock_file.environment(env.name().as_str())?;
+                let by_platform = env
+                    .platforms()
                     .into_iter()
-                    .map(move |locked_env| {
-                        (
-                            env.clone(),
-                            locked_env
-                                .pypi_packages_by_platform()
-                                .filter_map(|(lock_platform, records)| {
-                                    // Skip names that aren't valid pixi platform
-                                    // names; the platform is re-solved instead.
-                                    let platform =
-                                        PixiPlatformName::try_from(lock_platform.name().as_str())
-                                            .ok()?;
-                                    Some((
-                                        platform,
-                                        Arc::new(PypiRecordsByName::from_iter(
-                                            records.map(|r| r.clone().into()),
-                                        )),
-                                    ))
-                                })
-                                .collect(),
-                        )
+                    .filter_map(|platform| {
+                        let lock_platform =
+                            resolve_lock_platform(&lock_file, &platform, env.workspace_manifest())?;
+                        let records = locked_env
+                            .pypi_packages(lock_platform)?
+                            .map(|r| r.clone().into());
+                        Some((platform, Arc::new(PypiRecordsByName::from_iter(records))))
                     })
+                    .collect();
+                Some((env, by_platform))
             })
             .collect::<HashMap<_, HashMap<_, _>>>();
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -938,7 +938,13 @@ impl<'p> LockFileDerivedData<'p> {
                     &filter.skip_direct,
                     &filter.target_packages,
                 );
-                let lock_platform = self.lock_file.platform(platform.name().as_str());
+                // Fall back to the base subdir so a pre-rich, base-keyed lock still
+                // resolves when the install platform is rich (e.g. `osx-arm64-macos-12-0`).
+                let lock_platform = resolve_lock_platform(
+                    &self.lock_file,
+                    platform.name(),
+                    environment.workspace_manifest(),
+                );
                 let result = subset.filter(lock_platform.and_then(|p| locked_env.packages(p)))?;
                 let packages = result.install;
                 let ignored = result.ignore;
@@ -1185,7 +1191,13 @@ impl<'p> LockFileDerivedData<'p> {
 
                 // Get the locked environment from the lock file.
                 let locked_env = self.locked_env(environment)?;
-                let lock_platform = self.lock_file.platform(pixi_platform.name().as_str());
+                // Same base-subdir fallback as the pypi prefix update above, for a
+                // rich `pixi_platform` against a pre-rich, base-keyed lock.
+                let lock_platform = resolve_lock_platform(
+                    &self.lock_file,
+                    pixi_platform.name(),
+                    environment.workspace_manifest(),
+                );
                 let packages = lock_platform.and_then(|p| locked_env.packages(p));
                 let packages = if let Some(iter) = packages {
                     iter.collect_vec()


### PR DESCRIPTION
When an environment declares a rich platform (e.g. `linux-64-glibc-2-30`) but the lock file predates rich platform names and is keyed by the base subdir (`linux-64`), `resolve_lock_platform` lets the base entry satisfy the rich platform. Conda was therefore judged up-to-date and its records stayed keyed under the base name, while the pypi solve looked them up by the rich name and failed with 'there is no compatible Python interpreter for ...'.

Load locked conda and pypi records keyed by the environment's declared platform names, resolving each to 

### How Has This Been Tested?

By running the tests locally

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
