### PR TITLE
fix: Handle CONDA_OVERRIDE_* in pixi global install

### DIFF
--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -291,7 +291,7 @@ impl LockedEnvironmentHash {
 
 impl LockedEnvironmentHash {
     /// Create an invalid hash for revalidation purposes
-    pub(crate) fn invalid() -> Self {
+    pub fn invalid() -> Self {
         LockedEnvironmentHash("invalid-hash".to_string())
     }
 }
@@ -310,6 +310,17 @@ pub struct PlatformData {
 }
 
 impl PlatformData {
+    /// A platform definition from a subdir and the virtual packages that
+    /// define it. Used by callers outside this module (e.g. `pixi global`)
+    /// that compute the two fields themselves rather than from a
+    /// [`PixiPlatform`].
+    pub fn new(subdir: Platform, virtual_packages: Vec<GenericVirtualPackage>) -> Self {
+        Self {
+            subdir,
+            virtual_packages,
+        }
+    }
+
     /// The conda subdir this platform targets, e.g. `linux-64`.
     pub fn subdir(&self) -> Platform {
         self.subdir
@@ -354,25 +365,27 @@ impl Display for PlatformData {
 /// lock-free via [`pixi_utils::EnvironmentFingerprint::read`], so it
 /// isn't part of this struct.
 #[derive(Serialize, Deserialize)]
-pub(crate) struct EnvironmentFile {
+pub struct EnvironmentFile {
     /// The path to the manifest file that was used to create the environment.
-    pub(crate) manifest_path: PathBuf,
+    pub manifest_path: PathBuf,
     /// The name of the environment.
-    pub(crate) environment_name: String,
+    pub environment_name: String,
     /// The version of the pixi that was used to create the environment.
-    pub(crate) pixi_version: String,
+    pub pixi_version: String,
     /// The hash of the lock file that was used to create the environment.
-    pub(crate) environment_lock_file_hash: LockedEnvironmentHash,
+    /// `pixi global` environments aren't validated against a workspace lock
+    /// file, so they record [`LockedEnvironmentHash::invalid`] here.
+    pub environment_lock_file_hash: LockedEnvironmentHash,
     /// The platform the environment was resolved with (subdir + the virtual
     /// packages the workspace declared for it). `None` on environments written
     /// by an older pixi, or when no declared platform runs on this machine.
     #[serde(default)]
-    pub(crate) resolved_platform: Option<PlatformData>,
+    pub resolved_platform: Option<PlatformData>,
     /// The minimum platform the installed packages actually require (the subdir
     /// plus only the virtual packages some resolved dependency depends on). Can
     /// be weaker than [`Self::resolved_platform`]. `None` as above.
     #[serde(default)]
-    pub(crate) minimum_supported_platform: Option<PlatformData>,
+    pub minimum_supported_platform: Option<PlatformData>,
 }
 
 /// The path to the environment file in the `conda-meta` directory of the
@@ -386,7 +399,7 @@ fn environment_file_path(environment_dir: &Path) -> PathBuf {
 /// Write information about the environment to a file in the environment
 /// directory. Used by the prefix updating to validate if it needs to be
 /// updated.
-pub(crate) fn write_environment_file(
+pub fn write_environment_file(
     environment_dir: &Path,
     env_file: EnvironmentFile,
 ) -> miette::Result<PathBuf> {

--- a/crates/pixi_core/src/lock_file/virtual_packages.rs
+++ b/crates/pixi_core/src/lock_file/virtual_packages.rs
@@ -136,64 +136,79 @@ pub(crate) fn compute_minimal_required_platforms(
         return HashMap::new();
     };
 
-    // subdir -> (virtual-package name -> highest-version requirement seen)
-    let mut required: HashMap<Platform, HashMap<PackageName, GenericVirtualPackage>> =
-        HashMap::new();
+    // subdir -> all `depends` strings of its resolved conda packages, unioned
+    // across the declared platforms that share a subdir.
+    let mut depends_by_subdir: HashMap<Platform, Vec<String>> = HashMap::new();
 
     for platform in declared_platforms {
         let lock_platform = super::resolve_lock_platform_for(environment.lock_file(), platform);
         let Some(conda_packages) = lock_platform.and_then(|p| environment.conda_packages(p)) else {
             continue;
         };
-        let conda_packages = conda_packages.collect_vec();
-        let all_depends: Vec<&str> = conda_packages
-            .iter()
-            .flat_map(|data| data.depends())
-            .map(|s| s.as_str())
-            .collect_vec();
-        let Ok(specs) = get_required_virtual_packages_from_depends(&all_depends) else {
-            continue;
-        };
-
-        let aggregated = required.entry(platform.subdir()).or_default();
-        for spec in specs {
-            let Some(name) = spec.name.as_exact() else {
-                continue;
-            };
-            // A version-less spec (bare `__cuda`) still requires presence;
-            // version 0 loses to any versioned requirement but is never dropped.
-            let version = spec
-                .version
-                .as_ref()
-                .and_then(spec_version)
-                .cloned()
-                .unwrap_or_else(|| Version::major(0));
-            aggregated
-                .entry(name.clone())
-                .and_modify(|existing| {
-                    if version > existing.version {
-                        existing.version = version.clone();
-                    }
-                })
-                .or_insert_with(|| GenericVirtualPackage {
-                    name: name.clone(),
-                    version,
-                    build_string: String::new(),
-                });
-        }
+        let entry = depends_by_subdir.entry(platform.subdir()).or_default();
+        entry.extend(
+            conda_packages
+                .flat_map(|data| data.depends())
+                .map(ToString::to_string),
+        );
     }
 
-    required
+    depends_by_subdir
         .into_iter()
-        .map(|(subdir, vps)| {
-            let mut vps: Vec<GenericVirtualPackage> = vps.into_values().collect();
-            vps.sort_by(|a, b| a.name.as_normalized().cmp(b.name.as_normalized()));
+        .map(|(subdir, depends)| {
+            let depends: Vec<&str> = depends.iter().map(String::as_str).collect_vec();
             (
                 subdir,
-                PixiPlatform::from_required_virtual_packages(subdir, vps),
+                PixiPlatform::from_required_virtual_packages(
+                    subdir,
+                    minimal_required_virtual_packages(&depends),
+                ),
             )
         })
         .collect()
+}
+
+/// The virtual packages that some dependency in `depends` requires: each
+/// accepted virtual package at the highest version seen across all `depends`,
+/// with a version-less requirement (bare `__cuda`) pinned to version 0 so it
+/// survives but loses to any versioned one. The result is sorted by name.
+///
+/// This is the per-subdir core of `compute_minimal_required_platforms`,
+/// shared with `pixi global` which derives the same minimum from an installed
+/// environment's records rather than a lock file.
+pub fn minimal_required_virtual_packages(depends: &[&str]) -> Vec<GenericVirtualPackage> {
+    let Ok(specs) = get_required_virtual_packages_from_depends(depends) else {
+        return Vec::new();
+    };
+
+    let mut aggregated: HashMap<PackageName, GenericVirtualPackage> = HashMap::new();
+    for spec in specs {
+        let Some(name) = spec.name.as_exact() else {
+            continue;
+        };
+        let version = spec
+            .version
+            .as_ref()
+            .and_then(spec_version)
+            .cloned()
+            .unwrap_or_else(|| Version::major(0));
+        aggregated
+            .entry(name.clone())
+            .and_modify(|existing| {
+                if version > existing.version {
+                    existing.version = version.clone();
+                }
+            })
+            .or_insert_with(|| GenericVirtualPackage {
+                name: name.clone(),
+                version,
+                build_string: String::new(),
+            });
+    }
+
+    let mut vps: Vec<GenericVirtualPackage> = aggregated.into_values().collect();
+    vps.sort_by(|a, b| a.name.as_normalized().cmp(b.name.as_normalized()));
+    vps
 }
 
 /// Get the wheel filenames from the lock file pypi package data

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -28,6 +28,10 @@ use pixi_command_dispatcher::{
 };
 use pixi_config::{Config, RunPostLinkScripts, default_channel_config, pixi_home};
 use pixi_consts::consts::{self};
+use pixi_core::environment::{
+    EnvironmentFile, LockedEnvironmentHash, PlatformData, write_environment_file,
+};
+use pixi_core::lock_file::virtual_packages::minimal_required_virtual_packages;
 use pixi_core::repodata::Repodata;
 use pixi_manifest::PrioritizedChannel;
 use pixi_path::AbsPathBuf;
@@ -46,7 +50,6 @@ use rattler_conda_types::{
 };
 use rattler_networking::LazyClient;
 use rattler_repodata_gateway::Gateway;
-// Removed unused rattler_solve imports
 use rattler_virtual_packages::{
     DetectVirtualPackageError, VirtualPackage, VirtualPackageOverrides,
 };
@@ -561,10 +564,12 @@ impl Project {
         self.config.global_channel_config()
     }
 
-    /// Check if the platform matches the current platform (OS)
-    /// We only need to detect virtual packages if the platform is the current
-    /// one. Otherwise, we use an empty list
-    pub(crate) fn virtual_packages_for(
+    /// The virtual packages to solve an environment against. For the current
+    /// platform these are detected from the machine, honoring any
+    /// `CONDA_OVERRIDE_*` variables (e.g. `CONDA_OVERRIDE_CUDA=12.0`) so the
+    /// solve respects run constraints on virtual packages. For any other
+    /// platform the machine can't be inspected, so the list is empty.
+    fn virtual_packages_for(
         platform: &Platform,
     ) -> Result<Vec<GenericVirtualPackage>, DetectVirtualPackageError> {
         if platform
@@ -572,11 +577,13 @@ impl Project {
             .map(|p| p == Platform::current().only_platform().unwrap_or(""))
             .unwrap_or(false)
         {
-            Ok(VirtualPackage::detect(&VirtualPackageOverrides::default())?
-                .iter()
-                .cloned()
-                .map(GenericVirtualPackage::from)
-                .collect())
+            Ok(
+                VirtualPackage::detect(&VirtualPackageOverrides::from_env())?
+                    .iter()
+                    .cloned()
+                    .map(GenericVirtualPackage::from)
+                    .collect(),
+            )
         } else {
             Ok(vec![])
         }
@@ -609,6 +616,7 @@ impl Project {
             .into_diagnostic()?;
 
         let platform = environment.platform.unwrap_or_else(Platform::current);
+        let solve_virtual_packages = Self::virtual_packages_for(&platform).into_diagnostic()?;
 
         // Convert dependency specs to binary specs for CommandDispatcher
         let mut pixi_specs = DependencyMap::default();
@@ -626,10 +634,7 @@ impl Project {
             .map(|channel| channel.base_url.clone())
             .collect::<Vec<_>>();
 
-        let build_environment = BuildEnvironment::simple(
-            platform,
-            Self::virtual_packages_for(&platform).into_diagnostic()?,
-        );
+        let build_environment = BuildEnvironment::simple(platform, solve_virtual_packages.clone());
         // Create solve spec (compute-engine keys path).
         let solve_spec = SolvePixiEnvironmentSpec {
             dependencies: pixi_specs,
@@ -683,6 +688,14 @@ impl Project {
             }
         }
 
+        // The minimum platform the installed packages actually require: the
+        // subdir plus only the virtual packages some resolved dependency depends
+        // on. Collected before the records are consumed by the installer.
+        let resolved_depends: Vec<String> = pixi_records
+            .iter()
+            .flat_map(|record| record.package_record().depends.iter().cloned())
+            .collect();
+
         let result = command_dispatcher
             .install_pixi_environment(InstallPixiEnvironmentSpec {
                 name: env_name.to_string(),
@@ -700,8 +713,51 @@ impl Project {
             })
             .await?;
 
+        self.write_environment_file(
+            env_name,
+            &prefix,
+            platform,
+            solve_virtual_packages,
+            &resolved_depends,
+        )?;
+
         let install_changes = get_install_changes(result.transaction);
         Ok(EnvironmentUpdate::new(install_changes, dependencies_names))
+    }
+
+    /// Record the resolved and minimum-supported platforms in the environment's
+    /// `conda-meta/pixi` marker file, mirroring what non-global environments
+    /// write. The resolved platform is the subdir plus the virtual packages the
+    /// solve ran against (machine detection honoring `CONDA_OVERRIDE_*`); the
+    /// minimum-supported platform keeps only the virtual packages some installed
+    /// record actually depends on.
+    fn write_environment_file(
+        &self,
+        env_name: &EnvironmentName,
+        prefix: &Prefix,
+        platform: Platform,
+        resolved_virtual_packages: Vec<GenericVirtualPackage>,
+        resolved_depends: &[String],
+    ) -> miette::Result<()> {
+        let resolved_platform = PlatformData::new(platform, resolved_virtual_packages);
+        let depends: Vec<&str> = resolved_depends.iter().map(String::as_str).collect();
+        let minimum_supported_platform =
+            PlatformData::new(platform, minimal_required_virtual_packages(&depends));
+
+        write_environment_file(
+            prefix.root(),
+            EnvironmentFile {
+                manifest_path: self.manifest.path.clone(),
+                environment_name: env_name.to_string(),
+                pixi_version: consts::PIXI_VERSION.to_string(),
+                // Global environments aren't validated against a workspace lock
+                // file, so this hash is never read back; record a placeholder.
+                environment_lock_file_hash: LockedEnvironmentHash::invalid(),
+                resolved_platform: Some(resolved_platform),
+                minimum_supported_platform: Some(minimum_supported_platform),
+            },
+        )?;
+        Ok(())
     }
 
     /// Remove an environment from the manifest and the global installation.
@@ -1879,5 +1935,18 @@ mod tests {
                 .into()
         );
         assert_eq!(package, "python".parse().unwrap());
+    }
+
+    /// A platform on a different OS than the local machine can't be inspected
+    /// for virtual packages, so the solve gets an empty list rather than this
+    /// machine's detected packages.
+    #[test]
+    fn test_virtual_packages_for_non_current_platform_is_empty() {
+        let other = if Platform::current().only_platform() == Some("win") {
+            Platform::Linux64
+        } else {
+            Platform::Win64
+        };
+        assert!(Project::virtual_packages_for(&other).unwrap().is_empty());
     }
 }

--- a/docs/global_tools/manifest.md
+++ b/docs/global_tools/manifest.md
@@ -125,6 +125,26 @@ pixi global remove --environment my-env package-a package-b
 ```
 
 
+## Platform
+
+Each environment is solved for a single platform, defaulting to your current one.
+Set it explicitly with `--platform` or by editing the `platform` key:
+
+```toml
+[envs.vim]
+channels = ["conda-forge"]
+platform = "osx-64"
+dependencies = { vim = "*" }
+```
+
+Some packages are constrained by [virtual packages](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html) like `__cuda`.
+These are detected on your machine each time an environment is solved, so `pixi global install`, `update` and `sync` honor the run constraints those packages place on virtual packages.
+You can override what is detected with the `CONDA_OVERRIDE_*` environment variables, for example:
+
+```shell
+CONDA_OVERRIDE_CUDA=12.0 pixi global install cuda-tool
+```
+
 ## Exposed executables
 
 One can instruct `pixi global install`, under which name it will expose executables:

--- a/docs/global_tools/manifest.md
+++ b/docs/global_tools/manifest.md
@@ -142,7 +142,7 @@ These are detected on your machine each time an environment is solved, so `pixi 
 You can override what is detected with the `CONDA_OVERRIDE_*` environment variables, for example:
 
 ```shell
-CONDA_OVERRIDE_CUDA=12.0 pixi global install cuda-tool
+CONDA_OVERRIDE_CUDA=12.0 pixi global install <SomeCudaTool>
 ```
 
 ## Exposed executables

--- a/tests/integration_python/pixi_global/test_global.py
+++ b/tests/integration_python/pixi_global/test_global.py
@@ -9,7 +9,13 @@ import pytest
 import tomli_w
 from inline_snapshot import snapshot
 
-from ..common import ExitCode, bat_extension, exec_extension, verify_cli_command
+from ..common import (
+    CURRENT_PLATFORM,
+    ExitCode,
+    bat_extension,
+    exec_extension,
+    verify_cli_command,
+)
 
 MANIFEST_VERSION = 1
 
@@ -1189,6 +1195,48 @@ def test_install_platform(pixi: Path, tmp_path: Path) -> None:
         env=env,
         stderr_contains="No candidates were found",
     )
+
+
+@pytest.mark.skipif(
+    CURRENT_PLATFORM not in ("linux-64", "win-64"),
+    reason="the `cuda` test package is only built for linux-64 and win-64",
+)
+def test_install_respects_conda_override_cuda(
+    pixi: Path, tmp_path: Path, virtual_packages_channel: str
+) -> None:
+    """`cuda` declares a `__cuda >= 12` run requirement. Global install solves
+    against the host's virtual packages, so `CONDA_OVERRIDE_CUDA` decides
+    whether the solve exposes a high enough `__cuda` to satisfy it: the package
+    installs only when the override is `>= 12`."""
+
+    def cuda_meta(home: Path) -> Path:
+        return home / "envs" / "cuda" / "conda-meta"
+
+    # An override `>= 12` satisfies the requirement and installs into the
+    # enclosed PIXI_HOME; `"12"` and `"12.0"` are equivalent versions.
+    for case, override in (("bare", "12"), ("dotted", "12.0")):
+        home = tmp_path / case
+        verify_cli_command(
+            [pixi, "global", "install", "--channel", virtual_packages_channel, "cuda"],
+            env={"PIXI_HOME": str(home), "CONDA_OVERRIDE_CUDA": override},
+        )
+        assert list(cuda_meta(home).glob("cuda-*.json")), (
+            f"cuda should be installed when CONDA_OVERRIDE_CUDA={override!r}"
+        )
+
+    # A too-low version and a disabled (`""`) `__cuda` both leave the run
+    # requirement unsatisfiable, so the solve fails and nothing is installed.
+    for case, override in (("too-low", "11.0"), ("disabled", "")):
+        home = tmp_path / case
+        verify_cli_command(
+            [pixi, "global", "install", "--channel", virtual_packages_channel, "cuda"],
+            ExitCode.FAILURE,
+            env={"PIXI_HOME": str(home), "CONDA_OVERRIDE_CUDA": override},
+            stderr_contains="__cuda >=12",
+        )
+        assert not cuda_meta(home).exists(), (
+            f"cuda must not be installed when CONDA_OVERRIDE_CUDA={override!r}"
+        )
 
 
 def test_install_channels(


### PR DESCRIPTION
This is a counter proposal to PR #6325 by @baszalmstra.

The issue that go reported is basically that `pixi global install` ignores CONDA_OVERRIDE_* variables. The user was using `CONDA_OVERRIDE_CUDA=12` to limit his support to a version lower than what was available on his machine and pixi install still installing for `__cuda=13`.

So we need to take CONDA_OVERRIDE_* into account. This change uses the auto-detected rich platform as a base line (which takes CONDA_OVERRIDE_* into accound), and stores the minimum and the version an environment was resolved for in the generated environment, so that the information does not get lost between runs.

@baszalmstra PR #6325 used system requirements table to the pixi-global toml manifest for this

Fixes: #6323