### PR TITLE
chore(release backends): reconcile the pixi-build-api-version requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-cmake"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-mojo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6033,7 +6033,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-r"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rattler-build"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "fs-err",
@@ -6081,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-ros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "astral-reqwest-middleware",
  "async-trait",
@@ -6113,7 +6113,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-rust"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "cargo_toml",

--- a/crates/pixi_build_cmake/Cargo.toml
+++ b/crates/pixi_build_cmake/Cargo.toml
@@ -3,7 +3,7 @@ description = "CMake build backend for Pixi"
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-cmake"
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_mojo/Cargo.toml
+++ b/crates/pixi_build_mojo/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-mojo"
-version = "0.2.0"
+version = "0.2.1"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-python"
-version = "0.6.0"
+version = "0.6.1"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_r/Cargo.toml
+++ b/crates/pixi_build_r/Cargo.toml
@@ -3,7 +3,7 @@ description = "R build backend for Pixi"
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-r"
-version = "0.1.1"
+version = "0.1.2"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rattler_build/Cargo.toml
+++ b/crates/pixi_build_rattler_build/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-rattler-build"
-version = "0.4.0"
+version = "0.4.1"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-ros"
 repository.workspace = true
-version = "0.6.0"
+version = "0.6.1"
 
 [package.metadata.dist]
 dist = false

--- a/crates/pixi_build_rust/Cargo.toml
+++ b/crates/pixi_build_rust/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-rust"
 repository.workspace = true
-version = "0.5.0"
+version = "0.5.1"
 
 [package.metadata.dist]
 dist = false

--- a/pixi-build-backends/recipe/all-backends/recipe.yaml
+++ b/pixi-build-backends/recipe/all-backends/recipe.yaml
@@ -3,7 +3,6 @@
 schema_version: 1
 
 context:
-  api_version: "5"
   cmake_version: ${{ env.get('PIXI_BUILD_CMAKE_VERSION', default='0.1.0dev') }}
   mojo_version: ${{ env.get('PIXI_BUILD_MOJO_VERSION', default='0.1.0dev') }}
   python_backend_version: ${{ env.get('PIXI_BUILD_PYTHON_VERSION', default='0.1.0dev') }}
@@ -85,28 +84,6 @@ outputs:
             then: cargo-bundle-licenses --format yaml --output $PREFIX/THIRDPARTY.yml
           - if: win
             then: cargo-bundle-licenses --format yaml --output %PREFIX%\THIRDPARTY.yml
-
-  # === API Version (metadata only) ===
-  - package:
-      name: pixi-build-api-version
-      version: ${{ api_version }}
-
-    build:
-      noarch: generic
-
-    source:
-      - path: ../../..
-
-    about:
-      homepage: https://github.com/prefix-dev/pixi-build-backends
-      summary: The protocol version for pixi build backends.
-      description: |
-        This package is used to define the API version of the protocol used by pixi build backends.
-      license: BSD-3-Clause
-      license_file:
-        - LICENSE
-      documentation: https://prefix-dev.github.io/pixi-build-backends
-      repository: https://github.com/prefix-dev/pixi-build-backends
 
   # === pixi-build-cmake ===
   - package:

--- a/pixi.lock
+++ b/pixi.lock
@@ -30,6 +30,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/patchelf-0.18.0-h3f2d84a_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-rattler-0.25.0-py310h70157a2_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rattler-build-0.65.0-ha759004_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
@@ -37,12 +38,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/sccache-0.15.0-he64ecbb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
@@ -70,6 +74,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/patchelf-0.18.0-h5ad3122_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/py-rattler-0.25.0-py310h45743d3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.14.4-hfd9ac0a_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/rattler-build-0.65.0-h1d7f6d8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
@@ -77,12 +82,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/sccache-0.15.0-hb434046_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
@@ -92,12 +100,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       osx-64:
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
@@ -117,6 +128,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/py-rattler-0.25.0-py310h21b85f7_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/python-3.14.4-h7c6738f_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rattler-build-0.65.0-h6193a51_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
@@ -125,12 +137,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       osx-arm64:
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
@@ -151,6 +166,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/py-rattler-0.25.0-py310hbaa5893_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.4-h4c637c5_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rattler-build-0.65.0-h20b3172_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
@@ -159,12 +175,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       win-64:
+      - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
@@ -182,6 +201,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.52.0-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/py-rattler-0.25.0-py310hb39080a_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/python-3.14.4-h4b44e0e_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/win-64/rattler-build-0.65.0-he94b42d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -77,6 +77,7 @@ sccache = ">=0.15,<0.16"
 # tooling from the backends-release feature.
 #
 [feature.backends-release-deps.dependencies]
