### PR TITLE
fix: set exclude-newer for `pixi-build-rust` to `0d`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,9 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]
 preview = ["pixi-build"]
 requires-pixi = ">=0.67"
 
+[exclude-newer]
+pixi-build-rust = "0d"
+
 [workspace.build-variants]
 rust_compiler_version = [">=1.94,<1.95"]
 


### PR DESCRIPTION
### Description

I tried pixi main and noticed that it couldn't find compatible backends. exclude-newer was the reason, which means we can't test the newest pixi with that setting. Let's exclude `pixi-build-rust` therefore