### PR TITLE
fix: read env var BUILD_EDITABLE_PYTHON consistently

### DIFF
--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -151,6 +151,20 @@ impl PythonGenerator {
     }
 }
 
+/// Apply the `BUILD_EDITABLE_PYTHON` override to the requested editable flag.
+///
+/// `"true"` forces editable, any other value forces non-editable, and an unset
+/// variable keeps `params_editable`. Both the build script and the input globs
+/// must use this value, otherwise a forced non-editable build bakes in sources
+/// the globs never track.
+///
+/// TODO: remove this env var override as soon as we have profiles
+fn effective_editable(params_editable: bool) -> bool {
+    std::env::var("BUILD_EDITABLE_PYTHON")
+        .map(|val| val == "true")
+        .unwrap_or(params_editable)
+}
+
 #[async_trait::async_trait]
 impl GenerateRecipe for PythonGenerator {
     type Config = PythonBackendConfig;
@@ -359,10 +373,7 @@ impl GenerateRecipe for PythonGenerator {
 
         let build_platform = Platform::current();
 
-        // TODO: remove this env var override as soon as we have profiles
-        let editable = std::env::var("BUILD_EDITABLE_PYTHON")
-            .map(|val| val == "true")
-            .unwrap_or(params.editable);
+        let editable = effective_editable(params.editable);
 
         let build_script = BuildScriptContext {
             installer,
@@ -451,6 +462,10 @@ impl GenerateRecipe for PythonGenerator {
         _workdir: impl AsRef<Path>,
         editable: bool,
     ) -> miette::Result<Vec<String>> {
+        // Match the override the build script uses, so a non-editable build
+        // tracks the `**/*.py` it bakes in.
+        let editable = effective_editable(editable);
+
         let base_globs = Vec::from([
             // Project configuration
             "setup.py",


### PR DESCRIPTION
### Description

We read the env var BUILD_EDITABLE_PYTHON only in one of two places where it was needed
Fixes #6467 
### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code