### PR TITLE
feat: inline environments

### DIFF
--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -9,6 +9,11 @@ use url::Url;
 
 pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";
 pub const DEFAULT_FEATURE_NAME: &str = DEFAULT_ENVIRONMENT_NAME;
+
+/// Prefix of the implicit feature that is synthesized for an environment which
+/// defines dependencies inline. This prefix is reserved: user-defined features
+/// may not start with it.
+pub const ENVIRONMENT_FEATURE_PREFIX: &str = "env:";
 pub const PYPROJECT_PIXI_PREFIX: &str = "tool.pixi";
 
 pub const WORKSPACE_MANIFEST: &str = "pixi.toml";

--- a/crates/pixi_core/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@mismatch-channel-priority.snap.new
+++ b/crates/pixi_core/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@mismatch-channel-priority.snap.new
@@ -1,0 +1,8 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/tests.rs
+assertion_line: 263
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project
+    Diagnostic severity: error
+    Caused by: the lock file was solved with a different channel priority (strict) than the one selected (disabled)

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CondaConstraints, SpecType, WorkspaceTarget, channel::PrioritizedChannel, consts,
-    pypi::pypi_options::PypiOptions, target::Targets, workspace::ChannelPriority,
+    CondaConstraints, EnvironmentName, SpecType, WorkspaceTarget, channel::PrioritizedChannel,
+    consts, pypi::pypi_options::PypiOptions, target::Targets, workspace::ChannelPriority,
     workspace::SolveStrategy,
 };
 use crate::{InlinePackageManifest, PixiPlatform, PixiPlatformName};
@@ -67,6 +67,16 @@ impl From<String> for FeatureName {
 impl FeatureName {
     pub const DEFAULT: Self = FeatureName(Cow::Borrowed(consts::DEFAULT_FEATURE_NAME));
 
+    /// Constructs the implicit feature name for the inline dependencies of an
+    /// environment, e.g. `env:dev` for the environment `dev`.
+    pub fn environment(name: &EnvironmentName) -> Self {
+        FeatureName(Cow::Owned(format!(
+            "{}{}",
+            consts::ENVIRONMENT_FEATURE_PREFIX,
+            name.as_str()
+        )))
+    }
+
     /// Returns the string representation of the feature.
     pub fn as_str(&self) -> &str {
         &self.0
@@ -77,9 +87,41 @@ impl FeatureName {
         self == &Self::DEFAULT
     }
 
+    /// Returns true if this is an implicit feature synthesized for an
+    /// environment that defines dependencies inline.
+    pub fn is_environment(&self) -> bool {
+        self.0.starts_with(consts::ENVIRONMENT_FEATURE_PREFIX)
+    }
+
+    /// Returns the name of the environment this feature was synthesized for, if
+    /// it is an environment feature.
+    pub fn environment_name(&self) -> Option<&str> {
+        self.0.strip_prefix(consts::ENVIRONMENT_FEATURE_PREFIX)
+    }
+
     /// Returns the name of the feature if it is not default.
     pub fn non_default(&self) -> Option<&str> {
         self.is_default().not().then(|| self.as_str())
+    }
+
+    /// Renders the feature for user-facing diagnostics, describing an
+    /// environment feature as `environment '<name>'` and any other feature as
+    /// `feature '<name>'`.
+    pub fn user_facing(&self) -> UserFacingFeatureName<'_> {
+        UserFacingFeatureName(self)
+    }
+}
+
+/// Helper returned by [`FeatureName::user_facing`] that renders a feature name
+/// for diagnostics without exposing the internal `env:` prefix.
+pub struct UserFacingFeatureName<'a>(&'a FeatureName);
+
+impl fmt::Display for UserFacingFeatureName<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.environment_name() {
+            Some(name) => write!(f, "environment '{name}'"),
+            None => write!(f, "feature '{}'", self.0.as_str()),
+        }
     }
 }
 
