### PR TITLE
fix: source dependency matchspec conversion

### DIFF
--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -29,18 +29,14 @@ fn to_pixi_spec_v1(
                 version,
                 build,
                 build_number,
-                extras: None,
-                flags: None,
+                extras,
+                flags,
                 subdir,
                 license,
-                condition: None,
-                track_features: None,
-            } = source.matchspec.clone()
-            else {
-                unimplemented!(
-                    "a particular field is not implemented in the pixi to pbt conversion"
-                );
-            };
+                condition,
+                // `track_features` is a deprecated matchspec field and is not propagated.
+                track_features: _,
+            } = source.matchspec.clone();
             let location = match source.location {
                 SourceLocationSpec::Url(url_spec) => {
                     let pixi_spec::UrlSpec {
@@ -84,8 +80,11 @@ fn to_pixi_spec_v1(
                 version,
                 build,
                 build_number,
+                extras,
+                flags,
                 subdir,
                 license,
+                condition,
             })
         }
         itertools::Either::Right(binary) => {
@@ -272,10 +271,10 @@ pub fn to_project_model_v1(
 mod tests {
     use std::path::PathBuf;
 
-    use pixi_manifest::Preview;
     use pixi_manifest::toml::{
         FromTomlStr, PackageDefaults, TomlPackage, WorkspacePackageProperties,
     };
+    use pixi_manifest::{KnownPreviewFeature, Preview};
     use rattler_conda_types::ChannelConfig;
     use rstest::rstest;
 
@@ -403,6 +402,56 @@ mod tests {
         let flags = flags.iter().map(|flag| flag.as_str()).collect::<Vec<_>>();
 
         assert_eq!(flags, vec!["cuda", "blas_openblas"]);
+    }
+
+    #[test]
+    fn test_source_dependency_matchspec_fields_are_converted_to_project_model() {
+        let input = r#"
+        name = "example"
+        version = "0.1.0"
+
+        [build]
+        backend = { name = "pixi-build-rattler-build", version = "0.3.*" }
+
+        [host-dependencies]
+        python.git = "https://github.com/lucascolley/cpython"
+        python.subdirectory = "Tools/pixi-packages"
+        python.rev = "8b5b0c29797cf88d78ef014916a5e5a5d51bbf95"
+        python.flags = ["asan"]
+        "#;
+
+        let manifest = TomlPackage::from_toml_str(input)
+            .unwrap()
+            .into_manifest(
+                WorkspacePackageProperties::default(),
+                PackageDefaults::default(),
+                &Preview::from_iter([KnownPreviewFeature::PixiBuild]),
+                std::path::Path::new(""),
+            )
+            .unwrap()
+            .value;
+
+        let project_model = super::to_project_model_v1(&manifest, &some_channel_config()).unwrap();
+        let host_dependencies = project_model
+            .targets
+            .expect("targets are forwarded")
+            .default_target
+            .expect("default target is forwarded")
+            .host_dependencies
+            .expect("host dependencies are forwarded");
+        let python = host_dependencies
+            .iter()
+            .find_map(|(name, spec)| (name.as_str() == "python").then_some(spec))
+            .expect("python dependency exists");
+
+        match python {
+            super::pbt::PackageSpec::Source(source) => {
+                let flags = source.flags.as_ref().expect("source flags are forwarded");
+                assert_eq!(flags.len(), 1);
+                assert_eq!(flags[0].to_string(), "asan");
+            }
+            other => panic!("expected Source spec, got {other:?}"),
+        }
     }
 
     /// Regression test: `to_target_v1` must propagate `[package.run-constraints]`

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -422,11 +422,22 @@ pub struct SourcePackageSpec {
     /// The build number of the package
     #[cfg_attr(feature = "schemars", schemars(with = "Option<String>"))]
     pub build_number: Option<BuildNumberSpec>,
+    /// Optional extra dependencies to select for the package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extras: Option<Vec<String>>,
+    /// Plain string flags used to select package variants.
+    #[serde_as(as = "Option<Vec<DisplayFromStr>>")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<Vec<String>>"))]
+    pub flags: Option<Vec<StringMatcher>>,
     /// The subdir of the channel
     pub subdir: Option<String>,
-    /// The md5 hash of the package
     /// The license of the package
     pub license: Option<String>,
+    /// The condition under which this match spec applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "schemars", schemars(with = "Option<serde_json::Value>"))]
+    pub condition: Option<MatchSpecCondition>,
 }
 
 impl From<PathSpec> for SourcePackageSpec {
@@ -436,8 +447,11 @@ impl From<PathSpec> for SourcePackageSpec {
             version: None,
             build: None,
             build_number: None,
+            extras: None,
+            flags: None,
             subdir: None,
             license: None,
+            condition: None,
         }
     }
 }
@@ -449,8 +463,11 @@ impl From<UrlSpec> for SourcePackageSpec {
             version: None,
             build: None,
             build_number: None,
+            extras: None,
+            flags: None,
             subdir: None,
             license: None,
+            condition: None,
         }
     }
 }
@@ -462,8 +479,11 @@ impl From<GitSpec> for SourcePackageSpec {
             version: None,
             build: None,
             build_number: None,
+            extras: None,
+            flags: None,
             subdir: None,
             license: None,
+            condition: None,
         }
     }
 }
