### PR TITLE
fix(workspace): forward declared __cuda_arch to the solver

### DIFF
--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -14,7 +14,7 @@ use pixi_manifest::{
 };
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_lock::LockFile;
-use rattler_virtual_packages::{Archspec, Cuda, LibC, Linux, Osx, VirtualPackage};
+use rattler_virtual_packages::{Archspec, Cuda, CudaArch, LibC, Linux, Osx, VirtualPackage};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
@@ -62,6 +62,9 @@ fn generic_to_virtual_package(gvp: &GenericVirtualPackage) -> Option<VirtualPack
             version: gvp.version.clone(),
         })),
         "__cuda" => Some(VirtualPackage::Cuda(Cuda {
+            version: gvp.version.clone(),
+        })),
+        "__cuda_arch" => Some(VirtualPackage::CudaArch(CudaArch {
             version: gvp.version.clone(),
         })),
         "__archspec" => {


### PR DESCRIPTION
## Problem

A workspace platform that declares the `__cuda_arch` virtual package — either through the raw `__cuda_arch` key or the `cuda = { driver, arch }` table — had it silently dropped before solving. `generic_to_virtual_package` translates a platform's declared virtual packages into rattler's typed `VirtualPackage` enum, but it had no arm for `__cuda_arch`, so the entry fell through to `None`.

As a result, solving a platform that requested a CUDA compute capability failed:

```
× failed to solve the environment
╰─▶ Cannot solve the request because of: causal-conv1d * cannot be installed
    because there are no viable options:
    ├─ causal-conv1d 1.6.2.post1 would require
    │  └─ __cuda_arch >=12.0, for which no candidates were found.
```

The requested compute capability was never offered to the solver.

## Fix

Add the missing match arm mapping `__cuda_arch` to `VirtualPackage::CudaArch` (available in `rattler_virtual_packages` 3.0). The declared compute capability now reaches the solver and drives capability-specific build selection — each platform resolves the build compiled for its `__cuda_arch` (e.g. `sm90` / `sm100` / `sm120`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)