### PR TITLE
feat: inline package definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7016,6 +7016,7 @@ dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
  "tracing",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6505,6 +6505,7 @@ dependencies = [
  "pixi_consts",
  "pixi_git",
  "pixi_glob",
+ "pixi_manifest",
  "pixi_path",
  "pixi_record",
  "pixi_spec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6996,6 +6996,7 @@ dependencies = [
  "pixi_pypi_spec",
  "pixi_spec",
  "pixi_spec_containers",
+ "pixi_stable_hash",
  "pixi_test_utils",
  "pixi_toml",
  "pyproject-toml",

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -1470,6 +1470,7 @@ async fn test_multiple_prefix_update() {
         variant_config,
         None,
         command_dispatcher,
+        Default::default(),
     );
 
     let pixi_records = Vec::from([

--- a/crates/pixi_build_discovery/src/discovery.rs
+++ b/crates/pixi_build_discovery/src/discovery.rs
@@ -233,23 +233,65 @@ impl DiscoveredBackend {
     /// Convert a package manifest and corresponding workspace manifest into a
     /// discovered backend, with optional platform-specific configuration.
     pub fn from_package_and_workspace(
-        // source_path: PathBuf,
         package_manifest: &WithProvenance<PackageManifest>,
         workspace: &WithProvenance<WorkspaceManifest>,
         channel_config: &ChannelConfig,
     ) -> Result<Self, SpecConversionError> {
-        let WithProvenance {
-            value: package_manifest,
-            provenance,
-        } = package_manifest;
-
         let workspace_root = workspace
             .provenance
             .path
             .parent()
             .expect("workspace manifest should have a parent directory")
             .to_path_buf();
+        let manifest_path = package_manifest.provenance.path.clone();
+        let source_anchor = manifest_path
+            .parent()
+            .expect("points to a file")
+            .to_path_buf();
+        Self::from_manifests(
+            &package_manifest.value,
+            &workspace.value,
+            workspace_root,
+            manifest_path,
+            source_anchor,
+            channel_config,
+        )
+    }
 
+    /// Convert an inline package definition into a discovered backend. The
+    /// source has no on-disk manifest, so the paths anchor at `source_dir`
+    /// directly instead of being derived from a manifest file's provenance. The
+    /// synthetic `manifest_path` (`source_dir/pixi.toml`) never names a real
+    /// file; only its parent is meaningful, since the backend uses it to anchor
+    /// relative paths.
+    pub fn from_inline_package_and_workspace(
+        package_manifest: &PackageManifest,
+        workspace_manifest: &WorkspaceManifest,
+        source_dir: &Path,
+        channel_config: &ChannelConfig,
+    ) -> Result<Self, SpecConversionError> {
+        Self::from_manifests(
+            package_manifest,
+            workspace_manifest,
+            source_dir.to_path_buf(),
+            source_dir.join("pixi.toml"),
+            source_dir.to_path_buf(),
+            channel_config,
+        )
+    }
+
+    /// Shared core of [`Self::from_package_and_workspace`] and
+    /// [`Self::from_inline_package_and_workspace`]: build the backend spec from
+    /// already-resolved directory anchors, independent of where the manifests
+    /// were loaded from.
+    fn from_manifests(
+        package_manifest: &PackageManifest,
+        workspace_manifest: &WorkspaceManifest,
+        workspace_root: PathBuf,
+        manifest_path: PathBuf,
+        source_anchor: PathBuf,
+        channel_config: &ChannelConfig,
+    ) -> Result<Self, SpecConversionError> {
         // Construct the project model from the manifest
         let project_model = to_project_model_v1(package_manifest, channel_config)?;
 
@@ -265,7 +307,7 @@ impl DiscoveredBackend {
         let named_channels = match build_system.channels.as_ref() {
             Some(channels) => itertools::Either::Left(channels.iter()),
             None => itertools::Either::Right(PrioritizedChannel::sort_channels_by_priority(
-                workspace.value.workspace.channels.iter(),
+                workspace_manifest.workspace.channels.iter(),
             )),
         };
         let channels = named_channels
@@ -306,13 +348,9 @@ impl DiscoveredBackend {
             }),
             init_params: BackendInitializationParams {
                 workspace_root,
-                manifest_path: provenance.path.clone(),
+                manifest_path,
                 build_source: build_system.source,
-                source_anchor: provenance
-                    .path
-                    .parent()
-                    .expect("points to a file")
-                    .to_path_buf(),
+                source_anchor,
                 project_model: Some(project_model),
                 configuration: build_system.config.map(|config| {
                     config

--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -661,6 +661,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         env_ref: env_ref.clone(),
         build_string_prefix: args.build_string_prefix.clone(),
         build_number: args.build_number,
+        inline: None,
     };
     let backend_metadata = command_dispatcher
         .build_backend_metadata(backend_metadata_spec.clone())
@@ -721,6 +722,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             source_location: source_location.clone(),
             preferred_build_source: Arc::new(BTreeMap::new()),
             env_ref: env_ref.clone(),
+            inline: None,
             installed_source_hints: Default::default(),
         };
         let records = command_dispatcher
@@ -764,6 +766,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 archive_type: f.archive_type,
                 compression_level: f.compression_level.into(),
             }),
+            inline: None,
         };
         let built = command_dispatcher
             .engine()

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -59,6 +59,7 @@ pixi_compute_sources = { workspace = true }
 pixi_consts = { workspace = true }
 pixi_git = { workspace = true }
 pixi_glob = { workspace = true }
+pixi_manifest = { workspace = true }
 pixi_path = { workspace = true }
 pixi_record = { workspace = true }
 pixi_spec = { workspace = true, features = ["pixi_build_types"] }

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -29,7 +29,7 @@ use crate::input_hash::{
 };
 use crate::keys::BackendBinaryFingerprintKey;
 use crate::{
-    BackendHandle, BuildEnvironment, EnvironmentRef, InstantiateBackendError,
+    BackendHandle, BuildEnvironment, EnvironmentRef, InlinePackage, InstantiateBackendError,
     InstantiateBackendKey, ProjectModelOverrides, SourceCheckout, SourceCheckoutError,
     SourceCheckoutExt,
     build::{PinnedSourceCodeLocation, SourceRecordOrCheckout, WorkDirKey},
@@ -104,6 +104,12 @@ pub struct BuildBackendMetadataSpec {
     /// model. Overrides any value declared in the manifest.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_number: Option<u64>,
+
+    /// Inline package definition for this source. When set, the
+    /// backend is built from this manifest instead of discovering one on disk.
+    /// Part of the key identity via its content hash.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline: Option<InlinePackage>,
 }
 
 /// Compute-engine [`Key`] for the public-facing backend-metadata
@@ -152,6 +158,7 @@ impl Key for BuildBackendMetadataKey {
             exclude_newer: (*exclude_newer).clone(),
             build_string_prefix: self.0.build_string_prefix.clone(),
             build_number: self.0.build_number,
+            inline: self.0.inline.clone(),
         };
 
         ctx.compute(&BuildBackendMetadataInnerKey::new(inner)).await
@@ -203,6 +210,12 @@ pub struct BuildBackendMetadataInner {
     /// model when set. Part of the cache key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build_number: Option<u64>,
+
+    /// Inline package definition for this source. Distinguishes
+    /// two inline definitions that resolve to the same source location and
+    /// invalidates when the inline table is edited (via its content hash).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inline: Option<InlinePackage>,
 }
 
 /// The metadata of a source checkout.
@@ -704,12 +717,19 @@ impl BuildBackendMetadataInner {
             .checkout_pinned_source(self.manifest_source.clone())
             .await?;
 
-        let discovered_backend = ctx
-            .compute(&crate::DiscoveredBackendKey::new(
-                manifest_source_checkout.path.as_std_path(),
-            ))
-            .await
-            .map_err(BuildBackendMetadataError::Discovery)?;
+        // An inline package definition provides its manifest from
+        // the consuming workspace rather than from the checkout. When one is
+        // carried on this request, the backend is built from it directly,
+        // skipping on-disk discovery. The synthetic provenance is anchored at
+        // the checked-out source so the backend builds the code that was checked
+        // out; the inline manifest carries no `build.source` of its own.
+        let discovered_backend = crate::inline_package::discover_backend(
+            ctx,
+            manifest_source_checkout.path.as_std_path(),
+            self.inline.as_ref(),
+        )
+        .await
+        .map_err(BuildBackendMetadataError::Discovery)?;
 
         let manifest_source_anchor =
             SourceAnchor::from(SourceLocationSpec::from(self.manifest_source.clone()));
@@ -820,6 +840,7 @@ impl BuildBackendMetadataInner {
             exclude_newer: self.exclude_newer.clone(),
             enabled_protocols: enabled_protocols.as_ref().clone(),
             source: manifest_source_location.clone().into(),
+            inline_content_hash: self.inline.as_ref().map(|inline| inline.content_hash),
         };
         let cache_read_result = cache
             .read(&cache_key)
@@ -954,7 +975,8 @@ impl BuildBackendMetadataInner {
                         .to_path_buf(),
                     self.exclude_newer.clone(),
                 )
-                .with_project_model_overrides(self.project_model_overrides()),
+                .with_project_model_overrides(self.project_model_overrides())
+                .with_inline(self.inline.clone()),
             )
             .await
             .map_err(|e: Arc<InstantiateBackendError>| {

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -108,7 +108,10 @@ pub struct BuildBackendMetadataSpec {
     /// Inline package definition for this source. When set, the
     /// backend is built from this manifest instead of discovering one on disk.
     /// Part of the key identity via its content hash.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::inline_package::serialize_optional_content_hash"
+    )]
     pub inline: Option<InlinePackage>,
 }
 
@@ -214,7 +217,10 @@ pub struct BuildBackendMetadataInner {
     /// Inline package definition for this source. Distinguishes
     /// two inline definitions that resolve to the same source location and
     /// invalidates when the inline table is edited (via its content hash).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::inline_package::serialize_optional_content_hash"
+    )]
     pub inline: Option<InlinePackage>,
 }
 
@@ -840,7 +846,7 @@ impl BuildBackendMetadataInner {
             exclude_newer: self.exclude_newer.clone(),
             enabled_protocols: enabled_protocols.as_ref().clone(),
             source: manifest_source_location.clone().into(),
-            inline_content_hash: self.inline.as_ref().map(|inline| inline.content_hash.as_u64()),
+            inline_content_hash: self.inline.as_ref().map(|inline| inline.content_hash),
         };
         let cache_read_result = cache
             .read(&cache_key)

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -840,7 +840,7 @@ impl BuildBackendMetadataInner {
             exclude_newer: self.exclude_newer.clone(),
             enabled_protocols: enabled_protocols.as_ref().clone(),
             source: manifest_source_location.clone().into(),
-            inline_content_hash: self.inline.as_ref().map(|inline| inline.content_hash),
+            inline_content_hash: self.inline.as_ref().map(|inline| inline.content_hash.as_u64()),
         };
         let cache_read_result = cache
             .read(&cache_key)

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -85,12 +85,19 @@ pub fn compute_artifact_cache_key(
     host_source_dep_sha256s: &[Sha256Hash],
     project_model_overrides: &crate::ProjectModelOverrides,
     package_format: Option<pixi_build_types::procedures::conda_build_v1::CondaPackageFormat>,
+    inline_content_hash: Option<u64>,
 ) -> ArtifactCacheKey {
     let mut hasher = Xxh3::new();
     record.name().as_normalized().hash(&mut hasher);
     record.manifest_source.hash(&mut hasher);
     record.build_source.hash(&mut hasher);
     record.variants.hash(&mut hasher);
+    // An inline package definition's content hash is not otherwise
+    // represented on disk, so it must enter the key explicitly: editing the
+    // inline `[package]` table then invalidates the built artifact even when the
+    // source files are untouched. `None` for ordinary source packages keeps
+    // their key unchanged.
+    inline_content_hash.hash(&mut hasher);
     build_platform.hash(&mut hasher);
     host_platform.hash(&mut hasher);
     backend_identifier.hash(&mut hasher);
@@ -955,6 +962,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         )
         .to_string()
     }
@@ -1024,6 +1032,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         )
         .to_string();
         let k2 = compute_artifact_cache_key(
@@ -1034,6 +1043,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
             None,
         )
         .to_string();
@@ -1052,6 +1062,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         )
         .to_string();
         let k2 = compute_artifact_cache_key(
@@ -1062,6 +1073,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
             None,
         )
         .to_string();
@@ -1144,6 +1156,7 @@ mod cache_key_tests {
             &[sha(0xaa)],
             &Default::default(),
             None,
+            None,
         )
         .to_string();
         let k2 = compute_artifact_cache_key(
@@ -1154,6 +1167,7 @@ mod cache_key_tests {
             &[],
             &[sha(0xbb)],
             &Default::default(),
+            None,
             None,
         )
         .to_string();
@@ -1176,6 +1190,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         )
         .to_string();
         let host_only = compute_artifact_cache_key(
@@ -1186,6 +1201,7 @@ mod cache_key_tests {
             &[],
             &[sha(0xaa)],
             &Default::default(),
+            None,
             None,
         )
         .to_string();
@@ -1250,6 +1266,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         );
         let osx_arm = compute_artifact_cache_key(
             &r,
@@ -1259,6 +1276,7 @@ mod cache_key_tests {
             &[],
             &[],
             &Default::default(),
+            None,
             None,
         );
         assert_ne!(linux, osx_arm);
@@ -1276,6 +1294,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         );
         let prefixed = compute_artifact_cache_key(
             &r,
@@ -1288,6 +1307,7 @@ mod cache_key_tests {
                 build_string_prefix: Some("foobar".to_string()),
                 build_number: None,
             },
+            None,
             None,
         );
         assert_ne!(bare, prefixed);
@@ -1305,6 +1325,7 @@ mod cache_key_tests {
             &[],
             &Default::default(),
             None,
+            None,
         );
         let numbered = compute_artifact_cache_key(
             &r,
@@ -1317,6 +1338,7 @@ mod cache_key_tests {
                 build_string_prefix: None,
                 build_number: Some(42),
             },
+            None,
             None,
         );
         assert_ne!(bare, numbered);
@@ -1339,6 +1361,7 @@ mod cache_key_tests {
                 archive_type: CondaArchiveType::Conda,
                 compression_level: Default::default(),
             }),
+            None,
         );
         let tar_bz2 = compute_artifact_cache_key(
             &r,
@@ -1352,6 +1375,7 @@ mod cache_key_tests {
                 archive_type: CondaArchiveType::TarBz2,
                 compression_level: Default::default(),
             }),
+            None,
         );
         assert_ne!(conda, tar_bz2);
     }
@@ -1377,6 +1401,7 @@ mod cache_key_tests {
                 &[],
                 &Default::default(),
                 Some(pf(level)),
+                None,
             )
         };
         let default_level = key(CondaCompressionLevel::Named(NamedCompressionLevel::Default));

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -33,6 +33,7 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::{DateTime, Utc};
 use pixi_build_types::InputGlobSet;
 use pixi_compute_engine::ComputeCtx;
+use pixi_manifest::InlineContentHash;
 use pixi_path::{AbsPath, AbsPathBuf};
 use pixi_record::{UnresolvedPixiRecord, UnresolvedSourceRecord};
 use rattler_conda_types::{PackageName, Platform, RepoDataRecord};