+py-rattler = ">=0.25,<0.26"
 questionary = ">=2.1,<3"
 rich = ">=15,<16"
 "ruamel.yaml" = ">=0.19,<0.20"

--- a/scripts/release_backends.py
+++ b/scripts/release_backends.py
@@ -12,12 +12,15 @@ import subprocess
 import sys
 import tempfile
 import urllib.request
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import questionary
 import tomlkit
+from rattler import MatchSpec, VersionSpec
+from rattler.exceptions import InvalidVersionSpecError
 from rich.console import Console
 from rich.prompt import Confirm
 from rich.table import Table
@@ -26,51 +29,75 @@ from ruamel.yaml import YAML
 UPSTREAM_REPO = "prefix-dev/pixi"
 USE_JJ = Path(".jj").is_dir()
 
-# Each entry needs "binary" and "version_file".  Optional overrides:
+# Name of the protocol package whose requirement range is kept identical across
+# every backend declaration site.
+API_PKG = "pixi-build-api-version"
+
+# The all-backends recipe declares per-output run requirements and is also the
+# read-only source of truth for context.api_version (the version of the
+# pixi-build-api-version package itself).
+ALL_BACKENDS_RECIPE = Path("pixi-build-backends/recipe/all-backends/recipe.yaml")
+
+# Each entry needs "binary", "version_file", "pixi_manifest", and "feedstock".
+# Optional overrides:
 #   version_table      – defaults to "package"
 #   in_cargo_workspace – defaults to False
 BACKEND_DEFS: list[dict[str, Any]] = [
     {
         "binary": "pixi-build-cmake",
         "version_file": "crates/pixi_build_cmake/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_cmake/pixi.toml",
         "in_cargo_workspace": True,
         "feedstock": "conda-forge/pixi-build-cmake-feedstock",
     },
     {
         "binary": "pixi-build-python",
         "version_file": "crates/pixi_build_python/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_python/pixi.toml",
         "in_cargo_workspace": True,
         "feedstock": "conda-forge/pixi-build-python-feedstock",
     },
     {
         "binary": "pixi-build-rust",
         "version_file": "crates/pixi_build_rust/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_rust/pixi.toml",
         "in_cargo_workspace": True,
         "feedstock": "conda-forge/pixi-build-rust-feedstock",
     },
     {
         "binary": "pixi-build-mojo",
         "version_file": "crates/pixi_build_mojo/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_mojo/pixi.toml",
         "in_cargo_workspace": True,
         "feedstock": "conda-forge/pixi-build-mojo-feedstock",
     },
     {
         "binary": "pixi-build-rattler-build",
         "version_file": "crates/pixi_build_rattler_build/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_rattler_build/pixi.toml",
         "in_cargo_workspace": True,
         "feedstock": "conda-forge/pixi-build-rattler-build-feedstock",
     },
     {
         "binary": "pixi-build-ros",
         "version_file": "crates/pixi_build_ros/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_ros/pixi.toml",
         "in_cargo_workspace": True,
         "feedstock": "conda-forge/pixi-build-ros-feedstock",
+    },
+    {
+        "binary": "pixi-build-r",
+        "version_file": "crates/pixi_build_r/Cargo.toml",
+        "pixi_manifest": "crates/pixi_build_r/pixi.toml",
+        "in_cargo_workspace": True,
+        "feedstock": "conda-forge/pixi-build-r-feedstock",
     },
 ]
 
 STEPS = [
     "Choose version bumps",
     "Apply version bumps and update lock files",
+    "Reconcile api-version requirement",
     "Run linting",
     "Commit and push changes",
     "Create and merge PR",
@@ -157,6 +184,174 @@ def set_version(path: Path, new_version: str, table: str = "package") -> None:
     doc = tomlkit.parse(path.read_text())
     doc[table]["version"] = new_version
     path.write_text(tomlkit.dumps(doc))
+
+
+def parse_api_requirement(entry: str) -> str | None:
+    """Extract the spec from a "pixi-build-api-version <spec>" run requirement.
+
+    Returns the spec portion (e.g. ">=5,<6"), an empty string when the package is
+    listed without a spec, or None when the entry is for another package.
+    """
+    spec = MatchSpec(entry)
+    if str(spec.name.normalized) != API_PKG:
+        return None
+    return str(spec.version) if spec.version is not None else ""
+
+
+def read_crate_specs() -> dict[str, tuple[Path, str]]:
+    """Map backend binary name to its crate pixi.toml path and api-version spec."""
+    specs: dict[str, tuple[Path, str]] = {}
+    for spec in BACKEND_DEFS:
+        path = Path(spec["pixi_manifest"])
+        doc: Any = tomlkit.parse(path.read_text())
+        specs[spec["binary"]] = (path, str(doc["package"]["run-dependencies"][API_PKG]))
+    return specs
+
+
+def set_crate_spec(path: Path, target: str) -> None:
+    """Write the api-version run-dependency in a crate pixi.toml."""
+    doc = tomlkit.parse(path.read_text())
+    doc["package"]["run-dependencies"][API_PKG] = target
+    path.write_text(tomlkit.dumps(doc))
+
+
+def discover_recipe_specs(data: Any) -> dict[str, str]:
+    """Map backend binary name to its api-version spec in the all-backends recipe.
+
+    Skips the staging output and the pixi-build-api-version package output itself.
+    """
+    specs: dict[str, str] = {}
+    for output in data.get("outputs", []):
+        package = output.get("package")
+        if not package:
+            continue
+        name = package.get("name")
+        if name == API_PKG:
+            continue
+        run_reqs = output.get("requirements", {}).get("run")
+        if not run_reqs:
+            continue
+        for entry in run_reqs:
+            spec = parse_api_requirement(str(entry))
+            if spec is not None:
+                specs[name] = spec
+                break
+    return specs
+
+
+def rewrite_run_api_spec(run_reqs: Any, target: str) -> str | None:
+    """Rewrite the pixi-build-api-version entry in a requirements.run list.
+
+    Preserves the surrounding list. Returns the previous spec when it was
+    changed, otherwise None.
+    """
+    for i, entry in enumerate(run_reqs):
+        spec = parse_api_requirement(str(entry))
+        if spec is None:
+            continue
+        new_entry = f"{API_PKG} {target}".strip()
+        if str(entry) != new_entry:
+            run_reqs[i] = new_entry
+            return spec
+        return None
+    return None
+
+
+def set_recipe_specs(target: str) -> list[str]:
+    """Set every backend run requirement in the all-backends recipe to target.
+
+    Returns the names of the outputs that were changed.
+    """
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    data: Any = yaml.load(ALL_BACKENDS_RECIPE)
+    changed: list[str] = []
+    for output in data.get("outputs", []):
+        package = output.get("package")
+        if not package or package.get("name") == API_PKG:
+            continue
+        run_reqs = output.get("requirements", {}).get("run")
+        if not run_reqs:
+            continue
+        if rewrite_run_api_spec(run_reqs, target) is not None:
+            changed.append(str(package.get("name")))
+    if changed:
+        yaml.dump(data, ALL_BACKENDS_RECIPE)
+    return changed
+
+
+def gh_fetch_file(repo: str, path: str, ref: str | None = None) -> str | None:
+    """Fetch a file's raw content from GitHub, returning None on failure."""
+    endpoint = f"repos/{repo}/contents/{path}"
+    if ref:
+        endpoint += f"?ref={ref}"
+    result = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/vnd.github.raw", endpoint],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def fetch_feedstock_spec(feedstock: str) -> str | None:
+    """Read the api-version spec from a feedstock recipe on its default branch.
+
+    Raises RuntimeError when the recipe cannot be fetched. Returns None when the
+    recipe carries no pixi-build-api-version run requirement.
+    """
+    content = gh_fetch_file(feedstock, "recipe/recipe.yaml")
+    if content is None:
+        raise RuntimeError(f"could not fetch recipe for {feedstock}")
+    data: Any = YAML().load(content)
+    run_reqs = data.get("requirements", {}).get("run") or []
+    for entry in run_reqs:
+        spec = parse_api_requirement(str(entry))
+        if spec is not None:
+            return spec
+    return None
+
+
+def validate_spec(spec: str) -> str | None:
+    """Return an error message when spec does not parse as a version spec."""
+    try:
+        VersionSpec(spec)
+    except InvalidVersionSpecError as exc:
+        return f"not a valid version spec: {exc}"
+    return None
+
+
+def read_target_from_main() -> str:
+    """Read the agreed api-version requirement from the local sites on main.
+
+    Exits when a site cannot be read or when main carries internal drift.
+    """
+    specs: dict[str, str] = {}
+    for spec in BACKEND_DEFS:
+        path = spec["pixi_manifest"]
+        content = gh_fetch_file(UPSTREAM_REPO, path, ref="main")
+        if content is None:
+            console.print(f"[bold red]Could not read {path} from main[/bold red]")
+            sys.exit(1)
+        doc: Any = tomlkit.parse(content)
+        specs[path] = str(doc["package"]["run-dependencies"][API_PKG])
+
+    content = gh_fetch_file(UPSTREAM_REPO, str(ALL_BACKENDS_RECIPE), ref="main")
+    if content is None:
+        console.print(f"[bold red]Could not read {ALL_BACKENDS_RECIPE} from main[/bold red]")
+        sys.exit(1)
+    data = YAML().load(content)
+    for name, spec in discover_recipe_specs(data).items():
+        specs[f"recipe:{name}"] = spec
+
+    unique = set(specs.values())
+    if len(unique) != 1:
+        console.print("[bold red]main has internal api-version drift:[/bold red]")
+        for site, spec in specs.items():
+            console.print(f"    {site}: {spec}")
+        sys.exit(1)
+    return unique.pop()
 
 
 def run(cmd: list[str]) -> None:
@@ -286,14 +481,26 @@ def compute_tarball_sha256(tag: str) -> str:
     return digest
 
 
-def update_feedstock_recipe(recipe_path: Path, new_version: str, sha256: str) -> None:
-    """Update version, sha256, and build number in a feedstock recipe."""
+def update_feedstock_recipe(
+    recipe_path: Path, new_version: str, sha256: str, api_target: str | None = None
+) -> None:
+    """Update version, sha256, build number, and api-version in a feedstock recipe.
+
+    The api-version requirement is only rewritten when it actually differs from
+    api_target.
+    """
     yaml = YAML()
     yaml.preserve_quotes = True
-    data = yaml.load(recipe_path)
+    data: Any = yaml.load(recipe_path)
     data["context"]["version"] = new_version
     data["source"]["sha256"] = sha256
     data["build"]["number"] = 0
+    if api_target is not None:
+        run_reqs = data.get("requirements", {}).get("run")
+        if run_reqs is not None:
+            old = rewrite_run_api_spec(run_reqs, api_target)
+            if old is not None:
+                console.print(f"  Set {API_PKG} {old} -> [green]{api_target}[/green]")
     yaml.dump(data, recipe_path)
 
 
@@ -306,7 +513,7 @@ def run_in_dir(cmd: list[str], cwd: Path) -> None:
         sys.exit(1)
 
 
-def update_feedstock(backend: Backend, clone_dir: Path) -> None:
+def update_feedstock(backend: Backend, clone_dir: Path, api_target: str | None = None) -> None:
     """Update recipe, rerender, and open a PR for an already-cloned feedstock."""
     feedstock = backend.feedstock
     tag = backend.tag
@@ -323,7 +530,7 @@ def update_feedstock(backend: Backend, clone_dir: Path) -> None:
 
     # Update recipe
     recipe_path = clone_dir / "recipe" / "recipe.yaml"
-    update_feedstock_recipe(recipe_path, version, sha256)
+    update_feedstock_recipe(recipe_path, version, sha256, api_target)
     console.print(f"  Updated {recipe_path.name}")
 
     # Rerender
@@ -363,6 +570,116 @@ def show_versions(backends: list[Backend]) -> None:
     for b in backends:
         table.add_row(b.binary, b.version)
     console.print(table)
+
+
+@dataclass
+class ApiRow:
+    binary: str
+    pixi_spec: str | None
+    recipe_spec: str | None
+    feedstock_spec: str | None
+    feedstock_error: bool = False
+
+
+def build_api_rows(
+    crate_specs: dict[str, tuple[Path, str]],
+    recipe_specs: dict[str, str],
+    feedstock_by_binary: dict[str, str],
+) -> list[ApiRow]:
+    rows: list[ApiRow] = []
+    for binary in sorted(set(crate_specs) | set(recipe_specs)):
+        pixi_spec = crate_specs.get(binary, (None, None))[1]
+        recipe_spec = recipe_specs.get(binary)
+        feedstock_spec: str | None = None
+        feedstock_error = False
+        try:
+            feedstock_spec = fetch_feedstock_spec(feedstock_by_binary[binary])
+        except RuntimeError as exc:
+            feedstock_error = True
+            console.print(f"  [yellow]warning:[/yellow] {exc}")
+        rows.append(ApiRow(binary, pixi_spec, recipe_spec, feedstock_spec, feedstock_error))
+    return rows
+
+
+def _cell(value: str | None, agreed: str) -> str:
+    if value is None:
+        return "[dim]-[/dim]"
+    color = "green" if value == agreed else "red"
+    return f"[{color}]{value}[/{color}]"
+
+
+def _feedstock_cell(row: ApiRow, agreed: str) -> str:
+    if row.feedstock_error:
+        return "[yellow]?[/yellow]"
+    return _cell(row.feedstock_spec, agreed)
+
+
+def show_api_matrix(rows: list[ApiRow], agreed: str) -> None:
+    table = Table(title=f"{API_PKG} requirement")
+    table.add_column("Backend", style="cyan")
+    table.add_column("pixi.toml")
+    table.add_column("all-backends")
+    table.add_column("conda-forge")
+    for row in rows:
+        table.add_row(
+            row.binary,
+            _cell(row.pixi_spec, agreed),
+            _cell(row.recipe_spec, agreed),
+            _feedstock_cell(row, agreed),
+        )
+    console.print(table)
+
+
+def reconcile_api_version() -> None:
+    """Show the api-version requirement across all sites and reconcile the local ones."""
+    crate_specs = read_crate_specs()
+    recipe_specs = discover_recipe_specs(YAML().load(ALL_BACKENDS_RECIPE))
+    feedstock_by_binary = {d["binary"]: d["feedstock"] for d in BACKEND_DEFS}
+
+    rows = build_api_rows(crate_specs, recipe_specs, feedstock_by_binary)
+
+    local_specs = [s for row in rows for s in (row.pixi_spec, row.recipe_spec) if s is not None]
+    comparable = local_specs + [
+        row.feedstock_spec for row in rows if row.feedstock_spec is not None
+    ]
+    agreed = Counter(comparable).most_common(1)[0][0] if comparable else ""
+
+    show_api_matrix(rows, agreed)
+    console.print()
+
+    current = Counter(local_specs).most_common(1)[0][0] if local_specs else agreed
+
+    if len(set(comparable)) <= 1:
+        if not Confirm.ask(f"All sites agree on {current!r}. Bump it?", default=False):
+            console.print("  [dim]Leaving api-version requirement unchanged.[/dim]")
+            return
+    else:
+        console.print(
+            "  [yellow]Sites disagree; choose the value to reconcile the local sites to.[/yellow]"
+        )
+
+    while True:
+        target = _ask(questionary.text(f"{API_PKG} requirement:", default=current)).strip()
+        error = validate_spec(target)
+        if error is None:
+            break
+        console.print(f"  [red]{error}[/red]")
+
+    changed_files: list[str] = []
+    for _binary, (path, spec) in crate_specs.items():
+        if spec != target:
+            set_crate_spec(path, target)
+            changed_files.append(str(path))
+    changed_outputs = set_recipe_specs(target)
+
+    if changed_files or changed_outputs:
+        console.print(f"\n  Set {API_PKG} to [green]{target}[/green]:")
+        for path_str in changed_files:
+            console.print(f"    {path_str}")
+        if changed_outputs:
+            console.print(f"    {ALL_BACKENDS_RECIPE} ({', '.join(changed_outputs)})")
+    else:
+        console.print(f"\n  [dim]Local sites already at {target}.[/dim]")
 
 
 def main() -> None:
@@ -434,14 +751,21 @@ def main() -> None:
 
             completed.append("Applied version bumps and updated lock files")
 
-        # Step 3: Run linting
+        # Step 3: Reconcile api-version requirement
+        step += 1
+        if start_step <= step:
+            console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
+            reconcile_api_version()
+            completed.append("Reconciled api-version requirement")
+
+        # Step 4: Run linting
         step += 1
         if start_step <= step:
             console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
             run(["pixi", "run", "--environment", "lefthook", "lint-fast"])
             completed.append("Linting passed")
 
-        # Step 4: Commit and push changes
+        # Step 5: Commit and push changes
         step += 1
         if start_step <= step:
             console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
@@ -449,7 +773,7 @@ def main() -> None:
             commit_and_push(remote, branch, "chore: bump backend versions")
             completed.append(f"Committed and pushed to {branch}")
 
-        # Step 5: Create and merge PR
+        # Step 6: Create and merge PR
         step += 1
         if start_step <= step:
             console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
@@ -457,7 +781,7 @@ def main() -> None:
             Confirm.ask("PR created and merged?", default=False)
             completed.append("PR created and merged")
 
-        # Step 6: Choose backends to tag
+        # Step 7: Choose backends to tag
         step += 1
         if start_step <= step:
             console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
@@ -487,7 +811,7 @@ def main() -> None:
 
             completed.append("Chose backends to tag")
 
-        # Step 7: Create tags and push
+        # Step 8: Create tags and push
         step += 1
         if start_step <= step:
             console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
@@ -514,7 +838,7 @@ def main() -> None:
 
             completed.append("Created and pushed tags")
 
-        # Step 8: Update conda-forge feedstocks
+        # Step 9: Update conda-forge feedstocks
         step += 1
         if start_step <= step:
             console.print(f"\n[bold]Step {step}. {STEPS[step - 1]}[/bold]\n")
@@ -564,8 +888,14 @@ def main() -> None:
 
                     console.print()
                     if Confirm.ask("Proceed?", default=True):
+                        # Read the target from main so this step does not depend on
+                        # local working-copy state when resumed directly.
+                        api_target = read_target_from_main()
+                        console.print(
+                            f"  Reconciling {API_PKG} to [cyan]{api_target}[/cyan] on main\n"
+                        )
                         for b, clone_dir in outdated:
-                            update_feedstock(b, clone_dir)
+                            update_feedstock(b, clone_dir, api_target)
                         completed.append("Updated conda-forge feedstocks")
                     else:
                         console.print("[dim]Skipped feedstock updates.[/dim]")


### PR DESCRIPTION
### Description

- remove `pixi-build-api-version` package from our recipe.yaml. `conda-forge` is a requirement anyway and I published a lot of versions in advance
- makes sure all pixi-build-api version requirements are the same
- ask user whether the requirement needs to be updated
- present current state in a nice table


~~Draft until https://github.com/conda-forge/staged-recipes/pull/33771 is merged~~

### How Has This Been Tested?

Ran parts of it locally. Will make a real release on Monday

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
