### PR TITLE
chore: switch from basedpyright to ty

### DIFF
--- a/crates/pixi_core/Cargo.toml
+++ b/crates/pixi_core/Cargo.toml
@@ -21,9 +21,9 @@ dialoguer = { workspace = true }
 dunce = { workspace = true }
 fancy_display = { workspace = true }
 fs-err = { workspace = true }
-hex = { workspace = true }
 fs_extra = { workspace = true }
 futures = { workspace = true }
+hex = { workspace = true }
 human_bytes = { workspace = true }
 humantime = { workspace = true }
 indexmap = { workspace = true }

--- a/examples/opencv/calibrate.py
+++ b/examples/opencv/calibrate.py
@@ -1,5 +1,3 @@
-# pyright: reportOptionalMemberAccess=false
-
 import cv2
 import numpy as np
 

--- a/examples/opencv/webcam_capture.py
+++ b/examples/opencv/webcam_capture.py
@@ -1,5 +1,3 @@
-# pyright: reportOptionalMemberAccess=false
-
 import os
 
 import cv2

--- a/examples/rerun_example/force_driven_lock_file_graph.py
+++ b/examples/rerun_example/force_driven_lock_file_graph.py
@@ -1,5 +1,3 @@
-# pyright: reportIndexIssue=false, reportMissingParameterType=false, reportUnknownLambdaType=false
-
 import hashlib
 import sys
 

--- a/examples/solve-groups/test_imports.py
+++ b/examples/solve-groups/test_imports.py
@@ -1,5 +1,3 @@
-# pyright: reportUnusedImport=false
-
 import os
 import sys
 

--- a/examples/turtlesim/turtle_marker_viz_ROS2.py
+++ b/examples/turtlesim/turtle_marker_viz_ROS2.py
@@ -1,5 +1,3 @@
-# pyright: reportUntypedBaseClass=false, reportUnannotatedClassAttribute=false
-
 from math import sin, cos
 import rclpy
 from rclpy.node import Node

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -63,12 +63,12 @@ pre-commit:
     - name: typos
       stage_fixed: true
       run: pixi {run} -e default typos
-
-pre-push:
-  jobs:
     - name: typecheck-python
       glob: "*.{py,pyi}"
       run: pixi {run} -e default typecheck-python
+
+pre-push:
+  jobs:
     - name: cargo-clippy
       glob: "*.rs"
       run: pixi {run} -e default cargo-clippy

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,31 +1,10 @@
 version: 7
 platforms:
 - name: linux-64
-  virtual-packages:
-  - __unix=0=0
-  - __linux=4.18
-  - __glibc=2.28
-  - __archspec=0=x86_64
 - name: linux-aarch64
-  virtual-packages:
-  - __unix=0=0
-  - __linux=4.18
-  - __glibc=2.28
-  - __archspec=0=aarch64
 - name: osx-64
-  virtual-packages:
-  - __unix=0=0
-  - __osx=13.0
-  - __archspec=0=x86_64
 - name: osx-arm64
-  virtual-packages:
-  - __unix=0=0
-  - __osx=13.0
-  - __archspec=0=m1
 - name: win-64
-  virtual-packages:
-  - __win=10.0
-  - __archspec=0=x86_64
 environments:
   backends-release:
     channels:
