### PR TITLE
feat: deprecate `[system-requirements]` table

### DIFF
--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -218,7 +218,21 @@ impl<'de> toml_span::Deserialize<'de> for TomlFeature {
             })
             .collect();
         let pypi_options = th.optional("pypi-options");
-        let system_requirements = th.optional("system-requirements").unwrap_or_default();
+        let system_requirements: Option<Spanned<SystemRequirements>> =
+            th.optional("system-requirements");
+        if let Some(system_requirements) = &system_requirements
+            && !system_requirements.value.is_empty()
+        {
+            warnings.push(
+                Deprecation::system_requirements(Some(
+                    system_requirements.span.start..system_requirements.span.end,
+                ))
+                .into(),
+            );
+        }
+        let system_requirements = system_requirements
+            .map(|system_requirements| system_requirements.value)
+            .unwrap_or_default();
 
         th.finalize(None)?;
 

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -206,6 +206,12 @@ impl TomlManifest {
         // Sysreqs flow through this local map for the per-feature compatibility
         // check and the `[system-requirements]` migration; nothing else keeps
         // hold of them.
+        if let Some(system_requirements) = &self.system_requirements
+            && !system_requirements.value.is_empty()
+        {
+            warnings
+                .push(Deprecation::system_requirements(system_requirements.span.clone()).into());
+        }
         let default_sysreqs = self
             .system_requirements
             .map(PixiSpanned::into_inner)
@@ -1552,6 +1558,65 @@ mod test {
           · ╰──── replace this with 'dependencies'
         9 │
           ╰────
+        "#
+        );
+    }
+
+    #[test]
+    fn test_system_requirements_deprecation_warning() {
+        assert_snapshot!(
+            expect_parse_warnings(
+                r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ['linux-64']
+
+        [system-requirements]
+        cuda = "12"
+        "#,
+            ),
+            @r#"
+         ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
+          ╭─[pixi.toml:7:9]
+        6 │
+        7 │ ╭─▶         [system-requirements]
+        8 │ ├─▶         cuda = "12"
+          · ╰──── declare these on the `platforms` entries instead
+        9 │
+          ╰────
+         help: e.g. platforms = [{ platform = "linux-64", cuda = "12" }]
+        "#
+        );
+    }
+
+    #[test]
+    fn test_feature_system_requirements_deprecation_warning() {
+        assert_snapshot!(
+            expect_parse_warnings(
+                r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ['linux-64']
+
+        [feature.cuda.system-requirements]
+        cuda = "12"
+
+        [environments]
+        cuda = ["cuda"]
+        "#,
+            ),
+            @r#"
+         ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
+          ╭─[pixi.toml:7:9]
+        6 │
+        7 │ ╭─▶         [feature.cuda.system-requirements]
+        8 │ ├─▶         cuda = "12"
+          · ╰──── declare these on the `platforms` entries instead
+        9 │
+          ╰────
+         help: e.g. platforms = [{ platform = "linux-64", cuda = "12" }]
         "#
         );
     }

--- a/crates/pixi_manifest/src/warning/deprecation.rs
+++ b/crates/pixi_manifest/src/warning/deprecation.rs
@@ -26,6 +26,26 @@ impl Deprecation {
         }
     }
 
+    /// Deprecation of the legacy `[system-requirements]` table in favor of
+    /// virtual packages declared on the `platforms` entries.
+    pub fn system_requirements(span: Option<Range<usize>>) -> Self {
+        let labels = span
+            .map(|span| {
+                vec![LabeledSpan::new_primary_with_span(
+                    Some("declare these on the `platforms` entries instead".to_string()),
+                    SourceSpan::new(span.start.into(), span.end - span.start),
+                )]
+            })
+            .unwrap_or_default();
+        Self {
+            message:
+                "the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`"
+                    .into(),
+            labels,
+            help: Some(r#"e.g. platforms = [{ platform = "linux-64", cuda = "12" }]"#.into()),
+        }
+    }
+
     /// Deprecation of the legacy `[package.target.*]` dependency tables in
     /// favor of `if(<expression>)` conditional dependency tables. `help` carries
     /// the tailored replacement suggestion.


### PR DESCRIPTION
Emit a deprecation warning when a manifest declares `[system-requirements]`, at both the workspace level and `[feature.*.system-requirements]`. The warning points users to declaring virtual packages on `platforms` entries instead, e.g. `platforms = [{ platform = "linux-64", cuda = "12" }]`.

Fixes: #6437 

### How Has This Been Tested?

Some new unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
