### PR TITLE
fix(platforms): Do not fail when asked to install an environment with an unused requirement not used

### DIFF
--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -1163,14 +1163,16 @@ impl<'p> LockFileDerivedData<'p> {
             .get_or_try_init(async {
                 // Create object to update the prefix
                 let group = GroupedEnvironment::Environment(environment.clone());
-                let pixi_platform = environment
-                    .named_or_best_declared_platform(self.target_platform.as_ref())
-                    .ok_or_else(|| {
-                        miette::miette!(
-                            "no platform supported by environment '{}' matches the current system",
-                            environment.name().fancy_display()
-                        )
-                    })?;
+                // Mirror `update_prefix`: fall back to the minimum-compatible
+                // platform so an unsatisfied but unused system-requirement (e.g.
+                // a `cuda` requirement no locked package needs) doesn't block the
+                // install.
+                let pixi_platform = self.install_platform(environment).ok_or_else(|| {
+                    miette::miette!(
+                        "no platform supported by environment '{}' matches the current system",
+                        environment.name().fancy_display()
+                    )
+                })?;
 
                 // Use cached conda_prefix_updater if available, otherwise create new
                 let cache_key = lock_file::outdated::BuildCacheKey::new(

--- a/crates/pixi_core/src/workspace/errors.rs
+++ b/crates/pixi_core/src/workspace/errors.rs
@@ -77,17 +77,24 @@ impl Diagnostic for UnsupportedPlatformError {
             .filter_map(|req| conda_override_hint(req.name.as_normalized(), Some(&req.version)))
             .collect();
 
-        if overrides.is_empty() {
-            Some(Box::new(format!(
+        let base = if overrides.is_empty() {
+            format!(
                 "supported platforms are {}",
                 self.environments_platforms.iter().format(", ")
-            )))
+            )
         } else {
-            Some(Box::new(format!(
+            format!(
                 "Mock the missing virtual packages via the environment, e.g.:\n  {}",
                 overrides.join("\n  ")
-            )))
-        }
+            )
+        };
+        // `--platform` pins a target and skips host virtual-package
+        // validation, so it's the escape hatch when the machine can't run any
+        // declared platform.
+        Some(Box::new(format!(
+            "{base}\nOr install for a target this machine cannot run with \
+             `pixi install --platform <platform>`."
+        )))
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
@@ -202,6 +209,7 @@ mod tests {
         );
         let help = e.help().unwrap().to_string();
         assert!(help.contains("CONDA_OVERRIDE_CUDA=11"), "{help}");
+        assert!(help.contains("pixi install --platform"), "{help}");
     }
 
     #[test]
@@ -238,6 +246,7 @@ mod tests {
         );
         let help = e.help().unwrap().to_string();
         assert!(help.contains("supported platforms are linux-64"), "{help}");
+        assert!(help.contains("pixi install --platform"), "{help}");
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -603,6 +603,63 @@ packages:
         );
     }
 
+    /// `install_platform`'s fallback (the fix for an unsatisfied-but-unused
+    /// system requirement): when no declared platform matches the host, the
+    /// environment still resolves to the minimum-compatible platform as long as
+    /// the resolved packages need none of the unsatisfied virtual packages.
+    #[test]
+    fn minimum_compatible_platform_ignores_unused_requirement() {
+        let current = Platform::current();
+        let manifest = format!(
+            r#"
+            [workspace]
+            name = "demo"
+            channels = []
+            platforms = [{{ name = "gpu", platform = "{current}", cuda = "99" }}]
+            "#
+        );
+        let workspace =
+            crate::Workspace::from_str(std::path::Path::new("pixi.toml"), &manifest).unwrap();
+        let environment = workspace.default_environment();
+
+        let lock = |depends: &str| {
+            let source = format!(
+                r#"version: 7
+platforms:
+- name: gpu
+  subdir: {current}
+  virtual-packages:
+  - __cuda=99
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      gpu:
+      - conda: https://conda.anaconda.org/conda-forge/{current}/foo-1.0-h0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/{current}/foo-1.0-h0.conda
+{depends}"#
+            );
+            rattler_lock::LockFile::from_str_with_base_directory(&source, None).unwrap()
+        };
+
+        // The resolved package needs no virtual packages: fall back to the gpu
+        // platform's subdir even though the host lacks `__cuda=99`.
+        let platform = minimum_compatible_declared_platform(&environment, &lock(""))
+            .expect("falls back to the minimum-compatible platform");
+        assert_eq!(platform.subdir(), current);
+
+        // The resolved package needs a `__cuda` no machine provides: no
+        // fallback, and the unmet requirement is surfaced.
+        let unmet = minimum_compatible_declared_platform(
+            &environment,
+            &lock("  depends:\n  - __cuda >=9999\n"),
+        )
+        .expect_err("an unsatisfiable resolved requirement has no fallback");
+        assert!(unmet.iter().any(|vp| vp.name.as_normalized() == "__cuda"));
+    }
+
     /// A machine-compatible declared platform classifies as "by design"
     /// without consulting any lock file.
     #[test]

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -212,10 +212,13 @@ pub fn minimum_compatible_declared_platform<'p>(
 
     let mut unmet: Option<Vec<GenericVirtualPackage>> = None;
     for subdir in &candidate_subdirs {
-        let Some(platform) = minimal.get(subdir) else {
-            continue;
-        };
-        let unsatisfied = unsatisfied_virtual_packages(platform, &system_virtual_packages);
+        // A subdir with no resolved packages requires no virtual packages, so
+        // the machine trivially satisfies it -- e.g. an empty environment whose
+        // only content is tasks still runs under an unsatisfiable requirement.
+        let unsatisfied = minimal
+            .get(subdir)
+            .map(|platform| unsatisfied_virtual_packages(platform, &system_virtual_packages))
+            .unwrap_or_default();
         if unsatisfied.is_empty() {
             if let Some(declared) = declared_platforms
                 .iter()
@@ -658,6 +661,43 @@ packages:
         )
         .expect_err("an unsatisfiable resolved requirement has no fallback");
         assert!(unmet.iter().any(|vp| vp.name.as_normalized() == "__cuda"));
+    }
+
+    /// An environment that resolved no packages at all (its subdir is absent
+    /// from the lock-minimum map) needs no virtual packages, so it runs even
+    /// when the host can't satisfy the declared requirement -- the fix for
+    /// tasks in empty environments under an unsatisfiable system requirement.
+    #[test]
+    fn minimum_compatible_platform_runs_empty_environment() {
+        let current = Platform::current();
+        let manifest = format!(
+            r#"
+            [workspace]
+            name = "demo"
+            channels = []
+            platforms = [{{ name = "gpu", platform = "{current}", cuda = "99" }}]
+            "#
+        );
+        let workspace =
+            crate::Workspace::from_str(std::path::Path::new("pixi.toml"), &manifest).unwrap();
+        let environment = workspace.default_environment();
+
+        let empty_lock = rattler_lock::LockFile::from_str_with_base_directory(
+            r#"version: 7
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages: {}
+packages: []
+"#,
+            None,
+        )
+        .unwrap();
+
+        let platform = minimum_compatible_declared_platform(&environment, &empty_lock)
+            .expect("an empty environment runs regardless of the declared requirement");
+        assert_eq!(platform.subdir(), current);
     }
 
     /// A machine-compatible declared platform classifies as "by design"

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -25,6 +25,10 @@ requires_cuda_channel = pytest.mark.skipif(
     CURRENT_PLATFORM not in CUDA_CHANNEL_SUBDIRS,
     reason="virtual_packages channel ships the cuda package only for linux-64 and win-64",
 )
+linux_only = pytest.mark.skipif(
+    not CURRENT_PLATFORM.startswith("linux"),
+    reason="a linux system requirement only gates installs on linux hosts",
+)
 
 
 def _write(manifest: Path, body: str) -> Path:
@@ -81,4 +85,35 @@ cuda = "*"
         [pixi, "install", "--manifest-path", manifest],
         ExitCode.SUCCESS,
         env={"CONDA_OVERRIDE_CUDA": "12"},
+    )
+
+
+@linux_only
+@pytest.mark.xfail(
+    strict=True,
+    reason="an empty environment has nothing to install, yet an unsatisfiable "
+    "linux requirement blocks running its task",
+)
+def test_task_runs_in_empty_environment(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """A task in an empty environment must always run, even when the declared
+    linux requirement exceeds the host kernel."""
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "empty-task"
+channels = []
+platforms = ["{CURRENT_PLATFORM}"]
+
+[system-requirements]
+linux = "8.0"
+
+[tasks]
+task1 = "echo task1"
+""",
+    )
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "task1"],
+        ExitCode.SUCCESS,
+        stdout_contains="task1",
     )

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -1,9 +1,7 @@
-"""Known bugs in the richer-platform / system-requirement model.
+"""Regression tests for the richer-platform / system-requirement model.
 
-Every test here asserts the *intended* behaviour and is marked
-``xfail(strict=True)`` because pixi currently gets it wrong. When a bug is
-fixed its test starts passing, the strict xfail turns that into a failure, and
-the marker (and this note) should be removed.
+Each test asserts the intended behaviour for a bug that pixi used to get
+wrong; they guard against regressions now that those bugs are fixed.
 
 All tests stay network-free: they use the in-repo ``virtual_packages`` channel
 (its ``cuda`` package depends on ``__cuda >=12``) and gate themselves on the
@@ -118,11 +116,6 @@ cuda = "*"
 
 
 @linux_only
-@pytest.mark.xfail(
-    strict=True,
-    reason="an empty environment has nothing to install, yet an unsatisfiable "
-    "linux requirement blocks running its task",
-)
 def test_task_runs_in_empty_environment(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """A task in an empty environment must always run, even when the declared
     linux requirement exceeds the host kernel."""

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -88,6 +88,35 @@ cuda = "*"
     )
 
 
+@requires_cuda_channel
+def test_cuda_override_below_package_floor_is_refused(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """Guard rail (passes today): below the package's ``__cuda >=12`` floor the
+    install must fail."""
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "cuda-floor"
+channels = ["{virtual_packages_channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[system-requirements]
+cuda = "42"
+
+[dependencies]
+cuda = "*"
+""",
+    )
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.FAILURE,
+        env={"CONDA_OVERRIDE_CUDA": "10"},
+        stderr_contains="__cuda >= 12",
+    )
+
+
 @linux_only
 @pytest.mark.xfail(
     strict=True,

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -117,3 +117,34 @@ task1 = "echo task1"
         ExitCode.SUCCESS,
         stdout_contains="task1",
     )