@@ -839,8 +859,11 @@ impl Hash for SourcePackageSpec {
             version,
             build,
             build_number,
+            extras,
+            flags,
             subdir,
             license,
+            condition,
         } = self;
 
         // Hash the location first to ensure compatibility with older versions.
@@ -848,9 +871,13 @@ impl Hash for SourcePackageSpec {
 
         // Add the new fields using StableHashBuilder for forward/backward
         // compatibility.
+        let condition = condition.as_ref().map(ToString::to_string);
         StableHashBuilder::<H>::new()
             .field("build", build)
             .field("build_number", build_number)
+            .field("condition", &condition)
+            .field("extras", extras)
+            .field("flags", flags)
             .field("license", license)
             .field("subdir", subdir)
             .field("version", version)

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -12,15 +12,21 @@ pub fn from_source_spec_v1(source: SourcePackageSpec) -> pixi_spec::SourceSpec {
         version,
         build,
         build_number,
+        extras,
+        flags,
         subdir,
         license,
+        condition,
     } = source;
     let matchspec = MatchspecFields {
         version,
         build,
         build_number,
+        extras,
+        flags,
         subdir,
         license,
+        condition,
         ..MatchspecFields::default()
     };
     from_source_package_location_spec(location).with_matchspec(matchspec)

--- a/schema/pixi_build_api.json
+++ b/schema/pixi_build_api.json
@@ -385,6 +385,26 @@
             "null"
           ]
         },
+        "extras": {
+          "description": "Optional extra dependencies to select for the package.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "flags": {
+          "description": "Plain string flags used to select package variants.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "subdir": {
           "description": "The subdir of the channel",
           "type": [
@@ -393,11 +413,14 @@
           ]
         },
         "license": {
-          "description": "The md5 hash of the package\nThe license of the package",
+          "description": "The license of the package",
           "type": [
             "string",
             "null"
           ]
+        },
+        "condition": {
+          "description": "The condition under which this match spec applies."
         }
       },
       "oneOf": [


### PR DESCRIPTION
### Motivation
- Prevent a conversion failure when source dependencies include matchspec selectors by preserving `extras`, `flags`, and `condition` when converting `pixi_spec` to the wire `pbt` model. 

### Description
- Propagate `extras`, `flags`, and `condition` from `MatchspecFields` in `to_pixi_spec_v1` so source package matchspec selectors are preserved. 
- Extend `pbt::SourcePackageSpec` in `crates/pixi_build_types/src/project_model.rs` to include `extras`, `flags`, and `condition` with `#[serde(default, skip_serializing_if = "Option::is_none")]` so absent fields do not change serialized output. 
- Include the `condition` (stringified) along with `extras` and `flags` in the stable hash for `SourcePackageSpec` to maintain hash stability. 
- Add a regression unit test in `crates/pixi_build_type_conversions/src/project_model.rs` that verifies a git host dependency with `python.flags = ["asan"]` is converted into a `pbt::PackageSpec::Source` and that `flags` are forwarded. 

### Testing
- Ran `cargo test -p pixi_build_type_conversions` and all tests passed. 
- Ran `cargo test -p pixi_build_types` and all tests passed. 
- Executed the new regression test verifying `python.flags` is forwarded and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4277429000832e93dbfd3111da27a7)