### PR TITLE
fix: ignore credentials when matching direct-URL PyPI deps

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -240,8 +240,16 @@ pub(crate) fn pypi_satisfies_requirement(
                     .strip_prefix("direct+")
                     .and_then(|str| Url::parse(str).ok())
                     .unwrap_or(locked_url.clone());
+                let locked_url = DisplaySafeUrl::from_url(locked_url);
 
-                if *spec_url.raw() == DisplaySafeUrl::from_url(locked_url.clone()) {
+                // Compare the URLs ignoring any userinfo (credentials). We redact
+                // credentials (e.g. `__token__` -> `****`) when writing the direct
+                // URL to the lock file, while the manifest keeps the literal
+                // credentials. A verbatim comparison would therefore spuriously
+                // fail under `--locked` for any authenticated direct URL, such as a
+                // wheel hosted on a private Azure Artifacts feed. This mirrors the
+                // username normalization already applied to git URLs below.
+                if spec_url.raw().without_credentials() == locked_url.without_credentials() {
                     return Ok(());
                 } else {
                     return Err(PlatformUnsat::LockedPyPIDirectUrlMismatch {
@@ -1245,6 +1253,66 @@ mod tests {
             &[],
         )
         .unwrap();
+    }
+
+    /// Regression test: a direct-URL wheel dependency whose credentials are
+    /// redacted to `****` in the lock file (while the manifest keeps the literal
+    /// credentials, e.g. `__token__`) must still satisfy `--locked`. Otherwise
+    /// authenticated direct URLs — such as a wheel hosted on a private Azure
+    /// Artifacts feed — can never be installed with `--locked`.
+    #[test]
+    fn test_pypi_direct_url_with_redacted_credentials_should_satisfy() {
+        // Locked data carries redacted credentials (`****`), as written to the
+        // lock file.
+        let locked_data = lock_for_test(make_wheel_package_with(
+            "pkg",
+            "1.0.0",
+            Verbatim::new(UrlOrPath::Url(
+                Url::parse("direct+https://****@example.com/feed/pkg-1.0.0-py3-none-any.whl")
+                    .unwrap(),
+            )),
+            None,
+            None,
+            vec![],
+            None,
+        ));
+
+        // The manifest keeps the literal credentials (`__token__`).
+        let spec = pep508_requirement_to_uv_requirement(
+            pep508_rs::Requirement::from_str(
+                "pkg @ https://__token__@example.com/feed/pkg-1.0.0-py3-none-any.whl",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        pypi_satisfies_requirement(
+            &spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+            &[],
+        )
+        .unwrap();
+
+        // Sanity check: a genuinely different URL (different filename) must still
+        // be reported as a mismatch, so credential stripping doesn't over-accept.
+        let non_matching_spec = pep508_requirement_to_uv_requirement(
+            pep508_rs::Requirement::from_str(
+                "pkg @ https://__token__@example.com/feed/pkg-2.0.0-py3-none-any.whl",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        pypi_satisfies_requirement(
+            &non_matching_spec,
+            &locked_data,
+            Path::new(""),
+            RequirementOrigin::Manifest,
+            &[],
+        )
+        .unwrap_err();
     }
 
     /// Regression test: removing a PyPI `index` from the manifest should


### PR DESCRIPTION
## Problem

For a PyPI dependency pinned by a **credentialed direct URL**, `pixi install --locked` fails with a direct-URL mismatch *on a lock file pixi itself just generated from the same manifest*.

When writing a direct URL to `pixi.lock`, pixi redacts the userinfo to `****` (via uv's `DisplaySafeUrl`), while the manifest keeps the literal credentials (e.g. the `__token__` placeholder used to trigger keyring lookups). The satisfiability check then compared the two **verbatim**:

```rust
if *spec_url.raw() == DisplaySafeUrl::from_url(locked_url.clone()) { … }
```

- `spec_url.raw()` → manifest URL with real userinfo (`__token__`)
- `locked_url` → lock URL with redacted userinfo (`****`)

Since `****` ≠ `__token__`, this is structurally guaranteed to fail for any authenticated direct URL — e.g. a wheel hosted on a private Azure DevOps Artifacts feed.

Reported in #6425.

## Fix

Compare the two URLs with userinfo stripped, using `DisplaySafeUrl::without_credentials()`. This mirrors the username normalization already applied to **git** URLs a few lines below in the same function (the `git@` ssh-username handling added in #6259). Userinfo is authentication, not artifact identity, so it should not participate in lock-file satisfiability — and it cannot round-trip anyway because pixi redacts it on write.

The change is limited to userinfo: scheme/host/path/query are still compared, so genuinely different URLs are still rejected.

## Test

Adds `test_pypi_direct_url_with_redacted_credentials_should_satisfy`:
- A locked wheel with redacted credentials (`direct+https://****@…/pkg-1.0.0-…whl`) is satisfied by a manifest requirement carrying literal credentials (`https://__token__@…/pkg-1.0.0-…whl`).
- A negative case (different filename) still returns a mismatch, ensuring credential stripping doesn't over-accept.

## Notes

- Does not change how URLs are written to the lock file (credentials remain redacted there).
- A broader follow-up could redact userinfo consistently across **all** lock-write paths (index URLs are currently stored verbatim) and compare userinfo-stripped everywhere, but that's out of scope for this targeted fix.

Fixes #6425