### PR TITLE
Add per-index `exclude-newer` overrides for PyPI extra indexes

### DIFF
--- a/crates/pixi_cli/src/workspace/export/conda_environment.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_environment.rs
@@ -200,7 +200,7 @@ fn build_env_yaml(
         }
         if let Some(ref extra_index_urls) = pypi_options.extra_index_urls {
             for extra_index_url in extra_index_urls {
-                pip_dependencies.insert(0, format!("--extra-index-url {extra_index_url}"));
+                pip_dependencies.insert(0, format!("--extra-index-url {}", extra_index_url.url));
             }
         }
         if let Some(ref index_url) = pypi_options.index_url {
@@ -368,7 +368,7 @@ fn build_env_yaml_from_lock_file(
         }
         if let Some(ref extra_index_urls) = pypi_options.extra_index_urls {
             for extra_index_url in extra_index_urls {
-                pip_dependencies.insert(0, format!("--extra-index-url {extra_index_url}"));
+                pip_dependencies.insert(0, format!("--extra-index-url {}", extra_index_url.url));
             }
         }
         if let Some(ref index_url) = pypi_options.index_url {

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -1201,7 +1201,7 @@ mod tests {
                 .extra_index_urls
                 .unwrap()
                 .iter()
-                .map(|i| i.to_string())
+                .map(|i| i.url.to_string())
                 .collect_vec(),
             vec!["https://1.com/"]
         );
@@ -1212,7 +1212,7 @@ mod tests {
                 .extra_index_urls
                 .unwrap()
                 .iter()
-                .map(|i| i.to_string())
+                .map(|i| i.url.to_string())
                 .collect_vec(),
             vec!["https://2.com/"]
         );
@@ -1229,7 +1229,7 @@ mod tests {
                 .extra_index_urls
                 .unwrap()
                 .iter()
-                .map(|i| i.to_string())
+                .map(|i| i.url.to_string())
                 .collect_vec(),
             vec!["https://1.com/", "https://2.com/"]
         )

--- a/crates/pixi_manifest/src/pypi/pypi_options.rs
+++ b/crates/pixi_manifest/src/pypi/pypi_options.rs
@@ -4,6 +4,7 @@ use indexmap::IndexMap;
 use indexmap::IndexSet;
 use pep508_rs::PackageName;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
+use pixi_spec::IndexExcludeNewer;
 use serde::{Serialize, Serializer, ser::SerializeSeq};
 use thiserror::Error;
 use url::Url;
@@ -149,6 +150,50 @@ impl NoBinary {
     }
 }
 
+/// An extra PyPI index URL with an optional per-index `exclude-newer` override.
+///
+/// Serializes as a bare URL string when no override is set, or as an inline
+/// table `{ url = "...", exclude-newer = ... }` otherwise. Mirrors the conda
+/// `ChannelInlineTable` (see [`crate::PrioritizedChannel`]).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PypiExtraIndex {
+    /// The extra index URL.
+    pub url: Url,
+    /// Overrides the workspace-level `exclude-newer` cutoff for packages served
+    /// from this index only. `None` inherits the global cutoff.
+    pub exclude_newer: Option<IndexExcludeNewer>,
+}
+
+impl PypiExtraIndex {
+    /// Creates an extra index from a URL without a per-index `exclude-newer`
+    /// override (i.e. inheriting the global cutoff).
+    pub fn from_url(url: Url) -> Self {
+        Self {
+            url,
+            exclude_newer: None,
+        }
+    }
+}
+
+impl Serialize for PypiExtraIndex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match &self.exclude_newer {
+            // Serialize as a bare URL string when there is no override.
+            None => self.url.serialize(serializer),
+            Some(exclude_newer) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("url", &self.url)?;
+                map.serialize_entry("exclude-newer", exclude_newer)?;
+                map.end()
+            }
+        }
+    }
+}
+
 /// Specific options for a PyPI registries
 #[derive(Debug, Clone, PartialEq, Serialize, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -156,7 +201,7 @@ pub struct PypiOptions {
     /// The index URL to use as the primary pypi index
     pub index_url: Option<Url>,
     /// Any extra indexes to use, that will be searched after the primary index
-    pub extra_index_urls: Option<Vec<Url>>,
+    pub extra_index_urls: Option<Vec<PypiExtraIndex>>,
     /// Flat indexes also called `--find-links` in pip
     /// These are flat listings of distributions
     pub find_links: Option<Vec<FindLinksUrlOrPath>>,
