### PR TITLE
docs: Move the robotics section in the nav bar

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,9 @@ Pixi is a **fast, modern, and reproducible** package management tool for develop
 - [🌍 **Global Tools**](global_tools/introduction.md)
   Install global tools, safely isolated. Replacing `apt`, `homebrew`, `winget`.
 
+- [🤖 **Robotics**](robotics.md)
+  First-class ROS 2 support via RoboStack — cross-platform, reproducible robotics development.
+
 ---
 
 ## Quick Demo

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - First Workspace: first_workspace.md
       - Basic Usage: getting_started.md
       - The Conda Ecosystem: conda_ecosystem.md
+      - Using Pixi for Robotics: robotics.md
   - Tutorials:
       - Python:
           - Basic Usage: python/tutorial.md
@@ -146,7 +147,6 @@ nav:
           - Variants: build/variants.md
           - Advanced Building Using rattler-build: build/advanced_cpp.md
           - Cross Compilation using rattler-build: build/cross_compilation.md
-          - Using Pixi for Robotics: robotics.md
       - Dependency Types: build/dependency_types.md
       - Workspace Dependencies: build/workspace_dependencies.md
       - Build Backends:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,6 @@ extra:
 
 nav:
   - Home: index.md
-  - Robotics: robotics.md
   - Getting Started:
       - Installation: installation.md
       - First Workspace: first_workspace.md
@@ -147,6 +146,7 @@ nav:
           - Variants: build/variants.md
           - Advanced Building Using rattler-build: build/advanced_cpp.md
           - Cross Compilation using rattler-build: build/cross_compilation.md
+          - Using Pixi for Robotics: robotics.md
       - Dependency Types: build/dependency_types.md
       - Workspace Dependencies: build/workspace_dependencies.md
       - Build Backends:


### PR DESCRIPTION
### Description

I [mentioned on Discord](https://discord.com/channels/1082332781146800168/1085116502375673876/1519438001619472384) that it's a little weird to see the "Robotics" link right underneath "Home". @Hofer-Julian suggested I open a PR, so here it is!

cc @ruben-arts wdyt about putting it under Tutorials?
