### PR TITLE
perf: parallelize lockfile source pypi and conda satisfiability checks

### DIFF
--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -265,6 +265,12 @@ async fn find_unsatisfiable_targets<'p>(
 
     let project_config = project.config();
 
+    // First pass: run the cheap, synchronous environment-level checks for
+    // every environment up front. Environments whose platforms still need
+    // verifying are collected so that the expensive per-platform verification
+    // can run concurrently across *all* environments, instead of completing
+    // one environment's platforms before starting the next.
+    let mut environments_to_verify = Vec::new();
     for environment in project.environments() {
         let platforms = environment.platforms();
 
@@ -359,11 +365,21 @@ async fn find_unsatisfiable_targets<'p>(
             }
         }
 
-        // Verify each individual platform in parallel
-        let mut platform_futures = CancellationAwareFutures::new(command_dispatcher.executor());
+        environments_to_verify.push((environment, locked_environment, platforms));
+    }
+
+    // Second pass: verify every (environment, platform) pair concurrently.
+    // Platform verification is largely IO-bound (resolving source records
+    // against build backends, building PyPI metadata, ...) and each pair is
+    // independent, so we batch them all into a single set of futures rather
+    // than draining one environment's platforms before starting the next.
+    // The shared `build_caches` / `static_metadata_cache` are `DashMap`s, so
+    // concurrent access across environments is safe.
+    let mut platform_futures = CancellationAwareFutures::new(command_dispatcher.executor());
+    for (environment, locked_environment, platforms) in &environments_to_verify {
         for platform in platforms {
             let ctx = VerifySatisfiabilityContext {
-                environment: &environment,
+                environment,
                 command_dispatcher: command_dispatcher.clone(),
                 platform: platform.clone(),
                 project_root: project.root(),
@@ -374,60 +390,69 @@ async fn find_unsatisfiable_targets<'p>(
                 static_metadata_cache: &static_metadata_cache,
                 resolver,
             };
+            let locked_environment = *locked_environment;
             platform_futures.push(async move {
                 let result = verify_platform_satisfiability(&ctx, locked_environment).await;
-                Ok::<_, CommandDispatcherError<std::convert::Infallible>>((platform, result))
+                Ok::<_, CommandDispatcherError<std::convert::Infallible>>((
+                    environment,
+                    platform.clone(),
+                    result,
+                ))
             });
         }
+    }
 