@@ -185,7 +230,7 @@ impl PypiOptions {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         index: Option<Url>,
-        extra_indexes: Option<Vec<Url>>,
+        extra_indexes: Option<Vec<PypiExtraIndex>>,
         flat_indexes: Option<Vec<FindLinksUrlOrPath>>,
         no_build_isolation: NoBuildIsolation,
         index_strategy: Option<IndexStrategy>,
@@ -224,7 +269,11 @@ impl PypiOptions {
                 FindLinksUrlOrPath::Url(url) => Some(url),
             });
 
-        let extra_indexes = self.extra_index_urls.iter().flatten();
+        let extra_indexes = self
+            .extra_index_urls
+            .iter()
+            .flatten()
+            .map(|index| &index.url);
         find_links
             .chain(extra_indexes)
             .chain(std::iter::once(self.index_url.as_ref()).flatten())
@@ -360,7 +409,13 @@ impl From<PypiOptions> for rattler_lock::PypiIndexes {
             .unwrap_or(pixi_consts::consts::DEFAULT_PYPI_INDEX_URL.clone());
         Self {
             indexes: std::iter::once(primary_index)
-                .chain(value.extra_index_urls.into_iter().flatten())
+                .chain(
+                    value
+                        .extra_index_urls
+                        .into_iter()
+                        .flatten()
+                        .map(|index| index.url),
+                )
                 .collect(),
             find_links: value
                 .find_links
@@ -528,7 +583,9 @@ mod tests {
         // Create the first set of options
         let opts = PypiOptions {
             index_url: Some(Url::parse("https://example.com/pypi").unwrap()),
-            extra_index_urls: Some(vec![Url::parse("https://example.com/extra").unwrap()]),
+            extra_index_urls: Some(vec![PypiExtraIndex::from_url(
+                Url::parse("https://example.com/extra").unwrap(),
+            )]),
             find_links: Some(vec![
                 FindLinksUrlOrPath::Path("/path/to/flat/index".into()),
                 FindLinksUrlOrPath::Url(Url::parse("https://flat.index").unwrap()),
@@ -563,7 +620,9 @@ mod tests {
         // Create the second set of options
         let opts2 = PypiOptions {
             index_url: None,
-            extra_index_urls: Some(vec![Url::parse("https://example.com/extra2").unwrap()]),
+            extra_index_urls: Some(vec![PypiExtraIndex::from_url(
+                Url::parse("https://example.com/extra2").unwrap(),
+            )]),
             find_links: Some(vec![
                 FindLinksUrlOrPath::Path("/path/to/flat/index2".into()),
                 FindLinksUrlOrPath::Url(Url::parse("https://flat.index2").unwrap()),

--- a/crates/pixi_manifest/src/toml/pypi_options.rs
+++ b/crates/pixi_manifest/src/toml/pypi_options.rs
@@ -1,7 +1,8 @@
 use std::{path::PathBuf, str::FromStr};
 
 use indexmap::IndexSet;
-use pixi_toml::{TomlEnum, TomlFromStr, TomlIndexMap, TomlWith};
+use pixi_spec::{ExcludeNewer, IndexExcludeNewer};
+use pixi_toml::{TomlEnum, TomlFromStr, TomlIndexMap};
 use toml_span::{
     DeserError, ErrorKind, Value,
     de_helpers::{TableHelper, expected},
@@ -10,8 +11,81 @@ use toml_span::{
 use url::Url;
 
 use crate::pypi::pypi_options::{
-    FindLinksUrlOrPath, NoBinary, NoBuild, NoBuildIsolation, PrereleaseMode, PypiOptions,
+    FindLinksUrlOrPath, NoBinary, NoBuild, NoBuildIsolation, PrereleaseMode, PypiExtraIndex,
+    PypiOptions,
 };
+
+/// Helper for deserializing a per-index `exclude-newer` value, which can be
+/// either `false` (to disable the cutoff) or a date/duration/timestamp string.
+struct TomlIndexExcludeNewer(IndexExcludeNewer);
+
+impl<'de> toml_span::Deserialize<'de> for TomlIndexExcludeNewer {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        match value.take() {
+            ValueInner::Boolean(false) => Ok(Self(IndexExcludeNewer::Disabled)),
+            ValueInner::Boolean(true) => Err(DeserError::from(toml_span::Error {
+                kind: ErrorKind::Custom(
+                    "`exclude-newer = true` is not valid; use a date, duration, or `false`".into(),
+                ),
+                span: value.span,
+                line_info: None,
+            })),
+            ValueInner::String(str) => {
+                let exclude_newer = ExcludeNewer::from_str(&str).map_err(|e| toml_span::Error {
+                    kind: ErrorKind::Custom(e.into()),
+                    span: value.span,
+                    line_info: None,
+                })?;
+                Ok(Self(IndexExcludeNewer::ExcludeNewer(exclude_newer)))
+            }
+            other => Err(expected(
+                "a date, duration, or timestamp string, or `false`",
+                other,
+                value.span,
+            )
+            .into()),
+        }
+    }
+}
+
+/// Layout of an extra index url in a toml file.
+///
+/// Supports the following formats:
+///
+/// ```toml
+/// extra-index-urls = [
+///     "https://pypi.org/simple",
+///     { url = "https://internal/simple", exclude-newer = false },
+///     { url = "https://other/simple", exclude-newer = "2025-01-01" },
+/// ]
+/// ```
+impl<'de> toml_span::Deserialize<'de> for PypiExtraIndex {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        match value.take() {
+            ValueInner::String(str) => {
+                let url = Url::parse(&str).map_err(|e| toml_span::Error {
+                    kind: ErrorKind::Custom(e.to_string().into()),
+                    span: value.span,
+                    line_info: None,
+                })?;
+                Ok(PypiExtraIndex {
+                    url,
+                    exclude_newer: None,
+                })
+            }
+            inner @ ValueInner::Table(_) => {
+                let mut th = TableHelper::new(&mut Value::with_span(inner, value.span))?;
+                let url = th.required::<TomlFromStr<_>>("url")?.into_inner();
+                let exclude_newer = th
+                    .optional::<TomlIndexExcludeNewer>("exclude-newer")
+                    .map(|x| x.0);
+                th.finalize(None)?;
+                Ok(PypiExtraIndex { url, exclude_newer })
+            }
+            other => Err(expected("a string or table", other, value.span).into()),
+        }
+    }
+}
 
 /// A helper struct to deserialize a [`pep508_rs::PackageName`] from a TOML
 /// string.
@@ -114,9 +188,7 @@ impl<'de> toml_span::Deserialize<'de> for PypiOptions {
         let index_url = th
             .optional::<TomlFromStr<_>>("index-url")
             .map(TomlFromStr::into_inner);
-        let extra_index_urls = th
-            .optional::<TomlWith<_, Vec<TomlFromStr<_>>>>("extra-index-urls")
-            .map(|x| x.into_inner());
+        let extra_index_urls = th.optional("extra-index-urls");
         let find_links = th.optional("find-links");
         let no_build_isolation = th.optional("no-build-isolation").unwrap_or_default();
         let index_strategy = th
@@ -283,7 +355,9 @@ mod test {
             deserialized_options,
             PypiOptions {
                 index_url: Some(Url::parse("https://example.com/pypi").unwrap()),
-                extra_index_urls: Some(vec![Url::parse("https://example.com/extra").unwrap()]),
+                extra_index_urls: Some(vec![PypiExtraIndex::from_url(
+                    Url::parse("https://example.com/extra").unwrap()
+                )]),
                 find_links: Some(vec![
                     FindLinksUrlOrPath::Path("/path/to/flat/index".into()),
                     FindLinksUrlOrPath::Url(Url::parse("https://flat.index").unwrap())
@@ -306,6 +380,52 @@ mod test {
                 skip_wheel_filename_check: None,
             },
         );
+    }
+
+    #[test]
+    fn test_deserialize_extra_index_urls_with_exclude_newer() {
+        let toml_str = r#"
+            extra-index-urls = [
+                "https://pypi.org/simple",
+                { url = "https://internal/simple" },
+                { url = "https://internal/simple", exclude-newer = false },
+                { url = "https://other/simple", exclude-newer = "2025-01-01" },
+            ]
+        "#;
+        let options = PypiOptions::from_toml_str(toml_str).unwrap();
+        let extra = options.extra_index_urls.unwrap();
+        assert_eq!(extra.len(), 4);
+        assert_eq!(
+            extra[0],
+            PypiExtraIndex::from_url("https://pypi.org/simple".parse().unwrap())
+        );
+        assert_eq!(extra[1].exclude_newer, None);
+        assert_eq!(extra[2].exclude_newer, Some(IndexExcludeNewer::Disabled));
+        assert_eq!(
+            extra[3].exclude_newer,
+            Some(IndexExcludeNewer::ExcludeNewer(
+                ExcludeNewer::from_str("2025-01-01").unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_extra_index_exclude_newer_true_is_error() {
+        let input =
+            r#"extra-index-urls = [{ url = "https://internal/simple", exclude-newer = true }]"#;
+        assert_snapshot!(format_parse_error(
+            input,
+            PypiOptions::from_toml_str(input).unwrap_err()
+        ));
+    }
+
+    #[test]
+    fn test_extra_index_missing_url_is_error() {
+        let input = r#"extra-index-urls = [{ exclude-newer = false }]"#;
+        assert_snapshot!(format_parse_error(
+            input,
+            PypiOptions::from_toml_str(input).unwrap_err()
+        ));
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__pypi_options__test__extra_index_exclude_newer_true_is_error.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__pypi_options__test__extra_index_exclude_newer_true_is_error.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pixi_manifest/src/toml/pypi_options.rs
+expression: "format_parse_error(input, PypiOptions::from_toml_str(input).unwrap_err())"
+---
+  × `exclude-newer = true` is not valid; use a date, duration, or `false`
+   ╭─[pixi.toml:1:72]
+ 1 │ extra-index-urls = [{ url = "https://internal/simple", exclude-newer = true }]
+   ·                                                                        ────
+   ╰────

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__pypi_options__test__extra_index_missing_url_is_error.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__pypi_options__test__extra_index_missing_url_is_error.snap
@@ -1,0 +1,9 @@
+---
+source: crates/pixi_manifest/src/toml/pypi_options.rs
+expression: "format_parse_error(input, PypiOptions::from_toml_str(input).unwrap_err())"
+---
+  × missing field 'url' in table
+   ╭─[pixi.toml:1:21]
+ 1 │ extra-index-urls = [{ exclude-newer = false }]
+   ·                     ─────────────────────────
+   ╰────

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__pypi_options__test__full.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__pypi_options__test__full.snap
@@ -22,31 +22,37 @@ PypiOptions {
     ),
     extra_index_urls: Some(
         [
-            Url {
-                scheme: "https",
-                cannot_be_a_base: false,
-                username: "",
-                password: None,
-                host: Some(
-                    Domain(
-                        "pypi.org",
+            PypiExtraIndex {
+                url: Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "pypi.org",
+                        ),
                     ),
-                ),
-                port: None,
-                path: "/simple",
-                query: None,
-                fragment: None,
+                    port: None,
+                    path: "/simple",
+                    query: None,
+                    fragment: None,
+                },
+                exclude_newer: None,
             },
-            Url {
-                scheme: "file",
-                cannot_be_a_base: false,
-                username: "",
-                password: None,
-                host: None,
-                port: None,
-                path: "/path/to/simple",
-                query: None,
-                fragment: None,
+            PypiExtraIndex {
+                url: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "/path/to/simple",
+                    query: None,
+                    fragment: None,
+                },
+                exclude_newer: None,
             },
         ],
     ),

--- a/crates/pixi_spec/src/exclude_newer.rs
+++ b/crates/pixi_spec/src/exclude_newer.rs
@@ -146,6 +146,31 @@ impl<'de> serde::Deserialize<'de> for ExcludeNewer {
     }
 }
 
+/// A per-index (or per-channel-like) `exclude-newer` override.
+///
+/// Unlike [`ExcludeNewer`], this can also explicitly *disable* the cutoff for a
+/// single index, which is required for private mirrors that do not expose
+/// `upload-time` metadata (where any cutoff would otherwise exclude every file).
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum IndexExcludeNewer {
+    /// `exclude-newer = false`: disable the cutoff for this index entirely.
+    Disabled,
+    /// A custom cutoff (date, duration, or timestamp) for this index.
+    ExcludeNewer(ExcludeNewer),
+}
+
+impl serde::Serialize for IndexExcludeNewer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Disabled => serializer.serialize_bool(false),
+            Self::ExcludeNewer(exclude_newer) => exclude_newer.serialize(serializer),
+        }
+    }
+}
+
 fn parse_exclude_newer_str(s: &str) -> Result<ExcludeNewer, String> {
     if let Ok(duration) = s.parse::<humantime::Duration>() {
         return Ok(ExcludeNewer::Duration(duration.into()));

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -24,7 +24,7 @@ use std::{fmt::Display, path::PathBuf, str::FromStr};
 
 pub use detailed::DetailedSpec;
 pub use dev_source::DevSourceSpec;
-pub use exclude_newer::{ExcludeNewer, ResolvedExcludeNewer};
+pub use exclude_newer::{ExcludeNewer, IndexExcludeNewer, ResolvedExcludeNewer};
 pub use git::{GitLocationSpec, GitReference, GitReferenceError, GitSpec};
 use itertools::Either;
 pub use matchspec_fields::MatchspecFields;

--- a/crates/pixi_uv_context/src/lib.rs
+++ b/crates/pixi_uv_context/src/lib.rs
@@ -191,12 +191,14 @@ impl UvResolutionContext {
         let http_retries = read_http_retries_from_env();
         let concurrency = build_concurrency(config);
 
-        let preview = Preview::default();
         // uv crates read a global `PREVIEW` static (`uv_preview::get` /
         // `uv_preview::is_enabled`) from feature-flag-gated code paths, and
-        // panic if it has not been initialized. Pixi never opts in to any
-        // preview features but must still register the value so those reads
-        // don't crash while, for instance, building a local source dist.
+        // panic if it has not been initialized. We must register the value so
+        // those reads don't crash while, for instance, building a local source
+        // dist. We also opt in to `IndexExcludeNewer` so that per-index
+        // `exclude-newer` overrides (set on `extra-index-urls`) take effect
+        // without emitting uv's experimental warning.
+        let preview = Preview::new(&[uv_preview::PreviewFeature::IndexExcludeNewer]);
         let _ = uv_preview::set(preview);
 
         Ok(Self {

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -12,18 +12,19 @@ use pixi_manifest::pypi::{
     ResolvedPypiExcludeNewer,
     pypi_options::{
         FindLinksUrlOrPath, IndexStrategy, NoBinary, NoBuild, NoBuildIsolation, PrereleaseMode,
-        PypiOptions,
+        PypiExtraIndex, PypiOptions,
     },
 };
 use pixi_record::{
     CondaEnvironmentFingerprint, LockedGitUrl, PinnedGitCheckout, PinnedGitSpec, PixiRecord,
 };
-use pixi_spec::GitReference as PixiReference;
+use pixi_spec::{GitReference as PixiReference, IndexExcludeNewer};
 use std::{collections::HashSet, fmt::Write};
 use uv_configuration::BuildOptions;
 use uv_configuration::TrustedHost;
 use uv_distribution_types::{
-    ConfigSettingEntry, ConfigSettings, GitSourceDist, Index, IndexLocations, IndexUrl,
+    ConfigSettingEntry, ConfigSettings, ExcludeNewerOverride, GitSourceDist, Index, IndexLocations,
+    IndexUrl,
 };
 use uv_normalize::{InvalidNameError, PackageName};
 use uv_pep508::{VerbatimUrl, VerbatimUrlError};
@@ -118,18 +119,16 @@ pub fn pypi_options_to_index_locations(
         .map(Index::from_index_url)
         .into_iter();
 
-    // Convert to list of extra indexes
-    let extra_indexes = options
-        .extra_index_urls
-        .clone()
-        .into_iter()
-        .flat_map(|urls| {
-            urls.into_iter()
-                .map(DisplaySafeUrl::from_url)
-                .map(VerbatimUrl::from_url)
-                .map(IndexUrl::from)
-                .map(Index::from_extra_index_url)
-        });
+    // Convert to list of extra indexes, carrying any per-index `exclude-newer`
+    // override onto the uv `Index`.
+    let extra_indexes = options.extra_index_urls.clone().into_iter().flatten().map(
+        |PypiExtraIndex { url, exclude_newer }| {
+            let index_url = IndexUrl::from(VerbatimUrl::from_url(DisplaySafeUrl::from_url(url)));
+            let mut index = Index::from_extra_index_url(index_url);
+            index.exclude_newer = to_index_exclude_newer_override(exclude_newer);
+            index
+        },
+    );
 
     let flat_indexes = if let Some(flat_indexes) = options.find_links.clone() {
         // Convert to list of flat indexes
@@ -725,6 +724,25 @@ fn to_exclude_newer_timestamp(
     timestamp.into()
 }
 
+/// Converts a per-index `exclude-newer` override to uv's [`ExcludeNewerOverride`].
+///
+/// `None` means the index inherits the global cutoff; `Disabled` disables the
+/// cutoff for that index; a value resolves any relative duration to an absolute
+/// timestamp (mirroring the global/per-package path).
+fn to_index_exclude_newer_override(
+    exclude_newer: Option<IndexExcludeNewer>,
+) -> Option<ExcludeNewerOverride> {
+    match exclude_newer {
+        None => None,
+        Some(IndexExcludeNewer::Disabled) => Some(ExcludeNewerOverride::Disabled),
+        Some(IndexExcludeNewer::ExcludeNewer(exclude_newer)) => {
+            Some(ExcludeNewerOverride::Enabled(Box::new(
+                to_exclude_newer_timestamp(exclude_newer.cutoff()),
+            )))
+        }
+    }
+}
+
 /// Converts a resolved PyPI exclude-newer configuration to `uv_resolver::ExcludeNewer`.
 pub fn to_exclude_newer(exclude_newer: &ResolvedPypiExcludeNewer) -> uv_resolver::ExcludeNewer {
     let package_cutoffs = exclude_newer
@@ -958,5 +976,50 @@ mod tests {
         // ...and the base backend settings are preserved.
         assert!(rendered.contains("backend-key"));
         assert!(rendered.contains("backend-value"));
+    }
+
+    #[test]
+    fn test_per_index_exclude_newer_is_applied() {
+        use pixi_spec::ExcludeNewer;
+
+        let options = PypiOptions {
+            extra_index_urls: Some(vec![
+                PypiExtraIndex::from_url("https://inherit/simple".parse().unwrap()),
+                PypiExtraIndex {
+                    url: "https://disabled/simple".parse().unwrap(),
+                    exclude_newer: Some(IndexExcludeNewer::Disabled),
+                },
+                PypiExtraIndex {
+                    url: "https://custom/simple".parse().unwrap(),
+                    exclude_newer: Some(IndexExcludeNewer::ExcludeNewer(
+                        ExcludeNewer::from_str("2025-01-01").unwrap(),
+                    )),
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let base_path = std::path::Path::new("/abs/path");
+        let index_locations = pypi_options_to_index_locations(&options, base_path).unwrap();
+
+        let exclude_newer_for = |needle: &str| {
+            index_locations
+                .indexes()
+                .find(|index| index.url().to_string().contains(needle))
+                .and_then(|index| index.exclude_newer().cloned())
+        };
+
+        // No override -> inherits the global cutoff.
+        assert_eq!(exclude_newer_for("inherit"), None);
+        // `false` -> disabled for this index.
+        assert_eq!(
+            exclude_newer_for("disabled"),
+            Some(ExcludeNewerOverride::Disabled)
+        );
+        // A value -> enabled with the resolved cutoff for this index.
+        assert!(matches!(
+            exclude_newer_for("custom"),
+            Some(ExcludeNewerOverride::Enabled(_))
+        ));
     }
 }

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -371,6 +371,10 @@ torch = "0d"
     Note that for Pypi package indexes the package index must support the `upload-time` field as specified in [`PEP 700`](https://peps.python.org/pep-0700/).
     If the field is not present for a given distribution, the distribution will be treated as unavailable. PyPI provides `upload-time` for all packages.
 
+    If a private mirror does not expose `upload-time`, you can exempt it from the cutoff with a
+    per-index override on [`extra-index-urls`](#alternative-registries):
+    `{ url = "https://internal/simple", exclude-newer = false }`.
+
 ### `build-variants` (optional)
 
 !!! warning "Preview Feature"
@@ -554,6 +558,10 @@ Often you might want to use an alternative or extra index for your workspace. Th
    **Only one** `index-url` can be defined per environment.
 - `extra-index-urls`: adds an extra index url. The urls are used in the order they are defined. And
    are preferred over the `index-url`. These are merged across features into an environment.
+   Each entry may be a plain URL string, or an inline table `{ url = "...", exclude-newer = ... }`
+   that overrides the workspace-level [`exclude-newer`](#exclude-newer-optional) for packages served
+   from that index only. Use `exclude-newer = false` to disable the cutoff for an index — for
+   example a private mirror that does not expose `upload-time` metadata (see the note below).
 - `find-links`: which can either be a path `{path = './links'}` or a url `{url = 'https://example.com/links'}`.
    This is similar to the `--find-links` option in `pip`. These are merged across features into an
    environment.
@@ -563,9 +571,20 @@ An example:
 ```toml
 [pypi-options]
 index-url = "https://pypi.org/simple"
-extra-index-urls = ["https://example.com/simple"]
+extra-index-urls = [
+    "https://example.com/simple",
+    # No exclude-newer cutoff for this index (it does not expose `upload-time`):
+    { url = "https://internal.example.com/simple", exclude-newer = false },
+    # A custom cutoff for this index only:
+    { url = "https://other.example.com/simple", exclude-newer = "2025-01-01" },
+]
 find-links = [{path = './links'}]
 ```
+
+!!! note
+    Changing a per-index `exclude-newer` does not invalidate already locked PyPI packages (see the
+    satisfiability note under [`exclude-newer`](#exclude-newer-optional)). Run `pixi update` to
+    re-resolve PyPI packages after changing it.
 
 There are some [examples](https://github.com/prefix-dev/pixi/tree/main/examples/pypi-custom-registry) in the Pixi repository, that make use of this feature.
 

--- a/schema/model.py
+++ b/schema/model.py
@@ -906,6 +906,24 @@ class FindLinksURL(StrictBaseModel):
     )
 
 
+class ExtraIndexInlineTable(StrictBaseModel):
+    """An extra PyPI index with an optional per-index `exclude-newer` override."""
+
+    url: NonEmptyStr = Field(
+        description="The extra index URL",
+        examples=["https://pypi.org/simple"],
+    )
+    exclude_newer: ExcludeNewer | Literal[False] | None = Field(
+        None,
+        description="Override the workspace-level `exclude-newer` cutoff for this index only; "
+        "`false` disables the cutoff entirely (useful for indexes that do not expose upload times)",
+        examples=["2025-01-01", False],
+    )
+
+
+ExtraIndex = NonEmptyStr | ExtraIndexInlineTable
+
+
 class S3Options(StrictBaseModel):
     """Options related to S3 for this project"""
 
@@ -930,10 +948,14 @@ class PyPIOptions(StrictBaseModel):
         description="PyPI registry that should be used as the primary index",
         examples=["https://pypi.org/simple"],
     )
-    extra_index_urls: list[NonEmptyStr] | None = Field(
+    extra_index_urls: list[ExtraIndex] | None = Field(
         None,
-        description="Additional PyPI registries that should be used as extra indexes",
-        examples=[["https://pypi.org/simple"]],
+        description="Additional PyPI registries that should be used as extra indexes. "
+        "Each entry may be a URL string or an inline table with a per-index `exclude-newer` override.",
+        examples=[
+            ["https://pypi.org/simple"],
+            [{"url": "https://internal/simple", "exclude-newer": False}],
+        ],
     )
     find_links: list[FindLinksPath | FindLinksURL] | None = Field(
         None,

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -741,6 +741,44 @@
         }
       }
     },
+    "ExtraIndexInlineTable": {
+      "title": "ExtraIndexInlineTable",
+      "description": "An extra PyPI index with an optional per-index `exclude-newer` override.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exclude-newer": {
+          "title": "Exclude-Newer",
+          "description": "Override the workspace-level `exclude-newer` cutoff for this index only; `false` disables the cutoff entirely (useful for indexes that do not expose upload times)",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})|\\d{4}-\\d{2}-\\d{2}|(\\d+\\s*[A-Za-z]+\\s*)+)$"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ],
+          "examples": [
+            "2025-01-01",
+            false
+          ]
+        },
+        "url": {
+          "title": "Url",
+          "description": "The extra index URL",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "https://pypi.org/simple"
+          ]
+        }
+      }
+    },
     "Feature": {
       "title": "Feature",
       "description": "A composable aspect of the project which can contribute dependencies and tasks to an environment",
@@ -1921,15 +1959,28 @@
         },
         "extra-index-urls": {
           "title": "Extra-Index-Urls",
-          "description": "Additional PyPI registries that should be used as extra indexes",
+          "description": "Additional PyPI registries that should be used as extra indexes. Each entry may be a URL string or an inline table with a per-index `exclude-newer` override.",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ExtraIndexInlineTable"
+              }
+            ]
           },
           "examples": [
             [
               "https://pypi.org/simple"
+            ],
+            [
+              {
+                "exclude-newer": false,
+                "url": "https://internal/simple"
+              }
             ]
           ]
         },

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -484,6 +484,44 @@
         }
       }
     },
+    "ExtraIndexInlineTable": {
+      "title": "ExtraIndexInlineTable",
+      "description": "An extra PyPI index with an optional per-index `exclude-newer` override.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exclude-newer": {
+          "title": "Exclude-Newer",
+          "description": "Override the workspace-level `exclude-newer` cutoff for this index only; `false` disables the cutoff entirely (useful for indexes that do not expose upload times)",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})|\\d{4}-\\d{2}-\\d{2}|(\\d+\\s*[A-Za-z]+\\s*)+)$"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ],
+          "examples": [
+            "2025-01-01",
+            false
+          ]
+        },
+        "url": {
+          "title": "Url",
+          "description": "The extra index URL",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "https://pypi.org/simple"
+          ]
+        }
+      }
+    },
     "Feature": {
       "title": "Feature",
       "description": "A composable aspect of the project which can contribute dependencies and tasks to an environment",
@@ -1664,15 +1702,28 @@
         },
         "extra-index-urls": {
           "title": "Extra-Index-Urls",
-          "description": "Additional PyPI registries that should be used as extra indexes",
+          "description": "Additional PyPI registries that should be used as extra indexes. Each entry may be a URL string or an inline table with a per-index `exclude-newer` override.",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ExtraIndexInlineTable"
+              }
+            ]
           },
           "examples": [
             [
               "https://pypi.org/simple"
+            ],
+            [
+              {
+                "exclude-newer": false,
+                "url": "https://internal/simple"
+              }
             ]
           ]
         },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -765,6 +765,44 @@
         }
       }
     },
+    "ExtraIndexInlineTable": {
+      "title": "ExtraIndexInlineTable",
+      "description": "An extra PyPI index with an optional per-index `exclude-newer` override.",
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "exclude-newer": {
+          "title": "Exclude-Newer",
+          "description": "Override the workspace-level `exclude-newer` cutoff for this index only; `false` disables the cutoff entirely (useful for indexes that do not expose upload times)",
+          "anyOf": [
+            {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})|\\d{4}-\\d{2}-\\d{2}|(\\d+\\s*[A-Za-z]+\\s*)+)$"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ],
+          "examples": [
+            "2025-01-01",
+            false
+          ]
+        },
+        "url": {
+          "title": "Url",
+          "description": "The extra index URL",
+          "type": "string",
+          "minLength": 1,
+          "examples": [
+            "https://pypi.org/simple"
+          ]
+        }
+      }
+    },
     "Feature": {
       "title": "Feature",
       "description": "A composable aspect of the project which can contribute dependencies and tasks to an environment",
@@ -1945,15 +1983,28 @@
         },
         "extra-index-urls": {
           "title": "Extra-Index-Urls",
-          "description": "Additional PyPI registries that should be used as extra indexes",
+          "description": "Additional PyPI registries that should be used as extra indexes. Each entry may be a URL string or an inline table with a per-index `exclude-newer` override.",
           "type": "array",
           "items": {
-            "type": "string",
-            "minLength": 1
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ExtraIndexInlineTable"
+              }
+            ]
           },
           "examples": [
             [
               "https://pypi.org/simple"
+            ],
+            [
+              {
+                "exclude-newer": false,
+                "url": "https://internal/simple"
+              }
             ]
           ]
         },


### PR DESCRIPTION
xref #6158

### Description

This PR adds support for per-index `exclude-newer` overrides on PyPI extra indexes, allowing users to customize the package cutoff date for individual indexes. This is particularly useful for private mirrors that do not expose `upload-time` metadata.

**Key Changes:**

1. **New `PypiExtraIndex` struct** (`crates/pixi_manifest/src/pypi/pypi_options.rs`):
   - Replaces `Vec<Url>` with `Vec<PypiExtraIndex>` to carry both URL and optional per-index `exclude-newer` override
   - Implements custom serialization to maintain backward compatibility (bare URL strings when no override is set)
   - Provides `from_url()` constructor for simple cases

2. **New `IndexExcludeNewer` enum** (`crates/pixi_spec/src/exclude_newer.rs`):
   - Allows disabling the cutoff entirely (`false`) or specifying a custom cutoff for an index
   - Differs from `ExcludeNewer` by supporting explicit disabling, which is required for indexes without `upload-time` metadata

3. **TOML deserialization support** (`crates/pixi_manifest/src/toml/pypi_options.rs`):
   - Implements custom deserializers for `PypiExtraIndex` and `IndexExcludeNewer`
   - Supports both simple URL strings and inline tables: `{ url = "...", exclude-newer = ... }`
   - Validates that `exclude-newer = true` is rejected with a helpful error message

4. **uv integration** (`crates/pixi_uv_conversions/src/conversions.rs`):
   - Maps per-index overrides to uv's `ExcludeNewerOverride` on each `Index`
   - Properly handles `None` (inherit global), `Disabled`, and custom cutoff values

5. **Schema updates** (`schema/model.py` and JSON schemas):
   - Added `ExtraIndexInlineTable` definition
   - Updated `extra-index-urls` to accept both URL strings and inline tables
   - Updated documentation with examples and guidance

**Example Usage:**

```toml
[tool.pixi.pypi-options]
extra-index-urls = [
    "https://pypi.org/simple",                                    # inherits global cutoff
    { url = "https://internal/simple", exclude-newer = false },   # disables cutoff
    { url = "https://other/simple", exclude-newer = "2025-01-01" } # custom cutoff
]
```

### How Has This Been Tested?

- Added comprehensive unit tests in `crates/pixi_manifest/src/toml/pypi_options.rs`:
  - `test_deserialize_extra_index_urls_with_exclude_newer`: validates parsing of all three formats
  - `test_extra_index_exclude_newer_true_is_error`: ensures `true` is rejected with helpful error
  - `test_extra_index_missing_url_is_error`: validates required `url` field
- Added integration test in `crates/pixi_uv_conversions/src/conversions.rs`:
  - `test_per_index_exclude_newer_is_applied`: verifies per-index overrides are correctly applied to uv indexes
- Updated existing snapshot tests to reflect new `PypiExtraIndex` structure
- All schema changes validated against model definitions

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`

https://claude.ai/code/session_01DbjDfm5GLLeu9pR8XQy7hy