### PR TITLE
fix: removing environment updates lockfile

### DIFF
--- a/crates/pixi/tests/integration_rust/update_tests.rs
+++ b/crates/pixi/tests/integration_rust/update_tests.rs
@@ -391,3 +391,88 @@ async fn test_update_git_pypi_when_requested() {
     // We expect the fragment to be the latest commit, not the first
     assert_eq!(pkg_fragment, fixture.latest_commit());
 }
+
+/// Regression test for https://github.com/prefix-dev/pixi/issues/6245
+///
+/// When an environment is removed from the manifest, the lock-file should be
+/// regenerated to drop the now non-existent environment, instead of reporting
+/// that it is already up-to-date.
+#[tokio::test]
+async fn test_removing_environment_unsatisfies_lock_file() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("foo", "1").finish());
+    package_database.add_package(Package::build("bar", "1").finish());
+
+    // Write the repodata to disk
+    let channel_dir = TempDir::new().unwrap();
+    package_database
+        .write_repodata(channel_dir.path())
+        .await
+        .unwrap();
+
+    let channel = url::Url::from_file_path(channel_dir.path()).unwrap();
+    let platform = Platform::current();
+
+    // Start with two environments, `a` and `b`, each backed by their own feature.
+    let manifest_with_both = format!(
+        r#"
+    [project]
+    name = "test-remove-environment"
+    channels = ["{channel}"]
+    platforms = ["{platform}"]
+
+    [feature.a.dependencies]
+    foo = "*"
+
+    [feature.b.dependencies]
+    bar = "*"
+
+    [environments]
+    a = {{ features = ["a"] }}
+    b = {{ features = ["b"] }}
+    "#
+    );
+
+    let pixi = PixiControl::from_manifest(&manifest_with_both).unwrap();
+
+    // Solve the initial lock-file and verify both environments are present.
+    let lock_file = pixi.update_lock_file().await.unwrap();
+    assert!(
+        lock_file.environment("a").is_some(),
+        "environment `a` should be in the lock-file"
+    );
+    assert!(
+        lock_file.environment("b").is_some(),
+        "environment `b` should be in the lock-file"
+    );
+
+    // Remove environment `b` from the manifest.
+    let manifest_without_b = format!(
+        r#"
+    [project]
+    name = "test-remove-environment"
+    channels = ["{channel}"]
+    platforms = ["{platform}"]
+
+    [feature.a.dependencies]
+    foo = "*"
+
+    [environments]
+    a = {{ features = ["a"] }}
+    "#
+    );
+    pixi.update_manifest(&manifest_without_b).unwrap();
+
+    // Re-solving should regenerate the lock-file and drop environment `b`.
+    let lock_file = pixi.update_lock_file().await.unwrap();
+    assert!(
+        lock_file.environment("a").is_some(),
+        "environment `a` should still be in the lock-file"
+    );
+    assert!(
+        lock_file.environment("b").is_none(),
+        "environment `b` should have been removed from the lock-file"
+    );
+}

--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -78,6 +78,11 @@ pub struct OutdatedEnvironments<'p> {
     /// channels changed.
     pub disregard_locked_content: DisregardLockedContent<'p>,
 
+    /// The names of environments that are present in the lock-file but no
+    /// longer exist in the workspace manifest. These environments should be
+    /// removed from the lock-file.
+    pub removed_environments: HashSet<String>,
+
     /// Lazily initialized UV context for building dynamic metadata.
     /// This is shared between satisfiability checking and pypi resolution.
     pub uv_context: OnceCell<UvResolutionContext>,
@@ -187,10 +192,24 @@ impl<'p> OutdatedEnvironments<'p> {
                 .extend(platforms.iter().cloned());
         }
 