@@ -505,6 +547,30 @@ mod tests {
 
     use super::*;
     use crate::WorkspaceManifest;
+
+    #[test]
+    fn test_environment_feature_name() {
+        let name = FeatureName::environment(&EnvironmentName::Named("dev".to_string()));
+        assert_eq!(name.as_str(), "env:dev");
+        assert!(name.is_environment());
+        assert!(!name.is_default());
+        assert_eq!(name.environment_name(), Some("dev"));
+        assert_eq!(name.user_facing().to_string(), "environment 'dev'");
+    }
+
+    #[test]
+    fn test_regular_feature_name_is_not_environment() {
+        let name = FeatureName::from("dev");
+        assert!(!name.is_environment());
+        assert_eq!(name.environment_name(), None);
+        assert_eq!(name.user_facing().to_string(), "feature 'dev'");
+
+        // A feature whose name merely starts with `env` (but not `env:`) is a
+        // normal feature.
+        let name = FeatureName::from("environment");
+        assert!(!name.is_environment());
+        assert_eq!(name.environment_name(), None);
+    }
 
     #[test]
     fn test_dependencies_borrowed() {

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -609,4 +609,38 @@ mod tests {
             "expected to find the security extra defined on the including extra"
         );
     }
+
+    #[test]
+    fn test_inline_environment_dependencies() {
+        const PYPROJECT: &str = r#"
+            [project]
+            name = "example"
+
+            [tool.pixi.workspace]
+            channels = ["conda-forge"]
+            platforms = ["linux-64"]
+
+            [tool.pixi.environments.dev.dependencies]
+            git = "*"
+            "#;
+
+        let manifest = super::PyProjectManifest::from_toml_str(PYPROJECT).unwrap();
+        let (workspace_manifest, _, _) = manifest.into_workspace_manifest(Path::new("")).unwrap();
+
+        // The implicit `env:dev` feature is prepended to the environment.
+        let dev = workspace_manifest
+            .environment("dev")
+            .expect("dev environment exists");
+        assert_eq!(dev.features, vec!["env:dev".to_string()]);
+
+        let feature = workspace_manifest
+            .feature(&FeatureName::from("env:dev"))
+            .expect("the inline feature exists");
+        assert!(
+            feature
+                .dependencies(crate::SpecType::Run, None)
+                .unwrap()
+                .contains_key("git")
+        );
+    }
 }

--- a/crates/pixi_manifest/src/toml/environment.rs
+++ b/crates/pixi_manifest/src/toml/environment.rs
@@ -1,9 +1,17 @@
+use std::collections::HashMap;
+
+use indexmap::{IndexMap, IndexSet};
+use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
+use pixi_toml::{Same, TomlHashMap, TomlIndexMap, TomlIndexSet, TomlWith};
 use toml_span::{DeserError, Spanned, Value, de_helpers::expected};
 
 use crate::{
-    Feature, FeatureName, TomlError, WithWarnings,
-    toml::{TomlFeature, TomlWorkspace, preview::TomlPreview},
+    Activation, Feature, FeatureName, SystemRequirements, TargetSelector, Task, TaskName, TomlError,
+    Warning, WithWarnings,
+    pypi::pypi_options::PypiOptions,
+    toml::{TomlFeature, TomlPrioritizedChannel, TomlTarget, TomlWorkspace, preview::TomlPreview, task::TomlTask},
     utils::{PixiSpanned, package_map::UniquePackageMap},
+    workspace::{ChannelPriority, SolveStrategy},
 };
 
 /// Helper struct to deserialize the environment from TOML.
