### PR TITLE
fix: refresh conda-meta/pixi marker when a platform changes

### DIFF
--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -2053,3 +2053,85 @@ async fn install_all_skips_unsupported_environments() {
             "install -e other should fail because it does not support the current platform",
         );
 }
+
+/// Editing a declared virtual package (here the `linux` system requirement)
+/// must refresh the `conda-meta/pixi` marker's resolved platform on the next
+/// quick-validating command, even though the locked package set is unchanged.
+///
+/// `pixi install` always revalidates and would mask the bug, so we drive the
+/// quick-validate path directly the way `pixi shell-hook` / `run` / `shell` do:
+/// [`LockFileDerivedData::prefix`] with [`UpdateMode::QuickValidate`]. That path
+/// short-circuits on a matching hash, so before the fix it left the recorded
+/// platform stale. Both kernel versions stay below any realistic host kernel so
+/// the install always succeeds. Linux-only: the `__linux` requirement only
+/// gates installs on linux hosts.
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn quick_validate_refreshes_resolved_platform() {
+    let channel_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/data/channels/channels/virtual_packages");
+    let channel_path = fs_err::canonicalize(channel_path).expect("canonicalize channel path");
+    let channel_url = Url::from_directory_path(&channel_path).expect("valid file url");
+
+    let manifest = |linux: &str| {
+        format!(
+            r#"
+[workspace]
+name = "marker-refresh"
+channels = ["{channel_url}"]
+platforms = ["linux-64"]
+
+[system-requirements]
+linux = "{linux}"
+
+[dependencies]
+no-deps = "*"
+"#
+        )
+    };
+
+    let pixi = PixiControl::from_manifest(&manifest("4.18")).unwrap();
+
+    // First install records the resolved platform with `__linux 4.18`.
+    pixi.install().await.unwrap();
+
+    // Tighten the requirement; the locked package set is identical, so only the
+    // marker's resolved platform should change.
+    pixi.update_manifest(&manifest("5.4")).unwrap();
+
+    // Drive the quick-validate path the way `pixi shell-hook` does.
+    let workspace = pixi.workspace().unwrap();
+    let environment = workspace.default_environment();
+    let lock_file = workspace
+        .update_lock_file(None, UpdateLockFileOptions::default())
+        .await
+        .unwrap()
+        .0;
+    lock_file
+        .prefix(
+            &environment,
+            UpdateMode::QuickValidate,
+            &ReinstallPackages::default(),
+            &InstallFilter::default(),
+        )
+        .await
+        .unwrap();
+
+    // The marker must now report `__linux 5.4` rather than the stale `4.18`.
+    let marker_path = pixi
+        .default_env_path()
+        .unwrap()
+        .join(consts::CONDA_META_DIR)
+        .join(consts::ENVIRONMENT_FILE_NAME);
+    let marker: serde_json::Value =
+        serde_json::from_str(&fs_err::read_to_string(&marker_path).unwrap()).unwrap();
+    let virtual_packages: Vec<rattler_conda_types::GenericVirtualPackage> =
+        serde_json::from_value(marker["resolved_platform"]["virtual_packages"].clone())
+            .expect("resolved_platform should record virtual packages");
+    assert!(
+        virtual_packages
+            .iter()
+            .any(|vp| vp.name.as_normalized() == "__linux" && vp.version.to_string() == "5.4"),
+        "resolved platform should declare __linux 5.4, got {virtual_packages:?}"
+    );
+}

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -215,6 +215,22 @@ impl Display for EnvironmentHash {
     }
 }
 
+/// Cache key for the **quick-validate** fast path that decides whether an
+/// installed prefix is still up-to-date.
+///
+/// The hash is stored in the prefix's `conda-meta/pixi` marker at install time.
+/// On a later quick-validating command (`pixi run` / `shell` / `shell-hook`,
+/// which pass [`UpdateMode::QuickValidate`] to [`LockFileDerivedData::prefix`])
+/// the marker's hash is compared against a freshly computed one; a match
+/// short-circuits the install entirely, so neither the packages nor the marker
+/// itself are rewritten. `pixi install` always revalidates and never consults
+/// this hash.
+///
+/// Because a match suppresses the marker rewrite, the hash must fold in every
+/// input the marker records. Hence it covers not only the locked packages but
+/// also the install platform's subdir and declared virtual packages (the
+/// marker's `resolved_platform`): omit those and editing a virtual package such
+/// as `__linux` leaves the recorded platform stale.
 #[derive(Debug, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LockedEnvironmentHash(String);
 impl LockedEnvironmentHash {
@@ -247,6 +263,22 @@ impl LockedEnvironmentHash {
                     }
                     LockedPackage::Pypi(_) => {}
                 }
