### PR TITLE
chore: bump backend versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-cmake"
-version = "0.3.14"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-mojo"
-version = "0.1.14"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rattler-build"
-version = "0.3.13"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-ros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "astral-reqwest-middleware",
  "async-trait",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rust"
-version = "0.4.11"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "cargo_toml",

--- a/crates/pixi_build_cmake/Cargo.toml
+++ b/crates/pixi_build_cmake/Cargo.toml
@@ -3,7 +3,7 @@ description = "CMake build backend for Pixi"
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-cmake"
-version = "0.3.14"
+version = "0.4.0"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_mojo/Cargo.toml
+++ b/crates/pixi_build_mojo/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-mojo"
-version = "0.1.14"
+version = "0.2.0"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-python"
-version = "0.5.2"
+version = "0.6.0"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rattler_build/Cargo.toml
+++ b/crates/pixi_build_rattler_build/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-rattler-build"
-version = "0.3.13"
+version = "0.4.0"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-ros"
 repository.workspace = true
-version = "0.5.0"
+version = "0.6.0"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rust/Cargo.toml
+++ b/crates/pixi_build_rust/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-rust"
 repository.workspace = true
-version = "0.4.11"
+version = "0.5.0"
 
 [package.metadata.dist]
 dist = false


### PR DESCRIPTION
Bumps backend versions in preparation for a release.

I made a minor bump, since it requires a different pixi-build-api version.