### PR TITLE
fix(task): correct `task list` runnability and show every task

### DIFF
--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -91,12 +91,10 @@ pub async fn list_tasks(
             workspace
                 .environments()
                 .iter()
-                .filter_map(
-                    |env| match classify_environment_runnability(env, lock_file.as_ref()) {
-                        EnvironmentRunnability::Unsupported => None,
-                        runnability => Some((env.clone(), (runnability, env.get_filtered_tasks()))),
-                    },
-                )
+                .map(|env| {
+                    let runnability = classify_environment_runnability(env, lock_file.as_ref());
+                    (env.clone(), (runnability, env.get_filtered_tasks()))
+                })
                 .collect()
         };
 

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -428,15 +428,19 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             continue;
         }
 
+        // Classify how this machine runs the task's environment. A `--platform`
+        // override means the user vouches for the machine, so skip the check.
+        let runnability =
+            (args.lock_and_install_config.allow_installs() && user_platform.is_none()).then(|| {
+                classify_environment_runnability(
+                    &executable_task.run_environment,
+                    Some(lock_file.as_lock_file()),
+                )
+            });
+
         // Fail before announcing a task whose environment can't run here at
         // all; by-accident environments proceed and `--platform` overrides.
-        if args.lock_and_install_config.allow_installs()
-            && user_platform.is_none()
-            && classify_environment_runnability(
-                &executable_task.run_environment,
-                Some(lock_file.as_lock_file()),
-            ) == EnvironmentRunnability::Unsupported
-        {
+        if runnability == Some(EnvironmentRunnability::Unsupported) {
             return Err(
                 match verify_current_platform_can_run_environment(
                     &executable_task.run_environment,
@@ -552,8 +556,13 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                     );
                 }
 
-                // Check if we allow installs
-                if args.lock_and_install_config.allow_installs() {
+                // A dependency-less environment installs nothing that could
+                // require a virtual package the machine lacks, so skip the
+                // prefix build and platform validation -- its tasks run
+                // anywhere, relying only on the host environment.
+                if args.lock_and_install_config.allow_installs()
+                    && runnability != Some(EnvironmentRunnability::NoDependencies)
+                {
                     // No `--platform`: pin to the platform this environment was
                     // last installed for, not a sibling's bare subdir.
                     if user_platform.is_none() {

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -678,13 +678,13 @@ fn command_not_found<'p>(workspace: &'p Workspace, explicit_environment: Option<
         );
     }
 
-    // Help user when there is no task available because the platform is not
-    // supported
-    if workspace
-        .environments()
-        .iter()
-        .all(|env| env.best_declared_platform().is_none())
-    {
+    // Point at the missing platform only when it is genuinely what blocks the
+    // run. An environment that installs nothing, or whose packages the machine
+    // already satisfies, runs here regardless of the declared platforms, so
+    // suggesting `platform add` would send the user after the wrong problem.
+    if workspace.environments().iter().all(|env| {
+        classify_environment_runnability(env, None) == EnvironmentRunnability::Unsupported
+    }) {
         pixi_progress::println!(
             "\nHelp: This platform ({}) is not supported. Please run the following command to add this platform to the workspace:\n\n\tpixi workspace platform add {}",
             Platform::current(),

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -302,6 +302,13 @@ fn runnability_rank(runnability: EnvironmentRunnability) -> u8 {
     }
 }
 
+/// Collapses whitespace so a description always occupies exactly one table
+/// row: an embedded newline would add a line the row colouring can't account
+/// for, and an embedded tab would open a spurious column.
+fn single_line(value: &str) -> String {
+    value.split_whitespace().join(" ")
+}
+
 /// Create a human-readable representation of a list of tasks.
 /// Using a tabwriter for described tasks.
 fn print_tasks(
@@ -338,7 +345,7 @@ fn print_tasks(
             if entry.1.is_none()
                 && let Some(description) = task.description()
             {
-                entry.1 = Some(description.to_string());
+                entry.1 = Some(single_line(description));
             }
         }
     }

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -278,16 +278,28 @@ fn print_heading(value: &str) {
 }
 
 /// How a task's environment runs on this machine, rendered as a dim suffix
-/// after the task name: by design (the resolved platform's requirements are
-/// met), by accident (only the resolved packages' minimum requirements are),
-/// or not at all (only reachable via an explicit `--environment`).
+/// after the task name: no dependency (nothing to constrain the platform), by
+/// design (the resolved platform's requirements are met), by accident (only
+/// the resolved packages' minimum requirements are), or not at all.
 fn runnability_suffix(runnability: EnvironmentRunnability) -> console::StyledObject<&'static str> {
     console::style(match runnability {
+        EnvironmentRunnability::NoDependencies => "(no dependency)",
         EnvironmentRunnability::ByDesign => "(by design)",
         EnvironmentRunnability::ByAccident => "(by accident)",
         EnvironmentRunnability::Unsupported => "(not runnable here)",
     })
     .dim()
+}
+
+/// Orders runnability from worst to best so a task reachable in several
+/// environments keeps the most favourable verdict.
+fn runnability_rank(runnability: EnvironmentRunnability) -> u8 {
+    match runnability {
+        EnvironmentRunnability::Unsupported => 0,
+        EnvironmentRunnability::ByAccident => 1,
+        EnvironmentRunnability::ByDesign => 2,
+        EnvironmentRunnability::NoDependencies => 3,
+    }
 }
 
 /// Create a human-readable representation of a list of tasks.
@@ -314,60 +326,64 @@ fn print_tasks(
         return Ok(());
     }
 
-    let mut all_tasks: BTreeMap<TaskName, EnvironmentRunnability> = BTreeMap::new();
-    let mut formatted_descriptions: BTreeMap<TaskName, String> = BTreeMap::new();
-
-    task_map.values().for_each(|(runnability, tasks)| {
-        tasks.iter().for_each(|(taskname, task)| {
-            // A task defined in several environments gets the best verdict:
-            // running picks a compatible environment when one exists.
-            all_tasks
-                .entry(taskname.clone())
-                .and_modify(|existing| {
-                    if *runnability == EnvironmentRunnability::ByDesign {
-                        *existing = EnvironmentRunnability::ByDesign;
-                    }
-                })
-                .or_insert(*runnability);
-            if let Some(description) = task.description() {
-                formatted_descriptions.insert(
-                    taskname.clone(),
-                    format!("{}", console::style(description).italic()),
-                );
+    // One row per task, deduplicated across environments, keeping the best
+    // verdict and the first description seen.
+    let mut rows: BTreeMap<TaskName, (EnvironmentRunnability, Option<String>)> = BTreeMap::new();
+    for (runnability, tasks) in task_map.values() {
+        for (taskname, task) in tasks {
+            let entry = rows.entry(taskname.clone()).or_insert((*runnability, None));
+            if runnability_rank(*runnability) > runnability_rank(entry.0) {
+                entry.0 = *runnability;
             }
-        });
-    });
-
-    print_heading("Tasks that can run on this machine:");
-    let formatted_tasks: String = all_tasks
-        .iter()
-        .map(|(name, runnability)| {
-            format!(
-                "{} {}",
-                name.fancy_display(),
-                runnability_suffix(*runnability)
-            )
-        })
-        .join(", ");
-    eprintln!("{formatted_tasks}");
-
-    let mut writer = tabwriter::TabWriter::new(std::io::stdout());
-    let header_style = console::Style::new().bold().cyan();
-    let header = format!(
-        "{}\t{}",
-        header_style.apply_to("Task"),
-        header_style.apply_to("Description"),
-    );
-    writeln!(writer, "{}", header)?;
-    for (taskname, row) in formatted_descriptions {
-        writeln!(writer, "{}\t{}", taskname.fancy_display(), row)?;
+            if entry.1.is_none()
+                && let Some(description) = task.description()
+            {
+                entry.1 = Some(description.to_string());
+            }
+        }
     }
 
-    writer.flush().inspect_err(|e| {
-        if e.kind() == std::io::ErrorKind::BrokenPipe {
+    // Align the columns on plain text, then colour whole lines afterwards so
+    // the ANSI styling never throws off the tab stops.
+    let mut writer = tabwriter::TabWriter::new(Vec::new());
+    writeln!(writer, "Task\tDescription")?;
+    for (taskname, (_, description)) in &rows {
+        writeln!(
+            writer,
+            "{}\t{}",
+            taskname.as_str(),
+            description.as_deref().unwrap_or(""),
+        )?;
+    }
+    writer.flush()?;
+    let table = String::from_utf8(writer.into_inner().expect("tab-aligned table is buffered"))
+        .expect("tab-aligned table is valid utf-8");
+
+    let header_style = console::Style::new().bold().cyan();
+    let mut output = String::new();
+    let mut lines = table.lines();
+    if let Some(header) = lines.next() {
+        output.push_str(&format!("{}\n", header_style.apply_to(header)));
+    }
+    for ((_, (runnability, _)), line) in rows.iter().zip(lines) {
+        match runnability {
+            EnvironmentRunnability::Unsupported => {
+                output.push_str(&format!("{}\n", console::style(line).dim()));
+            }
+            _ => output.push_str(&format!("{line}\n")),
+        }
+    }
+
+    let mut stdout = std::io::stdout();
+    if let Err(error) = stdout
+        .write_all(output.as_bytes())
+        .and_then(|()| stdout.flush())
+    {
+        if error.kind() == std::io::ErrorKind::BrokenPipe {
             std::process::exit(0);
         }
-    })?;
+        return Err(error);
+    }
 
     Ok(())
 }

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -548,10 +548,12 @@ fn environment_has_dependencies(environment: &Environment<'_>) -> bool {
 /// Classify how the current machine (including virtual-package overrides)
 /// runs `environment`:
 ///
-/// - an environment without dependencies installs nothing that could require a
-///   virtual package the machine lacks, so platform requirements don't apply;
-/// - otherwise it runs by design when the machine satisfies a declared
-///   platform's virtual packages (the platform it resolves for);
+/// - it runs by design when the machine satisfies a declared platform's virtual
+///   packages (the platform it resolves for), so its prefix builds normally even
+///   when it has no dependencies;
+/// - otherwise an environment without dependencies installs nothing that could
+///   require a virtual package the machine lacks, so platform requirements don't
+///   apply;
 /// - by accident when the machine only meets the minimum the resolved packages
 ///   require (computed from the lock file);
 /// - and is unsupported when it meets neither.
@@ -569,12 +571,15 @@ pub fn classify_environment_runnability(
         return EnvironmentRunnability::ByDesign;
     }
 
-    if !environment_has_dependencies(environment) {
-        return EnvironmentRunnability::NoDependencies;
-    }
-
+    // A machine that satisfies a declared platform runs the environment as
+    // resolved, so build its prefix normally -- even without dependencies, an
+    // empty prefix still backs activation env vars.
     if environment.best_declared_platform().is_some() {
         return EnvironmentRunnability::ByDesign;
+    }
+
+    if !environment_has_dependencies(environment) {
+        return EnvironmentRunnability::NoDependencies;
     }
 
     match lock_file.map(|lock| minimum_compatible_declared_platform(environment, lock)) {

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -512,6 +512,9 @@ pub fn verify_run_platform(
 /// (only the resolved packages' minimum requirements).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EnvironmentRunnability {
+    /// The environment has no dependencies, so it installs nothing that could
+    /// require a virtual package the machine lacks.
+    NoDependencies,
     /// The machine satisfies the platform the environment was resolved for.
     ByDesign,
     /// The machine only satisfies the resolved packages' minimum requirements.
@@ -520,10 +523,42 @@ pub enum EnvironmentRunnability {
     Unsupported,
 }
 
+/// Whether `environment` declares any conda or PyPI dependency on any of its
+/// platforms. An environment with no dependencies installs nothing, so no
+/// package can require a virtual package the machine lacks.
+fn environment_has_dependencies(environment: &Environment<'_>) -> bool {
+    if environment.has_pypi_dependencies() {
+        return true;
+    }
+    if !environment.combined_dependencies(None).is_empty() {
+        return true;
+    }
+    // `combined_dependencies(None)` skips platform-specific tables, so check
+    // each declared platform for target-specific dependencies too.
+    let manifest = environment.workspace_manifest();
+    let env_platform_names = environment.platforms();
+    manifest
+        .workspace
+        .platforms
+        .iter()
+        .filter(|platform| env_platform_names.contains(platform.name()))
+        .any(|platform| !environment.combined_dependencies(Some(platform)).is_empty())
+}
+
 /// Classify how the current machine (including virtual-package overrides)
-/// runs `environment`: from the resolved/minimum platforms recorded in
-/// `conda-meta/pixi` when installed, else from the declared platforms and
-/// the lock file's minimal requirements.
+/// runs `environment`:
+///
+/// - an environment without dependencies installs nothing that could require a
+///   virtual package the machine lacks, so platform requirements don't apply;
+/// - otherwise it runs by design when the machine satisfies a declared
+///   platform's virtual packages (the platform it resolves for);
+/// - by accident when the machine only meets the minimum the resolved packages
+///   require (computed from the lock file);
+/// - and is unsupported when it meets neither.
+///
+/// Unlike run-time validation, this never consults the `conda-meta/pixi`
+/// marker: the marker records the platform a *previous* install resolved for,
+/// which goes stale when the manifest changes.
 pub fn classify_environment_runnability(
     environment: &Environment<'_>,
     lock_file: Option<&LockFile>,
@@ -534,36 +569,14 @@ pub fn classify_environment_runnability(
         return EnvironmentRunnability::ByDesign;
     }
 
-    if let (Some(resolved), Some(minimum)) = environment.installed_platforms() {
-        let current = environment
-            .workspace()
-            .host_platform(
-                PlatformSource::Defaults,
-                PlatformOverrides::EnvironmentVariableOverrides,
-            )
-            .subdir();
-        let base_subdirs = environment
-            .workspace_manifest()
-            .workspace
-            .candidate_subdirs(current);
-        let base_capabilities = environment
-            .workspace()
-            .host_platform(
-                PlatformSource::AutoDetected,
-                PlatformOverrides::EnvironmentVariableOverrides,
-            )
-            .declared_virtual_packages()
-            .to_vec();
-        return match classify_run_platform(&base_subdirs, &base_capabilities, &resolved, &minimum) {
-            RunPlatformVerdict::Compatible => EnvironmentRunnability::ByDesign,
-            RunPlatformVerdict::OnlyMinimum(_) => EnvironmentRunnability::ByAccident,
-            RunPlatformVerdict::BelowMinimum(_) => EnvironmentRunnability::Unsupported,
-        };
+    if !environment_has_dependencies(environment) {
+        return EnvironmentRunnability::NoDependencies;
     }
 
     if environment.best_declared_platform().is_some() {
         return EnvironmentRunnability::ByDesign;
     }
+
     match lock_file.map(|lock| minimum_compatible_declared_platform(environment, lock)) {
         Some(Ok(_)) => EnvironmentRunnability::ByAccident,
         Some(Err(_)) | None => EnvironmentRunnability::Unsupported,
@@ -627,6 +640,9 @@ mod tests {
             name = "demo"
             channels = []
             platforms = [{{ name = "gpu", platform = "{current}", cuda = "99" }}]
+
+            [dependencies]
+            foo = "*"
             "#
         );
         let workspace =
@@ -780,6 +796,9 @@ packages: []
             name = "demo"
             channels = []
             platforms = ["{current}"]
+
+            [dependencies]
+            foo = "*"
             "#
         );
         let workspace =
@@ -787,6 +806,28 @@ packages: []
         assert_eq!(
             classify_environment_runnability(&workspace.default_environment(), None),
             EnvironmentRunnability::ByDesign,
+        );
+    }
+
+    /// An environment without dependencies classifies as "no dependencies"
+    /// even when its declared platform demands virtual packages this machine
+    /// lacks: nothing it installs can require them.
+    #[test]
+    fn classify_runnability_no_dependencies() {
+        let current = Platform::current();
+        let manifest = format!(
+            r#"
+            [workspace]
+            name = "demo"
+            channels = []
+            platforms = [{{ name = "gpu", platform = "{current}", cuda = "99" }}]
+            "#
+        );
+        let workspace =
+            crate::Workspace::from_str(std::path::Path::new("pixi.toml"), &manifest).unwrap();
+        assert_eq!(
+            classify_environment_runnability(&workspace.default_environment(), None),
+            EnvironmentRunnability::NoDependencies,
         );
     }
 

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -527,14 +527,19 @@ pub enum EnvironmentRunnability {
 /// platforms. An environment with no dependencies installs nothing, so no
 /// package can require a virtual package the machine lacks.
 fn environment_has_dependencies(environment: &Environment<'_>) -> bool {
+    let has_conda_dependencies = |platform: Option<&PixiPlatform>| {
+        !environment.combined_dependencies(platform).is_empty()
+            || !environment.combined_dev_dependencies(platform).is_empty()
+    };
+
     if environment.has_pypi_dependencies() {
         return true;
     }
-    if !environment.combined_dependencies(None).is_empty() {
+    if has_conda_dependencies(None) {
         return true;
     }
-    // `combined_dependencies(None)` skips platform-specific tables, so check
-    // each declared platform for target-specific dependencies too.
+    // Passing `None` skips platform-specific tables, so check each declared
+    // platform for target-specific dependencies too.
     let manifest = environment.workspace_manifest();
     let env_platform_names = environment.platforms();
     manifest
@@ -542,7 +547,7 @@ fn environment_has_dependencies(environment: &Environment<'_>) -> bool {
         .platforms
         .iter()
         .filter(|platform| env_platform_names.contains(platform.name()))
-        .any(|platform| !environment.combined_dependencies(Some(platform)).is_empty())
+        .any(|platform| has_conda_dependencies(Some(platform)))
 }
 
 /// Classify how the current machine (including virtual-package overrides)
@@ -833,6 +838,31 @@ packages: []
         assert_eq!(
             classify_environment_runnability(&workspace.default_environment(), None),
             EnvironmentRunnability::NoDependencies,
+        );
+    }
+
+    /// Develop dependencies bring their own transitive packages into the
+    /// prefix, so an environment declaring only those still has dependencies.
+    #[test]
+    fn classify_runnability_counts_dev_dependencies() {
+        let current = Platform::current();
+        let manifest = format!(
+            r#"
+            [workspace]
+            name = "demo"
+            channels = []
+            platforms = [{{ name = "gpu", platform = "{current}", cuda = "99" }}]
+            preview = ["pixi-build"]
+
+            [dev]
+            mypkg = {{ path = "mypkg" }}
+            "#
+        );
+        let workspace =
+            crate::Workspace::from_str(std::path::Path::new("pixi.toml"), &manifest).unwrap();
+        assert_eq!(
+            classify_environment_runnability(&workspace.default_environment(), None),
+            EnvironmentRunnability::Unsupported,
         );
     }
 

--- a/docs/workspace/advanced_tasks.md
+++ b/docs/workspace/advanced_tasks.md
@@ -647,24 +647,17 @@ build = { cmd = "build", description = "Build everything" }
 test = { cmd = "test", description = "Run all tests" }
 ```
 
-Now, the command `pixi task list` will not only list all task names but also
-the their descriptions.
+Now, the command `pixi task list` will not only list all task names but also their descriptions.
 
 ```shell
 pixi task list
-Tasks that can run on this machine:
------------------------------------
-build (by design), echo (by design), test (by design)
 Task   Description
 build  Build everything
 echo   Friendly greeting to a Pixi user
 test   Run all tests
 ```
 
-Each task is annotated with how the current machine runs its environment:
-*by design* when the machine satisfies the platform the environment was
-resolved for, or *by accident* when it only meets the resolved packages'
-minimum requirements.
+Tasks whose environment cannot run on the current machine are shown dimmed.
 
 This list can be very helpful to quickly find the right tasks.
 
@@ -676,8 +669,7 @@ Tasks can get quite long:
 echo-arg = { cmd = "echo {{ ARGUMENT }}", args = [{"arg" = "ARGUMENT", "default" = "hello"}], description = "Display the given argument" }
 ```
 
-While it is possible to add line breaks inside the task in your `pixi.toml` to
-make the task more readable:
+While it is possible to add line breaks inside the task in your `pixi.toml` to make the task more readable:
 
 ```toml title="pixi.toml"
 echo-arg = {
@@ -687,9 +679,7 @@ echo-arg = {
 }
 ```
 
-it will not work in `pyproject.toml` because it supports only TOML 1.0,
-that doesn't allow line breaks inside the task specification.
-Other tools can't parse the `pyproject.toml` anymore.
+it will not work in `pyproject.toml` because it supports only TOML 1.0, that doesn't allow line breaks inside the task specification. Other tools can't parse the `pyproject.toml` anymore.
 So if you use an editable dependency:
 
 ```toml title="pyproject.toml"

--- a/tests/integration_python/test_edge_cases.py
+++ b/tests/integration_python/test_edge_cases.py
@@ -341,10 +341,12 @@ def test_help_warning_when_platform_not_supported(pixi: Path, tmp_pixi_workspace
     manifest_toml["workspace"]["platforms"] = [foreign_platform]
     manifest_path.write_text(tomli_w.dumps(manifest_toml))
 
-    # Check if the command throws an error for unsupported platform
+    # The dependency-less environment runs anywhere, so `bla` is treated as a
+    # free-form command and reported as not found. When no environment supports
+    # the current platform, the not-found message points at adding it.
     verify_cli_command(
         [pixi, "run", "--manifest-path", tmp_pixi_workspace, "bla"],
-        ExitCode.FAILURE,
+        ExitCode.COMMAND_NOT_FOUND,
         stderr_contains=["pixi workspace platform add"],
     )
 
@@ -448,8 +450,42 @@ platforms = ["{other_platform}"]
     )
 
 
-def test_run_fails_on_unsupported_platform(pixi: Path, tmp_pixi_workspace: Path) -> None:
-    """Test that pixi run fails when run on an unsupported platform (issue #5071)"""
+def test_run_fails_on_unsupported_platform_with_dependency(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    """An environment with a dependency resolves for its declared platform; on a
+    machine that platform can't run, `pixi run` fails instead of executing the
+    task (issue #5071)."""
+    other_platform = get_other_platform()
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+[workspace]
+name = "test"
+channels = ["{dummy_channel_1}"]
+platforms = ["{other_platform}"]
+
+[dependencies]
+dummy-a = "*"
+
+[tasks]
+hello = "echo hello from unsupported platform test"
+"""
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "hello"],
+        ExitCode.FAILURE,
+        stderr_contains=[other_platform, CURRENT_PLATFORM],
+        stderr_excludes="hello from unsupported platform test",
+    )
+
+
+def test_run_succeeds_on_unsupported_platform_without_dependency(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """An environment without dependencies installs nothing that could require a
+    virtual package the machine lacks, so its tasks run on any platform even when
+    the workspace only declares another platform."""
     other_platform = get_other_platform()
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     toml = f"""
@@ -465,9 +501,8 @@ hello = "echo hello from unsupported platform test"
 
     verify_cli_command(
         [pixi, "run", "--manifest-path", manifest, "hello"],
-        ExitCode.FAILURE,
-        stderr_contains=[other_platform, CURRENT_PLATFORM],
-        stderr_excludes="hello from unsupported platform test",
+        ExitCode.SUCCESS,
+        stdout_contains="hello from unsupported platform test",
     )
 
 

--- a/tests/integration_python/test_edge_cases.py
+++ b/tests/integration_python/test_edge_cases.py
@@ -339,15 +339,35 @@ def test_help_warning_when_platform_not_supported(pixi: Path, tmp_pixi_workspace
     manifest_path = tmp_pixi_workspace / "pixi.toml"
     manifest_toml = tomli.loads(manifest_path.read_text())
     manifest_toml["workspace"]["platforms"] = [foreign_platform]
+    # A dependency is what ties the environment to that platform; without one
+    # the environment installs nothing and runs anywhere.
+    manifest_toml["dependencies"] = {"dummy-a": "*"}
     manifest_path.write_text(tomli_w.dumps(manifest_toml))
 
-    # The dependency-less environment runs anywhere, so `bla` is treated as a
-    # free-form command and reported as not found. When no environment supports
-    # the current platform, the not-found message points at adding it.
+    # Listing the tasks doesn't touch the lock file, so this reaches the hint
+    # without solving for the foreign platform.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", tmp_pixi_workspace],
+        stderr_contains=["pixi workspace platform add"],
+    )
+
+
+def test_no_platform_help_without_dependencies(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """A dependency-less environment installs nothing and runs anywhere, so an
+    unknown command is just that: pointing at the missing platform would send
+    the user after the wrong problem."""
+    verify_cli_command([pixi, "init", tmp_pixi_workspace])
+
+    foreign_platform = "linux-64" if CURRENT_PLATFORM.startswith("win") else "win-64"
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_toml = tomli.loads(manifest_path.read_text())
+    manifest_toml["workspace"]["platforms"] = [foreign_platform]
+    manifest_path.write_text(tomli_w.dumps(manifest_toml))
+
     verify_cli_command(
         [pixi, "run", "--manifest-path", tmp_pixi_workspace, "bla"],
         ExitCode.COMMAND_NOT_FOUND,
-        stderr_contains=["pixi workspace platform add"],
+        stderr_excludes=["pixi workspace platform add"],
     )
 
 

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -134,10 +134,10 @@ def test_inline_task_listed(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_
     )
     manifest.write_text(toml)
 
-    # `pixi task list` prints the task names to stderr.
+    # `pixi task list` prints the task table to stdout.
     verify_cli_command(
         [pixi, "task", "list", "--manifest-path", manifest],
-        stderr_contains="greet",
+        stdout_contains="greet",
     )
 
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1025,6 +1025,29 @@ def test_pixi_task_list_platforms(pixi: Path, tmp_pixi_workspace: Path) -> None:
     )
 
 
+def test_pixi_task_list_multiline_description(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """A description spanning several lines is collapsed onto its own row so the
+    tasks sorted after it still show up."""
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = """
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
+
+        [tasks]
+        aaa = { cmd = "echo aaa", description = "first\\nsecond" }
+        zzz = { cmd = "echo zzz", description = "last task" }
+        """
+    manifest.write_text(toml)
+    result = verify_cli_command(
+        [pixi, "task", "list", "--manifest-path", manifest],
+        stdout_contains=["aaa", "zzz"],
+    )
+    # Header plus one row per task, nothing swallowed or split.
+    assert len(result.stdout.strip().splitlines()) == 3
+
+
 def test_pixi_add_alias(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     toml = """

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1021,7 +1021,7 @@ def test_pixi_task_list_platforms(pixi: Path, tmp_pixi_workspace: Path) -> None:
         """
     manifest.write_text(toml)
     verify_cli_command(
-        [pixi, "task", "list", "--manifest-path", manifest], stderr_contains=["foo", "bar"]
+        [pixi, "task", "list", "--manifest-path", manifest], stdout_contains=["foo", "bar"]
     )
 
 


### PR DESCRIPTION
`pixi task list` derived an environment's runnability from the `conda-meta/pixi` install marker, which records the platform a *previous* install resolved for and goes stale when the manifest changes -- so tasks were reported runnable "by design" for an environment the current manifest can no longer install. It also dropped environments it deemed unsupported and had no way to represent an environment with no dependencies at all.

Classification now ignores the install marker and works from the manifest and lock file:

- an environment with no dependencies reports "no dependency" -- nothing it installs can require a virtual package the machine lacks;
- otherwise it is "by design" when the machine satisfies a declared platform's virtual packages, "by accident" when it only meets the locked packages' minimum, and "unsupported" when it meets neither.

`task list` now prints every task in one table with a Status column, dimming tasks whose environment cannot run here instead of hiding them.

Fixes: #1347

### How Has This Been Tested?

By experimenting with a test project (and a new test)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
