### PR TITLE
fix: set clap ID for pixi auth verbose flag

### DIFF
--- a/crates/pixi_cli/src/auth.rs
+++ b/crates/pixi_cli/src/auth.rs
@@ -1,0 +1,52 @@
+//! Thin wrapper around rattler's auth CLI.
+
+use clap::{Parser, Subcommand};
+use miette::IntoDiagnostic;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[command(subcommand)]
+    subcommand: Option<AuthCommand>,
+}
+
+#[derive(Subcommand, Debug)]
+enum AuthCommand {
+    /// Show stored authentication entries and non-secret token metadata
+    Status {
+        #[arg(value_name = "HOST")]
+        host: Option<String>,
+    },
+    /// Store authentication information for a given host
+    Login {
+        #[arg(value_name = "HOST")]
+        host: String,
+    },
+    /// Remove authentication information for a given host
+    Logout {
+        #[arg(value_name = "HOST")]
+        host: String,
+    },
+}
+
+pub async fn execute(args: Args) -> miette::Result<()> {
+    let mut argv: Vec<String> = vec!["auth".to_string()];
+    match args.subcommand {
+        Some(AuthCommand::Status { host }) => {
+            argv.push("status".to_string());
+            argv.extend(host);
+        }
+        Some(AuthCommand::Login { host }) => {
+            argv.extend(["login".to_string(), host]);
+        }
+        Some(AuthCommand::Logout { host }) => {
+            argv.extend(["logout".to_string(), host]);
+        }
+        None => argv.push("--help".to_string()),
+    }
+    let argv: Vec<&str> = argv.iter().map(String::as_str).collect();
+    rattler::cli::auth::execute(
+        rattler::cli::auth::Args::try_parse_from(&argv).into_diagnostic()?,
+    )
+    .await
+    .into_diagnostic()
+}

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -11,6 +11,7 @@
 use clap::builder::styling::{AnsiColor, Color, Style};
 use clap::{CommandFactory, Parser};
 use indicatif::ProgressDrawTarget;
+#[cfg(not(feature = "console-subscriber"))]
 use miette::IntoDiagnostic;
 use pixi_consts::consts;
 use pixi_core::environment::LockFileUsage;

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -20,6 +20,7 @@ use std::{env, io::IsTerminal};
 use tracing::level_filters::LevelFilter;
 
 pub mod add;
+pub mod auth;
 pub mod build;
 pub mod clean;
 pub mod cli_config;
@@ -156,7 +157,7 @@ pub enum Command {
     // Commands in alphabetical order
     #[clap(visible_alias = "a")]
     Add(add::Args),
-    Auth(rattler::cli::auth::Args),
+    Auth(auth::Args),
     #[clap(hide = true)]
     Build(build::Args),
     Clean(clean::Args),
@@ -363,7 +364,7 @@ pub async fn execute_command(
         Command::Clean(cmd) => clean::execute(cmd).await,
         Command::Run(cmd) => run::execute(cmd).await,
         Command::Global(cmd) => global::execute(cmd).await,
-        Command::Auth(cmd) => rattler::cli::auth::execute(cmd).await.into_diagnostic(),
+        Command::Auth(cmd) => auth::execute(cmd).await,
         Command::Install(cmd) => install::execute(cmd).await,
         Command::Reinstall(cmd) => reinstall::execute(cmd).await,
         Command::Shell(cmd) => shell::execute(cmd).await,


### PR DESCRIPTION
### Description

This PR gives the `verbose` global flag of pixi auth a different clap ID, so it does not clashes with rattler's `verbose` option.

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes https://github.com/prefix-dev/pixi/issues/6466

### How Has This Been Tested?

Rebuilt and installed locally with:
```sh
pixi run install-as pixidev
```

and verified with:
```console
% pixidev auth status
Stored authentication entries:
prefix.dev
  ✓ Logged in to prefix.dev account flferretti (secret service (keyring))
  - Method: OAuth
  - Access token expires: *****
  - Refresh token: yes (lifetime not exposed by the provider)
  - Token scopes: 'channel:read', 'channel:upload', 'offline_access', 'openid', 'profile'
```

### AI Disclosure
This PR doesn't contain AI-generated content.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code