### PR TITLE
fix: PATH for current session for install.ps1

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -219,7 +219,7 @@ if (!$NoPathUpdate) {
         # For future sessions
         Write-Env -name 'PATH' -val "$BinDir;$PATH"
         # For current session
-        $Env:PATH = "$BinDir;$PATH"
+        $Env:PATH = "$BinDir;$Env:PATH"
         Write-Output "You may need to restart your shell"
     } else {
         Write-Output "$BinDir is already in PATH"


### PR DESCRIPTION
### Description

After running the pixi installer on Windows, the current shell session loses system PATH entries because the installer replaces $Env:PATH using only the user registry PATH (HKCU:\Environment) as the base, discarding the merged system and runtime entries that make up the full session PATH.

This PR changes the PATH for the current session to use the PATH from the current environment and not from the registry. 

Fixes #6377

### How Has This Been Tested?

There is reproducible code in the attached ticket. 

### AI Disclosure
This PR doesn't contain AI-generated content. 


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
