### PR TITLE
feat(publish): show resolved anaconda.org owner/label and warn on non-main labels

### DIFF
--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -1065,6 +1065,29 @@ async fn upload_to_anaconda(
         }
     };
 
+    // Make the resolved destination explicit. The second path segment of the
+    // URL is interpreted as a *label*, which is easy to confuse with a package
+    // page URL (e.g. `https://anaconda.org/<owner>/<package>`): pasting one
+    // silently uploads to a label named after the package. Each label has its
+    // own repodata, so anything other than `main` won't show up in the default
+    // channel repodata.
+    pixi_progress::println!(
+        "  Uploading to anaconda.org owner '{}' on label '{}'",
+        owner,
+        channel,
+    );
+    if channel != "main" {
+        pixi_progress::println!(
+            "{}packages on label '{}' appear under https://conda.anaconda.org/{}/label/{}/ and not in the default channel repodata (https://conda.anaconda.org/{}/). Pass `https://anaconda.org/{}` to upload to the `main` label.",
+            console::style(console::Emoji("⚠️  ", "warning: ")).yellow(),
+            channel,
+            owner,
+            channel,
+            owner,
+            owner,
+        );
+    }
+
     let anaconda_data = AnacondaData::new(
         owner,
         Some(vec![channel]),


### PR DESCRIPTION
When publishing to anaconda.org, the second path segment of the target URL is interpreted as a label. This is easy to confuse with an anaconda.org package-page URL (e.g. `https://anaconda.org/<owner>/<package>`): pasting one silently uploads the package to a label named after the package.

Since each label has its own repodata, packages on a non-`main` label do not show up in the default channel repodata, which is surprising. Print the resolved owner and label before uploading, and warn (with the correct label repodata URL) whenever the label is not `main`.


Claude-Session: https://claude.ai/code/session_01Yaw4Fec8pYux17kNjMPfDw

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
