### PR TITLE
chore: bump version to v0.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [0.71.0] - 2026-06-24
 #### ✨ Highlights
 
-This release adds a lot of exciting features!
+This release adds a lot of exciting features.
 
-The biggest one is that we deprecated `[system-requirements]` in favor of the much more expressive rich platform support.
+##### ⚠️ Breaking: Configurable Conda to PyPI name mappings
+
+Pixi now gives you more control over how conda packages are matched to PyPI packages.
+
+Previously you could already have an external map, in a file that overwrote the mappings we generate with [parselmouth](https://github.com/prefix-dev/parselmouth)
+
+There were a couple of problems though:
+1. It was alwys a full overwrite,
+2. We write a single-file compressed mapping, but it was not usable directly in Pixi and needed to be modified.
+
+Especially 2, limited people on corporate networks to host their own mappings. We've now made a bunch of improvements:
+
+Workspace conda-pypi-map now supports per-channel configuration with: 
+1. inline mappings, 
+2. remote mapping files, local was already supported, 
+3. Direct support for linking to: https://github.com/prefix-dev/parselmouth/blob/main/files/compressed_mapping.json
+4. overlay (new) vs replacement (old) behavior, 
+5. explicit opt-out for certain packages, 
+6. and finally control over the same-name heuristic. Meaning that in case of a fallback you can enable just taking the conda as the PyPI name.
+
+This makes it easier to fix individual name mismatches, use private channel mappings, or run reliably in
+offline and firewall-restricted environments.
+
+And with remote mapping files specifically, you could host an accurate mapping on your own infrastructure by using the compressed mapping, no need to hit an external network.
+
+
+```toml
+[workspace.conda-pypi-map]
+# Fix a few names while falling back to Pixi's default mapping.
+conda-forge = { mapping = { pytorch = "torch", not-on-pypi = false } }
+
+# Treat a custom mapping as the source of truth for a channel.
+my-company = { location = "mapping.json", mapping-mode = "replace" }
+
+# Disable PyPI name derivation for one channel.
+internal = false
+```
+
+The Python build backend also gains pypi-conda-map, letting pixi-build-python override PyPI-to-conda
+dependency mapping inline before consulting the mapping service:
+
+```toml
+[package.build.config]
+ignore-pypi-mapping = false
+pypi-conda-map = { torch = "pytorch", my-internal-pkg = false }
+```
+
+All in all, this is a breaking change, since bare mapping locations such as conda-forge = "mapping.json" are now additive overlays by default. 
+To restore the old source-of-truth behavior, use:
+
+```toml
+conda-forge = { location = "mapping.json", mapping-mode = "replace", same-name-heuristic = false }
+```
+
+`conda-pypi-map = false` now fully disables PyPI name derivation, including same-name guessing. The
+legacy `conda-pypi-map = {}` behavior is still supported but deprecated; spell it explicitly as:
+
+```toml
+conda-pypi-map = { conda-forge = { mapping-mode = "replace" } }
+```
+
+
+##### Rich platforms
+
+We deprecated `[system-requirements]` in favor of the much more expressive rich platform support.
 On top of operating systems and processor architecture, platforms can now also include system requirements like CUDA or glibc version:
 
 ```toml
@@ -25,6 +89,8 @@ platforms = [
 Speaking of CUDA, together with rich platforms we added support for [`__cuda_arch`](https://conda.org/learn/ceps/cep-0046/).
 We already supported `__cuda` which allows specifying the driver version you require.
 With `__cuda_arch`, you can specify the necessary hardware architecture.
+
+###### v3 Repodata
 
 We also added support for v3 repodata.
 That means you can declare extra dependency groups:
@@ -66,9 +132,10 @@ flags = [
 ] # Optional variant flags recorded in the package metadata
 ```
 
+###### Conditional dependencies
 
 Finally, we revamped the way we define conditional dependencies.
-We deprecated `[target.*.host,build,run-dependencies]` and introduce the following syntax:
+We deprecated `[package.target.*.host,build,run-dependencies]` and introduce the following syntax:
 
 ```toml
 # Only needed when cross-compiling (host platform differs from build platform).
@@ -84,7 +151,7 @@ libgl-devel = ">=1.7.0,<2"
 exceptiongroup = "*"
 ```
 
-NOTE: This only affects source dependencies. `[target.*.dependencies]` remains valid.
+NOTE: This only affects source dependencies, `[target.*.dependencies]` remains valid.
 
 
 #### <!-- 0 --> Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,172 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.71.0] - 2026-06-24
+#### ✨ Highlights
+
+This release adds a lot of exciting features!
+
+The biggest one is that we deprecated `[system-requirements]` in favor of the much more expressive rich platform support.
+On top of operating systems and processor architecture, platforms can now also include system requirements like CUDA or glibc version:
+
+```toml
+[workspace]
+platforms = [
+  "osx-arm64",
+  { platform = "linux-64", cuda = "12.0", glibc = "2.28" },
+  { name = "jetson-nano", platform = "linux-aarch64", cuda = "12.8" },
+]
+```
+
+Speaking of CUDA, together with rich platforms we added support for [`__cuda_arch`](https://conda.org/learn/ceps/cep-0046/).
+We already supported `__cuda` which allows specifying the driver version you require.
+With `__cuda_arch`, you can specify the necessary hardware architecture.
+
+We also added support for v3 repodata.
+That means you can declare extra dependency groups:
+
+```toml
+[package.extra-dependencies.test]
+hypothesis = "*"
+pytest = ">=8"
+
+[package.extra-dependencies.cuda]
+cupy = ">=13"
+```
+
+And of course you can also consume them:
+
+```toml
+[dependencies]
+mypackage = { path = "./mypackage", extras = ["test"] }
+```
+
+It also includes the `when` keyword:
+
+```toml
+[package.run-dependencies]
+unix-helper = { version = "*", when = "__unix" }
+```
+
+And it allows to set flags:
+
+```toml
+[package.build]
+backend = { name = "pixi-build-cmake", version = "0.*" }
+# not required:
+channels = ["https://prefix.dev/conda-forge"]
+config = { key = "value" } # Optional configuration, specific to the build backend
+flags = [
+  "cuda",
+  "blas_openblas",
+] # Optional variant flags recorded in the package metadata
+```
+
+
+Finally, we revamped the way we define conditional dependencies.
+We deprecated `[target.*.host,build,run-dependencies]` and introduce the following syntax:
+
+```toml
+# Only needed when cross-compiling (host platform differs from build platform).
+[package.build-dependencies."if(host_platform != build_platform)"]
+cross-python = "*"
+
+# Only on Linux.
+[package.host-dependencies."if(host_platform == 'linux-64')"]
+libgl-devel = ">=1.7.0,<2"
+
+# Based on a build variant.
+[package.host-dependencies."if(matches(python, '>=3.10'))"]
+exceptiongroup = "*"
+```
+
+NOTE: This only affects source dependencies. `[target.*.dependencies]` remains valid.
+
+
+#### <!-- 0 --> Breaking changes
+
+- Make conda-pypi mappings configurable by @tdejager in [#6333](https://github.com/prefix-dev/pixi/pull/6333)
+
+
+#### Added
+
+- Rich Platform support by @hunger in [#6178](https://github.com/prefix-dev/pixi/pull/6178)
+- Support extras, flags and when on conda dependencies by @Hofer-Julian in [#6262](https://github.com/prefix-dev/pixi/pull/6262)
+- Do not run tests un unsupported platforms by @hunger in [#6339](https://github.com/prefix-dev/pixi/pull/6339)
+- Support if(...) conditional package dependencies by @Hofer-Julian in [#6269](https://github.com/prefix-dev/pixi/pull/6269)
+- Support wildcard platform target selectors by @hunger in [#6301](https://github.com/prefix-dev/pixi/pull/6301)
+- `pixi add` skips already-present packages without version spec by @ruben-arts in [#6352](https://github.com/prefix-dev/pixi/pull/6352)
+- Make package.build.backend.version optional by @Hofer-Julian in [#6384](https://github.com/prefix-dev/pixi/pull/6384)
+- Add `--no-pypi` flag to conda-environment export by @baszalmstra in [#6380](https://github.com/prefix-dev/pixi/pull/6380)
+- Derive `c_stdlib` build variants from system requirements by @hunger in [#6320](https://github.com/prefix-dev/pixi/pull/6320)
+- Friendly __cuda_arch support by @hunger in [#6408](https://github.com/prefix-dev/pixi/pull/6408)
+
+
+#### Changed
+
+- Make test_info_output_extended platform-agnostic by @Hofer-Julian in [#6314](https://github.com/prefix-dev/pixi/pull/6314)
+- Key locked records by declared platform for rich platforms by @hunger in [#6315](https://github.com/prefix-dev/pixi/pull/6315)
+- Detect extra-dependency drift for source packages by @Hofer-Julian in [#6263](https://github.com/prefix-dev/pixi/pull/6263)
+- Attest the tarballs and the binary inside separately by @hunger in [#6266](https://github.com/prefix-dev/pixi/pull/6266)
+- Allow to re-order, do not sort in the one place that persisted by @hunger in [#6346](https://github.com/prefix-dev/pixi/pull/6346)
+- Recommend 'pixi workspace platform add' in target help by @hunger in [#6358](https://github.com/prefix-dev/pixi/pull/6358)
+- Do not fail when asked to install an environment with an unused requirement not used by @hunger in [#6389](https://github.com/prefix-dev/pixi/pull/6389)
+- Resolve pre-v7 lockfiles for migrated platforms by @hunger 
+- Use rust integration tests. by @hunger in [#6375](https://github.com/prefix-dev/pixi/pull/6375)
+- Relock advanced_cpp doc example by @tdejager in [#6403](https://github.com/prefix-dev/pixi/pull/6403)
+- Forward declared __cuda_arch to the solver by @hunger in [#6404](https://github.com/prefix-dev/pixi/pull/6404)
+- Repair main CI failures by @tdejager in [#6406](https://github.com/prefix-dev/pixi/pull/6406)
+
+
+#### Documentation
+
+- Remove pixi-inject page by @pavelzw in [#6276](https://github.com/prefix-dev/pixi/pull/6276)
+- Add a pixi-build v3 example using extras, flags and when by @Hofer-Julian in [#6264](https://github.com/prefix-dev/pixi/pull/6264)
+- Mention code execution of pixi-build in security section by @pavelzw in [#6361](https://github.com/prefix-dev/pixi/pull/6361)
+
+
+#### Fixed
+
+- Move examples satisfiability tests to Python by @Hofer-Julian in [#6300](https://github.com/prefix-dev/pixi/pull/6300)
+- Honor workspace [cache.*] overrides for conda-pypi mapping cache by @baszalmstra in [#6284](https://github.com/prefix-dev/pixi/pull/6284)
+- Stop source builds rebuilding from scratch on every run by @baszalmstra in [#6285](https://github.com/prefix-dev/pixi/pull/6285)
+- Suggest the correct cache config key in netfs-redirect warning by @baszalmstra in [#6282](https://github.com/prefix-dev/pixi/pull/6282)
+- Skip example satisfiability checks on unsupported platforms by @tdejager in [#6311](https://github.com/prefix-dev/pixi/pull/6311)
+- Skip pytorch doc examples on platforms they don't support by @hunger in [#6317](https://github.com/prefix-dev/pixi/pull/6317)
+- Stop requiring old backend version doc example by @Hofer-Julian in [#6338](https://github.com/prefix-dev/pixi/pull/6338)
+- Allow OCI channels by @baszalmstra in [#6341](https://github.com/prefix-dev/pixi/pull/6341)
+- Move workspace variants build test under pixi_build by @hunger in [#6345](https://github.com/prefix-dev/pixi/pull/6345)
+- Detect site-packages clobbering of conda packages by PyPI wheels by @tdejager in [#6344](https://github.com/prefix-dev/pixi/pull/6344)
+- Refactor test for pixi workspaces by @ruben-arts in [#6351](https://github.com/prefix-dev/pixi/pull/6351)
+- Removing environment updates lockfile by @ruben-arts in [#6337](https://github.com/prefix-dev/pixi/pull/6337)
+- Derive used variants from conditional dependencies by @Hofer-Julian in [#6354](https://github.com/prefix-dev/pixi/pull/6354)
+- Resolve initialization manifest bugs and restructure the init module by @samrosenf in [#6294](https://github.com/prefix-dev/pixi/pull/6294)
+- Update stale detached environment and build symlinks by @kilian-hu in [#6154](https://github.com/prefix-dev/pixi/pull/6154)
+- Anchor [tool.uv.sources] paths to workspace root in pixi.lock by @jevandezande in [#6187](https://github.com/prefix-dev/pixi/pull/6187)
+- Stop adapting backend behaviour based on build/host dependencies by @Hofer-Julian in [#6356](https://github.com/prefix-dev/pixi/pull/6356)
+- Verify PyPI lock file hashes during install by @tdejager in [#6353](https://github.com/prefix-dev/pixi/pull/6353)
+- Set exclude-newer for `pixi-build-rust` to `0d` by @Hofer-Julian in [#6394](https://github.com/prefix-dev/pixi/pull/6394)
+- Set macOS deployment target for PyPI source builds by @tdejager in [#6396](https://github.com/prefix-dev/pixi/pull/6396)
+- Install env in PyPI git add test by @tdejager in [#6401](https://github.com/prefix-dev/pixi/pull/6401)
+- Fix CI on main by @Hofer-Julian in [#6402](https://github.com/prefix-dev/pixi/pull/6402)
+- Abi3 run export handling for pixi-build-python by @pavelzw in [#5751](https://github.com/prefix-dev/pixi/pull/5751)
+- Refresh conda-meta/pixi marker when a platform changes by @hunger in [#6366](https://github.com/prefix-dev/pixi/pull/6366)
+- Pin boltons to 25.0.0 in purl hash-mapping test by @Hofer-Julian in [#6422](https://github.com/prefix-dev/pixi/pull/6422)
+
+
+#### Performance
+
+- Parallelize lockfile source pypi and conda satisfiability checks by @baszalmstra in [#6400](https://github.com/prefix-dev/pixi/pull/6400)
+
+
+#### Refactor
+
+- Pypi mapping module so that its a bit more logically named by @tdejager in [#6302](https://github.com/prefix-dev/pixi/pull/6302)
+
+
+#### New Contributors
+* @jevandezande made their first contribution in [#6187](https://github.com/prefix-dev/pixi/pull/6187)
+
 ### [0.70.2] - 2026-06-08
 
 #### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,8 @@ authors:
   - given-names: Julian
     family-names: Hofer
     email: julian.hofer@protonmail.com
-repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.70.2'
-url: 'https://pixi.sh/v0.70.2'
+repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.71.0'
+url: 'https://pixi.sh/v0.71.0'
 abstract: >-
   A cross-platform, language agnostic, package/project
   management tool for development in virtual environments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5904,7 +5904,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi"
-version = "0.70.2"
+version = "0.71.0"
 dependencies = [
  "astral-reqwest-middleware",
  "async-trait",

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 name = "pixi"
 readme.workspace = true
 repository.workspace = true
-version = "0.70.2"
+version = "0.71.0"
 
 [features]
 default = ["rustls"]

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -16,7 +16,7 @@ pub const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const PIXI_VERSION: &str = match option_env!("PIXI_VERSION") {
     Some(v) => v,
-    None => "0.70.2",
+    None => "0.71.0",
 };
 pub const PREFIX_FILE_NAME: &str = "pixi_env_prefix";
 pub const ENVIRONMENTS_DIR: &str = "envs";

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -31,7 +31,7 @@ It also makes use of `pixi shell-hook` to not rely on Pixi being installed in th
     For more examples, take a look at [pavelzw/pixi-docker-example](https://github.com/pavelzw/pixi-docker-example).
 
 ```Dockerfile
-FROM ghcr.io/prefix-dev/pixi:0.70.2 AS build
+FROM ghcr.io/prefix-dev/pixi:0.71.0 AS build
 
 # copy source code, pixi.toml and pixi.lock to the container
 WORKDIR /app

--- a/docs/integration/ci/github_actions.md
+++ b/docs/integration/ci/github_actions.md
@@ -10,7 +10,7 @@ We created [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) to 
 ```yaml
 - uses: prefix-dev/setup-pixi@v0.9.6
   with:
-    pixi-version: v0.70.2
+    pixi-version: v0.71.0
     cache: true
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}

--- a/docs/integration/editor/vscode.md
+++ b/docs/integration/editor/vscode.md
@@ -42,7 +42,7 @@ Then, create the following two files in the `.devcontainer` directory:
 ```dockerfile title=".devcontainer/Dockerfile"
 FROM mcr.microsoft.com/devcontainers/base:jammy
 
-ARG PIXI_VERSION=v0.70.2
+ARG PIXI_VERSION=v0.71.0
 
 RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -22,7 +22,7 @@
 .LINK
     https://github.com/prefix-dev/pixi
 .NOTES
-    Version: v0.70.2
+    Version: v0.71.0
 #>
 param (
     [string] $PixiVersion = 'latest',

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-# Version: v0.70.2
+# Version: v0.71.0
 
 __wrap__() {
     # Function to mask username and password in URLs for safe printing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ quote-style = "double"
 github_url = "https://github.com/prefix-dev/pixi"
 
 [tool.tbump.version]
-current = "0.70.2"
+current = "0.71.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -266,7 +266,7 @@
       "description": "The workspace's metadata information"
     }
   },
-  "$comment": "Generated from `pixi` v0.70.2",
+  "$comment": "Generated from `pixi` v0.71.0",
   "$defs": {
     "Activation": {
       "title": "Activation",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.70.2/schema/manifest/pyproject/schema.json",
+  "$id": "https://pixi.sh/v0.71.0/schema/manifest/pyproject/schema.json",
   "title": "`pyproject.toml` manifest file for `pixi`",
   "description": "A `pyproject.toml` with `[tool.pixi]`.",
   "type": "object",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.70.2/schema/manifest/schema.json",
+  "$id": "https://pixi.sh/v0.71.0/schema/manifest/schema.json",
   "title": "`pixi.toml` manifest file",
   "description": "The configuration for a [`pixi`](https://pixi.sh) project.",
   "type": "object",
@@ -10,7 +10,7 @@
       "title": "Schema",
       "description": "The schema identifier for the project's configuration",
       "type": "string",
-      "default": "https://pixi.sh/v0.70.2/schema/manifest/schema.json",
+      "default": "https://pixi.sh/v0.71.0/schema/manifest/schema.json",
       "format": "uri-reference"
     },
     "activation": {

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -15,7 +15,7 @@ from rattler import Platform
 # Regex pattern to match ANSI escape sequences
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 
-PIXI_VERSION = "0.70.2"
+PIXI_VERSION = "0.71.0"
 
 
 ALL_PLATFORMS = '["linux-64", "osx-64", "osx-arm64", "win-64", "linux-ppc64le", "linux-aarch64"]'


### PR DESCRIPTION
### [0.71.0] - 2026-06-24
#### ✨ Highlights

This release adds a lot of exciting features!

The biggest one is that we deprecated `[system-requirements]` in favor of the much more expressive rich platform support.
On top of operating systems and processor architecture, platforms can now also include system requirements like CUDA or glibc version:

```toml
[workspace]
platforms = [
  "osx-arm64",
  { platform = "linux-64", cuda = "12.0", glibc = "2.28" },
  { name = "jetson-nano", platform = "linux-aarch64", cuda = "12.8" },
]
```

Speaking of CUDA, together with rich platforms we added support for [`__cuda_arch`](https://conda.org/learn/ceps/cep-0046/).
We already supported `__cuda` which allows specifying the driver version you require.
With `__cuda_arch`, you can specify the necessary hardware architecture.

We also added support for v3 repodata.
That means you can declare extra dependency groups:

```toml
[package.extra-dependencies.test]
hypothesis = "*"
pytest = ">=8"

[package.extra-dependencies.cuda]
cupy = ">=13"
```

And of course you can also consume them:

```toml
[dependencies]
mypackage = { path = "./mypackage", extras = ["test"] }
```

It also includes the `when` keyword:

```toml
[package.run-dependencies]
unix-helper = { version = "*", when = "__unix" }
```

And it allows to set flags:

```toml
[package.build]
backend = { name = "pixi-build-cmake", version = "0.*" }
# not required:
channels = ["https://prefix.dev/conda-forge"]
config = { key = "value" } # Optional configuration, specific to the build backend
flags = [
  "cuda",
  "blas_openblas",
] # Optional variant flags recorded in the package metadata
```


Finally, we revamped the way we define conditional dependencies.
We deprecated `[target.*.host,build,run-dependencies]` and introduce the following syntax:

```toml
# Only needed when cross-compiling (host platform differs from build platform).
[package.build-dependencies."if(host_platform != build_platform)"]
cross-python = "*"

# Only on Linux.
[package.host-dependencies."if(host_platform == 'linux-64')"]
libgl-devel = ">=1.7.0,<2"

# Based on a build variant.
[package.host-dependencies."if(matches(python, '>=3.10'))"]
exceptiongroup = "*"
```

NOTE: This only affects source dependencies. `[target.*.dependencies]` remains valid.


#### <!-- 0 --> Breaking changes

- Make conda-pypi mappings configurable by @tdejager in [#6333](https://github.com/prefix-dev/pixi/pull/6333)


#### Added

- Rich Platform support by @hunger in [#6178](https://github.com/prefix-dev/pixi/pull/6178)
- Support extras, flags and when on conda dependencies by @Hofer-Julian in [#6262](https://github.com/prefix-dev/pixi/pull/6262)
- Do not run tests un unsupported platforms by @hunger in [#6339](https://github.com/prefix-dev/pixi/pull/6339)
- Support if(...) conditional package dependencies by @Hofer-Julian in [#6269](https://github.com/prefix-dev/pixi/pull/6269)
- Support wildcard platform target selectors by @hunger in [#6301](https://github.com/prefix-dev/pixi/pull/6301)
- `pixi add` skips already-present packages without version spec by @ruben-arts in [#6352](https://github.com/prefix-dev/pixi/pull/6352)
- Make package.build.backend.version optional by @Hofer-Julian in [#6384](https://github.com/prefix-dev/pixi/pull/6384)
- Add `--no-pypi` flag to conda-environment export by @baszalmstra in [#6380](https://github.com/prefix-dev/pixi/pull/6380)
- Derive `c_stdlib` build variants from system requirements by @hunger in [#6320](https://github.com/prefix-dev/pixi/pull/6320)
- Friendly __cuda_arch support by @hunger in [#6408](https://github.com/prefix-dev/pixi/pull/6408)


#### Changed

- Make test_info_output_extended platform-agnostic by @Hofer-Julian in [#6314](https://github.com/prefix-dev/pixi/pull/6314)
- Key locked records by declared platform for rich platforms by @hunger in [#6315](https://github.com/prefix-dev/pixi/pull/6315)
- Detect extra-dependency drift for source packages by @Hofer-Julian in [#6263](https://github.com/prefix-dev/pixi/pull/6263)
- Attest the tarballs and the binary inside separately by @hunger in [#6266](https://github.com/prefix-dev/pixi/pull/6266)
- Allow to re-order, do not sort in the one place that persisted by @hunger in [#6346](https://github.com/prefix-dev/pixi/pull/6346)
- Recommend 'pixi workspace platform add' in target help by @hunger in [#6358](https://github.com/prefix-dev/pixi/pull/6358)
- Do not fail when asked to install an environment with an unused requirement not used by @hunger in [#6389](https://github.com/prefix-dev/pixi/pull/6389)
- Resolve pre-v7 lockfiles for migrated platforms by @hunger 
- Use rust integration tests. by @hunger in [#6375](https://github.com/prefix-dev/pixi/pull/6375)
- Relock advanced_cpp doc example by @tdejager in [#6403](https://github.com/prefix-dev/pixi/pull/6403)
- Forward declared __cuda_arch to the solver by @hunger in [#6404](https://github.com/prefix-dev/pixi/pull/6404)
- Repair main CI failures by @tdejager in [#6406](https://github.com/prefix-dev/pixi/pull/6406)


#### Documentation

- Remove pixi-inject page by @pavelzw in [#6276](https://github.com/prefix-dev/pixi/pull/6276)
- Add a pixi-build v3 example using extras, flags and when by @Hofer-Julian in [#6264](https://github.com/prefix-dev/pixi/pull/6264)
- Mention code execution of pixi-build in security section by @pavelzw in [#6361](https://github.com/prefix-dev/pixi/pull/6361)


#### Fixed

- Move examples satisfiability tests to Python by @Hofer-Julian in [#6300](https://github.com/prefix-dev/pixi/pull/6300)
- Honor workspace [cache.*] overrides for conda-pypi mapping cache by @baszalmstra in [#6284](https://github.com/prefix-dev/pixi/pull/6284)
- Stop source builds rebuilding from scratch on every run by @baszalmstra in [#6285](https://github.com/prefix-dev/pixi/pull/6285)
- Suggest the correct cache config key in netfs-redirect warning by @baszalmstra in [#6282](https://github.com/prefix-dev/pixi/pull/6282)
- Skip example satisfiability checks on unsupported platforms by @tdejager in [#6311](https://github.com/prefix-dev/pixi/pull/6311)
- Skip pytorch doc examples on platforms they don't support by @hunger in [#6317](https://github.com/prefix-dev/pixi/pull/6317)
- Stop requiring old backend version doc example by @Hofer-Julian in [#6338](https://github.com/prefix-dev/pixi/pull/6338)
- Allow OCI channels by @baszalmstra in [#6341](https://github.com/prefix-dev/pixi/pull/6341)
- Move workspace variants build test under pixi_build by @hunger in [#6345](https://github.com/prefix-dev/pixi/pull/6345)
- Detect site-packages clobbering of conda packages by PyPI wheels by @tdejager in [#6344](https://github.com/prefix-dev/pixi/pull/6344)
- Refactor test for pixi workspaces by @ruben-arts in [#6351](https://github.com/prefix-dev/pixi/pull/6351)
- Removing environment updates lockfile by @ruben-arts in [#6337](https://github.com/prefix-dev/pixi/pull/6337)
- Derive used variants from conditional dependencies by @Hofer-Julian in [#6354](https://github.com/prefix-dev/pixi/pull/6354)
- Resolve initialization manifest bugs and restructure the init module by @samrosenf in [#6294](https://github.com/prefix-dev/pixi/pull/6294)
- Update stale detached environment and build symlinks by @kilian-hu in [#6154](https://github.com/prefix-dev/pixi/pull/6154)
- Anchor [tool.uv.sources] paths to workspace root in pixi.lock by @jevandezande in [#6187](https://github.com/prefix-dev/pixi/pull/6187)
- Stop adapting backend behaviour based on build/host dependencies by @Hofer-Julian in [#6356](https://github.com/prefix-dev/pixi/pull/6356)
- Verify PyPI lock file hashes during install by @tdejager in [#6353](https://github.com/prefix-dev/pixi/pull/6353)
- Set exclude-newer for `pixi-build-rust` to `0d` by @Hofer-Julian in [#6394](https://github.com/prefix-dev/pixi/pull/6394)
- Set macOS deployment target for PyPI source builds by @tdejager in [#6396](https://github.com/prefix-dev/pixi/pull/6396)
- Install env in PyPI git add test by @tdejager in [#6401](https://github.com/prefix-dev/pixi/pull/6401)
- Fix CI on main by @Hofer-Julian in [#6402](https://github.com/prefix-dev/pixi/pull/6402)
- Abi3 run export handling for pixi-build-python by @pavelzw in [#5751](https://github.com/prefix-dev/pixi/pull/5751)
- Refresh conda-meta/pixi marker when a platform changes by @hunger in [#6366](https://github.com/prefix-dev/pixi/pull/6366)
- Pin boltons to 25.0.0 in purl hash-mapping test by @Hofer-Julian in [#6422](https://github.com/prefix-dev/pixi/pull/6422)


#### Performance

- Parallelize lockfile source pypi and conda satisfiability checks by @baszalmstra in [#6400](https://github.com/prefix-dev/pixi/pull/6400)


#### Refactor

- Pypi mapping module so that its a bit more logically named by @tdejager in [#6302](https://github.com/prefix-dev/pixi/pull/6302)


#### New Contributors
* @jevandezande made their first contribution in [#6187](https://github.com/prefix-dev/pixi/pull/6187)