+        // Find environments that are present in the lock-file but no longer exist in
+        // the workspace manifest. These have to be removed from the lock-file.
+        let removed_environments = lock_file
+            .environments()
+            .map(|(name, _)| name.to_string())
+            .filter(|name| workspace.environment(name.as_str()).is_none())
+            .inspect(|name| {
+                tracing::info!(
+                    "environment '{name}' is out of date because it no longer exists in the manifest but is still present in the lock-file.",
+                );
+            })
+            .collect();
+
         Self {
             conda: outdated_conda,
             pypi: outdated_pypi,
             disregard_locked_content,
+            removed_environments,
             uv_context,
             build_caches,
             static_metadata_cache,
@@ -201,7 +220,7 @@ impl<'p> OutdatedEnvironments<'p> {
     /// Returns true if the lock file is up-to-date with the project (e.g. there
     /// are no outdated targets).
     pub(crate) fn is_empty(&self) -> bool {
-        self.conda.is_empty() && self.pypi.is_empty()
+        self.conda.is_empty() && self.pypi.is_empty() && self.removed_environments.is_empty()
     }
 }
 

--- a/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@removed-environment.snap
+++ b/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@removed-environment.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/tests.rs
+expression: s
+---
+environment 'removed' is in the lock-file but no longer exists in the project
+    Diagnostic severity: error

--- a/crates/pixi_core/src/lock_file/satisfiability/tests.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/tests.rs
@@ -47,6 +47,9 @@ enum LockfileUnsat {
     #[error("environment '{0}' is missing")]
     EnvironmentMissing(String),
 
+    #[error("environment '{0}' is in the lock-file but no longer exists in the project")]
+    EnvironmentRemoved(String),
+
     #[error("environment '{0}' does not satisfy the requirements of the project")]
     Environment(String, #[source] EnvironmentUnsat),
 
@@ -118,6 +121,14 @@ async fn verify_lock_file_satisfiability(
 
     let resolver = LockFileResolver::build(lock_file, project.root())
         .map_err(|err| LockfileUnsat::ResolverBuild(err.to_string()))?;
+
+    // Verify that the lock-file does not contain environments that no longer
+    // exist in the project.
+    for (name, _) in lock_file.environments() {
+        if project.environment(name).is_none() {
+            return Err(LockfileUnsat::EnvironmentRemoved(name.to_string()));
+        }
+    }
 
     // Verify individual environment satisfiability
     for env in project.environments() {

--- a/tests/data/non-satisfiability/removed-environment/pixi.lock
+++ b/tests/data/non-satisfiability/removed-environment/pixi.lock
@@ -1,0 +1,18 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/foobar-0.1.0-h2628c8c_0.conda
+  removed:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/foobar-0.1.0-h2628c8c_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/win-64/foobar-0.1.0-h2628c8c_0.conda
+  sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
+  md5: defd5d375853a2caff36a19d2d81a28e

--- a/tests/data/non-satisfiability/removed-environment/pixi.toml
+++ b/tests/data/non-satisfiability/removed-environment/pixi.toml
@@ -1,0 +1,8 @@
+[workspace]
+channels = ["conda-forge"]
+name = "removed-environment"
+platforms = ["win-64"]
+version = "0.1.0"
+
+[dependencies]
+foobar = "0.1.0"


### PR DESCRIPTION
### Description

Removing an environment from the manifest did not unsatisfy the lock-file: the outdated-environment detection in `OutdatedEnvironments::from_workspace_and_lock_file` only iterated over **manifest** environments, so an environment that lingered in the lock-file but no longer existed in the manifest was never noticed. `pixi lock` reported `✔ Lock-file was already up-to-date` and left the orphaned environment in `pixi.lock`.

This PR detects environments that exist in the lock-file but not in the workspace manifest and treats them as outdated. That triggers a lock-file rebuild, which naturally drops the removed environment since the lock-file builder only emits manifest environments. Records of the unaffected environments are carried over, so no unnecessary re-solving happens.

#### Example

Given this manifest with two environments:

```toml
[workspace]
name = "example"
channels = ["conda-forge"]
platforms = ["osx-arm64"]

[feature.a.dependencies]
python = "*"

[feature.b.dependencies]
rust = "*"

[environments]
a = ["a"]
b = ["b"]
```

After running `pixi lock`, remove (or comment out) environment `b`:

```toml
[environments]
a = ["a"]
# b = ["b"]
```

**Before this change:**

```
$ pixi lock
✔ Lock-file was already up-to-date
```

The lock-file still contains environment `b`.

**After this change:**

```
$ pixi lock
✔ Updated lock-file
Environment: b
Platform: osx-arm64
- rust 1.87.0
...
```

Environment `b` is removed from the lock-file.

Fixes prefix-dev/pixi#6245

### How Has This Been Tested?

Added a regression test, `test_removing_environment_unsatisfies_lock_file` in `crates/pixi/tests/integration_rust/update_tests.rs`, which:

1. Creates a workspace with two environments `a` and `b`, each backed by its own feature, and solves the lock-file.
2. Asserts both environments are present in the lock-file.
3. Removes environment `b` from the manifest and re-solves.
4. Asserts that `b` is dropped from the lock-file while `a` remains.

I (Ruben) tested it manually and it works 🎉 

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
