### PR TITLE
fix: stop requiring old backend version doc example

### DIFF
--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/packages/cpp_math/pixi.toml
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/packages/cpp_math/pixi.toml
@@ -3,7 +3,7 @@ name = "cpp_math"
 version = "0.1.0"
 
 [package.build]
-backend = { name = "pixi-build-cmake", version = "0.3.9.*" }
+backend = { name = "pixi-build-cmake", version = "*" }
 
 # --8<-- [start:host-dependencies]
 [package.host-dependencies]

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.toml
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.toml
@@ -35,7 +35,7 @@ name = "python_rich"
 version = "0.1.0"
 
 [package.build]
-backend = { name = "pixi-build-python", version = "0.*" }
+backend = { name = "pixi-build-python", version = "*" }
 
 [package.build.config]
 noarch = false


### PR DESCRIPTION
It only fails on Windows, so I can't test it, so let's hope this is the reason