@@ -246,10 +225,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libcompiler-rt-22.1.3-hb700be7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
@@ -281,7 +256,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mimalloc-3.2.7-h54a6638_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mold-2.40.4-h122c784_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/nodejs-25.6.0-he4ff34a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/patchelf-0.18.0-h3f2d84a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
@@ -295,6 +269,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rpds-py-0.30.0-py314h2e6c369_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.15.10-h7805a7d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
@@ -302,6 +277,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/taplo-0.10.0-h2d22210_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ty-0.0.48-h4e94fc0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/typos-1.43.4-hdab8a38_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zizmor-1.22.0-hb17b654_0.conda
@@ -310,7 +286,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/basedpyright-1.38.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_linux-64-22.1.3-hffcefe0_0.conda
@@ -333,10 +308,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_117.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nodejs-wheel-24.13.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -348,19 +324,23 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.95.0-unix_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.1.14.14-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
@@ -390,10 +370,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.22.2-hfd895c2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_101.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp22.1-22.1.3-default_he95a3c9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libcompiler-rt-22.1.3-hfefdfc9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libcurl-8.19.0-hc57f145_0.conda
@@ -426,7 +402,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mimalloc-3.2.7-h7ac5ae9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mold-2.40.4-h4c4c02a_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/nodejs-25.6.0-hfb02533_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.1-h546c87b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/patchelf-0.18.0-h5ad3122_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
@@ -440,6 +415,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/rhash-1.4.6-h86ecc28_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/rpds-py-0.30.0-py314h02b7a91_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ruff-0.15.10-h9f438e6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/rust-1.95.0-h6cf38e9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/rust_linux-aarch64-1.95.0-hd7b9871_2.conda
@@ -447,6 +423,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/taplo-0.10.0-h3618846_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tbb-2022.3.0-hfefdfc9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/ty-0.0.48-h47ce4e6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/typos-1.43.4-h1ebd7d5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/zizmor-1.22.0-h069e38c_0.conda
@@ -455,7 +432,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/basedpyright-1.38.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_linux-aarch64-22.1.3-hfefdfc9_0.conda
@@ -478,10 +454,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-aarch64-14.3.0-h57c8d61_117.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nodejs-wheel-24.13.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -493,26 +470,29 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.95.0-unix_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-aarch64-unknown-linux-gnu-1.95.0-hbe8e118_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-aarch64-2.28-h585391f_9.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.1.14.14-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       osx-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/basedpyright-1.38.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-19.1.7-h138dee1_1.conda
@@ -532,10 +512,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/macosx_deployment_target_osx-64-13.0-h2830193_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nodejs-wheel-24.13.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -547,19 +528,23 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.95.0-unix_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.95.0-h38e4360_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_6.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.1.14.14-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/actionlint-1.7.10-hd7b282e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
@@ -585,10 +570,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.22.2-h207b36a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ld64-956.6-llvm19_1_hc3792c1_4.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ld64_osx-64-956.6-llvm19_1_hcae3351_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libabseil-20260107.1-cxx17_h7ed6875_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp19.1-19.1.7-default_hd70426c_7.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.19.0-h8f0b9e4_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.0-h19cb2f5_1.conda
@@ -613,7 +594,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-19-19.1.7-h879f4bc_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-19.1.7-hb0207f0_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-64/nodejs-25.6.0-hf3170e9_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/perl-5.32.1-7_h10d778d_perl5.conda
@@ -626,6 +606,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rhash-1.4.6-h6e16a3a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rpds-py-0.30.0-py314ha7b6dee_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/ruamel.yaml.clib-0.2.15-py314hd330473_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ruff-0.15.10-h16586dd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rust-1.95.0-h5655b98_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/rust_osx-64-1.95.0-hce10650_2.conda
@@ -634,6 +615,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/taplo-0.10.0-hffa81eb_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/ty-0.0.48-h479939e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/typos-1.43.4-ha35cfd3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zizmor-1.22.0-ha9c3995_0.conda
@@ -643,7 +625,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/basedpyright-1.38.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-19.1.7-he32a8d3_1.conda
@@ -663,10 +644,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/macosx_deployment_target_osx-arm64-13.0-h95484f9_7.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nodejs-wheel-24.13.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -678,19 +660,23 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.95.0-unix_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.95.0-hf6ec828_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_6.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.1.14.14-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/actionlint-1.7.10-hecf0d97_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
@@ -716,10 +702,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ld64-956.6-llvm19_1_he86490a_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm19_1_ha2625f7_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp19.1-19.1.7-default_hf3020a7_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.19.0-hd5a2499_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
@@ -745,7 +727,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-19-19.1.7-h91fd4e7_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-19.1.7-h855ad52_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/nodejs-25.6.0-hbfc8e16_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/perl-5.32.1-7_h4614cfb_perl5.conda
@@ -758,6 +739,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rhash-1.4.6-h5505292_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rpds-py-0.30.0-py314haad56a0_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.15-py314ha14b1ff_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ruff-0.15.10-hc5c3a1d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rust-1.95.0-h4ff7c5d_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/rust_osx-arm64-1.95.0-h9bac32b_2.conda
@@ -766,6 +748,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/taplo-0.10.0-h2b2570c_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/ty-0.0.48-hdfcc030_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/typos-1.43.4-h748bcf4_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zizmor-1.22.0-h6fdd925_0.conda
@@ -775,7 +758,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/basedpyright-1.38.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
@@ -793,10 +775,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/nodejs-wheel-24.13.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -808,12 +791,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/questionary-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-src-1.95.0-win_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.1.14.14-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
@@ -821,6 +807,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/actionlint-1.7.10-he477eed_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
@@ -846,7 +833,6 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libuv-1.51.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/nodejs-25.6.0-he453025_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pkg-config-0.29.2-h88c491f_1009.conda
@@ -856,12 +842,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/pyyaml-6.0.3-py314h2359020_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/rattler-build-0.65.0-he94b42d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/rpds-py-0.30.0-py314h9f07db2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/ruff-0.15.10-h02f8532_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/shellcheck-0.11.0-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/taplo-0.10.0-h63977a8_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ty-0.0.48-hc21aad4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/typos-1.43.4-h77a83cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
@@ -3906,52 +3894,6 @@ packages:
   license_family: Apache
   size: 264243
   timestamp: 1745264221534
-- conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-  sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
-  md5: 6f7b4302263347698fd24565fbf11310
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - libabseil-static =20260107.1=cxx17*
-  - abseil-cpp =20260107.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1384817
-  timestamp: 1770863194876
-- conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-  sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
-  md5: 72c8fd1af66bd67bf580645b426513ed
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 79965
-  timestamp: 1764017188531
-- conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-  sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
-  md5: 366b40a69f0ad6072561c1d09301c886
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.2.0 hb03c661_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 34632
-  timestamp: 1764017199083
-- conda: https://prefix.dev/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-  sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
-  md5: 4ffbb341c8b616aa2494b6afb26a0c5f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.2.0 hb03c661_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 298378
-  timestamp: 1764017210931
 - conda: https://prefix.dev/conda-forge/linux-64/libclang-cpp21.1-21.1.8-default_h99862b1_4.conda
   sha256: aa61ed39af5944d05cd27672d2b520dbf2b3428575fbc7192acede709bed974a
   md5: 80edae9c0a5feaf93fa2996c266d1ce7
@@ -4520,30 +4462,6 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 891641
   timestamp: 1738195959188
