### PR TITLE
fix: set macOS deployment target for PyPI source builds

### DIFF
--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -220,6 +220,11 @@ pub struct LazyBuildDispatch<'a> {
 
     pub ignore_packages: Option<HashSet<rattler_conda_types::PackageName>>,
 
+    /// macOS deployment target (`MACOSX_DEPLOYMENT_TARGET`) to export to PyPI
+    /// source builds so a wheel built during resolution is tagged like the
+    /// install-side build (see `pixi_install_pypi`). `None` off macOS.
+    macos_deployment_target: Option<String>,
+
     /// Shared error holder for storing initialization errors that can be retrieved
     /// after the LazyBuildDispatch is consumed (e.g., in catch_unwind scenarios)
     pub last_error: Arc<OnceCell<LazyBuildDispatchError>>,
@@ -295,6 +300,7 @@ impl<'a> LazyBuildDispatch<'a> {
         no_build_isolation: NoBuildIsolation,
         lazy_deps: &'a LazyBuildDispatchDependencies,
         ignore_packages: Option<HashSet<rattler_conda_types::PackageName>>,
+        macos_deployment_target: Option<String>,
         disallow_install_conda_prefix: bool,
         last_error: Arc<OnceCell<LazyBuildDispatchError>>,
     ) -> Self {
@@ -311,6 +317,7 @@ impl<'a> LazyBuildDispatch<'a> {
             disallow_install_conda_prefix,
             workspace_cache: WorkspaceCache::default(),
             ignore_packages,
+            macos_deployment_target,
             last_error,
         }
     }
