### PR TITLE
test: install env in PyPI git add test

### DIFF
--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -1128,13 +1128,18 @@ platforms = ["{platform}"]
     )
     .unwrap();
 
-    // Add python
-    pixi.add("python>=3.13.2,<3.14").await.unwrap();
+    // Add python and install the environment. Resolving PyPI source dependencies may need
+    // to invoke the build backend for metadata, which requires an instantiated conda prefix.
+    pixi.add("python>=3.13.2,<3.14")
+        .with_install(true)
+        .await
+        .unwrap();
 
     // Add a package
     pixi.add("boltons")
         .set_pypi(true)
         .with_git_url(Url::parse("https://github.com/mahmoud/boltons.git").unwrap())
+        .with_install(true)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary
- install the conda environment in `add_pypi_git` before resolving a PyPI git source dependency

Boltons has a dynamic version, not sure if thats new and requires a python interpreter. It could be that recent changes changed something to the caching semantics, that cause a specific failure. I dont know for sure, but I do know an interpreter is needed in this case.


## Testing
- `cargo test -p pixi --test integration_rust add_pypi_git --features online_tests -- --nocapture`