-- conda: https://prefix.dev/conda-forge/linux-64/nodejs-25.6.0-he4ff34a_0.conda
-  sha256: 47087abab5101f40850d682945d247fcbcb5cc6b634acacbb0d8d051da880661
-  md5: c006c24744746dbe28220810f7a247dc
-  depends:
-  - libgcc >=14
-  - __glibc >=2.28,<3.0.a0
-  - libstdcxx >=14
-  - openssl >=3.5.5,<4.0a0
-  - libuv >=1.51.0,<2.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libabseil >=20260107.0,<20260108.0a0
-  - libabseil * cxx17*
-  - c-ares >=1.34.6,<2.0a0
-  - libnghttp2 >=1.67.0,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - icu >=78.2,<79.0a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 18763079
-  timestamp: 1770638788411
 - conda: https://prefix.dev/conda-forge/linux-64/nushell-0.113.0-h25c72ac_0.conda
   sha256: fce4f2e65bd6e63a088e43109d58f0c48fdd9f019c72aae79b0c6b4c6f2211be
   md5: e3c371d67e389b956616bc73d2ae2799
@@ -4952,6 +4870,23 @@ packages:
   license_family: BSD
   size: 3301196
   timestamp: 1769460227866
+- conda: https://prefix.dev/conda-forge/linux-64/ty-0.0.48-h4e94fc0_0.conda
+  noarch: python
+  sha256: 118f4f2093ed7be760f8d8d5358c4a45954a4a8f969b23b48748e7fbc18fcb64
+  md5: 73ece86feebb525a5dce6990a68a765d
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 10266064
+  timestamp: 1781147268979
 - conda: https://prefix.dev/conda-forge/linux-64/typos-1.43.4-hdab8a38_0.conda
   sha256: 44c0381bab8184f008ea8b68087649f54d041bb493770ad1b3dd91aac64243a3
   md5: 02851c243207872444e5f415f17d9691
@@ -5575,48 +5510,6 @@ packages:
   license_family: Apache
   size: 227184
   timestamp: 1745265544057
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
-  sha256: 37675140819e10235a8ff342cb09f688f843ac390b64856d8e230700bbd7d5aa
-  md5: 2a19160c13e688710dd200812fc9a6d3
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - abseil-cpp =20260107.1
-  - libabseil-static =20260107.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1401836
-  timestamp: 1770863223557
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
-  sha256: 5fa8c163c8d776503aa68cdaf798ff9440c76a0a1c3ea84e0c43dbf1ece8af4d
-  md5: 8ec1d03f3000108899d1799d9964f281
-  depends:
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 80030
-  timestamp: 1764017273715
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
-  sha256: 494365e8f58799ea95a6e82334ef696e9c2120aecd6626121694b30a15033301
-  md5: 47e5b71b77bb8b47b4ecf9659492977f
-  depends:
-  - libbrotlicommon 1.2.0 he30d5cf_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 33166
-  timestamp: 1764017282936
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlienc-1.2.0-he30d5cf_1.conda
-  sha256: f998c03257b9aa1f7464446af2cf424862f0e54258a2a588309853e45ae771df
-  md5: 6553a5d017fe14859ea8a4e6ea5def8f
-  depends:
-  - libbrotlicommon 1.2.0 he30d5cf_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 309304
-  timestamp: 1764017292044
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libclang-cpp21.1-21.1.8-default_he95a3c9_4.conda
   sha256: 4aa7c1fc1e6c7dca538fee80fc0eece8aaf7031e2c1c009962719825fba6c0e6
   md5: 2be12f5a030a353c7f8735ebd5b80876
@@ -6139,30 +6032,6 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 926034
   timestamp: 1738196018799
-- conda: https://prefix.dev/conda-forge/linux-aarch64/nodejs-25.6.0-hfb02533_0.conda
-  sha256: 39fcce1ee617636042f203e5e4ec53c87e1e240b8eeecffc97631c33b1e52fab
-  md5: 2661606b4174d7bbf31e60680eec5e6f
-  depends:
-  - libgcc >=14
-  - __glibc >=2.28,<3.0.a0
-  - libstdcxx >=14
-  - icu >=78.2,<79.0a0
-  - c-ares >=1.34.6,<2.0a0
-  - libnghttp2 >=1.67.0,<2.0a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libuv >=1.51.0,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - openssl >=3.5.5,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - libabseil >=20260107.0,<20260108.0a0
-  - libabseil * cxx17*
-  - libsqlite >=3.51.2,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 25099409
-  timestamp: 1770638814190
 - conda: https://prefix.dev/conda-forge/linux-aarch64/nushell-0.113.0-ha2bec05_0.conda
   sha256: eaeabfc2a44d8c996f522e9c135f08c6baaa2b0360841ea3cd1f73206a38ee01
   md5: 56b9cb336e4143f7bb5172f551fe9367
@@ -6550,6 +6419,22 @@ packages:
   license_family: BSD
   size: 3368666
   timestamp: 1769464148928
+- conda: https://prefix.dev/conda-forge/linux-aarch64/ty-0.0.48-h47ce4e6_0.conda
+  noarch: python
+  sha256: 8319317b4f5f2750a02c7c9b838b4899e546c2f2bd3fef04704f0ba466d97153
+  md5: 072e8e5d424ee4307ac0b6e63d3c1199
+  depends:
+  - python
+  - libgcc >=14
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 9783260
+  timestamp: 1781147272175
 - conda: https://prefix.dev/conda-forge/linux-aarch64/typos-1.43.4-h1ebd7d5_0.conda
   sha256: 7c28f3064fe07e03a25005062e0a79dc44ae930371fad9af57314d68f081b00a
   md5: 1ab52f82c30db0ea020b916513d0ffcc
@@ -6795,17 +6680,6 @@ packages:
   license_family: MIT
   size: 143810
   timestamp: 1740887689966
-- conda: https://prefix.dev/conda-forge/noarch/basedpyright-1.38.0-pyhcf101f3_0.conda
-  sha256: a73a082e162657eefa7a23a53e1d41bd2a69073f20d5469b86f9b6767c3236f1
-  md5: 30c466cd5f5b395ca7aec7febed68e1b
-  depends:
-  - python >=3.10
-  - nodejs >=20
-  - nodejs-wheel >=20.13.1
-  - python
-  license: MIT AND Apache-2.0
-  size: 8713313
-  timestamp: 1770856178274
 - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
   sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
   md5: 5267bef8efea4127aacd1f4e1f149b6e
@@ -7633,16 +7507,6 @@ packages:
   license_family: MIT
   size: 14496
   timestamp: 1770589901008
-- conda: https://prefix.dev/conda-forge/noarch/nodejs-wheel-24.13.0-pyhd8ed1ab_0.conda
-  sha256: 0c2a846c81d1d9a6e50d27d812825bd5e09113824b21ca8efabdfca70898adf3
-  md5: 5aa43fffe2258164fa8e4128f915c133
-  depends:
-  - nodejs
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 12528
-  timestamp: 1768440635289
 - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
   sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
   md5: b76541e68fea4d511b1ac46a28dcd2c6
@@ -8802,48 +8666,6 @@ packages:
   license_family: Apache
   size: 248882
   timestamp: 1745264331196
-- conda: https://prefix.dev/conda-forge/osx-64/libabseil-20260107.1-cxx17_h7ed6875_0.conda
-  sha256: 2b4ff36082ddfbacc47ac6e11d4dd9f3403cd109ce8d7f0fbee0cdd47cdef013
-  md5: 317f40d7bd7bf6d54b56d4a5b5f5085d
-  depends:
-  - __osx >=10.13
-  - libcxx >=19
-  constrains:
-  - libabseil-static =20260107.1=cxx17*
-  - abseil-cpp =20260107.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1217836
-  timestamp: 1770863510112
-- conda: https://prefix.dev/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda
-  sha256: 4c19b211b3095f541426d5a9abac63e96a5045e509b3d11d4f9482de53efe43b
-  md5: f157c098841474579569c85a60ece586
-  depends:
-  - __osx >=10.13
-  license: MIT
-  license_family: MIT
-  size: 78854
-  timestamp: 1764017554982
-- conda: https://prefix.dev/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda
-  sha256: 729158be90ae655a4e0427fe4079767734af1f9b69ff58cf94ca6e8d4b3eb4b7
-  md5: 63186ac7a8a24b3528b4b14f21c03f54
-  depends:
-  - __osx >=10.13
-  - libbrotlicommon 1.2.0 h8616949_1
-  license: MIT
-  license_family: MIT
-  size: 30835
-  timestamp: 1764017584474
-- conda: https://prefix.dev/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda
-  sha256: 8ece7b41b6548d6601ac2c2cd605cf2261268fc4443227cc284477ed23fbd401
-  md5: 12a58fd3fc285ce20cf20edf21a0ff8f
-  depends:
-  - __osx >=10.13
-  - libbrotlicommon 1.2.0 h8616949_1
-  license: MIT
-  license_family: MIT
-  size: 310355
-  timestamp: 1764017609985
 - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp19.1-19.1.7-default_hd70426c_7.conda
   sha256: 3e8588828d2586722328ea39a7cf48c50a32f7661b55299075741ef7c8875ad5
   md5: b671ac86f33848f3bc3a6066d21c37dd
@@ -9349,29 +9171,6 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 822259
   timestamp: 1738196181298
-- conda: https://prefix.dev/conda-forge/osx-64/nodejs-25.6.0-hf3170e9_0.conda
-  sha256: e9f5e03bb6a897a5aee9cca7dd8c4bb3499e550ef2452b86dbbe8dcbdb95ac9f
-  md5: ae71bd5936cbcb23662e6f9ff6dc6e8f
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libuv >=1.51.0,<2.0a0
-  - libabseil >=20260107.0,<20260108.0a0
-  - libabseil * cxx17*
-  - libzlib >=1.3.1,<2.0a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - openssl >=3.5.5,<4.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - c-ares >=1.34.6,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - icu >=78.2,<79.0a0
-  - libnghttp2 >=1.67.0,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 18240518
-  timestamp: 1770638761598
 - conda: https://prefix.dev/conda-forge/osx-64/nushell-0.113.0-h03e26d9_0.conda
   sha256: cc15d56ead50c06734c188235bce720e49c558c3ae21dc13e11ce1a9f276b9b9
   md5: baac0411419c6f5e80452407f9bb74ed
@@ -9742,6 +9541,22 @@ packages:
   license_family: BSD
   size: 3282953
   timestamp: 1769460532442
+- conda: https://prefix.dev/conda-forge/osx-64/ty-0.0.48-h479939e_0.conda
+  noarch: python
+  sha256: 8d6dc0a4d17e9d583d6049d754d5abb40adb0d6396c28edacb1a9872c92d565f
+  md5: 52526a07c27123e6da44249999a00cec
+  depends:
+  - python
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 9927971
+  timestamp: 1781147670272
 - conda: https://prefix.dev/conda-forge/osx-64/typos-1.43.4-ha35cfd3_0.conda
   sha256: 6d0ed4aaef2fcc147d18e168357d0a36f21d960af9c8142914935b35818bd4d8
   md5: fd1c4b268465dc747e8dc7700750ef56
@@ -10282,48 +10097,6 @@ packages:
   license_family: Apache
   size: 188306
   timestamp: 1745264362794
-- conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-  sha256: 756611fbb8d2957a5b4635d9772bd8432cb6ddac05580a6284cca6fdc9b07fca
-  md5: bb65152e0d7c7178c0f1ee25692c9fd1
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  constrains:
-  - abseil-cpp =20260107.1
-  - libabseil-static =20260107.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1229639
-  timestamp: 1770863511331
-- conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
-  sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
-  md5: 006e7ddd8a110771134fcc4e1e3a6ffa
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 79443
-  timestamp: 1764017945924
-- conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
-  sha256: 2eae444039826db0454b19b52a3390f63bfe24f6b3e63089778dd5a5bf48b6bf
-  md5: 079e88933963f3f149054eec2c487bc2
-  depends:
-  - __osx >=11.0
-  - libbrotlicommon 1.2.0 hc919400_1
-  license: MIT
-  license_family: MIT
-  size: 29452
-  timestamp: 1764017979099
-- conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
-  sha256: 01436c32bb41f9cb4bcf07dda647ce4e5deb8307abfc3abdc8da5317db8189d1
-  md5: b2b7c8288ca1a2d71ff97a8e6a1e8883
-  depends:
-  - __osx >=11.0
-  - libbrotlicommon 1.2.0 hc919400_1
-  license: MIT
-  license_family: MIT
-  size: 290754
-  timestamp: 1764018009077
 - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp19.1-19.1.7-default_hf3020a7_7.conda
   sha256: 89b8aed26ef89c9e56939d1acefa91ecf2e198923bfcc41f116c0de42ce869cb
   md5: 5600ae1b88144099572939e773f4b20b
@@ -10851,29 +10624,6 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 797030
   timestamp: 1738196177597
-- conda: https://prefix.dev/conda-forge/osx-arm64/nodejs-25.6.0-hbfc8e16_0.conda
-  sha256: c38aa92663709f65c7010f81bd8f65081314065003fd1c861b800dfaf2ffd4fe
-  md5: 7e46a14f9d8d29db1181301b3a2ff539
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  - libnghttp2 >=1.67.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libabseil >=20260107.0,<20260108.0a0
-  - libabseil * cxx17*
-  - zstd >=1.5.7,<1.6.0a0
-  - libuv >=1.51.0,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - c-ares >=1.34.6,<2.0a0
-  - icu >=78.2,<79.0a0
-  license: MIT
-  license_family: MIT
-  size: 17245453
-  timestamp: 1770638770471
 - conda: https://prefix.dev/conda-forge/osx-arm64/nushell-0.113.0-h4226ba7_0.conda
   sha256: 0b0c87afc44ae78400551dffa92ee6c7be9efc720bd39cfa32aa7ce18c9a89cc
   md5: 09b0da788ec57f5029da21dc3cd5ba39
@@ -11249,6 +10999,22 @@ packages:
   license_family: BSD
   size: 3127137
   timestamp: 1769460817696
+- conda: https://prefix.dev/conda-forge/osx-arm64/ty-0.0.48-hdfcc030_0.conda
+  noarch: python
+  sha256: 14c858f2af130cd7780ac74a8cfe2fe017157c856658651e6dff8858bece40df
+  md5: af47ba01190cc77582d95417548d6173
+  depends:
+  - python
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 9231191
+  timestamp: 1781147605886
 - conda: https://prefix.dev/conda-forge/osx-arm64/typos-1.43.4-h748bcf4_0.conda
   sha256: 1be40812241856c49e34bc9cc918451154328e3d920e7b7e082bdee6f63b4421
   md5: 55fad43887a49072e65397d36624f9ae
@@ -12037,13 +11803,6 @@ packages:
     - libzlib >=1.3.2,<2.0a0
   size: 58347
   timestamp: 1774072851498
-- conda: https://prefix.dev/conda-forge/win-64/nodejs-25.6.0-he453025_0.conda
-  sha256: 94576d4a299906d5c70433651064b99cf4acf66227a1bf54321211a9ecd01fb1
-  md5: ab691b6dad3762d3580ff42752fd38cf
-  license: MIT
-  license_family: MIT
-  size: 31092662
-  timestamp: 1770638766628
 - conda: https://prefix.dev/conda-forge/win-64/nushell-0.113.0-he61bdd1_0.conda
   sha256: eda4c1318bdd7c5c6d733dd6bf1158929d2d7f09a2fd29d45bd8aceaec05bee2
   md5: 6bfa9f4f2df04f411ff061786a8e176d
@@ -12381,6 +12140,22 @@ packages:
   license_family: BSD
   size: 3526350
   timestamp: 1769460339384