@@ -348,7 +355,7 @@ impl<'a> LazyBuildDispatch<'a> {
                     .map_err(|err| LazyBuildDispatchError::InitializationError(err.into()))?;
 
                 // get the activation vars
-                let env_vars = get_activated_environment_variables(
+                let mut env_vars = get_activated_environment_variables(
                     &self.project_env_vars,
                     &self.environment,
                     CurrentEnvVarBehavior::Exclude,
@@ -357,7 +364,18 @@ impl<'a> LazyBuildDispatch<'a> {
                     false,
                 )
                 .await
-                .map_err(|err| LazyBuildDispatchError::InitializationError(err.into()))?;
+                .map_err(|err| LazyBuildDispatchError::InitializationError(err.into()))?
+                .clone();
+
+                // Match the resolver's macOS target when building sdists during
+                // resolution, so any wheel built here is tagged like the
+                // install-side build (see `pixi_install_pypi`). Respect a value
+                // already provided by conda activation or the user.
+                if let Some(target) = &self.macos_deployment_target {
+                    env_vars
+                        .entry("MACOSX_DEPLOYMENT_TARGET".to_string())
+                        .or_insert_with(|| target.clone());
+                }
 
                 let python_path = prefix
                     .python_status

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -59,6 +59,9 @@ pub struct UvBuildDispatchParams<'a> {
     index_locations: &'a IndexLocations,
     flat_index: &'a FlatIndex,
     dependency_metadata: &'a DependencyMetadata,
+    /// Settings passed to the PEP 517 backend.
+    backend_config_settings: &'a ConfigSettings,
+    /// Settings exposed to uv for the built-wheel cache key.
     config_settings: &'a ConfigSettings,
     package_config_settings: PackageConfigSettings,
     build_options: &'a BuildOptions,
@@ -94,6 +97,7 @@ impl<'a> UvBuildDispatchParams<'a> {
             index_locations,
             flat_index,
             dependency_metadata,
+            backend_config_settings: config_settings,
             config_settings,
             package_config_settings: PackageConfigSettings::default(),
             build_options,
@@ -166,6 +170,12 @@ impl<'a> UvBuildDispatchParams<'a> {
         self
     }
 
+    /// Set config settings used only for uv's built-wheel cache key.
+    pub fn with_cache_config_settings(mut self, cache_config_settings: &'a ConfigSettings) -> Self {
+        self.config_settings = cache_config_settings;
+        self
+    }
+
     #[expect(unused)]
     pub fn with_package_config_settings(
         mut self,
@@ -220,9 +230,7 @@ pub struct LazyBuildDispatch<'a> {
 
     pub ignore_packages: Option<HashSet<rattler_conda_types::PackageName>>,
 
-    /// macOS deployment target (`MACOSX_DEPLOYMENT_TARGET`) to export to PyPI
-    /// source builds so a wheel built during resolution is tagged like the
-    /// install-side build (see `pixi_install_pypi`). `None` off macOS.
+    /// `MACOSX_DEPLOYMENT_TARGET` for PyPI source builds. `None` off macOS.
     macos_deployment_target: Option<String>,
 
     /// Shared error holder for storing initialization errors that can be retrieved
@@ -367,10 +375,8 @@ impl<'a> LazyBuildDispatch<'a> {
                 .map_err(|err| LazyBuildDispatchError::InitializationError(err.into()))?
                 .clone();
 
-                // Match the resolver's macOS target when building sdists during
-                // resolution, so any wheel built here is tagged like the
-                // install-side build (see `pixi_install_pypi`). Respect a value
-                // already provided by conda activation or the user.
+                // Ensure macOS sdists are built for pixi's resolved target,
+                // not the host OS version. Preserve explicit config.
                 if let Some(target) = &self.macos_deployment_target {
                     env_vars
                         .entry("MACOSX_DEPLOYMENT_TARGET".to_string())
@@ -433,7 +439,7 @@ impl<'a> LazyBuildDispatch<'a> {
                     self.params.dependency_metadata,
                     self.params.shared_state.clone(),
                     self.params.index_strategy,
-                    self.params.config_settings,
+                    self.params.backend_config_settings,
                     package_config_settings,
                     build_isolation,
                     extra_build_requires,

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -37,7 +37,7 @@ use pixi_uv_conversions::{
 };
 use pypi_modifiers::{
     pypi_marker_env::determine_marker_environment,
-    pypi_tags::{get_pypi_tags, is_python_record},
+    pypi_tags::{get_pypi_tags, is_python_record, macos_deployment_target},
 };
 use rattler_digest::{Md5, Sha256, parse_digest_from_hex};
 use rattler_lock::{
@@ -569,6 +569,7 @@ pub async fn resolve_pypi(
         pypi_options.no_build_isolation.clone(),
         lazy_build_dispatch_deps,
         None,
+        macos_deployment_target(pixi_platform),
         disallow_install_conda_prefix,
         Arc::clone(&last_error),
     );

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -31,9 +31,10 @@ use pixi_reporters::{UvReporter, UvReporterOptions};
 use pixi_uv_conversions::{
     ConversionError, WorkspaceAnchor, as_uv_req, configure_insecure_hosts_for_tls_bypass,
     convert_uv_requirements_to_pep508, into_pinned_git_spec, into_uv_git_reference,
-    into_uv_git_sha, pypi_options_to_build_options, pypi_options_to_index_locations,
-    to_index_strategy, to_prerelease_mode, to_requirements_relative_to, to_uv_normalize,
-    to_uv_version, to_version_specifiers,
+    into_uv_git_sha, pypi_cache_config_settings_with_macos_deployment_target,
+    pypi_options_to_build_options, pypi_options_to_index_locations, to_index_strategy,
+    to_prerelease_mode, to_requirements_relative_to, to_uv_normalize, to_uv_version,
+    to_version_specifiers,
 };
 use pypi_modifiers::{
     pypi_marker_env::determine_marker_environment,
@@ -489,11 +490,15 @@ pub async fn resolve_pypi(
 
     let dependency_metadata = DependencyMetadata::default();
 
-    // Metadata extraction is env-independent, so no scoping here; the build cache
-    // is scoped per environment at install time (see `CacheScopedBuildContext` in
-    // pixi_install_pypi). Keeping the fingerprint out of `config_settings` also
-    // avoids breaking strict PEP 517 backends like meson-python. See #6271 and #6226.
+    // Source-build metadata is independent of the conda environment, so do not
+    // include the conda fingerprint here. Only include cache discriminators that
+    // affect the wheel artifact itself.
     let config_settings = ConfigSettings::default();
+    let deployment_target = macos_deployment_target(pixi_platform);
+    let cache_config_settings = pypi_cache_config_settings_with_macos_deployment_target(
+        &config_settings,
+        deployment_target.as_deref(),
+    );
     let build_params = UvBuildDispatchParams::new(
         &registry_client,
         &context.cache,
@@ -518,7 +523,8 @@ pub async fn resolve_pypi(
     .with_shared_state(context.shared_state.fork())
     .with_no_sources(context.no_sources.clone())
     .with_concurrency(context.concurrency.clone())
-    .with_link_mode(link_mode);
+    .with_link_mode(link_mode)
+    .with_cache_config_settings(&cache_config_settings);
 
     // Use cached build dispatch dependencies
     let lazy_build_dispatch_deps = &build_cache.lazy_build_dispatch_deps;
@@ -569,7 +575,7 @@ pub async fn resolve_pypi(
         pypi_options.no_build_isolation.clone(),
         lazy_build_dispatch_deps,
         None,
-        macos_deployment_target(pixi_platform),
+        deployment_target,
         disallow_install_conda_prefix,
         Arc::clone(&last_error),
     );

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -24,7 +24,7 @@ use pixi_uv_conversions::{
     to_requirements_relative_to,
 };
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
-use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record};
+use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record, macos_deployment_target};
 use rattler_conda_types::GenericVirtualPackage;
 use rattler_lock::UrlOrPath;
 use typed_path::Utf8TypedPathBuf;
@@ -738,6 +738,7 @@ async fn read_local_package_metadata(
         pypi_options.no_build_isolation.clone(),
         &cache.lazy_build_dispatch_deps,
         None,
+        macos_deployment_target(ctx.platform),
         false,
         Arc::clone(&last_error),
     );

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -20,8 +20,8 @@ use pixi_spec::Subdirectory;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
     WorkspaceAnchor, configure_insecure_hosts_for_tls_bypass, into_pixi_reference,
-    pypi_options_to_build_options, pypi_options_to_index_locations, to_index_strategy,
-    to_requirements_relative_to,
+    pypi_cache_config_settings_with_macos_deployment_target, pypi_options_to_build_options,
+    pypi_options_to_index_locations, to_index_strategy, to_requirements_relative_to,
 };
 use pypi_modifiers::pypi_marker_env::determine_marker_environment;
 use pypi_modifiers::pypi_tags::{get_pypi_tags, is_python_record, macos_deployment_target};
@@ -663,11 +663,15 @@ async fn read_local_package_metadata(
         )
     };
 
-    // Metadata extraction is env-independent, so no scoping here; the build cache
-    // is scoped per environment at install time (see `CacheScopedBuildContext` in
-    // pixi_install_pypi). Keeping the fingerprint out of `config_settings` also
-    // avoids breaking strict PEP 517 backends like meson-python. See #6271 and #6226.
+    // Source-build metadata is independent of the conda environment, so do not
+    // include the conda fingerprint here. Only include cache discriminators that
+    // affect the wheel artifact itself.
     let config_settings = ConfigSettings::default();
+    let deployment_target = macos_deployment_target(ctx.platform);
+    let cache_config_settings = pypi_cache_config_settings_with_macos_deployment_target(
+        &config_settings,
+        deployment_target.as_deref(),
+    );
     let build_params = UvBuildDispatchParams::new(
         &registry_client,
         &ctx.uv_context.cache,
@@ -682,7 +686,8 @@ async fn read_local_package_metadata(
     .with_workspace_cache(ctx.uv_context.workspace_cache.clone())
     .with_shared_state(ctx.uv_context.shared_state.fork())
     .with_no_sources(ctx.uv_context.no_sources.clone())
-    .with_concurrency(ctx.uv_context.concurrency.clone());
+    .with_concurrency(ctx.uv_context.concurrency.clone())
+    .with_cache_config_settings(&cache_config_settings);
 
     // Get or create conda prefix updater for the environment. Use the host
     // platform because we can only install/run Python on the local machine,
@@ -738,7 +743,7 @@ async fn read_local_package_metadata(
         pypi_options.no_build_isolation.clone(),
         &cache.lazy_build_dispatch_deps,
         None,
-        macos_deployment_target(ctx.platform),
+        deployment_target,
         false,
         Arc::clone(&last_error),
     );

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -29,7 +29,7 @@ use pixi_uv_conversions::{
 use plan::{InstallPlanner, InstallReason, NeedReinstall, PyPIInstallationPlan};
 use pypi_modifiers::{
     Tags,
-    pypi_tags::{get_pypi_tags, is_python_record},
+    pypi_tags::{get_pypi_tags, is_python_record, macos_deployment_target},
 };
 use rattler_lock::{PypiDistributionData, PypiIndexes, PypiPackageData, UrlOrPath};
 use rayon::prelude::*;
@@ -959,11 +959,24 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             .with_starting_tasks(remote.iter().map(|(d, _)| format!("{}", d.name())))
             .with_top_level_message("Preparing distributions");
 
-        let env_vars = if let Some(lazy_vars) = &self.context_config.environment_variables_lazy {
+        let mut env_vars = if let Some(lazy_vars) = &self.context_config.environment_variables_lazy
+        {
             lazy_vars.resolve().await?
         } else {
             HashMap::new()
         };
+
+        // When building a macOS wheel from an sdist, target the same macOS
+        // version the resolver targets (from `[system-requirements] macos` / the
+        // `__osx` virtual package). Without this, CMake-based build backends
+        // (e.g. scikit-build-core) tag the wheel with the building machine's
+        // macOS version, which uv then rejects as incompatible. Respect a value
+        // already provided by conda activation or the user.
+        if !env_vars.contains_key("MACOSX_DEPLOYMENT_TARGET")
+            && let Some(target) = macos_deployment_target(self.config.platform)
+        {
+            env_vars.insert("MACOSX_DEPLOYMENT_TARGET".to_string(), target);
+        }
         // Wrap the dispatch so the conda-environment fingerprint scopes the build
         // cache key without reaching the PEP 517 backend (see
         // `CacheScopedBuildContext`).

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -24,7 +24,8 @@ use pixi_utils::prefix::Prefix;
 use pixi_uv_context::UvResolutionContext;
 use pixi_uv_conversions::{
     BuildIsolation, configure_insecure_hosts_for_tls_bypass, locked_indexes_to_index_locations,
-    pypi_cache_config_settings, pypi_options_to_build_options, to_exclude_newer, to_index_strategy,
+    pypi_cache_config_settings, pypi_cache_config_settings_with_macos_deployment_target,
+    pypi_options_to_build_options, to_exclude_newer, to_index_strategy,
 };
 use plan::{InstallPlanner, InstallReason, NeedReinstall, PyPIInstallationPlan};
 use pypi_modifiers::{
@@ -546,6 +547,11 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
         // stay scoped per environment (#6226).
         let config_settings = ConfigSettings::default();
         let cache_config_settings = pypi_cache_config_settings(&config_settings, pixi_records);
+        let deployment_target = macos_deployment_target(self.config.platform);
+        let cache_config_settings = pypi_cache_config_settings_with_macos_deployment_target(
+            &cache_config_settings,
+            deployment_target.as_deref(),
+        );
 
         // Setup the interpreter from the conda prefix
         let python_location = self.config.prefix.root().join(python_interpreter_path);
@@ -966,12 +972,8 @@ impl<'a> PyPIEnvironmentUpdater<'a> {
             HashMap::new()
         };
 
-        // When building a macOS wheel from an sdist, target the same macOS
-        // version the resolver targets (from `[system-requirements] macos` / the
-        // `__osx` virtual package). Without this, CMake-based build backends
-        // (e.g. scikit-build-core) tag the wheel with the building machine's
-        // macOS version, which uv then rejects as incompatible. Respect a value
-        // already provided by conda activation or the user.
+        // Ensure macOS sdists are built for pixi's resolved target, not the
+        // host OS version. Preserve explicit config.
         if !env_vars.contains_key("MACOSX_DEPLOYMENT_TARGET")
             && let Some(target) = macos_deployment_target(self.config.platform)
         {

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -35,6 +35,9 @@ use crate::{ConversionError, VersionError, WorkspaceAnchor};
 /// `config_settings` key carrying the conda-environment fingerprint.
 const CONDA_ENVIRONMENT_CONFIG_SETTING: &str = "pixi-conda-environment";
 
+/// Cache-only key for pixi's implicit `MACOSX_DEPLOYMENT_TARGET`.
+const MACOS_DEPLOYMENT_TARGET_CONFIG_SETTING: &str = "pixi-macos-deployment-target";
+
 /// Builds the [`ConfigSettings`] used to scope the PyPI source-build cache to the
 /// conda environment: a wheel built against one set of conda dependencies is not
 /// reused in an environment that resolves different ones (issue #6226).
@@ -58,6 +61,25 @@ pub fn pypi_cache_config_settings(
             .expect("the fingerprint is always a valid `KEY=VALUE` config setting");
     let fingerprint_settings: ConfigSettings = std::iter::once(entry).collect();
     config_settings.clone().merge(fingerprint_settings)
+}
+
+/// Add pixi's implicit `MACOSX_DEPLOYMENT_TARGET` to uv's source-build cache
+/// key. The variable affects wheel tags, but third-party sdists may not declare
+/// it in `[tool.uv].cache-keys`.
+pub fn pypi_cache_config_settings_with_macos_deployment_target(
+    config_settings: &ConfigSettings,
+    macos_deployment_target: Option<&str>,
+) -> ConfigSettings {
+    let Some(target) = macos_deployment_target else {
+        return config_settings.clone();
+    };
+
+    let entry = ConfigSettingEntry::from_str(&format!(
+        "{MACOS_DEPLOYMENT_TARGET_CONFIG_SETTING}={target}"
+    ))
+    .expect("the macOS deployment target is always a valid `KEY=VALUE` config setting");
+    let target_settings: ConfigSettings = std::iter::once(entry).collect();
+    config_settings.clone().merge(target_settings)
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -1139,6 +1161,26 @@ mod tests {
         assert!(rendered.contains(CONDA_ENVIRONMENT_CONFIG_SETTING));
         assert!(rendered.contains(&expected));
         // ...and the base backend settings are preserved.
+        assert!(rendered.contains("backend-key"));
+        assert!(rendered.contains("backend-value"));
+    }
+
+    #[test]
+    fn pypi_cache_config_settings_with_macos_deployment_target_layers_on_base() {
+        let base: ConfigSettings =
+            std::iter::once(ConfigSettingEntry::from_str("backend-key=backend-value").unwrap())
+                .collect();
+        let settings = pypi_cache_config_settings_with_macos_deployment_target(&base, Some("12.0"));
+
+        let rendered = settings.escape_for_python();
+        assert!(rendered.contains(MACOS_DEPLOYMENT_TARGET_CONFIG_SETTING));
+        assert!(rendered.contains("12.0"));
+        assert!(rendered.contains("backend-key"));
+        assert!(rendered.contains("backend-value"));
+
+        let without_target = pypi_cache_config_settings_with_macos_deployment_target(&base, None);
+        let rendered = without_target.escape_for_python();
+        assert!(!rendered.contains(MACOS_DEPLOYMENT_TARGET_CONFIG_SETTING));
         assert!(rendered.contains("backend-key"));
         assert!(rendered.contains("backend-value"));
     }

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -163,13 +163,20 @@ fn get_windows_platform_tags(
     ))
 }
 
+/// Resolve the macOS version pixi targets for `platform`: the declared `__osx`
+/// virtual package (from `[system-requirements] macos`), falling back to the
+/// channel default for the subdir. Callers must ensure `platform` is macOS --
+/// the fallback [`default_mac_os_version`] panics otherwise.
+fn macos_target_version(platform: &PixiPlatform) -> Version {
+    declared_version(platform.declared_virtual_packages(), "__osx")
+        .unwrap_or_else(|| default_mac_os_version(platform.subdir()))
+}
+
 /// Get macos specific platform tags
 fn get_macos_platform_tags(
     platform: &PixiPlatform,
 ) -> Result<uv_platform_tags::Platform, PyPITagError> {
-    let osx_version = declared_version(platform.declared_virtual_packages(), "__osx")
-        .unwrap_or_else(|| default_mac_os_version(platform.subdir()));
-    let (major, minor) = macos_major_minor(&osx_version, "macos")?;
+    let (major, minor) = macos_major_minor(&macos_target_version(platform), "macos")?;
 
     let arch = get_arch_tags(platform)?;
 
@@ -180,6 +187,23 @@ fn get_macos_platform_tags(
         },
         arch,
     ))
+}
+
+/// The macOS deployment target (`"<major>.<minor>"`) pixi targets for
+/// `platform`, or `None` when the target platform is not macOS.
+///
+/// Pixi exports this as `MACOSX_DEPLOYMENT_TARGET` when building PyPI packages
+/// from an sdist so the produced wheel is tagged with the same macOS version the
+/// resolver targets. CMake-based build backends (e.g. scikit-build-core)
+/// otherwise default the deployment target to the *building* machine's macOS
+/// version, producing a wheel tag uv rejects as incompatible with the resolved
+/// target (see [`get_macos_platform_tags`]).
+pub fn macos_deployment_target(platform: &PixiPlatform) -> Option<String> {
+    if !platform.subdir().is_osx() {
+        return None;
+    }
+    let (major, minor) = macos_major_minor(&macos_target_version(platform), "macos").ok()?;
+    Some(format!("{major}.{minor}"))
 }
 
 /// Single-segment fallback for [`Version::as_major_minor`]: returns the
@@ -443,6 +467,47 @@ mod tests {
                 major: 15,
                 minor: 0
             }
+        );
+    }
+
+    #[test]
+    fn test_macos_deployment_target() {
+        // A declared `__osx` (from `[system-requirements] macos`) wins.
+        let platform = PixiPlatform::from_required_virtual_packages(
+            Platform::OsxArm64,
+            vec![GenericVirtualPackage {
+                name: "__osx".parse().unwrap(),
+                version: "12.0".parse().unwrap(),
+                build_string: "0".to_string(),
+            }],
+        );
+        assert_eq!(macos_deployment_target(&platform), Some("12.0".to_string()));
+
+        // A single-segment declaration gets a `.0` minor.
+        let platform = PixiPlatform::from_required_virtual_packages(
+            Platform::OsxArm64,
+            vec![GenericVirtualPackage {
+                name: "__osx".parse().unwrap(),
+                version: "15".parse().unwrap(),
+                build_string: "0".to_string(),
+            }],
+        );
+        assert_eq!(macos_deployment_target(&platform), Some("15.0".to_string()));
+
+        // No declaration falls back to the subdir default.
+        assert_eq!(
+            macos_deployment_target(&PixiPlatform::from_subdir(Platform::OsxArm64)),
+            Some("13.0".to_string())
+        );
+
+        // Non-macOS targets get nothing.
+        assert_eq!(
+            macos_deployment_target(&PixiPlatform::from_subdir(Platform::Linux64)),
+            None
+        );
+        assert_eq!(
+            macos_deployment_target(&PixiPlatform::from_subdir(Platform::Win64)),
+            None
         );
     }
 

--- a/crates/pypi_modifiers/src/pypi_tags.rs
+++ b/crates/pypi_modifiers/src/pypi_tags.rs
@@ -163,10 +163,8 @@ fn get_windows_platform_tags(
     ))
 }
 
-/// Resolve the macOS version pixi targets for `platform`: the declared `__osx`
-/// virtual package (from `[system-requirements] macos`), falling back to the
-/// channel default for the subdir. Callers must ensure `platform` is macOS --
-/// the fallback [`default_mac_os_version`] panics otherwise.
+/// macOS version pixi targets: declared `__osx`, else the subdir default.
+/// Call only for macOS platforms.
 fn macos_target_version(platform: &PixiPlatform) -> Version {
     declared_version(platform.declared_virtual_packages(), "__osx")
         .unwrap_or_else(|| default_mac_os_version(platform.subdir()))
@@ -189,15 +187,8 @@ fn get_macos_platform_tags(
     ))
 }
 
-/// The macOS deployment target (`"<major>.<minor>"`) pixi targets for
-/// `platform`, or `None` when the target platform is not macOS.
-///
-/// Pixi exports this as `MACOSX_DEPLOYMENT_TARGET` when building PyPI packages
-/// from an sdist so the produced wheel is tagged with the same macOS version the
-/// resolver targets. CMake-based build backends (e.g. scikit-build-core)
-/// otherwise default the deployment target to the *building* machine's macOS
-/// version, producing a wheel tag uv rejects as incompatible with the resolved
-/// target (see [`get_macos_platform_tags`]).
+/// Return pixi's macOS deployment target as `"<major>.<minor>"`, or `None` for
+/// non-macOS platforms.
 pub fn macos_deployment_target(platform: &PixiPlatform) -> Option<String> {
     if !platform.subdir().is_osx() {
         return None;


### PR DESCRIPTION
### Description

Fixes #6392.

Pixi can solve for a lower macOS target than the machine doing the build. In the reported example, the workspace targets macOS 12, but the build happens on macOS 15. Some PyPI source builds then produce a wheel tagged for the host macOS version, and uv rejects it because it does not match the platform pixi resolved for.

The confusing part is that the error message mentions the current host platform, but uv checks the built wheel against the tags pixi handed it during resolution. So if pixi resolves for macOS 12 and the backend builds a macOS 15-tagged wheel, uv reports it as incompatible even on a macOS 15 machine.

This PR makes PyPI source builds use pixi's resolved macOS deployment target instead of defaulting to the host OS version. That keeps wheels built during resolve/install aligned with the platform tags pixi already uses.

It also scopes the source-build cache by that deployment target, so changing the target does not reuse a wheel built for a different macOS deployment target.

The existing `examples/llama-index-inference` workspace is a good way to exercise this. It targets `osx-arm64` with `macos = "12.0"`, while `llama-cpp-python` may build from an sdist. On a newer macOS ARM machine, that previously produced a host-tagged wheel like `macosx_15_0_arm64`, which uv rejected against pixi's macOS 12 tags.

### Testing

```bash
cargo test -p pypi_modifiers test_macos_deployment_target --lib
cargo test -p pixi_uv_conversions pypi_cache_config_settings --lib
cargo check -p pixi_core -p pixi_install_pypi -p pixi_uv_conversions -p pypi_modifiers
cargo fmt --manifest-path ../../Cargo.toml --all --check
```

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: pi coding agent

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added sufficient tests to cover my changes.
