### PR TITLE
fix: point MSI license sidecar at the workspace-root LICENSE

### DIFF
--- a/crates/pixi/wix/main.wxs
+++ b/crates/pixi/wix/main.wxs
@@ -105,7 +105,7 @@
                          further down in this file.
                     -->
                     <Component Id='License' Guid='0ab111aa-4a6e-4322-a256-5d69a69dfb9e'>
-                      <File Id='LicenseFile' Name='LICENSE' DiskId='1' Source='LICENSE' />
+                      <File Id='LicenseFile' Name='LICENSE' DiskId='1' Source='..\..\LICENSE' />
 
                       <RegistryKey Root="HKCU" Key="Software\Prefix GmbH\pixi">
                           <RegistryValue Name="License" Value="1" Type="string" KeyPath="yes" />


### PR DESCRIPTION
cargo-wix runs with `cwd=crates/pixi`, where light resolves `Source='LICENSE'` relative to the working directory. LICENSE only exists at the workspace root, so use a relative path to it.