+- conda: https://prefix.dev/conda-forge/win-64/ty-0.0.48-hc21aad4_0.conda
+  noarch: python
+  sha256: 1bedcbd4ecef13b6b50a213793e03b68b2a6638ec8767380c54486da98b048dc
+  md5: fc7bea0076528c486cf660cf0dbddbf0
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 10342777
+  timestamp: 1781147616723
 - conda: https://prefix.dev/conda-forge/win-64/typos-1.43.4-h77a83cd_0.conda
   sha256: cb084c97414f92d0b47e449be08e68cdb2e1ef53b931c04144ac9db6c4e21c6f
   md5: 1db9b622b06557e1ebce63e8abcf44cb

--- a/pixi.toml
+++ b/pixi.toml
@@ -68,11 +68,18 @@ RUSTC_WRAPPER = "sccache"
 
 [feature.backends-release.dependencies]
 gh = ">=2,<3"
-questionary = ">=2.1,<3"
 rattler-build = ">=0.65,<0.66"
+sccache = ">=0.15,<0.16"
+
+#
+# Python packages imported by scripts/release_backends.py. Kept in their own
+# feature so the type checker can resolve them without pulling in the build
+# tooling from the backends-release feature.
+#
+[feature.backends-release-deps.dependencies]
+questionary = ">=2.1,<3"
 rich = ">=15,<16"
 "ruamel.yaml" = ">=0.19,<0.20"
-sccache = ">=0.15,<0.16"
 tomlkit = ">=0.15,<0.16"
 
 [feature.backends-release.tasks]
@@ -169,7 +176,6 @@ mike-serve = { cmd = "mike serve", description = "Serve versioned docs with mike
 #
 [feature.lint.dependencies]
 actionlint = ">=1.7.7,<2"
-basedpyright = ">=1.31.6,<2"
 cargo-deny = ">=0.19,<0.19.9" # 0.18.5 breaks license checking for uv crates
 cargo-shear = ">=1.7.1,<2"
 dprint = ">=0.49.1,<0.51"
@@ -179,6 +185,7 @@ shellcheck = ">=0.11,<0.12"
 taplo = ">=0.10.0,<0.11"
 typos = ">=1.38.1,<2"
 zizmor = ">=1.18.0,<2"
+ty = ">=0.0.48,<0.0.49"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086" }, description = "Lint GitHub Actions workflows" }
@@ -194,7 +201,7 @@ ruff-lint = { cmd = "ruff check --fix --exit-non-zero-on-fix --force-exclude", d
 shell-fmt = { cmd = "shfmt --write --indent=4 --simplify --binary-next-line", description = "Format shell scripts" }
 toml-fmt = { cmd = "taplo fmt", env = { RUST_LOG = "warn" }, description = "Format TOML files" }
 toml-lint = { cmd = "taplo lint --verbose **/pixi.toml", description = "Lint TOML files" }
-typecheck-python = { cmd = "basedpyright", description = "Type check Python code" }
+typecheck-python = { cmd = "ty check", description = "Type check Python code" }
 typos = { cmd = "typos --force-exclude", description = "Check for typos" }
 zizmor = { cmd = "zizmor .github/ --min-severity=medium", description = "Security audit GitHub Actions" }
 
@@ -392,6 +399,7 @@ pre-commit-install-minimal = { cmd = "lefthook install pre-commit", description 
 [environments]
 backends-release = { features = [
   "backends-release",
+  "backends-release-deps",
   "python",
 ], solve-group = "python" }
 default = { features = [
@@ -402,6 +410,7 @@ default = { features = [
   "dev",
   "lint",
   "schema",
+  "backends-release-deps",
 ], solve-group = "python" }
 dist = { features = ["dist"] }
 # TODO: get rid of rust in the docs env, figure out what to do with the docs generation code.

--- a/pixi.toml
+++ b/pixi.toml
@@ -183,9 +183,9 @@ go-shfmt = ">=3.12.0,<4"
 ruff = ">=0.15.10,<0.16"
 shellcheck = ">=0.11,<0.12"
 taplo = ">=0.10.0,<0.11"
+ty = ">=0.0.48,<0.0.49"
 typos = ">=1.38.1,<2"
 zizmor = ">=1.18.0,<2"
-ty = ">=0.0.48,<0.0.49"
 
 [feature.lint.tasks]
 actionlint = { cmd = "actionlint", env = { SHELLCHECK_OPTS = "-e SC2086" }, description = "Lint GitHub Actions workflows" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,8 @@ name = "candidate"
 default = ""
 
 [tool.ty.environment]
-python-version = "3.13"
 python-platform = "all"
+python-version = "3.13"
 
 [tool.ty.src]
 exclude = [
@@ -126,5 +126,5 @@ exclude = [
 include = ["docs/**", "examples/**"]
 
 [tool.ty.overrides.rules]
-unresolved-import = "ignore"
 unresolved-attribute = "ignore"
+unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,12 @@ name = "candidate"
 # the default value to use, if there is no match
 default = ""
 
-[tool.basedpyright]
-ignore = [
+[tool.ty.environment]
+python-version = "3.13"
+python-platform = "all"
+
+[tool.ty.src]
+exclude = [
   "**/*.ipynb",
   "**/docs_hooks.py",
   "scripts/test_native_certs.py",
@@ -114,16 +118,13 @@ ignore = [
   "target",
   "pytest-temp",
 ]
-pythonPlatform = "All"
-pythonVersion = "3.13"
-typeCheckingMode = "all"
 
-reportAny = false
-reportExplicitAny = false
-reportUnnecessaryIsInstance = false
-reportUnusedCallResult = false
+# The docs and examples snippets import third-party packages that are not part
+# of the type-checking environment, so their unresolved imports and the
+# follow-on attribute errors are not actionable here.
+[[tool.ty.overrides]]
+include = ["docs/**", "examples/**"]
 
-executionEnvironments = [
-  { root = "docs", reportMissingImports = false, reportMissingModuleSource = false, reportUnknownVariableType = false, reportUnknownMemberType = false, reportUnusedCallResult = false, reportUnknownArgumentType = false },
-  { root = "examples", reportMissingImports = false, reportMissingModuleSource = false, reportCallIssue = false, reportArgumentType = false, reportAttributeAccessIssue = false, reportUnknownMemberType = false, reportUnknownVariableType = false, reportUnknownParameterType = false, reportUnknownArgumentType = false, reportUnusedCallResult = false, reportMissingParameterType = false, reportUntypedFunctionDecorator = false },
-]
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"
+unresolved-attribute = "ignore"

--- a/schema/model.py
+++ b/schema/model.py
@@ -7,7 +7,7 @@ import json
 from copy import deepcopy
 from pathlib import Path
 import tomllib
-from typing import Annotated, Any, Literal, ClassVar, override, TYPE_CHECKING
+from typing import Annotated, Any, Literal, ClassVar, cast, override, TYPE_CHECKING
 from enum import Enum
 
 from pydantic import (
@@ -1350,7 +1350,7 @@ class SchemaJsonEncoder(json.JSONEncoder):
     def encode(self, o: object):
         """Overload the default ``encode`` behavior."""
         if isinstance(o, dict):
-            o = self.normalize_schema(deepcopy(o))  # pyright: ignore[reportUnknownArgumentType]
+            o = self.normalize_schema(cast("dict[str, Any]", deepcopy(o)))
 
         return super().encode(o)
 
@@ -1419,7 +1419,7 @@ class SchemaJsonEncoder(json.JSONEncoder):
         if key not in obj or not isinstance(obj[key], dict):
             return obj
         obj[key] = {
-            k: self.normalize_schema(v) if isinstance(v, dict) else v  # pyright: ignore[reportUnknownArgumentType]
+            k: self.normalize_schema(v) if isinstance(v, dict) else v
             for k, v in sorted(obj[key].items(), key=lambda kv: kv[0])
         }
         return obj

--- a/schema/test_manifest.py
+++ b/schema/test_manifest.py
@@ -184,12 +184,12 @@ def test_real_manifests(
 
 
 def test_gh_1089_fastjsonschema(manifest_schemata: TRawSchemata) -> None:
-    import fastjsonschema  # pyright: ignore [reportMissingTypeStubs]
+    import fastjsonschema
 
     for manifest_name, schemata in manifest_schemata.items():
         for schema_name, schema in schemata.items():
             print(manifest_name, schema_name)
-            fastjsonschema.compile(schema)  # pyright: ignore [reportUnknownMemberType]
+            fastjsonschema.compile(schema)
 
 
 def test_gh_1089_python_jsonschema(manifest_schemata: TRawSchemata) -> None:

--- a/scripts/release_backends.py
+++ b/scripts/release_backends.py
@@ -16,12 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import questionary  # pyright: ignore[reportMissingImports]
-import tomlkit  # pyright: ignore[reportMissingImports]
+import questionary
+import tomlkit
 from rich.console import Console
 from rich.prompt import Confirm
 from rich.table import Table
-from ruamel.yaml import YAML  # pyright: ignore[reportMissingImports,reportUnknownVariableType]
+from ruamel.yaml import YAML
 
 UPSTREAM_REPO = "prefix-dev/pixi"
 USE_JJ = Path(".jj").is_dir()
@@ -135,8 +135,8 @@ def load_backends() -> list[Backend]:
 
 
 def get_version(path: Path, table: str = "package") -> str:
-    doc = tomlkit.parse(path.read_text())  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-    version = doc[table]["version"]  # pyright: ignore[reportUnknownVariableType]
+    doc = tomlkit.parse(path.read_text())
+    version = doc[table]["version"]
     if not isinstance(version, str):
         raise ValueError(f"Could not find version in {path}")
     return version
@@ -154,9 +154,9 @@ def bump_version(version: str, bump_type: str) -> str:
 
 
 def set_version(path: Path, new_version: str, table: str = "package") -> None:
-    doc = tomlkit.parse(path.read_text())  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    doc = tomlkit.parse(path.read_text())
     doc[table]["version"] = new_version
-    path.write_text(tomlkit.dumps(doc))  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+    path.write_text(tomlkit.dumps(doc))
 
 
 def run(cmd: list[str]) -> None:
@@ -238,16 +238,16 @@ def _ask(question: Any) -> Any:
 
 
 def select(message: str, choices: list[str], default: str | None = None) -> str:
-    result: str = _ask(questionary.select(message, choices=choices, default=default))  # pyright: ignore[reportUnknownMemberType]
+    result: str = _ask(questionary.select(message, choices=choices, default=default))
     return result
 
 
 def checkbox(message: str, backends: list[Backend]) -> list[Backend]:
     choices: list[Any] = [
-        questionary.Choice(f"{b.binary} v{b.version}", value=i, checked=True)  # pyright: ignore[reportUnknownMemberType]
+        questionary.Choice(f"{b.binary} v{b.version}", value=i, checked=True)
         for i, b in enumerate(backends)
     ]
-    selected_indices: list[int] = _ask(questionary.checkbox(message, choices=choices))  # pyright: ignore[reportUnknownMemberType]
+    selected_indices: list[int] = _ask(questionary.checkbox(message, choices=choices))
     return [backends[i] for i in selected_indices]
 
 
@@ -267,10 +267,10 @@ def get_latest_tag_version(binary: str) -> str | None:
 
 def get_feedstock_version(clone_dir: Path) -> str:
     """Read the version from a feedstock's recipe.yaml."""
-    yaml = YAML()  # pyright: ignore[reportUnknownVariableType]
-    data = yaml.load(clone_dir / "recipe" / "recipe.yaml")  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-    version: str = data["context"]["version"]  # pyright: ignore[reportUnknownVariableType]
-    return version  # pyright: ignore[reportUnknownVariableType]
+    yaml = YAML()
+    data = yaml.load(clone_dir / "recipe" / "recipe.yaml")
+    version: str = data["context"]["version"]
+    return version
 
 
 def compute_tarball_sha256(tag: str) -> str:
@@ -288,13 +288,13 @@ def compute_tarball_sha256(tag: str) -> str:
 
 def update_feedstock_recipe(recipe_path: Path, new_version: str, sha256: str) -> None:
     """Update version, sha256, and build number in a feedstock recipe."""
-    yaml = YAML()  # pyright: ignore[reportUnknownVariableType]
+    yaml = YAML()
     yaml.preserve_quotes = True
-    data = yaml.load(recipe_path)  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
+    data = yaml.load(recipe_path)
     data["context"]["version"] = new_version
     data["source"]["sha256"] = sha256
     data["build"]["number"] = 0
-    yaml.dump(data, recipe_path)  # pyright: ignore[reportUnknownMemberType]
+    yaml.dump(data, recipe_path)
 
 
 def run_in_dir(cmd: list[str], cwd: Path) -> None:

--- a/tests/data/run_signals/test.py
+++ b/tests/data/run_signals/test.py
@@ -1,5 +1,3 @@
-# pyright: basic
-
 import sys
 import signal
 import time

--- a/tests/integration_python/pixi_build/conftest.py
+++ b/tests/integration_python/pixi_build/conftest.py
@@ -21,7 +21,7 @@ def simple_workspace(
     request: pytest.FixtureRequest,
 ) -> Workspace:
     """Create a simple workspace for build tests."""
-    name: str = request.node.name  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+    name: str = request.node.name
 
     # Make sure the tmp workspace is cleared before each test
     # This is important for windows where we might have issues with file locks if we try to delete after the test

--- a/tests/integration_python/pixi_build/test_conditional_dependencies.py
+++ b/tests/integration_python/pixi_build/test_conditional_dependencies.py
@@ -25,14 +25,17 @@ def write_workspace(
     build_variants: dict[str, list[str]] | None = None,
 ) -> Path:
     """Write a workspace manifest with a source package using `pixi-build-cmake`."""
+    workspace: dict[str, Any] = {
+        # The channel also contains stub `cmake` and `ninja` packages for
+        # the build environment of the backend, locking stays offline.
+        "channels": [channel],
+        "platforms": platforms,
+        "preview": ["pixi-build"],
+    }
+    if build_variants is not None:
+        workspace["build-variants"] = build_variants
     manifest: dict[str, Any] = {
-        "workspace": {
-            # The channel also contains stub `cmake` and `ninja` packages for
-            # the build environment of the backend, locking stays offline.
-            "channels": [channel],
-            "platforms": platforms,
-            "preview": ["pixi-build"],
-        },
+        "workspace": workspace,
         "dependencies": {PACKAGE_NAME: {"path": "."}},
         "package": {
             "name": PACKAGE_NAME,
@@ -45,8 +48,6 @@ def write_workspace(
             "run-dependencies": run_dependencies,
         },
     }
-    if build_variants is not None:
-        manifest["workspace"]["build-variants"] = build_variants
     manifest_path = workspace_dir.joinpath("pixi.toml")
     manifest_path.write_text(tomli_w.dumps(manifest))
     return manifest_path

--- a/tests/integration_python/test_workspace_platform.py
+++ b/tests/integration_python/test_workspace_platform.py
@@ -24,13 +24,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 from .common import CURRENT_PLATFORM, ExitCode, verify_cli_command
-
-try:
-    import yaml  # type: ignore[import-untyped]
-except ImportError:
-    yaml = None
 
 
 # ----------------------------------------------------------------------------
@@ -70,8 +66,6 @@ def _platforms_from_toml(manifest: Path) -> list[str | dict[str, Any]]:
 
 def _lockfile_platforms(workspace_dir: Path) -> list[str | dict[str, Any]]:
     """Read the `platforms:` block at the top of `pixi.lock`."""
-    if yaml is None:
-        pytest.skip("PyYAML not available; lockfile-shape tests need it")
     lock = workspace_dir / "pixi.lock"
     assert lock.exists(), f"expected lockfile at {lock}"
     data = yaml.safe_load(lock.read_text())

--- a/tests/wheel_tests/conftest.py
+++ b/tests/wheel_tests/conftest.py
@@ -1,5 +1,3 @@
-# pyright: reportUnusedParameter=false
-
 from pathlib import Path
 from typing import Any
 


### PR DESCRIPTION
I got annoyed with the slowness of basedpyright and it's lacking inference.

With `ty` everything is fast and infers most things, sometimes even without proper type hints.

Typecheck is therefore now a fast lint!