### PR TITLE
fix: derive used variants from conditional dependencies

### DIFF
--- a/crates/pixi_build_backend/src/traits/project.rs
+++ b/crates/pixi_build_backend/src/traits/project.rs
@@ -52,28 +52,25 @@ impl ProjectModel for pbt::ProjectModel {
     }
 
     fn used_variants(&self) -> HashSet<NormalizedKey> {
-        let build_dependencies = self
+        // Conditional dependencies are included as a may-use
+        // over-approximation: a variant key that only appears under an
+        // `if(...)` condition must still produce variant combinations.
+        // Spurious keys are harmless because the build hash only
+        // incorporates actually used variables.
+        let dependencies = self
             .targets()
             .iter()
-            .flat_map(|target| target.build_dependencies())
+            .flat_map(|targets| [targets.dependencies(), targets.conditional_dependencies()])
             .collect_vec();
 
-        let host_dependencies = self
-            .targets()
+        dependencies
             .iter()
-            .flat_map(|target| target.host_dependencies())
-            .collect_vec();
-
-        let run_dependencies = self
-            .targets()
-            .iter()
-            .flat_map(|target| target.run_dependencies())
-            .collect_vec();
-
-        build_dependencies
-            .iter()
-            .chain(host_dependencies.iter())
-            .chain(run_dependencies.iter())
+            .flat_map(|deps| {
+                deps.build
+                    .iter()
+                    .chain(deps.host.iter())
+                    .chain(deps.run.iter())
+            })
             .filter(|(_, spec)| spec.can_be_used_as_variant())
             .map(|(name, _)| name.as_str().into())
             .collect()
@@ -83,4 +80,42 @@ impl ProjectModel for pbt::ProjectModel {
 /// Return a spec of a project model that matches any version
 pub fn new_spec<P: ProjectModel>() -> <<P as ProjectModel>::Targets as Targets>::Spec {
     P::Targets::empty_spec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn used_variants_includes_conditional_dependencies() {
+        let model: pbt::ProjectModel = serde_json::from_value(serde_json::json!({
+            "name": "example",
+            "version": "0.1.0",
+            "targets": {
+                "defaultTarget": {
+                    "runDependencies": {
+                        "boltons": { "binary": { "version": "*" } }
+                    }
+                },
+                "conditional": {
+                    "unix": {
+                        "hostDependencies": {
+                            "openssl": { "binary": { "version": "*" } }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let used_variants = model.used_variants();
+        assert!(
+            used_variants.contains(&NormalizedKey::from("boltons")),
+            "default target dependency names should be reported"
+        );
+        assert!(
+            used_variants.contains(&NormalizedKey::from("openssl")),
+            "dependency names that only appear under a condition should be reported"
+        );
+    }
 }

--- a/crates/pixi_build_backend/src/traits/targets.rs
+++ b/crates/pixi_build_backend/src/traits/targets.rs
@@ -102,6 +102,12 @@ pub trait Targets {
     /// Return all dependencies of the default target
     fn dependencies(&self) -> Dependencies<'_, Self::Spec>;
 
+    /// Return all dependencies declared under conditional targets, ignoring
+    /// the conditions. This is a may-use over-approximation: an entry is
+    /// included even when its condition never evaluates to true for a
+    /// particular build.
+    fn conditional_dependencies(&self) -> Dependencies<'_, Self::Spec>;
+
     /// Return the run dependencies of the default target
     fn run_dependencies(&self) -> IndexMap<&SourcePackageName, &Self::Spec>;
 
@@ -181,5 +187,24 @@ impl Targets for pbt::Targets {
         let run_constraints = self.run_constraints();
 
         Dependencies::new(run_deps, run_constraints, host_deps, build_deps)
+    }
+
+    fn conditional_dependencies(&self) -> Dependencies<'_, Self::Spec> {
+        let conditional_targets = || self.conditional.iter().flatten().map(|(_, target)| target);
+
+        let run = conditional_targets()
+            .flat_map(|target| target.run_dependencies.iter().flatten())
+            .collect();
+        let run_constraints = conditional_targets()
+            .flat_map(|target| target.run_constraints.iter().flatten())
+            .collect();
+        let host = conditional_targets()
+            .flat_map(|target| target.host_dependencies.iter().flatten())
+            .collect();
+        let build = conditional_targets()
+            .flat_map(|target| target.build_dependencies.iter().flatten())
+            .collect();
+
+        Dependencies::new(run, run_constraints, host, build)
     }
 }


### PR DESCRIPTION
### Description

Variant keys that only appear under if(...) conditional targets did not produce variant combinations because used_variants only walks the dependencies of the default target. Include conditional dependencies as a may-use over-approximation; spurious keys are harmless because the build hash only incorporates actually used variables.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

`pixi run test`

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