+            }
+        }
+
+        // Fold in the install platform recorded by the marker (see the type's
+        // docs). Sort the virtual packages first so the hash is independent of
+        // the order they appear in the manifest.
+        if let Some(platform) = platform {
+            platform.subdir().to_string().hash(&mut hasher);
+            let mut virtual_packages: Vec<String> = platform
+                .declared_virtual_packages()
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            virtual_packages.sort_unstable();
+            for virtual_package in virtual_packages {
+                virtual_package.hash(&mut hasher);
             }
         }
 
@@ -817,6 +849,85 @@ mod tests {
         let parsed: EnvironmentFile = serde_json::from_str(json).expect("legacy file parses");
         assert!(parsed.resolved_platform.is_none());
         assert!(parsed.minimum_supported_platform.is_none());
+    }
+
+    /// A linux-64 lock environment with no packages, so the quick-validate
+    /// hash varies only with the platform passed to `from_environment`.
+    fn empty_linux_lock() -> rattler_lock::LockFile {
+        let mut builder = rattler_lock::LockFile::builder()
+            .with_platforms(vec![rattler_lock::PlatformData {
+                name: rattler_lock::PlatformName::try_from("linux-64").unwrap(),
+                subdir: Platform::Linux64,
+                virtual_packages: vec![],
+            }])
+            .unwrap();
+        builder.set_channels("default", Vec::<rattler_lock::Channel>::new());
+        builder.finish()
+    }
+
+    fn linux_platform_with_kernel(version: &str) -> PixiPlatform {
+        let linux = GenericVirtualPackage {
+            name: PackageName::from_str("__linux").unwrap(),
+            version: Version::from_str(version).unwrap(),
+            build_string: String::new(),
+        };
+        PixiPlatform::new(
+            PixiPlatformName::try_from("linux-box").unwrap(),
+            Platform::Linux64,
+            vec![linux],
+        )
+        .unwrap()
+    }
+
+    /// The quick-validate hash must change when the install platform's declared
+    /// virtual packages change, even though the locked package set is identical.
+    /// Otherwise editing `__linux` in the manifest leaves the `conda-meta/pixi`
+    /// marker's resolved platform stale (the bug this test guards).
+    #[test]
+    fn hash_changes_when_platform_virtual_packages_change() {
+        let lock_file = empty_linux_lock();
+        let environment = lock_file.environment("default").unwrap();
+
+        let old = linux_platform_with_kernel("5.9");
+        let new = linux_platform_with_kernel("7.0");
+
+        let hash_old = LockedEnvironmentHash::from_environment(environment, Some(&old));
+        let hash_new = LockedEnvironmentHash::from_environment(environment, Some(&new));
+        assert_ne!(hash_old, hash_new);
+
+        // The same platform hashes identically, so the marker is rewritten only
+        // once after a change rather than on every subsequent run.
+        let hash_old_again = LockedEnvironmentHash::from_environment(environment, Some(&old));
+        assert_eq!(hash_old, hash_old_again);
+    }
+
+    /// The hash is independent of the order virtual packages are declared in, so
+    /// reordering them in the manifest doesn't trigger a needless reinstall.
+    #[test]
+    fn hash_independent_of_virtual_package_order() {
+        let lock_file = empty_linux_lock();
+        let environment = lock_file.environment("default").unwrap();
+
+        let gvp = |name: &str, version: &str| GenericVirtualPackage {
+            name: PackageName::from_str(name).unwrap(),
+            version: Version::from_str(version).unwrap(),
+            build_string: String::new(),
+        };
+        let make = |packages: Vec<GenericVirtualPackage>| {
+            PixiPlatform::new(
+                PixiPlatformName::try_from("linux-box").unwrap(),
+                Platform::Linux64,
+                packages,
+            )
+            .unwrap()
+        };
+        let one = make(vec![gvp("__linux", "7.0"), gvp("__cuda", "12")]);
+        let other = make(vec![gvp("__cuda", "12"), gvp("__linux", "7.0")]);
+
+        assert_eq!(
+            LockedEnvironmentHash::from_environment(environment, Some(&one)),
+            LockedEnvironmentHash::from_environment(environment, Some(&other)),
+        );
     }
 
     /// `PlatformData` stores the platform's composition (subdir + declared


### PR DESCRIPTION
The quick-validate cache hash only covered the locked packages' URLs and checksums, using the install platform solely to pick which lock entry to read. Editing a declared virtual package (e.g. `__linux`) in the manifest left the locked package set unchanged, so the hash matched, the prefix was treated as up-to-date, and the conda-meta/pixi marker was never rewritten. Its recorded resolved/minimum platform then drifted from the manifest, which `pixi info` surfaced as a "Resolved platform" stale relative to "Target platforms".

Fold the install platform's subdir and declared virtual packages into the hash so such an edit invalidates the cache and refreshes the marker on the next install. The virtual packages are sorted before hashing so the result is independent of their declaration order in the manifest.

### How Has This Been Tested?

A new unit test, playing with the examples

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
