### PR TITLE
fix: allow OCI channels

### DIFF
--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -215,10 +215,15 @@ pub fn build_reqwest_middleware_stack(
         default_retry_policy(),
     )));
 
+    // The mirror middleware is only needed when mirrors are configured.
     if !config.mirror_map().is_empty() {
         result.push(Arc::new(mirror_middleware(config)));
-        result.push(Arc::new(oci_middleware(client.clone())));
     }
+
+    // The OCI middleware rewrites `oci://` requests into real registry requests
+    // and is a no-op for other URL schemes. It must be installed unconditionally
+    // so that `oci://` channels work even without a mirror configured.
+    result.push(Arc::new(oci_middleware(client.clone())));
 
     result.push(Arc::new(GCSMiddleware::default()));
 
@@ -320,14 +325,17 @@ impl LazyReqwestClient {
 }
 
 pub fn uv_middlewares(config: &Config, client: LazyReqwestClient) -> Vec<Arc<dyn Middleware>> {
-    let mut middlewares: Vec<Arc<dyn Middleware>> = if config.mirror_map().is_empty() {
-        vec![]
-    } else {
-        vec![
-            Arc::new(mirror_middleware(config)),
-            Arc::new(oci_middleware(client.clone())),
-        ]
-    };
+    let mut middlewares: Vec<Arc<dyn Middleware>> = Vec::new();
+
+    // The mirror middleware is only needed when mirrors are configured.
+    if !config.mirror_map().is_empty() {
+        middlewares.push(Arc::new(mirror_middleware(config)));
+    }
+
+    // The OCI middleware rewrites `oci://` requests into real registry requests
+    // and is a no-op for other URL schemes. It must be installed unconditionally
+    // so that `oci://` channels work even without a mirror configured.
+    middlewares.push(Arc::new(oci_middleware(client.clone())));
 
     // Add authentication middleware after mirror rewriting so it can authenticate
     // against the rewritten URLs (important for mirrors that require different
@@ -374,11 +382,12 @@ mod tests {
         let client = LazyReqwestClient::new(&config).unwrap();
         let middlewares = uv_middlewares(&config, client);
 
-        // Should have: auth middleware only
+        // Should have: OCI + auth middleware. The OCI middleware is installed
+        // unconditionally so that `oci://` channels work without a mirror.
         assert_eq!(
             middlewares.len(),
-            1,
-            "Expected exactly 1 middleware (auth) when no mirrors configured, got {}",
+            2,
+            "Expected exactly 2 middlewares (OCI, auth) when no mirrors configured, got {}",
             middlewares.len()
         );
     }

--- a/crates/pixi_utils/src/reqwest.rs
+++ b/crates/pixi_utils/src/reqwest.rs
@@ -325,17 +325,14 @@ impl LazyReqwestClient {
 }
 
 pub fn uv_middlewares(config: &Config, client: LazyReqwestClient) -> Vec<Arc<dyn Middleware>> {
-    let mut middlewares: Vec<Arc<dyn Middleware>> = Vec::new();
-
-    // The mirror middleware is only needed when mirrors are configured.
-    if !config.mirror_map().is_empty() {
-        middlewares.push(Arc::new(mirror_middleware(config)));
-    }
-
-    // The OCI middleware rewrites `oci://` requests into real registry requests
-    // and is a no-op for other URL schemes. It must be installed unconditionally
-    // so that `oci://` channels work even without a mirror configured.
-    middlewares.push(Arc::new(oci_middleware(client.clone())));
+    let mut middlewares: Vec<Arc<dyn Middleware>> = if config.mirror_map().is_empty() {
+        vec![]
+    } else {
+        vec![
+            Arc::new(mirror_middleware(config)),
+            Arc::new(oci_middleware(client.clone())),
+        ]
+    };
 
     // Add authentication middleware after mirror rewriting so it can authenticate
     // against the rewritten URLs (important for mirrors that require different
@@ -382,12 +379,11 @@ mod tests {
         let client = LazyReqwestClient::new(&config).unwrap();
         let middlewares = uv_middlewares(&config, client);
 
-        // Should have: OCI + auth middleware. The OCI middleware is installed
-        // unconditionally so that `oci://` channels work without a mirror.
+        // Should have: auth middleware only
         assert_eq!(
             middlewares.len(),
-            2,
-            "Expected exactly 2 middlewares (OCI, auth) when no mirrors configured, got {}",
+            1,
+            "Expected exactly 1 middleware (auth) when no mirrors configured, got {}",
             middlewares.len()
         );
     }


### PR DESCRIPTION
### Description

Using an `oci://` channel in pixi previously failed unless a mirror was configured, surfacing as a "URL scheme is not allowed" error. This change makes `oci://` channels work out of the box, so commands like the following resolve and install without any extra mirror setup:

```
pixi global install <package> -c oci://ghcr.io/channel-mirrors/conda-forge
```

### How Has This Been Tested?
Ran an install against an OCI channel with no mirror configured and confirmed it resolves and installs without the "URL scheme is not allowed" error. Existing unit tests in `pixi_utils` continue to pass.
### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude
### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.