### PR TITLE
fix(ci): repair main CI failures

### DIFF
--- a/.github/workflows/backends-release.yml
+++ b/.github/workflows/backends-release.yml
@@ -81,6 +81,7 @@ jobs:
           pixi run -e backends-release build-backend-packages ${{ matrix.target }}
 
       - name: Show sccache stats
+        if: ${{ always() }}
         shell: bash
         run: pixi run -e backends-release sccache --stop-server
 
@@ -95,7 +96,7 @@ jobs:
           path: output/**/*.conda
 
       - name: Kill any lingering processes (Windows)
-        if: runner.os == 'Windows'
+        if: ${{ always() && runner.os == 'Windows' }}
         shell: powershell
         run: |
           # Kill any Python processes

--- a/docs/source_files/pixi_workspaces/pixi_build/advanced_cpp/pixi.lock
+++ b/docs/source_files/pixi_workspaces/pixi_build/advanced_cpp/pixi.lock
@@ -103,7 +103,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
-      - conda_source: cpp_math[95f31bf5] @ .
+      - conda_source: cpp_math[8df4a783] @ .
 packages:
 - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -3158,23 +3158,24 @@ packages:
     - vcomp14 >=14.51.36231
   size: 120684
   timestamp: 1781320948530
-- conda: https://prefix.dev/conda-forge/win-64/vs2017_win-64-19.16.27033-hddac466_20.conda
-  sha256: 92eea55b912a2a05f691fb7f2dde41d9f62894ee9aeb309b167673ada11e9e71
-  md5: e61f52a2e0f68e75f143f67872eefdfc
+- conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_39.conda
+  sha256: 434b4f517b7119675930d17749bf123558271f3f316b217f7ac759e6d7121e9d
+  md5: 59f1d09ae752b761542975d7b6ad1b89
   depends:
   - vswhere
   constrains:
-  - vs_win-64 2017.9
+  - vs_win-64 2022.14
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
   run_exports:
     strong:
-    - vc >=14.1,<15
-    - vc14_runtime >=14.16.27033
-  size: 19764
-  timestamp: 1716231224784
+    - vc >=14.3,<15
+    - vc14_runtime >=14.44.35208
+    - ucrt >=10.0.20348.0
+  size: 24190
+  timestamp: 1781320983107
 - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
   sha256: 368d8628424966fd8f9c8018326a9c779e06913dd39e646cf331226acc90e5b2
   md5: 053b84beec00b71ea8ff7a4f84b55207
@@ -3405,12 +3406,13 @@ packages:
   - conda: https://prefix.dev/conda-forge/osx-64/python-3.12.13-ha9537fe_0_cpython.conda
   - conda: https://prefix.dev/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
   - conda: https://prefix.dev/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
-- conda_source: cpp_math[95f31bf5] @ .
+- conda_source: cpp_math[8df4a783] @ .
   variants:
     target_platform: win-64
   depends:
-  - vc >=14.1,<15
-  - vc14_runtime >=14.16.27033
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
   - python_abi 3.12.* *_cp312
   build_packages:
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
@@ -3430,7 +3432,7 @@ packages:
   - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
   - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
   - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vs2017_win-64-19.16.27033-hddac466_20.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_39.conda
   - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
   host_packages:
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda

--- a/pixi-build-backends/recipe/variants.yaml
+++ b/pixi-build-backends/recipe/variants.yaml
@@ -53,4 +53,4 @@ python_min:
 
 # Pin the compiler used
 rust_compiler_version:
-  - 1.94.0
+  - 1.95.0


### PR DESCRIPTION
## Summary
- relock the advanced_cpp pixi-build docs example with CI-style backend overrides
- build backend conda packages with Rust 1.95 to satisfy sysinfo
- run backend cleanup even after failures to reduce Windows EBUSY noise

## Validation
- pixi run build-workspace-release
- pixi run -e python-test pytest --showlocals -vv tests/integration_python/pixi_build/test_docs_examples.py::TestPixiBuild::test_doc_pixi_workspaces_pixi_build --pixi-build=release -k advanced_cpp
- pixi run actionlint .github/workflows/backends-release.yml
- rattler-build render-only checks for osx-arm64 and linux-64 backend recipes