-        // Collect all platform results
-        while let Some(result) = platform_futures.next().await {
-            match result {
-                Ok((platform, outcome)) => {
-                    match outcome {
-                        Ok((verified_env, locked_pypi)) => {
-                            verified_environments
-                                .insert((environment.clone(), platform.clone()), verified_env);
-                            locked_pypi_by_env_platform
-                                .insert((environment.clone(), platform), locked_pypi);
-                        }
-                        Err(CommandDispatcherError::Cancelled) => {
-                            // Cancellation is handled by CancellationAwareFutures;
-                            // remaining platforms will be skipped automatically.
-                        }
-                        Err(CommandDispatcherError::Failed(unsat)) if unsat.is_pypi_only() => {
-                            tracing::info!(
-                                "the pypi dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
-                                environment.name().fancy_display()
-                            );
+    // Collect all platform results
+    while let Some(result) = platform_futures.next().await {
+        match result {
+            Ok((environment, platform, outcome)) => {
+                match outcome {
+                    Ok((verified_env, locked_pypi)) => {
+                        verified_environments
+                            .insert((environment.clone(), platform.clone()), verified_env);
+                        locked_pypi_by_env_platform
+                            .insert((environment.clone(), platform), locked_pypi);
+                    }
+                    Err(CommandDispatcherError::Cancelled) => {
+                        // Cancellation is handled by CancellationAwareFutures;
+                        // remaining platforms will be skipped automatically.
+                    }
+                    Err(CommandDispatcherError::Failed(unsat)) if unsat.is_pypi_only() => {
+                        tracing::info!(
+                            "the pypi dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
+                            environment.name().fancy_display()
+                        );
 
-                            unsatisfiable_targets
-                                .outdated_pypi
-                                .entry(environment.clone())
-                                .or_default()
-                                .insert(platform);
-                        }
-                        Err(CommandDispatcherError::Failed(unsat)) => {
-                            tracing::info!(
-                                "the dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
-                                environment.name().fancy_display()
-                            );
+                        unsatisfiable_targets
+                            .outdated_pypi
+                            .entry(environment.clone())
+                            .or_default()
+                            .insert(platform);
+                    }
+                    Err(CommandDispatcherError::Failed(unsat)) => {
+                        tracing::info!(
+                            "the dependencies of environment '{0}' for platform {platform} are out of date because {unsat}",
+                            environment.name().fancy_display()
+                        );
 
-                            unsatisfiable_targets
-                                .outdated_conda
-                                .entry(environment.clone())
-                                .or_default()
-                                .insert(platform);
-                        }
+                        unsatisfiable_targets
+                            .outdated_conda
+                            .entry(environment.clone())
+                            .or_default()
+                            .insert(platform);
                     }
                 }
-                Err(CommandDispatcherError::Cancelled) => {
-                    unreachable!("platform task cannot cancel")
-                }
-                Err(CommandDispatcherError::Failed(_)) => unreachable!("platform task cannot fail"),
             }
+            Err(CommandDispatcherError::Cancelled) => {
+                unreachable!("platform task cannot cancel")
+            }
+            Err(CommandDispatcherError::Failed(_)) => unreachable!("platform task cannot fail"),
         }
     }
+
+    // Drop the drained futures so the borrows they held on the shared caches
+    // are released before those caches are moved into the return value below.
+    drop(platform_futures);
 
     // Verify grouped environments
     for solve_group in project.solve_groups() {

--- a/crates/pixi_core/src/lock_file/outdated.rs
+++ b/crates/pixi_core/src/lock_file/outdated.rs
@@ -265,11 +265,8 @@ async fn find_unsatisfiable_targets<'p>(
 
     let project_config = project.config();
 
-    // First pass: run the cheap, synchronous environment-level checks for
-    // every environment up front. Environments whose platforms still need
-    // verifying are collected so that the expensive per-platform verification
-    // can run concurrently across *all* environments, instead of completing
-    // one environment's platforms before starting the next.
+    // First pass: cheap synchronous environment-level checks. Collect the
+    // environments whose platforms still need verifying.
     let mut environments_to_verify = Vec::new();
     for environment in project.environments() {
         let platforms = environment.platforms();
@@ -369,12 +366,8 @@ async fn find_unsatisfiable_targets<'p>(
     }
 
     // Second pass: verify every (environment, platform) pair concurrently.
-    // Platform verification is largely IO-bound (resolving source records
-    // against build backends, building PyPI metadata, ...) and each pair is
-    // independent, so we batch them all into a single set of futures rather
-    // than draining one environment's platforms before starting the next.
-    // The shared `build_caches` / `static_metadata_cache` are `DashMap`s, so
-    // concurrent access across environments is safe.
+    // Each pair is independent and IO-bound, and the shared caches are
+    // `DashMap`s, so a single batch is safe and overlaps across environments.
     let mut platform_futures = CancellationAwareFutures::new(command_dispatcher.executor());
     for (environment, locked_environment, platforms) in &environments_to_verify {
         for platform in platforms {
@@ -450,8 +443,7 @@ async fn find_unsatisfiable_targets<'p>(
         }
     }
 
-    // Drop the drained futures so the borrows they held on the shared caches
-    // are released before those caches are moved into the return value below.
+    // Release the futures' borrows on the shared caches before moving them out.
     drop(platform_futures);
 
     // Verify grouped environments

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -246,9 +246,9 @@ pub async fn verify_platform_satisfiability(
     // the same env the solver previously chose. Failures emit a
     // specific [`PlatformUnsat`] variant carrying the offending spec
     // so re-locking is forced with informative diagnostics.
-    // Records needing a backend check are independent and IO-bound (each
-    // contacts the build backend), so resolve them concurrently and
-    // reassemble in the original order.
+    //
+    // Backend checks are independent and IO-bound, so run them concurrently
+    // and reassemble in the original order.
     let mut resolve_futures = CancellationAwareFutures::new(ctx.command_dispatcher.executor());
     for (index, record) in unresolved_records.into_iter().enumerate() {
         let platform_setup = &platform_setup;

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -246,51 +246,67 @@ pub async fn verify_platform_satisfiability(
     // the same env the solver previously chose. Failures emit a
     // specific [`PlatformUnsat`] variant carrying the offending spec
     // so re-locking is forced with informative diagnostics.
-    let mut resolved_records = Vec::new();
-    for record in unresolved_records {
-        match record {
-            UnresolvedPixiRecord::Binary(record) => {
-                resolved_records.push(PixiRecord::Binary(record))
-            }
-            UnresolvedPixiRecord::Source(record) => {
-                let needs_backend_check = record.data.is_partial() || record.has_mutable_source();
-                if needs_backend_check {
-                    // Partial records carry no version/build material in
-                    // the lock file, so they must be resolved from the
-                    // backend. Mutable sources (path-based, or with a
-                    // path-based build source) must also re-evaluate via
-                    // the backend because the manifest can change without
-                    // any lock file-visible signal -- there is no
-                    // content-pinned identifier we can use to detect
-                    // edits to e.g. host-dependencies. Skipping the
-                    // backend here would silently accept stale lock files.
-                    let resolved =
-                        verify_partial_source_record_against_backend(ctx, &platform_setup, &record)
-                            .await?;
-                    resolved_records.push(PixiRecord::Source(resolved));
-                } else {
-                    // Fully immutable + full record: the source is
-                    // content-pinned (git commit / url+sha), so the
-                    // backend cannot tell us anything we can't already
-                    // read off the locked record. Trust the locked
-                    // metadata as-is and avoid contacting the backend
-                    // (which would otherwise require it to be available
-                    // just to pass satisfiability).
-                    let full_record =
-                        Arc::unwrap_or_clone(record).try_map_data(|data| match data {
-                            SourceRecordData::Full(data) => Ok(data),
-                            SourceRecordData::Partial(p) => Err(p),
-                        });
-                    match full_record {
-                        Ok(full) => resolved_records.push(PixiRecord::Source(Arc::new(full))),
-                        Err(_) => {
-                            unreachable!("guarded by `data.is_partial()` check above")
+    // Records needing a backend check are independent and IO-bound (each
+    // contacts the build backend), so resolve them concurrently and
+    // reassemble in the original order.
+    let mut resolve_futures = CancellationAwareFutures::new(ctx.command_dispatcher.executor());
+    for (index, record) in unresolved_records.into_iter().enumerate() {
+        let platform_setup = &platform_setup;
+        resolve_futures.push(async move {
+            let resolved = match record {
+                UnresolvedPixiRecord::Binary(record) => PixiRecord::Binary(record),
+                UnresolvedPixiRecord::Source(record) => {
+                    let needs_backend_check =
+                        record.data.is_partial() || record.has_mutable_source();
+                    if needs_backend_check {
+                        // Partial records carry no version/build material in
+                        // the lock file, so they must be resolved from the
+                        // backend. Mutable sources (path-based, or with a
+                        // path-based build source) must also re-evaluate via
+                        // the backend because the manifest can change without
+                        // any lock file-visible signal -- there is no
+                        // content-pinned identifier we can use to detect
+                        // edits to e.g. host-dependencies. Skipping the
+                        // backend here would silently accept stale lock files.
+                        let resolved = verify_partial_source_record_against_backend(
+                            ctx,
+                            platform_setup,
+                            &record,
+                        )
+                        .await?;
+                        PixiRecord::Source(resolved)
+                    } else {
+                        // Fully immutable + full record: the source is
+                        // content-pinned (git commit / url+sha), so the
+                        // backend cannot tell us anything we can't already
+                        // read off the locked record. Trust the locked
+                        // metadata as-is and avoid contacting the backend
+                        // (which would otherwise require it to be available
+                        // just to pass satisfiability).
+                        let full_record =
+                            Arc::unwrap_or_clone(record).try_map_data(|data| match data {
+                                SourceRecordData::Full(data) => Ok(data),
+                                SourceRecordData::Partial(p) => Err(p),
+                            });
+                        match full_record {
+                            Ok(full) => PixiRecord::Source(Arc::new(full)),
+                            Err(_) => {
+                                unreachable!("guarded by `data.is_partial()` check above")
+                            }
                         }
                     }
                 }
-            }
-        }
+            };
+            Ok::<_, CommandDispatcherError<Box<PlatformUnsat>>>((index, resolved))
+        });
     }
+
+    let mut indexed_records: Vec<(usize, PixiRecord)> = resolve_futures.try_collect().await?;
+    indexed_records.sort_by_key(|(index, _)| *index);
+    let resolved_records: Vec<PixiRecord> = indexed_records
+        .into_iter()
+        .map(|(_, record)| record)
+        .collect();
 
     // Create a lookup table from package name to package record. Returns an error
     // if we find a duplicate entry for a record

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -412,9 +412,8 @@ pub(super) async fn lock_pypi_packages(
     unresolved_pypi_environment: &PypiRecordsByName,
     building_pixi_records: Result<PixiRecordsByName, PlatformUnsat>,
 ) -> Result<LockedPypiRecordsByName, CommandDispatcherError<Box<PlatformUnsat>>> {
-    // Reading local package metadata can drive a build backend, so each
-    // local-directory record is independent and IO-bound. Resolve them
-    // concurrently and reassemble in the original order.
+    // Reading local package metadata is independent and IO-bound, so resolve
+    // records concurrently and reassemble in the original order.
     let mut metadata_futures = CancellationAwareFutures::new(ctx.command_dispatcher.executor());
     for (index, record) in unresolved_pypi_environment.records.iter().enumerate() {
         let building_pixi_records = &building_pixi_records;

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -8,10 +8,13 @@ use std::{
 use uv_redacted::DisplaySafeUrl;
 
 use dashmap::DashMap;
+use futures::TryStreamExt;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use pep440_rs::VersionSpecifiers;
-use pixi_command_dispatcher::{CommandDispatcher, CommandDispatcherError};
+use pixi_command_dispatcher::{
+    CommandDispatcher, CommandDispatcherError, executor::CancellationAwareFutures,
+};
 use pixi_git::url::RepositoryUrl;
 use pixi_install_pypi::LockedPypiRecord;
 use pixi_manifest::{EnvironmentName, FeaturesExt, HasWorkspaceManifest, PixiPlatform};
@@ -409,100 +412,109 @@ pub(super) async fn lock_pypi_packages(
     unresolved_pypi_environment: &PypiRecordsByName,
     building_pixi_records: Result<PixiRecordsByName, PlatformUnsat>,
 ) -> Result<LockedPypiRecordsByName, CommandDispatcherError<Box<PlatformUnsat>>> {
-    let mut locked_pypi_records: Vec<LockedPypiRecord> =
-        Vec::with_capacity(unresolved_pypi_environment.len());
-    for record in &unresolved_pypi_environment.records {
-        let pkg = record.as_package_data();
+    // Reading local package metadata can drive a build backend, so each
+    // local-directory record is independent and IO-bound. Resolve them
+    // concurrently and reassemble in the original order.
+    let mut metadata_futures = CancellationAwareFutures::new(ctx.command_dispatcher.executor());
+    for (index, record) in unresolved_pypi_environment.records.iter().enumerate() {
+        let building_pixi_records = &building_pixi_records;
+        metadata_futures.push(async move {
+            let pkg = record.as_package_data();
 
-        // Only local directories can drift. Git/URL/archive sources are
-        // content-pinned by the lock and trusted as-is.
-        let metadata = if let UrlOrPath::Path(path) = &**pkg.location() {
-            let absolute_path = if path.is_absolute() {
-                Cow::Borrowed(Path::new(path.as_str()))
-            } else {
-                Cow::Owned(ctx.project_root.join(Path::new(path.as_str())))
-            };
-
-            if absolute_path.is_dir() {
-                // Lock says wheel but path is a directory, needs re-solve.
-                if pkg.as_wheel().is_some() {
-                    return Err(CommandDispatcherError::Failed(Box::new(
-                        PlatformUnsat::DistributionShouldBeSource {
-                            name: pkg.name().clone(),
-                        },
-                    )));
-                }
-
-                let uv_ctx = ctx
-                    .uv_context
-                    .get_or_try_init(|| {
-                        UvResolutionContext::from_config(
-                            ctx.config,
-                            ctx.environment.workspace().client()?.clone(),
-                        )
-                    })
-                    .map_err(|e| {
-                        CommandDispatcherError::Failed(Box::new(
-                            PlatformUnsat::FailedToReadLocalMetadata(
-                                pkg.name().clone(),
-                                format!("failed to initialize UV context: {e}"),
-                            ),
-                        ))
-                    })?;
-
-                let pixi_platform = ctx
-                    .environment
-                    .workspace_manifest()
-                    .workspace
-                    .platform_by_name(&ctx.platform)
-                    .ok_or_else(|| {
-                        CommandDispatcherError::Failed(Box::new(
-                            PlatformUnsat::FailedToReadLocalMetadata(
-                                pkg.name().clone(),
-                                format!(
-                                    "workspace does not define a platform named '{}'",
-                                    ctx.platform
-                                ),
-                            ),
-                        ))
-                    })?;
-
-                let build_ctx = BuildMetadataContext {
-                    environment: ctx.environment,
-                    locked_pixi_records,
-                    platform: pixi_platform,
-                    project_root: ctx.project_root,
-                    uv_context: uv_ctx,
-                    project_env_vars: &ctx.project_env_vars,
-                    command_dispatcher: ctx.command_dispatcher.clone(),
-                    build_caches: ctx.build_caches,
-                    building_pixi_records: &building_pixi_records,
-                    static_metadata_cache: ctx.static_metadata_cache,
+            // Only local directories can drift. Git/URL/archive sources are
+            // content-pinned by the lock and trusted as-is.
+            let metadata = if let UrlOrPath::Path(path) = &**pkg.location() {
+                let absolute_path = if path.is_absolute() {
+                    Cow::Borrowed(Path::new(path.as_str()))
+                } else {
+                    Cow::Owned(ctx.project_root.join(Path::new(path.as_str())))
                 };
 
-                read_local_package_metadata(&absolute_path, pkg.name(), &build_ctx)
-                    .await
-                    .map_err(|e| CommandDispatcherError::Failed(Box::new(e)))?
+                if absolute_path.is_dir() {
+                    // Lock says wheel but path is a directory, needs re-solve.
+                    if pkg.as_wheel().is_some() {
+                        return Err(CommandDispatcherError::Failed(Box::new(
+                            PlatformUnsat::DistributionShouldBeSource {
+                                name: pkg.name().clone(),
+                            },
+                        )));
+                    }
+
+                    let uv_ctx = ctx
+                        .uv_context
+                        .get_or_try_init(|| {
+                            UvResolutionContext::from_config(
+                                ctx.config,
+                                ctx.environment.workspace().client()?.clone(),
+                            )
+                        })
+                        .map_err(|e| {
+                            CommandDispatcherError::Failed(Box::new(
+                                PlatformUnsat::FailedToReadLocalMetadata(
+                                    pkg.name().clone(),
+                                    format!("failed to initialize UV context: {e}"),
+                                ),
+                            ))
+                        })?;
+
+                    let pixi_platform = ctx
+                        .environment
+                        .workspace_manifest()
+                        .workspace
+                        .platform_by_name(&ctx.platform)
+                        .ok_or_else(|| {
+                            CommandDispatcherError::Failed(Box::new(
+                                PlatformUnsat::FailedToReadLocalMetadata(
+                                    pkg.name().clone(),
+                                    format!(
+                                        "workspace does not define a platform named '{}'",
+                                        ctx.platform
+                                    ),
+                                ),
+                            ))
+                        })?;
+
+                    let build_ctx = BuildMetadataContext {
+                        environment: ctx.environment,
+                        locked_pixi_records,
+                        platform: pixi_platform,
+                        project_root: ctx.project_root,
+                        uv_context: uv_ctx,
+                        project_env_vars: &ctx.project_env_vars,
+                        command_dispatcher: ctx.command_dispatcher.clone(),
+                        build_caches: ctx.build_caches,
+                        building_pixi_records,
+                        static_metadata_cache: ctx.static_metadata_cache,
+                    };
+
+                    read_local_package_metadata(&absolute_path, pkg.name(), &build_ctx)
+                        .await
+                        .map_err(|e| CommandDispatcherError::Failed(Box::new(e)))?
+                } else {
+                    None
+                }
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
-        // Determine the version: prefer the wheel version from the lock file,
-        // fall back to the version read from the source tree metadata.
-        let version = pkg
-            .version()
-            .cloned()
-            .or_else(|| metadata.as_ref().and_then(|m| m.version.clone()))
-            .unwrap_or_else(|| pep440_rs::MIN_VERSION.clone());
+            // Determine the version: prefer the wheel version from the lock file,
+            // fall back to the version read from the source tree metadata.
+            let version = pkg
+                .version()
+                .cloned()
+                .or_else(|| metadata.as_ref().and_then(|m| m.version.clone()))
+                .unwrap_or_else(|| pep440_rs::MIN_VERSION.clone());
 
-        locked_pypi_records.push(record.lock(version));
+            Ok::<_, CommandDispatcherError<Box<PlatformUnsat>>>((index, record.lock(version)))
+        });
     }
 
+    let mut indexed_records: Vec<(usize, LockedPypiRecord)> =
+        metadata_futures.try_collect().await?;
+    indexed_records.sort_by_key(|(index, _)| *index);
+
     Ok(LockedPypiRecordsByName::from_iter(
-        locked_pypi_records.drain(..),
+        indexed_records.into_iter().map(|(_, record)| record),
     ))
 }
 


### PR DESCRIPTION
### Description

The lock file satisfiability check did a lot of independent work sequentially. Environments were verified one after another, and within a single platform the source record resolution and local PyPI metadata reads were done one record at a time. Most of this work is IO bound (talking to build backends, reading local metadata), so the check spent much of its time waiting instead of overlapping that work. This is most noticeable in workspaces with several environments or many source/local dependencies.

This PR makes that work run concurrently. Environment and platform verification now run as a single batch instead of finishing one environment before starting the next. Source record resolution and local PyPI metadata reads within a platform are batched as well. Results are reassembled in their original order so the outcome is unchanged, and the command dispatcher still bounds the actual concurrency.

### How Has This Been Tested?

Running this locally on the navigation2 stack yields:

```
❯ hyperfine "F:/projects/pixi/target/release/pixi.exe lock" "pixi lock" -w 1
Benchmark 1: F:/projects/pixi/target/release/pixi.exe lock
  Time (mean ± σ):     506.9 ms ±  34.9 ms    [User: 702.5 ms, System: 426.2 ms]
  Range (min … max):   482.2 ms … 603.2 ms    10 runs

Benchmark 2: pixi lock
  Time (mean ± σ):     673.0 ms ±   5.9 ms    [User: 508.8 ms, System: 212.2 ms]
  Range (min … max):   664.2 ms … 684.4 ms    10 runs

Summary
  F:/projects/pixi/target/release/pixi.exe lock ran
    1.33 ± 0.09 times faster than pixi lock
```

(it takes roughly 400ms to parse the lockfile)

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas