### PR TITLE
fix(manifest): recommend 'pixi workspace platform add' in target help

### DIFF
--- a/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
+++ b/crates/pixi_manifest/src/manifests/snapshots/pixi_manifest__manifests__workspace__tests__invalid_target_specific.snap
@@ -26,4 +26,4 @@ expression: "expect_parse_warnings(&format!(\"{PROJECT_BOILERPLATE}\\n{}\", exam
    ·            ╰── target selector specified here
  9 │             invalid_platform = "henk"
    ╰────
-  help: Add 'foobar' to the supported platforms, using `pixi project platform add foobar`
+  help: Add 'foobar' to the supported platforms, using `pixi workspace platform add foobar`

--- a/crates/pixi_manifest/src/toml/mod.rs
+++ b/crates/pixi_manifest/src/toml/mod.rs
@@ -113,10 +113,10 @@ fn create_unsupported_selector_warning(
     ))
     .with_help(match suggestions.as_slice() {
         [single] => format!(
-            "Add '{single}' to the supported platforms, using `pixi project platform add {single}`",
+            "Add '{single}' to the supported platforms, using `pixi workspace platform add {single}`",
         ),
         many => format!(
-            "Add one of {0} to the supported platforms, using `pixi project platform add {1}`",
+            "Add one of {0} to the supported platforms, using `pixi workspace platform add {1}`",
             many.iter()
                 .format_with(", ", |p, f| f(&format_args!("'{p}'"))),
             many[0],

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_excluded_target_selector.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_excluded_target_selector.snap
@@ -14,7 +14,7 @@ expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"t
     ·                              ╰── target selector specified here
  11 │
     ╰────
-  help: Add one of 'osx-arm64', 'osx-64' to the supported platforms, using `pixi project platform add osx-arm64`
+  help: Add one of 'osx-arm64', 'osx-64' to the supported platforms, using `pixi workspace platform add osx-arm64`
 
   ⚠ The feature 'foo' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any
   │ set `pinning-strategy`

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_target_selector.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__feature__test__mismatching_target_selector.snap
@@ -14,7 +14,7 @@ expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"t
    ·                                ╰── target selector specified here
  8 │
    ╰────
-  help: Add 'osx-64' to the supported platforms, using `pixi project platform add osx-64`
+  help: Add 'osx-64' to the supported platforms, using `pixi workspace platform add osx-64`
 
   ⚠ The feature 'foo' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any
   │ set `pinning-strategy`

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__mismatching_multi_target_selector.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__mismatching_multi_target_selector.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/pixi_manifest/src/toml/manifest.rs
 expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"test\"\n        channels = []\n        platforms = ['win-64']\n\n        [target.osx.dependencies]\n        \"#,)"
-snapshot_kind: text
 ---
   ⚠ The target selector 'osx' does not match any of the platforms supported by the workspace
    ╭─[pixi.toml:7:17]
@@ -15,4 +14,4 @@ snapshot_kind: text
    ·                  ╰── target selector specified here
  8 │
    ╰────
-  help: Add one of 'osx-64', 'osx-arm64' to the supported platforms, using `pixi project platform add osx-64`
+  help: Add one of 'osx-64', 'osx-arm64' to the supported platforms, using `pixi workspace platform add osx-64`

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__mismatching_target_selector.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__mismatching_target_selector.snap
@@ -14,4 +14,4 @@ expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"t
    ·                    ╰── target selector specified here
  8 │
    ╰────
-  help: Add 'osx-64' to the supported platforms, using `pixi project platform add osx-64`
+  help: Add 'osx-64' to the supported platforms, using `pixi workspace platform add osx-64`

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -791,7 +791,7 @@ def test_dont_error_on_missing_platform(pixi: Path, tmp_pixi_workspace: Path) ->
     # This should not error, but should spawn a warning with a helping message.
     verify_cli_command(
         [pixi, "install", "--manifest-path", manifest],
-        stderr_contains=["pixi project platform add zos-z"],
+        stderr_contains=["pixi workspace platform add zos-z"],
     )
 
 


### PR DESCRIPTION
... over `pixi project platform add` -- which does not exist anymore.

Just a small drive-by fix.

### How Has This Been Tested?

By running the existing tests.

### AI Disclosure

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