@@ -85,7 +86,7 @@ pub fn compute_artifact_cache_key(
     host_source_dep_sha256s: &[Sha256Hash],
     project_model_overrides: &crate::ProjectModelOverrides,
     package_format: Option<pixi_build_types::procedures::conda_build_v1::CondaPackageFormat>,
-    inline_content_hash: Option<u64>,
+    inline_content_hash: Option<InlineContentHash>,
 ) -> ArtifactCacheKey {
     let mut hasher = Xxh3::new();
     record.name().as_normalized().hash(&mut hasher);

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -77,6 +77,12 @@ pub struct BuildBackendMetadataCacheKey {
 
     /// The pinned source location
     pub source: CanonicalSourceCodeLocation,
+
+    /// Content hash of the inline package definition, if any. The
+    /// inline manifest replaces on-disk discovery, so the same source location
+    /// with a different inline table must not share a cache entry; editing the
+    /// table changes this hash and forces a rebuild.
+    pub inline_content_hash: Option<u64>,
 }
 
 impl BuildBackendMetadataCache {
@@ -120,6 +126,7 @@ impl MetadataCacheKey<BuildBackendMetadataCache> for BuildBackendMetadataCacheKe
         host_virtual_packages.hash(&mut hasher);
 
         self.enabled_protocols.hash(&mut hasher);
+        self.inline_content_hash.hash(&mut hasher);
         let source_dir = self.source.cache_unique_key();
         CacheKeyString::new(format!(
             "{source_dir}/{}-{}",

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -22,6 +22,7 @@ use crate::BuildEnvironment;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use pixi_build_discovery::EnabledProtocols;
 use pixi_build_types::procedures::conda_outputs::CondaOutput;
+use pixi_manifest::InlineContentHash;
 use pixi_path::AbsPathBuf;
 use pixi_record::VariantValue;
 use pixi_spec::ResolvedExcludeNewer;
@@ -82,7 +83,7 @@ pub struct BuildBackendMetadataCacheKey {
     /// inline manifest replaces on-disk discovery, so the same source location
     /// with a different inline table must not share a cache entry; editing the
     /// table changes this hash and forces a rebuild.
-    pub inline_content_hash: Option<u64>,
+    pub inline_content_hash: Option<InlineContentHash>,
 }
 
 impl BuildBackendMetadataCache {

--- a/crates/pixi_command_dispatcher/src/inline_package.rs
+++ b/crates/pixi_command_dispatcher/src/inline_package.rs
@@ -23,7 +23,8 @@ use std::{
 use pixi_build_discovery::{DiscoveredBackend, DiscoveryError};
 use pixi_compute_engine::ComputeCtx;
 use pixi_manifest::{
-    ManifestKind, ManifestProvenance, PackageManifest, WithProvenance, WorkspaceManifest,
+    InlineContentHash, ManifestKind, ManifestProvenance, PackageManifest, WithProvenance,
+    WorkspaceManifest,
 };
 use pixi_spec::SpecConversionError;
 use rattler_conda_types::ChannelConfig;
@@ -44,8 +45,8 @@ pub struct InlinePackage {
     pub manifest: Arc<PackageManifest>,
     /// The consuming workspace manifest (used for channels and workspace root).
     pub workspace: Arc<WorkspaceManifest>,
-    /// Deterministic hash of `(dependency name, package manifest)`.
-    pub content_hash: u64,
+    /// Content fingerprint of `(dependency name, package manifest)`.
+    pub content_hash: InlineContentHash,
 }
 
 impl InlinePackage {
@@ -89,7 +90,7 @@ impl serde::Serialize for InlinePackage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         // Only the content hash is part of cache identity; the manifests are
         // reconstructed from the consuming manifest, never from a cache.
-        serializer.serialize_u64(self.content_hash)
+        serializer.serialize_u64(self.content_hash.as_u64())
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/inline_package.rs
+++ b/crates/pixi_command_dispatcher/src/inline_package.rs
@@ -1,0 +1,119 @@
+//! Inline package definitions.
+//!
+//! An inline package definition lives in a consuming workspace's manifest
+//! rather than in a `pixi.toml` at the source. The build pipeline still checks
+//! out the source code, but instead of discovering a manifest on disk it uses
+//! the inline [`PackageManifest`] carried here.
+//!
+//! The definition is threaded directly through the compute specs that need it
+//! (the solve, metadata, instantiation and build keys) rather than looked up
+//! from a side registry, so the inline content participates in every
+//! content-addressed cache key. `content_hash` provides the cheap, hashable
+//! identity: it is a deterministic hash of `(dependency name, package
+//! manifest)` computed at manifest-assembly time, so it distinguishes two
+//! inline definitions that resolve to the same source location and changes
+//! whenever the definition is edited.
+
+use std::{
+    hash::{Hash, Hasher},
+    path::Path,
+    sync::Arc,
+};
+
+use pixi_build_discovery::{DiscoveredBackend, DiscoveryError};
+use pixi_compute_engine::ComputeCtx;
+use pixi_manifest::{
+    ManifestKind, ManifestProvenance, PackageManifest, WithProvenance, WorkspaceManifest,
+};
+use pixi_spec::SpecConversionError;
+use rattler_conda_types::ChannelConfig;
+
+use crate::{discovered_backend::DiscoveredBackendKey, injected_config::ChannelConfigKey};
+
+/// An inline package definition together with the workspace manifest that
+/// declared it. Both are needed to construct a build backend without reading a
+/// manifest from disk.
+///
+/// `Hash`, `Eq` and `Serialize` go through [`Self::content_hash`] alone: the
+/// manifests behind the `Arc`s are not themselves hashable, and the hash is a
+/// faithful content fingerprint, so two `InlinePackage`s with the same hash are
+/// treated as identical by the compute engine.
+#[derive(Clone, Debug)]
+pub struct InlinePackage {
+    /// The inline package manifest.
+    pub manifest: Arc<PackageManifest>,
+    /// The consuming workspace manifest (used for channels and workspace root).
+    pub workspace: Arc<WorkspaceManifest>,
+    /// Deterministic hash of `(dependency name, package manifest)`.
+    pub content_hash: u64,
+}
+
+impl InlinePackage {
+    /// Build a [`DiscoveredBackend`] from the inline manifest, skipping on-disk
+    /// discovery. The synthetic manifest is anchored at the source *directory*
+    /// (a `path` source may point straight at a file such as a recipe.yaml, in
+    /// which case the directory is its parent), so the backend builds the code
+    /// that was checked out.
+    pub fn discovered_backend(
+        &self,
+        source_path: &Path,
+        channel_config: &ChannelConfig,
+    ) -> Result<DiscoveredBackend, SpecConversionError> {
+        let source_dir = if source_path.is_file() {
+            source_path.parent().unwrap_or(source_path)
+        } else {
+            source_path
+        };
+        let provenance = ManifestProvenance::new(source_dir.join("pixi.toml"), ManifestKind::Pixi);
+        let package = WithProvenance::new((*self.manifest).clone(), provenance.clone());
+        let workspace = WithProvenance::new((*self.workspace).clone(), provenance);
+        DiscoveredBackend::from_package_and_workspace(&package, &workspace, channel_config)
+    }
+}
+
+impl PartialEq for InlinePackage {
+    fn eq(&self, other: &Self) -> bool {
+        self.content_hash == other.content_hash
+    }
+}
+
+impl Eq for InlinePackage {}
+
+impl Hash for InlinePackage {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.content_hash.hash(state);
+    }
+}
+
+impl serde::Serialize for InlinePackage {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Only the content hash is part of cache identity; the manifests are
+        // reconstructed from the consuming manifest, never from a cache.
+        serializer.serialize_u64(self.content_hash)
+    }
+}
+
+/// Discover the build backend for a checked-out source, honoring an inline
+/// package definition.
+///
+/// When `inline` is set the backend is built from the inline manifest with
+/// synthetic provenance anchored at `source_path`, skipping on-disk discovery
+/// entirely. Otherwise discovery falls back to the content-addressed
+/// [`DiscoveredBackendKey`], which reads a manifest from the checkout. The
+/// returned [`DiscoveryError`] is mapped by each caller into its own error type.
+pub(crate) async fn discover_backend(
+    ctx: &mut ComputeCtx,
+    source_path: &Path,
+    inline: Option<&InlinePackage>,
+) -> Result<Arc<DiscoveredBackend>, Arc<DiscoveryError>> {
+    match inline {
+        Some(inline) => {
+            let channel_config = ctx.compute(&ChannelConfigKey).await;
+            inline
+                .discovered_backend(source_path, &channel_config)
+                .map(Arc::new)
+                .map_err(|err| Arc::new(DiscoveryError::SpecConversionError(err)))
+        }
+        None => ctx.compute(&DiscoveredBackendKey::new(source_path)).await,
+    }
+}

--- a/crates/pixi_command_dispatcher/src/inline_package.rs
+++ b/crates/pixi_command_dispatcher/src/inline_package.rs
@@ -88,8 +88,12 @@ impl Hash for InlinePackage {
 
 impl serde::Serialize for InlinePackage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        // Only the content hash is part of cache identity; the manifests are
-        // reconstructed from the consuming manifest, never from a cache.
+        // `Serialize` is required transitively: `BuildBackendMetadataSpec` carries
+        // an `Option<InlinePackage>` and is serialized through the reporter views
+        // ([`SourceMetadataReporterSpec`](crate::SourceMetadataReporterSpec) and
+        // friends) that the event reporter dumps as JSON. The manifests behind the
+        // `Arc`s are not serializable and are never reconstructed from a cache, so
+        // the content hash alone is a faithful, self-contained representation.
         serializer.serialize_u64(self.content_hash.as_u64())
     }
 }

--- a/crates/pixi_command_dispatcher/src/inline_package.rs
+++ b/crates/pixi_command_dispatcher/src/inline_package.rs
@@ -22,10 +22,7 @@ use std::{
 
 use pixi_build_discovery::{DiscoveredBackend, DiscoveryError};
 use pixi_compute_engine::ComputeCtx;
-use pixi_manifest::{
-    InlineContentHash, ManifestKind, ManifestProvenance, PackageManifest, WithProvenance,
-    WorkspaceManifest,
-};
+use pixi_manifest::{InlineContentHash, PackageManifest, WorkspaceManifest};
 use pixi_spec::SpecConversionError;
 use rattler_conda_types::ChannelConfig;
 
@@ -35,10 +32,10 @@ use crate::{discovered_backend::DiscoveredBackendKey, injected_config::ChannelCo
 /// declared it. Both are needed to construct a build backend without reading a
 /// manifest from disk.
 ///
-/// `Hash`, `Eq` and `Serialize` go through [`Self::content_hash`] alone: the
-/// manifests behind the `Arc`s are not themselves hashable, and the hash is a
-/// faithful content fingerprint, so two `InlinePackage`s with the same hash are
-/// treated as identical by the compute engine.
+/// `Hash` and `Eq` go through [`Self::content_hash`] alone: the manifests behind
+/// the `Arc`s are not themselves hashable, and the hash is a faithful content
+/// fingerprint, so two `InlinePackage`s with the same hash are treated as
+/// identical by the compute engine.
 #[derive(Clone, Debug)]
 pub struct InlinePackage {
     /// The inline package manifest.
@@ -65,10 +62,12 @@ impl InlinePackage {
         } else {
             source_path
         };
-        let provenance = ManifestProvenance::new(source_dir.join("pixi.toml"), ManifestKind::Pixi);
-        let package = WithProvenance::new((*self.manifest).clone(), provenance.clone());
-        let workspace = WithProvenance::new((*self.workspace).clone(), provenance);
-        DiscoveredBackend::from_package_and_workspace(&package, &workspace, channel_config)
+        DiscoveredBackend::from_inline_package_and_workspace(
+            &self.manifest,
+            &self.workspace,
+            source_dir,
+            channel_config,
+        )
     }
 }
 
@@ -86,24 +85,29 @@ impl Hash for InlinePackage {
     }
 }
 
-impl serde::Serialize for InlinePackage {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        // `Serialize` is required transitively: `BuildBackendMetadataSpec` carries
-        // an `Option<InlinePackage>` and is serialized through the reporter views
-        // ([`SourceMetadataReporterSpec`](crate::SourceMetadataReporterSpec) and
-        // friends) that the event reporter dumps as JSON. The manifests behind the
-        // `Arc`s are not serializable and are never reconstructed from a cache, so
-        // the content hash alone is a faithful, self-contained representation.
-        serializer.serialize_u64(self.content_hash.as_u64())
+/// Serialize an optional inline definition as just its content hash. Used via
+/// `#[serde(serialize_with = ...)]` on the `inline` field of the
+/// [`BuildBackendMetadataSpec`](crate::BuildBackendMetadataSpec)-family structs,
+/// the only ones that derive `Serialize` for their event JSON. The manifests
+/// behind the `Arc`s are not serializable and are never reconstructed from this
+/// output (only `Hash`/`Eq` drive cache identity), so the content hash alone is
+/// a faithful, self-contained representation.
+pub(crate) fn serialize_optional_content_hash<S: serde::Serializer>(
+    inline: &Option<InlinePackage>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match inline {
+        Some(inline) => serializer.serialize_some(&inline.content_hash.as_u64()),
+        None => serializer.serialize_none(),
     }
 }
 
 /// Discover the build backend for a checked-out source, honoring an inline
 /// package definition.
 ///
-/// When `inline` is set the backend is built from the inline manifest with
-/// synthetic provenance anchored at `source_path`, skipping on-disk discovery
-/// entirely. Otherwise discovery falls back to the content-addressed
+/// When `inline` is set the backend is built from the inline manifest with its
+/// paths anchored at `source_path`, skipping on-disk discovery entirely.
+/// Otherwise discovery falls back to the content-addressed
 /// [`DiscoveredBackendKey`], which reads a manifest from the checkout. The
 /// returned [`DiscoveryError`] is mapped by each caller into its own error type.
 pub(crate) async fn discover_backend(

--- a/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
@@ -151,8 +151,12 @@ async fn install_inner(
         variant_configuration: spec.variant_configuration.clone(),
         variant_files: spec.variant_files.clone(),
     };
+    // Inline package definitions for the source records in this
+    // install, looked up per record by name when building from source.
+    let inline_packages = Arc::new(std::mem::take(&mut spec.inline_packages));
     let mapper = {
         let shared = shared.clone();
+        let inline_packages = inline_packages.clone();
         async move |sub_ctx: &mut ComputeCtx,
                     source: Arc<pixi_record::UnresolvedSourceRecord>|
                     -> Result<
@@ -179,6 +183,7 @@ async fn install_inner(
                 // Source packages built during `pixi install` are unpacked
                 // immediately, so use the cheapest compression.
                 package_format: Some(CondaPackageFormat::fast()),
+                inline: inline_packages.get(&name).cloned(),
             };
             // A failed cross-build is usually the platform mismatch, not the
             // recipe. Compare the real machine: installs set build_platform to the target.

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -57,6 +57,12 @@ pub struct InstallPixiEnvironmentSpec {
     pub variant_configuration: Option<BTreeMap<String, Vec<VariantValue>>>,
 
     pub variant_files: Option<Vec<PathBuf>>,
+
+    /// Inline package definitions keyed by package name. Source
+    /// records whose name matches build from the inline manifest instead of
+    /// discovering one on disk. Empty when no inline definitions are in scope.
+    #[serde(skip)]
+    pub inline_packages: HashMap<PackageName, crate::InlinePackage>,
 }
 
 pub struct InstallPixiEnvironmentResult {
@@ -97,6 +103,7 @@ impl InstallPixiEnvironmentSpec {
             channels: Vec::new(),
             variant_configuration: None,
             variant_files: None,
+            inline_packages: HashMap::new(),
         }
     }
 }

--- a/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
@@ -1,5 +1,6 @@
 //! Compute-engine Key that spawns a build-backend handle for a source
-//! checkout. Discovers the backend via [`DiscoveredBackendKey`], applies
+//! checkout. Discovers the backend via
+//! [`DiscoveredBackendKey`](crate::discovered_backend::DiscoveredBackendKey), applies
 //! [`BackendOverrideKey`](crate::BackendOverrideKey) through
 //! [`ResolvedBackendCommandKey`], then dispatches to an in-memory
 //! instantiator, a system command, or a solved ephemeral build env. Keyed
@@ -36,10 +37,11 @@ use rattler_shell::{
 use thiserror::Error;
 use tokio::sync::Mutex;
 
+use crate::InlinePackage;
 use crate::compute_data::HasInstantiateBackendReporter;
-use crate::discovered_backend::DiscoveredBackendKey;
 use crate::ephemeral_env::{EphemeralEnvError, EphemeralEnvKey, EphemeralEnvSpec};
 use crate::injected_config::ToolBuildEnvironmentKey;
+use crate::inline_package::discover_backend;
 use crate::reporter::InstantiateBackendReporter;
 use crate::resolved_backend_command::{ResolvedBackendCommand, ResolvedBackendCommandKey};
 use pixi_compute_cache_dirs::CacheDirsKey;
@@ -107,6 +109,12 @@ pub struct InstantiateBackendKey {
     /// User-supplied overrides applied to the discovered project model
     /// before backend initialization.
     pub project_model_overrides: ProjectModelOverrides,
+
+    /// Inline package definition for this source. When set, the
+    /// backend is built from this manifest instead of on-disk discovery. Part
+    /// of the key identity via its content hash, so distinct inline definitions
+    /// at the same path spawn distinct backends.
+    pub inline: Option<InlinePackage>,
 }
 
 impl InstantiateBackendKey {
@@ -129,6 +137,7 @@ impl InstantiateBackendKey {
             build_source_dir,
             exclude_newer,
             project_model_overrides: ProjectModelOverrides::default(),
+            inline: None,
         }
     }
 
@@ -136,6 +145,13 @@ impl InstantiateBackendKey {
     /// backend's `initialize` call.
     pub fn with_project_model_overrides(mut self, overrides: ProjectModelOverrides) -> Self {
         self.project_model_overrides = overrides;
+        self
+    }
+
+    /// Attach an inline package definition so the backend is built
+    /// from it instead of discovering a manifest on disk.
+    pub fn with_inline(mut self, inline: Option<InlinePackage>) -> Self {
+        self.inline = inline;
         self
     }
 }
@@ -193,11 +209,12 @@ impl Key for InstantiateBackendKey {
     async fn compute(&self, ctx: &mut ComputeCtx) -> Self::Value {
         // Discover the backend for this source path. Discovery runs
         // before the reporter lifecycle is queued so the `on_queued`
-        // event can carry the resolved backend name.
-        let discovered = ctx
-            .compute(&DiscoveredBackendKey::new(&self.source_path))
+        // event can carry the resolved backend name. An inline package
+        // definition bypasses on-disk discovery.
+        let discovered = discover_backend(ctx, &self.source_path, self.inline.as_ref())
             .await
-            .map_err(|e| Arc::new(InstantiateBackendError::Discovery(e)))?;
+            .map_err(InstantiateBackendError::Discovery)
+            .map_err(Arc::new)?;
 
         // Resolve the backend spec with the manifest anchor.
         let BackendSpec::JsonRpc(resolved_spec) = discovered
@@ -471,7 +488,8 @@ fn ephemeral_env_spec_for(
 ///
 /// Identifying the backend for cache-keying purposes goes through the
 /// same dependency-resolution pipeline as a real instantiation
-/// ([`DiscoveredBackendKey`] → [`ResolvedBackendCommandKey`] →
+/// ([`DiscoveredBackendKey`](crate::discovered_backend::DiscoveredBackendKey) →
+/// [`ResolvedBackendCommandKey`] →
 /// [`EphemeralEnvKey`] for env-spec backends), but stops once the
 /// resolved version is known. All three are content-addressed compute
 /// keys, so when an actual instantiation runs later in the same
@@ -497,11 +515,12 @@ pub async fn resolve_backend_identifier(
     source_path: &std::path::Path,
     manifest_source_anchor: SourceAnchor,
     exclude_newer: Option<ResolvedExcludeNewer>,
+    inline: Option<&InlinePackage>,
 ) -> Result<String, Arc<InstantiateBackendError>> {
-    let discovered = ctx
-        .compute(&DiscoveredBackendKey::new(source_path))
+    let discovered = discover_backend(ctx, source_path, inline)
         .await
-        .map_err(|e| Arc::new(InstantiateBackendError::Discovery(e)))?;
+        .map_err(InstantiateBackendError::Discovery)
+        .map_err(Arc::new)?;
 
     let BackendSpec::JsonRpc(resolved_spec) = discovered
         .backend_spec

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
@@ -180,10 +180,7 @@ async fn resolve_source_package_inner(
     let source_hints = spec.installed_source_hints.clone();
     // Fold the inline definition's content hash into each assembled record's
     // identifier so editing the inline table changes the lock entry.
-    let inline_content_hash = spec
-        .inline
-        .as_ref()
-        .map(|inline| inline.content_hash.as_u64());
+    let inline_content_hash = spec.inline.as_ref().map(|inline| inline.content_hash);
     let mapper = ComputeCtx::declare_join_closure(
         async move |bctx: &mut ComputeCtx, output: CondaOutput| {
             assemble_source_record(

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
@@ -17,8 +17,8 @@ use rattler_conda_types::PackageName;
 use tracing::instrument;
 
 use crate::{
-    BuildBackendMetadataSpec, EnvironmentRef, InstalledSourceHints, PtrArc, SourceMetadataError,
-    SourceMetadataReporterSpec, SourceRecordError,
+    BuildBackendMetadataSpec, EnvironmentRef, InlinePackage, InstalledSourceHints, PtrArc,
+    SourceMetadataError, SourceMetadataReporterSpec, SourceRecordError,
     build::PinnedSourceCodeLocation,
     compute_data::HasSourceMetadataReporter,
     keys::{
@@ -42,6 +42,9 @@ pub struct ResolveSourcePackageSpec {
     pub source_location: SourceLocationSpec,
     pub preferred_build_source: Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     pub env_ref: EnvironmentRef,
+    /// Inline package definition for this dependency, if it was
+    /// declared with an inline `package` table in the consuming manifest.
+    pub inline: Option<InlinePackage>,
     /// Source-record hints inherited from the enclosing SPEK; forwarded
     /// verbatim into nested build/host solves so every layer of the
     /// recursion agrees on one canonical hint per
@@ -123,6 +126,7 @@ impl Key for ResolveSourcePackageKey {
                 env_ref: spec.env_ref.clone(),
                 build_string_prefix: None,
                 build_number: None,
+                inline: spec.inline.clone(),
             },
             exclude_newer: None,
         };
@@ -162,6 +166,7 @@ async fn resolve_source_package_inner(
             preferred_build_source: own_pin,
             manifest_pin_override,
             env_ref: spec.env_ref.clone(),
+            inline: spec.inline.clone(),
         }))
         .await
         .map_err(map_source_metadata_error)?;
@@ -173,10 +178,21 @@ async fn resolve_source_package_inner(
     let preferred = Arc::clone(&spec.preferred_build_source);
     let env_ref = spec.env_ref.clone();
     let source_hints = spec.installed_source_hints.clone();
+    // Fold the inline definition's content hash into each assembled record's
+    // identifier so editing the inline table changes the lock entry.
+    let inline_content_hash = spec.inline.as_ref().map(|inline| inline.content_hash);
     let mapper = ComputeCtx::declare_join_closure(
         async move |bctx: &mut ComputeCtx, output: CondaOutput| {
-            assemble_source_record(bctx, &source, &output, &preferred, &env_ref, &source_hints)
-                .await
+            assemble_source_record(
+                bctx,
+                &source,
+                &output,
+                &preferred,
+                &env_ref,
+                &source_hints,
+                inline_content_hash,
+            )
+            .await
         },
     );
     let records = ctx

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_package.rs
@@ -180,7 +180,10 @@ async fn resolve_source_package_inner(
     let source_hints = spec.installed_source_hints.clone();
     // Fold the inline definition's content hash into each assembled record's
     // identifier so editing the inline table changes the lock entry.
-    let inline_content_hash = spec.inline.as_ref().map(|inline| inline.content_hash);
+    let inline_content_hash = spec
+        .inline
+        .as_ref()
+        .map(|inline| inline.content_hash.as_u64());
     let mapper = ComputeCtx::declare_join_closure(
         async move |bctx: &mut ComputeCtx, output: CondaOutput| {
             assemble_source_record(

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -34,6 +34,7 @@ use crate::{
     reporter::SourceRecordReporter,
 };
 use pixi_compute_reporters::{Active, LifecycleKind, ReporterLifecycle};
+use pixi_manifest::InlineContentHash;
 
 /// Resolve one variant's [`SourceRecord`] from an assembled
 /// [`CondaOutput`] + pinned source location.
@@ -54,7 +55,7 @@ pub(super) async fn assemble_source_record(
     preferred_build_source: &Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     env_ref: &EnvironmentRef,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
-    inline_content_hash: Option<u64>,
+    inline_content_hash: Option<InlineContentHash>,
 ) -> Result<Arc<SourceRecord>, SourceRecordError> {
     // Reporter lifecycle for this variant's source-record assembly.
     // Build a `SourceRecordReporterSpec` from the data flowing through here so
@@ -115,7 +116,7 @@ async fn assemble_source_record_inner(
     preferred_build_source: &Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     env_ref: &EnvironmentRef,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
-    inline_content_hash: Option<u64>,
+    inline_content_hash: Option<InlineContentHash>,
 ) -> Result<Arc<SourceRecord>, SourceRecordError> {
     let source_location = SourceLocationSpec::from(source.manifest_source().clone());
     let source_anchor = SourceAnchor::from(source_location.clone());
@@ -414,7 +415,10 @@ async fn assemble_source_record_inner(
             .into_iter()
             .map(pixi_record::UnresolvedPixiRecord::from)
             .collect(),
-        inline_content_hash,
+        // `pixi_record` is below `pixi_manifest` in the dependency graph and
+        // cannot name `InlineContentHash`, so unwrap to the raw `u64` here, at
+        // the one crate boundary where the newtype can no longer travel.
+        inline_content_hash.map(InlineContentHash::as_u64),
     );
 
     Ok(Arc::new(record))

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -54,6 +54,7 @@ pub(super) async fn assemble_source_record(
     preferred_build_source: &Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     env_ref: &EnvironmentRef,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
+    inline_content_hash: Option<u64>,
 ) -> Result<Arc<SourceRecord>, SourceRecordError> {
     // Reporter lifecycle for this variant's source-record assembly.
     // Build a `SourceRecordReporterSpec` from the data flowing through here so
@@ -75,6 +76,7 @@ pub(super) async fn assemble_source_record(
             env_ref: env_ref.clone(),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
         exclude_newer: None,
     };
@@ -97,6 +99,7 @@ pub(super) async fn assemble_source_record(
         preferred_build_source,
         env_ref,
         installed_source_hints,
+        inline_content_hash,
     );
     match active_id {
         Some(id) => id.scope_active(work).await,
@@ -112,6 +115,7 @@ async fn assemble_source_record_inner(
     preferred_build_source: &Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     env_ref: &EnvironmentRef,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
+    inline_content_hash: Option<u64>,
 ) -> Result<Arc<SourceRecord>, SourceRecordError> {
     let source_location = SourceLocationSpec::from(source.manifest_source().clone());
     let source_anchor = SourceAnchor::from(source_location.clone());
@@ -410,6 +414,7 @@ async fn assemble_source_record_inner(
             .into_iter()
             .map(pixi_record::UnresolvedPixiRecord::from)
             .collect(),
+        inline_content_hash,
     );
 
     Ok(Arc::new(record))
@@ -464,6 +469,9 @@ async fn nested_solve(
         strategy: SolveStrategy::default(),
         preferred_build_source: Arc::clone(preferred_build_source),
         env_ref: env_ref.derived(pkg_name.clone(), kind),
+        // A nested build/host env solves binary/source build deps; inline
+        // definitions apply only to the consumer's direct dependencies.
+        inline_packages: Default::default(),
     };
 
     // Wrap the nested SolvePixiEnvironmentKey call in a cycle

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -37,8 +37,9 @@ use tracing::instrument;
 
 use crate::{
     BuildBackendMetadataSpec, DerivedEnvKind, DevSourceMetadataKey, DevSourceMetadataSpec,
-    EnvironmentRef, HasWorkspaceEnvRegistry, InstalledSourceHints, MissingChannelError,
-    PixiSolveEnvironmentSpec, PixiSolveReporter, PtrArc, SolvePixiEnvironmentError, SourceMetadata,
+    EnvironmentRef, HasWorkspaceEnvRegistry, InlinePackage, InstalledSourceHints,
+    MissingChannelError, PixiSolveEnvironmentSpec, PixiSolveReporter, PtrArc,
+    SolvePixiEnvironmentError, SourceMetadata,
     build::PinnedSourceCodeLocation,
     compute_data::HasPixiSolveReporter,
     cycle::CycleEnvironment,
@@ -122,6 +123,11 @@ pub struct SolvePixiEnvironmentSpec {
     /// stay content-addressed.
     pub preferred_build_source: Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     pub env_ref: EnvironmentRef,
+    /// Inline package definitions keyed by dependency name. A seed
+    /// source dependency whose name matches builds from the inline manifest
+    /// instead of discovering one on disk. Their content hashes are part of the
+    /// key identity.
+    pub inline_packages: Arc<BTreeMap<PackageName, InlinePackage>>,
 }
 
 impl Hash for SolvePixiEnvironmentSpec {
@@ -138,6 +144,7 @@ impl Hash for SolvePixiEnvironmentSpec {
             strategy,
             preferred_build_source,
             env_ref,
+            inline_packages,
         } = self;
         dependencies.hash(state);
         constraints.hash(state);
@@ -147,6 +154,7 @@ impl Hash for SolvePixiEnvironmentSpec {
         mem::discriminant(strategy).hash(state);
         preferred_build_source.hash(state);
         env_ref.hash(state);
+        inline_packages.hash(state);
     }
 }
 
@@ -161,6 +169,7 @@ impl PartialEq for SolvePixiEnvironmentSpec {
             && mem::discriminant(&self.strategy) == mem::discriminant(&other.strategy)
             && self.preferred_build_source == other.preferred_build_source
             && self.env_ref == other.env_ref
+            && self.inline_packages == other.inline_packages
     }
 }
 
@@ -328,6 +337,7 @@ async fn compute_inner(
         &spec.env_ref,
         &spec.preferred_build_source,
         &spec.installed_source_hints,
+        &spec.inline_packages,
     )
     .await?;
     tracing::debug!(
@@ -449,6 +459,7 @@ async fn walk_and_resolve(
     env_ref: &EnvironmentRef,
     preferred_build_source: &Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
+    inline_packages: &Arc<BTreeMap<PackageName, InlinePackage>>,
 ) -> Result<Vec<Arc<pixi_record::SourceRecord>>, SolvePixiEnvironmentError> {
     let mut all_records: Vec<Arc<pixi_record::SourceRecord>> = Vec::new();
     let mut seen_sources: HashSet<(PackageName, SourceLocationSpec)> = HashSet::new();
@@ -473,7 +484,8 @@ async fn walk_and_resolve(
                 seen: &mut HashSet<(PackageName, SourceLocationSpec)>,
                 name: PackageName,
                 location: SourceLocationSpec,
-                parent: Option<PackageName>| {
+                parent: Option<PackageName>,
+                inline: Option<InlinePackage>| {
         if !seen.insert((name.clone(), location.clone())) {
             return;
         }
@@ -482,6 +494,7 @@ async fn walk_and_resolve(
             source_location: location,
             preferred_build_source: Arc::clone(preferred_build_source),
             env_ref: env_ref.clone(),
+            inline,
             installed_source_hints: installed_source_hints.clone(),
         });
         pending.push(p.compute(async move |sub_ctx: &mut ComputeCtx| {
@@ -531,6 +544,9 @@ async fn walk_and_resolve(
     };
 
     for (name, spec) in seeds {
+        // Seeds are the consumer's direct dependencies, the only place inline
+        // package definitions are declared.
+        let inline = inline_packages.get(&name).cloned();
         push(
             &mut p,
             &mut pending,
@@ -538,6 +554,7 @@ async fn walk_and_resolve(
             name,
             spec.location,
             None,
+            inline,
         );
     }
 
@@ -575,6 +592,9 @@ async fn walk_and_resolve(
                         child_name,
                         resolved_location,
                         Some(parent_pkg.clone()),
+                        // Transitive source deps carry their own on-disk
+                        // manifest; inline definitions never apply to them.
+                        None,
                     );
                 }
             }
@@ -628,6 +648,7 @@ async fn process_dev_sources(
                 env_ref,
                 build_string_prefix: None,
                 build_number: None,
+                inline: None,
             },
         });
         metadata_futs.push(ctx.compute(&key));

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -318,10 +318,28 @@ async fn compute_inner(
     // assembled records (not raw `CondaOutput.run_dependencies`) is
     // essential: source deps introduced purely via build-env or host-env
     // run-exports only appear on the assembled record.
-    let seeds: Vec<(PackageName, SourceSpec)> = source_specs
+    //
+    // Inline package definitions are the consumer's own run/host/build source
+    // dependencies, so they are attached to those seeds and never to the
+    // dev-source-contributed ones (`inline: None`); this keeps a dev-source
+    // dependency from inheriting the inline definition of an identically named
+    // regular dependency.
+    let seeds: Vec<SourceSeed> = source_specs
         .iter_specs()
-        .map(|(n, s)| (n.clone(), s.clone()))
-        .chain(dev_source_source_specs.into_specs())
+        .map(|(name, source)| SourceSeed {
+            name: name.clone(),
+            source: source.clone(),
+            inline: spec.inline_packages.get(name).cloned(),
+        })
+        .chain(
+            dev_source_source_specs
+                .into_specs()
+                .map(|(name, source)| SourceSeed {
+                    name,
+                    source,
+                    inline: None,
+                }),
+        )
         .collect();
 
     // Source-record hints for this solve. Keyed on
@@ -337,7 +355,6 @@ async fn compute_inner(
         &spec.env_ref,
         &spec.preferred_build_source,
         &spec.installed_source_hints,
-        &spec.inline_packages,
     )
     .await?;
     tracing::debug!(
@@ -426,6 +443,14 @@ async fn compute_inner(
     Ok(Arc::new((*result).clone()))
 }
 
+/// A direct source dependency to resolve, paired with the inline package
+/// definition the consumer declared for it (if any).
+struct SourceSeed {
+    name: PackageName,
+    source: SourceSpec,
+    inline: Option<InlinePackage>,
+}
+
 /// Discover + resolve every source package reachable from the
 /// seed specs.
 ///
@@ -455,11 +480,10 @@ async fn compute_inner(
 #[allow(clippy::mutable_key_type)]
 async fn walk_and_resolve(
     ctx: &mut ComputeCtx,
-    seeds: Vec<(PackageName, SourceSpec)>,
+    seeds: Vec<SourceSeed>,
     env_ref: &EnvironmentRef,
     preferred_build_source: &Arc<BTreeMap<PackageName, PinnedSourceSpec>>,
     installed_source_hints: &PtrArc<InstalledSourceHints>,
-    inline_packages: &Arc<BTreeMap<PackageName, InlinePackage>>,
 ) -> Result<Vec<Arc<pixi_record::SourceRecord>>, SolvePixiEnvironmentError> {
     let mut all_records: Vec<Arc<pixi_record::SourceRecord>> = Vec::new();
     let mut seen_sources: HashSet<(PackageName, SourceLocationSpec)> = HashSet::new();
@@ -543,16 +567,18 @@ async fn walk_and_resolve(
         }));
     };
 
-    for (name, spec) in seeds {
-        // Seeds are the consumer's direct dependencies, the only place inline
-        // package definitions are declared.
-        let inline = inline_packages.get(&name).cloned();
+    for SourceSeed {
+        name,
+        source,
+        inline,
+    } in seeds
+    {
         push(
             &mut p,
             &mut pending,
             &mut seen_sources,
             name,
-            spec.location,
+            source.location,
             None,
             inline,
         );

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -201,7 +201,7 @@ async fn compute_inner(
         &host_source_dep_sha256s,
         &project_model_overrides,
         spec.package_format,
-        spec.inline.as_ref().map(|inline| inline.content_hash.as_u64()),
+        spec.inline.as_ref().map(|inline| inline.content_hash),
     );
 
     // On artifact cache hit, return without invoking the backend.

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -86,6 +86,11 @@ pub struct SourceBuildSpec {
     /// Folds into the artifact cache key but not the workspace key, so
     /// different formats share build state but get distinct artifacts.
     pub package_format: Option<CondaPackageFormat>,
+
+    /// Inline package definition for this source. Repopulated from
+    /// the consuming manifest by the installer; when set, the backend is built
+    /// from it instead of discovering a manifest in the checkout.
+    pub inline: Option<crate::InlinePackage>,
 }
 
 /// Built artifact plus its sha256 and a
@@ -174,6 +179,7 @@ async fn compute_inner(
         manifest_checkout.path.as_std_path(),
         manifest_anchor.clone(),
         spec.exclude_newer.clone(),
+        spec.inline.as_ref(),
     )
     .await
     .map_err(|err: Arc<crate::InstantiateBackendError>| {
@@ -195,6 +201,7 @@ async fn compute_inner(
         &host_source_dep_sha256s,
         &project_model_overrides,
         spec.package_format,
+        spec.inline.as_ref().map(|inline| inline.content_hash),
     );
 
     // On artifact cache hit, return without invoking the backend.
@@ -236,7 +243,8 @@ async fn compute_inner(
                 build_source_dir,
                 spec.exclude_newer.clone(),
             )
-            .with_project_model_overrides(project_model_overrides),
+            .with_project_model_overrides(project_model_overrides)
+            .with_inline(spec.inline.clone()),
         )
         .await
         .map_err(|err: Arc<crate::InstantiateBackendError>| {
@@ -535,6 +543,9 @@ async fn build_source_deps(
                 // Nested source deps are unpacked into the parent's
                 // prefix immediately; use the cheapest compression.
                 package_format: Some(CondaPackageFormat::fast()),
+                // A nested source dependency carries its own on-disk manifest;
+                // inline definitions apply only to the consumer's direct deps.
+                inline: None,
             };
             let result = sub_ctx.compute(&SourceBuildKey::new(nested_spec)).await?;
             Ok(result.artifact_sha256)
@@ -662,6 +673,9 @@ async fn install_prefix(
         channels: spec.channels.clone(),
         variant_configuration: spec.variant_configuration.clone(),
         variant_files: spec.variant_files.clone(),
+        // Build/host environments install pre-built packages; no inline
+        // definitions apply here.
+        inline_packages: Default::default(),
     };
     let result = ctx
         .install_pixi_environment(install_spec)

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -201,7 +201,7 @@ async fn compute_inner(
         &host_source_dep_sha256s,
         &project_model_overrides,
         spec.package_format,
-        spec.inline.as_ref().map(|inline| inline.content_hash),
+        spec.inline.as_ref().map(|inline| inline.content_hash.as_u64()),
     );
 
     // On artifact cache hit, return without invoking the backend.

--- a/crates/pixi_command_dispatcher/src/keys/source_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_metadata.rs
@@ -19,8 +19,8 @@ use rattler_conda_types::PackageName;
 use tracing::instrument;
 
 use crate::{
-    BuildBackendMetadataKey, BuildBackendMetadataSpec, EnvironmentRef, PackageNotProvidedError,
-    SourceMetadataError, build::PinnedSourceCodeLocation,
+    BuildBackendMetadataKey, BuildBackendMetadataSpec, EnvironmentRef, InlinePackage,
+    PackageNotProvidedError, SourceMetadataError, build::PinnedSourceCodeLocation,
 };
 use pixi_compute_sources::SourceCheckoutExt;
 
@@ -95,6 +95,9 @@ pub struct SourceMetadataSpec {
     /// Environment context (channels, build env, variants,
     /// exclude_newer, channel_priority).
     pub env_ref: EnvironmentRef,
+    /// Inline package definition for this dependency. When set,
+    /// the backend is built from this manifest instead of on-disk discovery.
+    pub inline: Option<InlinePackage>,
 }
 
 /// What [`SourceMetadataKey`] returns: the pinned source location
@@ -175,6 +178,9 @@ impl Key for SourceMetadataKey {
             env_ref: spec.env_ref.clone(),
             build_string_prefix: None,
             build_number: None,
+            // Carry the inline package definition so backend
+            // discovery uses it instead of reading a manifest from the checkout.
+            inline: spec.inline.clone(),
         };
         let build_backend_metadata = ctx
             .compute(&BuildBackendMetadataKey::new(backend_metadata_spec))

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -51,6 +51,7 @@ pub mod environment;
 mod ephemeral_env;
 mod errors;
 mod injected_config;
+mod inline_package;
 mod input_globs;
 mod input_hash;
 mod install_binary;
@@ -107,6 +108,7 @@ pub use errors::{
 pub use injected_config::{
     BackendOverrideKey, ChannelConfigKey, EnabledProtocolsKey, ToolBuildEnvironmentKey,
 };
+pub use inline_package::InlinePackage;
 pub use install_pixi::{
     InstallPixiEnvironmentError, InstallPixiEnvironmentExt, InstallPixiEnvironmentResult,
     InstallPixiEnvironmentSpec,

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -89,6 +89,7 @@ fn empty_pixi_env_spec() -> SolvePixiEnvironmentSpec {
                 channel_priority: Default::default(),
             },
         )),
+        inline_packages: Default::default(),
     }
 }
 
@@ -252,6 +253,7 @@ pub async fn simple_test() {
             channels: vec![channel_url],
             variant_configuration: None,
             variant_files: None,
+            inline_packages: Default::default(),
         })
         .await
         .unwrap();
@@ -878,6 +880,7 @@ pub async fn test_dev_source_metadata() {
             ),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
     };
 
@@ -969,6 +972,7 @@ pub async fn test_dev_source_metadata_package_not_provided() {
             ),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
     };
 
@@ -1056,6 +1060,7 @@ pub async fn test_dev_source_metadata_with_variants() {
             )),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
     };
 
@@ -1827,6 +1832,7 @@ pub async fn test_metadata_not_refetched_when_no_files_changed() {
             ),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
     };
 
@@ -1924,6 +1930,7 @@ pub async fn test_metadata_refetched_when_source_file_modified() {
             ),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
     };
 

--- a/crates/pixi_core/src/environment/conda_prefix.rs
+++ b/crates/pixi_core/src/environment/conda_prefix.rs
@@ -157,7 +157,6 @@ impl CondaPrefixUpdater {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         channels: Vec<ChannelUrl>,
         name: GroupedEnvironmentName,

--- a/crates/pixi_core/src/environment/conda_prefix.rs
+++ b/crates/pixi_core/src/environment/conda_prefix.rs
@@ -83,6 +83,10 @@ pub struct CondaPrefixUpdaterInner {
     pub exclude_newer: Option<ResolvedExcludeNewer>,
     pub command_dispatcher: CommandDispatcher,
 
+    /// Inline package definitions for this environment, used to
+    /// build source packages without an on-disk manifest.
+    pub inline_packages: HashMap<PackageName, pixi_command_dispatcher::InlinePackage>,
+
     /// A flag that indicates if the prefix was created.
     created: AsyncOnceCell<CondaPrefixUpdated>,
 }
@@ -110,6 +114,11 @@ impl CondaPrefixUpdaterBuilder<'_> {
             .group
             .exclude_newer_config_resolved(&self.group.channel_config())
             .into_diagnostic()?;
+        let inline_packages = self
+            .group
+            .combined_inline_packages(Some(&self.platform))
+            .into_iter()
+            .collect();
 
         Ok(CondaPrefixUpdater::new(
             channels,
@@ -120,6 +129,7 @@ impl CondaPrefixUpdaterBuilder<'_> {
             variant_config,
             exclude_newer,
             self.command_dispatcher,
+            inline_packages,
         ))
     }
 }
@@ -147,6 +157,7 @@ impl CondaPrefixUpdater {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         channels: Vec<ChannelUrl>,
         name: GroupedEnvironmentName,
@@ -156,6 +167,7 @@ impl CondaPrefixUpdater {
         variant_config: VariantConfig,
         exclude_newer: Option<ResolvedExcludeNewer>,
         command_dispatcher: CommandDispatcher,
+        inline_packages: HashMap<PackageName, pixi_command_dispatcher::InlinePackage>,
     ) -> Self {
         Self {
             inner: Arc::new(CondaPrefixUpdaterInner {
@@ -167,6 +179,7 @@ impl CondaPrefixUpdater {
                 variant_config,
                 exclude_newer,
                 command_dispatcher,
+                inline_packages,
                 created: Default::default(),
             }),
         }
@@ -200,6 +213,7 @@ impl CondaPrefixUpdater {
                     self.inner.command_dispatcher.clone(),
                     reinstall_packages,
                     ignore_packages,
+                    self.inner.inline_packages.clone(),
                 )
                 .await?;
 
@@ -232,6 +246,7 @@ pub async fn update_prefix_conda(
     command_dispatcher: CommandDispatcher,
     reinstall_packages: Option<HashSet<PackageName>>,
     ignore_packages: Option<HashSet<PackageName>>,
+    inline_packages: HashMap<PackageName, pixi_command_dispatcher::InlinePackage>,
 ) -> miette::Result<CondaPrefixInstallResult> {
     // Try to increase the rlimit to a sensible value for installation.
     try_increase_rlimit_to_sensible();
@@ -270,6 +285,7 @@ pub async fn update_prefix_conda(
             channels,
             variant_configuration: Some(variant_configuration),
             variant_files: Some(variant_files),
+            inline_packages,
         })
         .await?;
 

--- a/crates/pixi_core/src/lock_file/satisfiability/legacy/cache.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/legacy/cache.rs
@@ -133,6 +133,7 @@ fn from_wire_source(wire: WireSource) -> UnresolvedSourceRecord {
             wire.variants,
             build_packages,
             host_packages,
+            None,
         ),
     }
 }

--- a/crates/pixi_core/src/lock_file/satisfiability/legacy/key.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/legacy/key.rs
@@ -164,6 +164,7 @@ impl Key for LegacySourceEnvKey {
                 source_location: SourceLocationSpec::from(self.manifest_source.clone()),
                 preferred_build_source: self.preferred_build_source.clone(),
                 env_ref: self.env_ref.clone(),
+                inline: None,
                 installed_source_hints: self.installed_source_hints.clone(),
             }))
             .await?;

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -524,6 +524,7 @@ async fn resolve_single_dev_dependency(
             env_ref: EnvironmentRef::Workspace(workspace_env_ref),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         },
     };
 

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -113,6 +113,19 @@ pub(super) async fn verify_partial_source_record_against_backend(
 
     let pkg_name = record.name().clone();
 
+    // Look up this package's inline definition from the current
+    // manifest, if any. It is needed both to re-query metadata without an
+    // on-disk manifest and so an edit to the inline table re-derives different
+    // outputs (forcing a re-lock).
+    let pixi_platform = pixi_manifest::HasWorkspaceManifest::workspace_manifest(ctx.environment)
+        .workspace
+        .platform_by_name(&ctx.platform);
+    let inline =
+        crate::workspace::grouped_environment::GroupedEnvironment::from(ctx.environment.clone())
+            .combined_inline_packages(pixi_platform)
+            .get(&pkg_name)
+            .cloned();
+
     // Query fresh backend metadata for the source's manifest checkout.
     let backend_metadata = ctx
         .command_dispatcher
@@ -127,6 +140,7 @@ pub(super) async fn verify_partial_source_record_against_backend(
             ),
             build_string_prefix: None,
             build_number: None,
+            inline: inline.clone(),
         })
         .await
         .map_err(|e| match e {

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -2916,6 +2916,12 @@ async fn spawn_solve_conda_environment_task(
             channel_priority: channel_priority.into(),
         },
     ));
+
+    // Inline package definitions for this environment, threaded
+    // into the solve so backend discovery uses them instead of reading a
+    // manifest from disk.
+    let inline_packages = Arc::new(group.combined_inline_packages(Some(pixi_platform)));
+
     // Pass partial source records through alongside binary and full
     // source records: their `manifest_source` and `build_packages` /
     // `host_packages` flow into `InstalledSourceHints`, which the
@@ -2938,6 +2944,7 @@ async fn spawn_solve_conda_environment_task(
             strategy,
             preferred_build_source: Arc::new(pin_overrides),
             env_ref,
+            inline_packages,
         }))
         .await
         .map_err_into_dispatcher(|source| SolveCondaEnvironmentError::SolveFailed {

--- a/crates/pixi_core/src/workspace/grouped_environment.rs
+++ b/crates/pixi_core/src/workspace/grouped_environment.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -149,9 +149,23 @@ impl<'p> GroupedEnvironment<'p> {
         platform: Option<&PixiPlatform>,
     ) -> BTreeMap<PackageName, pixi_command_dispatcher::InlinePackage> {
         let mut merged: IndexMap<PackageName, &InlinePackageManifest> = IndexMap::new();
-        for feature in self.features().rev() {
-            for (name, manifest) in feature.inline_packages(platform) {
-                merged.insert(name, manifest);
+        let mut decided: HashSet<PackageName> = HashSet::new();
+        // `features` yields features from highest to lowest priority. The
+        // highest priority feature that declares a package as a dependency
+        // decides whether it carries an inline definition; a plain (non-inline)
+        // declaration in a higher priority feature suppresses an inline
+        // definition from a lower priority one.
+        for feature in self.features() {
+            let feature_inline = feature.inline_packages(platform);
+            let Some(dependencies) = feature.combined_dependencies(platform) else {
+                continue;
+            };
+            for name in dependencies.names() {
+                if decided.insert(name.clone())
+                    && let Some(manifest) = feature_inline.get(name)
+                {
+                    merged.insert(name.clone(), *manifest);
+                }
             }
         }
         if merged.is_empty() {

--- a/crates/pixi_core/src/workspace/grouped_environment.rs
+++ b/crates/pixi_core/src/workspace/grouped_environment.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use fancy_display::FancyDisplay;
 use indexmap::IndexMap;
@@ -7,8 +9,8 @@ use itertools::Either;
 use ordermap::OrderSet;
 use pixi_consts::consts;
 use pixi_manifest::{
-    EnvironmentName, Feature, HasFeaturesIter, HasWorkspaceManifest, PixiPlatform,
-    WorkspaceManifest,
+    EnvironmentName, Feature, HasFeaturesIter, HasWorkspaceManifest, InlinePackageManifest,
+    PixiPlatform, WorkspaceManifest,
 };
 use pixi_spec::SourceLocationSpec;
 use pixi_utils::prefix::Prefix;
@@ -133,6 +135,42 @@ impl<'p> GroupedEnvironment<'p> {
             }
         }
         result
+    }
+
+    /// Returns the combined inline package definitions for this grouped
+    /// environment, resolved into dispatcher
+    /// [`InlinePackage`](pixi_command_dispatcher::InlinePackage)s ready to thread
+    /// through the solve and install. Definitions from all features are merged;
+    /// later features override earlier ones with the same name. The consuming
+    /// workspace manifest is attached so the backend can be built without an
+    /// on-disk manifest.
+    pub fn combined_inline_packages(
+        &self,
+        platform: Option<&PixiPlatform>,
+    ) -> BTreeMap<PackageName, pixi_command_dispatcher::InlinePackage> {
+        let mut merged: IndexMap<PackageName, &InlinePackageManifest> = IndexMap::new();
+        for feature in self.features().rev() {
+            for (name, manifest) in feature.inline_packages(platform) {
+                merged.insert(name, manifest);
+            }
+        }
+        if merged.is_empty() {
+            return BTreeMap::new();
+        }
+        let workspace = Arc::new(self.workspace_manifest().clone());
+        merged
+            .into_iter()
+            .map(|(name, inline)| {
+                (
+                    name,
+                    pixi_command_dispatcher::InlinePackage {
+                        manifest: Arc::new(inline.manifest.clone()),
+                        workspace: workspace.clone(),
+                        content_hash: inline.content_hash,
+                    },
+                )
+            })
+            .collect()
     }
 }
 

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -654,6 +654,7 @@ impl Project {
                     channel_priority: Default::default(),
                 },
             )),
+            inline_packages: Default::default(),
         };
 
         // Solve via SolvePixiEnvironmentKey (new keys path).
@@ -710,6 +711,7 @@ impl Project {
                 force_reinstall: force_reinstall_packages,
                 variant_configuration: None,
                 variant_files: None,
+                inline_packages: Default::default(),
             })
             .await?;
 
@@ -1580,6 +1582,7 @@ impl Project {
             )),
             build_string_prefix: None,
             build_number: None,
+            inline: None,
         };
 
         // Get the metadata using the command dispatcher

--- a/crates/pixi_manifest/Cargo.toml
+++ b/crates/pixi_manifest/Cargo.toml
@@ -29,6 +29,7 @@ pixi_default_versions = { workspace = true }
 pixi_pypi_spec = { workspace = true }
 pixi_spec = { workspace = true }
 pixi_spec_containers = { workspace = true }
+pixi_stable_hash = { workspace = true }
 pixi_toml = { workspace = true }
 # Python specific dependencies, may require patches!
 pyproject-toml = { workspace = true }

--- a/crates/pixi_manifest/Cargo.toml
+++ b/crates/pixi_manifest/Cargo.toml
@@ -49,6 +49,7 @@ toml-span = { workspace = true, features = ["serde"] }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -80,19 +80,34 @@ pub struct BuildBackend {
 
 impl Hash for PackageBuild {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.backend.hash(state);
+        // Bind every field so adding a new one fails to compile until it is
+        // accounted for here. A silently unhashed field would let two builds
+        // that differ only in that field collide in the content-addressed cache.
+        let Self {
+            backend,
+            additional_dependencies,
+            channels,
+            source,
+            config,
+            flags,
+            target_config,
+            build_string_prefix,
+            build_number,
+            secrets,
+        } = self;
+        backend.hash(state);
         // The dependency and target-config maps are `IndexMap`s; their
         // declaration order is stable, so hash their entries in order.
-        self.additional_dependencies.len().hash(state);
-        for (name, spec) in &self.additional_dependencies {
+        additional_dependencies.len().hash(state);
+        for (name, spec) in additional_dependencies {
             name.hash(state);
             spec.hash(state);
         }
-        self.channels.hash(state);
-        self.source.hash(state);
-        self.config.hash(state);
-        self.flags.hash(state);
-        match &self.target_config {
+        channels.hash(state);
+        source.hash(state);
+        config.hash(state);
+        flags.hash(state);
+        match target_config {
             Some(target_config) => {
                 target_config.len().hash(state);
                 for (selector, config) in target_config {
@@ -102,9 +117,9 @@ impl Hash for PackageBuild {
             }
             None => usize::MAX.hash(state),
         }
-        self.build_string_prefix.hash(state);
-        self.build_number.hash(state);
-        self.secrets.hash(state);
+        build_string_prefix.hash(state);
+        build_number.hash(state);
+        secrets.hash(state);
     }
 }
 

--- a/crates/pixi_manifest/src/build_system.rs
+++ b/crates/pixi_manifest/src/build_system.rs
@@ -1,5 +1,7 @@
 //! Defines the build section for the pixi manifest.
 
+use std::hash::{Hash, Hasher};
+
 use indexmap::IndexMap;
 use pixi_spec::{PixiSpec, SourceLocationSpec};
 use rattler_conda_types::{Flag, NamedChannelOrUrl};
@@ -67,13 +69,43 @@ impl PackageBuild {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash)]
 pub struct BuildBackend {
     /// The name of the build backend to install
     pub name: rattler_conda_types::PackageName,
 
     /// The spec for the backend
     pub spec: PixiSpec,
+}
+
+impl Hash for PackageBuild {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.backend.hash(state);
+        // The dependency and target-config maps are `IndexMap`s; their
+        // declaration order is stable, so hash their entries in order.
+        self.additional_dependencies.len().hash(state);
+        for (name, spec) in &self.additional_dependencies {
+            name.hash(state);
+            spec.hash(state);
+        }
+        self.channels.hash(state);
+        self.source.hash(state);
+        self.config.hash(state);
+        self.flags.hash(state);
+        match &self.target_config {
+            Some(target_config) => {
+                target_config.len().hash(state);
+                for (selector, config) in target_config {
+                    selector.hash(state);
+                    config.hash(state);
+                }
+            }
+            None => usize::MAX.hash(state),
+        }
+        self.build_string_prefix.hash(state);
+        self.build_number.hash(state);
+        self.secrets.hash(state);
+    }
 }
 
 impl PackageBuild {

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -3,7 +3,7 @@ use crate::{
     pypi::pypi_options::PypiOptions, target::Targets, workspace::ChannelPriority,
     workspace::SolveStrategy,
 };
-use crate::{PixiPlatform, PixiPlatformName};
+use crate::{InlinePackageManifest, PixiPlatform, PixiPlatformName};
 use indexmap::{IndexMap, IndexSet};
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 use pixi_spec::PixiSpec;
@@ -423,6 +423,24 @@ impl Feature {
                     Some(Cow::Owned(acc.as_ref().overwrite(deps)))
                 }
             })
+    }
+
+    /// Returns the inline package definitions of the feature for a given
+    /// `platform`. Definitions from more specific targets
+    /// override less specific ones with the same name.
+    pub fn inline_packages<'a>(
+        &'a self,
+        platform: Option<&'a PixiPlatform>,
+    ) -> IndexMap<PackageName, &'a InlinePackageManifest> {
+        let mut result = IndexMap::new();
+        // Resolve targets from least to most specific so more specific targets
+        // overwrite the entries of less specific ones.
+        for target in self.targets.resolve(platform).rev() {
+            for (name, manifest) in &target.inline_packages {
+                result.insert(name.clone(), manifest);
+            }
+        }
+        result
     }
 
     /// Returns the version constraints of the feature for a given `platform`.

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::Not;
 use std::{
     borrow::{Borrow, Cow},
+    collections::HashSet,
     convert::Infallible,
     fmt,
     hash::{Hash, Hasher},
@@ -426,18 +427,33 @@ impl Feature {
     }
 
     /// Returns the inline package definitions of the feature for a given
-    /// `platform`. Definitions from more specific targets
-    /// override less specific ones with the same name.
+    /// `platform`.
+    ///
+    /// The most specific target that declares a package as a dependency decides
+    /// whether it carries an inline definition. A less specific target's inline
+    /// definition must not leak onto a package that a more specific target
+    /// already declares without one, so a plain (non-inline) declaration in a
+    /// more specific target suppresses an inline definition from a less specific
+    /// one.
     pub fn inline_packages<'a>(
         &'a self,
         platform: Option<&'a PixiPlatform>,
     ) -> IndexMap<PackageName, &'a InlinePackageManifest> {
         let mut result = IndexMap::new();
-        // Resolve targets from least to most specific so more specific targets
-        // overwrite the entries of less specific ones.
-        for target in self.targets.resolve(platform).rev() {
-            for (name, manifest) in &target.inline_packages {
-                result.insert(name.clone(), manifest);
+        let mut decided: HashSet<PackageName> = HashSet::new();
+        // `resolve` yields targets from most to least specific.
+        for target in self.targets.resolve(platform) {
+            let Some(dependencies) = target.combined_dependencies() else {
+                continue;
+            };
+            for name in dependencies.names() {
+                // The first (most specific) target to declare the package wins;
+                // its inline definition (or absence of one) is final.
+                if decided.insert(name.clone())
+                    && let Some(manifest) = target.inline_packages.get(name)
+                {
+                    result.insert(name.clone(), manifest);
+                }
             }
         }
         result

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -59,7 +59,10 @@ pub use spec_type::SpecType;
 pub use system_requirements::{
     GLIBC_FAMILY, LibCFamilyAndVersion, LibCSystemRequirement, MUSL_FAMILY, SystemRequirements,
 };
-pub use target::{InlinePackageManifest, PackageTarget, TargetSelector, Targets, WorkspaceTarget};
+pub use target::{
+    InlineContentHash, InlinePackageManifest, PackageTarget, TargetSelector, Targets,
+    WorkspaceTarget,
+};
 pub use task::{Task, TaskName};
 use thiserror::Error;
 pub use warning::{Warning, WarningWithSource, WithWarnings};

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -59,7 +59,7 @@ pub use spec_type::SpecType;
 pub use system_requirements::{
     GLIBC_FAMILY, LibCFamilyAndVersion, LibCSystemRequirement, MUSL_FAMILY, SystemRequirements,
 };
-pub use target::{PackageTarget, TargetSelector, Targets, WorkspaceTarget};
+pub use target::{InlinePackageManifest, PackageTarget, TargetSelector, Targets, WorkspaceTarget};
 pub use task::{Task, TaskName};
 use thiserror::Error;
 pub use warning::{Warning, WarningWithSource, WithWarnings};

--- a/crates/pixi_manifest/src/manifests/package.rs
+++ b/crates/pixi_manifest/src/manifests/package.rs
@@ -1,3 +1,5 @@
+use std::hash::{Hash, Hasher};
+
 use indexmap::IndexMap;
 use pixi_build_types::ConditionalExpression;
 
@@ -23,4 +25,19 @@ pub struct PackageManifest {
     /// `[package.target.<platform>]` tables are lowered into entries of this
     /// map at parse time.
     pub conditional_dependencies: IndexMap<ConditionalExpression, PackageTarget>,
+}
+
+impl Hash for PackageManifest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.package.hash(state);
+        self.build.hash(state);
+        self.dependencies.hash(state);
+        // `conditional_dependencies` is an `IndexMap`; its declaration order is
+        // stable, so hash its entries in order.
+        self.conditional_dependencies.len().hash(state);
+        for (expression, target) in &self.conditional_dependencies {
+            expression.hash(state);
+            target.hash(state);
+        }
+    }
 }

--- a/crates/pixi_manifest/src/package.rs
+++ b/crates/pixi_manifest/src/package.rs
@@ -4,7 +4,7 @@ use rattler_conda_types::Version;
 use url::Url;
 
 /// Defines the contents of the `[package]` section of the project manifest.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash)]
 pub struct Package {
     /// The name of the project
     pub name: Option<String>,

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, collections::HashMap, str::FromStr};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    str::FromStr,
+};
 
 use indexmap::{IndexMap, map::Entry};
 use itertools::Either;
@@ -13,6 +18,7 @@ use crate::{
     PixiPlatformName, PlatformGlob, PyPiDependencies, SpecType,
     activation::Activation,
     dependencies::{CondaConstraints, CondaDevDependencies},
+    manifests::PackageManifest,
     task::{Task, TaskName},
     utils::PixiSpanned,
 };
@@ -37,6 +43,11 @@ pub struct WorkspaceTarget {
     /// installed without building the packages themselves
     pub dev_dependencies: Option<CondaDevDependencies>,
 
+    /// Inline package definitions attached to source dependencies in this
+    /// target. Keyed by dependency name; the matching source
+    /// spec lives in [`Self::dependencies`].
+    pub inline_packages: IndexMap<PackageName, InlinePackageManifest>,
+
     /// Version constraints for this target.
     ///
     /// Constraints limit the versions of packages that can be installed without
@@ -51,6 +62,19 @@ pub struct WorkspaceTarget {
     pub tasks: HashMap<TaskName, Task>,
 }
 
+/// An inline package definition converted to a [`PackageManifest`], together
+/// with a content hash of that manifest. The hash incorporates the dependency
+/// name, so two definitions that resolve to the same source location but differ
+/// in name or content get distinct hashes; editing the definition changes the
+/// assembled manifest and thus the hash, invalidating caches.
+#[derive(Debug, Clone)]
+pub struct InlinePackageManifest {
+    /// The converted package manifest.
+    pub manifest: PackageManifest,
+    /// Deterministic hash of `(dependency name, package manifest)`.
+    pub content_hash: u64,
+}
+
 /// A package target describes the dependencies for a specific platform.
 #[derive(Default, Debug, Clone)]
 pub struct PackageTarget {
@@ -59,6 +83,25 @@ pub struct PackageTarget {
 
     /// Extra groups declared by the package for this target.
     pub extra_dependencies: IndexMap<ExtraGroupName, DependencyMap<PackageName, PixiSpec>>,
+}
+
+impl Hash for PackageTarget {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // `dependencies` is a `HashMap`; iterate the spec types in a fixed order
+        // so the hash does not depend on the map's iteration order.
+        for spec_type in [SpecType::Run, SpecType::Host, SpecType::Build] {
+            if let Some(dependencies) = self.dependencies.get(&spec_type) {
+                spec_type.hash(state);
+                dependencies.hash(state);
+            }
+        }
+        // `extra_dependencies` is an `IndexMap`; its declaration order is stable.
+        self.extra_dependencies.len().hash(state);
+        for (group, dependencies) in &self.extra_dependencies {
+            group.hash(state);
+            dependencies.hash(state);
+        }
+    }
 }
 
 impl WorkspaceTarget {

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -102,12 +102,18 @@ pub struct PackageTarget {
 
 impl Hash for PackageTarget {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash each dependency table as a named field through `StableHashBuilder`:
-        // empty tables are skipped, so adding a new default-empty dependency
-        // category later leaves the hash of existing targets unchanged, and the
-        // fields are folded in a fixed order independent of the `HashMap` layout.
+        // Bind every field so adding a new one fails to compile until it is
+        // hashed here. Hash each dependency table as a named field through
+        // `StableHashBuilder`: empty tables are skipped, so adding a new
+        // default-empty dependency category later leaves the hash of existing
+        // targets unchanged, and the fields are folded in a fixed order
+        // independent of the `HashMap` layout.
+        let Self {
+            dependencies,
+            extra_dependencies,
+        } = self;
         let collect = |spec_type: SpecType| -> Vec<(&PackageName, &PixiSpec)> {
-            self.dependencies
+            dependencies
                 .get(&spec_type)
                 .into_iter()
                 .flat_map(|dependencies| dependencies.iter_specs())
@@ -117,8 +123,7 @@ impl Hash for PackageTarget {
         let host = collect(SpecType::Host);
         let build = collect(SpecType::Build);
         // `extra_dependencies` is an `IndexMap`; its declaration order is stable.
-        let extra: Vec<(&ExtraGroupName, Vec<(&PackageName, &PixiSpec)>)> = self
-            .extra_dependencies
+        let extra: Vec<(&ExtraGroupName, Vec<(&PackageName, &PixiSpec)>)> = extra_dependencies
             .iter()
             .map(|(group, dependencies)| (group, dependencies.iter_specs().collect()))
             .collect();

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -10,6 +10,7 @@ use itertools::Either;
 use pixi_build_types::ExtraGroupName;
 use pixi_spec::PixiSpec;
 use pixi_spec_containers::DependencyMap;
+use pixi_stable_hash::StableHashBuilder;
 use rattler_conda_types::{PackageName, ParsePlatformError, Platform};
 
 use super::error::DependencyError;
@@ -101,20 +102,33 @@ pub struct PackageTarget {
 
 impl Hash for PackageTarget {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // `dependencies` is a `HashMap`; iterate the spec types in a fixed order
-        // so the hash does not depend on the map's iteration order.
-        for spec_type in [SpecType::Run, SpecType::Host, SpecType::Build] {
-            if let Some(dependencies) = self.dependencies.get(&spec_type) {
-                spec_type.hash(state);
-                dependencies.hash(state);
-            }
-        }
+        // Hash each dependency table as a named field through `StableHashBuilder`:
+        // empty tables are skipped, so adding a new default-empty dependency
+        // category later leaves the hash of existing targets unchanged, and the
+        // fields are folded in a fixed order independent of the `HashMap` layout.
+        let collect = |spec_type: SpecType| -> Vec<(&PackageName, &PixiSpec)> {
+            self.dependencies
+                .get(&spec_type)
+                .into_iter()
+                .flat_map(|dependencies| dependencies.iter_specs())
+                .collect()
+        };
+        let run = collect(SpecType::Run);
+        let host = collect(SpecType::Host);
+        let build = collect(SpecType::Build);
         // `extra_dependencies` is an `IndexMap`; its declaration order is stable.
-        self.extra_dependencies.len().hash(state);
-        for (group, dependencies) in &self.extra_dependencies {
-            group.hash(state);
-            dependencies.hash(state);
-        }
+        let extra: Vec<(&ExtraGroupName, Vec<(&PackageName, &PixiSpec)>)> = self
+            .extra_dependencies
+            .iter()
+            .map(|(group, dependencies)| (group, dependencies.iter_specs().collect()))
+            .collect();
+
+        StableHashBuilder::new()
+            .field("build_dependencies", &build)
+            .field("extra_dependencies", &extra)
+            .field("host_dependencies", &host)
+            .field("run_dependencies", &run)
+            .finish(state);
     }
 }
 

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -62,17 +62,31 @@ pub struct WorkspaceTarget {
     pub tasks: HashMap<TaskName, Task>,
 }
 
+/// Content fingerprint of an inline package definition.
+///
+/// A dedicated newtype keeps this value from being confused with arbitrary
+/// `u64`s as it is threaded through cache keys. It is a deterministic hash of
+/// `(dependency name, package manifest)`, so two definitions that resolve to the
+/// same source location but differ in name or content get distinct fingerprints,
+/// and editing the definition changes the fingerprint, invalidating caches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InlineContentHash(pub u64);
+
+impl InlineContentHash {
+    /// Returns the underlying hash value.
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
 /// An inline package definition converted to a [`PackageManifest`], together
-/// with a content hash of that manifest. The hash incorporates the dependency
-/// name, so two definitions that resolve to the same source location but differ
-/// in name or content get distinct hashes; editing the definition changes the
-/// assembled manifest and thus the hash, invalidating caches.
+/// with a content hash of that manifest.
 #[derive(Debug, Clone)]
 pub struct InlinePackageManifest {
     /// The converted package manifest.
     pub manifest: PackageManifest,
-    /// Deterministic hash of `(dependency name, package manifest)`.
-    pub content_hash: u64,
+    /// Content fingerprint of `(dependency name, package manifest)`.
+    pub content_hash: InlineContentHash,
 }
 
 /// A package target describes the dependencies for a specific platform.

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::Path};
 
 use indexmap::{IndexMap, IndexSet};
 use pixi_toml::{Same, TomlHashMap, TomlIndexMap, TomlIndexSet, TomlWith};
@@ -12,7 +12,10 @@ use crate::{
         PlatformSpan, TomlPrioritizedChannel, TomlTarget, TomlWorkspace,
         create_unsupported_selector_warning, preview::TomlPreview, task::TomlTask,
     },
-    utils::{PixiSpanned, package_map::UniquePackageMap},
+    utils::{
+        PixiSpanned,
+        package_map::{DependencyTable, UniquePackageMap},
+    },
     warning::Deprecation,
     workspace::{ChannelPriority, SolveStrategy},
 };
@@ -26,9 +29,9 @@ pub struct TomlFeature {
     pub system_requirements: SystemRequirements,
     pub target: IndexMap<PixiSpanned<TargetSelector>, TomlTarget>,
     pub solve_strategy: Option<SolveStrategy>,
-    pub dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub host_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub build_dependencies: Option<PixiSpanned<UniquePackageMap>>,
+    pub dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub host_dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub build_dependencies: Option<PixiSpanned<DependencyTable>>,
     pub pypi_dependencies: Option<IndexMap<PypiPackageName, PixiPypiSpec>>,
     pub dev: Option<IndexMap<rattler_conda_types::PackageName, pixi_spec::TomlLocationSpec>>,
 
@@ -59,6 +62,7 @@ impl TomlFeature {
         name: FeatureName,
         preview: &TomlPreview,
         workspace: &TomlWorkspace,
+        root_directory: &Path,
     ) -> Result<WithWarnings<(Feature, SystemRequirements)>, TomlError> {
         let WithWarnings {
             value: default_target,
@@ -74,7 +78,7 @@ impl TomlFeature {
             tasks: self.tasks,
             warnings: self.warnings,
         }
-        .into_workspace_target(None, preview)?;
+        .into_workspace_target(None, preview, root_directory)?;
 
         let feature_platform_names = self
             .platforms
@@ -129,7 +133,11 @@ impl TomlFeature {
             let WithWarnings {
                 value: target,
                 warnings: mut target_warnings,
-            } = target.into_workspace_target(Some(selector.value.clone()), preview)?;
+            } = target.into_workspace_target(
+                Some(selector.value.clone()),
+                preview,
+                root_directory,
+            )?;
             targets.insert(selector, target);
             warnings.append(&mut target_warnings);
         }
@@ -168,7 +176,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlFeature {
             .map(TomlIndexMap::into_inner)
             .unwrap_or_default();
         let dependencies = th.optional("dependencies");
-        let host_dependencies: Option<Spanned<UniquePackageMap>> = th.optional("host-dependencies");
+        let host_dependencies: Option<Spanned<DependencyTable>> = th.optional("host-dependencies");
         if let Some(host_dependencies) = &host_dependencies {
             warnings.push(
                 Deprecation::renamed_field(
@@ -181,7 +189,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlFeature {
         }
         let host_dependencies = host_dependencies.map(From::from);
 
-        let build_dependencies: Option<Spanned<UniquePackageMap>> =
+        let build_dependencies: Option<Spanned<DependencyTable>> =
             th.optional("build-dependencies");
         if let Some(build_dependencies) = &build_dependencies {
             warnings.push(

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -10,7 +10,8 @@ use crate::{
     pypi::pypi_options::PypiOptions,
     toml::{
         PlatformSpan, TomlPrioritizedChannel, TomlTarget, TomlWorkspace,
-        create_unsupported_selector_warning, preview::TomlPreview, task::TomlTask,
+        WorkspacePackageProperties, create_unsupported_selector_warning, preview::TomlPreview,
+        task::TomlTask,
     },
     utils::{
         PixiSpanned,
@@ -62,6 +63,7 @@ impl TomlFeature {
         name: FeatureName,
         preview: &TomlPreview,
         workspace: &TomlWorkspace,
+        workspace_package_properties: &WorkspacePackageProperties,
         root_directory: &Path,
     ) -> Result<WithWarnings<(Feature, SystemRequirements)>, TomlError> {
         let WithWarnings {
@@ -78,7 +80,12 @@ impl TomlFeature {
             tasks: self.tasks,
             warnings: self.warnings,
         }
-        .into_workspace_target(None, preview, root_directory)?;
+        .into_workspace_target(
+            None,
+            preview,
+            workspace_package_properties,
+            root_directory,
+        )?;
 
         let feature_platform_names = self
             .platforms
@@ -136,6 +143,7 @@ impl TomlFeature {
             } = target.into_workspace_target(
                 Some(selector.value.clone()),
                 preview,
+                workspace_package_properties,
                 root_directory,
             )?;
             targets.insert(selector, target);

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -918,7 +918,10 @@ mod test {
     use rattler_conda_types::Platform;
 
     use super::*;
-    use crate::{PixiPlatform, toml::FromTomlStr, utils::test_utils::expect_parse_warnings};
+    use crate::{
+        InlineContentHash, PixiPlatform, toml::FromTomlStr,
+        utils::test_utils::expect_parse_warnings,
+    };
 
     /// A helper function that generates a snapshot of the error message when
     /// parsing a manifest TOML. The error is returned.
@@ -1437,7 +1440,7 @@ mod test {
     }
 
     /// Parse a manifest and return the content hash of the named inline package.
-    fn inline_content_hash(manifest: &str, package: &str) -> u64 {
+    fn inline_content_hash(manifest: &str, package: &str) -> InlineContentHash {
         let manifest = <TomlManifest as FromTomlStr>::from_toml_str(manifest).expect("parse toml");
         let (ws, _pkg, _warnings) = manifest
             .into_workspace_manifest(

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -162,6 +162,26 @@ impl TomlManifest {
         let preview = &workspace.value.preview;
         let pixi_build_enabled = preview.is_enabled(KnownPreviewFeature::PixiBuild);
 
+        // Inline package definitions declared on dependencies are converted into
+        // full package manifests while building the targets below, so they must
+        // inherit the same workspace package properties an on-disk `[package]`
+        // would. Assemble those properties from the workspace's external
+        // properties up front; the workspace manifest itself is not built yet.
+        let inline_workspace_properties = WorkspacePackageProperties {
+            name: external.name.clone(),
+            version: external.version.clone(),
+            description: external.description.clone(),
+            authors: external.authors.clone(),
+            license: external.license.clone(),
+            license_file: external.license_file.clone(),
+            readme: external.readme.clone(),
+            homepage: external.homepage.clone(),
+            repository: external.repository.clone(),
+            documentation: external.documentation.clone(),
+            dependencies: IndexMap::new(),
+            workspace_root: Some(root_directory.to_path_buf()),
+        };
+
         let WithWarnings {
             value: default_workspace_target,
             mut warnings,
@@ -176,7 +196,12 @@ impl TomlManifest {
             tasks: self.tasks.map(PixiSpanned::into_inner).unwrap_or_default(),
             warnings: self.warnings,
         }
-        .into_workspace_target(None, preview, root_directory)?;
+        .into_workspace_target(
+            None,
+            preview,
+            &inline_workspace_properties,
+            root_directory,
+        )?;
 
         let known_platforms = &workspace.value.platforms.value;
 
@@ -204,6 +229,7 @@ impl TomlManifest {
             } = target.into_workspace_target(
                 Some(selector.value.clone()),
                 preview,
+                &inline_workspace_properties,
                 root_directory,
             )?;
             workspace_targets.insert(selector, workspace_target);
@@ -273,6 +299,7 @@ impl TomlManifest {
                     name.value.clone(),
                     preview,
                     &workspace.value,
+                    &inline_workspace_properties,
                     root_directory,
                 )?;
                 warnings.append(&mut feature_warnings);

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -1541,6 +1541,61 @@ mod test {
         );
     }
 
+    /// Parse a `pyproject.toml` whose `[tool.pixi]` table declares an inline
+    /// package and return that package's content hash.
+    fn inline_content_hash_pyproject(manifest: &str, package: &str) -> InlineContentHash {
+        let manifest =
+            crate::pyproject::PyProjectManifest::from_toml_str(manifest).expect("parse pyproject");
+        let (ws, _pkg, _warnings) = manifest
+            .into_workspace_manifest(Path::new(""))
+            .expect("convert pyproject to workspace manifest");
+        let name = rattler_conda_types::PackageName::new_unchecked(package);
+        ws.default_feature()
+            .targets
+            .default()
+            .inline_packages
+            .get(&name)
+            .expect("inline package stored")
+            .content_hash
+    }
+
+    #[test]
+    fn test_inline_content_hash_is_consumer_format_independent() {
+        // The same inline definition declared in a `pixi.toml` `[dependencies]`
+        // entry and in a `pyproject.toml` `[tool.pixi.dependencies]` entry must
+        // assemble to the same package manifest. The content hash folds in the
+        // dependency name and package manifest but not the consuming workspace,
+        // so the two formats must hash equally; otherwise the build cache key
+        // would depend on which manifest format the consumer happened to use.
+        let pixi_toml = r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [dependencies]
+            pkg = { path = "pkg", package = { build = { backend = { name = "pixi-build-python", version = "*" } }, run-dependencies = { rich = ">=13.9.4,<14" } } }
+            "#;
+        let pyproject = r#"
+            [project]
+            name = "consumer"
+            version = "0.1.0"
+            requires-python = ">=3.11"
+
+            [tool.pixi.workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [tool.pixi.dependencies]
+            pkg = { path = "pkg", package = { build = { backend = { name = "pixi-build-python", version = "*" } }, run-dependencies = { rich = ">=13.9.4,<14" } } }
+            "#;
+        assert_eq!(
+            inline_content_hash(pixi_toml, "pkg"),
+            inline_content_hash_pyproject(pyproject, "pkg"),
+        );
+    }
+
     #[test]
     fn test_package_inherits_workspace_dependency() {
         // The host-dependencies entry uses { workspace = true } and the

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -31,7 +31,10 @@ use crate::{
         WorkspacePackageProperties, create_unsupported_selector_warning,
         environment::TomlEnvironmentList, task::TomlTask,
     },
-    utils::{PixiSpanned, package_map::UniquePackageMap},
+    utils::{
+        PixiSpanned,
+        package_map::{DependencyTable, UniquePackageMap},
+    },
     warning::Deprecation,
 };
 
@@ -44,9 +47,9 @@ pub struct TomlManifest {
 
     pub system_requirements: Option<PixiSpanned<SystemRequirements>>,
     pub target: Option<PixiSpanned<IndexMap<PixiSpanned<TargetSelector>, TomlTarget>>>,
-    pub dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub host_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub build_dependencies: Option<PixiSpanned<UniquePackageMap>>,
+    pub dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub host_dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub build_dependencies: Option<PixiSpanned<DependencyTable>>,
 
     /// Version constraints - limit versions of packages that can be installed
     /// without explicitly requiring them.
@@ -173,7 +176,7 @@ impl TomlManifest {
             tasks: self.tasks.map(PixiSpanned::into_inner).unwrap_or_default(),
             warnings: self.warnings,
         }
-        .into_workspace_target(None, preview)?;
+        .into_workspace_target(None, preview, root_directory)?;
 
         let known_platforms = &workspace.value.platforms.value;
 
@@ -198,7 +201,11 @@ impl TomlManifest {
             let WithWarnings {
                 value: workspace_target,
                 warnings: mut target_warnings,
-            } = target.into_workspace_target(Some(selector.value.clone()), preview)?;
+            } = target.into_workspace_target(
+                Some(selector.value.clone()),
+                preview,
+                root_directory,
+            )?;
             workspace_targets.insert(selector, workspace_target);
             warnings.append(&mut target_warnings);
         }
@@ -262,7 +269,12 @@ impl TomlManifest {
                 let WithWarnings {
                     value: (feature, sysreqs),
                     warnings: mut feature_warnings,
-                } = feature.into_feature(name.value.clone(), preview, &workspace.value)?;
+                } = feature.into_feature(
+                    name.value.clone(),
+                    preview,
+                    &workspace.value,
+                    root_directory,
+                )?;
                 warnings.append(&mut feature_warnings);
                 feature_sysreqs.insert(name.value.clone(), sysreqs);
                 feature_name_to_span
@@ -738,7 +750,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlManifest {
 
         let dependencies = th.optional("dependencies");
 
-        let host_dependencies: Option<Spanned<UniquePackageMap>> = th.optional("host-dependencies");
+        let host_dependencies: Option<Spanned<DependencyTable>> = th.optional("host-dependencies");
         if let Some(host_dependencies) = &host_dependencies {
             warnings.push(
                 Deprecation::renamed_field(
@@ -751,7 +763,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlManifest {
         }
         let host_dependencies = host_dependencies.map(From::from);
 
-        let build_dependencies: Option<Spanned<UniquePackageMap>> =
+        let build_dependencies: Option<Spanned<DependencyTable>> =
             th.optional("build-dependencies");
         if let Some(build_dependencies) = &build_dependencies {
             warnings.push(
@@ -1376,6 +1388,154 @@ mod test {
             .get(&rattler_conda_types::PackageName::new_unchecked("numpy"))
             .expect("numpy in workspace pool");
         assert_eq!(numpy.version.as_ref().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_inline_package_definition_in_dependencies() {
+        // An inline package definition on a source dependency is captured on the
+        // target while the source spec stays in the regular dependency map.
+        let manifest = <TomlManifest as FromTomlStr>::from_toml_str(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [dependencies]
+            rust-package = { git = "https://github.com/user/repo.git", package.build = { backend = { name = "pixi-build-rust", version = "*" } } }
+            "#,
+        )
+        .expect("parse toml");
+        let (ws, _pkg, _warnings) = manifest
+            .into_workspace_manifest(
+                ExternalWorkspaceProperties::default(),
+                PackageDefaults::default(),
+                Path::new(""),
+            )
+            .expect("convert to workspace manifest");
+
+        let default_target = ws.default_feature().targets.default();
+        let name = rattler_conda_types::PackageName::new_unchecked("rust-package");
+
+        // The source spec is retained as a normal dependency.
+        let spec = default_target
+            .run_dependencies()
+            .and_then(|deps| deps.get(&name))
+            .expect("source spec retained");
+        assert!(spec.iter().all(|s| s.is_source()));
+
+        // The inline package definition is captured on the target.
+        let inline = default_target
+            .inline_packages
+            .get(&name)
+            .expect("inline package stored")
+            .manifest
+            .clone();
+        assert_eq!(inline.build.backend.name.as_normalized(), "pixi-build-rust");
+        // The build source is taken from the dependency spec, not the inline body.
+        assert!(inline.build.source.is_none());
+    }
+
+    /// Parse a manifest and return the content hash of the named inline package.
+    fn inline_content_hash(manifest: &str, package: &str) -> u64 {
+        let manifest = <TomlManifest as FromTomlStr>::from_toml_str(manifest).expect("parse toml");
+        let (ws, _pkg, _warnings) = manifest
+            .into_workspace_manifest(
+                ExternalWorkspaceProperties::default(),
+                PackageDefaults::default(),
+                Path::new(""),
+            )
+            .expect("convert to workspace manifest");
+        let name = rattler_conda_types::PackageName::new_unchecked(package);
+        ws.default_feature()
+            .targets
+            .default()
+            .inline_packages
+            .get(&name)
+            .expect("inline package stored")
+            .content_hash
+    }
+
+    // A workspace declaring a single inline package `pkg`. The helpers below
+    // perturb one aspect at a time to pin down what the content hash reacts to.
+    const INLINE_HASH_MANIFEST: &str = r#"
+        [workspace]
+        channels = []
+        platforms = ['linux-64']
+        preview = ["pixi-build"]
+
+        [dependencies]
+        pkg = { git = "https://github.com/user/repo.git", package = { build = { backend = { name = "pixi-build-rust", version = "*" } } } }
+        "#;
+
+    #[test]
+    fn test_inline_content_hash_is_deterministic() {
+        // Parsing the same definition twice yields the same hash; nothing
+        // run-dependent leaks into it.
+        assert_eq!(
+            inline_content_hash(INLINE_HASH_MANIFEST, "pkg"),
+            inline_content_hash(INLINE_HASH_MANIFEST, "pkg"),
+        );
+    }
+
+    #[test]
+    fn test_inline_content_hash_ignores_formatting() {
+        // The hash is taken over the assembled manifest, not the source text.
+        // Dotted keys and a different field order parse to the same manifest, so
+        // they must hash equally.
+        let reformatted = r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [dependencies]
+            pkg = { git = "https://github.com/user/repo.git", package.build.backend = { version = "*", name = "pixi-build-rust" } }
+            "#;
+        assert_eq!(
+            inline_content_hash(INLINE_HASH_MANIFEST, "pkg"),
+            inline_content_hash(reformatted, "pkg"),
+        );
+    }
+
+    #[test]
+    fn test_inline_content_hash_changes_with_build_config() {
+        // `build.config` is backend configuration that is not otherwise
+        // represented in the build cache key, so editing it must change the
+        // content hash. This is the property that makes hashing the whole
+        // manifest (rather than just the dependencies) necessary.
+        let with_config = r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [dependencies]
+            pkg = { git = "https://github.com/user/repo.git", package = { build = { backend = { name = "pixi-build-rust", version = "*" }, config = { extra = "value" } } } }
+            "#;
+        assert_ne!(
+            inline_content_hash(INLINE_HASH_MANIFEST, "pkg"),
+            inline_content_hash(with_config, "pkg"),
+        );
+    }
+
+    #[test]
+    fn test_inline_content_hash_folds_in_dependency_name() {
+        // Two identical inline tables declared under different dependency names
+        // get distinct hashes, so they never collide in the cache.
+        let other_name = r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [dependencies]
+            other = { git = "https://github.com/user/repo.git", package = { build = { backend = { name = "pixi-build-rust", version = "*" } } } }
+            "#;
+        assert_ne!(
+            inline_content_hash(INLINE_HASH_MANIFEST, "pkg"),
+            inline_content_hash(other_name, "other"),
+        );
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -1,26 +1,37 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    path::Path,
+};
 
 use indexmap::IndexMap;
 use pixi_spec::{PixiSpec, TomlLocationSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_toml::{TomlHashMap, TomlIndexMap};
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
+use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
-    Activation, KnownPreviewFeature, SpecType, TargetSelector, Task, TaskName, TomlError, Warning,
-    WithWarnings, WorkspaceTarget,
+    Activation, InlinePackageManifest, KnownPreviewFeature, SpecType, TargetSelector, Task,
+    TaskName, TomlError, Warning, WithWarnings, WorkspaceTarget,
     error::GenericError,
-    toml::{preview::TomlPreview, task::TomlTask},
-    utils::{PixiSpanned, package_map::UniquePackageMap},
+    toml::{
+        PackageDefaults, TomlPackage, WorkspacePackageProperties, preview::TomlPreview,
+        task::TomlTask,
+    },
+    utils::{
+        PixiSpanned,
+        package_map::{DependencyTable, UniquePackageMap},
+    },
 };
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 use rattler_conda_types::PackageName;
 
 #[derive(Debug, Default)]
 pub struct TomlTarget {
-    pub dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub host_dependencies: Option<PixiSpanned<UniquePackageMap>>,
-    pub build_dependencies: Option<PixiSpanned<UniquePackageMap>>,
+    pub dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub host_dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub build_dependencies: Option<PixiSpanned<DependencyTable>>,
     pub pypi_dependencies: Option<IndexMap<PypiPackageName, PixiPypiSpec>>,
     pub dev_dependencies: Option<IndexMap<PackageName, TomlLocationSpec>>,
 
@@ -40,18 +51,35 @@ pub struct TomlTarget {
 
 impl TomlTarget {
     /// Called to convert this instance into a workspace target of a feature.
+    ///
+    /// `root_directory` is the directory of the manifest that defines this
+    /// target; it is used to resolve and convert any inline package
+    /// definitions.
     pub fn into_workspace_target(
         self,
         target: Option<TargetSelector>,
         preview: &TomlPreview,
+        root_directory: &Path,
     ) -> Result<WithWarnings<WorkspaceTarget>, TomlError> {
         let pixi_build_enabled = preview.is_enabled(KnownPreviewFeature::PixiBuild);
 
+        let TomlTarget {
+            dependencies,
+            host_dependencies,
+            build_dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            mut warnings,
+        } = self;
+
         if pixi_build_enabled {
-            if let Some(host_dependencies) = self.host_dependencies {
+            if let Some(host_dependencies) = &host_dependencies {
                 return Err(TomlError::Generic(
                     GenericError::new("When `pixi-build` is enabled, host-dependencies can only be specified for a package.")
-                        .with_opt_span(host_dependencies.span)
+                        .with_opt_span(host_dependencies.span.clone())
                         .with_span_label("host-dependencies specified here")
                         .with_help(match target {
                             None => "Did you mean [package.host-dependencies]?".to_string(),
@@ -60,10 +88,10 @@ impl TomlTarget {
                         .with_opt_label("pixi-build is enabled here", preview.get_span(KnownPreviewFeature::PixiBuild))));
             }
 
-            if let Some(build_dependencies) = self.build_dependencies {
+            if let Some(build_dependencies) = &build_dependencies {
                 return Err(TomlError::Generic(
                     GenericError::new("When `pixi-build` is enabled, build-dependencies can only be specified for a package.")
-                        .with_opt_span(build_dependencies.span)
+                        .with_opt_span(build_dependencies.span.clone())
                         .with_span_label("build-dependencies specified here")
                         .with_help(match target {
                             None => "Did you mean [package.build-dependencies]?".to_string(),
@@ -74,9 +102,52 @@ impl TomlTarget {
             }
         }
 
+        // Peel inline package definitions off each consumer dependency table,
+        // leaving the source specs to flow into the regular dependency map.
+        let mut inline_toml: IndexMap<PackageName, PixiSpanned<TomlPackage>> = IndexMap::new();
+        let dependencies = split_inline_packages(dependencies, &mut inline_toml)?;
+        let host_dependencies = split_inline_packages(host_dependencies, &mut inline_toml)?;
+        let build_dependencies = split_inline_packages(build_dependencies, &mut inline_toml)?;
+
+        // Convert the inline package definitions into full package manifests.
+        // Their build source is taken from the surrounding dependency spec, so
+        // the converted manifests carry no `build.source` of their own.
+        let full_preview = preview.clone().into_preview().value;
+        let mut inline_packages: IndexMap<PackageName, InlinePackageManifest> = IndexMap::new();
+        for (name, package) in inline_toml {
+            let WithWarnings {
+                value: manifest,
+                warnings: mut package_warnings,
+            } = package.value.into_manifest(
+                WorkspacePackageProperties::default(),
+                PackageDefaults::default(),
+                &full_preview,
+                root_directory,
+            )?;
+            warnings.append(&mut package_warnings);
+
+            // Fingerprint the assembled manifest so editing the inline
+            // definition invalidates the content-addressed build caches it
+            // feeds. The dependency name is folded in so two identical inline
+            // tables declared under different names stay distinct.
+            let content_hash = {
+                let mut hasher = Xxh3::new();
+                name.as_normalized().hash(&mut hasher);
+                manifest.hash(&mut hasher);
+                hasher.finish()
+            };
+
+            inline_packages.insert(
+                name,
+                InlinePackageManifest {
+                    manifest,
+                    content_hash,
+                },
+            );
+        }
+
         // Convert dev dependencies from TomlLocationSpec to SourceLocationSpec
-        let dev_dependencies = self
-            .dev_dependencies
+        let dev_dependencies = dev_dependencies
             .map(|dev_map| {
                 dev_map
                     .into_iter()
@@ -96,8 +167,7 @@ impl TomlTarget {
 
         // Convert constraints from UniquePackageMap to DependencyMap.
         // Source specs are never valid in [constraints], regardless of pixi-build mode.
-        let constraints = self
-            .constraints
+        let constraints = constraints
             .map(|c| {
                 if let Some((name, _)) = c.value.specs.iter().find(|(_, spec)| spec.is_source()) {
                     return Err(TomlError::Generic(
@@ -122,13 +192,13 @@ impl TomlTarget {
             value: WorkspaceTarget {
                 dependencies: combine_target_dependencies(
                     [
-                        (SpecType::Run, self.dependencies),
-                        (SpecType::Host, self.host_dependencies),
-                        (SpecType::Build, self.build_dependencies),
+                        (SpecType::Run, dependencies),
+                        (SpecType::Host, host_dependencies),
+                        (SpecType::Build, build_dependencies),
                     ],
                     pixi_build_enabled,
                 )?,
-                pypi_dependencies: self.pypi_dependencies.map(|index_map| {
+                pypi_dependencies: pypi_dependencies.map(|index_map| {
                     // Convert IndexMap to DependencyMap
                     index_map.into_iter().collect()
                 }),
@@ -136,13 +206,39 @@ impl TomlTarget {
                     // Convert IndexMap to DependencyMap
                     index_map.into_iter().collect()
                 }),
+                inline_packages,
                 constraints,
-                activation: self.activation,
-                tasks: self.tasks,
+                activation,
+                tasks,
             },
-            warnings: self.warnings,
+            warnings,
         })
     }
+}
+
+/// Splits a consumer dependency table into its source specs and inline package
+/// definitions, draining the latter into `inline`. Errors if a package name
+/// already has an inline definition in another table.
+fn split_inline_packages(
+    table: Option<PixiSpanned<DependencyTable>>,
+    inline: &mut IndexMap<PackageName, PixiSpanned<TomlPackage>>,
+) -> Result<Option<PixiSpanned<UniquePackageMap>>, TomlError> {
+    let Some(PixiSpanned { span, value }) = table else {
+        return Ok(None);
+    };
+    let DependencyTable {
+        specs,
+        inline_packages,
+    } = value;
+    for (name, package) in inline_packages {
+        if inline.insert(name.clone(), package).is_some() {
+            return Err(TomlError::Generic(GenericError::new(format!(
+                "the package '{}' has more than one inline definition",
+                name.as_source()
+            ))));
+        }
+    }
+    Ok(Some(PixiSpanned { span, value: specs }))
 }
 
 /// Combines different target dependencies into a single map.

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -12,7 +12,8 @@ use toml_span::{DeserError, Value, de_helpers::TableHelper};
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
-    Activation, InlinePackageManifest, KnownPreviewFeature, SpecType, TargetSelector, Task,
+    Activation, InlineContentHash, InlinePackageManifest, KnownPreviewFeature, SpecType,
+    TargetSelector, Task,
     TaskName, TomlError, Warning, WithWarnings, WorkspaceTarget,
     error::GenericError,
     toml::{
@@ -134,7 +135,7 @@ impl TomlTarget {
                 let mut hasher = Xxh3::new();
                 name.as_normalized().hash(&mut hasher);
                 manifest.hash(&mut hasher);
-                hasher.finish()
+                InlineContentHash(hasher.finish())
             };
 
             inline_packages.insert(

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -13,8 +13,7 @@ use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
     Activation, InlineContentHash, InlinePackageManifest, KnownPreviewFeature, SpecType,
-    TargetSelector, Task,
-    TaskName, TomlError, Warning, WithWarnings, WorkspaceTarget,
+    TargetSelector, Task, TaskName, TomlError, Warning, WithWarnings, WorkspaceTarget,
     error::GenericError,
     toml::{
         PackageDefaults, TomlPackage, WorkspacePackageProperties, preview::TomlPreview,
@@ -55,11 +54,14 @@ impl TomlTarget {
     ///
     /// `root_directory` is the directory of the manifest that defines this
     /// target; it is used to resolve and convert any inline package
-    /// definitions.
+    /// definitions. `workspace_package_properties` are the consuming workspace's
+    /// values that inline package definitions inherit from when they use
+    /// `{ workspace = true }`.
     pub fn into_workspace_target(
         self,
         target: Option<TargetSelector>,
         preview: &TomlPreview,
+        workspace_package_properties: &WorkspacePackageProperties,
         root_directory: &Path,
     ) -> Result<WithWarnings<WorkspaceTarget>, TomlError> {
         let pixi_build_enabled = preview.is_enabled(KnownPreviewFeature::PixiBuild);
@@ -112,7 +114,12 @@ impl TomlTarget {
 
         // Convert the inline package definitions into full package manifests.
         // Their build source is taken from the surrounding dependency spec, so
-        // the converted manifests carry no `build.source` of their own.
+        // the converted manifests carry no `build.source` of their own. They
+        // inherit the consuming workspace's package properties, so
+        // `{ workspace = true }` fields resolve as they would for an on-disk
+        // `[package]`. Package defaults stay empty: an inline definition
+        // describes a dependency, not the consuming project, so it must not pick
+        // up the consumer's `[project]` metadata implicitly.
         let full_preview = preview.clone().into_preview().value;
         let mut inline_packages: IndexMap<PackageName, InlinePackageManifest> = IndexMap::new();
         for (name, package) in inline_toml {
@@ -120,7 +127,7 @@ impl TomlTarget {
                 value: manifest,
                 warnings: mut package_warnings,
             } = package.value.into_manifest(
-                WorkspacePackageProperties::default(),
+                workspace_package_properties.clone(),
                 PackageDefaults::default(),
                 &full_preview,
                 root_directory,

--- a/crates/pixi_manifest/src/utils/package_map.rs
+++ b/crates/pixi_manifest/src/utils/package_map.rs
@@ -8,9 +8,13 @@ use serde::{
     Deserialize, Deserializer, Serialize,
     de::{DeserializeSeed, MapAccess, Visitor},
 };
-use toml_span::{DeserError, Span, Value, de_helpers::expected, value::ValueInner};
+use toml_span::{
+    DeserError, Span, Value,
+    de_helpers::{TableHelper, expected},
+    value::ValueInner,
+};
 
-use crate::{TomlError, error::GenericError, utils::PixiSpanned};
+use crate::{TomlError, error::GenericError, toml::TomlPackage, utils::PixiSpanned};
 
 #[derive(Clone, Default, Debug, Serialize)]
 pub struct UniquePackageMap {
@@ -164,68 +168,214 @@ impl<'de> DeserializeSeed<'de> for PackageMap<'_> {
 
 impl<'de> toml_span::Deserialize<'de> for UniquePackageMap {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
-        let table = match value.take() {
-            ValueInner::Table(table) => table,
-            inner => return Err(expected("a table", inner, value.span).into()),
-        };
+        Ok(deserialize_dependency_table(value, InlinePackages::Deny)?.specs)
+    }
+}
 
-        let mut errors = DeserError { errors: vec![] };
-        let mut result = Self::default();
-        for (key, mut value) in table.into_iter().sorted_by_key(|(k, _)| k.span.start) {
-            let name = match PackageName::from_str(&key.name) {
-                Ok(name) => {
-                    if let Some(first) = result.name_spans.get(&name) {
-                        errors.errors.push(toml_span::Error {
-                            kind: toml_span::ErrorKind::DuplicateKey {
-                                key: key.name.into_owned(),
-                                first: Span {
-                                    start: first.start,
-                                    end: first.end,
-                                },
-                            },
-                            span: key.span,
-                            line_info: None,
-                        });
-                        None
-                    } else {
-                        Some(name)
-                    }
-                }
-                Err(e) => {
+/// Whether a dependency table accepts inline package definitions.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InlinePackages {
+    /// Peel `package` sub-tables off each spec and collect them.
+    Allow,
+    /// Leave any `package` key in place so the spec parser rejects it.
+    Deny,
+}
+
+/// A dependency table that may carry inline package definitions.
+///
+/// Behaves like a [`UniquePackageMap`] but additionally captures any inline
+/// package definitions (`package = { ... }`) attached to individual dependency
+/// specs. An inline definition describes a conda source dependency's package,
+/// so it is only accepted next to a `git`, `path` or `url` source. The conda
+/// dependency tables (`[dependencies]`, `[host-dependencies]`,
+/// `[build-dependencies]`) use this type because that is where source
+/// dependencies may appear.
+#[derive(Default, Debug)]
+pub struct DependencyTable {
+    /// The dependency specs with any inline `package` keys peeled off.
+    pub specs: UniquePackageMap,
+
+    /// Inline `package` tables keyed by dependency name. Each is the parsed
+    /// `package = { ... }` sub-table of the matching source spec.
+    pub inline_packages: IndexMap<rattler_conda_types::PackageName, PixiSpanned<TomlPackage>>,
+}
+
+impl<'de> toml_span::Deserialize<'de> for DependencyTable {
+    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
+        deserialize_dependency_table(value, InlinePackages::Allow)
+    }
+}
+
+/// Deserializes a table of `name = <spec>` pairs into a [`DependencyTable`],
+/// optionally peeling inline package definitions off each value.
+///
+/// When `inline` is [`InlinePackages::Allow`], a `package` sub-table is removed
+/// from each value before the remaining keys are parsed as a [`PixiSpec`], and
+/// the parsed [`TomlPackage`] is collected into
+/// [`DependencyTable::inline_packages`] keyed by the same dependency name. When
+/// it is [`InlinePackages::Deny`] the value is parsed verbatim, leaving any
+/// `package` key to be rejected by the spec parser, and the returned
+/// `inline_packages` is empty.
+fn deserialize_dependency_table<'de>(
+    value: &mut Value<'de>,
+    inline: InlinePackages,
+) -> Result<DependencyTable, DeserError> {
+    let table = match value.take() {
+        ValueInner::Table(table) => table,
+        inner => return Err(expected("a table", inner, value.span).into()),
+    };
+
+    let mut errors = DeserError { errors: vec![] };
+    let mut result = UniquePackageMap::default();
+    let mut inline_packages = IndexMap::new();
+    for (key, mut value) in table.into_iter().sorted_by_key(|(k, _)| k.span.start) {
+        let name = match PackageName::from_str(&key.name) {
+            Ok(name) => {
+                if let Some(first) = result.name_spans.get(&name) {
                     errors.errors.push(toml_span::Error {
-                        kind: toml_span::ErrorKind::Custom(e.to_string().into()),
+                        kind: toml_span::ErrorKind::DuplicateKey {
+                            key: key.name.into_owned(),
+                            first: Span {
+                                start: first.start,
+                                end: first.end,
+                            },
+                        },
                         span: key.span,
                         line_info: None,
                     });
                     None
+                } else {
+                    Some(name)
                 }
-            };
+            }
+            Err(e) => {
+                errors.errors.push(toml_span::Error {
+                    kind: toml_span::ErrorKind::Custom(e.to_string().into()),
+                    span: key.span,
+                    line_info: None,
+                });
+                None
+            }
+        };
 
-            let spec: Option<PixiSpec> = match toml_span::Deserialize::deserialize(&mut value) {
-                Ok(spec) => Some(spec),
+        // Peel off an inline package definition when the surrounding table
+        // permits it. This happens before spec parsing because `TomlSpec`
+        // rejects unknown keys.
+        let inline_package = match inline {
+            InlinePackages::Allow => match peel_inline_package(&mut value) {
+                Ok(inline) => inline,
                 Err(e) => {
                     errors.merge(e);
                     None
                 }
-            };
+            },
+            InlinePackages::Deny => None,
+        };
 
-            if let (Some(name), Some(spec)) = (name, spec) {
-                result.specs.insert(name.clone(), spec);
-                result
-                    .name_spans
-                    .insert(name.clone(), key.span.start..key.span.end);
-                result
-                    .value_spans
-                    .insert(name, value.span.start..value.span.end);
+        let spec: Option<PixiSpec> = match toml_span::Deserialize::deserialize(&mut value) {
+            Ok(spec) => Some(spec),
+            Err(e) => {
+                errors.merge(e);
+                None
+            }
+        };
+
+        // An inline package definition describes how to build source code, so
+        // the surrounding spec must point at a git, path or url source.
+        if inline_package.is_some()
+            && let Some(spec) = spec.as_ref()
+            && !spec.is_source()
+        {
+            errors.errors.push(toml_span::Error {
+                kind: toml_span::ErrorKind::Custom(
+                    "an inline package definition requires a `git`, `path` or `url` source location"
+                        .into(),
+                ),
+                span: value.span,
+                line_info: None,
+            });
+        }
+
+        if let (Some(name), Some(spec)) = (name, spec) {
+            result.specs.insert(name.clone(), spec);
+            result
+                .name_spans
+                .insert(name.clone(), key.span.start..key.span.end);
+            result
+                .value_spans
+                .insert(name.clone(), value.span.start..value.span.end);
+            if let Some(package) = inline_package {
+                inline_packages.insert(name, package);
             }
         }
-
-        if errors.errors.is_empty() {
-            Ok(result)
-        } else {
-            Err(errors)
-        }
     }
+
+    if errors.errors.is_empty() {
+        Ok(DependencyTable {
+            specs: result,
+            inline_packages,
+        })
+    } else {
+        Err(errors)
+    }
+}
+
+/// Peels an inline package definition off a single dependency value.
+///
+/// Returns the parsed [`TomlPackage`] when `value` is a table containing a
+/// `package` key, leaving `value` holding the remaining keys (the source spec).
+/// Returns `None` otherwise. Rejects an explicit `package.name` (the name comes
+/// from the dependency key) and a `package.build.source` (the source comes from
+/// the surrounding spec).
+fn peel_inline_package<'de>(
+    value: &mut Value<'de>,
+) -> Result<Option<PixiSpanned<TomlPackage>>, DeserError> {
+    if value
+        .as_table()
+        .is_none_or(|table| !table.contains_key("package"))
+    {
+        return Ok(None);
+    }
+
+    let mut th = TableHelper::new(value)?;
+    let package = th.take("package");
+    th.finalize(Some(value))?;
+
+    let Some((_, mut package_value)) = package else {
+        return Ok(None);
+    };
+    let span = package_value.span;
+
+    let package = <TomlPackage as toml_span::Deserialize>::deserialize(&mut package_value)?;
+
+    if package.name.is_some() {
+        return Err(toml_span::Error {
+            kind: toml_span::ErrorKind::Custom(
+                "an inline package definition cannot set `name`; it is taken from the dependency key"
+                    .into(),
+            ),
+            span,
+            line_info: None,
+        }
+        .into());
+    }
+
+    if package.build.source.is_some() {
+        return Err(toml_span::Error {
+            kind: toml_span::ErrorKind::Custom(
+                "an inline package definition cannot set `build.source`; the source is taken from the dependency spec"
+                    .into(),
+            ),
+            span,
+            line_info: None,
+        }
+        .into());
+    }
+
+    Ok(Some(PixiSpanned {
+        span: Some(span.start..span.end),
+        value: package,
+    }))
 }
 
 #[cfg(test)]
@@ -246,5 +396,112 @@ mod test {
             input,
             UniquePackageMap::from_toml_str(input).unwrap_err()
         ));
+    }
+
+    /// An inline package definition is peeled off and the remaining keys parse
+    /// as the source spec.
+    #[test]
+    fn test_inline_package_basic() {
+        let input = r#"
+        rust-package = { git = "https://github.com/user/repo.git", package.build = { backend = { name = "pixi-build-rust", version = "1.0" } } }
+        "#;
+        let table = DependencyTable::from_toml_str(input).unwrap();
+
+        let name = PackageName::from_str("rust-package").unwrap();
+        let spec = table.specs.specs.get(&name).expect("spec retained");
+        assert!(spec.is_source(), "the spec should remain a source spec");
+
+        let inline = table
+            .inline_packages
+            .get(&name)
+            .expect("inline package captured");
+        assert_eq!(
+            inline.value.build.backend.value.name.value.as_normalized(),
+            "pixi-build-rust"
+        );
+    }
+
+    /// The dotted `package.build` form is sugar for the full `[package]` table,
+    /// whose own dependency tables are parsed too.
+    #[test]
+    fn test_inline_package_full_table() {
+        let input = r#"
+        rust-package = { git = "https://github.com/user/repo.git", package = { build = { backend = { name = "pixi-build-rust", version = "1.0" } }, run-dependencies = { foo = "*" } } }
+        "#;
+        let table = DependencyTable::from_toml_str(input).unwrap();
+        let name = PackageName::from_str("rust-package").unwrap();
+        let inline = table.inline_packages.get(&name).expect("inline captured");
+        assert!(
+            inline.value.run_dependencies.is_some(),
+            "package run-dependencies should be parsed"
+        );
+    }
+
+    /// `package.name` is taken from the dependency key and may not be set.
+    #[test]
+    fn test_inline_package_rejects_explicit_name() {
+        let input = r#"
+        rust-package = { git = "https://x/y.git", package = { name = "other", build = { backend = { name = "b", version = "1.0" } } } }
+        "#;
+        let err = DependencyTable::from_toml_str(input).unwrap_err();
+        assert!(
+            format_parse_error(input, err).contains("cannot set `name`"),
+            "expected a name-rejection error"
+        );
+    }
+
+    /// The source comes from the surrounding spec, so `package.build.source` is
+    /// rejected.
+    #[test]
+    fn test_inline_package_rejects_build_source() {
+        let input = r#"
+        rust-package = { git = "https://x/y.git", package = { build = { backend = { name = "b", version = "1.0" }, source = { path = "elsewhere" } } } }
+        "#;
+        let err = DependencyTable::from_toml_str(input).unwrap_err();
+        assert!(
+            format_parse_error(input, err).contains("cannot set `build.source`"),
+            "expected a build.source-rejection error"
+        );
+    }
+
+    /// An inline definition without a source location is meaningless.
+    #[test]
+    fn test_inline_package_requires_source_location() {
+        let input = r#"
+        rust-package = { version = "1.0", package.build = { backend = { name = "b", version = "1.0" } } }
+        "#;
+        let err = DependencyTable::from_toml_str(input).unwrap_err();
+        assert!(
+            format_parse_error(input, err).contains("requires a `git`, `path` or `url` source"),
+            "expected a missing-source-location error"
+        );
+    }
+
+    /// Tables that do not accept inline definitions ([`UniquePackageMap`]) leave
+    /// the `package` key in place so it surfaces as an unexpected key.
+    #[test]
+    fn test_inline_package_rejected_in_unique_map() {
+        let input = r#"
+        rust-package = { git = "https://x/y.git", package.build = { backend = { name = "b", version = "1.0" } } }
+        "#;
+        assert!(
+            UniquePackageMap::from_toml_str(input).is_err(),
+            "inline definitions must not be accepted by UniquePackageMap"
+        );
+    }
+
+    /// Inline definitions do not nest: an inline package's own dependency tables
+    /// are parsed as plain [`UniquePackageMap`]s, which reject a `package` key.
+    /// So an inline definition placed inside another inline definition's
+    /// `run-dependencies` is an error, not a recursively-built package.
+    #[test]
+    fn test_inline_package_does_not_nest() {
+        let input = r#"
+        outer = { git = "https://x/y.git", package = { build = { backend = { name = "b", version = "1.0" } }, run-dependencies = { inner = { git = "https://x/z.git", package.build = { backend = { name = "b", version = "1.0" } } } } } }
+        "#;
+        assert!(
+            DependencyTable::from_toml_str(input).is_err(),
+            "a nested inline definition must be rejected, not built recursively"
+        );
     }
 }

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -76,6 +76,7 @@ pub fn compute_identifier_hash<D: HashIdentifyingData>(
     data: &D,
     build_packages: &[crate::UnresolvedPixiRecord],
     host_packages: &[crate::UnresolvedPixiRecord],
+    inline_content_hash: Option<u64>,
 ) -> String {
     let mut hasher = xxhash_rust::xxh3::Xxh3::default();
     manifest_source.hash(&mut hasher);
@@ -84,6 +85,10 @@ pub fn compute_identifier_hash<D: HashIdentifyingData>(
     hash_dep_records(&mut hasher, build_packages);
     hash_dep_records(&mut hasher, host_packages);
     data.hash_identifying(&mut hasher);
+    // An inline package definition is not represented on disk, so
+    // it must enter the identity explicitly. Editing the inline table changes
+    // this hash, which marks the locked record as outdated and forces a rebuild.
+    inline_content_hash.hash(&mut hasher);
     format_short_hash(hasher.finish())
 }
 
@@ -413,6 +418,7 @@ impl<D> SourceRecord<D> {
             &self.data,
             &self.build_packages,
             &self.host_packages,
+            None,
         )
     }
 }
@@ -432,6 +438,7 @@ impl<D: HashIdentifyingData> SourceRecord<D> {
         variants: BTreeMap<String, VariantValue>,
         build_packages: Vec<crate::UnresolvedPixiRecord>,
         host_packages: Vec<crate::UnresolvedPixiRecord>,
+        inline_content_hash: Option<u64>,
     ) -> Self {
         let identifier_hash = compute_identifier_hash(
             &manifest_source,
@@ -440,6 +447,7 @@ impl<D: HashIdentifyingData> SourceRecord<D> {
             &data,
             &build_packages,
             &host_packages,
+            inline_content_hash,
         );
         Self {
             data,
@@ -830,6 +838,7 @@ impl SourceRecord<SourceRecordData> {
                 &record_data,
                 &build_packages,
                 &host_packages,
+                None,
             )
         });
         Ok(Self::from_parts_with_hash(

--- a/docs/build/inline_packages.md
+++ b/docs/build/inline_packages.md
@@ -1,0 +1,61 @@
+A source dependency normally points at a directory or repository that contains
+its own Pixi manifest with a `[package]` section.
+Pixi reads that manifest to learn how to build the package.
+
+For small packages, or for code in another repository that does not ship a
+`pixi.toml`, writing a separate manifest is more work than the package is worth.
+An inline package definition lets you describe the package directly on the
+dependency instead.
+
+!!! warning
+    Inline package definitions are part of the `pixi-build` preview and will
+    change until it is stabilized. Add `"pixi-build"` to `workspace.preview` to
+    use them.
+
+## Defining a package inline
+
+Add a `package` table to the source dependency. The build definition goes under
+`package.build`, exactly as it would in a standalone `pixi.toml`:
+
+```toml title="pixi.toml"
+[dependencies]
+rust-package = { git = "https://github.com/user/repo.git", package.build.backend.name = "pixi-build-rust" }
+```
+
+Pixi builds `rust-package` from the given source using the inline definition,
+without looking for a `pixi.toml` in the repository.
+
+## The source comes from the dependency
+
+However, the allowed keys are not exact the same as with `[package]`.
+For once, 'he source location stays on the dependency itself through the usual `git`,
+`path`, or `url` fields. You do not repeat it inside `package.build.source`;
+setting `package.build.source` on an inline definition is an error.
+
+A `path` source is resolved relative to the manifest that declares the
+dependency:
+
+```toml title="pixi.toml"
+[dependencies]
+my-lib = { path = "vendor/my-lib", package.build.backend.name = "pixi-build-cmake" }
+```
+
+Also, you don't specify `package.name`.
+Pixi can infer from your dependency declaration that the name has to be `my-lib`.
+
+## What you can define inline
+
+Apart from that, inline definition accepts the same fields as a standalone `[package]`
+section.
+Besides `build`, you can declare the package's own version, dependencies, and so on:
+
+```toml title="pixi.toml"
+[dependencies]
+my-lib = { git = "https://github.com/user/repo.git", package = { version = "1.2.3", build = { backend = { name = "pixi-build-cmake" } }, run-dependencies = { fmt = ">=10" } } }
+```
+
+## Where inline definitions are allowed
+
+Inline definitions are accepted wherever a source dependency is, namely
+`[dependencies]`, and their `[feature.*]` and `[target.*]` variants.
+They are not allowed in `[package.build-dependencies]`, `[package.host-dependencies]` and `[package.run-dependencies]`. 

--- a/docs/build/inline_packages.md
+++ b/docs/build/inline_packages.md
@@ -27,8 +27,8 @@ without looking for a `pixi.toml` in the repository.
 
 ## The source comes from the dependency
 
-However, the allowed keys are not exact the same as with `[package]`.
-For once, 'he source location stays on the dependency itself through the usual `git`,
+However, the allowed keys are not exactly the same as with `[package]`.
+For once, the source location stays on the dependency itself through the usual `git`,
 `path`, or `url` fields. You do not repeat it inside `package.build.source`;
 setting `package.build.source` on an inline definition is an error.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
       - Key Concepts:
           - Compilers: build/key_concepts/compilers.md
       - Package Source: build/package_source.md
+      - Inline Package Definitions: build/inline_packages.md
       - Dev Packages: build/dev.md
   - Distributing:
       - Prefix.dev Channel: deployment/prefix.md

--- a/schema/model.py
+++ b/schema/model.py
@@ -440,6 +440,17 @@ class MatchspecTable(BinaryMatchspecTable):
     branch: NonEmptyStr | None = Field(None, description="A git branch to use")
     subdirectory: NonEmptyStr | None = Field(None, description="A subdirectory to use in the repo")
 
+    package: Package | None = Field(
+        None,
+        description=(
+            "An inline package definition for this source dependency, instead of a "
+            "separate `pixi.toml`. The package name is taken from the dependency key "
+            "and the source is taken from this spec, so `name` and `build.source` are "
+            "not set here."
+        ),
+        examples=[{"build": {"backend": {"name": "pixi-build-rust"}}}],
+    )
+
 
 class SourceSpecTable(StrictBaseModel):
     """A precise description of a source package location."""

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -1194,6 +1194,19 @@
           "type": "string",
           "pattern": "^[a-fA-F0-9]{32}$"
         },
+        "package": {
+          "$ref": "#/$defs/Package",
+          "description": "An inline package definition for this source dependency, instead of a separate `pixi.toml`. The package name is taken from the dependency key and the source is taken from this spec, so `name` and `build.source` are not set here.",
+          "examples": [
+            {
+              "build": {
+                "backend": {
+                  "name": "pixi-build-rust"
+                }
+              }
+            }
+          ]
+        },
         "path": {
           "title": "Path",
           "description": "The path to the package",
@@ -1390,6 +1403,19 @@
           "description": "The md5 hash of the package",
           "type": "string",
           "pattern": "^[a-fA-F0-9]{32}$"
+        },
+        "package": {
+          "$ref": "#/$defs/Package",
+          "description": "An inline package definition for this source dependency, instead of a separate `pixi.toml`. The package name is taken from the dependency key and the source is taken from this spec, so `name` and `build.source` are not set here.",
+          "examples": [
+            {
+              "build": {
+                "backend": {
+                  "name": "pixi-build-rust"
+                }
+              }
+            }
+          ]
         },
         "path": {
           "title": "Path",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -937,6 +937,19 @@
           "type": "string",
           "pattern": "^[a-fA-F0-9]{32}$"
         },
+        "package": {
+          "$ref": "#/$defs/Package",
+          "description": "An inline package definition for this source dependency, instead of a separate `pixi.toml`. The package name is taken from the dependency key and the source is taken from this spec, so `name` and `build.source` are not set here.",
+          "examples": [
+            {
+              "build": {
+                "backend": {
+                  "name": "pixi-build-rust"
+                }
+              }
+            }
+          ]
+        },
         "path": {
           "title": "Path",
           "description": "The path to the package",
@@ -1133,6 +1146,19 @@
           "description": "The md5 hash of the package",
           "type": "string",
           "pattern": "^[a-fA-F0-9]{32}$"
+        },
+        "package": {
+          "$ref": "#/$defs/Package",
+          "description": "An inline package definition for this source dependency, instead of a separate `pixi.toml`. The package name is taken from the dependency key and the source is taken from this spec, so `name` and `build.source` are not set here.",
+          "examples": [
+            {
+              "build": {
+                "backend": {
+                  "name": "pixi-build-rust"
+                }
+              }
+            }
+          ]
         },
         "path": {
           "title": "Path",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1218,6 +1218,19 @@
           "type": "string",
           "pattern": "^[a-fA-F0-9]{32}$"
         },
+        "package": {
+          "$ref": "#/$defs/Package",
+          "description": "An inline package definition for this source dependency, instead of a separate `pixi.toml`. The package name is taken from the dependency key and the source is taken from this spec, so `name` and `build.source` are not set here.",
+          "examples": [
+            {
+              "build": {
+                "backend": {
+                  "name": "pixi-build-rust"
+                }
+              }
+            }
+          ]
+        },
         "path": {
           "title": "Path",
           "description": "The path to the package",
@@ -1414,6 +1427,19 @@
           "description": "The md5 hash of the package",
           "type": "string",
           "pattern": "^[a-fA-F0-9]{32}$"
+        },
+        "package": {
+          "$ref": "#/$defs/Package",
+          "description": "An inline package definition for this source dependency, instead of a separate `pixi.toml`. The package name is taken from the dependency key and the source is taken from this spec, so `name` and `build.source` are not set here.",
+          "examples": [
+            {
+              "build": {
+                "backend": {
+                  "name": "pixi-build-rust"
+                }
+              }
+            }
+          ]
         },
         "path": {
           "title": "Path",

--- a/tests/integration_python/pixi_build/test_inline_packages.py
+++ b/tests/integration_python/pixi_build/test_inline_packages.py
@@ -110,9 +110,55 @@ def test_inline_overrides_ondisk_recipe(pixi: Path, tmp_pixi_workspace: Path) ->
     )
 
 
-def test_inline_definition_inherits_workspace_version(
-    pixi: Path, tmp_pixi_workspace: Path
-) -> None:
+@pytest.mark.slow
+def test_inline_overrides_ondisk_recipe_pyproject(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """Inline definitions must thread through the build pipeline identically when
+    the consumer manifest is a `pyproject.toml` with a `[tool.pixi]` table.
+
+    A `pyproject.toml` carrying `[tool.pixi]` is a first-class Pixi manifest, so
+    declaring an inline package there must work exactly as in a `pixi.toml`. This
+    reuses the discriminating setup of `test_inline_overrides_ondisk_recipe`: the
+    source ships a valid recipe.yaml, but the inline package names a backend that
+    cannot exist. If the inline definition declared under `[tool.pixi]` is
+    honoured, resolving the bogus backend must fail; if it is dropped on the way
+    out of the pyproject parser, on-disk discovery silently builds via the real
+    rattler-build backend and the command wrongly succeeds.
+    """
+    write_recipe_source(tmp_pixi_workspace / "pkg")
+    package = {"build": {"backend": {"name": "pixi-build-does-not-exist"}}}
+    manifest = tmp_pixi_workspace / "pyproject.toml"
+    manifest.write_text(
+        tomli_w.dumps(
+            {
+                "project": {
+                    "name": "consumer",
+                    "version": "0.1.0",
+                    "requires-python": ">=3.11",
+                },
+                "tool": {
+                    "pixi": {
+                        "workspace": {
+                            "channels": [CONDA_FORGE_CHANNEL],
+                            "platforms": [CURRENT_PLATFORM],
+                            "preview": ["pixi-build"],
+                        },
+                        "dependencies": {
+                            "simple-package": {"path": "pkg", "package": package},
+                        },
+                    }
+                },
+            }
+        )
+    )
+
+    verify_cli_command(
+        [pixi, "install", "-v", "--manifest-path", manifest],
+        expected_exit_code=ExitCode.FAILURE,
+        stderr_contains="pixi-build-does-not-exist",
+    )
+
+
+def test_inline_definition_inherits_workspace_version(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """An inline package must be able to inherit package metadata from the
     consuming workspace, just like an on-disk `[package]`.
 

--- a/tests/integration_python/pixi_build/test_inline_packages.py
+++ b/tests/integration_python/pixi_build/test_inline_packages.py
@@ -108,3 +108,136 @@ def test_inline_overrides_ondisk_recipe(pixi: Path, tmp_pixi_workspace: Path) ->
         expected_exit_code=ExitCode.FAILURE,
         stderr_contains="pixi-build-does-not-exist",
     )
+
+
+def test_inline_definition_inherits_workspace_version(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """An inline package must be able to inherit package metadata from the
+    consuming workspace, just like an on-disk `[package]`.
+
+    The workspace here defines a version (`9.9.9`), and the inline package
+    requests it with `version = { workspace = true }`. Loading the manifest must
+    succeed and resolve the version from the workspace. Today it fails with
+    "the workspace does not define a 'version'" because inline definitions are
+    converted with an empty `WorkspacePackageProperties` instead of the consuming
+    workspace's, so there is no package-to-workspace relationship to inherit from.
+
+    `workspace environment list` only loads and converts the manifest (no solve
+    or build), so this stays a fast, offline regression guard.
+    """
+    write_recipe_source(tmp_pixi_workspace / "pkg")
+    manifest = tmp_pixi_workspace / "pyproject.toml"
+    manifest.write_text(
+        tomli_w.dumps(
+            {
+                "project": {
+                    "name": "consumer",
+                    "version": "9.9.9",
+                    "requires-python": ">=3.11",
+                },
+                "tool": {
+                    "pixi": {
+                        "workspace": {
+                            "channels": [CONDA_FORGE_CHANNEL],
+                            "platforms": [CURRENT_PLATFORM],
+                            "preview": ["pixi-build"],
+                        },
+                        "dependencies": {
+                            "simple-package": {
+                                "path": "pkg",
+                                "package": {
+                                    "version": {"workspace": True},
+                                    "build": {
+                                        "backend": {
+                                            "name": "pixi-build-rattler-build",
+                                            "version": "*",
+                                        }
+                                    },
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        )
+    )
+
+    verify_cli_command(
+        [pixi, "workspace", "environment", "list", "--manifest-path", manifest],
+        expected_exit_code=ExitCode.SUCCESS,
+        stderr_excludes="does not define a 'version'",
+    )
+
+
+@pytest.mark.slow
+def test_lower_priority_inline_does_not_leak_onto_plain_dependency(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """An inline definition must only apply when it belongs to the feature that
+    wins the dependency. A lower-priority feature's inline definition must not
+    attach to a higher-priority feature's plain (non-inline) source dependency of
+    the same name.
+
+    Feature `high` (listed first, higher priority) declares `simple-package` as a
+    plain source dependency with no inline definition, so it must build via
+    on-disk discovery -- the source ships its own `pixi.toml` naming
+    `highbogusbackend`. Feature `low` declares the same package with an inline
+    definition naming `lowbogusbackend`. Because the winning feature carries no
+    inline definition, resolution must reach `highbogusbackend`.
+
+    Today inline definitions are merged across all of an environment's features
+    by package name (`combined_inline_packages`), regardless of which feature
+    wins the dependency, so `low`'s inline definition leaks in and resolution
+    wrongly reaches `lowbogusbackend`. A single environment is used so the
+    surfaced backend is unambiguous (no cross-environment error ordering).
+    """
+    source = tmp_pixi_workspace / "pkg"
+    source.mkdir(parents=True, exist_ok=True)
+    source.joinpath("pixi.toml").write_text(
+        tomli_w.dumps(
+            {
+                "workspace": {
+                    "channels": [CONDA_FORGE_CHANNEL],
+                    "platforms": [CURRENT_PLATFORM],
+                    "preview": ["pixi-build"],
+                },
+                "package": {
+                    "name": "simple-package",
+                    "version": "0.1.0",
+                    "build": {"backend": {"name": "highbogusbackend"}},
+                },
+            }
+        )
+    )
+    manifest = tmp_pixi_workspace / "pixi.toml"
+    manifest.write_text(
+        tomli_w.dumps(
+            {
+                "workspace": {
+                    "channels": [CONDA_FORGE_CHANNEL],
+                    "platforms": [CURRENT_PLATFORM],
+                    "preview": ["pixi-build"],
+                },
+                "feature": {
+                    "high": {"dependencies": {"simple-package": {"path": "pkg"}}},
+                    "low": {
+                        "dependencies": {
+                            "simple-package": {
+                                "path": "pkg",
+                                "package": {"build": {"backend": {"name": "lowbogusbackend"}}},
+                            }
+                        }
+                    },
+                },
+                "environments": {"env": ["high", "low"]},
+            }
+        )
+    )
+
+    verify_cli_command(
+        [pixi, "install", "-v", "--manifest-path", manifest, "--environment", "env"],
+        expected_exit_code=ExitCode.FAILURE,
+        stderr_contains="highbogusbackend",
+        stderr_excludes="lowbogusbackend",
+    )

--- a/tests/integration_python/pixi_build/test_inline_packages.py
+++ b/tests/integration_python/pixi_build/test_inline_packages.py
@@ -232,11 +232,12 @@ def test_lower_priority_inline_does_not_leak_onto_plain_dependency(
     definition naming `lowbogusbackend`. Because the winning feature carries no
     inline definition, resolution must reach `highbogusbackend`.
 
-    Today inline definitions are merged across all of an environment's features
-    by package name (`combined_inline_packages`), regardless of which feature
-    wins the dependency, so `low`'s inline definition leaks in and resolution
-    wrongly reaches `lowbogusbackend`. A single environment is used so the
-    surfaced backend is unambiguous (no cross-environment error ordering).
+    `combined_inline_packages` resolves inline definitions per feature priority:
+    the highest-priority feature that declares the dependency decides whether it
+    carries an inline definition, so `high`'s plain declaration suppresses
+    `low`'s inline definition and resolution reaches `highbogusbackend`. A single
+    environment is used so the surfaced backend is unambiguous (no
+    cross-environment error ordering).
     """
     source = tmp_pixi_workspace / "pkg"
     source.mkdir(parents=True, exist_ok=True)

--- a/tests/integration_python/pixi_build/test_inline_packages.py
+++ b/tests/integration_python/pixi_build/test_inline_packages.py
@@ -1,0 +1,110 @@
+"""Integration test for inline package definitions overriding on-disk discovery.
+
+An inline package definition lets a source dependency carry its own ``[package]``
+table directly on the dependency spec, so the referenced source needs no on-disk
+``pixi.toml``::
+
+    [dependencies]
+    rust-app = { path = "pkg", package = { build = { backend = { name = "pixi-build-rust" } } } }
+
+Parse validation and the content-hash behaviour of inline definitions are covered
+by the ``pixi_manifest`` unit tests. What only a real run can prove is the
+*threading*: that an inline definition parsed from the manifest actually survives
+the whole build pipeline and reaches backend discovery, suppressing the on-disk
+recipe. That is what this test guards; the heavier build-and-run cases live in a
+separate, unmerged test module.
+
+Run it with::
+
+    pixi run test-specific-test inline_overrides        # release backends
+    pixi run test-specific-test-debug inline_overrides  # debug backends
+"""
+
+from pathlib import Path
+
+import pytest
+import tomli_w
+
+from .common import (
+    CONDA_FORGE_CHANNEL,
+    CURRENT_PLATFORM,
+    ExitCode,
+    verify_cli_command,
+)
+
+# rattler-build: a bare recipe.yaml that installs an executable. Mirrors
+# tests/data/pixi-build/simple-package.
+RECIPE_YAML = """\
+package:
+  name: simple-package
+  version: 0.1.0
+
+build:
+  number: 0
+  script:
+    - if: win
+      then:
+        - if not exist "%PREFIX%\\bin" mkdir "%PREFIX%\\bin"
+        - echo @echo off > %PREFIX%\\bin\\simple-package.bat
+        - echo echo hello from inline simple-package >> %PREFIX%\\bin\\simple-package.bat
+      else:
+        - mkdir -p $PREFIX/bin
+        - echo "#!/usr/bin/env bash" > $PREFIX/bin/simple-package
+        - echo "echo hello from inline simple-package" >> $PREFIX/bin/simple-package
+        - chmod +x $PREFIX/bin/simple-package
+"""
+
+
+def write_recipe_source(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    directory.joinpath("recipe.yaml").write_text(RECIPE_YAML)
+
+
+def write_consumer_manifest(
+    manifest_path: Path,
+    dependencies: dict,
+    tasks: dict | None = None,
+) -> None:
+    """Write a workspace pixi.toml that declares `dependencies`."""
+    manifest: dict = {
+        "workspace": {
+            "channels": [CONDA_FORGE_CHANNEL],
+            "platforms": [CURRENT_PLATFORM],
+            "preview": ["pixi-build"],
+        },
+        "dependencies": dependencies,
+    }
+    if tasks:
+        manifest["tasks"] = tasks
+    manifest_path.write_text(tomli_w.dumps(manifest))
+
+
+@pytest.mark.slow
+def test_inline_overrides_ondisk_recipe(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """The inline definition must take precedence over an on-disk recipe.yaml.
+
+    The source ships a valid recipe.yaml, but the inline package names a backend
+    that cannot exist. If inline definitions are honoured (skipping on-disk
+    discovery as designed), resolving the bogus backend must fail. If the inline
+    def is ignored, on-disk discovery silently builds via the real rattler-build
+    backend and the command wrongly succeeds -- which is exactly the dead-binding
+    bug this test guards against.
+
+    This is the discriminating counterpart to a plain "build via recipe.yaml"
+    test: such a test passes whether or not the inline path fires (the
+    rattler-build backend reads recipe.yaml either way), so it cannot tell a
+    working feature apart from a completely absent one. This test can.
+    """
+    write_recipe_source(tmp_pixi_workspace / "pkg")
+    package = {"build": {"backend": {"name": "pixi-build-does-not-exist"}}}
+    manifest = tmp_pixi_workspace / "pixi.toml"
+    write_consumer_manifest(
+        manifest,
+        {"simple-package": {"path": "pkg", "package": package}},
+    )
+
+    verify_cli_command(
+        [pixi, "install", "-v", "--manifest-path", manifest],
+        expected_exit_code=ExitCode.FAILURE,
+        stderr_contains="pixi-build-does-not-exist",
+    )


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #6381

This exposes 'package' within a PixiSpec, with the following exceptions:
- `name` is not allowed since it can be inferred
- `source` is not allowed, since we can just use the top-level `path`, `git` and `url`keys
- you can't add inline manifests to package dependencies

### How Has This Been Tested?

I've added an extensive Python test suite locally

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
