### PR TITLE
fix: detect host/build dependency changes in `--check`/`--dry-run`

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -3396,3 +3396,76 @@ bat = { version = "*", when = { package = "python", version = ">=3.10" } }
         "conditional extra dependency must preserve its `when=` clause, got {test_group:?}"
     );
 }
+
+/// Regression test for <https://github.com/prefix-dev/pixi/issues/6445>: a host
+/// dependency change re-solves the lock file without touching the run
+/// environment, so `--check`/`--dry-run` must not rely on `LockFileDiff`.
+#[tokio::test]
+async fn test_lock_check_detects_host_dependency_change() {
+    setup_tracing();
+
+    // Host-only dependency, no run-exports, so its version never reaches the run
+    // environment -- the case the diff is blind to.
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(Package::build("bar", "1").finish());
+    package_database.add_package(Package::build("bar", "2").finish());
+    let channel = package_database.into_channel().await.unwrap();
+
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(BackendOverride::from_memory(
+            PassthroughBackend::instantiator(),
+        ));
+
+    let source_dir = pixi.workspace_path().join("my-package");
+    fs::create_dir_all(&source_dir).unwrap();
+    let write_host_dep = |version: &str| {
+        fs::write(
+            source_dir.join("pixi.toml"),
+            format!(
+                r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+[package.build]
+backend = {{ name = "in-memory", version = "0.1.0" }}
+[package.host-dependencies]
+bar = "=={version}"
+"#
+            ),
+        )
+        .unwrap();
+    };
+    write_host_dep("1");
+    pixi.update_manifest(&format!(
+        r#"
+[workspace]
+channels = ["{channel}"]
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+[dependencies]
+my-package = {{ path = "./my-package" }}
+"#,
+        channel = channel.url(),
+        platform = Platform::current(),
+    ))
+    .unwrap();
+    pixi.lock().await.unwrap();
+
+    // Unchanged manifest: check passes (no false positive).
+    pixi.lock()
+        .with_check(true)
+        .with_dry_run(true)
+        .await
+        .unwrap();
+
+    // Bumped host dependency: check must now fail as out-of-date.
+    write_host_dep("2");
+    let err = pixi
+        .lock()
+        .with_check(true)
+        .with_dry_run(true)
+        .await
+        .expect_err("`pixi lock --check --dry-run` must fail when a host dependency changed");
+    assert!(format_diagnostic(err.as_ref()).contains("not up-to-date"));
+}

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -81,7 +81,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let json = serde_json::to_string_pretty(&json_diff).expect("failed to convert to json");
         println!("{json}");
     } else if args.dry_run {
-        if !diff.is_empty() {
+        if lock_updated {
             eprintln!(
                 "{}Dry-run: lock file would be updated (not written to disk)",
                 console::style(console::Emoji("i ", "i ")).blue()
@@ -91,7 +91,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 .context("failed to print lock file diff")?;
         } else {
             eprintln!(
-                "{}Dry-run:lock file would not change",
+                "{}Dry-run: lock file would not change",
                 console::style(console::Emoji("i ", "i ")).blue()
             );
         }
@@ -110,10 +110,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     }
 
-    // Return with a non-zero exit code if `--check` has been passed and the lock
-    // file has been updated
-    if args.check && !diff.is_empty() {
-        std::process::exit(1);
+    if args.check && lock_updated {
+        miette::bail!("lock file not up-to-date with the workspace");
     }
 
     Ok(())


### PR DESCRIPTION
### Description

`--check`/`--dry-run` keyed off LockFileDiff, which only compares resolved packages by location and so misses host/build dependency edits to source packages. Now they key off the lock_updated re-solve signal instead. --check returns an error rather than exit(1). Adds a regression test.

Fixes prefix-dev/pixi#6445

### How Has This Been Tested?

Added a unit test.

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude Opus 4.8

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.