### PR TITLE
chore: release-backend make skip default

### DIFF
--- a/scripts/release_backends.py
+++ b/scripts/release_backends.py
@@ -605,7 +605,7 @@ def bump() -> None:
         choice = select(
             f"{b.binary} ({b.version}):",
             ["skip", "patch", "minor", "major"],
-            default="patch",
+            default="skip",
         )
         if choice != "skip":
             b.new_version = bump_version(b.version, choice)


### PR DESCRIPTION
We used to default to "skip", and turns out that is the better option
