### PR TITLE
test: skip pytorch doc examples on platforms they don't support

### DIFF
--- a/tests/integration_python/test_docs_examples.py
+++ b/tests/integration_python/test_docs_examples.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import sys
 from pathlib import Path
@@ -183,14 +184,18 @@ def test_pytorch_documentation_examples(
     manifest = tmp_pixi_workspace.joinpath(toml_name)
     manifest.write_text(toml)
 
-    # Only solve if the platform is supported
-    if (
-        current_platform()
-        in verify_cli_command(
-            [pixi, "project", "platform", "ls", "--manifest-path", manifest],
+    # These examples declare rich platforms (e.g. `linux-64-cuda-12-0`) whose
+    # subdir is the base platform. Only install when the host subdir is among
+    # the declared platforms; CUDA-only examples can't install on e.g. macOS.
+    platform_ls = json.loads(
+        verify_cli_command(
+            [pixi, "project", "platform", "ls", "--json", "--manifest-path", manifest],
         ).stdout
-    ):
-        # Run the installation
+    )
+    supported_subdirs = {
+        entry["subdir"] for entry in platform_ls["platforms"] if not entry.get("is_autodetected")
+    }
+    if current_platform() in supported_subdirs:
         verify_cli_command(
             [pixi, "install", "--manifest-path", manifest],
             env={"CONDA_OVERRIDE_CUDA": "12.0"},


### PR DESCRIPTION
The pytorch example manifests now declare rich platforms (e.g. CUDA-only `linux-64-cuda-12-0`). The guard checked whether `current_platform()` was a substring of `platform ls`'s human output, which now always begins with a 'Your current machine was detected as: platform=<current>' header -- so the check always matched and `pixi install` ran (and failed with unsupported-platform) on hosts like macOS that the example doesn't target.

Parse `platform ls --json` and install only when the host subdir is among the declared platforms' subdirs.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude


### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