+
+
+@linux_only
+def test_task_runs_with_kernel_agnostic_dependency(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """A task must run when its dependency is kernel-agnostic, even with a
+    declared linux requirement the host cannot satisfy."""
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "dep-task"
+channels = ["{virtual_packages_channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[system-requirements]
+linux = "8.0"
+
+[dependencies]
+no-deps = "*"
+
+[tasks]
+task1 = "echo task1"
+""",
+    )
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "task1"],
+        ExitCode.SUCCESS,
+        stdout_contains="task1",
+    )

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -1,0 +1,94 @@
+"""Known bugs in the richer-platform / system-requirement model.
+
+Every test here asserts the *intended* behaviour and is marked
+``xfail(strict=True)`` because pixi currently gets it wrong. When a bug is
+fixed its test starts passing, the strict xfail turns that into a failure, and
+the marker (and this note) should be removed.
+
+All tests stay network-free: they use the in-repo ``virtual_packages`` channel
+(its ``cuda`` package depends on ``__cuda >=12``) and gate themselves on the
+host platform where the requirement only makes sense.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .common import CURRENT_PLATFORM, ExitCode, verify_cli_command
+
+# The virtual_packages channel only ships the cuda package for these subdirs.
+CUDA_CHANNEL_SUBDIRS = {"linux-64", "win-64"}
+
+requires_cuda_channel = pytest.mark.skipif(
+    CURRENT_PLATFORM not in CUDA_CHANNEL_SUBDIRS,
+    reason="virtual_packages channel ships the cuda package only for linux-64 and win-64",
+)
+
+
+def _write(manifest: Path, body: str) -> Path:
+    manifest.write_text(body)
+    return manifest
+
+
+@requires_cuda_channel
+@pytest.mark.xfail(
+    strict=True,
+    reason="pixi rejects the matching subdir when __cuda is absent, even though "
+    "the dependency does not need cuda",
+)
+def test_cuda_requirement_does_not_block_install(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """A cuda system requirement must not block installing an environment whose
+    dependencies do not need cuda."""
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "cuda-block"
+channels = ["{virtual_packages_channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[system-requirements]
+cuda = "42"
+
+[dependencies]
+no-deps = "*"
+""",
+    )
+    verify_cli_command([pixi, "install", "--manifest-path", manifest], ExitCode.SUCCESS)
+
+
+@requires_cuda_channel
+@pytest.mark.xfail(
+    strict=True,
+    reason="pixi enforces the declared cuda=42 instead of the package's actual "
+    "floor of 12, so install fails at CONDA_OVERRIDE_CUDA=12",
+)
+def test_cuda_override_at_package_floor_installs(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """At the package floor (``__cuda >=12``) the environment must install,
+    regardless of the higher declared ``cuda = "42"``."""
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "cuda-floor"
+channels = ["{virtual_packages_channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[system-requirements]
+cuda = "42"
+
+[dependencies]
+cuda = "*"
+""",
+    )
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "12"},
+    )

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -33,11 +33,6 @@ def _write(manifest: Path, body: str) -> Path:
 
 
 @requires_cuda_channel
-@pytest.mark.xfail(
-    strict=True,
-    reason="pixi rejects the matching subdir when __cuda is absent, even though "
-    "the dependency does not need cuda",
-)
 def test_cuda_requirement_does_not_block_install(
     pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
 ) -> None:
@@ -62,11 +57,6 @@ no-deps = "*"
 
 
 @requires_cuda_channel
-@pytest.mark.xfail(
-    strict=True,
-    reason="pixi enforces the declared cuda=42 instead of the package's actual "
-    "floor of 12, so install fails at CONDA_OVERRIDE_CUDA=12",
-)
 def test_cuda_override_at_package_floor_installs(
     pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
 ) -> None:


### PR DESCRIPTION
### Description

fix(install): don't block install on an unused system requirement

conda_prefix selected the install platform with named_or_best_declared_platform, which has no fallback: a declared system requirement the host can't meet (e.g. cuda) made install bail even when no locked package needs it. Use install_platform instead, matching update_prefix, so it falls back to the minimum-compatible platform.

### How Has This Been Tested?

A new integration test

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