@@ -24,15 +32,53 @@ pub struct TomlEnvironment {
 /// `system-requirements`).
 #[derive(Debug, Default)]
 pub struct TomlEnvironmentInline {
+    pub platforms: Option<Spanned<IndexSet<String>>>,
+    pub channels: Option<Vec<TomlPrioritizedChannel>>,
+    pub channel_priority: Option<ChannelPriority>,
+    pub solve_strategy: Option<SolveStrategy>,
+    pub target: IndexMap<PixiSpanned<TargetSelector>, TomlTarget>,
     pub dependencies: Option<PixiSpanned<UniquePackageMap>>,
+    pub pypi_dependencies: Option<IndexMap<PypiPackageName, PixiPypiSpec>>,
+    pub dev_dependencies:
+        Option<IndexMap<rattler_conda_types::PackageName, pixi_spec::TomlLocationSpec>>,
+    pub constraints: Option<PixiSpanned<UniquePackageMap>>,
+    pub activation: Option<Activation>,
+    pub tasks: HashMap<TaskName, Task>,
+    pub pypi_options: Option<PypiOptions>,
+    pub warnings: Vec<Warning>,
 }
 
 impl TomlEnvironmentInline {
     /// Returns true if the environment does not define any inline feature
     /// content, in which case no implicit feature needs to be synthesized.
     pub fn is_empty(&self) -> bool {
-        let Self { dependencies } = self;
-        dependencies.is_none()
+        let Self {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
+            dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            warnings: _,
+        } = self;
+        platforms.is_none()
+            && channels.is_none()
+            && channel_priority.is_none()
+            && solve_strategy.is_none()
+            && target.is_empty()
+            && dependencies.is_none()
+            && pypi_dependencies.is_none()
+            && dev_dependencies.is_none()
+            && constraints.is_none()
+            && activation.is_none()
+            && tasks.is_empty()
+            && pypi_options.is_none()
     }
 
     /// Builds the implicit feature that carries the environment's inline
@@ -43,13 +89,41 @@ impl TomlEnvironmentInline {
         preview: &TomlPreview,
         workspace: &TomlWorkspace,
     ) -> Result<WithWarnings<Feature>, TomlError> {
-        let Self { dependencies } = self;
+        let Self {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
+            dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            warnings,
+        } = self;
         let WithWarnings {
             value: (feature, _system_requirements),
             warnings,
         } = TomlFeature {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
             dependencies,
-            ..TomlFeature::default()
+            pypi_dependencies,
+            dev: dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            host_dependencies: None,
+            build_dependencies: None,
+            system_requirements: SystemRequirements::default(),
+            warnings,
         }
         .into_feature(name, preview, workspace)?;
         Ok(WithWarnings::from(feature).with_warnings(warnings))
@@ -65,15 +139,67 @@ pub enum TomlEnvironmentList {
 impl<'de> toml_span::Deserialize<'de> for TomlEnvironment {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = toml_span::de_helpers::TableHelper::new(value)?;
+        let mut warnings = Vec::new();
 
         let features = th.optional_s("features");
         let solve_group = th.optional("solve-group");
         let no_default_feature = th.optional("no-default-feature");
+
+        // Inline feature content. `host-dependencies`, `build-dependencies` and
+        // `system-requirements` are intentionally not accepted here and are
+        // rejected by `finalize` below.
+        let platforms = th
+            .optional::<TomlWith<_, Spanned<TomlIndexSet<Same>>>>("platforms")
+            .map(TomlWith::into_inner);
+        let channels = th.optional("channels");
+        let channel_priority = th.optional("channel-priority");
+        let solve_strategy = th.optional("solve-strategy");
+        let target = th
+            .optional::<TomlIndexMap<_, _>>("target")
+            .map(TomlIndexMap::into_inner)
+            .unwrap_or_default();
         let dependencies = th.optional("dependencies");
+        let pypi_dependencies = th
+            .optional::<TomlIndexMap<_, _>>("pypi-dependencies")
+            .map(TomlIndexMap::into_inner);
+        let dev_dependencies = th
+            .optional::<TomlIndexMap<_, _>>("dev")
+            .map(TomlIndexMap::into_inner);
+        let constraints = th.optional("constraints");
+        let activation = th.optional("activation");
+        let tasks = th
+            .optional::<TomlHashMap<_, TomlTask>>("tasks")
+            .map(TomlHashMap::into_inner)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(key, value)| {
+                let WithWarnings {
+                    value: task,
+                    warnings: mut task_warnings,
+                } = value;
+                warnings.append(&mut task_warnings);
+                (key, task)
+            })
+            .collect();
+        let pypi_options = th.optional("pypi-options");
 
         th.finalize(None)?;
 
-        let inline = TomlEnvironmentInline { dependencies };
+        let inline = TomlEnvironmentInline {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
+            dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            warnings,
+        };
 
         if features.is_none() && solve_group.is_none() && inline.is_empty() {
             return Err(DeserError::from(toml_span::Error {

--- a/crates/pixi_manifest/src/toml/environment.rs
+++ b/crates/pixi_manifest/src/toml/environment.rs
@@ -1,5 +1,11 @@
 use toml_span::{DeserError, Spanned, Value, de_helpers::expected};
 
+use crate::{
+    Feature, FeatureName, TomlError, WithWarnings,
+    toml::{TomlFeature, TomlWorkspace, preview::TomlPreview},
+    utils::{PixiSpanned, package_map::UniquePackageMap},
+};
+
 /// Helper struct to deserialize the environment from TOML.
 /// The environment description can only hold these values.
 #[derive(Debug)]
@@ -7,11 +13,52 @@ pub struct TomlEnvironment {
     pub features: Option<Spanned<Vec<Spanned<String>>>>,
     pub solve_group: Option<String>,
     pub no_default_feature: bool,
+    /// Feature content defined directly on the environment. This is turned into
+    /// an implicit feature that is prepended to the environment's features.
+    pub inline: TomlEnvironmentInline,
+}
+
+/// The feature content that can be defined directly on an environment. This is
+/// the same content as a regular feature, minus the fields that only make sense
+/// on a feature (`host-dependencies`, `build-dependencies` and
+/// `system-requirements`).
+#[derive(Debug, Default)]
+pub struct TomlEnvironmentInline {
+    pub dependencies: Option<PixiSpanned<UniquePackageMap>>,
+}
+
+impl TomlEnvironmentInline {
+    /// Returns true if the environment does not define any inline feature
+    /// content, in which case no implicit feature needs to be synthesized.
+    pub fn is_empty(&self) -> bool {
+        let Self { dependencies } = self;
+        dependencies.is_none()
+    }
+
+    /// Builds the implicit feature that carries the environment's inline
+    /// content.
+    pub fn into_feature(
+        self,
+        name: FeatureName,
+        preview: &TomlPreview,
+        workspace: &TomlWorkspace,
+    ) -> Result<WithWarnings<Feature>, TomlError> {
+        let Self { dependencies } = self;
+        let WithWarnings {
+            value: (feature, _system_requirements),
+            warnings,
+        } = TomlFeature {
+            dependencies,
+            ..TomlFeature::default()
+        }
+        .into_feature(name, preview, workspace)?;
+        Ok(WithWarnings::from(feature).with_warnings(warnings))
+    }
 }
 
 #[derive(Debug)]
 pub enum TomlEnvironmentList {
-    Map(TomlEnvironment),
+    Map(Box<TomlEnvironment>),
     Seq(Spanned<Vec<Spanned<String>>>),
 }
 
@@ -22,10 +69,13 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironment {
         let features = th.optional_s("features");
         let solve_group = th.optional("solve-group");
         let no_default_feature = th.optional("no-default-feature");
+        let dependencies = th.optional("dependencies");
 
         th.finalize(None)?;
 
-        if features.is_none() && solve_group.is_none() {
+        let inline = TomlEnvironmentInline { dependencies };
+
+        if features.is_none() && solve_group.is_none() && inline.is_empty() {
             return Err(DeserError::from(toml_span::Error {
                 kind: toml_span::ErrorKind::MissingField("features"),
                 span: value.span,
@@ -37,6 +87,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironment {
             features,
             solve_group,
             no_default_feature: no_default_feature.unwrap_or_default(),
+            inline,
         })
     }
 }
@@ -48,9 +99,9 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironmentList {
                 toml_span::Deserialize::deserialize(value)?,
             ))
         } else if value.as_table().is_some() {
-            Ok(TomlEnvironmentList::Map(
+            Ok(TomlEnvironmentList::Map(Box::new(
                 toml_span::Deserialize::deserialize(value)?,
-            ))
+            )))
         } else {
             Err(expected("either a map or a sequence", value.take(), value.span).into())
         }

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TomlFeature {
     pub platforms: Option<Spanned<IndexSet<String>>>,
     pub channels: Option<Vec<TomlPrioritizedChannel>>,

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -22,6 +22,7 @@ use crate::{
     Activation, Environment, EnvironmentName, Environments, Feature, FeatureName,
     KnownPreviewFeature, PixiPlatform, PixiPlatformName, SolveGroups, SystemRequirements,
     TargetSelector, Targets, Task, TaskName, TomlError, Warning, WithWarnings, WorkspaceManifest,
+    consts,
     environment::EnvironmentIdx,
     error::{FeatureNotEnabled, GenericError},
     manifests::PackageManifest,
@@ -290,6 +291,17 @@ impl TomlManifest {
                         GenericError::new("The feature 'default' is reserved and cannot be redefined")
                             .with_opt_span(name.span)
                             .with_help("All tables at the root of the document are implicitly added to the 'default' feature, use those instead."),
+                    ));
+                }
+                if name.value.is_environment() {
+                    return Err(TomlError::from(
+                        GenericError::new(format!(
+                            "The feature name '{}' is reserved: feature names starting with '{}' are synthesized for environments that define dependencies inline",
+                            name.value.as_str(),
+                            consts::ENVIRONMENT_FEATURE_PREFIX,
+                        ))
+                            .with_opt_span(name.span)
+                            .with_help("Define these dependencies directly under the environment table, or rename the feature."),
                     ));
                 }
                 let WithWarnings {
@@ -2093,6 +2105,30 @@ mod test {
         [feature.default.dependencies]
         "#,
         ));
+    }
+
+    #[test]
+    fn test_reserved_env_feature_name() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = []
+
+        [feature."env:dev".dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × The feature name 'env:dev' is reserved: feature names starting with 'env:' are synthesized for environments that define dependencies inline
+           ╭─[pixi.toml:7:19]
+         6 │
+         7 │         [feature."env:dev".dependencies]
+           ·                   ───────
+         8 │         git = "*"
+           ╰────
+          help: Define these dependencies directly under the environment table, or rename the feature.
+        "###);
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -2280,6 +2280,70 @@ mod test {
     }
 
     #[test]
+    fn test_environment_inline_full_content() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = ["conda-forge"]
+        platforms = ["linux-64", "osx-64"]
+
+        [environments.dev]
+        channels = ["bioconda"]
+        platforms = ["linux-64"]
+        dependencies = { git = "*" }
+        pypi-dependencies = { requests = "*" }
+
+        [environments.dev.tasks]
+        greet = "echo hi"
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        let feature = manifest
+            .feature("env:dev")
+            .expect("the inline feature exists");
+
+        assert!(
+            feature
+                .dependencies(crate::SpecType::Run, None)
+                .unwrap()
+                .contains_key("git")
+        );
+        assert!(!feature.pypi_dependencies(None).unwrap().is_empty());
+        assert!(feature.channels.is_some());
+        assert!(feature.platforms.is_some());
+        assert_eq!(feature.targets.default().tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_environment_inline_host_dependencies_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.host-dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+          │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
+           ╭─[pixi.toml:7:27]
+         6 │
+         7 │         [environments.dev.host-dependencies]
+           ·                           ────────┬────────
+           ·                                   ╰── 'host-dependencies' was not expected here
+         8 │         git = "*"
+           ╰────
+          help: Did you mean 'dependencies'?
+        "###);
+    }
+
+    #[test]
     fn test_parse_dev_path() {
         let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             r#"

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -30,7 +30,8 @@ use crate::{
     toml::{
         PackageDefaults, PlatformSpan, TomlFeature, TomlPackage, TomlTarget, TomlWorkspace,
         WorkspacePackageProperties, create_unsupported_selector_warning,
-        environment::TomlEnvironmentList, task::TomlTask,
+        environment::{TomlEnvironment, TomlEnvironmentList},
+        task::TomlTask,
     },
     utils::{
         PixiSpanned,
@@ -355,22 +356,56 @@ impl TomlManifest {
         let mut features_used_by_environments = HashSet::new();
         for (name, env) in toml_environments {
             // Decompose the TOML
-            let (included_features, features_span, solve_group, no_default_feature) = match env {
-                TomlEnvironmentList::Map(env) => {
-                    let (features, features_span) = env.features.map_or_else(
-                        || (Vec::new(), None),
-                        |Spanned { value, span }| (value, Some(span)),
-                    );
-                    (
-                        features,
-                        features_span,
-                        env.solve_group,
-                        env.no_default_feature,
-                    )
+            let (inline, included_features, features_span, solve_group, no_default_feature) =
+                match env {
+                    TomlEnvironmentList::Map(env) => {
+                        let TomlEnvironment {
+                            features,
+                            solve_group,
+                            no_default_feature,
+                            inline,
+                        } = *env;
+                        let (features, features_span) = features.map_or_else(
+                            || (Vec::new(), None),
+                            |Spanned { value, span }| (value, Some(span)),
+                        );
+                        (
+                            Some(inline),
+                            features,
+                            features_span,
+                            solve_group,
+                            no_default_feature,
+                        )
+                    }
+                    TomlEnvironmentList::Seq(features) => {
+                        (None, features.value, Some(features.span), None, false)
+                    }
+                };
+
+            // Synthesize the implicit feature that carries the environment's
+            // inline content and prepend it to the environment's features.
+            let inline_feature_name = match inline {
+                Some(inline) if !inline.is_empty() => {
+                    if name.is_default() {
+                        return Err(TomlError::from(
+                            GenericError::new(
+                                "The 'default' environment cannot define dependencies inline",
+                            )
+                            .with_help(
+                                "Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.",
+                            ),
+                        ));
+                    }
+                    let feature_name = FeatureName::environment(&name);
+                    let WithWarnings {
+                        value: feature,
+                        warnings: mut feature_warnings,
+                    } = inline.into_feature(feature_name.clone(), preview, &workspace.value)?;
+                    warnings.append(&mut feature_warnings);
+                    features.insert(feature_name.clone(), feature);
+                    Some(feature_name)
                 }
-                TomlEnvironmentList::Seq(features) => {
-                    (features.value, Some(features.span), None, false)
-                }
+                _ => None,
             };
 
             features_used_by_environments
@@ -379,7 +414,14 @@ impl TomlManifest {
             // Verify that the features of the environment actually exist and that they are
             // not defined twice.
             let mut features_seen_where = HashMap::new();
-            let mut used_features = Vec::with_capacity(included_features.len());
+            let mut used_features = Vec::with_capacity(included_features.len() + 1);
+            if let Some(feature_name) = &inline_feature_name {
+                used_features.push(
+                    features
+                        .get(feature_name)
+                        .expect("the inline feature was just inserted"),
+                );
+            }
             for Spanned {
                 value: feature_name,
                 span,
@@ -450,11 +492,17 @@ impl TomlManifest {
                 ));
             }
 
+            let mut feature_names: Vec<String> =
+                included_features.into_iter().map(Spanned::take).collect();
+            if let Some(feature_name) = inline_feature_name {
+                feature_names.insert(0, feature_name.into());
+            }
+
             let environment_idx = EnvironmentIdx(environments.environments.len());
             environments.by_name.insert(name.clone(), environment_idx);
             environments.environments.push(Some(Environment {
                 name,
-                features: included_features.into_iter().map(Spanned::take).collect(),
+                features: feature_names,
                 solve_group: solve_group.map(|sg| solve_groups.add(sg, environment_idx)),
                 no_default_feature,
             }));
@@ -2128,6 +2176,106 @@ mod test {
          8 │         git = "*"
            ╰────
           help: Define these dependencies directly under the environment table, or rename the feature.
+        "###);
+    }
+
+    #[test]
+    fn test_environment_inline_dependencies() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.dependencies]
+        git = "*"
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        // Defining dependencies inline auto-declares the environment and
+        // prepends the implicit `env:dev` feature to its feature list.
+        let dev = manifest.environment("dev").expect("dev environment exists");
+        assert_eq!(dev.features, vec!["env:dev".to_string()]);
+
+        // The implicit feature carries the inline dependency.
+        let feature = manifest
+            .feature("env:dev")
+            .expect("the inline feature exists");
+        let deps = feature.dependencies(crate::SpecType::Run, None).unwrap();
+        assert!(deps.contains_key("git"));
+    }
+
+    #[test]
+    fn test_environment_inline_dependencies_with_features() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.python.dependencies]
+        python = "*"
+
+        [environments.dev]
+        features = ["python"]
+        dependencies = { git = "*" }
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        // The implicit feature is prepended before the referenced features.
+        let dev = manifest.environment("dev").expect("dev environment exists");
+        assert_eq!(
+            dev.features,
+            vec!["env:dev".to_string(), "python".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_environment_without_inline_content_has_no_feature() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.python.dependencies]
+        python = "*"
+
+        [environments]
+        dev = { features = ["python"] }
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        // A purely compositional environment does not synthesize a feature.
+        assert!(manifest.feature("env:dev").is_none());
+        let dev = manifest.environment("dev").expect("dev environment exists");
+        assert_eq!(dev.features, vec!["python".to_string()]);
+    }
+
+    #[test]
+    fn test_environment_default_inline_dependencies_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.default.dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × The 'default' environment cannot define dependencies inline
+          help: Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.
         "###);
     }
 

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
+assertion_line: 167
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
    ╭─[pixi.toml:2:21]
  1 │
  2 │             env = { feat = ["foo", "bar"] }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
-assertion_line: 167
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+  │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
    ╭─[pixi.toml:2:21]
  1 │
  2 │             env = { feat = ["foo", "bar"] }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
+assertion_line: 203
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
    ╭─[pixi.toml:2:36]
  1 │
  2 │             env = { features = [], solve_groups = "group" }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
-assertion_line: 203
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+  │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
    ╭─[pixi.toml:2:36]
  1 │
  2 │             env = { features = [], solve_groups = "group" }

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1284,6 +1284,8 @@ The environments table is defined using the following fields:
   But the different environments contain different subsets of the solve-groups dependencies set.
 - `no-default-feature`: Whether to include the default feature in that environment. The default is `false`, to include the default feature.
 
+Additionally, most fields that a [feature](#the-feature-table) accepts - `dependencies`, `pypi-dependencies`, `tasks`, `activation`, `channels`, `platforms`, `constraints`, `target` and more - can be set directly on an environment. See [Defining dependencies directly on an environment](#defining-dependencies-directly-on-an-environment).
+
 ```toml title="Full environments table specification"
 [environments]
 test = {features = ["test"], solve-group = "test"}
@@ -1324,6 +1326,40 @@ When an environment comprises several features (including the default feature):
   as the `platforms` defined at workspace level (unless overridden in the feature). This means that
   it is usually a good idea to set the workspace `platforms` to all platforms it can support across
   its environments.
+
+#### Defining dependencies directly on an environment
+
+Features are the right tool when you want to *share* dependencies between environments.
+When something belongs to a single environment, you can skip the feature and define it directly on the environment:
+
+```toml title="Inline environment dependencies"
+[environments.dev.dependencies]
+git = "*"
+
+[environments.test.dependencies]
+pytest = "*"
+pytest-xdist = "*"
+```
+
+This defines two environments, `dev` and `test`, without any intermediate feature.
+All feature content is available this way: `dependencies`, `pypi-dependencies`, `tasks`, `activation`, `channels`, `channel-priority`, `solve-strategy`, `platforms`, `constraints`, `target` and `pypi-options`.
+`host-dependencies`, `build-dependencies` and `system-requirements` are not accepted here; they belong on a feature.
+
+Inline content can be combined with shared features.
+The inline content takes precedence over the referenced features, which is relevant for the fields where order matters (such as `tasks` and `activation`):
+
+```toml title="Inline content combined with shared features"
+[feature.python.dependencies]
+python = "3.14.*"
+
+[environments.dev]
+features = ["python"]
+dependencies = { git = "*" }
+```
+
+Under the hood pixi synthesizes an implicit feature named `env:<environment-name>` (here `env:dev`) and prepends it to the environment's features.
+Because of this, feature names cannot start with `env:`.
+The `default` environment cannot define dependencies inline; add them to the top-level tables (for example `[dependencies]`) instead, as those already belong to the default environment.
 
 ## Global configuration
 

--- a/schema/model.py
+++ b/schema/model.py
@@ -822,6 +822,56 @@ class Environment(StrictBaseModel):
         False,
         description="Whether to add the default feature to this environment",
     )
+    # Inline feature content. Defining any of these synthesizes an implicit
+    # feature that is prepended to the environment's features. `host-dependencies`,
+    # `build-dependencies` and `system-requirements` are intentionally not allowed
+    # here; they belong on a feature.
+    channels: list[Channel] | None = Field(
+        None,
+        description="The `conda` channels that can be considered when solving this environment",
+    )
+    channel_priority: ChannelPriority | None = Field(
+        None,
+        examples=["strict", "disabled"],
+        description="""The type of channel priority that is used in the solve.
+- 'strict': only take the package from the channel it exist in first.
+- 'disabled': group all dependencies together as if there is no channel difference.""",
+    )
+    solve_strategy: SolveStrategy | None = Field(
+        None,
+        examples=["lowest", "lowest-direct", "highest"],
+        description="""The strategy that is used in the solve.
+- 'highest': solve all packages to the highest compatible version.
+- 'lowest': solve all packages to the lowest compatible version.
+- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.""",
+    )
+    platforms: list[Platform | PlatformName] | None = Field(
+        None,
+        description="The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+    )
+    dependencies: Dependencies = DependenciesField
+    constraints: Dependencies = ConstraintsField
+    pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
+        None, description="The PyPI dependencies of this environment"
+    )
+    dev: dict[CondaPackageName, SourceSpecTable] | None = Field(
+        None,
+        description="Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+    )
+    tasks: dict[TaskName, TaskInlineTable | list[DependsOn] | NonEmptyStr] | None = Field(
+        None, description="The tasks provided by this environment"
+    )
+    activation: Activation | None = Field(
+        None, description="The scripts used on the activation of this environment"
+    )
+    target: dict[TargetName, Target] | None = Field(
+        None,
+        description="Machine-specific aspects of this environment",
+        examples=[{"linux": {"dependencies": {"python": "3.8"}}}],
+    )
+    pypi_options: PyPIOptions | None = Field(
+        None, description="Options related to PyPI indexes for this environment"
+    )
 
 
 ######################

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -805,6 +805,88 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "activation": {
+          "$ref": "#/$defs/Activation",
+          "description": "The scripts used on the activation of this environment"
+        },
+        "channel-priority": {
+          "$ref": "#/$defs/ChannelPriority",
+          "description": "The type of channel priority that is used in the solve.\n- 'strict': only take the package from the channel it exist in first.\n- 'disabled': group all dependencies together as if there is no channel difference.",
+          "examples": [
+            "strict",
+            "disabled"
+          ]
+        },
+        "channels": {
+          "title": "Channels",
+          "description": "The `conda` channels that can be considered when solving this environment",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ChannelInlineTable"
+              }
+            ]
+          }
+        },
+        "constraints": {
+          "title": "Constraints",
+          "description": "The `conda` version constraints. These constrain the versions of packages that may be installed without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dev": {
+          "title": "Dev",
+          "description": "Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SourceSpecTable"
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
         "features": {
           "title": "Features",
           "description": "The features that define the environment",
@@ -820,11 +902,123 @@
           "type": "boolean",
           "default": false
         },
+        "platforms": {
+          "title": "Platforms",
+          "description": "The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Platform"
+              },
+              {
+                "type": "string",
+                "maxLength": 64,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z]$"
+              }
+            ]
+          }
+        },
+        "pypi-dependencies": {
+          "title": "Pypi-Dependencies",
+          "description": "The PyPI dependencies of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIVersion"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitBranchRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitTagRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitRevRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIPathRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIUrlRequirement"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "pypi-options": {
+          "$ref": "#/$defs/PyPIOptions",
+          "description": "Options related to PyPI indexes for this environment"
+        },
         "solve-group": {
           "title": "Solve-Group",
           "description": "The group name for environments that should be solved together",
           "type": "string",
           "minLength": 1
+        },
+        "solve-strategy": {
+          "$ref": "#/$defs/SolveStrategy",
+          "description": "The strategy that is used in the solve.\n- 'highest': solve all packages to the highest compatible version.\n- 'lowest': solve all packages to the lowest compatible version.\n- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.",
+          "examples": [
+            "lowest",
+            "lowest-direct",
+            "highest"
+          ]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Machine-specific aspects of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Target"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "linux": {
+                "dependencies": {
+                  "python": "3.8"
+                }
+              }
+            }
+          ]
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks provided by this environment",
+          "type": "object",
+          "patternProperties": {
+            "^[^\\s\\$]+$": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TaskInlineTable"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/DependsOn"
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "description": "A valid task name.",
+            "minLength": 1
+          }
         }
       }
     },

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -548,6 +548,88 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "activation": {
+          "$ref": "#/$defs/Activation",
+          "description": "The scripts used on the activation of this environment"
+        },
+        "channel-priority": {
+          "$ref": "#/$defs/ChannelPriority",
+          "description": "The type of channel priority that is used in the solve.\n- 'strict': only take the package from the channel it exist in first.\n- 'disabled': group all dependencies together as if there is no channel difference.",
+          "examples": [
+            "strict",
+            "disabled"
+          ]
+        },
+        "channels": {
+          "title": "Channels",
+          "description": "The `conda` channels that can be considered when solving this environment",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ChannelInlineTable"
+              }
+            ]
+          }
+        },
+        "constraints": {
+          "title": "Constraints",
+          "description": "The `conda` version constraints. These constrain the versions of packages that may be installed without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dev": {
+          "title": "Dev",
+          "description": "Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SourceSpecTable"
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
         "features": {
           "title": "Features",
           "description": "The features that define the environment",
@@ -563,11 +645,123 @@
           "type": "boolean",
           "default": false
         },
+        "platforms": {
+          "title": "Platforms",
+          "description": "The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Platform"
+              },
+              {
+                "type": "string",
+                "maxLength": 64,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z]$"
+              }
+            ]
+          }
+        },
+        "pypi-dependencies": {
+          "title": "Pypi-Dependencies",
+          "description": "The PyPI dependencies of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIVersion"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitBranchRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitTagRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitRevRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIPathRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIUrlRequirement"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "pypi-options": {
+          "$ref": "#/$defs/PyPIOptions",
+          "description": "Options related to PyPI indexes for this environment"
+        },
         "solve-group": {
           "title": "Solve-Group",
           "description": "The group name for environments that should be solved together",
           "type": "string",
           "minLength": 1
+        },
+        "solve-strategy": {
+          "$ref": "#/$defs/SolveStrategy",
+          "description": "The strategy that is used in the solve.\n- 'highest': solve all packages to the highest compatible version.\n- 'lowest': solve all packages to the lowest compatible version.\n- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.",
+          "examples": [
+            "lowest",
+            "lowest-direct",
+            "highest"
+          ]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Machine-specific aspects of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Target"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "linux": {
+                "dependencies": {
+                  "python": "3.8"
+                }
+              }
+            }
+          ]
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks provided by this environment",
+          "type": "object",
+          "patternProperties": {
+            "^[^\\s\\$]+$": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TaskInlineTable"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/DependsOn"
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "description": "A valid task name.",
+            "minLength": 1
+          }
         }
       }
     },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -829,6 +829,88 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "activation": {
+          "$ref": "#/$defs/Activation",
+          "description": "The scripts used on the activation of this environment"
+        },
+        "channel-priority": {
+          "$ref": "#/$defs/ChannelPriority",
+          "description": "The type of channel priority that is used in the solve.\n- 'strict': only take the package from the channel it exist in first.\n- 'disabled': group all dependencies together as if there is no channel difference.",
+          "examples": [
+            "strict",
+            "disabled"
+          ]
+        },
+        "channels": {
+          "title": "Channels",
+          "description": "The `conda` channels that can be considered when solving this environment",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ChannelInlineTable"
+              }
+            ]
+          }
+        },
+        "constraints": {
+          "title": "Constraints",
+          "description": "The `conda` version constraints. These constrain the versions of packages that may be installed without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dev": {
+          "title": "Dev",
+          "description": "Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SourceSpecTable"
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
         "features": {
           "title": "Features",
           "description": "The features that define the environment",
@@ -844,11 +926,123 @@
           "type": "boolean",
           "default": false
         },
+        "platforms": {
+          "title": "Platforms",
+          "description": "The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Platform"
+              },
+              {
+                "type": "string",
+                "maxLength": 64,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z]$"
+              }
+            ]
+          }
+        },
+        "pypi-dependencies": {
+          "title": "Pypi-Dependencies",
+          "description": "The PyPI dependencies of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIVersion"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitBranchRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitTagRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitRevRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIPathRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIUrlRequirement"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "pypi-options": {
+          "$ref": "#/$defs/PyPIOptions",
+          "description": "Options related to PyPI indexes for this environment"
+        },
         "solve-group": {
           "title": "Solve-Group",
           "description": "The group name for environments that should be solved together",
           "type": "string",
           "minLength": 1
+        },
+        "solve-strategy": {
+          "$ref": "#/$defs/SolveStrategy",
+          "description": "The strategy that is used in the solve.\n- 'highest': solve all packages to the highest compatible version.\n- 'lowest': solve all packages to the lowest compatible version.\n- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.",
+          "examples": [
+            "lowest",
+            "lowest-direct",
+            "highest"
+          ]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Machine-specific aspects of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Target"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "linux": {
+                "dependencies": {
+                  "python": "3.8"
+                }
+              }
+            }
+          ]
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks provided by this environment",
+          "type": "object",
+          "patternProperties": {
+            "^[^\\s\\$]+$": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TaskInlineTable"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/DependsOn"
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "description": "A valid task name.",
+            "minLength": 1
+          }
         }
       }
     },


### PR DESCRIPTION
### Description

Not to be confused with inline packages, this PR implements the ability to do this:

```toml
[environments.dev.dependencies]
git = "*"

[environments.test.dependencies]
pytest = "*"
pytest-xdist = "*"

# features can still be added
[feature.python.dependencies]
python = "3.14.*"

[environments]
dev = { features = ["python"] }
test = { features = ["python"] }
```

Fixes #5317

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
