### PR TITLE
fix: preserve declared platforms for manifests without system-requirements

### DIFF
--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -2923,6 +2923,46 @@ platforms = ["linux-64", "osx-64"]
     }
 
     #[test]
+    fn test_rich_platform_and_feature_reference_are_all_listed() {
+        let file_contents = r#"
+[workspace]
+channels = ["https://prefix.dev/conda-forge"]
+platforms = [
+  "linux-64",
+  { platform = "linux-64", cuda = "12.9" },
+]
+
+[feature.cuda-backends]
+platforms = ["linux-64-cuda-12-9"]
+"#;
+        let workspace = parse_pixi_toml(file_contents);
+
+        // The workspace must list both the bare subdir and the rich
+        // cuda-tagged platform, with the rich entry synthesised to a stable
+        // name. The feature reference resolves to the existing entry without
+        // adding a duplicate.
+        let names: Vec<String> = workspace
+            .manifest
+            .workspace
+            .platforms
+            .iter()
+            .map(|p| p.name().to_string())
+            .collect();
+        assert_eq!(names, ["linux-64", "linux-64-cuda-12-9"]);
+
+        // The feature's declared platform points at the synthesised name.
+        let feature = &workspace.manifest.features[&FeatureName::from("cuda-backends")];
+        let feature_platforms: Vec<String> = feature
+            .platforms
+            .as_ref()
+            .expect("feature declares platforms")
+            .iter()
+            .map(|name| name.to_string())
+            .collect();
+        assert_eq!(feature_platforms, ["linux-64-cuda-12-9"]);
+    }
+
+    #[test]
     fn test_remove_platforms() {
         // Using known files in the project so the test succeed including the file
         // check.

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -508,11 +508,13 @@ fn migrate_system_requirements_to_platforms(
     features: &mut IndexMap<FeatureName, Feature>,
     feature_sysreqs: &HashMap<FeatureName, SystemRequirements>,
 ) -> Result<(), TomlError> {
-    let mut originals: IndexSet<PixiPlatform> = std::mem::take(&mut workspace.platforms);
     // A workspace that already declares custom names or per-platform virtual
     // packages can't accept the legacy `[system-requirements]` shim -- it
     // would be ambiguous which set of declarations wins.
-    let all_simple_subdir = originals.iter().all(PixiPlatform::is_subdir_platform);
+    let all_simple_subdir = workspace
+        .platforms
+        .iter()
+        .all(PixiPlatform::is_subdir_platform);
 
     let has_any_sysreqs = feature_sysreqs.values().any(|s| !s.is_empty());
     // Any feature (incl. default) carries `[system-requirements]` and the
@@ -521,9 +523,24 @@ fn migrate_system_requirements_to_platforms(
     workspace.must_migrate = all_simple_subdir && has_any_sysreqs;
 
     if all_simple_subdir {
-        extend_originals_with_referenced_subdirs(&mut originals, features)?;
+        extend_originals_with_referenced_subdirs(&mut workspace.platforms, features)?;
     }
 
+    // Without `[system-requirements]` there is nothing to migrate: keep every
+    // declared platform exactly as written -- including two distinct platforms
+    // that share a subdir, e.g. `linux-64` plus `linux-64-cuda-12-9` -- and
+    // only check that each feature reference resolves.
+    if !has_any_sysreqs {
+        for feature in features.values() {
+            validate_referenced_platforms(&workspace.platforms, feature)?;
+        }
+        return Ok(());
+    }
+
+    // Legacy migration: rebuild the platform list so each bare subdir is
+    // replaced by the virtual-package-bearing variant its system requirements
+    // imply, and rewrite each feature's platforms to name those entries.
+    let originals: IndexSet<PixiPlatform> = std::mem::take(&mut workspace.platforms);
     for feature in features.values_mut() {
         let sysreqs = feature_sysreqs.get(&feature.name);
         if sysreqs.is_none_or(SystemRequirements::is_empty) {
@@ -567,6 +584,26 @@ fn extend_originals_with_referenced_subdirs(
                 )))
             })?;
             originals.insert(PixiPlatform::from_subdir(subdir));
+        }
+    }
+    Ok(())
+}
+
+/// Error if any name in `feature.platforms` does not resolve to a platform
+/// declared in the workspace.
+fn validate_referenced_platforms(
+    platforms: &IndexSet<PixiPlatform>,
+    feature: &Feature,
+) -> Result<(), TomlError> {
+    let Some(names) = feature.platforms.as_ref() else {
+        return Ok(());
+    };
+    for name in names {
+        if !platforms.iter().any(|p| p.name() == name) {
+            return Err(TomlError::from(GenericError::new(format!(
+                "feature '{}' references platform '{}' which is not declared in the workspace",
+                feature.name, name,
+            ))));
         }
     }
     Ok(())
@@ -1124,6 +1161,32 @@ mod test {
                 .unwrap()
                 .as_str(),
             "linux-64",
+        );
+    }
+
+    #[test]
+    fn test_rich_workspace_feature_references_undeclared_platform_errors() {
+        // No system-requirements, so `extend_originals_with_referenced_subdirs`
+        // doesn't run for this rich-platform workspace; a feature naming a
+        // platform the workspace never declares must still be rejected.
+        let result = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+            [workspace]
+            name = "test"
+            channels = []
+            platforms = ["linux-64", { platform = "linux-64", cuda = "12.9" }]
+
+            [feature.gpu]
+            platforms = ["linux-64-cuda-13-0"]
+            "#,
+            Path::new(""),
+        );
+        let err = result.expect_err("undeclared feature platform must error");
+        assert!(
+            err.error
+                .to_string()
+                .contains("references platform 'linux-64-cuda-13-0' which is not declared"),
+            "unexpected error: {err:?}",
         );
     }
 


### PR DESCRIPTION
migrate_system_requirements_to_platforms runs on every manifest parse, not just ones with a [system-requirements] table. Its unconditional take-and-rebuild of workspace.platforms deduplicated by subdir, so a workspace declaring two platforms on the same subdir (e.g. bare "linux-64" alongside { platform = "linux-64", cuda = "12.9" }) silently dropped the bare entry after parsing.

Skip the rebuild entirely when no feature carries system-requirements: keep the declared platforms verbatim and only validate that each feature's platform references resolve. The legacy migration path is unchanged for manifests that actually use [system-requirements].

Add tests covering the rich-platform passthrough and the undeclared feature-reference error.

Fixes: #6455 

### How Has This Been Tested?

New tests added in this PR

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
