### PR TITLE
feat: inline environments

### DIFF
--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -633,7 +633,7 @@ async fn add_unconstrained_dependency() {
     let bar_spec = project
         .workspace
         .value
-        .feature("unreferenced")
+        .feature(&FeatureName::from("unreferenced"))
         .expect("feature 'unreferenced' is missing")
         .combined_dependencies(None)
         .unwrap_or_default()

--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -161,6 +161,7 @@ pub trait HasDependencyConfig: Sized {
             pypi: false,
             platforms: Default::default(),
             feature: Default::default(),
+            environment: Default::default(),
             git: Default::default(),
             rev: Default::default(),
             subdir: Default::default(),

--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -840,7 +840,7 @@ impl TasksControl<'_> {
                 commands: vec![],
                 depends_on: None,
                 platform: platform.map(Into::into),
-                feature: feature_name.non_default().map(str::to_owned),
+                feature: feature_name.non_default().map(FeatureName::from),
                 cwd: None,
                 default_environment: None,
                 env: Default::default(),
@@ -856,7 +856,7 @@ impl TasksControl<'_> {
         &self,
         name: TaskName,
         platform: Option<Platform>,
-        feature_name: Option<String>,
+        feature_name: Option<FeatureName>,
     ) -> miette::Result<()> {
         task::execute(task::Args {
             config_source: isolated_config_source(),

--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -558,6 +558,7 @@ impl PixiControl {
                 },
                 config: Default::default(),
                 feature: None,
+                environment: None,
                 priority: None,
                 prepend: false,
             },
@@ -580,6 +581,7 @@ impl PixiControl {
                 },
                 config: Default::default(),
                 feature: None,
+                environment: None,
                 priority: None,
                 prepend: false,
             },
@@ -841,6 +843,7 @@ impl TasksControl<'_> {
                 depends_on: None,
                 platform: platform.map(Into::into),
                 feature: feature_name.non_default().map(FeatureName::from),
+                environment: None,
                 cwd: None,
                 default_environment: None,
                 env: Default::default(),
@@ -868,6 +871,7 @@ impl TasksControl<'_> {
                 names: vec![name],
                 platform: platform.map(Into::into),
                 feature: feature_name,
+                environment: None,
             }),
         })
         .await
@@ -881,6 +885,7 @@ impl TasksControl<'_> {
                 platform: platform.map(Into::into),
                 alias: name,
                 depends_on: vec![],
+                environment: None,
                 description: None,
             },
         }

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -448,6 +448,7 @@ impl<I: Interface> WorkspaceContext<I> {
         &self,
         name: TaskName,
         task: Task,
+        feature: FeatureName,
         platform: Option<PixiPlatformName>,
     ) -> miette::Result<()> {
         crate::workspace::task::alias_task(
@@ -455,6 +456,7 @@ impl<I: Interface> WorkspaceContext<I> {
             self.workspace_mut()?,
             name,
             task,
+            feature,
             platform,
         )
         .await

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -138,7 +138,7 @@ impl<I: Interface> WorkspaceContext<I> {
         &self,
         platform: Vec<PixiPlatform>,
         no_install: bool,
-        feature: Option<String>,
+        feature: FeatureName,
     ) -> miette::Result<()> {
         crate::workspace::workspace::platform::add(
             &self.interface,
@@ -154,7 +154,7 @@ impl<I: Interface> WorkspaceContext<I> {
         &self,
         platform: Vec<PixiPlatform>,
         no_install: bool,
-        feature: Option<String>,
+        feature: FeatureName,
     ) -> miette::Result<()> {
         crate::workspace::workspace::platform::remove(
             &self.interface,
@@ -203,7 +203,7 @@ impl<I: Interface> WorkspaceContext<I> {
         candidate: PixiPlatform,
         explicit_name: bool,
         no_install: bool,
-        feature: Option<String>,
+        feature: FeatureName,
     ) -> miette::Result<()> {
         crate::workspace::workspace::platform::add_auto_detected(
             &self.interface,

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -36,7 +36,7 @@ pub async fn add_conda_dep(
     let pixi_platforms = resolve_platforms(&workspace_platforms, &dep_options.platforms)?;
     workspace
         .manifest()
-        .add_platforms(pixi_platforms.iter(), &FeatureName::DEFAULT)?;
+        .add_platforms(pixi_platforms.iter(), &FeatureName::Default)?;
 
     let mut match_specs = IndexMap::default();
     let mut source_specs = IndexMap::default();
@@ -137,7 +137,7 @@ pub async fn add_pypi_dep(
     let pixi_platforms = resolve_platforms(&workspace_platforms, &options.platforms)?;
     workspace
         .manifest()
-        .add_platforms(pixi_platforms.iter(), &FeatureName::DEFAULT)?;
+        .add_platforms(pixi_platforms.iter(), &FeatureName::Default)?;
 
     // TODO: add dry_run logic to add
     let dry_run = false;

--- a/crates/pixi_api/src/workspace/remove/mod.rs
+++ b/crates/pixi_api/src/workspace/remove/mod.rs
@@ -167,7 +167,7 @@ mod tests {
 
     fn options() -> DependencyOptions {
         DependencyOptions {
-            feature: FeatureName::DEFAULT,
+            feature: FeatureName::Default,
             platforms: vec![],
             no_install: true,
             lock_file_usage: LockFileUsage::Frozen,

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -53,7 +53,7 @@ fn declare_platform_and_add_task(
     if let Some(p) = &pixi_platform {
         workspace
             .manifest()
-            .add_platforms(std::slice::from_ref(p).iter(), &FeatureName::DEFAULT)?;
+            .add_platforms(std::slice::from_ref(p).iter(), &FeatureName::Default)?;
     }
     workspace
         .manifest()
@@ -151,7 +151,7 @@ pub async fn alias_task<I: Interface>(
         &mut workspace,
         &name,
         &task,
-        &FeatureName::DEFAULT,
+        &FeatureName::Default,
         platform.as_ref(),
     )?;
     workspace.save().await.into_diagnostic()?;

--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -145,15 +145,10 @@ pub async fn alias_task<I: Interface>(
     mut workspace: WorkspaceMut,
     name: TaskName,
     task: Task,
+    feature: FeatureName,
     platform: Option<PixiPlatformName>,
 ) -> miette::Result<()> {
-    declare_platform_and_add_task(
-        &mut workspace,
-        &name,
-        &task,
-        &FeatureName::Default,
-        platform.as_ref(),
-    )?;
+    declare_platform_and_add_task(&mut workspace, &name, &task, &feature, platform.as_ref())?;
     workspace.save().await.into_diagnostic()?;
 
     interface
@@ -210,9 +205,9 @@ pub async fn remove_tasks<I: Interface>(
         {
             interface
                 .error(&format!(
-                    "Task `{}` does not exist for the `{}` feature",
+                    "Task `{}` does not exist for {}",
                     name.fancy_display().bold(),
-                    console::style(&feature).bold(),
+                    console::style(feature.user_facing()).bold(),
                 ))
                 .await;
             continue;

--- a/crates/pixi_api/src/workspace/workspace/channel.rs
+++ b/crates/pixi_api/src/workspace/workspace/channel.rs
@@ -17,7 +17,7 @@ use crate::Interface;
 #[derive(Deserialize, Serialize, Debug, Default)]
 pub struct ChannelOptions {
     pub channels: Vec<NamedChannelOrUrl>,
-    pub feature: Option<String>,
+    pub feature: FeatureName,
     pub no_install: bool,
     pub lock_file_usage: LockFileUsage,
 }
@@ -45,7 +45,7 @@ pub async fn add<I: Interface>(
     // Add the channels to the manifest
     workspace.manifest().add_channels(
         prioritized_channels(&options.channels, priority),
-        &feature_name(&options.feature),
+        &options.feature,
         prepend,
     )?;
 
@@ -89,7 +89,7 @@ pub async fn remove<I: Interface>(
     // Remove the channels from the manifest
     workspace.manifest().remove_channels(
         prioritized_channels(&options.channels, priority),
-        &feature_name(&options.feature),
+        &options.feature,
     )?;
 
     // Try to update the lock file without the removed channels
@@ -130,7 +130,7 @@ pub async fn set<I: Interface>(
     // Set the channels in the manifest (this replaces all existing channels)
     workspace.manifest().set_channels(
         prioritized_channels(&options.channels, None),
-        &feature_name(&options.feature),
+        &options.feature,
     )?;
 
     // Update the lock file with the new channel configuration
@@ -162,12 +162,6 @@ pub async fn set<I: Interface>(
     .await?;
 
     Ok(())
-}
-
-fn feature_name(feature: &Option<String>) -> FeatureName {
-    feature
-        .clone()
-        .map_or_else(FeatureName::default, FeatureName::from)
 }
 
 fn prioritized_channels(

--- a/crates/pixi_api/src/workspace/workspace/environment.rs
+++ b/crates/pixi_api/src/workspace/workspace/environment.rs
@@ -3,7 +3,7 @@ use pixi_core::{
     Workspace,
     workspace::{Environment, WorkspaceMut},
 };
-use pixi_manifest::EnvironmentName;
+use pixi_manifest::{EnvironmentName, NewEnvironment};
 
 use crate::Interface;
 
@@ -35,10 +35,10 @@ pub async fn add<I: Interface>(
 
     // Add the platforms to the lock file
     workspace.manifest().add_environment(
-        name.as_str().to_string(),
-        features,
-        solve_group,
-        no_default_feature,
+        NewEnvironment::new(name.as_str())
+            .with_features(features)
+            .with_solve_group(solve_group)
+            .with_no_default_feature(no_default_feature),
     )?;
 
     // Save the workspace to disk

--- a/crates/pixi_api/src/workspace/workspace/feature.rs
+++ b/crates/pixi_api/src/workspace/workspace/feature.rs
@@ -17,7 +17,7 @@ pub async fn list_features(workspace: &Workspace) -> IndexMap<FeatureName, Featu
     workspace
         .workspace
         .value
-        .all_features()
+        .user_features()
         .map(|(name, feature)| (name.clone(), feature.clone()))
         .collect()
 }

--- a/crates/pixi_api/src/workspace/workspace/feature.rs
+++ b/crates/pixi_api/src/workspace/workspace/feature.rs
@@ -14,7 +14,12 @@ use rattler_conda_types::PackageName;
 use crate::{Interface, workspace::workspace::environment};
 
 pub async fn list_features(workspace: &Workspace) -> IndexMap<FeatureName, Feature> {
-    workspace.workspace.value.features.clone()
+    workspace
+        .workspace
+        .value
+        .all_features()
+        .map(|(name, feature)| (name.clone(), feature.clone()))
+        .collect()
 }
 
 pub async fn list_feature_channels(

--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -125,10 +125,8 @@ pub async fn add_auto_detected<I: Interface>(
     candidate: PixiPlatform,
     explicit_name: bool,
     no_install: bool,
-    feature: Option<String>,
+    feature_name: FeatureName,
 ) -> miette::Result<()> {
-    let feature_name = feature.map_or_else(FeatureName::default, FeatureName::from);
-
     // Content-based dedup: an existing platform with the same definition *is*
     // this machine, regardless of name.
     let existing = workspace
@@ -236,10 +234,8 @@ pub async fn add<I: Interface>(
     mut workspace: WorkspaceMut,
     platforms: Vec<PixiPlatform>,
     no_install: bool,
-    feature: Option<String>,
+    feature_name: FeatureName,
 ) -> miette::Result<()> {
-    let feature_name = feature.map_or_else(FeatureName::default, FeatureName::from);
-
     // Add the platforms to the manifest; `added` holds only those that caused
     // an actual change so already-declared platforms are reported as no-ops.
     let added = workspace
@@ -268,18 +264,20 @@ pub async fn add<I: Interface>(
         let message = if added.contains(platform) {
             format!(
                 "Added {}",
-                feature_name.non_default().map_or_else(
-                    || platform.to_string(),
-                    |name| format!("{platform} to the feature {name}")
-                )
+                if feature_name.is_default() {
+                    platform.to_string()
+                } else {
+                    format!("{platform} to {}", feature_name.user_facing())
+                }
             )
         } else {
             format!(
                 "Platform {} is already present; nothing to do",
-                feature_name.non_default().map_or_else(
-                    || platform.to_string(),
-                    |name| format!("{platform} in the feature {name}")
-                )
+                if feature_name.is_default() {
+                    platform.to_string()
+                } else {
+                    format!("{platform} in {}", feature_name.user_facing())
+                }
             )
         };
         interface.success(&message).await;
@@ -293,10 +291,8 @@ pub async fn remove<I: Interface>(
     mut workspace: WorkspaceMut,
     platforms: Vec<PixiPlatform>,
     no_install: bool,
-    feature: Option<String>,
+    feature_name: FeatureName,
 ) -> miette::Result<()> {
-    let feature_name = feature.map_or_else(FeatureName::default, FeatureName::from);
-
     // Remove the platform(s) from the manifest
     workspace
         .manifest()
@@ -323,10 +319,11 @@ pub async fn remove<I: Interface>(
         interface
             .success(&format!(
                 "Removed {}",
-                feature_name.non_default().map_or_else(
-                    || platform.to_string(),
-                    |name| format!("{platform} from the feature {name}")
-                )
+                if feature_name.is_default() {
+                    platform.to_string()
+                } else {
+                    format!("{platform} from {}", feature_name.user_facing())
+                }
             ))
             .await;
     }

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -116,7 +116,7 @@ impl TryFrom<&Args> for DependencyOptions {
 
     fn try_from(args: &Args) -> miette::Result<Self> {
         Ok(DependencyOptions {
-            feature: args.dependency_config.feature.clone(),
+            feature: args.dependency_config.feature_name(),
             platforms: args.dependency_config.platforms.clone(),
             no_install: args.no_install_config.no_install,
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::has_specs::HasSpecs;
 use clap::Parser;
 use indexmap::IndexMap;
@@ -301,7 +303,7 @@ pub struct DependencyConfig {
     pub platforms: Vec<PixiPlatformName>,
 
     /// The feature for which the dependency should be modified.
-    #[clap(long, short, default_value_t)]
+    #[clap(long, short, default_value_t, value_parser = FeatureName::from_str)]
     pub feature: FeatureName,
 
     /// The git url to use when adding a git dependency

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -13,12 +13,13 @@ use pixi_core::Workspace;
 use pixi_core::environment::LockFileUsage;
 use pixi_core::workspace::DiscoveryStart;
 use pixi_manifest::FeaturesExt;
-use pixi_manifest::{FeatureName, PixiPlatformName, SpecType};
+use pixi_manifest::{EnvironmentName, FeatureName, PixiPlatformName, SpecType};
 use pixi_spec::GitReference;
 use rattler_conda_types::ChannelConfig;
 use rattler_conda_types::{Channel, NamedChannelOrUrl};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::str::FromStr;
 use url::Url;
 
 use pixi_git::GIT_URL_QUERY_REV_TYPE;
@@ -304,6 +305,12 @@ pub struct DependencyConfig {
     #[clap(long, short, default_value_t)]
     pub feature: FeatureName,
 
+    /// The environment for which the dependency should be modified. The
+    /// dependency is written to the content defined inline on the
+    /// environment, creating the environment if it does not exist.
+    #[clap(long, short, value_name = "ENVIRONMENT", value_parser = parse_inline_environment, conflicts_with_all = ["feature", "host", "build"])]
+    pub environment: Option<EnvironmentName>,
+
     /// The git url to use when adding a git dependency
     #[clap(long, short, help_heading = consts::CLAP_GIT_OPTIONS)]
     pub git: Option<Url>,
@@ -317,7 +324,30 @@ pub struct DependencyConfig {
     pub subdir: Option<String>,
 }
 
+/// Parses the value of an `--environment` flag that writes inline content to
+/// the environment. The default environment is rejected because its content
+/// lives in the top-level tables.
+pub(crate) fn parse_inline_environment(value: &str) -> Result<EnvironmentName, String> {
+    let name = EnvironmentName::from_str(value).map_err(|error| error.to_string())?;
+    if name.is_default() {
+        return Err(String::from(
+            "the 'default' environment cannot define its content inline; add the content to the top-level tables (for example '[dependencies]' or '[tasks]'), they already belong to the default environment",
+        ));
+    }
+    Ok(name)
+}
+
 impl DependencyConfig {
+    /// The feature the edit applies to: the feature synthesized for the
+    /// environment when `--environment` is given, otherwise the `--feature`
+    /// value.
+    pub(crate) fn feature_name(&self) -> FeatureName {
+        match &self.environment {
+            Some(environment) => FeatureName::environment(environment),
+            None => self.feature.clone(),
+        }
+    }
+
     pub(crate) fn dependency_type(&self) -> DependencyType {
         if self.pypi {
             DependencyType::PypiDependency
@@ -367,14 +397,17 @@ impl DependencyConfig {
                 console::style(self.platforms.iter().join(", ")).bold()
             )
         }
-        // Print something if we've modified for features
-        if let Some(feature) = self.feature.non_default() {
-            {
-                eprintln!(
-                    "{operation} these only for feature: {}",
-                    consts::FEATURE_STYLE.apply_to(feature)
-                )
-            }
+        // Print something if we've modified for an environment or a feature
+        if let Some(environment) = &self.environment {
+            eprintln!(
+                "{operation} these only for environment: {}",
+                consts::ENVIRONMENT_STYLE.apply_to(environment)
+            )
+        } else if let Some(feature) = self.feature.non_default() {
+            eprintln!(
+                "{operation} these only for feature: {}",
+                consts::FEATURE_STYLE.apply_to(feature)
+            )
         }
     }
 

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -324,6 +324,19 @@ pub struct DependencyConfig {
     pub subdir: Option<String>,
 }
 
+/// Resolves the `--feature`/`--environment` flag pair to the feature a
+/// manifest edit applies to: the feature synthesized for the environment when
+/// `--environment` is given, otherwise the `--feature` value.
+pub(crate) fn feature_from_flags(
+    environment: Option<&EnvironmentName>,
+    feature: Option<&FeatureName>,
+) -> FeatureName {
+    match environment {
+        Some(environment) => FeatureName::environment(environment),
+        None => feature.cloned().unwrap_or_default(),
+    }
+}
+
 /// Parses the value of an `--environment` flag that writes inline content to
 /// the environment. The default environment is rejected because its content
 /// lives in the top-level tables.

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::has_specs::HasSpecs;
 use clap::Parser;
 use indexmap::IndexMap;
@@ -303,7 +301,7 @@ pub struct DependencyConfig {
     pub platforms: Vec<PixiPlatformName>,
 
     /// The feature for which the dependency should be modified.
-    #[clap(long, short, default_value_t, value_parser = FeatureName::from_str)]
+    #[clap(long, short, default_value_t)]
     pub feature: FeatureName,
 
     /// The git url to use when adding a git dependency

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -19,7 +19,6 @@ use rattler_conda_types::ChannelConfig;
 use rattler_conda_types::{Channel, NamedChannelOrUrl};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::str::FromStr;
 use url::Url;
 
 use pixi_git::GIT_URL_QUERY_REV_TYPE;
@@ -308,7 +307,7 @@ pub struct DependencyConfig {
     /// The environment for which the dependency should be modified. The
     /// dependency is written to the content defined inline on the
     /// environment, creating the environment if it does not exist.
-    #[clap(long, short, value_name = "ENVIRONMENT", value_parser = parse_inline_environment, conflicts_with_all = ["feature", "host", "build"])]
+    #[clap(long, short, value_name = "ENVIRONMENT", conflicts_with_all = ["feature", "host", "build"])]
     pub environment: Option<EnvironmentName>,
 
     /// The git url to use when adding a git dependency
@@ -335,19 +334,6 @@ pub(crate) fn feature_from_flags(
         Some(environment) => FeatureName::environment(environment),
         None => feature.cloned().unwrap_or_default(),
     }
-}
-
-/// Parses the value of an `--environment` flag that writes inline content to
-/// the environment. The default environment is rejected because its content
-/// lives in the top-level tables.
-pub(crate) fn parse_inline_environment(value: &str) -> Result<EnvironmentName, String> {
-    let name = EnvironmentName::from_str(value).map_err(|error| error.to_string())?;
-    if name.is_default() {
-        return Err(String::from(
-            "the 'default' environment cannot define its content inline; add the content to the top-level tables (for example '[dependencies]' or '[tasks]'), they already belong to the default environment",
-        ));
-    }
-    Ok(name)
 }
 
 impl DependencyConfig {

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -56,8 +56,8 @@ pub struct Args {
     pub environment: Option<String>,
 
     /// A name for the created feature
-    #[clap(long, short)]
-    pub feature: Option<String>,
+    #[clap(long, short, value_parser = FeatureName::from_str)]
+    pub feature: Option<FeatureName>,
 
     #[clap(flatten)]
     pub config: ConfigCli,
@@ -87,19 +87,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 struct MissingEnvironmentName;
 
 fn get_feature_and_environment(
-    feature_arg: &Option<String>,
+    feature_arg: &Option<FeatureName>,
     environment_arg: &Option<String>,
     fallback: impl Fn() -> Result<String, MissingEnvironmentName>,
 ) -> Result<(FeatureName, EnvironmentName), miette::Report> {
     let feature_string = match (feature_arg, environment_arg) {
-        (Some(f), _) => f.clone(),
+        (Some(f), _) => f.as_str().to_string(),
         (_, Some(e)) => e.clone(),
         _ => fallback()?,
     };
 
     let environment_string = match (environment_arg, feature_arg) {
         (Some(e), _) => e.clone(),
-        (_, Some(f)) => f.clone(),
+        (_, Some(f)) => f.as_str().to_string(),
         _ => fallback()?,
     };
 

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -239,24 +239,15 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
         Some(env) => {
             // otherwise, add feature to environment if it is not already there
             if !env.features().any(|f| f.name == feature_name) {
-                let env_name = env.name().as_str().to_string();
-                let features = {
-                    let features = env
-                        .features()
-                        .map(|f| f.name.as_str().to_string())
-                        .chain(std::iter::once(feature_name.to_string()))
-                        .collect();
-                    Some(features)
-                };
-                let solve_group = env.solve_group().map(|g| g.name().to_string());
-                let no_default_feature = env.no_default_feature();
+                let features = env
+                    .features()
+                    .map(|f| f.name.clone())
+                    .chain(std::iter::once(feature_name.clone()))
+                    .collect();
 
-                workspace.manifest().add_environment(
-                    env_name,
-                    features,
-                    solve_group,
-                    no_default_feature,
-                )?;
+                workspace
+                    .manifest()
+                    .update_environment_features(&environment_name, features)?;
             }
         }
     }

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -56,7 +56,7 @@ pub struct Args {
     pub environment: Option<String>,
 
     /// A name for the created feature
-    #[clap(long, short, value_parser = FeatureName::from_str)]
+    #[clap(long, short)]
     pub feature: Option<FeatureName>,
 
     #[clap(flatten)]

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -7,7 +7,8 @@ use pixi_api::workspace::platforms::resolve_platforms;
 use pixi_config::ConfigCli;
 use pixi_core::{WorkspaceLocator, environment::sanity_check_workspace};
 use pixi_manifest::{
-    EnvironmentName, FeatureName, HasFeaturesIter, PixiPlatformName, PrioritizedChannel,
+    EnvironmentName, FeatureName, HasFeaturesIter, NewEnvironment, PixiPlatformName,
+    PrioritizedChannel,
 };
 use pixi_utils::conda_environment_file::CondaEnvFile;
 use pixi_uv_conversions::convert_uv_requirements_to_pep508;
@@ -194,9 +195,9 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
             .environment(&environment_name)
             .is_none()
     {
-        workspace
-            .manifest()
-            .add_environment(environment_name.to_string(), None, None, true)?;
+        workspace.manifest().add_environment(
+            NewEnvironment::new(environment_name.as_str()).with_no_default_feature(true),
+        )?;
     }
 
     // Resolve the platform names. Import doesn't have a target workspace
@@ -249,10 +250,9 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
             None => {
                 // add environment if it does not already exist
                 workspace.manifest().add_environment(
-                    environment_name.to_string(),
-                    Some(vec![feature_name.to_string()]),
-                    None,
-                    true,
+                    NewEnvironment::new(environment_name.as_str())
+                        .with_features(vec![feature_name.to_string()])
+                        .with_no_default_feature(true),
                 )?;
             }
             Some(env) => {

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -51,11 +51,13 @@ pub struct Args {
     #[arg(long = "platform", short, value_name = "PLATFORM")]
     pub platforms: Vec<PixiPlatformName>,
 
-    /// A name for the created environment
+    /// A name for the created environment. Without `--feature` the imported
+    /// content is written inline on the environment.
     #[clap(long, short)]
     pub environment: Option<String>,
 
-    /// A name for the created feature
+    /// A name for the created feature. The feature is added to the
+    /// environment of the same name unless `--environment` is given.
     #[clap(long, short)]
     pub feature: Option<FeatureName>,
 
@@ -91,22 +93,21 @@ fn get_feature_and_environment(
     environment_arg: &Option<String>,
     fallback: impl Fn() -> Result<String, MissingEnvironmentName>,
 ) -> Result<(FeatureName, EnvironmentName), miette::Report> {
-    let feature_string = match (feature_arg, environment_arg) {
-        (Some(f), _) => f.as_str().to_string(),
-        (_, Some(e)) => e.clone(),
-        _ => fallback()?,
-    };
-
     let environment_string = match (environment_arg, feature_arg) {
         (Some(e), _) => e.clone(),
         (_, Some(f)) => f.as_str().to_string(),
         _ => fallback()?,
     };
+    let environment_name = EnvironmentName::from_str(&environment_string)?;
 
-    Ok((
-        FeatureName::from(feature_string),
-        EnvironmentName::from_str(&environment_string)?,
-    ))
+    // Without an explicit feature the imported content is written inline on
+    // the environment; a named feature keeps the feature + environment pair.
+    let feature_name = match feature_arg {
+        Some(feature) => feature.clone(),
+        None => FeatureName::environment(&environment_name),
+    };
+
+    Ok((feature_name, environment_name))
 }
 
 fn convert_uv_requirements_txt_to_pep508(
@@ -183,6 +184,21 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
         }
     };
 
+    // An imported file describes a complete environment, so an environment
+    // created for inline content must not include the workspace's default
+    // feature. It is created up front because the manifest edits below would
+    // otherwise create it with the default feature included.
+    if feature_name.is_environment()
+        && workspace
+            .workspace()
+            .environment(&environment_name)
+            .is_none()
+    {
+        workspace
+            .manifest()
+            .add_environment(environment_name.to_string(), None, None, true)?;
+    }
+
     // Resolve the platform names. Import doesn't have a target workspace
     // yet (or at least, doesn't read its platforms here), so each name has
     // to parse as a conda subdir. The user can rename the resulting
@@ -226,28 +242,32 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
     let targets = workspace.target_selectors_for_platforms(&platform_names);
     workspace.add_specs(conda_deps, pypi_deps, &targets, &feature_name)?;
 
-    match workspace.workspace().environment(&environment_name) {
-        None => {
-            // add environment if it does not already exist
-            workspace.manifest().add_environment(
-                environment_name.to_string(),
-                Some(vec![feature_name.to_string()]),
-                None,
-                true,
-            )?;
-        }
-        Some(env) => {
-            // otherwise, add feature to environment if it is not already there
-            if !env.features().any(|f| f.name == feature_name) {
-                let features = env
-                    .features()
-                    .map(|f| f.name.clone())
-                    .chain(std::iter::once(feature_name.clone()))
-                    .collect();
+    // Inline content is wired to its environment by the manifest edits above;
+    // only a named feature needs to be registered on the environment.
+    if !feature_name.is_environment() {
+        match workspace.workspace().environment(&environment_name) {
+            None => {
+                // add environment if it does not already exist
+                workspace.manifest().add_environment(
+                    environment_name.to_string(),
+                    Some(vec![feature_name.to_string()]),
+                    None,
+                    true,
+                )?;
+            }
+            Some(env) => {
+                // otherwise, add feature to environment if it is not already there
+                if !env.features().any(|f| f.name == feature_name) {
+                    let features = env
+                        .features()
+                        .map(|f| f.name.clone())
+                        .chain(std::iter::once(feature_name.clone()))
+                        .collect();
 
-                workspace
-                    .manifest()
-                    .update_environment_features(&environment_name, features)?;
+                    workspace
+                        .manifest()
+                        .update_environment_features(&environment_name, features)?;
+                }
             }
         }
     }

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -144,7 +144,7 @@ impl Display for EnvironmentInfo {
             bold.apply_to("Features"),
             self.features
                 .iter()
-                .map(|feature| feature.fancy_display())
+                .map(|feature| consts::FEATURE_STYLE.apply_to(feature.to_string()))
                 .format(", ")
         )?;
         if let Some(solve_group) = &self.solve_group {

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -144,7 +144,7 @@ impl Display for EnvironmentInfo {
             bold.apply_to("Features"),
             self.features
                 .iter()
-                .map(|feature| consts::FEATURE_STYLE.apply_to(feature.to_string()))
+                .map(|feature| feature.fancy_display())
                 .format(", ")
         )?;
         if let Some(solve_group) = &self.solve_group {
@@ -505,7 +505,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
                     EnvironmentInfo {
                         name: env.name().clone(),
-                        features: env.features().map(|feature| feature.name.clone()).collect(),
+                        features: env
+                            .features()
+                            .map(|feature| feature.name.clone())
+                            .filter(|name| !name.is_environment())
+                            .collect(),
                         solve_group: env
                             .solve_group()
                             .map(|solve_group| solve_group.name().to_string()),

--- a/crates/pixi_cli/src/remove/error.rs
+++ b/crates/pixi_cli/src/remove/error.rs
@@ -322,7 +322,7 @@ pandas = "*"
                 &manifest,
                 "polars",
                 DependencyType::CondaDependency(SpecType::Run),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @r"
@@ -341,7 +341,7 @@ pandas = "*"
                 &manifest,
                 "ruff",
                 DependencyType::PypiDependency,
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @r"
@@ -360,7 +360,7 @@ pandas = "*"
                 &manifest,
                 "openssl",
                 DependencyType::CondaDependency(SpecType::Run),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @r"
@@ -379,7 +379,7 @@ pandas = "*"
                 &manifest,
                 "cmake",
                 DependencyType::CondaDependency(SpecType::Run),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @r"
@@ -399,7 +399,7 @@ pandas = "*"
                 &manifest,
                 "numpy",
                 DependencyType::CondaDependency(SpecType::Run),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @r"
@@ -419,7 +419,7 @@ pandas = "*"
                 &manifest,
                 "polrs",
                 DependencyType::PypiDependency,
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @r"
@@ -438,7 +438,7 @@ pandas = "*"
                 &manifest,
                 "fizzbuzz",
                 DependencyType::CondaDependency(SpecType::Run),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 &[],
             ),
             @"  × dependency `fizzbuzz` was not found in dependencies"

--- a/crates/pixi_cli/src/remove/error.rs
+++ b/crates/pixi_cli/src/remove/error.rs
@@ -171,7 +171,7 @@ fn walk_dependencies<'a>(
     platforms: &[PixiPlatformName],
 ) -> impl Iterator<Item = DepEntry<'a>> + 'a {
     let platform_opts = to_platform_options(manifest, platforms);
-    manifest.features.iter().flat_map(move |(feat_name, feat)| {
+    manifest.all_features().flat_map(move |(feat_name, feat)| {
         platform_opts
             .clone()
             .into_iter()

--- a/crates/pixi_cli/src/remove/error.rs
+++ b/crates/pixi_cli/src/remove/error.rs
@@ -498,8 +498,8 @@ pandas = "*"
     #[test]
     fn missing_dep_lives_inline_on_environment() {
         // `pixi remove git` when git is only defined inline on an
-        // environment. `--feature env:dev` is rejected by the CLI, so the
-        // help must point at the manifest table instead.
+        // environment. Inline content is not addressable as a feature, so
+        // the help must point at the manifest table instead.
         let manifest = parse(
             r#"
 [workspace]

--- a/crates/pixi_cli/src/remove/error.rs
+++ b/crates/pixi_cli/src/remove/error.rs
@@ -48,7 +48,9 @@ impl Display for DependencyRemovalError {
             self.name,
             Slot::from(self.dependency_type).table_name()
         )?;
-        if !self.feature.is_default() {
+        if let Some(environment) = self.feature.environment_name() {
+            write!(f, " of environment `{environment}`")?;
+        } else if !self.feature.is_default() {
             write!(f, " of feature `{}`", self.feature)?;
         }
         Ok(())
@@ -222,14 +224,21 @@ fn is_exact_match(
 }
 
 fn format_exact_location(name: &str, slot: Slot, feature: &FeatureName) -> String {
-    // Content defined inline on an environment cannot be addressed via
-    // `--feature`, so point at the manifest table instead.
+    // Content defined inline on an environment is addressed via
+    // `--environment` rather than `--feature`.
     if let Some(environment_name) = feature.environment_name() {
+        let mut parts = vec!["pixi".to_string(), "remove".to_string()];
+        if let Some(flag) = slot.cli_flag() {
+            parts.push(flag.to_string());
+        }
+        parts.push("--environment".to_string());
+        parts.push(environment_name.to_string());
+        parts.push(name.to_string());
         return format!(
-            "`{name}` is defined inline on environment `{}`; remove it from the '[environments.{}.{}]' table in the manifest",
-            consts::ENVIRONMENT_STYLE.apply_to(environment_name),
-            environment_name,
+            "`{name}` is a {} entry of environment `{}`; try `{}`",
             slot.table_name(),
+            consts::ENVIRONMENT_STYLE.apply_to(environment_name),
+            parts.join(" "),
         );
     }
     let feature_part = if feature.is_default() {
@@ -498,8 +507,7 @@ pandas = "*"
     #[test]
     fn missing_dep_lives_inline_on_environment() {
         // `pixi remove git` when git is only defined inline on an
-        // environment. Inline content is not addressable as a feature, so
-        // the help must point at the manifest table instead.
+        // environment. The help points at the `--environment` flag.
         let manifest = parse(
             r#"
 [workspace]
@@ -524,7 +532,7 @@ git = "*"
             ),
             @r"
           × dependency `git` was not found in dependencies
-          help: `git` is defined inline on environment `dev`; remove it from the '[environments.dev.dependencies]' table in the manifest
+          help: `git` is a dependencies entry of environment `dev`; try `pixi remove --environment dev git`
         "
         );
     }

--- a/crates/pixi_cli/src/remove/error.rs
+++ b/crates/pixi_cli/src/remove/error.rs
@@ -222,6 +222,16 @@ fn is_exact_match(
 }
 
 fn format_exact_location(name: &str, slot: Slot, feature: &FeatureName) -> String {
+    // Content defined inline on an environment cannot be addressed via
+    // `--feature`, so point at the manifest table instead.
+    if let Some(environment_name) = feature.environment_name() {
+        return format!(
+            "`{name}` is defined inline on environment `{}`; remove it from the '[environments.{}.{}]' table in the manifest",
+            consts::ENVIRONMENT_STYLE.apply_to(environment_name),
+            environment_name,
+            slot.table_name(),
+        );
+    }
     let feature_part = if feature.is_default() {
         "the default feature".to_string()
     } else {
@@ -481,6 +491,40 @@ pandas = "*"
             @r"
           × dependency `pandas` was not found in dependencies of feature `dev`
           help: `pandas` is a pypi-dependencies entry in feature `dev`; try `pixi remove --pypi --feature dev pandas`
+        "
+        );
+    }
+
+    #[test]
+    fn missing_dep_lives_inline_on_environment() {
+        // `pixi remove git` when git is only defined inline on an
+        // environment. `--feature env:dev` is rejected by the CLI, so the
+        // help must point at the manifest table instead.
+        let manifest = parse(
+            r#"
+[workspace]
+name = "test"
+channels = []
+platforms = ["linux-64"]
+
+[dependencies]
+ruff = "*"
+
+[environments.dev.dependencies]
+git = "*"
+"#,
+        );
+        insta::assert_snapshot!(
+            render(
+                &manifest,
+                "git",
+                DependencyType::CondaDependency(SpecType::Run),
+                &FeatureName::Default,
+                &[],
+            ),
+            @r"
+          × dependency `git` was not found in dependencies
+          help: `git` is defined inline on environment `dev`; remove it from the '[environments.dev.dependencies]' table in the manifest
         "
         );
     }

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -54,7 +54,7 @@ impl TryFrom<&Args> for DependencyOptions {
 
     fn try_from(args: &Args) -> miette::Result<Self> {
         Ok(DependencyOptions {
-            feature: args.dependency_config.feature.clone(),
+            feature: args.dependency_config.feature_name(),
             platforms: args.dependency_config.platforms.clone(),
             no_install: args.no_install_config.no_install,
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
@@ -72,7 +72,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
 
     let dependency_type = args.dependency_config.dependency_type();
-    let feature = args.dependency_config.feature.clone();
+    let feature = args.dependency_config.feature_name();
     let platforms = args.dependency_config.platforms.clone();
 
     let result = match dependency_type {

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -62,7 +62,7 @@ pub struct RemoveArgs {
 
     /// The environment for which the task should be removed. The task is
     /// removed from the tasks defined inline on the environment.
-    #[arg(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    #[arg(long, short, conflicts_with = "feature")]
     pub environment: Option<EnvironmentName>,
 }
 
@@ -92,7 +92,7 @@ pub struct AddArgs {
     /// The environment for which the task should be added. The task is
     /// written to the tasks defined inline on the environment, creating the
     /// environment if it does not exist.
-    #[arg(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    #[arg(long, short, conflicts_with = "feature")]
     pub environment: Option<EnvironmentName>,
 
     /// The working directory relative to the root of the workspace.
@@ -149,7 +149,7 @@ pub struct AliasArgs {
     /// The environment for which the alias should be added. The alias is
     /// written to the tasks defined inline on the environment, creating the
     /// environment if it does not exist.
-    #[arg(long, short, value_parser = crate::cli_config::parse_inline_environment)]
+    #[arg(long, short)]
     pub environment: Option<EnvironmentName>,
 
     /// The description of the alias task

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -57,8 +57,8 @@ pub struct RemoveArgs {
     pub platform: Option<PixiPlatformName>,
 
     /// The feature for which the task should be removed.
-    #[arg(long, short)]
-    pub feature: Option<String>,
+    #[arg(long, short, value_parser = FeatureName::from_str)]
+    pub feature: Option<FeatureName>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -81,8 +81,8 @@ pub struct AddArgs {
     pub platform: Option<PixiPlatformName>,
 
     /// The feature for which the task should be added.
-    #[arg(long, short)]
-    pub feature: Option<String>,
+    #[arg(long, short, value_parser = FeatureName::from_str)]
+    pub feature: Option<FeatureName>,
 
     /// The working directory relative to the root of the workspace.
     #[arg(long)]
@@ -418,10 +418,7 @@ async fn add_task(
     workspace_ctx: WorkspaceContext<CliInterface>,
     args: AddArgs,
 ) -> miette::Result<()> {
-    let feature = args
-        .clone()
-        .feature
-        .map_or_else(FeatureName::default, FeatureName::from);
+    let feature = args.feature.clone().unwrap_or_default();
 
     workspace_ctx
         .add_task(
@@ -451,12 +448,7 @@ async fn remove_tasks(
     args: RemoveArgs,
 ) -> miette::Result<()> {
     workspace_ctx
-        .remove_task(
-            args.names,
-            args.platform,
-            args.feature
-                .map_or_else(FeatureName::default, FeatureName::from),
-        )
+        .remove_task(args.names, args.platform, args.feature.unwrap_or_default())
         .await
 }
 

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -59,6 +59,11 @@ pub struct RemoveArgs {
     /// The feature for which the task should be removed.
     #[arg(long, short)]
     pub feature: Option<FeatureName>,
+
+    /// The environment for which the task should be removed. The task is
+    /// removed from the tasks defined inline on the environment.
+    #[arg(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    pub environment: Option<EnvironmentName>,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -83,6 +88,12 @@ pub struct AddArgs {
     /// The feature for which the task should be added.
     #[arg(long, short)]
     pub feature: Option<FeatureName>,
+
+    /// The environment for which the task should be added. The task is
+    /// written to the tasks defined inline on the environment, creating the
+    /// environment if it does not exist.
+    #[arg(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    pub environment: Option<EnvironmentName>,
 
     /// The working directory relative to the root of the workspace.
     #[arg(long)]
@@ -134,6 +145,12 @@ pub struct AliasArgs {
     /// The platform for which the alias should be added
     #[arg(long, short)]
     pub platform: Option<PixiPlatformName>,
+
+    /// The environment for which the alias should be added. The alias is
+    /// written to the tasks defined inline on the environment, creating the
+    /// environment if it does not exist.
+    #[arg(long, short, value_parser = crate::cli_config::parse_inline_environment)]
+    pub environment: Option<EnvironmentName>,
 
     /// The description of the alias task
     #[arg(long)]
@@ -418,7 +435,8 @@ async fn add_task(
     workspace_ctx: WorkspaceContext<CliInterface>,
     args: AddArgs,
 ) -> miette::Result<()> {
-    let feature = args.feature.clone().unwrap_or_default();
+    let feature =
+        crate::cli_config::feature_from_flags(args.environment.as_ref(), args.feature.as_ref());
 
     workspace_ctx
         .add_task(
@@ -436,8 +454,15 @@ async fn alias_task(
     workspace_ctx: WorkspaceContext<CliInterface>,
     args: AliasArgs,
 ) -> miette::Result<()> {
+    let feature = crate::cli_config::feature_from_flags(args.environment.as_ref(), None);
+
     workspace_ctx
-        .alias_task(args.clone().alias, args.clone().into(), args.platform)
+        .alias_task(
+            args.clone().alias,
+            args.clone().into(),
+            feature,
+            args.platform,
+        )
         .await?;
 
     Ok(())
@@ -447,8 +472,11 @@ async fn remove_tasks(
     workspace_ctx: WorkspaceContext<CliInterface>,
     args: RemoveArgs,
 ) -> miette::Result<()> {
+    let feature =
+        crate::cli_config::feature_from_flags(args.environment.as_ref(), args.feature.as_ref());
+
     workspace_ctx
-        .remove_task(args.names, args.platform, args.feature.unwrap_or_default())
+        .remove_task(args.names, args.platform, feature)
         .await
 }
 

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -57,7 +57,7 @@ pub struct RemoveArgs {
     pub platform: Option<PixiPlatformName>,
 
     /// The feature for which the task should be removed.
-    #[arg(long, short, value_parser = FeatureName::from_str)]
+    #[arg(long, short)]
     pub feature: Option<FeatureName>,
 }
 
@@ -81,7 +81,7 @@ pub struct AddArgs {
     pub platform: Option<PixiPlatformName>,
 
     /// The feature for which the task should be added.
-    #[arg(long, short, value_parser = FeatureName::from_str)]
+    #[arg(long, short)]
     pub feature: Option<FeatureName>,
 
     /// The working directory relative to the root of the workspace.
@@ -480,20 +480,26 @@ fn build_env_feature_task_map(project: &Workspace) -> Vec<EnvTasks> {
 #[derive(Serialize, Debug)]
 struct EnvTasks {
     environment: String,
+    /// Tasks defined inline on the environment itself.
+    tasks: Vec<SerializableTask>,
     features: Vec<SerializableFeature>,
 }
 
 impl From<&Environment<'_>> for EnvTasks {
     fn from(env: &Environment) -> Self {
+        let mut tasks = Vec::new();
+        let mut features = Vec::new();
+        for (feature_name, task_map) in env.feature_tasks().iter() {
+            if feature_name.is_environment() {
+                tasks.extend(serializable_tasks(task_map));
+            } else {
+                features.push(SerializableFeature::from((*feature_name, task_map)));
+            }
+        }
         Self {
             environment: env.name().to_string(),
-            features: env
-                .feature_tasks()
-                .iter()
-                .map(|(feature_name, task_map)| {
-                    SerializableFeature::from((*feature_name, task_map))
-                })
-                .collect(),
+            tasks,
+            features,
         }
     }
 }
@@ -511,17 +517,21 @@ struct SerializableTask {
     info: TaskInfo,
 }
 
+fn serializable_tasks(task_map: &HashMap<&TaskName, &Task>) -> Vec<SerializableTask> {
+    task_map
+        .iter()
+        .map(|(task_name, task)| SerializableTask {
+            name: task_name.to_string(),
+            info: TaskInfo::from(*task),
+        })
+        .collect()
+}
+
 impl From<(&FeatureName, &HashMap<&TaskName, &Task>)> for SerializableFeature {
     fn from((feature_name, task_map): (&FeatureName, &HashMap<&TaskName, &Task>)) -> Self {
         Self {
             name: feature_name.to_string(),
-            tasks: task_map
-                .iter()
-                .map(|(task_name, task)| SerializableTask {
-                    name: task_name.to_string(),
-                    info: TaskInfo::from(*task),
-                })
-                .collect(),
+            tasks: serializable_tasks(task_map),
         }
     }
 }

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use std::cmp::Ordering;
 
 use clap::Parser;
@@ -62,7 +64,7 @@ pub struct UpgradeSpecsArgs {
     pub packages: Option<Vec<String>>,
 
     /// The feature to update
-    #[clap(long = "feature", short = 'f')]
+    #[clap(long = "feature", short = 'f', value_parser = FeatureName::from_str)]
     pub feature: Option<FeatureName>,
 
     /// The packages which should be excluded

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use std::cmp::Ordering;
 
 use clap::Parser;
@@ -64,7 +62,7 @@ pub struct UpgradeSpecsArgs {
     pub packages: Option<Vec<String>>,
 
     /// The feature to update
-    #[clap(long = "feature", short = 'f', value_parser = FeatureName::from_str)]
+    #[clap(long = "feature", short = 'f')]
     pub feature: Option<FeatureName>,
 
     /// The packages which should be excluded

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -89,7 +89,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             // synthesized feature.
             let manifest = &workspace.workspace().workspace.value;
             let feature_name = FeatureName::environment(environment_arg);
-            match manifest.features.get(&feature_name) {
+            match manifest.feature(&feature_name) {
                 Some(feature) => Vec::from([feature.clone()]),
                 None if manifest.environment(environment_arg).is_some() => miette::bail!(
                     "the environment {} does not define any content inline",
@@ -114,9 +114,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 .workspace()
                 .workspace
                 .value
-                .features
-                .clone()
-                .into_values()
+                .all_features()
+                .map(|(_, feature)| feature.clone())
                 .collect()
         }
     };

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -66,7 +66,7 @@ pub struct UpgradeSpecsArgs {
     pub feature: Option<FeatureName>,
 
     /// The environment whose inline dependencies should be updated
-    #[clap(long = "environment", short = 'e', value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    #[clap(long = "environment", short = 'e', conflicts_with = "feature")]
     pub environment: Option<EnvironmentName>,
 
     /// The packages which should be excluded

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -14,8 +14,8 @@ use pixi_core::{
 };
 use pixi_diff::{LockFileDiff, LockFileJsonDiff};
 use pixi_manifest::{
-    DependencyOverwriteBehavior, FeatureName, PixiPlatform, SpecType, TargetSelector,
-    WorkspaceTarget,
+    DependencyOverwriteBehavior, EnvironmentName, FeatureName, PixiPlatform, SpecType,
+    TargetSelector, WorkspaceTarget,
 };
 use pixi_pypi_spec::{PixiPypiSource, PixiPypiSpec, PypiPackageName};
 use pixi_spec::PixiSpec;
@@ -65,6 +65,10 @@ pub struct UpgradeSpecsArgs {
     #[clap(long = "feature", short = 'f')]
     pub feature: Option<FeatureName>,
 
+    /// The environment whose inline dependencies should be updated
+    #[clap(long = "environment", short = 'e', value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    pub environment: Option<EnvironmentName>,
+
     /// The packages which should be excluded
     #[clap(long, conflicts_with = "packages")]
     pub exclude: Option<Vec<String>>,
@@ -80,7 +84,23 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let mut workspace = workspace.modify()?;
 
     let features = {
-        if let Some(feature_arg) = &args.specs.feature {
+        if let Some(environment_arg) = &args.specs.environment {
+            // The inline dependencies of an environment live on its
+            // synthesized feature.
+            let manifest = &workspace.workspace().workspace.value;
+            let feature_name = FeatureName::environment(environment_arg);
+            match manifest.features.get(&feature_name) {
+                Some(feature) => Vec::from([feature.clone()]),
+                None if manifest.environment(environment_arg).is_some() => miette::bail!(
+                    "the environment {} does not define any content inline",
+                    environment_arg.fancy_display()
+                ),
+                None => miette::bail!(
+                    "could not find an environment named {}",
+                    environment_arg.fancy_display()
+                ),
+            }
+        } else if let Some(feature_arg) = &args.specs.feature {
             // Ensure that the given feature exists
             let Some(feature) = workspace.workspace().workspace.value.feature(feature_arg) else {
                 miette::bail!(

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use std::io::Write;
 
 use clap::Parser;
@@ -6,6 +8,7 @@ use miette::IntoDiagnostic;
 use pixi_api::{WorkspaceContext, workspace::ChannelOptions};
 use pixi_config::ConfigCli;
 use pixi_core::WorkspaceLocator;
+use pixi_manifest::FeatureName;
 use rattler_conda_types::NamedChannelOrUrl;
 
 use crate::{
@@ -50,8 +53,8 @@ pub struct AddRemoveArgs {
     pub config: ConfigCli,
 
     /// The name of the feature to modify.
-    #[clap(long, short)]
-    pub feature: Option<String>,
+    #[clap(long, short, value_parser = FeatureName::from_str)]
+    pub feature: Option<FeatureName>,
 }
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -67,7 +70,7 @@ impl TryFrom<&AddRemoveArgs> for ChannelOptions {
     fn try_from(args: &AddRemoveArgs) -> Result<Self, Self::Error> {
         Ok(Self {
             channels: args.channel.clone(),
-            feature: args.feature.clone(),
+            feature: args.feature.clone().map(|f| f.to_string()),
             no_install: args.no_install_config.no_install,
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
         })

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -6,7 +6,7 @@ use miette::IntoDiagnostic;
 use pixi_api::{WorkspaceContext, workspace::ChannelOptions};
 use pixi_config::ConfigCli;
 use pixi_core::WorkspaceLocator;
-use pixi_manifest::FeatureName;
+use pixi_manifest::{EnvironmentName, FeatureName};
 use rattler_conda_types::NamedChannelOrUrl;
 
 use crate::{
@@ -53,6 +53,11 @@ pub struct AddRemoveArgs {
     /// The name of the feature to modify.
     #[clap(long, short)]
     pub feature: Option<FeatureName>,
+
+    /// The environment to modify. The channel is written to the channels
+    /// defined inline on the environment.
+    #[clap(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    pub environment: Option<EnvironmentName>,
 }
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -68,7 +73,10 @@ impl TryFrom<&AddRemoveArgs> for ChannelOptions {
     fn try_from(args: &AddRemoveArgs) -> Result<Self, Self::Error> {
         Ok(Self {
             channels: args.channel.clone(),
-            feature: args.feature.clone().map(|f| f.to_string()),
+            feature: crate::cli_config::feature_from_flags(
+                args.environment.as_ref(),
+                args.feature.as_ref(),
+            ),
             no_install: args.no_install_config.no_install,
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
         })

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -56,7 +56,7 @@ pub struct AddRemoveArgs {
 
     /// The environment to modify. The channel is written to the channels
     /// defined inline on the environment.
-    #[clap(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    #[clap(long, short, conflicts_with = "feature")]
     pub environment: Option<EnvironmentName>,
 }
 

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use std::io::Write;
 
 use clap::Parser;
@@ -53,7 +51,7 @@ pub struct AddRemoveArgs {
     pub config: ConfigCli,
 
     /// The name of the feature to modify.
-    #[clap(long, short, value_parser = FeatureName::from_str)]
+    #[clap(long, short)]
     pub feature: Option<FeatureName>,
 }
 

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -104,7 +104,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     "- {}: \n    features: {}{}",
                     e.name().fancy_display(),
                     e.features()
-                        .map(|f| consts::FEATURE_STYLE.apply_to(f.name.to_string()))
+                        .filter(|f| !f.name.is_environment())
+                        .map(|f| f.name.fancy_display())
                         .format(", "),
                     if let Some(solve_group) = e.solve_group() {
                         format!(

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -103,7 +103,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 envs.iter().format_with("\n", |e, f| f(&format_args!(
                     "- {}: \n    features: {}{}",
                     e.name().fancy_display(),
-                    e.features().map(|f| f.name.fancy_display()).format(", "),
+                    e.features()
+                        .map(|f| consts::FEATURE_STYLE.apply_to(f.name.to_string()))
+                        .format(", "),
                     if let Some(solve_group) = e.solve_group() {
                         format!(
                             "\n    solve_group: {}",

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -97,32 +97,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .into_diagnostic()?;
                 return Ok(());
             }
-            writeln!(
-                std::io::stdout(),
-                "Environments:\n{}",
-                envs.iter().format_with("\n", |e, f| f(&format_args!(
-                    "- {}: \n    features: {}{}",
-                    e.name().fancy_display(),
-                    e.features()
-                        .filter(|f| !f.name.is_environment())
-                        .map(|f| f.name.fancy_display())
-                        .format(", "),
-                    if let Some(solve_group) = e.solve_group() {
-                        format!(
-                            "\n    solve_group: {}",
-                            consts::SOLVE_GROUP_STYLE.apply_to(solve_group.name())
-                        )
-                    } else {
-                        "".to_string()
+            writeln!(std::io::stdout(), "{}", format_environment_list(&envs))
+                .inspect_err(|e| {
+                    if e.kind() == std::io::ErrorKind::BrokenPipe {
+                        std::process::exit(0);
                     }
-                )))
-            )
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
-            .into_diagnostic()?;
+                })
+                .into_diagnostic()?;
         }
         Command::Add(args) => {
             workspace_ctx
@@ -139,4 +120,90 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+/// Renders the `Environments:` block shown by
+/// `pixi workspace environment list`.
+fn format_environment_list(envs: &[pixi_core::workspace::Environment<'_>]) -> String {
+    format!(
+        "Environments:\n{}",
+        envs.iter().format_with("\n", |e, f| {
+            // Content the environment defines inline lives on its
+            // synthesized feature; render it under the environment.
+            let inline_details = e
+                .features()
+                .find(|feature| feature.name.is_environment())
+                .map(super::feature_detail_lines)
+                .unwrap_or_default();
+
+            f(&format_args!(
+                "- {}:\n    features: {}{}{}",
+                e.name().fancy_display(),
+                e.features()
+                    .filter(|f| !f.name.is_environment())
+                    .map(|f| f.name.fancy_display())
+                    .format(", "),
+                if let Some(solve_group) = e.solve_group() {
+                    format!(
+                        "\n    solve_group: {}",
+                        consts::SOLVE_GROUP_STYLE.apply_to(solve_group.name())
+                    )
+                } else {
+                    "".to_string()
+                },
+                if inline_details.is_empty() {
+                    "".to_string()
+                } else {
+                    format!("\n{}", inline_details.join("\n"))
+                }
+            ))
+        })
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pixi_core::Workspace;
+
+    use super::*;
+
+    #[test]
+    fn environment_list_shows_inline_content() {
+        let workspace = Workspace::from_str(
+            Path::new("pixi.toml"),
+            r#"
+            [workspace]
+            name = "test"
+            channels = []
+            platforms = ["linux-64"]
+
+            [feature.lint.dependencies]
+            ruff = "*"
+
+            [environments]
+            lint = ["lint"]
+
+            [environments.dev.dependencies]
+            git = "*"
+
+            [environments.dev.tasks]
+            greet = "echo hello"
+            "#,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(format_environment_list(&workspace.environments()), @r"
+        Environments:
+        - default:
+            features: default
+        - lint:
+            features: lint, default
+        - dev:
+            features: default
+            dependencies: git
+            tasks: greet
+        ");
+    }
 }

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use std::io::Write;
 
 use clap::Parser;
@@ -27,6 +29,7 @@ pub struct Args {
 #[derive(Parser, Debug)]
 pub struct RemoveArgs {
     /// The name of the feature to remove
+    #[clap(value_parser = FeatureName::from_str)]
     pub feature: FeatureName,
 }
 

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -73,40 +73,7 @@ fn format_feature_list(features: &IndexMap<FeatureName, Feature>) -> String {
     format!(
         "Features:\n{}",
         features.iter().format_with("\n", |(name, feature), f| {
-            let deps: Vec<_> = feature
-                .dependencies(pixi_manifest::SpecType::Run, None)
-                .map(|d| d.names().map(|n| n.as_normalized().to_string()).collect())
-                .unwrap_or_default();
-
-            let pypi_deps: Vec<_> = feature
-                .pypi_dependencies(None)
-                .map(|d| d.names().map(|n| n.as_source().to_string()).collect())
-                .unwrap_or_default();
-
-            let tasks: Vec<_> = feature
-                .targets
-                .default()
-                .tasks
-                .keys()
-                .map(|k| k.as_str().to_string())
-                .collect();
-
-            let mut details = Vec::new();
-
-            if !deps.is_empty() {
-                let deps = deps.iter().map(|d| console::style(d).green()).join(", ");
-                details.push(format!("    dependencies: {deps}"));
-            }
-            if !pypi_deps.is_empty() {
-                let deps = pypi_deps
-                    .iter()
-                    .map(|d| console::style(d).blue())
-                    .join(", ");
-                details.push(format!("    pypi-dependencies: {deps}"));
-            }
-            if !tasks.is_empty() {
-                details.push(format!("    tasks: {}", tasks.join(", ")));
-            }
+            let details = super::feature_detail_lines(feature);
 
             f(&format_args!(
                 "- {}{}",

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -2,11 +2,12 @@ use std::io::Write;
 
 use clap::Parser;
 use fancy_display::FancyDisplay;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
-use pixi_manifest::FeatureName;
+use pixi_manifest::{Feature, FeatureName};
 
 use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
 
@@ -51,62 +52,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     match args.command {
         Command::List => {
             let features = workspace_ctx.list_features().await;
-            writeln!(
-                std::io::stdout(),
-                "Features:\n{}",
-                features.iter().format_with("\n", |(name, feature), f| {
-                    let deps: Vec<_> = feature
-                        .dependencies(pixi_manifest::SpecType::Run, None)
-                        .map(|d| d.names().map(|n| n.as_normalized().to_string()).collect())
-                        .unwrap_or_default();
-
-                    let pypi_deps: Vec<_> = feature
-                        .pypi_dependencies(None)
-                        .map(|d| d.names().map(|n| n.as_source().to_string()).collect())
-                        .unwrap_or_default();
-
-                    let tasks: Vec<_> = feature
-                        .targets
-                        .default()
-                        .tasks
-                        .keys()
-                        .map(|k| k.as_str().to_string())
-                        .collect();
-
-                    let mut details = Vec::new();
-
-                    if !deps.is_empty() {
-                        let deps = deps.iter().map(|d| console::style(d).green()).join(", ");
-                        details.push(format!("    dependencies: {deps}"));
+            writeln!(std::io::stdout(), "{}", format_feature_list(&features))
+                .inspect_err(|e| {
+                    if e.kind() == std::io::ErrorKind::BrokenPipe {
+                        std::process::exit(0);
                     }
-                    if !pypi_deps.is_empty() {
-                        let deps = pypi_deps
-                            .iter()
-                            .map(|d| console::style(d).blue())
-                            .join(", ");
-                        details.push(format!("    pypi-dependencies: {deps}"));
-                    }
-                    if !tasks.is_empty() {
-                        details.push(format!("    tasks: {}", tasks.join(", ")));
-                    }
-
-                    f(&format_args!(
-                        "- {}{}",
-                        name.fancy_display(),
-                        if !details.is_empty() {
-                            format!(":\n{}", details.join("\n"))
-                        } else {
-                            String::new()
-                        }
-                    ))
                 })
-            )
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
-            .into_diagnostic()?;
+                .into_diagnostic()?;
         }
         Command::Remove(args) => {
             workspace_ctx.remove_feature(&args.feature).await?;
@@ -114,4 +66,99 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     Ok(())
+}
+
+/// Renders the `Features:` block shown by `pixi workspace feature list`.
+fn format_feature_list(features: &IndexMap<FeatureName, Feature>) -> String {
+    format!(
+        "Features:\n{}",
+        features.iter().format_with("\n", |(name, feature), f| {
+            let deps: Vec<_> = feature
+                .dependencies(pixi_manifest::SpecType::Run, None)
+                .map(|d| d.names().map(|n| n.as_normalized().to_string()).collect())
+                .unwrap_or_default();
+
+            let pypi_deps: Vec<_> = feature
+                .pypi_dependencies(None)
+                .map(|d| d.names().map(|n| n.as_source().to_string()).collect())
+                .unwrap_or_default();
+
+            let tasks: Vec<_> = feature
+                .targets
+                .default()
+                .tasks
+                .keys()
+                .map(|k| k.as_str().to_string())
+                .collect();
+
+            let mut details = Vec::new();
+
+            if !deps.is_empty() {
+                let deps = deps.iter().map(|d| console::style(d).green()).join(", ");
+                details.push(format!("    dependencies: {deps}"));
+            }
+            if !pypi_deps.is_empty() {
+                let deps = pypi_deps
+                    .iter()
+                    .map(|d| console::style(d).blue())
+                    .join(", ");
+                details.push(format!("    pypi-dependencies: {deps}"));
+            }
+            if !tasks.is_empty() {
+                details.push(format!("    tasks: {}", tasks.join(", ")));
+            }
+
+            f(&format_args!(
+                "- {}{}",
+                name.fancy_display(),
+                if !details.is_empty() {
+                    format!(":\n{}", details.join("\n"))
+                } else {
+                    String::new()
+                }
+            ))
+        })
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pixi_core::Workspace;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn feature_list_hides_inline_environments() {
+        let workspace = Workspace::from_str(
+            Path::new("pixi.toml"),
+            r#"
+            [workspace]
+            name = "test"
+            channels = []
+            platforms = ["linux-64"]
+
+            [feature.lint.dependencies]
+            ruff = "*"
+
+            [environments]
+            lint = ["lint"]
+
+            [environments.dev.dependencies]
+            git = "*"
+            "#,
+        )
+        .unwrap();
+        let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+
+        let features = workspace_ctx.list_features().await;
+
+        insta::assert_snapshot!(format_feature_list(&features), @r"
+        Features:
+        - default
+        - lint:
+            dependencies: ruff
+        ");
+    }
 }

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use std::io::Write;
 
 use clap::Parser;
@@ -29,7 +27,6 @@ pub struct Args {
 #[derive(Parser, Debug)]
 pub struct RemoveArgs {
     /// The name of the feature to remove
-    #[clap(value_parser = FeatureName::from_str)]
     pub feature: FeatureName,
 }
 

--- a/crates/pixi_cli/src/workspace/mod.rs
+++ b/crates/pixi_cli/src/workspace/mod.rs
@@ -1,4 +1,6 @@
 use clap::Parser;
+use itertools::Itertools;
+use pixi_manifest::Feature;
 
 use crate::cli_config::WorkspaceConfig;
 
@@ -51,4 +53,46 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
         Command::RequiresPixi(args) => requires_pixi::execute(args).await?,
     };
     Ok(())
+}
+
+/// Indented detail lines describing a feature's content (dependencies,
+/// pypi-dependencies, tasks), shared by the `feature list` and
+/// `environment list` renderings.
+fn feature_detail_lines(feature: &Feature) -> Vec<String> {
+    let deps: Vec<_> = feature
+        .dependencies(pixi_manifest::SpecType::Run, None)
+        .map(|d| d.names().map(|n| n.as_normalized().to_string()).collect())
+        .unwrap_or_default();
+
+    let pypi_deps: Vec<_> = feature
+        .pypi_dependencies(None)
+        .map(|d| d.names().map(|n| n.as_source().to_string()).collect())
+        .unwrap_or_default();
+
+    let tasks: Vec<_> = feature
+        .targets
+        .default()
+        .tasks
+        .keys()
+        .map(|k| k.as_str().to_string())
+        .collect();
+
+    let mut details = Vec::new();
+
+    if !deps.is_empty() {
+        let deps = deps.iter().map(|d| console::style(d).green()).join(", ");
+        details.push(format!("    dependencies: {deps}"));
+    }
+    if !pypi_deps.is_empty() {
+        let deps = pypi_deps
+            .iter()
+            .map(|d| console::style(d).blue())
+            .join(", ");
+        details.push(format!("    pypi-dependencies: {deps}"));
+    }
+    if !tasks.is_empty() {
+        details.push(format!("    tasks: {}", tasks.join(", ")));
+    }
+
+    details
 }

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -1045,10 +1045,7 @@ fn format_workspace_platform_row(
     } else {
         ""
     };
-    let mut row = format!(
-        "{name_styled}: {body}{suffix}\n",
-        body = parts.join(", "),
-    );
+    let mut row = format!("{name_styled}: {body}{suffix}\n", body = parts.join(", "),);
     // Indented usage lines. The labels are padded so the two colons line
     // up when both are emitted; either is omitted if nothing references
     // the platform from that side. Names of environments/features that

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -494,7 +494,7 @@ async fn execute_add(
             args.virtual_packages,
             &raw_specs,
             args.no_install,
-            args.feature,
+            args.feature.map(|f| f.to_string()),
         )
         .await;
     }

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -326,7 +326,7 @@ pub struct AddArgs {
     pub no_install: bool,
 
     /// The name of the feature to add the platform to.
-    #[clap(long, short, value_parser = FeatureName::from_str)]
+    #[clap(long, short)]
     pub feature: Option<FeatureName>,
 }
 
@@ -405,7 +405,7 @@ pub struct RemoveArgs {
     pub no_install: bool,
 
     /// The name of the feature to remove the platform from.
-    #[clap(long, short, value_parser = FeatureName::from_str)]
+    #[clap(long, short)]
     pub feature: Option<FeatureName>,
 }
 

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -331,7 +331,7 @@ pub struct AddArgs {
 
     /// The environment to add the platform to. The platform is written to
     /// the platforms defined inline on the environment.
-    #[clap(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    #[clap(long, short, conflicts_with = "feature")]
     pub environment: Option<EnvironmentName>,
 }
 
@@ -415,7 +415,7 @@ pub struct RemoveArgs {
 
     /// The environment to remove the platform from. The platform is removed
     /// from the platforms defined inline on the environment.
-    #[clap(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    #[clap(long, short, conflicts_with = "feature")]
     pub environment: Option<EnvironmentName>,
 }
 

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -820,7 +820,7 @@ fn environments_and_features_using(
     let manifest = workspace.workspace_manifest();
     let name = platform.name();
 
-    for (feature_name, feature) in &manifest.features {
+    for (feature_name, feature) in manifest.all_features() {
         if let Some(platforms) = &feature.platforms
             && platforms.contains(name)
         {
@@ -943,8 +943,7 @@ impl MachineReachability {
             .collect();
 
         let unreachable_features: HashSet<String> = manifest
-            .features
-            .iter()
+            .all_features()
             .filter_map(|(name, feat)| {
                 // Only features that pin a `platforms = [...]` list can be
                 // "unreachable"; an implicit-platforms feature inherits

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -8,8 +8,8 @@ use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
 use pixi_core::workspace::{PlatformOverrides, PlatformSource};
 use pixi_manifest::{
-    FeatureName, FeaturesExt, HasWorkspaceManifest, PixiPlatform, PixiPlatformName, PlatformEdit,
-    PlatformMove, platform::subdir_default_virtual_packages,
+    EnvironmentName, FeatureName, FeaturesExt, HasWorkspaceManifest, PixiPlatform,
+    PixiPlatformName, PlatformEdit, PlatformMove, platform::subdir_default_virtual_packages,
 };
 use rattler_conda_types::{GenericVirtualPackage, PackageName, Platform, Version};
 use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
@@ -328,6 +328,11 @@ pub struct AddArgs {
     /// The name of the feature to add the platform to.
     #[clap(long, short)]
     pub feature: Option<FeatureName>,
+
+    /// The environment to add the platform to. The platform is written to
+    /// the platforms defined inline on the environment.
+    #[clap(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    pub environment: Option<EnvironmentName>,
 }
 
 #[derive(Parser, Debug)]
@@ -407,6 +412,11 @@ pub struct RemoveArgs {
     /// The name of the feature to remove the platform from.
     #[clap(long, short)]
     pub feature: Option<FeatureName>,
+
+    /// The environment to remove the platform from. The platform is removed
+    /// from the platforms defined inline on the environment.
+    #[clap(long, short, value_parser = crate::cli_config::parse_inline_environment, conflicts_with = "feature")]
+    pub environment: Option<EnvironmentName>,
 }
 
 #[derive(Parser, Debug, Default)]
@@ -494,7 +504,7 @@ async fn execute_add(
             args.virtual_packages,
             &raw_specs,
             args.no_install,
-            args.feature.map(|f| f.to_string()),
+            crate::cli_config::feature_from_flags(args.environment.as_ref(), args.feature.as_ref()),
         )
         .await;
     }
@@ -552,7 +562,7 @@ async fn execute_add(
         .add_platforms(
             platforms,
             args.no_install,
-            args.feature.map(|f| f.to_string()),
+            crate::cli_config::feature_from_flags(args.environment.as_ref(), args.feature.as_ref()),
         )
         .await
 }
@@ -566,7 +576,7 @@ async fn execute_add_auto_detected(
     virtual_packages: VirtualPackageArgs,
     raw_specs: &[String],
     no_install: bool,
-    feature: Option<String>,
+    feature: FeatureName,
 ) -> miette::Result<()> {
     let detected = workspace_ctx.workspace().host_platform(
         PlatformSource::AutoDetected,
@@ -769,7 +779,7 @@ async fn execute_remove(
         .remove_platforms(
             platforms,
             args.no_install,
-            args.feature.map(|f| f.to_string()),
+            crate::cli_config::feature_from_flags(args.environment.as_ref(), args.feature.as_ref()),
         )
         .await
 }

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -8,8 +8,8 @@ use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
 use pixi_core::workspace::{PlatformOverrides, PlatformSource};
 use pixi_manifest::{
-    FeaturesExt, HasWorkspaceManifest, PixiPlatform, PixiPlatformName, PlatformEdit, PlatformMove,
-    platform::subdir_default_virtual_packages,
+    FeatureName, FeaturesExt, HasWorkspaceManifest, PixiPlatform, PixiPlatformName, PlatformEdit,
+    PlatformMove, platform::subdir_default_virtual_packages,
 };
 use rattler_conda_types::{GenericVirtualPackage, PackageName, Platform, Version};
 use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
@@ -326,8 +326,8 @@ pub struct AddArgs {
     pub no_install: bool,
 
     /// The name of the feature to add the platform to.
-    #[clap(long, short)]
-    pub feature: Option<String>,
+    #[clap(long, short, value_parser = FeatureName::from_str)]
+    pub feature: Option<FeatureName>,
 }
 
 #[derive(Parser, Debug)]
@@ -405,8 +405,8 @@ pub struct RemoveArgs {
     pub no_install: bool,
 
     /// The name of the feature to remove the platform from.
-    #[clap(long, short)]
-    pub feature: Option<String>,
+    #[clap(long, short, value_parser = FeatureName::from_str)]
+    pub feature: Option<FeatureName>,
 }
 
 #[derive(Parser, Debug, Default)]
@@ -549,7 +549,11 @@ async fn execute_add(
     }
 
     workspace_ctx
-        .add_platforms(platforms, args.no_install, args.feature)
+        .add_platforms(
+            platforms,
+            args.no_install,
+            args.feature.map(|f| f.to_string()),
+        )
         .await
 }
 
@@ -762,7 +766,11 @@ async fn execute_remove(
         })
         .collect::<miette::Result<Vec<_>>>()?;
     workspace_ctx
-        .remove_platforms(platforms, args.no_install, args.feature)
+        .remove_platforms(
+            platforms,
+            args.no_install,
+            args.feature.map(|f| f.to_string()),
+        )
         .await
 }
 

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -743,14 +743,33 @@ async fn execute_list(
         let _ = writeln!(stdout, "\n{}", console::style("Platforms:").bold().bright());
     }
     let machine = HostMachine::detect(workspace);
-    let reachability = MachineReachability::compute(workspace, &machine);
-    let multiple_environments = workspace.environments().len() > 1;
-    for p in workspace_platforms.iter() {
-        let users = environments_and_features_using(workspace, p);
-        print_workspace_platform_row(p, &machine, &users, &reachability, multiple_environments);
-    }
+    let _ = write!(
+        stdout,
+        "{}",
+        format_workspace_platform_rows(workspace, &machine)
+    );
 
     Ok(())
+}
+
+/// Renders the rows under the `Platforms:` header: every workspace platform
+/// in declaration order, each followed by its usage lines.
+fn format_workspace_platform_rows(
+    workspace: &pixi_core::Workspace,
+    machine: &HostMachine,
+) -> String {
+    let reachability = MachineReachability::compute(workspace, machine);
+    let multiple_environments = workspace.environments().len() > 1;
+    workspace
+        .workspace_manifest()
+        .workspace
+        .platforms
+        .iter()
+        .map(|p| {
+            let users = environments_and_features_using(workspace, p);
+            format_workspace_platform_row(p, machine, &users, &reachability, multiple_environments)
+        })
+        .collect()
 }
 
 async fn execute_remove(
@@ -810,12 +829,15 @@ fn print_autodetected_host(workspace: &pixi_core::Workspace) {
 
 /// Walk all environments + features in the workspace and collect the names of
 /// those that reference `platform` by name. Used by the `list` output so the
-/// user can see what would break if they remove the entry.
+/// user can see what would break if they remove the entry. Platforms declared
+/// inline on an environment live on its synthesized feature; those are
+/// reported as inline environment declarations, not as features.
 fn environments_and_features_using(
     workspace: &pixi_core::Workspace,
     platform: &PixiPlatform,
 ) -> PlatformUsers {
     let mut features = Vec::new();
+    let mut inline_environments = Vec::new();
     let mut environments = Vec::new();
     let manifest = workspace.workspace_manifest();
     let name = platform.name();
@@ -824,7 +846,11 @@ fn environments_and_features_using(
         if let Some(platforms) = &feature.platforms
             && platforms.contains(name)
         {
-            features.push(feature_name.to_string());
+            if let Some(environment_name) = feature_name.environment_name() {
+                inline_environments.push(environment_name.to_string());
+            } else {
+                features.push(feature_name.to_string());
+            }
         }
     }
 
@@ -836,12 +862,16 @@ fn environments_and_features_using(
 
     PlatformUsers {
         features,
+        inline_environments,
         environments,
     }
 }
 
 struct PlatformUsers {
     features: Vec<String>,
+    /// Environments that declare the platform inline (on their synthesized
+    /// feature) rather than through a `[feature.<name>]` table.
+    inline_environments: Vec<String>,
     environments: Vec<String>,
 }
 
@@ -943,7 +973,7 @@ impl MachineReachability {
             .collect();
 
         let unreachable_features: HashSet<String> = manifest
-            .all_features()
+            .user_features()
             .filter_map(|(name, feat)| {
                 // Only features that pin a `platforms = [...]` list can be
                 // "unreachable"; an implicit-platforms feature inherits
@@ -965,15 +995,16 @@ impl MachineReachability {
 /// One row in the `Platforms:` block. Supported platforms are bold; blocking
 /// subdir / virtual packages are dimmed. Followed by indented usage lines:
 /// `Used in environments:` (only when the workspace has more than one
-/// environment) and `Used in features    :`, each emitted only when the
-/// manifest references the platform, with unreachable names dimmed.
-fn print_workspace_platform_row(
+/// environment), `Used in features    :`, and `Declared inline in
+/// environments:`, each emitted only when the manifest references the
+/// platform, with unreachable names dimmed.
+fn format_workspace_platform_row(
     platform: &PixiPlatform,
     machine: &HostMachine,
     users: &PlatformUsers,
     reachability: &MachineReachability,
     multiple_environments: bool,
-) {
+) -> String {
     let subdir = platform.subdir();
     let subdir_ok = machine.covers_subdir(subdir);
 
@@ -1014,10 +1045,8 @@ fn print_workspace_platform_row(
     } else {
         ""
     };
-    let mut stdout = std::io::stdout();
-    let _ = writeln!(
-        stdout,
-        "{name_styled}: {body}{suffix}",
+    let mut row = format!(
+        "{name_styled}: {body}{suffix}\n",
         body = parts.join(", "),
     );
     // Indented usage lines. The labels are padded so the two colons line
@@ -1026,19 +1055,27 @@ fn print_workspace_platform_row(
     // have no reachable platform on this machine are dimmed so users can
     // see at a glance which references they can act on locally.
     if multiple_environments && !users.environments.is_empty() {
-        let _ = writeln!(
-            stdout,
-            "    Used in environments: {}",
+        row.push_str(&format!(
+            "    Used in environments: {}\n",
             format_user_names(&users.environments, &reachability.unreachable_environments),
-        );
+        ));
     }
     if !users.features.is_empty() {
-        let _ = writeln!(
-            stdout,
-            "    Used in features    : {}",
+        row.push_str(&format!(
+            "    Used in features    : {}\n",
             format_user_names(&users.features, &reachability.unreachable_features),
-        );
+        ));
     }
+    if !users.inline_environments.is_empty() {
+        row.push_str(&format!(
+            "    Declared inline in environments: {}\n",
+            format_user_names(
+                &users.inline_environments,
+                &reachability.unreachable_environments
+            ),
+        ));
+    }
+    row
 }
 
 /// Join `names` as a comma-separated list, dimming any entry that's in
@@ -1101,6 +1138,7 @@ fn show_to_json(platform: &PixiPlatform, users: &PlatformUsers) -> serde_json::V
         ),
         "detected_virtual_packages": detected,
         "features": users.features,
+        "declared_inline_in_environments": users.inline_environments,
         "environments": users.environments,
     })
 }
@@ -1120,6 +1158,7 @@ fn autodetected_to_json() -> serde_json::Value {
         "virtual_packages": Vec::<String>::new(),
         "detected_virtual_packages": detected,
         "features": Vec::<String>::new(),
+        "declared_inline_in_environments": Vec::<String>::new(),
         "environments": Vec::<String>::new(),
         "is_current": true,
         "is_autodetected": true,
@@ -1128,7 +1167,79 @@ fn autodetected_to_json() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+    use pixi_core::Workspace;
+
     use super::*;
+
+    /// A workspace where a real feature and an inline environment both
+    /// declare the sole workspace platform.
+    fn inline_declaration_workspace() -> Workspace {
+        Workspace::from_str(
+            std::path::Path::new("pixi.toml"),
+            r#"
+            [workspace]
+            name = "platform-test"
+            channels = []
+            platforms = ["linux-64"]
+
+            [feature.cuda]
+            platforms = ["linux-64"]
+
+            [environments]
+            gpu = ["cuda"]
+
+            [environments.dev]
+            platforms = ["linux-64"]
+
+            [environments.dev.dependencies]
+            git = "*"
+            "#,
+        )
+        .unwrap()
+    }
+
+    /// A host that runs linux-64 with no customised virtual packages.
+    fn linux_machine() -> HostMachine {
+        HostMachine {
+            candidate_subdirs: vec![Platform::Linux64],
+            detected: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn list_reports_inline_environment_declarations_separately() {
+        let workspace = inline_declaration_workspace();
+        let rows = format_workspace_platform_rows(&workspace, &linux_machine());
+        insta::assert_snapshot!(rows, @r"
+        linux-64: platform=linux-64 (supported by current machine)
+            Used in environments: default, gpu, dev
+            Used in features    : cuda
+            Declared inline in environments: dev
+        ");
+    }
+
+    #[test]
+    fn list_json_reports_inline_environment_declarations_separately() {
+        let workspace = inline_declaration_workspace();
+        let platform = (&workspace)
+            .workspace_manifest()
+            .workspace
+            .platforms
+            .iter()
+            .next()
+            .expect("manifest declares one platform");
+        let users = environments_and_features_using(&workspace, platform);
+        let json = show_to_json(platform, &users);
+        assert_eq!(json["features"], serde_json::json!(["cuda"]));
+        assert_eq!(
+            json["declared_inline_in_environments"],
+            serde_json::json!(["dev"])
+        );
+        assert_eq!(
+            json["environments"],
+            serde_json::json!(["default", "gpu", "dev"])
+        );
+    }
 
     #[test]
     fn into_specs_rejects_glibc_on_windows() {

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -9,6 +9,11 @@ use url::Url;
 
 pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";
 pub const DEFAULT_FEATURE_NAME: &str = DEFAULT_ENVIRONMENT_NAME;
+
+/// Prefix of the implicit feature that is synthesized for an environment which
+/// defines dependencies inline. This prefix is reserved: user-defined features
+/// may not start with it.
+pub const ENVIRONMENT_FEATURE_PREFIX: &str = "env:";
 pub const PYPROJECT_PIXI_PREFIX: &str = "tool.pixi";
 
 pub const WORKSPACE_MANIFEST: &str = "pixi.toml";

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -9,11 +9,6 @@ use url::Url;
 
 pub const DEFAULT_ENVIRONMENT_NAME: &str = "default";
 pub const DEFAULT_FEATURE_NAME: &str = DEFAULT_ENVIRONMENT_NAME;
-
-/// Prefix of the implicit feature that is synthesized for an environment which
-/// defines dependencies inline. This prefix is reserved: user-defined features
-/// may not start with it.
-pub const ENVIRONMENT_FEATURE_PREFIX: &str = "env:";
 pub const PYPROJECT_PIXI_PREFIX: &str = "tool.pixi";
 
 pub const WORKSPACE_MANIFEST: &str = "pixi.toml";

--- a/crates/pixi_core/src/workspace/conda_pypi_map.rs
+++ b/crates/pixi_core/src/workspace/conda_pypi_map.rs
@@ -106,9 +106,8 @@ fn validate_mapped_channels_are_used<'a>(
         .into_diagnostic()?;
 
     let feature_channels: HashSet<_> = manifest
-        .features
-        .values()
-        .flat_map(|feature| feature.channels.iter())
+        .all_features()
+        .flat_map(|(_, feature)| feature.channels.iter())
         .flatten()
         .map(|pc| pc.channel.clone().into_channel(channel_config))
         .try_collect()

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -512,8 +512,7 @@ impl<'p> HasFeaturesIter<'p> for Environment<'p> {
         let manifest = self.workspace_manifest();
         let environment_features = self.environment.features.iter().map(|feature_name| {
             manifest
-                .features
-                .get(feature_name)
+                .feature(feature_name)
                 .expect("feature usage should have been validated upfront")
         });
 

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -513,7 +513,7 @@ impl<'p> HasFeaturesIter<'p> for Environment<'p> {
         let environment_features = self.environment.features.iter().map(|feature_name| {
             manifest
                 .features
-                .get(&FeatureName::from(feature_name.clone()))
+                .get(feature_name)
                 .expect("feature usage should have been validated upfront")
         });
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -1582,21 +1582,21 @@ mod tests {
             workspace
                 .workspace
                 .value
-                .tasks(Some(&osx64), &FeatureName::DEFAULT)
+                .tasks(Some(&osx64), &FeatureName::Default)
                 .unwrap()
         );
         assert_debug_snapshot!(
             workspace
                 .workspace
                 .value
-                .tasks(Some(&win64), &FeatureName::DEFAULT)
+                .tasks(Some(&win64), &FeatureName::Default)
                 .unwrap()
         );
         assert_debug_snapshot!(
             workspace
                 .workspace
                 .value
-                .tasks(Some(&linux64), &FeatureName::DEFAULT)
+                .tasks(Some(&linux64), &FeatureName::Default)
                 .unwrap()
         );
     }

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -751,9 +751,8 @@ impl Workspace {
             .map(|prioritized| &prioritized.channel)
             .chain(
                 manifest
-                    .features
-                    .values()
-                    .filter_map(|feature| feature.channels.as_ref())
+                    .all_features()
+                    .filter_map(|(_, feature)| feature.channels.as_ref())
                     .flatten()
                     .map(|prioritized| &prioritized.channel),
             )

--- a/crates/pixi_manifest/src/environment.rs
+++ b/crates/pixi_manifest/src/environment.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 use serde::{self, Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
-use crate::{consts::DEFAULT_ENVIRONMENT_NAME, solve_group::SolveGroupIdx};
+use crate::{FeatureName, consts::DEFAULT_ENVIRONMENT_NAME, solve_group::SolveGroupIdx};
 
 #[derive(Debug, Clone, Error, Diagnostic, PartialEq)]
 #[error(
@@ -163,7 +163,7 @@ pub struct Environment {
     ///
     /// Note that the default feature is always added to the set of features
     /// that make up the environment.
-    pub features: Vec<String>,
+    pub features: Vec<FeatureName>,
 
     /// An optional solver-group. Multiple environments can share the same
     /// solve-group. All the dependencies of the environment that share the

--- a/crates/pixi_manifest/src/environment.rs
+++ b/crates/pixi_manifest/src/environment.rs
@@ -150,6 +150,49 @@ impl<'de> Deserialize<'de> for EnvironmentName {
     }
 }
 
+/// Describes an environment that should be added to a manifest.
+///
+/// Construct it with [`NewEnvironment::new`] and refine it with the builder
+/// methods before passing it to `add_environment`.
+#[derive(Debug, Clone)]
+pub struct NewEnvironment {
+    pub(crate) name: String,
+    pub(crate) features: Option<Vec<String>>,
+    pub(crate) solve_group: Option<String>,
+    pub(crate) no_default_feature: bool,
+}
+
+impl NewEnvironment {
+    /// Creates a description of an environment with the given name and no
+    /// features, no solve group and the default feature included.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            features: None,
+            solve_group: None,
+            no_default_feature: false,
+        }
+    }
+
+    /// Sets the features that make up the environment.
+    pub fn with_features(mut self, features: impl Into<Option<Vec<String>>>) -> Self {
+        self.features = features.into();
+        self
+    }
+
+    /// Sets the solve group the environment belongs to.
+    pub fn with_solve_group(mut self, solve_group: impl Into<Option<String>>) -> Self {
+        self.solve_group = solve_group.into();
+        self
+    }
+
+    /// Sets whether the default feature is excluded from the environment.
+    pub fn with_no_default_feature(mut self, no_default_feature: bool) -> Self {
+        self.no_default_feature = no_default_feature;
+        self
+    }
+}
+
 /// An environment describes a set of features that are available together.
 ///
 /// Individual features cannot be used directly, instead they are grouped

--- a/crates/pixi_manifest/src/error.rs
+++ b/crates/pixi_manifest/src/error.rs
@@ -317,10 +317,13 @@ pub struct UnknownFeature {
 impl UnknownFeature {
     pub fn new(feature: String, manifest: impl Borrow<WorkspaceManifest>) -> Self {
         // Find the top 2 features that are closest to the feature name.
+        // Features synthesized for inline environment content cannot be
+        // referenced, so they are never suggested.
         let existing_features = manifest
             .borrow()
             .features
             .keys()
+            .filter(|f| !f.is_environment())
             .filter_map(|f| {
                 let distance = strsim::jaro(f.as_str(), &feature);
                 (distance > 0.6).then_some((distance, f))

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -12,34 +12,21 @@ use rattler_conda_types::PackageName;
 use serde::{Deserialize, Serialize};
 use std::ops::Not;
 use std::{
-    borrow::{Borrow, Cow},
-    collections::HashSet,
-    convert::Infallible,
-    fmt,
-    hash::{Hash, Hasher},
-    str::FromStr,
+    borrow::Cow, collections::HashSet, convert::Infallible, fmt, hash::Hash, str::FromStr,
 };
 
-/// The name of a feature. This is either a string or default for the default
+/// The name of a feature. This is either a name or default for the default
 /// feature.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub struct FeatureName(Cow<'static, str>);
-
-impl Default for FeatureName {
-    fn default() -> Self {
-        FeatureName::DEFAULT.clone()
-    }
+#[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub enum FeatureName {
+    #[default]
+    Default,
+    Named(String),
 }
 
 impl Serialize for FeatureName {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(self.as_str())
-    }
-}
-
-impl Hash for FeatureName {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_str().hash(state)
     }
 }
 
@@ -54,27 +41,36 @@ impl<'de> Deserialize<'de> for FeatureName {
 
 impl<'s> From<&'s str> for FeatureName {
     fn from(value: &'s str) -> Self {
-        FeatureName(Cow::Owned(value.to_owned()))
+        if value == consts::DEFAULT_FEATURE_NAME {
+            FeatureName::Default
+        } else {
+            FeatureName::Named(value.to_owned())
+        }
     }
 }
 
 impl From<String> for FeatureName {
     fn from(value: String) -> Self {
-        Self(Cow::Owned(value))
+        if value == consts::DEFAULT_FEATURE_NAME {
+            FeatureName::Default
+        } else {
+            FeatureName::Named(value)
+        }
     }
 }
 
 impl FeatureName {
-    pub const DEFAULT: Self = FeatureName(Cow::Borrowed(consts::DEFAULT_FEATURE_NAME));
-
     /// Returns the string representation of the feature.
     pub fn as_str(&self) -> &str {
-        &self.0
+        match self {
+            FeatureName::Default => consts::DEFAULT_FEATURE_NAME,
+            FeatureName::Named(name) => name,
+        }
     }
 
     /// Returns true if the feature is the default feature.
     pub fn is_default(&self) -> bool {
-        self == &Self::DEFAULT
+        matches!(self, FeatureName::Default)
     }
 
     /// Returns the name of the feature if it is not default.
@@ -83,9 +79,15 @@ impl FeatureName {
     }
 }
 
-impl Borrow<str> for FeatureName {
-    fn borrow(&self) -> &str {
-        self.as_str()
+impl PartialEq<str> for FeatureName {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for FeatureName {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
     }
 }
 
@@ -99,7 +101,10 @@ impl FromStr for FeatureName {
 
 impl From<FeatureName> for String {
     fn from(name: FeatureName) -> Self {
-        name.0.into_owned()
+        match name {
+            FeatureName::Default => consts::DEFAULT_FEATURE_NAME.to_owned(),
+            FeatureName::Named(name) => name,
+        }
     }
 }
 impl<'a> From<&'a FeatureName> for String {

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CondaConstraints, SpecType, WorkspaceTarget, channel::PrioritizedChannel, consts,
-    pypi::pypi_options::PypiOptions, target::Targets, workspace::ChannelPriority,
+    CondaConstraints, EnvironmentName, SpecType, WorkspaceTarget, channel::PrioritizedChannel,
+    consts, pypi::pypi_options::PypiOptions, target::Targets, workspace::ChannelPriority,
     workspace::SolveStrategy,
 };
 use crate::{InlinePackageManifest, PixiPlatform, PixiPlatformName};
@@ -11,9 +11,7 @@ use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::PackageName;
 use serde::{Deserialize, Serialize};
 use std::ops::Not;
-use std::{
-    borrow::Cow, collections::HashSet, convert::Infallible, fmt, hash::Hash, str::FromStr,
-};
+use std::{borrow::Cow, collections::HashSet, fmt, hash::Hash, str::FromStr};
 
 /// The name of a feature. This is either a name or default for the default
 /// feature.
@@ -22,11 +20,16 @@ pub enum FeatureName {
     #[default]
     Default,
     Named(String),
+    /// The implicit feature that is synthesized for an environment which
+    /// defines feature content (like dependencies) inline. It is displayed
+    /// with the reserved `env:` prefix, e.g. `env:dev` for the environment
+    /// `dev`.
+    Environment(EnvironmentName),
 }
 
 impl Serialize for FeatureName {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(self.as_str())
+        serializer.collect_str(self)
     }
 }
 
@@ -41,11 +44,7 @@ impl<'de> Deserialize<'de> for FeatureName {
 
 impl<'s> From<&'s str> for FeatureName {
     fn from(value: &'s str) -> Self {
-        if value == consts::DEFAULT_FEATURE_NAME {
-            FeatureName::Default
-        } else {
-            FeatureName::Named(value.to_owned())
-        }
+        FeatureName::from(value.to_owned())
     }
 }
 
@@ -53,6 +52,11 @@ impl From<String> for FeatureName {
     fn from(value: String) -> Self {
         if value == consts::DEFAULT_FEATURE_NAME {
             FeatureName::Default
+        } else if let Some(environment_name) = value
+            .strip_prefix(consts::ENVIRONMENT_FEATURE_PREFIX)
+            .and_then(|name| EnvironmentName::from_str(name).ok())
+        {
+            FeatureName::Environment(environment_name)
         } else {
             FeatureName::Named(value)
         }
@@ -60,11 +64,22 @@ impl From<String> for FeatureName {
 }
 
 impl FeatureName {
+    /// Constructs the implicit feature name for the inline content of an
+    /// environment, e.g. `env:dev` for the environment `dev`.
+    pub fn environment(name: &EnvironmentName) -> Self {
+        FeatureName::Environment(name.clone())
+    }
+
     /// Returns the string representation of the feature.
+    ///
+    /// For an environment feature this is the bare environment name; use the
+    /// [`fmt::Display`] implementation to get the canonical representation
+    /// including the `env:` prefix.
     pub fn as_str(&self) -> &str {
         match self {
             FeatureName::Default => consts::DEFAULT_FEATURE_NAME,
             FeatureName::Named(name) => name,
+            FeatureName::Environment(name) => name.as_str(),
         }
     }
 
@@ -73,9 +88,44 @@ impl FeatureName {
         matches!(self, FeatureName::Default)
     }
 
+    /// Returns true if this is an implicit feature synthesized for an
+    /// environment that defines feature content inline.
+    pub fn is_environment(&self) -> bool {
+        matches!(self, FeatureName::Environment(_))
+    }
+
+    /// Returns the name of the environment this feature was synthesized for, if
+    /// it is an environment feature.
+    pub fn environment_name(&self) -> Option<&EnvironmentName> {
+        match self {
+            FeatureName::Environment(name) => Some(name),
+            _ => None,
+        }
+    }
+
     /// Returns the name of the feature if it is not default.
     pub fn non_default(&self) -> Option<&str> {
         self.is_default().not().then(|| self.as_str())
+    }
+
+    /// Renders the feature for user-facing diagnostics, describing an
+    /// environment feature as `environment '<name>'` and any other feature as
+    /// `feature '<name>'`.
+    pub fn user_facing(&self) -> UserFacingFeatureName<'_> {
+        UserFacingFeatureName(self)
+    }
+}
+
+/// Helper returned by [`FeatureName::user_facing`] that renders a feature name
+/// for diagnostics without exposing the internal `env:` prefix.
+pub struct UserFacingFeatureName<'a>(&'a FeatureName);
+
+impl fmt::Display for UserFacingFeatureName<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            FeatureName::Environment(name) => write!(f, "environment '{name}'"),
+            _ => write!(f, "feature '{}'", self.0.as_str()),
+        }
     }
 }
 
@@ -92,29 +142,47 @@ impl PartialEq<&str> for FeatureName {
 }
 
 impl FromStr for FeatureName {
-    type Err = Infallible;
+    type Err = ParseFeatureNameError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with(consts::ENVIRONMENT_FEATURE_PREFIX) {
+            return Err(ParseFeatureNameError);
+        }
         Ok(FeatureName::from(s))
     }
 }
+
+/// Error returned when parsing a [`FeatureName`] from user input that uses the
+/// reserved `env:` prefix.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error(
+    "feature names starting with '{}' are reserved for environments that define their content inline",
+    consts::ENVIRONMENT_FEATURE_PREFIX
+)]
+pub struct ParseFeatureNameError;
 
 impl From<FeatureName> for String {
     fn from(name: FeatureName) -> Self {
         match name {
             FeatureName::Default => consts::DEFAULT_FEATURE_NAME.to_owned(),
             FeatureName::Named(name) => name,
+            FeatureName::Environment(_) => name.to_string(),
         }
     }
 }
 impl<'a> From<&'a FeatureName> for String {
     fn from(name: &'a FeatureName) -> Self {
-        name.as_str().to_owned()
+        name.to_string()
     }
 }
 impl fmt::Display for FeatureName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        match self {
+            FeatureName::Environment(name) => {
+                write!(f, "{}{}", consts::ENVIRONMENT_FEATURE_PREFIX, name.as_str())
+            }
+            _ => write!(f, "{}", self.as_str()),
+        }
     }
 }
 
@@ -510,6 +578,37 @@ mod tests {
 
     use super::*;
     use crate::WorkspaceManifest;
+
+    #[test]
+    fn test_environment_feature_name() {
+        let environment = EnvironmentName::Named("dev".to_string());
+        let name = FeatureName::environment(&environment);
+        assert_eq!(name.to_string(), "env:dev");
+        assert_eq!(name.as_str(), "dev");
+        assert!(name.is_environment());
+        assert!(!name.is_default());
+        assert_eq!(name.environment_name(), Some(&environment));
+        assert_eq!(name.user_facing().to_string(), "environment 'dev'");
+
+        // The canonical representation round-trips through `From<String>`.
+        assert_eq!(FeatureName::from(name.to_string()), name);
+        // User input cannot use the reserved prefix.
+        assert!("env:dev".parse::<FeatureName>().is_err());
+    }
+
+    #[test]
+    fn test_regular_feature_name_is_not_environment() {
+        let name = FeatureName::from("dev");
+        assert!(!name.is_environment());
+        assert_eq!(name.environment_name(), None);
+        assert_eq!(name.user_facing().to_string(), "feature 'dev'");
+
+        // A feature whose name merely starts with `env` (but not `env:`) is a
+        // normal feature.
+        let name = FeatureName::from("environment");
+        assert!(!name.is_environment());
+        assert_eq!(name.environment_name(), None);
+    }
 
     #[test]
     fn test_dependencies_borrowed() {

--- a/crates/pixi_manifest/src/feature.rs
+++ b/crates/pixi_manifest/src/feature.rs
@@ -21,9 +21,9 @@ pub enum FeatureName {
     Default,
     Named(String),
     /// The implicit feature that is synthesized for an environment which
-    /// defines feature content (like dependencies) inline. It is displayed
-    /// with the reserved `env:` prefix, e.g. `env:dev` for the environment
-    /// `dev`.
+    /// defines feature content (like dependencies) inline. It is an
+    /// implementation detail and never shown to the user as a feature;
+    /// diagnostics render it via [`FeatureName::user_facing`].
     Environment(EnvironmentName),
 }
 
@@ -52,11 +52,6 @@ impl From<String> for FeatureName {
     fn from(value: String) -> Self {
         if value == consts::DEFAULT_FEATURE_NAME {
             FeatureName::Default
-        } else if let Some(environment_name) = value
-            .strip_prefix(consts::ENVIRONMENT_FEATURE_PREFIX)
-            .and_then(|name| EnvironmentName::from_str(name).ok())
-        {
-            FeatureName::Environment(environment_name)
         } else {
             FeatureName::Named(value)
         }
@@ -65,16 +60,14 @@ impl From<String> for FeatureName {
 
 impl FeatureName {
     /// Constructs the implicit feature name for the inline content of an
-    /// environment, e.g. `env:dev` for the environment `dev`.
+    /// environment.
     pub fn environment(name: &EnvironmentName) -> Self {
         FeatureName::Environment(name.clone())
     }
 
     /// Returns the string representation of the feature.
     ///
-    /// For an environment feature this is the bare environment name; use the
-    /// [`fmt::Display`] implementation to get the canonical representation
-    /// including the `env:` prefix.
+    /// For an environment feature this is the bare environment name.
     pub fn as_str(&self) -> &str {
         match self {
             FeatureName::Default => consts::DEFAULT_FEATURE_NAME,
@@ -117,7 +110,8 @@ impl FeatureName {
 }
 
 /// Helper returned by [`FeatureName::user_facing`] that renders a feature name
-/// for diagnostics without exposing the internal `env:` prefix.
+/// for diagnostics, describing a synthesized environment feature as an
+/// environment rather than a feature.
 pub struct UserFacingFeatureName<'a>(&'a FeatureName);
 
 impl fmt::Display for UserFacingFeatureName<'_> {
@@ -142,31 +136,19 @@ impl PartialEq<&str> for FeatureName {
 }
 
 impl FromStr for FeatureName {
-    type Err = ParseFeatureNameError;
+    type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.starts_with(consts::ENVIRONMENT_FEATURE_PREFIX) {
-            return Err(ParseFeatureNameError);
-        }
         Ok(FeatureName::from(s))
     }
 }
-
-/// Error returned when parsing a [`FeatureName`] from user input that uses the
-/// reserved `env:` prefix.
-#[derive(Debug, Clone, thiserror::Error)]
-#[error(
-    "feature names starting with '{}' are reserved for environments that define their content inline",
-    consts::ENVIRONMENT_FEATURE_PREFIX
-)]
-pub struct ParseFeatureNameError;
 
 impl From<FeatureName> for String {
     fn from(name: FeatureName) -> Self {
         match name {
             FeatureName::Default => consts::DEFAULT_FEATURE_NAME.to_owned(),
             FeatureName::Named(name) => name,
-            FeatureName::Environment(_) => name.to_string(),
+            FeatureName::Environment(name) => name.as_str().to_owned(),
         }
     }
 }
@@ -177,12 +159,7 @@ impl<'a> From<&'a FeatureName> for String {
 }
 impl fmt::Display for FeatureName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FeatureName::Environment(name) => {
-                write!(f, "{}{}", consts::ENVIRONMENT_FEATURE_PREFIX, name.as_str())
-            }
-            _ => write!(f, "{}", self.as_str()),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -583,17 +560,15 @@ mod tests {
     fn test_environment_feature_name() {
         let environment = EnvironmentName::Named("dev".to_string());
         let name = FeatureName::environment(&environment);
-        assert_eq!(name.to_string(), "env:dev");
+        assert_eq!(name.to_string(), "dev");
         assert_eq!(name.as_str(), "dev");
         assert!(name.is_environment());
         assert!(!name.is_default());
         assert_eq!(name.environment_name(), Some(&environment));
         assert_eq!(name.user_facing().to_string(), "environment 'dev'");
 
-        // The canonical representation round-trips through `From<String>`.
-        assert_eq!(FeatureName::from(name.to_string()), name);
-        // User input cannot use the reserved prefix.
-        assert!("env:dev".parse::<FeatureName>().is_err());
+        // A regular feature with the same name is a distinct key.
+        assert_ne!(FeatureName::from("dev"), name);
     }
 
     #[test]
@@ -602,12 +577,6 @@ mod tests {
         assert!(!name.is_environment());
         assert_eq!(name.environment_name(), None);
         assert_eq!(name.user_facing().to_string(), "feature 'dev'");
-
-        // A feature whose name merely starts with `env` (but not `env:`) is a
-        // normal feature.
-        let name = FeatureName::from("environment");
-        assert!(!name.is_environment());
-        assert_eq!(name.environment_name(), None);
     }
 
     #[test]

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -36,7 +36,7 @@ pub use discovery::{
     DiscoveryStart, ExplicitManifestError, InvalidRequiresPixiError, LoadManifestsError, Manifests,
     PixiVersionMismatchError, WorkspaceDiscoverer, WorkspaceDiscoveryError,
 };
-pub use environment::{Environment, EnvironmentName};
+pub use environment::{Environment, EnvironmentName, NewEnvironment};
 pub use error::{DependencyError, TomlError};
 pub use feature::{Feature, FeatureName};
 pub use features_ext::FeaturesExt;

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -80,7 +80,7 @@ pub use crate::{
 /// Errors that can occur when getting a feature.
 #[derive(Debug, Clone, Error, Diagnostic)]
 pub enum GetFeatureError {
-    #[error("feature `{0}` does not exist")]
+    #[error("{} does not exist", .0.user_facing())]
     FeatureDoesNotExist(FeatureName),
 }
 

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use toml_edit::{Array, DocumentMut, Item, Table, Value, value};
 
 use crate::{
-    FeatureName, ManifestKind, ManifestProvenance, PixiPlatform, PixiPlatformName,
+    FeatureName, ManifestKind, ManifestProvenance, NewEnvironment, PixiPlatform, PixiPlatformName,
     PypiDependencyLocation, SpecType, TargetSelector, Task, TomlError,
     manifests::table_name::TableName, toml::TomlDocument, utils::WithSourceCode,
 };
@@ -662,15 +662,16 @@ impl ManifestDocument {
     }
 
     /// Adds an environment to the manifest
-    pub fn add_environment(
-        &mut self,
-        name: impl Into<String>,
-        features: Option<Vec<String>>,
-        solve_group: Option<String>,
-        no_default_features: bool,
-    ) -> Result<(), TomlError> {
+    pub fn add_environment(&mut self, environment: NewEnvironment) -> Result<(), TomlError> {
+        let NewEnvironment {
+            name,
+            features,
+            solve_group,
+            no_default_feature,
+        } = environment;
+
         // Construct the TOML value
-        let value = if solve_group.is_some() || no_default_features {
+        let value = if solve_group.is_some() || no_default_feature {
             let mut table = toml_edit::InlineTable::new();
             if let Some(features) = features {
                 table.insert("features", Array::from_iter(features).into());
@@ -678,7 +679,7 @@ impl ManifestDocument {
             if let Some(solve_group) = solve_group {
                 table.insert("solve-group", solve_group.into());
             }
-            if no_default_features {
+            if no_default_feature {
                 table.insert("no-default-feature", true.into());
             }
             Value::from(table)
@@ -695,7 +696,7 @@ impl ManifestDocument {
         let item = self
             .manifest_mut()
             .get_or_insert_nested_item(&env_table.as_keys())?;
-        pixi_toml_edit::upsert_entry(item, &name.into(), value)
+        pixi_toml_edit::upsert_entry(item, &name, value)
             .map_err(|_| TomlError::table_error("environments", &env_table.to_string()))?;
 
         Ok(())

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -701,6 +701,46 @@ impl ManifestDocument {
         Ok(())
     }
 
+    /// Replaces the `features` list of an existing environment entry while
+    /// leaving all other content of the entry (inline dependencies, tasks,
+    /// solve-group, ...) untouched.
+    pub fn update_environment_features(
+        &mut self,
+        name: &str,
+        features: Vec<String>,
+    ) -> Result<(), TomlError> {
+        let env_table = TableName::new()
+            .with_prefix(self.table_prefix())
+            .with_feature_name(Some(&FeatureName::Default))
+            .with_table(Some("environments"));
+
+        let table = self
+            .manifest_mut()
+            .get_or_insert_nested_table(&env_table.as_keys())?;
+        let features = Array::from_iter(features);
+        match table.get_mut(name) {
+            Some(item) => {
+                if let Some(entry) = item.as_table_like_mut() {
+                    if features.is_empty() {
+                        entry.remove("features");
+                        if entry.is_empty() {
+                            *item = Item::Value(Value::Array(Array::new()));
+                        }
+                    } else {
+                        entry.insert("features", Item::Value(features.into()));
+                    }
+                } else {
+                    // The environment is written as a plain array of features.
+                    *item = Item::Value(features.into());
+                }
+            }
+            None => {
+                table.insert(name, Item::Value(features.into()));
+            }
+        }
+        Ok(())
+    }
+
     /// Removes an environment from the manifest. Returns `true` if the
     /// environment was removed.
     pub fn remove_environment(&mut self, name: &str) -> Result<bool, TomlError> {

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -701,6 +701,47 @@ impl ManifestDocument {
         Ok(())
     }
 
+    /// Ensures the manifest entry of an environment is an explicit table so
+    /// that it can hold inline feature content. The shorthand forms
+    /// (`env = ["feature"]` and `env = { features = [...] }`) are converted;
+    /// a missing entry is left absent because nested table edits create the
+    /// table on demand.
+    pub fn ensure_environment_is_table(&mut self, name: &str) -> Result<(), TomlError> {
+        let env_table = TableName::new()
+            .with_prefix(self.table_prefix())
+            .with_feature_name(Some(&FeatureName::Default))
+            .with_table(Some("environments"));
+
+        let table = self
+            .manifest_mut()
+            .get_or_insert_nested_table(&env_table.as_keys())?;
+        let Some(item) = table.get_mut(name) else {
+            return Ok(());
+        };
+        match item {
+            Item::Value(Value::Array(features)) => {
+                let mut environment = Table::new();
+                if features.is_empty() {
+                    environment.set_implicit(true);
+                } else {
+                    environment.insert("features", Item::Value(Value::Array(features.clone())));
+                }
+                *item = Item::Table(environment);
+            }
+            Item::Value(Value::InlineTable(inline)) => {
+                *item = Item::Table(inline.clone().into_table());
+            }
+            _ => return Ok(()),
+        }
+        // The key kept the decor of its previous `key = value` form, which
+        // would leak whitespace into the rendered `[environments.<name>]`
+        // header.
+        if let Some(mut key) = table.key_mut(name) {
+            key.leaf_decor_mut().clear();
+        }
+        Ok(())
+    }
+
     /// Replaces the `features` list of an existing environment entry while
     /// leaving all other content of the entry (inline dependencies, tasks,
     /// solve-group, ...) untouched.

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -688,7 +688,7 @@ impl ManifestDocument {
 
         let env_table = TableName::new()
             .with_prefix(self.table_prefix())
-            .with_feature_name(Some(&FeatureName::DEFAULT))
+            .with_feature_name(Some(&FeatureName::Default))
             .with_table(Some("environments"));
 
         // Insert into the environment table
@@ -706,7 +706,7 @@ impl ManifestDocument {
     pub fn remove_environment(&mut self, name: &str) -> Result<bool, TomlError> {
         let env_table = TableName::new()
             .with_prefix(self.table_prefix())
-            .with_feature_name(Some(&FeatureName::DEFAULT))
+            .with_feature_name(Some(&FeatureName::Default))
             .with_table(Some("environments"));
 
         let item = self

--- a/crates/pixi_manifest/src/manifests/source.rs
+++ b/crates/pixi_manifest/src/manifests/source.rs
@@ -68,41 +68,48 @@ mod test {
     use insta::assert_snapshot;
     use rstest::rstest;
 
-    use crate::manifests::document::ManifestDocument;
+    use crate::{NewEnvironment, manifests::document::ManifestDocument};
 
     #[rstest]
     #[case::pixi_toml(ManifestDocument::empty_pixi())]
     #[case::pyproject_toml(ManifestDocument::empty_pyproject())]
     fn test_add_environment(#[case] mut source: ManifestDocument) {
         source
-            .add_environment("foo", Some(vec![]), None, false)
-            .unwrap();
-        source
-            .add_environment("bar", Some(vec![String::from("default")]), None, false)
+            .add_environment(NewEnvironment::new("foo").with_features(vec![]))
             .unwrap();
         source
             .add_environment(
-                "baz",
-                Some(vec![String::from("default")]),
-                Some(String::from("group1")),
-                false,
+                NewEnvironment::new("bar").with_features(vec![String::from("default")]),
             )
             .unwrap();
         source
             .add_environment(
-                "foobar",
-                Some(vec![String::from("default")]),
-                Some(String::from("group1")),
-                true,
+                NewEnvironment::new("baz")
+                    .with_features(vec![String::from("default")])
+                    .with_solve_group(String::from("group1")),
             )
             .unwrap();
         source
-            .add_environment("barfoo", Some(vec![String::from("default")]), None, true)
+            .add_environment(
+                NewEnvironment::new("foobar")
+                    .with_features(vec![String::from("default")])
+                    .with_solve_group(String::from("group1"))
+                    .with_no_default_feature(true),
+            )
+            .unwrap();
+        source
+            .add_environment(
+                NewEnvironment::new("barfoo")
+                    .with_features(vec![String::from("default")])
+                    .with_no_default_feature(true),
+            )
             .unwrap();
 
         // Overwrite
         source
-            .add_environment("bar", Some(vec![String::from("not-default")]), None, false)
+            .add_environment(
+                NewEnvironment::new("bar").with_features(vec![String::from("not-default")]),
+            )
             .unwrap();
 
         assert_snapshot!(
@@ -116,14 +123,20 @@ mod test {
     #[case::pyproject_toml(ManifestDocument::empty_pyproject())]
     fn test_remove_environment(#[case] mut source: ManifestDocument) {
         source
-            .add_environment("foo", Some(vec![String::from("default")]), None, false)
+            .add_environment(
+                NewEnvironment::new("foo").with_features(vec![String::from("default")]),
+            )
             .unwrap();
         source
-            .add_environment("bar", Some(vec![String::from("default")]), None, false)
+            .add_environment(
+                NewEnvironment::new("bar").with_features(vec![String::from("default")]),
+            )
             .unwrap();
         assert!(!source.remove_environment("default").unwrap());
         source
-            .add_environment("default", Some(vec![String::from("default")]), None, false)
+            .add_environment(
+                NewEnvironment::new("default").with_features(vec![String::from("default")]),
+            )
             .unwrap();
         assert!(source.remove_environment("default").unwrap());
         assert!(source.remove_environment("foo").unwrap());

--- a/crates/pixi_manifest/src/manifests/table_name.rs
+++ b/crates/pixi_manifest/src/manifests/table_name.rs
@@ -142,7 +142,7 @@ mod tests {
         assert_eq!(
             "dependencies".to_string(),
             TableName::new()
-                .with_feature_name(Some(&FeatureName::DEFAULT))
+                .with_feature_name(Some(&FeatureName::Default))
                 .with_table(Some("dependencies"))
                 .to_string()
         );
@@ -150,7 +150,7 @@ mod tests {
         assert_eq!(
             "target.linux-64.dependencies".to_string(),
             TableName::new()
-                .with_feature_name(Some(&FeatureName::DEFAULT))
+                .with_feature_name(Some(&FeatureName::Default))
                 .with_target(Some(TargetSelector::Subdir(
                     rattler_conda_types::Platform::Linux64,
                 )))

--- a/crates/pixi_manifest/src/manifests/table_name.rs
+++ b/crates/pixi_manifest/src/manifests/table_name.rs
@@ -63,18 +63,19 @@ impl TableName<'_> {
             keys.extend(prefix.split('.'));
         }
 
-        if self
-            .feature_name
-            .as_ref()
-            .is_some_and(|feature_name| !feature_name.is_default())
-        {
-            keys.push("feature");
-            keys.push(
-                self.feature_name
-                    .as_ref()
-                    .expect("we already verified")
-                    .as_str(),
-            );
+        match self.feature_name {
+            // The feature synthesized for an environment that defines its
+            // content inline lives under `[environments.<name>]`, not under
+            // `[feature.<name>]`.
+            Some(FeatureName::Environment(environment_name)) => {
+                keys.push("environments");
+                keys.push(environment_name.as_str());
+            }
+            Some(feature_name) if !feature_name.is_default() => {
+                keys.push("feature");
+                keys.push(feature_name.as_str());
+            }
+            _ => {}
         }
         if let Some(target) = &self.target {
             keys.push("target");
@@ -171,6 +172,29 @@ mod tests {
             "feature.test.target.linux-64.dependencies".to_string(),
             TableName::new()
                 .with_feature_name(Some(&feature_name))
+                .with_target(Some(TargetSelector::Subdir(
+                    rattler_conda_types::Platform::Linux64,
+                )))
+                .with_table(Some("dependencies"))
+                .to_string()
+        );
+
+        // The feature synthesized for an environment maps to the environment
+        // table instead of a feature table.
+        let environment_feature =
+            FeatureName::environment(&crate::EnvironmentName::Named("dev".to_string()));
+        assert_eq!(
+            "environments.dev.dependencies".to_string(),
+            TableName::new()
+                .with_feature_name(Some(&environment_feature))
+                .with_table(Some("dependencies"))
+                .to_string()
+        );
+
+        assert_eq!(
+            "environments.dev.target.linux-64.dependencies".to_string(),
+            TableName::new()
+                .with_feature_name(Some(&environment_feature))
                 .with_target(Some(TargetSelector::Subdir(
                     rattler_conda_types::Platform::Linux64,
                 )))

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -363,8 +363,15 @@ impl WorkspaceManifestMut<'_> {
         solve_group: Option<String>,
         no_default_feature: bool,
     ) -> miette::Result<()> {
-        // Make sure the features exist
+        // Make sure the features exist and can be referenced
         for feature in features.iter().flatten() {
+            if feature.starts_with(consts::ENVIRONMENT_FEATURE_PREFIX) {
+                return Err(miette!(
+                    help = "Content defined inline on an environment is private to that environment. Define a named feature to share content between environments.",
+                    "the feature '{feature}' cannot be referenced: names starting with '{}' refer to content defined inline on an environment",
+                    consts::ENVIRONMENT_FEATURE_PREFIX,
+                ));
+            }
             if self
                 .workspace
                 .features
@@ -389,6 +396,58 @@ impl WorkspaceManifestMut<'_> {
                 .into_iter()
                 .map(FeatureName::from)
                 .collect(),
+            solve_group: None,
+            no_default_feature,
+        });
+
+        if let Some(solve_group) = solve_group {
+            self.workspace
+                .solve_groups
+                .add(solve_group, environment_idx);
+        }
+
+        Ok(())
+    }
+
+    /// Replaces the features of an existing environment while preserving all
+    /// other content of its manifest entry, in particular content defined
+    /// inline on the environment. The feature synthesized for inline content
+    /// is kept in memory but never written to the manifest.
+    ///
+    /// This function modifies both the workspace and the TOML document. Use
+    /// `ManifestProvenance::save` to persist the changes to disk.
+    pub fn update_environment_features(
+        &mut self,
+        name: &EnvironmentName,
+        features: Vec<FeatureName>,
+    ) -> miette::Result<()> {
+        // Make sure the referenced features exist
+        for feature in &features {
+            if !feature.is_environment() && self.workspace.features.get(feature).is_none() {
+                return Err(UnknownFeature::new(feature.to_string(), &*self.workspace).into());
+            }
+        }
+
+        let Some(environment) = self.workspace.environments.find(name) else {
+            return Err(miette!("the environment '{name}' does not exist"));
+        };
+        let solve_group = environment
+            .solve_group
+            .map(|idx| self.workspace.solve_groups[idx].name.clone());
+        let no_default_feature = environment.no_default_feature;
+
+        self.document.update_environment_features(
+            name.as_str(),
+            features
+                .iter()
+                .filter(|feature| !feature.is_environment())
+                .map(|feature| feature.as_str().to_owned())
+                .collect(),
+        )?;
+
+        let environment_idx = self.workspace.environments.add(Environment {
+            name: name.clone(),
+            features,
             solve_group: None,
             no_default_feature,
         });
@@ -472,17 +531,16 @@ impl WorkspaceManifestMut<'_> {
                 .solve_group
                 .map(|idx| self.workspace.solve_groups[idx].name.clone());
 
-            // Update the environment, minus the removed feature
-            self.document.add_environment(
-                env.name.to_string(),
-                Some(
-                    updated_features
-                        .iter()
-                        .map(|f| f.as_str().to_owned())
-                        .collect(),
-                ),
-                solve_group.clone(),
-                env.no_default_feature,
+            // Update the environment's feature list, minus the removed
+            // feature, without touching the rest of the entry. The feature
+            // synthesized for inline content is implicit and never written.
+            self.document.update_environment_features(
+                env.name.as_str(),
+                updated_features
+                    .iter()
+                    .filter(|f| !f.is_environment())
+                    .map(|f| f.as_str().to_owned())
+                    .collect(),
             )?;
 
             let environment_idx = self.workspace.environments.add(Environment {
@@ -4773,6 +4831,103 @@ boltons = { workspace = true }
         assert!(!toml.contains("[feature.test]"));
         assert!(!toml.contains("[feature.used]"));
         assert!(toml.contains("[feature.also-used]"));
+    }
+
+    #[test]
+    fn test_remove_feature_keeps_inline_environment_content() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[feature.shared.dependencies]
+some-package = "*"
+
+[environments.dev]
+features = ["shared"]
+dependencies = { other-package = "*" }
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let modified = manifest
+            .remove_feature(&FeatureName::from_str("shared").unwrap())
+            .unwrap();
+        assert_eq!(modified, vec![EnvironmentName::from_str("dev").unwrap()]);
+
+        // The content defined inline on the environment survives and the
+        // synthesized feature is not written to the feature list.
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev]
+        dependencies = { other-package = "*" }
+        "###);
+
+        // The resulting document must still be a valid manifest.
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_update_environment_features_preserves_inline_content() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[feature.extra.dependencies]
+some-package = "*"
+
+[environments.dev]
+dependencies = { other-package = "*" }
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        manifest
+            .update_environment_features(
+                &environment_name,
+                vec![
+                    FeatureName::environment(&environment_name),
+                    FeatureName::from("extra"),
+                ],
+            )
+            .unwrap();
+
+        // The synthesized feature stays implicit while the named feature is
+        // written next to the inline content.
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.extra.dependencies]
+        some-package = "*"
+
+        [environments.dev]
+        dependencies = { other-package = "*" }
+        features = ["extra"]
+        "###);
+
+        let env = manifest.workspace.environment("dev").unwrap();
+        assert_eq!(
+            env.features,
+            vec![
+                FeatureName::environment(&environment_name),
+                FeatureName::from("extra"),
+            ]
+        );
+
+        parse_pixi_toml(&manifest.document.to_string());
     }
 
     #[test]

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -1098,6 +1098,42 @@ impl WorkspaceManifestMut<'_> {
         Ok(())
     }
 
+    /// Ensures that the environment backing a synthesized environment feature
+    /// exists so that inline content can be written to it. A missing
+    /// environment is created on the fly, including the default feature; the
+    /// shorthand manifest forms are converted to an explicit table first.
+    fn ensure_inline_environment(&mut self, feature_name: &FeatureName) -> miette::Result<()> {
+        let Some(name) = feature_name.environment_name() else {
+            return Ok(());
+        };
+        if name.is_default() {
+            return Err(miette!(
+                help = "add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment",
+                "the 'default' environment cannot define its content inline"
+            ));
+        }
+
+        self.document.ensure_environment_is_table(name.as_str())?;
+
+        match self.workspace.environments.find(name) {
+            None => {
+                self.workspace.environments.add(Environment {
+                    name: name.clone(),
+                    features: vec![feature_name.clone()],
+                    solve_group: None,
+                    no_default_feature: false,
+                });
+            }
+            Some(environment) if !environment.features.contains(feature_name) => {
+                let mut environment = environment.clone();
+                environment.features.insert(0, feature_name.clone());
+                self.workspace.environments.add(environment);
+            }
+            Some(_) => {}
+        }
+        Ok(())
+    }
+
     /// Add a pixi spec to the manifest
     ///
     /// This function modifies both the workspace and the TOML document. Use
@@ -1111,6 +1147,7 @@ impl WorkspaceManifestMut<'_> {
         feature_name: &FeatureName,
         overwrite_behavior: DependencyOverwriteBehavior,
     ) -> miette::Result<AddDependencyOutcome> {
+        self.ensure_inline_environment(feature_name)?;
         let mut any_added = false;
         let mut any_inherited = false;
         for target in to_target_options(targets) {
@@ -1187,6 +1224,9 @@ impl WorkspaceManifestMut<'_> {
         platforms: &[PixiPlatformName],
         feature_name: &FeatureName,
     ) -> Result<(), RemoveDependencyError> {
+        if self.workspace.features.get(feature_name).is_none() {
+            return Err(MissingTargetError::new(None, feature_name, consts::DEPENDENCIES).into());
+        }
         let mut any_removed = false;
         for platform_name in to_options(platforms) {
             let selector = self.platform_target_selector(platform_name.as_ref());
@@ -1233,6 +1273,7 @@ impl WorkspaceManifestMut<'_> {
         overwrite_behavior: DependencyOverwriteBehavior,
         location: Option<PypiDependencyLocation>,
     ) -> miette::Result<bool> {
+        self.ensure_inline_environment(feature_name)?;
         let mut any_added = false;
         for target in to_target_options(targets) {
             match self
@@ -1272,6 +1313,11 @@ impl WorkspaceManifestMut<'_> {
         platforms: &[PixiPlatformName],
         feature_name: &FeatureName,
     ) -> Result<(), RemoveDependencyError> {
+        if self.workspace.features.get(feature_name).is_none() {
+            return Err(
+                MissingTargetError::new(None, feature_name, consts::PYPI_DEPENDENCIES).into(),
+            );
+        }
         let mut any_removed = false;
         for platform_name in to_options(platforms) {
             let selector = self.platform_target_selector(platform_name.as_ref());
@@ -1604,10 +1650,14 @@ impl std::fmt::Display for MissingTargetError {
         match &self.platform {
             Some(platform) => write!(
                 f,
-                "No target for feature `{}` found on platform `{platform}`",
-                self.feature_name
+                "No target for {} found on platform `{platform}`",
+                self.feature_name.user_facing()
             ),
-            None => write!(f, "No default target for feature `{}`", self.feature_name),
+            None => write!(
+                f,
+                "No default target for {}",
+                self.feature_name.user_facing()
+            ),
         }
     }
 }
@@ -1624,6 +1674,11 @@ impl miette::Diagnostic for MissingTargetError {
             format!(
                 "Expected target for `{name}`, e.g.: `[{target_path}{section}]`",
                 name = self.feature_name,
+                section = self.section,
+            )
+        } else if let Some(environment) = self.feature_name.environment_name() {
+            format!(
+                "Expected target for environment '{environment}', e.g.: `[environments.{environment}.{target_path}{section}]`",
                 section = self.section,
             )
         } else {
@@ -4919,6 +4974,325 @@ dependencies = { other-package = "*" }
                 FeatureName::from("extra"),
             ]
         );
+
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    /// Adds a conda spec to an inline environment via its synthesized
+    /// feature. Both the parsed workspace and the argument are given so the
+    /// helper works for existing and freshly created environments.
+    fn add_dependency_to_environment(
+        manifest: &mut WorkspaceManifestMut<'_>,
+        spec: &str,
+        environment_name: &EnvironmentName,
+    ) -> miette::Result<AddDependencyOutcome> {
+        let (name, spec) = MatchSpec::from_str(spec, Strict).unwrap().into_nameless();
+        let spec = PixiSpec::from_nameless_matchspec(spec, &default_channel_config());
+        manifest.add_dependency(
+            name.as_exact().unwrap(),
+            &spec,
+            SpecType::Run,
+            &[],
+            &FeatureName::environment(environment_name),
+            DependencyOverwriteBehavior::Overwrite,
+        )
+    }
+
+    #[test]
+    fn test_add_dependency_to_inline_environment() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[environments.dev]
+dependencies = { other-package = "*" }
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        add_dependency_to_environment(&mut manifest, "numpy >=1.21", &environment_name).unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r#"
+
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev]
+        dependencies = { other-package = "*", numpy = ">=1.21" }
+        "#);
+
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_add_dependency_creates_inline_environment() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        add_dependency_to_environment(&mut manifest, "numpy >=1.21", &environment_name).unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.dependencies]
+        numpy = ">=1.21"
+        "###);
+
+        // The created environment carries the synthesized feature and still
+        // includes the default feature.
+        let environment = manifest.workspace.environment("dev").unwrap();
+        assert_eq!(
+            environment.features,
+            vec![FeatureName::environment(&environment_name)]
+        );
+        assert!(!environment.no_default_feature);
+
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_add_dependency_converts_environment_list_form() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[feature.lint.dependencies]
+ruff = "*"
+
+[environments]
+dev = ["lint"]
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        add_dependency_to_environment(&mut manifest, "numpy >=1.21", &environment_name).unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.lint.dependencies]
+        ruff = "*"
+
+        [environments.dev]
+        features = ["lint"]
+
+        [environments.dev.dependencies]
+        numpy = ">=1.21"
+        "###);
+
+        let environment = manifest.workspace.environment("dev").unwrap();
+        assert_eq!(
+            environment.features,
+            vec![
+                FeatureName::environment(&environment_name),
+                FeatureName::from("lint"),
+            ]
+        );
+
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_add_dependency_converts_environment_inline_table_form() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[feature.lint.dependencies]
+ruff = "*"
+
+[environments]
+dev = { features = ["lint"], no-default-feature = true }
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        add_dependency_to_environment(&mut manifest, "numpy >=1.21", &environment_name).unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.lint.dependencies]
+        ruff = "*"
+
+        [environments.dev]
+        features = ["lint"]
+        no-default-feature = true
+
+        [environments.dev.dependencies]
+        numpy = ">=1.21"
+        "###);
+
+        let environment = manifest.workspace.environment("dev").unwrap();
+        assert!(environment.no_default_feature);
+
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_add_dependency_to_default_environment_inline_errors() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let error =
+            add_dependency_to_environment(&mut manifest, "numpy >=1.21", &EnvironmentName::Default)
+                .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "the 'default' environment cannot define its content inline"
+        );
+    }
+
+    #[test]
+    fn test_remove_dependency_from_inline_environment() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[environments.dev.dependencies]
+numpy = ">=1.21"
+other-package = "*"
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        manifest
+            .remove_dependency(
+                &PackageName::from_str("numpy").unwrap(),
+                SpecType::Run,
+                &[],
+                &FeatureName::environment(&environment_name),
+            )
+            .unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.dependencies]
+        other-package = "*"
+        "###);
+
+        parse_pixi_toml(&manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_remove_dependency_from_environment_without_inline_content_errors() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[feature.lint.dependencies]
+ruff = "*"
+
+[environments]
+dev = ["lint"]
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        let error = manifest
+            .remove_dependency(
+                &PackageName::from_str("ruff").unwrap(),
+                SpecType::Run,
+                &[],
+                &FeatureName::environment(&environment_name),
+            )
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "No default target for environment 'dev'"
+        );
+    }
+
+    #[test]
+    fn test_add_pypi_dependency_to_inline_environment() {
+        let contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[environments.dev]
+dependencies = { python = "*" }
+"#;
+
+        let mut manifest = parse_pixi_toml(contents);
+        let mut manifest = manifest.editable();
+
+        let environment_name = EnvironmentName::from_str("dev").unwrap();
+        let requirement = pep508_rs::Requirement::from_str("numpy>=1.21").unwrap();
+        manifest
+            .add_pep508_dependency(
+                (&requirement, None),
+                &[],
+                &FeatureName::environment(&environment_name),
+                None,
+                DependencyOverwriteBehavior::Overwrite,
+                None,
+            )
+            .unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev]
+        dependencies = { python = "*" }
+
+        [environments.dev.pypi-dependencies]
+        numpy = ">=1.21"
+        "###);
 
         parse_pixi_toml(&manifest.document.to_string());
     }

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -365,13 +365,6 @@ impl WorkspaceManifestMut<'_> {
     ) -> miette::Result<()> {
         // Make sure the features exist and can be referenced
         for feature in features.iter().flatten() {
-            if feature.starts_with(consts::ENVIRONMENT_FEATURE_PREFIX) {
-                return Err(miette!(
-                    help = "Content defined inline on an environment is private to that environment. Define a named feature to share content between environments.",
-                    "the feature '{feature}' cannot be referenced: names starting with '{}' refer to content defined inline on an environment",
-                    consts::ENVIRONMENT_FEATURE_PREFIX,
-                ));
-            }
             if self
                 .workspace
                 .features

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -21,7 +21,7 @@ use crate::{
     PixiPlatformName, PlatformEdit, PlatformMove, Preview, PrioritizedChannel,
     PypiDependencyLocation, SpecType, TargetSelector, Task, TaskName, TomlError, WorkspaceTarget,
     consts,
-    environment::{Environment, EnvironmentName},
+    environment::{Environment, EnvironmentName, NewEnvironment},
     environments::Environments,
     error::{DependencyError, UnknownFeature},
     feature::{Feature, FeatureName},
@@ -358,15 +358,9 @@ impl WorkspaceManifestMut<'_> {
     ///
     /// This function modifies both the workspace and the TOML document. Use
     /// `ManifestProvenance::save` to persist the changes to disk.
-    pub fn add_environment(
-        &mut self,
-        name: String,
-        features: Option<Vec<String>>,
-        solve_group: Option<String>,
-        no_default_feature: bool,
-    ) -> miette::Result<()> {
+    pub fn add_environment(&mut self, environment: NewEnvironment) -> miette::Result<()> {
         // Make sure the features exist and can be referenced
-        for feature in features.iter().flatten() {
+        for feature in environment.features.iter().flatten() {
             if self
                 .workspace
                 .features
@@ -377,12 +371,14 @@ impl WorkspaceManifestMut<'_> {
             }
         }
 
-        self.document.add_environment(
-            name.clone(),
-            features.clone(),
-            solve_group.clone(),
+        self.document.add_environment(environment.clone())?;
+
+        let NewEnvironment {
+            name,
+            features,
+            solve_group,
             no_default_feature,
-        )?;
+        } = environment;
 
         let environment_idx = self.workspace.environments.add(Environment {
             name: EnvironmentName::Named(name),
@@ -4710,7 +4706,7 @@ boltons = { workspace = true }
         let mut manifest = manifest.editable();
 
         manifest
-            .add_environment(String::from("test"), Some(Vec::new()), None, false)
+            .add_environment(NewEnvironment::new("test").with_features(Vec::new()))
             .unwrap();
         assert!(manifest.workspace.environment("test").is_some());
     }
@@ -4732,10 +4728,7 @@ boltons = { workspace = true }
 
         manifest
             .add_environment(
-                String::from("test"),
-                Some(vec![String::from("foobar")]),
-                None,
-                false,
+                NewEnvironment::new("test").with_features(vec![String::from("foobar")]),
             )
             .unwrap();
         assert!(manifest.workspace.environment("test").is_some());
@@ -4758,10 +4751,7 @@ boltons = { workspace = true }
 
         let err = manifest
             .add_environment(
-                String::from("test"),
-                Some(vec![String::from("non-existing")]),
-                None,
-                false,
+                NewEnvironment::new("test").with_features(vec![String::from("non-existing")]),
             )
             .unwrap_err();
 

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -105,7 +105,7 @@ impl WorkspaceManifest {
         let mut features: Vec<&Feature> = environment
             .features
             .iter()
-            .filter_map(|name| self.features.get(&FeatureName::from(name.clone())))
+            .filter_map(|name| self.features.get(name))
             .collect();
         if !environment.no_default_feature {
             features.push(self.default_feature());
@@ -133,14 +133,14 @@ impl WorkspaceManifest {
     /// of the project manifest.
     pub fn default_feature(&self) -> &Feature {
         self.features
-            .get(&FeatureName::DEFAULT)
+            .get(&FeatureName::Default)
             .expect("default feature should always exist")
     }
 
     /// Returns a mutable reference to the default feature.
     pub(crate) fn default_feature_mut(&mut self) -> &mut Feature {
         self.features
-            .get_mut(&FeatureName::DEFAULT)
+            .get_mut(&FeatureName::Default)
             .expect("default feature should always exist")
     }
 
@@ -365,7 +365,12 @@ impl WorkspaceManifestMut<'_> {
     ) -> miette::Result<()> {
         // Make sure the features exist
         for feature in features.iter().flatten() {
-            if self.workspace.features.get(feature.as_str()).is_none() {
+            if self
+                .workspace
+                .features
+                .get(&FeatureName::from(feature.as_str()))
+                .is_none()
+            {
                 return Err(UnknownFeature::new(feature.to_string(), &*self.workspace).into());
             }
         }
@@ -379,7 +384,11 @@ impl WorkspaceManifestMut<'_> {
 
         let environment_idx = self.workspace.environments.add(Environment {
             name: EnvironmentName::Named(name),
-            features: features.unwrap_or_default(),
+            features: features
+                .unwrap_or_default()
+                .into_iter()
+                .map(FeatureName::from)
+                .collect(),
             solve_group: None,
             no_default_feature,
         });
@@ -447,15 +456,15 @@ impl WorkspaceManifestMut<'_> {
             .workspace
             .environments
             .iter()
-            .filter(|env| env.features.contains(&feature_name.to_string()))
+            .filter(|env| env.features.contains(feature_name))
             .cloned()
             .collect();
 
         for env in &environments_using_feature {
-            let updated_features: Vec<String> = env
+            let updated_features: Vec<FeatureName> = env
                 .features
                 .iter()
-                .filter(|f| f.as_str() != feature_name.to_string())
+                .filter(|f| *f != feature_name)
                 .cloned()
                 .collect();
 
@@ -466,7 +475,12 @@ impl WorkspaceManifestMut<'_> {
             // Update the environment, minus the removed feature
             self.document.add_environment(
                 env.name.to_string(),
-                Some(updated_features.clone()),
+                Some(
+                    updated_features
+                        .iter()
+                        .map(|f| f.as_str().to_owned())
+                        .collect(),
+                ),
                 solve_group.clone(),
                 env.no_default_feature,
             )?;
@@ -968,7 +982,7 @@ impl WorkspaceManifestMut<'_> {
         // for the entries that survive.
         let array = self
             .document
-            .get_array_mut("platforms", &FeatureName::DEFAULT)?;
+            .get_array_mut("platforms", &FeatureName::Default)?;
         pixi_toml_edit::retain_array_elements(array, |item| {
             let entry_name = if let Some(s) = item.as_str() {
                 Some(s)
@@ -1788,7 +1802,7 @@ start = "python -m flask run --port=5050"
             .add_pep508_dependency(
                 (&requirement, None),
                 &[],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 None,
                 DependencyOverwriteBehavior::Overwrite,
                 None,
@@ -1847,7 +1861,7 @@ start = "python -m flask run --port=5050"
         // Remove flask from pyproject
         let name = PypiPackageName::from_str("flask").unwrap();
         manifest
-            .remove_pypi_dependency(&name, &[], &FeatureName::DEFAULT)
+            .remove_pypi_dependency(&name, &[], &FeatureName::Default)
             .unwrap();
 
         assert!(
@@ -2566,21 +2580,21 @@ foo = "1.0"
             "baz",
             SpecType::Build,
             &[Platform::Linux64],
-            &FeatureName::DEFAULT,
+            &FeatureName::Default,
         );
         test_remove(
             file_contents,
             "bar",
             SpecType::Run,
             &[Platform::Win64],
-            &FeatureName::DEFAULT,
+            &FeatureName::Default,
         );
         test_remove(
             file_contents,
             "fooz",
             SpecType::Run,
             &[],
-            &FeatureName::DEFAULT,
+            &FeatureName::Default,
         );
     }
 
@@ -2613,7 +2627,7 @@ foo = "1.0"
                 &PackageName::new_unchecked("fooz"),
                 SpecType::Run,
                 &[],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -2873,7 +2887,7 @@ feature_target_dep = "*"
         );
 
         manifest
-            .add_platforms([pp(Platform::OsxArm64)].iter(), &FeatureName::DEFAULT)
+            .add_platforms([pp(Platform::OsxArm64)].iter(), &FeatureName::Default)
             .unwrap();
 
         assert_eq!(
@@ -2959,7 +2973,7 @@ platforms = [
         editable
             .add_platforms(
                 [PixiPlatform::from_subdir(Platform::OsxArm64)].iter(),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -3122,7 +3136,7 @@ platforms = ["linux-64", "osx-64"]
             parse_pixi_toml("[workspace]\nname = \"x\"\nchannels = []\nplatforms = [\"win-64\"]\n");
         workspace
             .editable()
-            .add_platforms(std::iter::once(&candidate), &FeatureName::DEFAULT)
+            .add_platforms(std::iter::once(&candidate), &FeatureName::Default)
             .unwrap();
         let doc = workspace.document.to_string();
 
@@ -3167,20 +3181,20 @@ platforms = ["linux-64", "osx-64"]
             parse_pixi_toml("[workspace]\nname = \"x\"\nchannels = []\nplatforms = [\"win-64\"]\n");
         workspace
             .editable()
-            .add_platforms(std::iter::once(&first), &FeatureName::DEFAULT)
+            .add_platforms(std::iter::once(&first), &FeatureName::Default)
             .unwrap();
 
         // Same subdir + virtual packages under a different name is rejected.
         let err = workspace
             .editable()
-            .add_platforms(std::iter::once(&second), &FeatureName::DEFAULT)
+            .add_platforms(std::iter::once(&second), &FeatureName::Default)
             .unwrap_err();
         assert!(err.to_string().contains("already declared as"), "{err}");
 
         // Re-adding the identical platform (same name + definition) is a no-op.
         workspace
             .editable()
-            .add_platforms(std::iter::once(&first), &FeatureName::DEFAULT)
+            .add_platforms(std::iter::once(&first), &FeatureName::Default)
             .unwrap();
     }
 
@@ -3269,7 +3283,7 @@ platforms = ["linux-64-cuda-12-9"]
         );
 
         manifest
-            .remove_platforms([pp(Platform::Linux64)].iter(), &FeatureName::DEFAULT)
+            .remove_platforms([pp(Platform::Linux64)].iter(), &FeatureName::Default)
             .unwrap();
 
         assert_eq!(
@@ -3359,7 +3373,7 @@ platforms = ["linux-64-cuda-12-9"]
 
         // Workspace-level remove of OsxArm64.
         manifest
-            .remove_platforms([pp(Platform::OsxArm64)].iter(), &FeatureName::DEFAULT)
+            .remove_platforms([pp(Platform::OsxArm64)].iter(), &FeatureName::Default)
             .unwrap();
 
         assert_eq!(
@@ -3485,7 +3499,7 @@ platforms = ["linux-64", "win-64"]
         let conda_forge =
             PrioritizedChannel::from(NamedChannelOrUrl::Name(String::from("conda-forge")));
         manifest
-            .add_channels([conda_forge.clone()], &FeatureName::DEFAULT, false)
+            .add_channels([conda_forge.clone()], &FeatureName::Default, false)
             .unwrap();
 
         let cuda_feature = FeatureName::from("cuda");
@@ -3519,7 +3533,7 @@ platforms = ["linux-64", "win-64"]
 
         // Try to add again, should not add more channels
         manifest
-            .add_channels([conda_forge.clone()], &FeatureName::DEFAULT, false)
+            .add_channels([conda_forge.clone()], &FeatureName::Default, false)
             .unwrap();
 
         assert_eq!(
@@ -3606,7 +3620,7 @@ platforms = ["linux-64", "win-64"]
             exclude_newer: None,
         };
         manifest
-            .add_channels([custom_channel.clone()], &FeatureName::DEFAULT, false)
+            .add_channels([custom_channel.clone()], &FeatureName::Default, false)
             .unwrap();
 
         assert!(
@@ -3625,7 +3639,7 @@ platforms = ["linux-64", "win-64"]
             exclude_newer: None,
         };
         manifest
-            .add_channels([prioritized_channel1.clone()], &FeatureName::DEFAULT, false)
+            .add_channels([prioritized_channel1.clone()], &FeatureName::Default, false)
             .unwrap();
 
         assert!(
@@ -3643,7 +3657,7 @@ platforms = ["linux-64", "win-64"]
             exclude_newer: None,
         };
         manifest
-            .add_channels([prioritized_channel2.clone()], &FeatureName::DEFAULT, false)
+            .add_channels([prioritized_channel2.clone()], &FeatureName::Default, false)
             .unwrap();
 
         assert!(
@@ -3693,7 +3707,7 @@ platforms = ["linux-64", "win-64"]
                     priority: None,
                     exclude_newer: None,
                 }],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -3728,7 +3742,7 @@ platforms = ["linux-64", "win-64"]
                         priority: None,
                         exclude_newer: None,
                     }],
-                    &FeatureName::DEFAULT,
+                    &FeatureName::Default,
                 )
                 .is_err()
         );
@@ -3755,7 +3769,7 @@ platforms = ["linux-64"]
                 [PrioritizedChannel::from(NamedChannelOrUrl::Name(
                     String::from("nvidia"),
                 ))],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 false,
             )
             .unwrap();
@@ -3793,7 +3807,7 @@ platforms = ["linux-64"]
                     priority: Some(10),
                     exclude_newer: None,
                 }],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 false,
             )
             .unwrap();
@@ -3832,7 +3846,7 @@ platforms = ["linux-64"]
                 [PrioritizedChannel::from(NamedChannelOrUrl::Name(
                     String::from("nvidia"),
                 ))],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 true,
             )
             .unwrap();
@@ -3870,7 +3884,7 @@ platforms = ["linux-64"]
                 [PrioritizedChannel::from(NamedChannelOrUrl::Name(
                     String::from("bioconda"),
                 ))],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -3906,7 +3920,7 @@ platforms = ["linux-64"]
                         .parse::<NamedChannelOrUrl>()
                         .unwrap(),
                 )],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -3942,7 +3956,7 @@ numpy = "*"
                 &rattler_conda_types::PackageName::from_str("httpx").unwrap(),
                 SpecType::Run,
                 &[],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -3979,7 +3993,7 @@ platforms = ["linux-64"]
                     priority: Some(10),
                     exclude_newer: None,
                 }],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 false,
             )
             .unwrap();
@@ -4011,7 +4025,7 @@ platforms = ["linux-64"]
                         .parse::<NamedChannelOrUrl>()
                         .unwrap(),
                 )],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -4310,7 +4324,7 @@ test = "test initial"
                 "default".into(),
                 Task::Plain("echo default".into()),
                 None,
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
         let linux64 = PixiPlatform::from_subdir(Platform::Linux64);
@@ -4319,7 +4333,7 @@ test = "test initial"
                 "target_linux".into(),
                 Task::Plain("echo target_linux".into()),
                 Some(&linux64),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
         manifest
@@ -4373,7 +4387,7 @@ bar = "*"
                 &spec,
                 SpecType::Run,
                 &[],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 DependencyOverwriteBehavior::Overwrite,
             )
             .unwrap();
@@ -4530,7 +4544,7 @@ boltons = { workspace = true }
                 &spec,
                 SpecType::Run,
                 &[],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 DependencyOverwriteBehavior::Overwrite,
             )
             .unwrap();
@@ -4558,7 +4572,7 @@ boltons = { workspace = true }
                 &spec,
                 SpecType::Run,
                 &[],
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
                 DependencyOverwriteBehavior::Overwrite,
             )
             .unwrap();
@@ -4709,7 +4723,12 @@ boltons = { workspace = true }
         assert!(modified.is_empty());
 
         // Check the feature was removed from the manifest
-        assert!(manifest.workspace.feature("test").is_none());
+        assert!(
+            manifest
+                .workspace
+                .feature(&FeatureName::from("test"))
+                .is_none()
+        );
 
         // Remove non-existent feature should succeed
         let result = manifest
@@ -4727,12 +4746,17 @@ boltons = { workspace = true }
         );
 
         // Check the feature was removed from the manifest
-        assert!(manifest.workspace.feature("used").is_none());
+        assert!(
+            manifest
+                .workspace
+                .feature(&FeatureName::from("used"))
+                .is_none()
+        );
 
         // Check the environment was updated (feature removed)
         let env = manifest.workspace.environment("test-env").unwrap();
-        assert!(!env.features.contains(&"used".to_string()));
-        assert!(env.features.contains(&"also-used".to_string()));
+        assert!(!env.features.contains(&FeatureName::from("used")));
+        assert!(env.features.contains(&FeatureName::from("also-used")));
 
         // Cannot remove default feature
         let result = manifest.remove_feature(&FeatureName::from_str("default").unwrap());
@@ -4775,7 +4799,7 @@ boltons = { workspace = true }
         assert!(manifest.default_feature().channel_priority.is_none());
         assert_eq!(
             manifest
-                .feature("strict")
+                .feature(&FeatureName::from("strict"))
                 .unwrap()
                 .channel_priority
                 .unwrap(),
@@ -4783,7 +4807,7 @@ boltons = { workspace = true }
         );
         assert_eq!(
             manifest
-                .feature("disabled")
+                .feature(&FeatureName::from("disabled"))
                 .unwrap()
                 .channel_priority
                 .unwrap(),
@@ -4820,7 +4844,7 @@ boltons = { workspace = true }
         // Add pytorch channel with prepend=true
         let pytorch = PrioritizedChannel::from(NamedChannelOrUrl::Name(String::from("pytorch")));
         manifest
-            .add_channels([pytorch.clone()], &FeatureName::DEFAULT, true)
+            .add_channels([pytorch.clone()], &FeatureName::Default, true)
             .unwrap();
 
         // Verify pytorch is first in the list
@@ -4839,7 +4863,7 @@ boltons = { workspace = true }
         // Add another channel without prepend
         let bioconda = PrioritizedChannel::from(NamedChannelOrUrl::Name(String::from("bioconda")));
         manifest
-            .add_channels([bioconda.clone()], &FeatureName::DEFAULT, false)
+            .add_channels([bioconda.clone()], &FeatureName::Default, false)
             .unwrap();
 
         // Verify order is still pytorch, conda-forge, bioconda
@@ -4884,7 +4908,7 @@ channels = ["nvidia", "pytorch"]
             PrioritizedChannel::from(NamedChannelOrUrl::Name(String::from("conda-forge"))),
         ];
         manifest
-            .set_channels(new_channels, &FeatureName::DEFAULT)
+            .set_channels(new_channels, &FeatureName::Default)
             .unwrap();
 
         // Verify channels were replaced
@@ -4987,7 +5011,7 @@ channels = ["nvidia", "pytorch"]
         manifest
             .remove_platforms(
                 [PixiPlatform::from_subdir(Platform::Linux64)].iter(),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -5340,7 +5364,7 @@ exclude-newer = "2015-12-02T02:07:43Z"
         )
         .expect("rich platform with name != subdir");
         editable
-            .add_platforms([&rich], &FeatureName::DEFAULT)
+            .add_platforms([&rich], &FeatureName::Default)
             .unwrap();
 
         // Flag clears, legacy tables are gone, feature platforms point at the
@@ -5389,7 +5413,7 @@ exclude-newer = "2015-12-02T02:07:43Z"
         editable
             .add_platforms(
                 [PixiPlatform::from_subdir(Platform::Osx64)].iter(),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -5432,7 +5456,7 @@ exclude-newer = "2015-12-02T02:07:43Z"
         editable
             .add_platforms(
                 [PixiPlatform::from_subdir(Platform::Linux64)].iter(),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -5648,7 +5672,7 @@ platforms = [
         editable
             .add_platforms(
                 [PixiPlatform::from_subdir(Platform::Linux64)].iter(),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 
@@ -5680,7 +5704,7 @@ platforms = [
         editable
             .remove_platforms(
                 [PixiPlatform::from_subdir(Platform::Osx64)].iter(),
-                &FeatureName::DEFAULT,
+                &FeatureName::Default,
             )
             .unwrap();
 

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -305,6 +305,8 @@ impl WorkspaceManifestMut<'_> {
             miette::bail!("task {} already exists", name);
         }
 
+        self.ensure_inline_environment(feature_name)?;
+
         // Add the task to the Toml manifest
         self.document
             .add_task(name.as_str(), task.clone(), platform, feature_name)?;

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -43,8 +43,11 @@ pub struct WorkspaceManifest {
     /// Information about the project
     pub workspace: Workspace,
 
-    /// All the features defined in the project.
-    pub features: IndexMap<FeatureName, Feature>,
+    /// All the features defined in the project, including the implicit
+    /// features synthesized for environments with inline content. Access
+    /// from outside the crate goes through [`Self::all_features`] or
+    /// [`Self::user_features`] so call sites choose a view deliberately.
+    pub(crate) features: IndexMap<FeatureName, Feature>,
 
     /// All the environments defined in the project.
     pub environments: Environments,
@@ -242,6 +245,24 @@ impl WorkspaceManifest {
         Q: ?Sized + Hash + Equivalent<FeatureName>,
     {
         self.features.get(name)
+    }
+
+    /// Every feature in the manifest, including the implicit features
+    /// synthesized for environments with inline content. This is the view
+    /// for resolution and other machinery that must see all feature content;
+    /// use [`Self::user_features`] when feature names are shown to the user.
+    pub fn all_features(&self) -> impl Iterator<Item = (&FeatureName, &Feature)> {
+        self.features.iter()
+    }
+
+    /// The features the user declared in the manifest: every feature except
+    /// the implicit ones synthesized for environments with inline content.
+    /// Inline content belongs to its environment, so this is the view for
+    /// anything that presents features to the user.
+    pub fn user_features(&self) -> impl Iterator<Item = (&FeatureName, &Feature)> {
+        self.features
+            .iter()
+            .filter(|(name, _)| !name.is_environment())
     }
 
     /// Returns the preview field of the project

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -990,6 +990,7 @@ impl WorkspaceManifestMut<'_> {
         if pixi_platforms.is_empty() {
             return Ok(IndexSet::new());
         }
+        self.ensure_inline_environment(feature_name)?;
         let platform_names: IndexSet<PixiPlatformName> =
             pixi_platforms.iter().map(|p| p.name().clone()).collect();
         let added_to_workspace = self.add_workspace_platforms(&pixi_platforms)?;
@@ -1078,7 +1079,8 @@ impl WorkspaceManifestMut<'_> {
             .collect();
         if !missing.is_empty() {
             miette::bail!(
-                "feature '{feature_name}' does not declare platform(s): {}",
+                "{} does not declare platform(s): {}",
+                feature_name.user_facing(),
                 missing.iter().map(|pn| pn.as_str()).join(", ")
             );
         }
@@ -1363,6 +1365,8 @@ impl WorkspaceManifestMut<'_> {
         feature_name: &FeatureName,
         prepend: bool,
     ) -> miette::Result<()> {
+        self.ensure_inline_environment(feature_name)?;
+
         // First collect all the new channels
         let to_add: IndexSet<_> = channels.into_iter().collect();
 
@@ -5249,10 +5253,7 @@ dev = ["lint"]
                 &FeatureName::environment(&environment_name),
             )
             .unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "No default target for environment 'dev'"
-        );
+        assert_eq!(error.to_string(), "No default target for environment 'dev'");
     }
 
     #[test]

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -1110,12 +1110,6 @@ impl WorkspaceManifestMut<'_> {
         let Some(name) = feature_name.environment_name() else {
             return Ok(());
         };
-        if name.is_default() {
-            return Err(miette!(
-                help = "add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment",
-                "the 'default' environment cannot define its content inline"
-            ));
-        }
 
         self.document.ensure_environment_is_table(name.as_str())?;
 
@@ -5167,7 +5161,7 @@ dev = { features = ["lint"], no-default-feature = true }
     }
 
     #[test]
-    fn test_add_dependency_to_default_environment_inline_errors() {
+    fn test_add_dependency_to_default_environment_inline() {
         let contents = r#"
 [workspace]
 name = "foo"
@@ -5178,13 +5172,26 @@ platforms = ["linux-64"]
         let mut manifest = parse_pixi_toml(contents);
         let mut manifest = manifest.editable();
 
-        let error =
-            add_dependency_to_environment(&mut manifest, "numpy >=1.21", &EnvironmentName::Default)
-                .unwrap_err();
+        add_dependency_to_environment(&mut manifest, "numpy >=1.21", &EnvironmentName::Default)
+            .unwrap();
+
+        assert_snapshot!(manifest.document.to_string(), @r###"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.default.dependencies]
+        numpy = ">=1.21"
+        "###);
+
+        let environment = manifest.workspace.environment("default").unwrap();
         assert_eq!(
-            error.to_string(),
-            "the 'default' environment cannot define its content inline"
+            environment.features,
+            vec![FeatureName::environment(&EnvironmentName::Default)]
         );
+
+        parse_pixi_toml(&manifest.document.to_string());
     }
 
     #[test]

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -637,4 +637,40 @@ mod tests {
             "expected to find the security extra defined on the including extra"
         );
     }
+
+    #[test]
+    fn test_inline_environment_dependencies() {
+        const PYPROJECT: &str = r#"
+            [project]
+            name = "example"
+
+            [tool.pixi.workspace]
+            channels = ["conda-forge"]
+            platforms = ["linux-64"]
+
+            [tool.pixi.environments.dev.dependencies]
+            git = "*"
+            "#;
+
+        let manifest = super::PyProjectManifest::from_toml_str(PYPROJECT).unwrap();
+        let (workspace_manifest, _, _) = manifest.into_workspace_manifest(Path::new("")).unwrap();
+
+        // The implicit `env:dev` feature is prepended to the environment.
+        let env_feature =
+            FeatureName::environment(&crate::EnvironmentName::Named("dev".to_string()));
+        let dev = workspace_manifest
+            .environment("dev")
+            .expect("dev environment exists");
+        assert_eq!(dev.features, vec![env_feature.clone()]);
+
+        let feature = workspace_manifest
+            .feature(&env_feature)
+            .expect("the inline feature exists");
+        assert!(
+            feature
+                .dependencies(crate::SpecType::Run, None)
+                .unwrap()
+                .contains_key("git")
+        );
+    }
 }

--- a/crates/pixi_manifest/src/pyproject.rs
+++ b/crates/pixi_manifest/src/pyproject.rs
@@ -655,7 +655,7 @@ mod tests {
         let manifest = super::PyProjectManifest::from_toml_str(PYPROJECT).unwrap();
         let (workspace_manifest, _, _) = manifest.into_workspace_manifest(Path::new("")).unwrap();
 
-        // The implicit `env:dev` feature is prepended to the environment.
+        // The implicit environment feature is prepended to the environment.
         let env_feature =
             FeatureName::environment(&crate::EnvironmentName::Named("dev".to_string()));
         let dev = workspace_manifest

--- a/crates/pixi_manifest/src/toml/environment.rs
+++ b/crates/pixi_manifest/src/toml/environment.rs
@@ -1,4 +1,12 @@
+use std::path::Path;
+
 use toml_span::{DeserError, Spanned, Value, de_helpers::expected};
+
+use crate::{
+    Feature, FeatureName, TomlError, WithWarnings,
+    toml::{TomlFeature, TomlWorkspace, WorkspacePackageProperties, preview::TomlPreview},
+    utils::{PixiSpanned, package_map::DependencyTable},
+};
 
 /// Helper struct to deserialize the environment from TOML.
 /// The environment description can only hold these values.
@@ -7,11 +15,60 @@ pub struct TomlEnvironment {
     pub features: Option<Spanned<Vec<Spanned<String>>>>,
     pub solve_group: Option<String>,
     pub no_default_feature: bool,
+    /// Feature content defined directly on the environment. This is turned into
+    /// an implicit feature that is prepended to the environment's features.
+    pub inline: TomlEnvironmentInline,
+}
+
+/// The feature content that can be defined directly on an environment. This is
+/// the same content as a regular feature, minus the fields that only make sense
+/// on a feature (`host-dependencies`, `build-dependencies` and
+/// `system-requirements`).
+#[derive(Debug, Default)]
+pub struct TomlEnvironmentInline {
+    pub dependencies: Option<PixiSpanned<DependencyTable>>,
+}
+
+impl TomlEnvironmentInline {
+    /// Returns true if the environment does not define any inline feature
+    /// content, in which case no implicit feature needs to be synthesized.
+    pub fn is_empty(&self) -> bool {
+        let Self { dependencies } = self;
+        dependencies.is_none()
+    }
+
+    /// Builds the implicit feature that carries the environment's inline
+    /// content.
+    pub fn into_feature(
+        self,
+        name: FeatureName,
+        preview: &TomlPreview,
+        workspace: &TomlWorkspace,
+        workspace_package_properties: &WorkspacePackageProperties,
+        root_directory: &Path,
+    ) -> Result<WithWarnings<Feature>, TomlError> {
+        let Self { dependencies } = self;
+        let WithWarnings {
+            value: (feature, _system_requirements),
+            warnings,
+        } = TomlFeature {
+            dependencies,
+            ..TomlFeature::default()
+        }
+        .into_feature(
+            name,
+            preview,
+            workspace,
+            workspace_package_properties,
+            root_directory,
+        )?;
+        Ok(WithWarnings::from(feature).with_warnings(warnings))
+    }
 }
 
 #[derive(Debug)]
 pub enum TomlEnvironmentList {
-    Map(TomlEnvironment),
+    Map(Box<TomlEnvironment>),
     Seq(Spanned<Vec<Spanned<String>>>),
 }
 
@@ -22,10 +79,13 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironment {
         let features = th.optional_s("features");
         let solve_group = th.optional("solve-group");
         let no_default_feature = th.optional("no-default-feature");
+        let dependencies = th.optional("dependencies");
 
         th.finalize(None)?;
 
-        if features.is_none() && solve_group.is_none() {
+        let inline = TomlEnvironmentInline { dependencies };
+
+        if features.is_none() && solve_group.is_none() && inline.is_empty() {
             return Err(DeserError::from(toml_span::Error {
                 kind: toml_span::ErrorKind::MissingField("features"),
                 span: value.span,
@@ -37,6 +97,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironment {
             features,
             solve_group,
             no_default_feature: no_default_feature.unwrap_or_default(),
+            inline,
         })
     }
 }
@@ -48,9 +109,9 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironmentList {
                 toml_span::Deserialize::deserialize(value)?,
             ))
         } else if value.as_table().is_some() {
-            Ok(TomlEnvironmentList::Map(
+            Ok(TomlEnvironmentList::Map(Box::new(
                 toml_span::Deserialize::deserialize(value)?,
-            ))
+            )))
         } else {
             Err(expected("either a map or a sequence", value.take(), value.span).into())
         }

--- a/crates/pixi_manifest/src/toml/environment.rs
+++ b/crates/pixi_manifest/src/toml/environment.rs
@@ -1,11 +1,22 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
+use indexmap::{IndexMap, IndexSet};
+use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
+use pixi_toml::{Same, TomlHashMap, TomlIndexMap, TomlIndexSet, TomlWith};
 use toml_span::{DeserError, Spanned, Value, de_helpers::expected};
 
 use crate::{
-    Feature, FeatureName, TomlError, WithWarnings,
-    toml::{TomlFeature, TomlWorkspace, WorkspacePackageProperties, preview::TomlPreview},
-    utils::{PixiSpanned, package_map::DependencyTable},
+    Activation, Feature, FeatureName, SystemRequirements, TargetSelector, Task, TaskName,
+    TomlError, Warning, WithWarnings,
+    pypi::pypi_options::PypiOptions,
+    toml::{
+        TomlFeature, TomlPrioritizedChannel, TomlTarget, TomlWorkspace, WorkspacePackageProperties,
+        preview::TomlPreview, task::TomlTask,
+    },
+    utils::{
+        PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
+    },
+    workspace::{ChannelPriority, SolveStrategy},
 };
 
 /// Helper struct to deserialize the environment from TOML.
@@ -26,15 +37,53 @@ pub struct TomlEnvironment {
 /// `system-requirements`).
 #[derive(Debug, Default)]
 pub struct TomlEnvironmentInline {
+    pub platforms: Option<Spanned<IndexSet<String>>>,
+    pub channels: Option<Vec<TomlPrioritizedChannel>>,
+    pub channel_priority: Option<ChannelPriority>,
+    pub solve_strategy: Option<SolveStrategy>,
+    pub target: IndexMap<PixiSpanned<TargetSelector>, TomlTarget>,
     pub dependencies: Option<PixiSpanned<DependencyTable>>,
+    pub pypi_dependencies: Option<IndexMap<PypiPackageName, PixiPypiSpec>>,
+    pub dev_dependencies:
+        Option<IndexMap<rattler_conda_types::PackageName, pixi_spec::TomlLocationSpec>>,
+    pub constraints: Option<PixiSpanned<InheritablePackageMap>>,
+    pub activation: Option<Activation>,
+    pub tasks: HashMap<TaskName, Task>,
+    pub pypi_options: Option<PypiOptions>,
+    pub warnings: Vec<Warning>,
 }
 
 impl TomlEnvironmentInline {
     /// Returns true if the environment does not define any inline feature
     /// content, in which case no implicit feature needs to be synthesized.
     pub fn is_empty(&self) -> bool {
-        let Self { dependencies } = self;
-        dependencies.is_none()
+        let Self {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
+            dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            warnings: _,
+        } = self;
+        platforms.is_none()
+            && channels.is_none()
+            && channel_priority.is_none()
+            && solve_strategy.is_none()
+            && target.is_empty()
+            && dependencies.is_none()
+            && pypi_dependencies.is_none()
+            && dev_dependencies.is_none()
+            && constraints.is_none()
+            && activation.is_none()
+            && tasks.is_empty()
+            && pypi_options.is_none()
     }
 
     /// Builds the implicit feature that carries the environment's inline
@@ -47,13 +96,41 @@ impl TomlEnvironmentInline {
         workspace_package_properties: &WorkspacePackageProperties,
         root_directory: &Path,
     ) -> Result<WithWarnings<Feature>, TomlError> {
-        let Self { dependencies } = self;
+        let Self {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
+            dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            warnings,
+        } = self;
         let WithWarnings {
             value: (feature, _system_requirements),
             warnings,
         } = TomlFeature {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
             dependencies,
-            ..TomlFeature::default()
+            pypi_dependencies,
+            dev: dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            host_dependencies: None,
+            build_dependencies: None,
+            system_requirements: SystemRequirements::default(),
+            warnings,
         }
         .into_feature(
             name,
@@ -76,14 +153,67 @@ impl<'de> toml_span::Deserialize<'de> for TomlEnvironment {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = toml_span::de_helpers::TableHelper::new(value)?;
 
+        let mut warnings = Vec::new();
+
         let features = th.optional_s("features");
         let solve_group = th.optional("solve-group");
         let no_default_feature = th.optional("no-default-feature");
+
+        // Inline feature content. `host-dependencies`, `build-dependencies` and
+        // `system-requirements` are intentionally not accepted here and are
+        // rejected by `finalize` below.
+        let platforms = th
+            .optional::<TomlWith<_, Spanned<TomlIndexSet<Same>>>>("platforms")
+            .map(TomlWith::into_inner);
+        let channels = th.optional("channels");
+        let channel_priority = th.optional("channel-priority");
+        let solve_strategy = th.optional("solve-strategy");
+        let target = th
+            .optional::<TomlIndexMap<_, _>>("target")
+            .map(TomlIndexMap::into_inner)
+            .unwrap_or_default();
         let dependencies = th.optional("dependencies");
+        let pypi_dependencies = th
+            .optional::<TomlIndexMap<_, _>>("pypi-dependencies")
+            .map(TomlIndexMap::into_inner);
+        let dev_dependencies = th
+            .optional::<TomlIndexMap<_, _>>("dev")
+            .map(TomlIndexMap::into_inner);
+        let constraints = th.optional("constraints");
+        let activation = th.optional("activation");
+        let tasks = th
+            .optional::<TomlHashMap<_, TomlTask>>("tasks")
+            .map(TomlHashMap::into_inner)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(key, value)| {
+                let WithWarnings {
+                    value: task,
+                    warnings: mut task_warnings,
+                } = value;
+                warnings.append(&mut task_warnings);
+                (key, task)
+            })
+            .collect();
+        let pypi_options = th.optional("pypi-options");
 
         th.finalize(None)?;
 
-        let inline = TomlEnvironmentInline { dependencies };
+        let inline = TomlEnvironmentInline {
+            platforms,
+            channels,
+            channel_priority,
+            solve_strategy,
+            target,
+            dependencies,
+            pypi_dependencies,
+            dev_dependencies,
+            constraints,
+            activation,
+            tasks,
+            pypi_options,
+            warnings,
+        };
 
         if features.is_none() && solve_group.is_none() && inline.is_empty() {
             return Err(DeserError::from(toml_span::Error {

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -134,7 +134,7 @@ impl TomlFeature {
                     .any(|p| feature_platforms.value.iter().any(|fp| fp == p.name()))
             {
                 let warning = create_unsupported_selector_warning(
-                    PlatformSpan::Feature(name.to_string(), feature_platforms.span),
+                    PlatformSpan::Feature(name.clone(), feature_platforms.span),
                     &selector,
                     &matching_platforms,
                 );

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TomlFeature {
     pub platforms: Option<Spanned<IndexSet<String>>>,
     pub channels: Option<Vec<TomlPrioritizedChannel>>,

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -395,16 +395,6 @@ impl TomlManifest {
             // inline content and prepend it to the environment's features.
             let inline_feature_name = match inline {
                 Some(inline) if !inline.is_empty() => {
-                    if name.is_default() {
-                        return Err(TomlError::from(
-                            GenericError::new(
-                                "The 'default' environment cannot define its content inline",
-                            )
-                            .with_help(
-                                "Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.",
-                            ),
-                        ));
-                    }
                     let feature_name = FeatureName::environment(&name);
                     let WithWarnings {
                         value: feature,
@@ -2914,21 +2904,45 @@ mod test {
     }
 
     #[test]
-    fn test_environment_default_inline_dependencies_rejected() {
-        assert_snapshot!(expect_parse_failure(
+    fn test_environment_default_inline_dependencies() {
+        // Inline content on the default environment is private to the default
+        // environment, unlike the top-level tables which belong to the default
+        // feature and are inherited by every environment.
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             r#"
         [workspace]
         name = "foo"
         channels = []
         platforms = ["linux-64"]
 
+        [dependencies]
+        python = "*"
+
         [environments.default.dependencies]
         git = "*"
         "#,
-        ), @r###"
-          × The 'default' environment cannot define its content inline
-          help: Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.
-        "###);
+            Path::new(""),
+        )
+        .unwrap();
+
+        let feature = manifest
+            .feature(&FeatureName::environment(&EnvironmentName::Default))
+            .expect("the inline feature exists");
+        assert!(
+            feature
+                .dependencies(crate::SpecType::Run, None)
+                .unwrap()
+                .contains_key("git")
+        );
+
+        let default = manifest
+            .environment("default")
+            .expect("default environment exists");
+        assert_eq!(
+            default.features,
+            vec![FeatureName::environment(&EnvironmentName::Default)]
+        );
+        assert!(!default.no_default_feature);
     }
 
     #[test]
@@ -3057,10 +3071,8 @@ mod test {
     }
 
     #[test]
-    fn test_environment_default_inline_tasks_rejected() {
-        // Any inline content on the default environment is rejected, not just
-        // dependencies.
-        assert_snapshot!(expect_parse_failure(
+    fn test_environment_default_inline_tasks() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             r#"
         [workspace]
         name = "foo"
@@ -3070,10 +3082,14 @@ mod test {
         [environments.default.tasks]
         greet = "echo hi"
         "#,
-        ), @r###"
-          × The 'default' environment cannot define its content inline
-          help: Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.
-        "###);
+            Path::new(""),
+        )
+        .unwrap();
+
+        let feature = manifest
+            .feature(&FeatureName::environment(&EnvironmentName::Default))
+            .expect("the inline feature exists");
+        assert_eq!(feature.targets.default().tasks.len(), 1);
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -2765,6 +2765,29 @@ mod test {
     }
 
     #[test]
+    fn test_reserved_env_feature_name() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = []
+
+        [feature."env:dev".dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × feature names starting with 'env:' are reserved for environments that define their content inline
+           ╭─[pixi.toml:7:19]
+         6 │
+         7 │         [feature."env:dev".dependencies]
+           ·                   ───────
+         8 │         git = "*"
+           ╰────
+        "###);
+    }
+
+    #[test]
     fn test_parse_dev_path() {
         let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             r#"

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -3088,6 +3088,80 @@ mod test {
     }
 
     #[test]
+    fn test_environment_inline_system_requirements_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.dependencies]
+        git = "*"
+
+        [environments.dev.system-requirements]
+        cuda = "12"
+        "#,
+        ), @r###"
+          × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+          │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
+            ╭─[pixi.toml:10:27]
+          9 │
+         10 │         [environments.dev.system-requirements]
+            ·                           ─────────┬─────────
+            ·                                    ╰── 'system-requirements' was not expected here
+         11 │         cuda = "12"
+            ╰────
+          help: Did you mean 'features'?
+        "###);
+    }
+
+    #[test]
+    fn test_environment_default_inline_tasks_rejected() {
+        // Any inline content on the default environment is rejected, not just
+        // dependencies.
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.default.tasks]
+        greet = "echo hi"
+        "#,
+        ), @r###"
+          × The 'default' environment cannot define dependencies inline
+          help: Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.
+        "###);
+    }
+
+    #[test]
+    fn test_reserved_env_feature_name_with_invalid_environment_name() {
+        // The prefix is reserved even when the rest is not a valid
+        // environment name.
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature."env:Not Valid".dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × feature names starting with 'env:' are reserved for environments that define their content inline
+           ╭─[pixi.toml:7:19]
+         6 │
+         7 │         [feature."env:Not Valid".dependencies]
+           ·                   ─────────────
+         8 │         git = "*"
+           ╰────
+        "###);
+    }
+
+    #[test]
     fn test_parse_dev_path() {
         let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             r#"

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -22,6 +22,7 @@ use crate::{
     Activation, Environment, EnvironmentName, Environments, Feature, FeatureName,
     KnownPreviewFeature, PixiPlatform, PixiPlatformName, SolveGroups, SystemRequirements,
     TargetSelector, Targets, Task, TaskName, TomlError, Warning, WithWarnings, WorkspaceManifest,
+    consts,
     environment::EnvironmentIdx,
     error::{FeatureNotEnabled, GenericError},
     manifests::PackageManifest,
@@ -29,7 +30,8 @@ use crate::{
     toml::{
         PackageDefaults, PlatformSpan, TomlFeature, TomlPackage, TomlTarget, TomlWorkspace,
         WorkspacePackageProperties, create_unsupported_selector_warning,
-        environment::TomlEnvironmentList, task::TomlTask,
+        environment::{TomlEnvironment, TomlEnvironmentList},
+        task::TomlTask,
     },
     utils::{
         PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
@@ -364,22 +366,62 @@ impl TomlManifest {
         let mut features_used_by_environments = HashSet::new();
         for (name, env) in toml_environments {
             // Decompose the TOML
-            let (included_features, features_span, solve_group, no_default_feature) = match env {
-                TomlEnvironmentList::Map(env) => {
-                    let (features, features_span) = env.features.map_or_else(
-                        || (Vec::new(), None),
-                        |Spanned { value, span }| (value, Some(span)),
-                    );
-                    (
-                        features,
-                        features_span,
-                        env.solve_group,
-                        env.no_default_feature,
-                    )
+            let (inline, included_features, features_span, solve_group, no_default_feature) =
+                match env {
+                    TomlEnvironmentList::Map(env) => {
+                        let TomlEnvironment {
+                            features,
+                            solve_group,
+                            no_default_feature,
+                            inline,
+                        } = *env;
+                        let (features, features_span) = features.map_or_else(
+                            || (Vec::new(), None),
+                            |Spanned { value, span }| (value, Some(span)),
+                        );
+                        (
+                            Some(inline),
+                            features,
+                            features_span,
+                            solve_group,
+                            no_default_feature,
+                        )
+                    }
+                    TomlEnvironmentList::Seq(features) => {
+                        (None, features.value, Some(features.span), None, false)
+                    }
+                };
+
+            // Synthesize the implicit feature that carries the environment's
+            // inline content and prepend it to the environment's features.
+            let inline_feature_name = match inline {
+                Some(inline) if !inline.is_empty() => {
+                    if name.is_default() {
+                        return Err(TomlError::from(
+                            GenericError::new(
+                                "The 'default' environment cannot define dependencies inline",
+                            )
+                            .with_help(
+                                "Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.",
+                            ),
+                        ));
+                    }
+                    let feature_name = FeatureName::environment(&name);
+                    let WithWarnings {
+                        value: feature,
+                        warnings: mut feature_warnings,
+                    } = inline.into_feature(
+                        feature_name.clone(),
+                        preview,
+                        &workspace.value,
+                        &inline_workspace_properties,
+                        root_directory,
+                    )?;
+                    warnings.append(&mut feature_warnings);
+                    features.insert(feature_name.clone(), feature);
+                    Some(feature_name)
                 }
-                TomlEnvironmentList::Seq(features) => {
-                    (features.value, Some(features.span), None, false)
-                }
+                _ => None,
             };
             let included_features: Vec<Spanned<FeatureName>> = included_features
                 .into_iter()
@@ -395,12 +437,33 @@ impl TomlManifest {
             // Verify that the features of the environment actually exist and that they are
             // not defined twice.
             let mut features_seen_where = HashMap::new();
-            let mut used_features = Vec::with_capacity(included_features.len());
+            let mut used_features = Vec::with_capacity(included_features.len() + 1);
+            if let Some(feature_name) = &inline_feature_name {
+                used_features.push(
+                    features
+                        .get(feature_name)
+                        .expect("the inline feature was just inserted"),
+                );
+            }
             for Spanned {
                 value: feature_name,
                 span,
             } in &included_features
             {
+                if feature_name.is_environment()
+                    || feature_name
+                        .as_str()
+                        .starts_with(consts::ENVIRONMENT_FEATURE_PREFIX)
+                {
+                    return Err(TomlError::from(
+                        GenericError::new(format!(
+                            "The feature '{feature_name}' cannot be referenced: names starting with '{}' refer to content defined inline on an environment",
+                            consts::ENVIRONMENT_FEATURE_PREFIX,
+                        ))
+                        .with_span((*span).into())
+                        .with_help("Content defined inline on an environment is private to that environment. Define a named feature to share content between environments."),
+                    ));
+                }
                 let Some(feature) = features.get(feature_name) else {
                     return Err(TomlError::from(
                         GenericError::new(format!(
@@ -466,11 +529,17 @@ impl TomlManifest {
                 ));
             }
 
+            let mut feature_names: Vec<FeatureName> =
+                included_features.into_iter().map(Spanned::take).collect();
+            if let Some(feature_name) = inline_feature_name {
+                feature_names.insert(0, feature_name);
+            }
+
             let environment_idx = EnvironmentIdx(environments.environments.len());
             environments.by_name.insert(name.clone(), environment_idx);
             environments.environments.push(Some(Environment {
                 name,
-                features: included_features.into_iter().map(Spanned::take).collect(),
+                features: feature_names,
                 solve_group: solve_group.map(|sg| solve_groups.add(sg, environment_idx)),
                 no_default_feature,
             }));
@@ -2784,6 +2853,168 @@ mod test {
            ·                   ───────
          8 │         git = "*"
            ╰────
+        "###);
+    }
+
+    #[test]
+    fn test_environment_inline_dependencies() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.dependencies]
+        git = "*"
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        // Defining dependencies inline auto-declares the environment and
+        // prepends the implicit `env:dev` feature to its feature list.
+        let env_feature = FeatureName::environment(&EnvironmentName::Named("dev".to_string()));
+        let dev = manifest.environment("dev").expect("dev environment exists");
+        assert_eq!(dev.features, vec![env_feature.clone()]);
+
+        // The implicit feature carries the inline dependency.
+        let feature = manifest
+            .feature(&env_feature)
+            .expect("the inline feature exists");
+        let deps = feature.dependencies(crate::SpecType::Run, None).unwrap();
+        assert!(deps.contains_key("git"));
+    }
+
+    #[test]
+    fn test_environment_inline_dependencies_with_features() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.python.dependencies]
+        python = "*"
+
+        [environments.dev]
+        features = ["python"]
+        dependencies = { git = "*" }
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        // The implicit feature is prepended before the referenced features.
+        let dev = manifest.environment("dev").expect("dev environment exists");
+        assert_eq!(
+            dev.features,
+            vec![
+                FeatureName::environment(&EnvironmentName::Named("dev".to_string())),
+                FeatureName::from("python"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_environment_without_inline_content_has_no_feature() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [feature.python.dependencies]
+        python = "*"
+
+        [environments]
+        dev = { features = ["python"] }
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        // A purely compositional environment does not synthesize a feature.
+        assert!(
+            manifest
+                .feature(&FeatureName::environment(&EnvironmentName::Named(
+                    "dev".to_string()
+                )))
+                .is_none()
+        );
+        let dev = manifest.environment("dev").expect("dev environment exists");
+        assert_eq!(dev.features, vec![FeatureName::from("python")]);
+    }
+
+    #[test]
+    fn test_environment_default_inline_dependencies_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.default.dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × The 'default' environment cannot define dependencies inline
+          help: Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.
+        "###);
+    }
+
+    #[test]
+    fn test_environment_feature_reference_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.dependencies]
+        git = "*"
+
+        [environments.test]
+        features = ["env:dev"]
+        "#,
+        ), @r###"
+          × The feature 'env:dev' cannot be referenced: names starting with 'env:' refer to content defined inline on an environment
+            ╭─[pixi.toml:11:22]
+         10 │         [environments.test]
+         11 │         features = ["env:dev"]
+            ·                      ───────
+         12 │
+            ╰────
+          help: Content defined inline on an environment is private to that environment. Define a named feature to share content between environments.
+        "###);
+    }
+
+    #[test]
+    fn test_environment_feature_self_reference_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev]
+        features = ["env:dev"]
+        dependencies = { git = "*" }
+        "#,
+        ), @r###"
+          × The feature 'env:dev' cannot be referenced: names starting with 'env:' refer to content defined inline on an environment
+           ╭─[pixi.toml:8:22]
+         7 │         [environments.dev]
+         8 │         features = ["env:dev"]
+           ·                      ───────
+         9 │         dependencies = { git = "*" }
+           ╰────
+          help: Content defined inline on an environment is private to that environment. Define a named feature to share content between environments.
         "###);
     }
 

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -399,10 +399,10 @@ impl TomlManifest {
                     if name.is_default() {
                         return Err(TomlError::from(
                             GenericError::new(
-                                "The 'default' environment cannot define dependencies inline",
+                                "The 'default' environment cannot define its content inline",
                             )
                             .with_help(
-                                "Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.",
+                                "Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.",
                             ),
                         ));
                     }
@@ -2964,8 +2964,8 @@ mod test {
         git = "*"
         "#,
         ), @r###"
-          × The 'default' environment cannot define dependencies inline
-          help: Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.
+          × The 'default' environment cannot define its content inline
+          help: Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.
         "###);
     }
 
@@ -3131,8 +3131,8 @@ mod test {
         greet = "echo hi"
         "#,
         ), @r###"
-          × The 'default' environment cannot define dependencies inline
-          help: Add these dependencies to the top-level tables (for example '[dependencies]'); they are part of the default environment.
+          × The 'default' environment cannot define its content inline
+          help: Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.
         "###);
     }
 

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -690,8 +690,8 @@ fn migrate_system_requirements_to_platforms(
         }
         if !all_simple_subdir {
             return Err(TomlError::from(GenericError::new(format!(
-                "feature '{}' uses `[system-requirements]` but the workspace declares per-platform virtual packages; remove the system-requirements table and declare the constraints on the platforms instead",
-                feature.name,
+                "{} uses `[system-requirements]` but the workspace declares per-platform virtual packages; remove the system-requirements table and declare the constraints on the platforms instead",
+                feature.name.user_facing(),
             ))));
         }
         let sysreqs = sysreqs.expect("checked just above");
@@ -720,8 +720,8 @@ fn extend_originals_with_referenced_subdirs(
             }
             let subdir = Platform::from_str(name.as_str()).map_err(|e| {
                 TomlError::from(GenericError::new(format!(
-                    "feature '{}' references platform '{}' which is neither declared in the workspace nor a valid conda subdir: {e}",
-                    feature.name, name,
+                    "{} references platform '{}' which is neither declared in the workspace nor a valid conda subdir: {e}",
+                    feature.name.user_facing(), name,
                 )))
             })?;
             originals.insert(PixiPlatform::from_subdir(subdir));
@@ -742,8 +742,9 @@ fn validate_referenced_platforms(
     for name in names {
         if !platforms.iter().any(|p| p.name() == name) {
             return Err(TomlError::from(GenericError::new(format!(
-                "feature '{}' references platform '{}' which is not declared in the workspace",
-                feature.name, name,
+                "{} references platform '{}' which is not declared in the workspace",
+                feature.name.user_facing(),
+                name,
             ))));
         }
     }
@@ -763,8 +764,9 @@ fn register_referenced_originals(
     for name in names {
         let original = originals.iter().find(|p| p.name() == name).ok_or_else(|| {
             TomlError::from(GenericError::new(format!(
-                "feature '{}' references platform '{}' which is not declared in the workspace",
-                feature.name, name,
+                "{} references platform '{}' which is not declared in the workspace",
+                feature.name.user_facing(),
+                name,
             )))
         })?;
         target.insert(original.clone());
@@ -788,8 +790,9 @@ fn synthesise_for_feature(
             .map(|name| {
                 Platform::from_str(name.as_str()).map_err(|e| {
                     TomlError::from(GenericError::new(format!(
-                        "feature '{}' references platform '{}' which is not a conda subdir: {e}",
-                        feature.name, name,
+                        "{} references platform '{}' which is not a conda subdir: {e}",
+                        feature.name.user_facing(),
+                        name,
                     )))
                 })
             })

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -326,7 +326,7 @@ impl TomlManifest {
                 warnings.append(&mut feature_warnings);
                 feature_sysreqs.insert(name.value.clone(), sysreqs);
                 feature_name_to_span
-                    .entry(name.value.clone().to_string())
+                    .entry(name.value.clone())
                     .or_insert(name.span);
                 Ok((name.value, feature))
             })
@@ -381,6 +381,13 @@ impl TomlManifest {
                     (features.value, Some(features.span), None, false)
                 }
             };
+            let included_features: Vec<Spanned<FeatureName>> = included_features
+                .into_iter()
+                .map(|Spanned { value, span }| Spanned {
+                    value: FeatureName::from(value),
+                    span,
+                })
+                .collect();
 
             features_used_by_environments
                 .extend(included_features.iter().map(|span| span.value.clone()));
@@ -394,7 +401,7 @@ impl TomlManifest {
                 span,
             } in &included_features
             {
-                let Some(feature) = features.get(feature_name.as_str()) else {
+                let Some(feature) = features.get(feature_name) else {
                     return Err(TomlError::from(
                         GenericError::new(format!(
                             "The feature '{feature_name}' is not defined in the manifest",
@@ -421,7 +428,7 @@ impl TomlManifest {
             if !no_default_feature {
                 used_features.push(
                     features
-                        .get(&FeatureName::DEFAULT)
+                        .get(&FeatureName::Default)
                         .expect("default feature must exist"),
                 );
             };
@@ -1064,7 +1071,7 @@ mod test {
         // it now points at the synthesised platforms rather than `None`.
         let default = workspace_manifest
             .features
-            .get(&FeatureName::DEFAULT)
+            .get(&FeatureName::Default)
             .unwrap();
         let mut default_platforms: Vec<&str> = default
             .platforms
@@ -1113,7 +1120,7 @@ mod test {
         // The default feature points at the bare platform.
         let default = workspace_manifest
             .features
-            .get(&FeatureName::DEFAULT)
+            .get(&FeatureName::Default)
             .unwrap();
         let default_platforms: Vec<&str> = default
             .platforms
@@ -2861,7 +2868,7 @@ mod test {
 
         // Extra feature should have develop dependencies
         let extra_feature = manifest
-            .feature("extra")
+            .feature(&FeatureName::from("extra"))
             .expect("extra feature should exist");
         let dev_deps = extra_feature
             .dev_dependencies(None)

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -2967,6 +2967,72 @@ mod test {
     }
 
     #[test]
+    fn test_environment_inline_full_content() {
+        let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = ["conda-forge"]
+        platforms = ["linux-64", "osx-64"]
+
+        [environments.dev]
+        channels = ["bioconda"]
+        platforms = ["linux-64"]
+        dependencies = { git = "*" }
+        pypi-dependencies = { requests = "*" }
+
+        [environments.dev.tasks]
+        greet = "echo hi"
+        "#,
+            Path::new(""),
+        )
+        .unwrap();
+
+        let feature = manifest
+            .feature(&FeatureName::environment(&EnvironmentName::Named(
+                "dev".to_string(),
+            )))
+            .expect("the inline feature exists");
+
+        assert!(
+            feature
+                .dependencies(crate::SpecType::Run, None)
+                .unwrap()
+                .contains_key("git")
+        );
+        assert!(!feature.pypi_dependencies(None).unwrap().is_empty());
+        assert!(feature.channels.is_some());
+        assert!(feature.platforms.is_some());
+        assert_eq!(feature.targets.default().tasks.len(), 1);
+    }
+
+    #[test]
+    fn test_environment_inline_host_dependencies_rejected() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "foo"
+        channels = []
+        platforms = ["linux-64"]
+
+        [environments.dev.host-dependencies]
+        git = "*"
+        "#,
+        ), @r###"
+          × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+          │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
+           ╭─[pixi.toml:7:27]
+         6 │
+         7 │         [environments.dev.host-dependencies]
+           ·                           ────────┬────────
+           ·                                   ╰── 'host-dependencies' was not expected here
+         8 │         git = "*"
+           ╰────
+          help: Did you mean 'dependencies'?
+        "###);
+    }
+
+    #[test]
     fn test_environment_feature_reference_rejected() {
         assert_snapshot!(expect_parse_failure(
             r#"

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -22,7 +22,6 @@ use crate::{
     Activation, Environment, EnvironmentName, Environments, Feature, FeatureName,
     KnownPreviewFeature, PixiPlatform, PixiPlatformName, SolveGroups, SystemRequirements,
     TargetSelector, Targets, Task, TaskName, TomlError, Warning, WithWarnings, WorkspaceManifest,
-    consts,
     environment::EnvironmentIdx,
     error::{FeatureNotEnabled, GenericError},
     manifests::PackageManifest,
@@ -450,20 +449,6 @@ impl TomlManifest {
                 span,
             } in &included_features
             {
-                if feature_name.is_environment()
-                    || feature_name
-                        .as_str()
-                        .starts_with(consts::ENVIRONMENT_FEATURE_PREFIX)
-                {
-                    return Err(TomlError::from(
-                        GenericError::new(format!(
-                            "The feature '{feature_name}' cannot be referenced: names starting with '{}' refer to content defined inline on an environment",
-                            consts::ENVIRONMENT_FEATURE_PREFIX,
-                        ))
-                        .with_span((*span).into())
-                        .with_help("Content defined inline on an environment is private to that environment. Define a named feature to share content between environments."),
-                    ));
-                }
                 let Some(feature) = features.get(feature_name) else {
                     return Err(TomlError::from(
                         GenericError::new(format!(
@@ -2837,29 +2822,6 @@ mod test {
     }
 
     #[test]
-    fn test_reserved_env_feature_name() {
-        assert_snapshot!(expect_parse_failure(
-            r#"
-        [workspace]
-        name = "foo"
-        channels = []
-        platforms = []
-
-        [feature."env:dev".dependencies]
-        git = "*"
-        "#,
-        ), @r###"
-          × feature names starting with 'env:' are reserved for environments that define their content inline
-           ╭─[pixi.toml:7:19]
-         6 │
-         7 │         [feature."env:dev".dependencies]
-           ·                   ───────
-         8 │         git = "*"
-           ╰────
-        "###);
-    }
-
-    #[test]
     fn test_environment_inline_dependencies() {
         let manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             r#"
@@ -2876,7 +2838,7 @@ mod test {
         .unwrap();
 
         // Defining dependencies inline auto-declares the environment and
-        // prepends the implicit `env:dev` feature to its feature list.
+        // prepends the implicit environment feature to its feature list.
         let env_feature = FeatureName::environment(&EnvironmentName::Named("dev".to_string()));
         let dev = manifest.environment("dev").expect("dev environment exists");
         assert_eq!(dev.features, vec![env_feature.clone()]);
@@ -3036,7 +2998,10 @@ mod test {
     }
 
     #[test]
-    fn test_environment_feature_reference_rejected() {
+    fn test_inline_environment_content_is_not_a_feature() {
+        // The implicit feature that carries an environment's inline content is
+        // private to that environment; another environment cannot pull it in
+        // by naming the environment in its feature list.
         assert_snapshot!(expect_parse_failure(
             r#"
         [workspace]
@@ -3048,42 +3013,17 @@ mod test {
         git = "*"
 
         [environments.test]
-        features = ["env:dev"]
+        features = ["dev"]
         "#,
         ), @r###"
-          × The feature 'env:dev' cannot be referenced: names starting with 'env:' refer to content defined inline on an environment
+          × The feature 'dev' is not defined in the manifest
             ╭─[pixi.toml:11:22]
          10 │         [environments.test]
-         11 │         features = ["env:dev"]
-            ·                      ───────
+         11 │         features = ["dev"]
+            ·                      ───
          12 │
             ╰────
-          help: Content defined inline on an environment is private to that environment. Define a named feature to share content between environments.
-        "###);
-    }
-
-    #[test]
-    fn test_environment_feature_self_reference_rejected() {
-        assert_snapshot!(expect_parse_failure(
-            r#"
-        [workspace]
-        name = "foo"
-        channels = []
-        platforms = ["linux-64"]
-
-        [environments.dev]
-        features = ["env:dev"]
-        dependencies = { git = "*" }
-        "#,
-        ), @r###"
-          × The feature 'env:dev' cannot be referenced: names starting with 'env:' refer to content defined inline on an environment
-           ╭─[pixi.toml:8:22]
-         7 │         [environments.dev]
-         8 │         features = ["env:dev"]
-           ·                      ───────
-         9 │         dependencies = { git = "*" }
-           ╰────
-          help: Content defined inline on an environment is private to that environment. Define a named feature to share content between environments.
+          help: Add the feature to the manifest
         "###);
     }
 
@@ -3133,31 +3073,6 @@ mod test {
         ), @r###"
           × The 'default' environment cannot define its content inline
           help: Add the content to the top-level tables (for example '[dependencies]' or '[tasks]'); they already belong to the default environment.
-        "###);
-    }
-
-    #[test]
-    fn test_reserved_env_feature_name_with_invalid_environment_name() {
-        // The prefix is reserved even when the rest is not a valid
-        // environment name.
-        assert_snapshot!(expect_parse_failure(
-            r#"
-        [workspace]
-        name = "foo"
-        channels = []
-        platforms = ["linux-64"]
-
-        [feature."env:Not Valid".dependencies]
-        git = "*"
-        "#,
-        ), @r###"
-          × feature names starting with 'env:' are reserved for environments that define their content inline
-           ╭─[pixi.toml:7:19]
-         6 │
-         7 │         [feature."env:Not Valid".dependencies]
-           ·                   ─────────────
-         8 │         git = "*"
-           ╰────
         "###);
     }
 

--- a/crates/pixi_manifest/src/toml/mod.rs
+++ b/crates/pixi_manifest/src/toml/mod.rs
@@ -40,7 +40,7 @@ pub use workspace::TomlWorkspace;
 use rattler_conda_types::Platform;
 
 use crate::PixiPlatform;
-use crate::{TargetSelector, TomlError, error::GenericError, utils::PixiSpanned};
+use crate::{FeatureName, TargetSelector, TomlError, error::GenericError, utils::PixiSpanned};
 
 pub trait FromTomlStr {
     fn from_toml_str(source: &str) -> Result<Self, TomlError>
@@ -83,7 +83,7 @@ pub(crate) fn reject_glob_in_package_target(
 /// An enum that contains a span to a `platforms =` section. Either from a
 /// feature or a workspace.
 enum PlatformSpan {
-    Feature(String, Span),
+    Feature(FeatureName, Span),
     Workspace(Span),
 }
 
@@ -93,7 +93,7 @@ fn create_unsupported_selector_warning(
     matching_platforms: &[&PixiPlatform],
 ) -> GenericError {
     let (feature_or_workspace, span) = match platform_span {
-        PlatformSpan::Feature(name, span) => (Cow::Owned(format!("feature '{name}'")), span),
+        PlatformSpan::Feature(name, span) => (Cow::Owned(name.user_facing().to_string()), span),
         PlatformSpan::Workspace(span) => (Cow::Borrowed("workspace"), span),
     };
 

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
+assertion_line: 167
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
    ╭─[pixi.toml:2:21]
  1 │
  2 │             env = { feat = ["foo", "bar"] }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_environment.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
-assertion_line: 167
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+  │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
    ╭─[pixi.toml:2:21]
  1 │
  2 │             env = { feat = ["foo", "bar"] }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
+assertion_line: 203
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
    ╭─[pixi.toml:2:36]
  1 │
  2 │             env = { features = [], solve_groups = "group" }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__environment__test__parse_invalid_solve_group.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/environment.rs
-assertion_line: 203
 expression: "format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err())"
 ---
-  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'dependencies'
+  × Unexpected keys, expected only 'features', 'solve-group', 'no-default-feature', 'platforms', 'channels', 'channel-priority', 'solve-strategy', 'target', 'dependencies', 'pypi-dependencies',
+  │ 'dev', 'constraints', 'activation', 'tasks', 'pypi-options'
    ╭─[pixi.toml:2:36]
  1 │
  2 │             env = { features = [], solve_groups = "group" }

--- a/docs/advanced/channel_logic.md
+++ b/docs/advanced/channel_logic.md
@@ -94,7 +94,7 @@ If you want to force a specific priority for a channel, you can use the `priorit
 The higher the number, the higher the priority.
 Non specified priorities are set to 0 but the index in the array still counts as a priority, where the first in the list has the highest priority.
 
-This priority definition is mostly important for [multiple environments](../workspace/multi_environment.md) with different channel priorities, as by default feature channels are prepended to the workspace channels.
+This priority definition is mostly important for [multiple environments](../workspace/multi_environment.md) with different channel priorities, as by default environment and feature channels are prepended to the workspace channels.
 
 ```toml
 [workspace]
@@ -102,19 +102,14 @@ name = "test_channel_priority"
 platforms = ["linux-64", "osx-64", "win-64", "osx-arm64"]
 channels = ["conda-forge"]
 
-[feature.a]
+[environments.a]
 channels = ["nvidia"]
 
-[feature.b]
+[environments.b]
 channels = [ "pytorch", {channel = "nvidia", priority = 1}]
 
-[feature.c]
+[environments.c]
 channels = [ "pytorch", {channel = "nvidia", priority = -1}]
-
-[environments]
-a = ["a"]
-b = ["b"]
-c = ["c"]
 ```
 This example creates 4 environments, `a`, `b`, `c`, and the default environment.
 Which will have the following channel order:

--- a/docs/integration/ci/github_actions.md
+++ b/docs/integration/ci/github_actions.md
@@ -89,14 +89,10 @@ python = ">=3.11"
 pip = "*"
 polars = ">=0.14.24,<0.21"
 
-[feature.py311.dependencies]
+[environments.py311.dependencies]
 python = "3.11.*"
-[feature.py312.dependencies]
+[environments.py312.dependencies]
 python = "3.12.*"
-
-[environments]
-py311 = ["py311"]
-py312 = ["py312"]
 ```
 
 #### Multiple environments using a matrix

--- a/docs/integration/extensions/pixi_skills.md
+++ b/docs/integration/extensions/pixi_skills.md
@@ -42,7 +42,7 @@ channels = ["conda-forge", "https://prefix.dev/skill-forge"]
 [dependencies]
 polars = ">=1,<2"
 
-[feature.dev.dependencies]
+[environments.dev.dependencies]
 agent-skill-polars = "*"
 ```
 

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -28,6 +28,8 @@ pixi add [OPTIONS] <SPEC>...
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The feature for which the dependency should be modified
 <br>**default**: `default`
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment for which the dependency should be modified. The dependency is written to the content defined inline on the environment, creating the environment if it does not exist
 - <a id="arg---editable" href="#arg---editable">`--editable`</a>
 :  Whether the pypi requirement should be editable
 - <a id="arg---index" href="#arg---index">`--index <INDEX>`</a>

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -14,6 +14,7 @@ pixi add --platform osx-64 clang # (7)!
 pixi add --no-install numpy # (8)!
 pixi add --no-lockfile-update numpy # (9)!
 pixi add --feature featurex numpy # (10)!
+pixi add --environment dev numpy # (28)!
 pixi add /absolute/path/to/package-1.0-hb0f4dca_0.conda # (11)!
 pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (12)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (13)!
@@ -62,6 +63,7 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pyp
 25. This will add the `boltons` package with the given `git` url and `e50d4a1` revision as `pypi` dependency.
 26. This will add the `boltons` package with the given `git` url and `v0.1.0` tag as `pypi` dependency.
 27. This will add the `boltons` package with the given `git` url, `v0.1.0` tag and the `boltons` folder in the repository as `pypi` dependency.
+28. This will add the `numpy` package to the dependencies defined inline on the environment `dev`, creating the environment if it does not exist.
 
 !!! tip "Need to specify build strings or hardware-specific packages?"
     For advanced package specifications including build strings, see the [Package Specifications](../../../concepts/package_specifications.md) guide.

--- a/docs/reference/cli/pixi/import.md
+++ b/docs/reference/cli/pixi/import.md
@@ -26,9 +26,9 @@ pixi import [OPTIONS] <FILE>
 :  The platforms for the imported environment. Accepts a workspace platform name; a bare conda subdir (e.g. `linux-64`) is also accepted. Names that aren't yet declared get auto-added as subdir platforms
 <br>May be provided more than once.
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
-:  A name for the created environment
+:  A name for the created environment. Without `--feature` the imported content is written inline on the environment
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
-:  A name for the created feature
+:  A name for the created feature. The feature is added to the environment of the same name unless `--environment` is given
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -28,6 +28,8 @@ pixi remove [OPTIONS] <SPEC>...
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The feature for which the dependency should be modified
 <br>**default**: `default`
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment for which the dependency should be modified. The dependency is written to the content defined inline on the environment, creating the environment if it does not exist
 
 ## Config Options
 - <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>

--- a/docs/reference/cli/pixi/remove_extender
+++ b/docs/reference/cli/pixi/remove_extender
@@ -10,6 +10,7 @@ pixi remove --build cmake
 pixi remove --pypi requests
 pixi remove --platform osx-64 --build clang
 pixi remove --feature featurex clang
+pixi remove --environment dev clang
 pixi remove --feature featurex --platform osx-64 clang
 pixi remove --feature featurex --platform osx-64 --build clang
 pixi remove --no-install numpy

--- a/docs/reference/cli/pixi/task/add.md
+++ b/docs/reference/cli/pixi/task/add.md
@@ -30,6 +30,8 @@ pixi task add [OPTIONS] <NAME> <COMMAND>...
 :  The platform for which the task should be added
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The feature for which the task should be added
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment for which the task should be added. The task is written to the tasks defined inline on the environment, creating the environment if it does not exist
 - <a id="arg---cwd" href="#arg---cwd">`--cwd <CWD>`</a>
 :  The working directory relative to the root of the workspace
 - <a id="arg---env" href="#arg---env">`--env <ENV>`</a>

--- a/docs/reference/cli/pixi/task/add_extender
+++ b/docs/reference/cli/pixi/task/add_extender
@@ -8,6 +8,7 @@ pixi task add tls ls --cwd tests
 pixi task add test cargo t --depends-on build
 pixi task add build-osx "METAL=1 cargo build" --platform osx-64
 pixi task add train python train.py --feature cuda
+pixi task add serve "python serve.py" --environment dev
 pixi task add publish-pypi "hatch publish --yes --repo main" --feature build --env HATCH_CONFIG=config/hatch.toml --description "Publish the package to pypi"
 ```
 
@@ -24,6 +25,9 @@ build-osx = "METAL=1 cargo build"
 
 [feature.cuda.tasks]
 train = "python train.py"
+
+[environments.dev.tasks]
+serve = "python serve.py"
 
 [feature.build.tasks]
 publish-pypi = { cmd = "hatch publish --yes --repo main", env = { HATCH_CONFIG = "config/hatch.toml" }, description = "Publish the package to pypi" }

--- a/docs/reference/cli/pixi/task/alias.md
+++ b/docs/reference/cli/pixi/task/alias.md
@@ -25,6 +25,8 @@ pixi task alias [OPTIONS] <ALIAS> <DEPENDS_ON>...
 ## Options
 - <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
 :  The platform for which the alias should be added
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment for which the alias should be added. The alias is written to the tasks defined inline on the environment, creating the environment if it does not exist
 - <a id="arg---description" href="#arg---description">`--description <DESCRIPTION>`</a>
 :  The description of the alias task
 

--- a/docs/reference/cli/pixi/task/alias_extender
+++ b/docs/reference/cli/pixi/task/alias_extender
@@ -6,6 +6,7 @@
 pixi task alias test-all test-py test-cpp test-rust
 pixi task alias --platform linux-64 test test-linux
 pixi task alias moo cow
+pixi task alias --environment dev moo cow
 ```
 
 --8<-- [end:example]

--- a/docs/reference/cli/pixi/task/remove.md
+++ b/docs/reference/cli/pixi/task/remove.md
@@ -23,5 +23,7 @@ pixi task remove [OPTIONS] [TASK_NAME]...
 :  The platform for which the task should be removed
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The feature for which the task should be removed
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment for which the task should be removed. The task is removed from the tasks defined inline on the environment
 
 --8<-- "docs/reference/cli/pixi/task/remove_extender:example"

--- a/docs/reference/cli/pixi/upgrade.md
+++ b/docs/reference/cli/pixi/upgrade.md
@@ -21,6 +21,8 @@ pixi upgrade [OPTIONS] [PACKAGES]...
 ## Options
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The feature to update
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment whose inline dependencies should be updated
 - <a id="arg---exclude" href="#arg---exclude">`--exclude <EXCLUDE>`</a>
 :  The packages which should be excluded
 <br>May be provided more than once.

--- a/docs/reference/cli/pixi/upgrade_extender
+++ b/docs/reference/cli/pixi/upgrade_extender
@@ -25,8 +25,9 @@ pixi upgrade numpy # (2)!
 pixi upgrade numpy pandas # (3)!
 pixi upgrade --manifest-path ~/myworkspace/pixi.toml numpy # (4)!
 pixi upgrade --feature lint python # (5)!
-pixi upgrade --json # (6)!
-pixi upgrade --dry-run # (7)!
+pixi upgrade --environment dev # (6)!
+pixi upgrade --json # (7)!
+pixi upgrade --dry-run # (8)!
 ```
 
 1. This will upgrade all packages to the latest version.
@@ -34,7 +35,8 @@ pixi upgrade --dry-run # (7)!
 3. This will upgrade the `numpy` and `pandas` packages to the latest version.
 4. This will upgrade the `numpy` package to the latest version in the manifest file at the given path.
 5. This will upgrade the `python` package in the `lint` feature.
-6. This will upgrade all packages and output the result in JSON format.
-7. This will show the packages that would be upgraded without actually upgrading them in the lock file or manifest.
+6. This will upgrade the dependencies defined inline on the environment `dev`.
+7. This will upgrade all packages and output the result in JSON format.
+8. This will show the packages that would be upgraded without actually upgrading them in the lock file or manifest.
 
 --8<-- [end:example]

--- a/docs/reference/cli/pixi/workspace/channel/add.md
+++ b/docs/reference/cli/pixi/workspace/channel/add.md
@@ -26,6 +26,8 @@ pixi workspace channel add [OPTIONS] <CHANNEL>...
 :  Add the channel(s) to the beginning of the channels list, making them the highest priority
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The name of the feature to modify
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to modify. The channel is written to the channels defined inline on the environment
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>

--- a/docs/reference/cli/pixi/workspace/channel/remove.md
+++ b/docs/reference/cli/pixi/workspace/channel/remove.md
@@ -26,6 +26,8 @@ pixi workspace channel remove [OPTIONS] <CHANNEL>...
 :  Add the channel(s) to the beginning of the channels list, making them the highest priority
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The name of the feature to modify
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to modify. The channel is written to the channels defined inline on the environment
 
 ## Config Options
 - <a id="arg---auth-file" href="#arg---auth-file">`--auth-file <AUTH_FILE>`</a>

--- a/docs/reference/cli/pixi/workspace/platform/add.md
+++ b/docs/reference/cli/pixi/workspace/platform/add.md
@@ -42,5 +42,7 @@ pixi workspace platform add [OPTIONS] [PLATFORM|NAME=PLATFORM|__NAME[=VERSION[=B
 <br>**env**: `PIXI_NO_INSTALL`
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The name of the feature to add the platform to
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to add the platform to. The platform is written to the platforms defined inline on the environment
 
 --8<-- "docs/reference/cli/pixi/workspace/platform/add_extender:example"

--- a/docs/reference/cli/pixi/workspace/platform/remove.md
+++ b/docs/reference/cli/pixi/workspace/platform/remove.md
@@ -25,5 +25,7 @@ pixi workspace platform remove [OPTIONS] <PLATFORM>...
 <br>**env**: `PIXI_NO_INSTALL`
 - <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  The name of the feature to remove the platform from
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+:  The environment to remove the platform from. The platform is removed from the platforms defined inline on the environment
 
 --8<-- "docs/reference/cli/pixi/workspace/platform/remove_extender:example"

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1384,7 +1384,7 @@ dependencies = { git = "*" }
 
 Under the hood pixi synthesizes an implicit feature named `env:<environment-name>` (here `env:dev`) and prepends it to the environment's features.
 Because of this, feature names cannot start with `env:`.
-The `default` environment cannot define dependencies inline; add them to the top-level tables (for example `[dependencies]`) instead, as those already belong to the default environment.
+The `default` environment cannot define its content inline; add it to the top-level tables (for example `[dependencies]` or `[tasks]`) instead, as those already belong to the default environment.
 
 ## Global configuration
 

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1383,7 +1383,7 @@ dependencies = { git = "*" }
 ```
 
 Inline content is private to its environment; it cannot be referenced from the feature list of another environment.
-The `default` environment cannot define its content inline; add it to the top-level tables (for example `[dependencies]` or `[tasks]`) instead, as those already belong to the default environment.
+This also applies to the `default` environment: content defined inline on `[environments.default]` belongs to the default environment only, while the top-level tables (for example `[dependencies]` or `[tasks]`) belong to the default feature and are therefore inherited by every environment that doesn't set `no-default-feature = true`.
 
 Inline content can also be edited from the command line: the manifest-editing commands (`pixi add`, `pixi remove`, `pixi upgrade`, `pixi task add/remove/alias`, `pixi workspace channel add/remove` and `pixi workspace platform add/remove`) accept an `--environment` flag next to `--feature`:
 

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1382,8 +1382,7 @@ features = ["python"]
 dependencies = { git = "*" }
 ```
 
-Under the hood pixi synthesizes an implicit feature named `env:<environment-name>` (here `env:dev`) and prepends it to the environment's features.
-Because of this, feature names cannot start with `env:`.
+Inline content is private to its environment; it cannot be referenced from the feature list of another environment.
 The `default` environment cannot define its content inline; add it to the top-level tables (for example `[dependencies]` or `[tasks]`) instead, as those already belong to the default environment.
 
 ## Global configuration

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1385,6 +1385,15 @@ dependencies = { git = "*" }
 Inline content is private to its environment; it cannot be referenced from the feature list of another environment.
 The `default` environment cannot define its content inline; add it to the top-level tables (for example `[dependencies]` or `[tasks]`) instead, as those already belong to the default environment.
 
+Inline content can also be edited from the command line: the manifest-editing commands (`pixi add`, `pixi remove`, `pixi upgrade`, `pixi task add/remove/alias`, `pixi workspace channel add/remove` and `pixi workspace platform add/remove`) accept an `--environment` flag next to `--feature`:
+
+```shell
+pixi add --environment dev git
+pixi task add --environment dev serve "python serve.py"
+```
+
+The content is written inline on the environment, creating the environment if it does not exist.
+
 ## Global configuration
 
 The global configuration options are documented in the [global configuration](../reference/pixi_configuration.md) section.

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -1309,6 +1309,8 @@ The environments table is defined using the following fields:
   But the different environments contain different subsets of the solve-groups dependencies set.
 - `no-default-feature`: Whether to include the default feature in that environment. The default is `false`, to include the default feature.
 
+Additionally, most fields that a [feature](#the-feature-table) accepts - `dependencies`, `pypi-dependencies`, `tasks`, `activation`, `channels`, `platforms`, `constraints`, `target` and more - can be set directly on an environment. See [Defining dependencies directly on an environment](#defining-dependencies-directly-on-an-environment).
+
 ```toml title="Full environments table specification"
 [environments]
 test = {features = ["test"], solve-group = "test"}
@@ -1349,6 +1351,40 @@ When an environment comprises several features (including the default feature):
   as the `platforms` defined at workspace level (unless overridden in the feature). This means that
   it is usually a good idea to set the workspace `platforms` to all platforms it can support across
   its environments.
+
+#### Defining dependencies directly on an environment
+
+Features are the right tool when you want to *share* dependencies between environments.
+When something belongs to a single environment, you can skip the feature and define it directly on the environment:
+
+```toml title="Inline environment dependencies"
+[environments.dev.dependencies]
+git = "*"
+
+[environments.test.dependencies]
+pytest = "*"
+pytest-xdist = "*"
+```
+
+This defines two environments, `dev` and `test`, without any intermediate feature.
+All feature content is available this way: `dependencies`, `pypi-dependencies`, `dev`, `tasks`, `activation`, `channels`, `channel-priority`, `solve-strategy`, `platforms`, `constraints`, `target` and `pypi-options`.
+`host-dependencies`, `build-dependencies` and `system-requirements` are not accepted here; define a feature if you need them.
+
+Inline content can be combined with shared features.
+The inline content takes precedence over the referenced features, which is relevant for the fields where order matters (such as `tasks` and `activation`):
+
+```toml title="Inline content combined with shared features"
+[feature.python.dependencies]
+python = "3.14.*"
+
+[environments.dev]
+features = ["python"]
+dependencies = { git = "*" }
+```
+
+Under the hood pixi synthesizes an implicit feature named `env:<environment-name>` (here `env:dev`) and prepends it to the environment's features.
+Because of this, feature names cannot start with `env:`.
+The `default` environment cannot define dependencies inline; add them to the top-level tables (for example `[dependencies]`) instead, as those already belong to the default environment.
 
 ## Global configuration
 

--- a/docs/source_files/pixi_tomls/multi-environment-docs.toml
+++ b/docs/source_files/pixi_tomls/multi-environment-docs.toml
@@ -1,0 +1,10 @@
+[workspace]
+channels = ["https://prefix.dev/conda-forge"]
+name = "pixi"
+platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]
+
+# --8<-- [start:docs-env]
+[environments.docs]
+dependencies = { mkdocs = "*" }
+no-default-feature = true
+# --8<-- [end:docs-env]

--- a/docs/source_files/pixi_tomls/multi-environment-py-envs.toml
+++ b/docs/source_files/pixi_tomls/multi-environment-py-envs.toml
@@ -3,17 +3,20 @@ channels = ["https://prefix.dev/conda-forge"]
 name = "pixi"
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]
 
+# --8<-- [start:py-envs]
+# The testing tools are shared, so they live in a feature.
 [feature.test.dependencies]
 pytest = "*"
 
-# --8<-- [start:py-envs]
-[feature.py311.dependencies]
-python = "3.11.*"
+[feature.test.tasks]
+test = "pytest"
 
-[feature.py312.dependencies]
-python = "3.12.*"
+# The python version is unique to each environment, so it is defined inline.
+[environments.test-py311]
+dependencies = { python = "3.11.*" }
+features = ["test"]
 
-[environments]
-test-py311 = ["py311", "test"]
-test-py312 = ["py312", "test"]
+[environments.test-py312]
+dependencies = { python = "3.12.*" }
+features = ["test"]
 # --8<-- [end:py-envs]

--- a/docs/source_files/pixi_tomls/multi-environment-simple.toml
+++ b/docs/source_files/pixi_tomls/multi-environment-simple.toml
@@ -3,17 +3,12 @@ channels = ["https://prefix.dev/conda-forge"]
 name = "pixi"
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64", "linux-aarch64"]
 
-# --8<-- [start:test-feat-dep]
-[feature.test.dependencies]
+# --8<-- [start:test-env-dep]
+[environments.test.dependencies]
 pytest = "*"
-# --8<-- [end:test-feat-dep]
+# --8<-- [end:test-env-dep]
 
-# --8<-- [start:test-env]
-[environments]
-test = ["test"]
-# --8<-- [end:test-env]
-
-# --8<-- [start:test-tasks]
-[feature.test.tasks]
+# --8<-- [start:test-env-tasks]
+[environments.test.tasks]
 test = "pytest"
-# --8<-- [end:test-tasks]
+# --8<-- [end:test-env-tasks]

--- a/docs/source_files/pixi_tomls/task_default_environment.toml
+++ b/docs/source_files/pixi_tomls/task_default_environment.toml
@@ -3,11 +3,8 @@ channels = ["conda-forge"]
 name = "task-default-environment"
 
 # --8<-- [start:default-environment]
-[feature.test.dependencies]
+[environments.test.dependencies]
 pytest = "*"
-
-[environments]
-test = ["test"] # An environment covering the "test" feature
 
 [tasks]
 test = { cmd = "pytest", default-environment = "test" }

--- a/docs/source_files/pixi_tomls/tasks_depends_on.toml
+++ b/docs/source_files/pixi_tomls/tasks_depends_on.toml
@@ -6,15 +6,11 @@ name = "tasks-depends-on"
 [tasks]
 test = "python --version"
 
-[feature.py311.dependencies]
+[environments.py311.dependencies]
 python = "3.11.*"
 
-[feature.py312.dependencies]
+[environments.py312.dependencies]
 python = "3.12.*"
-
-[environments]
-py311 = ["py311"]
-py312 = ["py312"]
 
 # Task that depends on other tasks in different environments
 [tasks.test-all]

--- a/docs/source_files/pixi_workspaces/introduction/multi_env/pixi.toml
+++ b/docs/source_files/pixi_workspaces/introduction/multi_env/pixi.toml
@@ -9,12 +9,8 @@ start = "python hello.py"
 [dependencies]
 cowpy = "1.1.*"
 
-[feature.py312.dependencies]
+[environments.py312.dependencies]
 python = "3.12.*"
 
-[feature.py313.dependencies]
+[environments.py313.dependencies]
 python = "3.13.*"
-
-[environments]
-py312 = ["py312"]
-py313 = ["py313"]

--- a/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.toml
+++ b/docs/source_files/pixi_workspaces/pixi_build/workspace_variants/pixi.toml
@@ -9,15 +9,11 @@ python_rich = { path = "." }
 # --8<-- [end:dependencies]
 
 # --8<-- [start:environments]
-[feature.py311.dependencies]
+[environments.py311.dependencies]
 python = "3.11.*"
 
-[feature.py312.dependencies]
+[environments.py312.dependencies]
 python = "3.12.*"
-
-[environments]
-py311 = ["py311"]
-py312 = ["py312"]
 # --8<-- [end:environments]
 
 

--- a/docs/switching_from/uv.md
+++ b/docs/switching_from/uv.md
@@ -73,11 +73,8 @@ uv uses `pyproject.toml` for project configuration and `uv.toml` for tool-level 
     numpy = ">=1.26"
     pandas = ">=2.0"
 
-    [feature.test.dependencies]
+    [environments.test.dependencies]
     pytest = ">=8.0"
-
-    [environments]
-    test = ["test"]
     ```
 
 === "Pixi (pyproject.toml)"
@@ -137,16 +134,16 @@ See [Multi Environment](../workspace/multi_environment.md).
 
 ### Dependency groups and extras
 
-uv uses [PEP 735 dependency groups](https://peps.python.org/pep-0735/) and optional dependencies (extras) to organize dependencies. Pixi uses **features**, composable sets of dependencies that map to environments:
+uv uses [PEP 735 dependency groups](https://peps.python.org/pep-0735/) and optional dependencies (extras) to organize dependencies. Pixi uses **environments**, which define their dependencies directly, and **features**, composable sets of dependencies that can be shared between environments:
 
 | uv                           | Pixi                                                                |
 |------------------------------|---------------------------------------------------------------------|
-| `[dependency-groups]`        | `[feature.<name>.dependencies]`                                     |
+| `[dependency-groups]`        | `[environments.<name>.dependencies]`                                |
 | `[project.optional-dependencies]` | `[feature.<name>.dependencies]` mapped to environments          |
 | `uv sync --group dev`       | `pixi install -e dev`                                               |
 | `uv sync --all-groups`      | `pixi install --all`                                                |
 
-Features are more flexible than dependency groups: they can include conda dependencies, platform-specific packages, system requirements, and activation scripts.
+Environments and features are more flexible than dependency groups: they can include conda dependencies, platform-specific packages, tasks, and activation scripts.
 
 ### Workspaces
 

--- a/docs/tutorials/multi_environment.md
+++ b/docs/tutorials/multi_environment.md
@@ -10,20 +10,20 @@ Setting up different environments for these different use cases can be a hassle,
 ## Glossary
 This tutorial possibly uses some new terms, here is a quick overview:
 
+#### **Environment**
+An environment is a collection of dependencies, tasks and more, that can be installed and activated to run tasks in.
+You can define multiple environments in one workspace.
+Defining environments is done by adding them to the `[environments]` table in the manifest file.
+An environment can define its content directly, e.g. `[environments.<name>.dependencies]`, or pull in shared content through features.
 #### **Feature**
-A feature defines a part of an environment, but are not useful without being part of an environment.
-You can define multiple features in one workspace.
+A feature defines a part of an environment, but is not useful without being part of an environment.
+Features exist to *share* content between environments.
 A feature can contain `tasks`, `dependencies`, `platforms`, `channels` and [more](../reference/pixi_manifest.md#the-feature-table).
 You can mix multiple features to create an environment.
 Features are defined by adding `[feature.<name>.*]` to a table in the manifest file.
-#### **Environment**
-An environment is a collection of features.
-Environments can actually be installed and activated to run tasks in.
-You can define multiple environments in one workspace.
-Defining environments is done by adding them to the `[environments]` table in the manifest file.
 #### **Default**
 Instead of specifying `[feature.<name>.dependencies]`, one can populate `[dependencies]` directly.
-These top level table, are added to the "default" feature, which is added to every environment, unless you specifically opt-out.
+These top level tables are added to the "default" feature, which is added to every environment, unless you specifically opt-out.
 
 ## Let's Get Started
 
@@ -38,8 +38,8 @@ pixi add python
 Now we have a new Pixi workspace with the following structure:
 ```
 ├── .pixi
-│   └── envs
-│       └── default
+│   └── envs
+│       └── default
 ├── pixi.lock
 └── pixi.toml
 ```
@@ -48,30 +48,13 @@ Note the `.pixi/envs/default` directory, this is where the default environment i
 If no environment is specified, Pixi will create or use the `default` environment.
 
 
-### Adding a feature
-Let's start adding a simple `test` feature to our workspace.
-We can do this through the command line, or by editing the `pixi.toml` file.
-Here we will use the command line, and add a `pytest` dependency to the `test` feature in our workspace.
-```shell
-pixi add --feature test pytest
-```
-This will add the following to our `pixi.toml` file:
-```toml
---8<-- "docs/source_files/pixi_tomls/multi-environment-simple.toml:test-feat-dep"
-```
-This table acts exactly the same as a normal `dependencies` table, but it is only used when the `test` feature is part of an environment.
-
 ### Adding an environment
-We will add the `test` environment to our workspace to add some testing tools.
-We can do this through the command line, or by editing the `pixi.toml` file.
-Here we will use the command line:
-```shell
-pixi workspace environment add test --feature test
-```
-This will add the following to our `pixi.toml` file:
+Let's add a simple `test` environment to our workspace.
+An environment that isn't shared with other environments doesn't need a feature; we can define its dependencies directly on the environment by editing the `pixi.toml` file:
 ```toml
---8<-- "docs/source_files/pixi_tomls/multi-environment-simple.toml:test-env"
+--8<-- "docs/source_files/pixi_tomls/multi-environment-simple.toml:test-env-dep"
 ```
+This table acts exactly the same as a normal `dependencies` table, but the dependency is only part of the `test` environment.
 
 ### Running a task
 We can now run a task in our new environment.
@@ -82,23 +65,18 @@ This has created the test environment, and run the `pytest --version` command in
 You can see the environment will be added to the `.pixi/envs` directory.
 ```shell
 ├── .pixi
-│   └── envs
-│       ├── default
-│       └── test
+│   └── envs
+│       ├── default
+│       └── test
 ```
 If you want to see the environment, you can use the `pixi list` command.
 ```shell
 pixi list --environment test
 ```
 
-If you have special test commands that always fit with the test environment you can add them to the `test` feature.
-```shell
-# Adding the 'test' task to the 'test' feature and setting it to run `pytest`
-pixi task add test --feature test pytest
-```
-This will add the following to our `pixi.toml` file:
+If you have special test commands that always fit with the test environment you can add them to the environment as well.
 ```toml
---8<-- "docs/source_files/pixi_tomls/multi-environment-simple.toml:test-tasks"
+--8<-- "docs/source_files/pixi_tomls/multi-environment-simple.toml:test-env-tasks"
 ```
 Now you don't have to specify the environment when running the test command.
 ```shell
@@ -121,19 +99,9 @@ To allow python being flexible in the new environments we need to set it to a mo
 pixi add "python=*"
 ```
 
-We will start by setting up two features, `py311` and `py312`.
-```shell
-pixi add --feature py311 python=3.11
-pixi add --feature py312 python=3.12
-```
-
-We'll add the `test` and Python features to the corresponding environments.
-```shell
-pixi workspace environment add test-py311 --feature py311 --feature test
-pixi workspace environment add test-py312 --feature py312 --feature test
-```
-
-This should result in adding the following to the `pixi.toml`:
+We now want two environments that share the testing tools, but differ in their Python version.
+This is exactly what features are for: sharing content between environments.
+We move the `pytest` dependency into a `test` feature, and give each environment its own Python version directly:
 ```toml
 --8<-- "docs/source_files/pixi_tomls/multi-environment-py-envs.toml:py-envs"
 ```
@@ -185,6 +153,8 @@ To accommodate the different use-cases we'll add a `production`, `test` and `def
 
 We make this the default environment as it will be the easiest to run locally, as it avoids the need to specify the environment when running tasks.
 
+We use features here because the `test` feature is shared between the `test` and `default` environments, and because the `default` environment cannot define dependencies directly (those live in the top-level tables).
+
 We'll also add the `solve-group` `prod` to the environments, this will make sure that the dependencies are solved as if they were in the same environment.
 This will result in the `production` environment having the exact same versions of the dependencies as the `default` and `test` environment.
 This way we can be sure that the project will run in the same way in all environments.
@@ -218,19 +188,14 @@ python   3.13.1   h4f43103_105_cp313  12.3 MiB  conda  python
 ```
 
 ### Non default environments
-When you want to have an environment that doesn't have the `default` feature, you can use the `--no-default-feature` flag.
-This will result in the environment not having the `default` feature, and only the features you specify.
+When you want to have an environment that doesn't have the `default` feature, you can use `no-default-feature`.
+This will result in the environment only having the content you specify.
 
 A common use-case of this would be having an environment that can generate your documentation.
 
-Let's add the `mkdocs` dependency to the `docs` feature.
-```shell
-pixi add --feature docs mkdocs
-```
-
-Now we can add the `docs` environment without the `default` feature.
-```shell
-pixi workspace environment add docs --feature docs --no-default-feature
+Since the documentation tools are only needed in one environment, we define the dependency directly on the environment:
+```toml
+--8<-- "docs/source_files/pixi_tomls/multi-environment-docs.toml:docs-env"
 ```
 
 If we run `pixi list -x -e docs` we can see that it only has the `mkdocs` dependency.

--- a/docs/workspace/multi_environment.md
+++ b/docs/workspace/multi_environment.md
@@ -21,10 +21,36 @@ There are a few things we wanted to keep in mind in the design:
 4. **Single environment Activation**: The design should allow only one environment to be active at any given time, simplifying the resolution process and preventing conflicts.
 5. **Fixed lock files**: It's crucial to preserve fixed lock files for consistency and predictability. Solutions must ensure reliability not just for authors but also for end-users, particularly at the time of lock file creation.
 
-### Feature & Environment Set Definitions
+### Environment & Feature Definitions
 
-Introduce environment sets into the `pixi.toml` this describes environments based on features. Introduce features into the `pixi.toml` that can describe parts of environments.
-As an environment goes beyond just `dependencies` the `feature` fields can be described by including the following fields:
+Environments are defined in the `pixi.toml` under the `[environments]` table.
+The content of an environment - dependencies, tasks and more - can be defined in two ways:
+
+- **directly on the environment**, for content that belongs to a single environment
+- **through features**, reusable parts that can be shared between environments
+
+When something is only needed in one environment, define it directly on the environment:
+
+```toml title="Environments with their own dependencies"
+[environments.lint.dependencies]
+pre-commit = "*"
+
+[environments.test.dependencies]
+pytest = "*"
+```
+
+When multiple environments share content, put the shared part in a feature and compose the environments from features:
+
+```toml title="Sharing dependencies through a feature"
+[feature.python.dependencies]
+python = "3.13.*"
+
+[environments]
+dev = { features = ["python"] }
+test = { features = ["python"] }
+```
+
+As an environment goes beyond just `dependencies`, both environments and features can be described by including the following fields:
 
 - `dependencies`: The conda package dependencies
 - `pypi-dependencies`: The pypi package dependencies
@@ -81,11 +107,8 @@ target.osx-arm64 = {dependencies = {mlx = "x.y.z"}}
 ```
 
 ```toml title="Define tasks as defaults of an environment"
-[feature.test.tasks]
+[environments.test.tasks]
 test = "pytest"
-
-[environments]
-test = ["test"]
 
 # `pixi run test` == `pixi run --environment test test`
 ```
@@ -121,12 +144,10 @@ test_prod = {features = ["py39", "test"], solve-group = "prod"}
 python = "*"
 numpy = "*"
 
-[feature.lint.dependencies]
-pre-commit = "*"
-
-[environments]
-# Create a custom environment which only has the `lint` feature (numpy isn't part of that env).
-lint = {features = ["lint"], no-default-feature = true}
+# Create a custom environment which only has the `pre-commit` dependency (numpy isn't part of that env).
+[environments.lint]
+no-default-feature = true
+dependencies = { pre-commit = "*" }
 ```
 
 ### lock file Structure
@@ -442,33 +463,33 @@ Initial write-up of the proposal: [GitHub Gist by 0xbe7a](https://gist.github.co
     matplotlib-base = ">=3.8.2,<3.9"
     ipykernel = ">=6.28.0,<6.29"
 
-    [feature.cuda]
+    [environments.cuda]
     platforms = ["win-64-cuda", "linux-64-cuda"]
     channels = ["nvidia", {channel = "pytorch", priority = -1}]
 
-    [feature.cuda.tasks]
+    [environments.cuda.tasks]
     train-model = "python train.py --cuda"
     evaluate-model = "python test.py --cuda"
 
-    [feature.cuda.dependencies]
+    [environments.cuda.dependencies]
     pytorch-cuda = {version = "12.1.*", channel = "pytorch"}
 
-    [feature.mlx]
+    [environments.mlx]
     platforms = ["osx-arm64-mlx"]
 
-    [feature.mlx.tasks]
+    [environments.mlx.tasks]
     train-model = "python train.py --mlx"
     evaluate-model = "python test.py --mlx"
 
-    [feature.mlx.dependencies]
+    [environments.mlx.dependencies]
     mlx = ">=0.16.0,<0.17.0"
 
+    # The default environment takes its content from features,
+    # so the cpu variant is defined as a feature.
     [feature.cpu]
     platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 
     [environments]
-    cuda = ["cuda"]
-    mlx = ["mlx"]
     default = ["cpu"]
     ```
 

--- a/schema/model.py
+++ b/schema/model.py
@@ -822,6 +822,56 @@ class Environment(StrictBaseModel):
         False,
         description="Whether to add the default feature to this environment",
     )
+    # Inline feature content. Defining any of these synthesizes an implicit
+    # feature that is prepended to the environment's features. `host-dependencies`,
+    # `build-dependencies` and `system-requirements` are intentionally not allowed
+    # here; they belong on a feature.
+    channels: list[Channel] | None = Field(
+        None,
+        description="The `conda` channels that can be considered when solving this environment",
+    )
+    channel_priority: ChannelPriority | None = Field(
+        None,
+        examples=["strict", "disabled"],
+        description="""The type of channel priority that is used in the solve.
+- 'strict': only take the package from the channel it exist in first.
+- 'disabled': group all dependencies together as if there is no channel difference.""",
+    )
+    solve_strategy: SolveStrategy | None = Field(
+        None,
+        examples=["lowest", "lowest-direct", "highest"],
+        description="""The strategy that is used in the solve.
+- 'highest': solve all packages to the highest compatible version.
+- 'lowest': solve all packages to the lowest compatible version.
+- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.""",
+    )
+    platforms: list[Platform | PlatformName] | None = Field(
+        None,
+        description="The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+    )
+    dependencies: Dependencies = DependenciesField
+    constraints: Dependencies = ConstraintsField
+    pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
+        None, description="The PyPI dependencies of this environment"
+    )
+    dev: dict[CondaPackageName, SourceSpecTable] | None = Field(
+        None,
+        description="Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+    )
+    tasks: dict[TaskName, TaskInlineTable | list[DependsOn] | NonEmptyStr] | None = Field(
+        None, description="The tasks provided by this environment"
+    )
+    activation: Activation | None = Field(
+        None, description="The scripts used on the activation of this environment"
+    )
+    target: dict[TargetName, Target] | None = Field(
+        None,
+        description="Machine-specific aspects of this environment",
+        examples=[{"linux": {"dependencies": {"python": "3.8"}}}],
+    )
+    pypi_options: PyPIOptions | None = Field(
+        None, description="Options related to PyPI indexes for this environment"
+    )
 
 
 ######################

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -805,6 +805,88 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "activation": {
+          "$ref": "#/$defs/Activation",
+          "description": "The scripts used on the activation of this environment"
+        },
+        "channel-priority": {
+          "$ref": "#/$defs/ChannelPriority",
+          "description": "The type of channel priority that is used in the solve.\n- 'strict': only take the package from the channel it exist in first.\n- 'disabled': group all dependencies together as if there is no channel difference.",
+          "examples": [
+            "strict",
+            "disabled"
+          ]
+        },
+        "channels": {
+          "title": "Channels",
+          "description": "The `conda` channels that can be considered when solving this environment",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ChannelInlineTable"
+              }
+            ]
+          }
+        },
+        "constraints": {
+          "title": "Constraints",
+          "description": "The `conda` version constraints. These constrain the versions of packages that may be installed without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dev": {
+          "title": "Dev",
+          "description": "Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SourceSpecTable"
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
         "features": {
           "title": "Features",
           "description": "The features that define the environment",
@@ -820,11 +902,123 @@
           "type": "boolean",
           "default": false
         },
+        "platforms": {
+          "title": "Platforms",
+          "description": "The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Platform"
+              },
+              {
+                "type": "string",
+                "maxLength": 64,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z]$"
+              }
+            ]
+          }
+        },
+        "pypi-dependencies": {
+          "title": "Pypi-Dependencies",
+          "description": "The PyPI dependencies of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIVersion"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitBranchRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitTagRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitRevRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIPathRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIUrlRequirement"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "pypi-options": {
+          "$ref": "#/$defs/PyPIOptions",
+          "description": "Options related to PyPI indexes for this environment"
+        },
         "solve-group": {
           "title": "Solve-Group",
           "description": "The group name for environments that should be solved together",
           "type": "string",
           "minLength": 1
+        },
+        "solve-strategy": {
+          "$ref": "#/$defs/SolveStrategy",
+          "description": "The strategy that is used in the solve.\n- 'highest': solve all packages to the highest compatible version.\n- 'lowest': solve all packages to the lowest compatible version.\n- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.",
+          "examples": [
+            "lowest",
+            "lowest-direct",
+            "highest"
+          ]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Machine-specific aspects of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Target"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "linux": {
+                "dependencies": {
+                  "python": "3.8"
+                }
+              }
+            }
+          ]
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks provided by this environment",
+          "type": "object",
+          "patternProperties": {
+            "^[^\\s\\$]+$": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TaskInlineTable"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/DependsOn"
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "description": "A valid task name.",
+            "minLength": 1
+          }
         }
       }
     },

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -548,6 +548,88 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "activation": {
+          "$ref": "#/$defs/Activation",
+          "description": "The scripts used on the activation of this environment"
+        },
+        "channel-priority": {
+          "$ref": "#/$defs/ChannelPriority",
+          "description": "The type of channel priority that is used in the solve.\n- 'strict': only take the package from the channel it exist in first.\n- 'disabled': group all dependencies together as if there is no channel difference.",
+          "examples": [
+            "strict",
+            "disabled"
+          ]
+        },
+        "channels": {
+          "title": "Channels",
+          "description": "The `conda` channels that can be considered when solving this environment",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ChannelInlineTable"
+              }
+            ]
+          }
+        },
+        "constraints": {
+          "title": "Constraints",
+          "description": "The `conda` version constraints. These constrain the versions of packages that may be installed without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dev": {
+          "title": "Dev",
+          "description": "Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SourceSpecTable"
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
         "features": {
           "title": "Features",
           "description": "The features that define the environment",
@@ -563,11 +645,123 @@
           "type": "boolean",
           "default": false
         },
+        "platforms": {
+          "title": "Platforms",
+          "description": "The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Platform"
+              },
+              {
+                "type": "string",
+                "maxLength": 64,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z]$"
+              }
+            ]
+          }
+        },
+        "pypi-dependencies": {
+          "title": "Pypi-Dependencies",
+          "description": "The PyPI dependencies of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIVersion"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitBranchRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitTagRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitRevRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIPathRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIUrlRequirement"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "pypi-options": {
+          "$ref": "#/$defs/PyPIOptions",
+          "description": "Options related to PyPI indexes for this environment"
+        },
         "solve-group": {
           "title": "Solve-Group",
           "description": "The group name for environments that should be solved together",
           "type": "string",
           "minLength": 1
+        },
+        "solve-strategy": {
+          "$ref": "#/$defs/SolveStrategy",
+          "description": "The strategy that is used in the solve.\n- 'highest': solve all packages to the highest compatible version.\n- 'lowest': solve all packages to the lowest compatible version.\n- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.",
+          "examples": [
+            "lowest",
+            "lowest-direct",
+            "highest"
+          ]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Machine-specific aspects of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Target"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "linux": {
+                "dependencies": {
+                  "python": "3.8"
+                }
+              }
+            }
+          ]
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks provided by this environment",
+          "type": "object",
+          "patternProperties": {
+            "^[^\\s\\$]+$": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TaskInlineTable"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/DependsOn"
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "description": "A valid task name.",
+            "minLength": 1
+          }
         }
       }
     },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -829,6 +829,88 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "activation": {
+          "$ref": "#/$defs/Activation",
+          "description": "The scripts used on the activation of this environment"
+        },
+        "channel-priority": {
+          "$ref": "#/$defs/ChannelPriority",
+          "description": "The type of channel priority that is used in the solve.\n- 'strict': only take the package from the channel it exist in first.\n- 'disabled': group all dependencies together as if there is no channel difference.",
+          "examples": [
+            "strict",
+            "disabled"
+          ]
+        },
+        "channels": {
+          "title": "Channels",
+          "description": "The `conda` channels that can be considered when solving this environment",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/ChannelInlineTable"
+              }
+            ]
+          }
+        },
+        "constraints": {
+          "title": "Constraints",
+          "description": "The `conda` version constraints. These constrain the versions of packages that may be installed without explicitly requiring them. If the package is installed as a dependency of another package, it must satisfy these constraints.",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dependencies": {
+          "title": "Dependencies",
+          "description": "The `conda` dependencies, consisting of a package name and a requirement in [MatchSpec](https://github.com/conda/conda/blob/078e7ee79381060217e1ec7f9b0e9cf80ecc8f3f/conda/models/match_spec.py) format",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/MatchspecTable"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "dev": {
+          "title": "Dev",
+          "description": "Source packages whose dependencies should be installed without building the package itself. Useful for development environments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/SourceSpecTable"
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
         "features": {
           "title": "Features",
           "description": "The features that define the environment",
@@ -844,11 +926,123 @@
           "type": "boolean",
           "default": false
         },
+        "platforms": {
+          "title": "Platforms",
+          "description": "The platforms that this environment supports. Each entry is either a conda subdir or the name of a workspace platform.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Platform"
+              },
+              {
+                "type": "string",
+                "maxLength": 64,
+                "pattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$|^[a-zA-Z]$"
+              }
+            ]
+          }
+        },
+        "pypi-dependencies": {
+          "title": "Pypi-Dependencies",
+          "description": "The PyPI dependencies of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "$ref": "#/$defs/PyPIVersion"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitBranchRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitTagRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIGitRevRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIPathRequirement"
+              },
+              {
+                "$ref": "#/$defs/PyPIUrlRequirement"
+              }
+            ]
+          },
+          "propertyNames": {
+            "minLength": 1
+          }
+        },
+        "pypi-options": {
+          "$ref": "#/$defs/PyPIOptions",
+          "description": "Options related to PyPI indexes for this environment"
+        },
         "solve-group": {
           "title": "Solve-Group",
           "description": "The group name for environments that should be solved together",
           "type": "string",
           "minLength": 1
+        },
+        "solve-strategy": {
+          "$ref": "#/$defs/SolveStrategy",
+          "description": "The strategy that is used in the solve.\n- 'highest': solve all packages to the highest compatible version.\n- 'lowest': solve all packages to the lowest compatible version.\n- 'lowest-direct': solve direct dependencies to the lowest compatible version and transitive ones to the highest compatible version.",
+          "examples": [
+            "lowest",
+            "lowest-direct",
+            "highest"
+          ]
+        },
+        "target": {
+          "title": "Target",
+          "description": "Machine-specific aspects of this environment",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Target"
+          },
+          "propertyNames": {
+            "minLength": 1
+          },
+          "examples": [
+            {
+              "linux": {
+                "dependencies": {
+                  "python": "3.8"
+                }
+              }
+            }
+          ]
+        },
+        "tasks": {
+          "title": "Tasks",
+          "description": "The tasks provided by this environment",
+          "type": "object",
+          "patternProperties": {
+            "^[^\\s\\$]+$": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TaskInlineTable"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/DependsOn"
+                  }
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "propertyNames": {
+            "description": "A valid task name.",
+            "minLength": 1
+          }
         }
       }
     },

--- a/tests/integration_python/test_import.py
+++ b/tests/integration_python/test_import.py
@@ -110,21 +110,19 @@ class TestCondaEnv:
         assert not os.path.isdir(tmp_pixi_workspace / ".pixi/envs")
 
         parsed_manifest = tomllib.loads(manifest_path.read_text())
-        assert "python" in parsed_manifest["feature"]["simple-env"]["dependencies"]
+        assert "python" in parsed_manifest["environments"]["simple-env"]["dependencies"]
         assert parsed_manifest == snapshot(
             {
                 # these keys are irrelevant and some are machine-dependent
                 "workspace": IsPartialDict,
                 "tasks": {},
                 "dependencies": {},
-                "feature": {
+                "environments": {
                     "simple-env": {
+                        "no-default-feature": True,
                         "channels": ["conda-forge"],
                         "dependencies": {"python": "*"},
                     }
-                },
-                "environments": {
-                    "simple-env": {"features": ["simple-env"], "no-default-feature": True}
                 },
             }
         )
@@ -152,21 +150,19 @@ class TestCondaEnv:
         )
 
         parsed_manifest = tomllib.loads(manifest_path.read_text())
-        assert "python" in parsed_manifest["feature"]["simple-env"]["dependencies"]
+        assert "python" in parsed_manifest["environments"]["simple-env"]["dependencies"]
         assert parsed_manifest == snapshot(
             {
                 # these keys are irrelevant and some are machine-dependent
                 "workspace": IsPartialDict,
                 "tasks": {},
                 "dependencies": {},
-                "feature": {
+                "environments": {
                     "simple-env": {
+                        "no-default-feature": True,
                         "channels": ["conda-forge"],
                         "dependencies": {"python": "*"},
                     }
-                },
-                "environments": {
-                    "simple-env": {"features": ["simple-env"], "no-default-feature": True}
                 },
             }
         )
@@ -232,24 +228,22 @@ class TestCondaEnv:
         parsed_manifest = tomllib.loads(manifest_path.read_text())
         assert (
             "python"
-            in parsed_manifest["feature"]["simple-env"]["target"]["linux-64"]["dependencies"]
+            in parsed_manifest["environments"]["simple-env"]["target"]["linux-64"]["dependencies"]
         )
-        assert "osx-arm64" not in parsed_manifest["feature"]["simple-env"]["target"]
+        assert "osx-arm64" not in parsed_manifest["environments"]["simple-env"]["target"]
         assert parsed_manifest == snapshot(
             {
                 # these keys are irrelevant and some are machine-dependent
                 "workspace": IsPartialDict,
                 "tasks": {},
                 "dependencies": {},
-                "feature": {
+                "environments": {
                     "simple-env": {
+                        "no-default-feature": True,
                         "platforms": ["linux-64"],
                         "channels": ["conda-forge"],
                         "target": {"linux-64": {"dependencies": {"python": "*"}}},
                     }
-                },
-                "environments": {
-                    "simple-env": {"features": ["simple-env"], "no-default-feature": True}
                 },
             }
         )
@@ -264,8 +258,8 @@ class TestCondaEnv:
         # Create a new project
         verify_cli_command([pixi, "init", tmp_pixi_workspace])
 
-        # by default, a new env and feature are created with the name of the imported file,
-        # with no-default-feature: True
+        # by default, the imported content is written inline on an environment
+        # named after the imported file, with no-default-feature: True
         verify_cli_command(
             [
                 pixi,
@@ -276,7 +270,7 @@ class TestCondaEnv:
             ],
         )
         parsed_manifest = tomllib.loads(manifest_path.read_text())
-        assert "simple-env" in parsed_manifest["environments"]["simple-env"]["features"]
+        assert "python" in parsed_manifest["environments"]["simple-env"]["dependencies"]
         assert parsed_manifest["environments"]["simple-env"]["no-default-feature"] is True
         assert parsed_manifest == snapshot(
             {
@@ -284,19 +278,18 @@ class TestCondaEnv:
                 "workspace": IsPartialDict,
                 "tasks": {},
                 "dependencies": {},
-                "feature": {
+                "environments": {
                     "simple-env": {
+                        "no-default-feature": True,
                         "channels": ["conda-forge"],
                         "dependencies": {"python": "*"},
                     }
                 },
-                "environments": {
-                    "simple-env": {"features": ["simple-env"], "no-default-feature": True}
-                },
             }
         )
 
-        # we can import into an existing feature
+        # importing with --feature creates the feature and registers it on
+        # the environment of the same name
         import_file_path = tmp_pixi_workspace / "cowpy.yml"
         with open(import_file_path, "w") as file:
             yaml.dump(self.cowpy_env_yaml, file)
@@ -323,11 +316,16 @@ class TestCondaEnv:
                 "feature": {
                     "simple-env": {
                         "channels": ["conda-forge"],
-                        "dependencies": {"python": "*", "cowpy": "*"},
+                        "dependencies": {"cowpy": "*"},
                     }
                 },
                 "environments": {
-                    "simple-env": {"features": ["simple-env"], "no-default-feature": True}
+                    "simple-env": {
+                        "features": ["simple-env"],
+                        "channels": ["conda-forge"],
+                        "no-default-feature": True,
+                        "dependencies": {"python": "*"},
+                    }
                 },
             }
         )
@@ -362,7 +360,7 @@ class TestCondaEnv:
                 "feature": {
                     "simple-env": {
                         "channels": ["conda-forge"],
-                        "dependencies": {"python": "*", "cowpy": "*"},
+                        "dependencies": {"cowpy": "*"},
                     },
                     "array-api-extra": {
                         "channels": ["conda-forge"],
@@ -372,7 +370,9 @@ class TestCondaEnv:
                 "environments": {
                     "simple-env": {
                         "features": ["simple-env", "array-api-extra"],
+                        "channels": ["conda-forge"],
                         "no-default-feature": True,
+                        "dependencies": {"python": "*"},
                     }
                 },
             }
@@ -401,7 +401,7 @@ class TestCondaEnv:
                 "feature": {
                     "simple-env": {
                         "channels": ["conda-forge"],
-                        "dependencies": {"python": "*", "cowpy": "*"},
+                        "dependencies": {"cowpy": "*"},
                     },
                     "array-api-extra": {
                         "channels": ["conda-forge"],
@@ -412,14 +412,16 @@ class TestCondaEnv:
                 "environments": {
                     "simple-env": {
                         "features": ["simple-env", "array-api-extra"],
+                        "channels": ["conda-forge"],
                         "no-default-feature": True,
+                        "dependencies": {"python": "*"},
                     },
                     "farm": {"features": ["farm"], "no-default-feature": True},
                 },
             }
         )
 
-        # we can create a new env (and a matching feature by default)
+        # `--environment` without a feature writes the content inline
         import_file_path = tmp_pixi_workspace / "array-api-extra.yml"
         verify_cli_command(
             [
@@ -432,7 +434,7 @@ class TestCondaEnv:
             ],
         )
         parsed_manifest = tomllib.loads(manifest_path.read_text())
-        assert "data" in parsed_manifest["environments"]["data"]["features"]
+        assert "array-api-extra" in parsed_manifest["environments"]["data"]["dependencies"]
         assert parsed_manifest == snapshot(
             {
                 # these keys are irrelevant and some are machine-dependent
@@ -442,22 +444,27 @@ class TestCondaEnv:
                 "feature": {
                     "simple-env": {
                         "channels": ["conda-forge"],
-                        "dependencies": {"python": "*", "cowpy": "*"},
+                        "dependencies": {"cowpy": "*"},
                     },
                     "array-api-extra": {
                         "channels": ["conda-forge"],
                         "dependencies": {"array-api-extra": "*"},
                     },
                     "farm": {"channels": ["conda-forge"], "dependencies": {"cowpy": "*"}},
-                    "data": {"channels": ["conda-forge"], "dependencies": {"array-api-extra": "*"}},
                 },
                 "environments": {
                     "simple-env": {
                         "features": ["simple-env", "array-api-extra"],
+                        "channels": ["conda-forge"],
                         "no-default-feature": True,
+                        "dependencies": {"python": "*"},
                     },
                     "farm": {"features": ["farm"], "no-default-feature": True},
-                    "data": {"features": ["data"], "no-default-feature": True},
+                    "data": {
+                        "no-default-feature": True,
+                        "channels": ["conda-forge"],
+                        "dependencies": {"array-api-extra": "*"},
+                    },
                 },
             }
         )
@@ -489,8 +496,9 @@ class TestCondaEnv:
                 "workspace": IsPartialDict,
                 "tasks": {},
                 "dependencies": {},
-                "feature": {
+                "environments": {
                     "complex-env": {
+                        "no-default-feature": True,
                         "channels": ["conda-forge", "bioconda"],
                         "dependencies": {
                             "cowpy": "1.1.4.*",
@@ -498,9 +506,6 @@ class TestCondaEnv:
                             "snakemake-minimal": "*",
                         },
                     }
-                },
-                "environments": {
-                    "complex-env": {"features": ["complex-env"], "no-default-feature": True}
                 },
             }
         )
@@ -534,15 +539,16 @@ class TestCondaEnv:
         parsed_manifest = tomllib.loads(manifest_path.read_text())
         assert (
             "https://someartifactory.com/artifactory/api/conda/chaos-conda-dev"
-            in parsed_manifest["feature"]["url-channel-dep-env"]["channels"]
+            in parsed_manifest["environments"]["url-channel-dep-env"]["channels"]
         )
         assert parsed_manifest == snapshot(
             {
                 "workspace": IsPartialDict,
                 "tasks": {},
                 "dependencies": {},
-                "feature": {
+                "environments": {
                     "url-channel-dep-env": {
+                        "no-default-feature": True,
                         "channels": [
                             "conda-forge",
                             "https://someartifactory.com/artifactory/api/conda/chaos-conda-dev",
@@ -553,12 +559,6 @@ class TestCondaEnv:
                                 "channel": "https://someartifactory.com/artifactory/api/conda/chaos-conda-dev",
                             }
                         },
-                    }
-                },
-                "environments": {
-                    "url-channel-dep-env": {
-                        "features": ["url-channel-dep-env"],
-                        "no-default-feature": True,
                     }
                 },
             }
@@ -809,7 +809,7 @@ cowpy==1.1.4
             }
         )
 
-        # we can create a new env (and a matching feature by default)
+        # `--environment` without a feature writes the content inline
         import_file_path = tmp_pixi_workspace / "xpx_requirements.txt"
         verify_cli_command(
             [
@@ -822,7 +822,7 @@ cowpy==1.1.4
             ],
         )
         parsed_manifest = tomllib.loads(manifest_path.read_text())
-        assert "data" in parsed_manifest["environments"]["data"]["features"]
+        assert "array-api-extra" in parsed_manifest["environments"]["data"]["pypi-dependencies"]
         assert parsed_manifest == snapshot(
             {
                 # these keys are irrelevant and some are machine-dependent
@@ -832,11 +832,13 @@ cowpy==1.1.4
                 "feature": {
                     "simple-env": {"pypi-dependencies": {"cowpy": "*", "array-api-extra": "*"}},
                     "numpy": {"pypi-dependencies": {"numpy": "<2"}},
-                    "data": {"pypi-dependencies": {"array-api-extra": "*"}},
                 },
                 "environments": {
                     "simple-env": {"features": ["simple-env", "numpy"], "no-default-feature": True},
-                    "data": {"features": ["data"], "no-default-feature": True},
+                    "data": {
+                        "no-default-feature": True,
+                        "pypi-dependencies": {"array-api-extra": "*"},
+                    },
                 },
             }
         )

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+
+from .common import CURRENT_PLATFORM, ExitCode, verify_cli_command
+
+
+def test_inline_environment_installs_and_runs(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    [workspace]
+    name = "test"
+    channels = ["{dummy_channel_1}"]
+    platforms = ["{CURRENT_PLATFORM}"]
+
+    [environments.dev]
+    dependencies = {{ dummy-a = "*" }}
+
+    [environments.dev.tasks]
+    greet = "echo hello-from-dev"
+    """
+    manifest.write_text(toml)
+
+    # The inline task runs in the inline environment.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "dev", "greet"],
+        stdout_contains="hello-from-dev",
+    )
+
+    # The inline dependency is installed in the environment.
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-a",
+    )
+
+
+def test_inline_environment_combines_with_features(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    [workspace]
+    name = "test"
+    channels = ["{dummy_channel_1}"]
+    platforms = ["{CURRENT_PLATFORM}"]
+
+    [feature.shared.dependencies]
+    dummy-b = "*"
+
+    [environments.dev]
+    features = ["shared"]
+    dependencies = {{ dummy-a = "*" }}
+    """
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains=["dummy-a", "dummy-b"],
+    )
+
+
+def test_reserved_env_feature_name_rejected(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    [workspace]
+    name = "test"
+    channels = ["{dummy_channel_1}"]
+    platforms = ["{CURRENT_PLATFORM}"]
+
+    [environments.dev]
+    dependencies = {{ dummy-a = "*" }}
+    """
+    manifest.write_text(toml)
+
+    # The reserved feature namespace is rejected on the CLI.
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest, "--feature", "env:dev", "dummy-b"],
+        ExitCode.INCORRECT_USAGE,
+        stderr_contains="reserved",
+    )
+
+    # Referencing the synthesized feature of another environment is rejected.
+    toml += """
+    [environments.other]
+    features = ["env:dev"]
+    """
+    manifest.write_text(toml)
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest, "--environment", "other"],
+        ExitCode.FAILURE,
+        stderr_contains="cannot be referenced",
+    )

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -829,8 +829,8 @@ def test_import_into_inline_environment_keeps_content(
         ],
     )
 
-    # The imported feature is added to the environment while the inline
-    # dependencies survive.
+    # The imported content is written inline on the environment while the
+    # existing inline dependencies survive.
     parsed = tomllib.loads(manifest.read_text())
     assert parsed["environments"]["dev"]["dependencies"]["dummy-a"] == "*"
     verify_cli_command(

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -363,11 +363,6 @@ def test_task_add_to_env_feature_rejected(
     )
 
 
-@pytest.mark.xfail(
-    reason="pixi upgrade writes the upgraded spec of an inline environment to a"
-    " dangling [feature.<env>.dependencies] table instead of the environment",
-    strict=True,
-)
 def test_upgrade_keeps_inline_environment(
     pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
 ) -> None:
@@ -389,9 +384,9 @@ def test_upgrade_keeps_inline_environment(
     parsed = tomllib.loads(manifest.read_text())
     # The default dependency is upgraded ...
     assert parsed["dependencies"]["package"] != "==0.1.0"
-    # ... while the inline environment dependency is left untouched and no
-    # reserved feature table is written to the manifest.
-    assert parsed["environments"]["dev"]["dependencies"]["package2"] == "==0.1.0"
+    # ... and so is the inline environment dependency, in place. No feature
+    # table may be written for the synthesized environment feature.
+    assert parsed["environments"]["dev"]["dependencies"]["package2"] != "==0.1.0"
     assert "feature" not in parsed
 
     # Upgrading the reserved feature directly is rejected.
@@ -415,9 +410,12 @@ def test_workspace_environment_list_shows_inline(
     )
     manifest.write_text(toml)
 
+    # The synthesized feature is rendered with its env: prefix so it cannot be
+    # mistaken for a regular feature.
     verify_cli_command(
         [pixi, "workspace", "environment", "list", "--manifest-path", manifest],
-        stdout_contains="dev",
+        stdout_contains=["dev", "env:dev"],
+        strip_ansi=True,
     )
 
 
@@ -632,11 +630,6 @@ def test_export_conda_environment_inline(
     )
 
 
-@pytest.mark.xfail(
-    reason="pixi workspace environment add accepts env: features and writes a"
-    " manifest that no longer parses",
-    strict=True,
-)
 def test_workspace_environment_add_referencing_env_feature_rejected(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
@@ -665,8 +658,28 @@ def test_workspace_environment_add_referencing_env_feature_rejected(
             "env:dev",
         ],
         ExitCode.FAILURE,
+        stderr_contains="cannot be referenced",
     )
     verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
+
+    # A near-miss on the bare environment name must not suggest the
+    # synthesized feature, which cannot be referenced.
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "environment",
+            "add",
+            "--manifest-path",
+            manifest,
+            "other",
+            "--feature",
+            "dev",
+        ],
+        ExitCode.FAILURE,
+        stderr_contains="not defined",
+        stderr_excludes="env:dev",
+    )
 
 
 def test_inline_solve_strategy(
@@ -690,11 +703,6 @@ def test_inline_solve_strategy(
     )
 
 
-@pytest.mark.xfail(
-    reason="pixi remove suggests `pixi remove --feature env:<name>`, which the"
-    " CLI rejects as a reserved feature name",
-    strict=True,
-)
 def test_remove_suggestion_is_actionable(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
@@ -717,18 +725,13 @@ def test_remove_suggestion_is_actionable(
     verify_cli_command(
         [pixi, "remove", "--manifest-path", manifest, "dummy-a"],
         ExitCode.FAILURE,
+        stderr_contains="[environments.dev.dependencies]",
         stderr_excludes="--feature env:dev",
     )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="drives a confirmation prompt through a pty")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@pytest.mark.xfail(
-    reason="pixi workspace feature remove rewrites environments that use the"
-    " feature, deleting inline content and referencing the synthesized feature"
-    " by its bare name",
-    strict=True,
-)
 def test_remove_feature_keeps_inline_content(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
@@ -781,6 +784,52 @@ def test_remove_feature_keeps_inline_content(
         [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
         stdout_contains="dummy-a",
         stdout_excludes="dummy-b",
+    )
+
+
+def test_import_into_inline_environment_keeps_content(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    environment_yml = tmp_pixi_workspace.joinpath("environment.yml")
+    environment_yml.write_text(
+        f"""
+        name: imported
+        channels:
+          - {dummy_channel_1}
+        dependencies:
+          - dummy-b
+        """
+    )
+
+    verify_cli_command(
+        [
+            pixi,
+            "import",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            environment_yml,
+        ],
+    )
+
+    # The imported feature is added to the environment while the inline
+    # dependencies survive.
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["dependencies"]["dummy-a"] == "*"
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains=["dummy-a", "dummy-b"],
     )
 
 

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -66,7 +66,7 @@ def test_inline_environment_combines_with_features(
     )
 
 
-def test_reserved_env_feature_name_rejected(
+def test_inline_content_is_not_a_feature(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
@@ -78,26 +78,18 @@ def test_reserved_env_feature_name_rejected(
 
     [environments.dev]
     dependencies = {{ dummy-a = "*" }}
-    """
-    manifest.write_text(toml)
 
-    # The reserved feature namespace is rejected on the CLI.
-    verify_cli_command(
-        [pixi, "add", "--manifest-path", manifest, "--feature", "env:dev", "dummy-b"],
-        ExitCode.INCORRECT_USAGE,
-        stderr_contains="reserved",
-    )
-
-    # Referencing the synthesized feature of another environment is rejected.
-    toml += """
     [environments.other]
-    features = ["env:dev"]
+    features = ["dev"]
     """
     manifest.write_text(toml)
+
+    # The inline content of the `dev` environment does not define a feature,
+    # so another environment cannot pull it in by name.
     verify_cli_command(
         [pixi, "install", "--manifest-path", manifest, "--environment", "other"],
         ExitCode.FAILURE,
-        stderr_contains="cannot be referenced",
+        stderr_contains="not defined",
     )
 
 
@@ -329,38 +321,10 @@ def test_pyproject_inline_environment(
     info = verify_cli_command([pixi, "info", "--json", "--manifest-path", manifest])
     data = json.loads(info.stdout)
     dev = next(env for env in data["environments_info"] if env["name"] == "dev")
-    assert dev["features"] == ["env:dev"]
+    # The synthesized feature that carries the inline content is an
+    # implementation detail; the content shows up on the environment itself.
+    assert dev["features"] == []
     assert dev["dependencies"] == ["dummy-a"]
-
-
-def test_task_add_to_env_feature_rejected(
-    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
-) -> None:
-    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
-    toml = (
-        workspace_header(dummy_channel_1)
-        + """
-    [environments.dev.dependencies]
-    dummy-a = "*"
-    """
-    )
-    manifest.write_text(toml)
-
-    verify_cli_command(
-        [
-            pixi,
-            "task",
-            "add",
-            "--manifest-path",
-            manifest,
-            "--feature",
-            "env:dev",
-            "greet",
-            "echo hi",
-        ],
-        ExitCode.INCORRECT_USAGE,
-        stderr_contains="reserved",
-    )
 
 
 def test_upgrade_keeps_inline_environment(
@@ -389,15 +353,15 @@ def test_upgrade_keeps_inline_environment(
     assert parsed["environments"]["dev"]["dependencies"]["package2"] != "==0.1.0"
     assert "feature" not in parsed
 
-    # Upgrading the reserved feature directly is rejected.
+    # Inline content is not addressable as a feature.
     verify_cli_command(
-        [pixi, "upgrade", "--manifest-path", manifest, "--feature", "env:dev"],
-        ExitCode.INCORRECT_USAGE,
-        stderr_contains="reserved",
+        [pixi, "upgrade", "--manifest-path", manifest, "--feature", "dev"],
+        ExitCode.FAILURE,
+        stderr_contains="could not find a feature",
     )
 
 
-def test_workspace_environment_list_shows_inline(
+def test_workspace_environment_list_hides_inline_feature(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
@@ -410,11 +374,12 @@ def test_workspace_environment_list_shows_inline(
     )
     manifest.write_text(toml)
 
-    # The synthesized feature is rendered with its env: prefix so it cannot be
-    # mistaken for a regular feature.
+    # The synthesized feature that carries the inline content is not listed
+    # among the environment's features.
     verify_cli_command(
         [pixi, "workspace", "environment", "list", "--manifest-path", manifest],
-        stdout_contains=["dev", "env:dev"],
+        stdout_contains=["dev", "features: default"],
+        stdout_excludes="features: dev",
         strip_ansi=True,
     )
 
@@ -471,7 +436,7 @@ def test_workspace_environment_add_existing_inline(
     verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
 
 
-def test_info_shows_env_feature(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+def test_info_hides_env_feature(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     toml = (
         workspace_header(dummy_channel_1)
@@ -485,7 +450,10 @@ def test_info_shows_env_feature(pixi: Path, tmp_pixi_workspace: Path, dummy_chan
     info = verify_cli_command([pixi, "info", "--json", "--manifest-path", manifest])
     data = json.loads(info.stdout)
     dev = next(env for env in data["environments_info"] if env["name"] == "dev")
-    assert "env:dev" in dev["features"]
+    # Only real features are listed; the inline content shows up in the
+    # environment's dependencies instead.
+    assert dev["features"] == ["default"]
+    assert dev["dependencies"] == ["dummy-a"]
 
 
 def test_lockfile_contains_inline_env(
@@ -529,7 +497,8 @@ def test_feature_and_environment_same_name(
     )
     manifest.write_text(toml)
 
-    # The named feature `dev` and the implicit feature `env:dev` coexist.
+    # The named feature `dev` and the inline content of the environment
+    # `dev` coexist.
     verify_cli_command(
         [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
         stdout_contains=["dummy-a", "dummy-b"],
@@ -630,7 +599,7 @@ def test_export_conda_environment_inline(
     )
 
 
-def test_workspace_environment_add_referencing_env_feature_rejected(
+def test_workspace_environment_add_referencing_inline_content_rejected(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
@@ -643,27 +612,9 @@ def test_workspace_environment_add_referencing_env_feature_rejected(
     )
     manifest.write_text(toml)
 
-    # Adding an environment that references the reserved feature must fail
-    # instead of writing a manifest that no longer parses.
-    verify_cli_command(
-        [
-            pixi,
-            "workspace",
-            "environment",
-            "add",
-            "--manifest-path",
-            manifest,
-            "other",
-            "--feature",
-            "env:dev",
-        ],
-        ExitCode.FAILURE,
-        stderr_contains="cannot be referenced",
-    )
-    verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
-
-    # A near-miss on the bare environment name must not suggest the
-    # synthesized feature, which cannot be referenced.
+    # The environment's inline content is not a feature, so an environment
+    # referencing it by name must fail instead of writing a manifest that no
+    # longer parses. The synthesized feature must not be suggested either.
     verify_cli_command(
         [
             pixi,
@@ -678,8 +629,8 @@ def test_workspace_environment_add_referencing_env_feature_rejected(
         ],
         ExitCode.FAILURE,
         stderr_contains="not defined",
-        stderr_excludes="env:dev",
     )
+    verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
 
 
 def test_inline_solve_strategy(
@@ -719,14 +670,14 @@ def test_remove_suggestion_is_actionable(
     )
     manifest.write_text(toml)
 
-    # The dependency only exists inline on the environment. The error must not
-    # suggest `--feature env:dev`, because that flag value is rejected as
-    # reserved by the CLI.
+    # The dependency only exists inline on the environment. The error must
+    # point at the manifest table, because inline content is not addressable
+    # with `--feature`.
     verify_cli_command(
         [pixi, "remove", "--manifest-path", manifest, "dummy-a"],
         ExitCode.FAILURE,
         stderr_contains="[environments.dev.dependencies]",
-        stderr_excludes="--feature env:dev",
+        stderr_excludes="--feature",
     )
 
 

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -1099,6 +1099,120 @@ def test_task_alias_with_environment_flag(
     )
 
 
+def test_workspace_channel_add_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str, dummy_channel_2: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "channel",
+            "add",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "--no-install",
+            dummy_channel_2,
+        ],
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["channels"] == [dummy_channel_2]
+    assert "feature" not in parsed
+
+    # dummy-x only exists in dummy_channel_2, so the inline channel is used.
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest, "--environment", "dev", "dummy-x"],
+    )
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-x",
+    )
+
+    # The inline dependency must go first, otherwise removing the channel
+    # correctly fails to re-solve the environment.
+    verify_cli_command(
+        [pixi, "remove", "--manifest-path", manifest, "--environment", "dev", "dummy-x"],
+    )
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "channel",
+            "remove",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "--no-install",
+            dummy_channel_2,
+        ],
+    )
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["channels"] == []
+
+
+def test_workspace_platform_add_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    other_platform = "osx-64" if CURRENT_PLATFORM != "osx-64" else "linux-64"
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "platform",
+            "add",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "--no-install",
+            other_platform,
+        ],
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["platforms"] == [other_platform]
+
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "platform",
+            "remove",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "--no-install",
+            other_platform,
+        ],
+    )
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["platforms"] == []
+
+
 def test_inline_channel_priority_and_solve_strategy(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str, dummy_channel_2: str
 ) -> None:

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -917,17 +917,25 @@ def test_add_with_environment_flag_converts_list_form(
     )
 
 
-def test_add_with_environment_flag_rejects_default(
+def test_add_with_environment_flag_default(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     manifest.write_text(workspace_header(dummy_channel_1))
 
-    # Content of the default environment lives in the top-level tables.
+    # Inline content on the default environment applies to the default
+    # environment only, unlike the top-level tables whose content is inherited
+    # by every environment.
     verify_cli_command(
         [pixi, "add", "--manifest-path", manifest, "--environment", "default", "dummy-a"],
-        ExitCode.INCORRECT_USAGE,
-        stderr_contains="cannot define its content inline",
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert "dummy-a" in parsed["environments"]["default"]["dependencies"]
+    assert "dependencies" not in parsed
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest],
+        stdout_contains="dummy-a",
     )
 
 

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -361,6 +361,61 @@ def test_upgrade_keeps_inline_environment(
     )
 
 
+def test_upgrade_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(multiple_versions_channel_1)
+        + """
+    [dependencies]
+    package = "==0.1.0"
+
+    [environments.dev.dependencies]
+    package2 = "==0.1.0"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command([pixi, "upgrade", "--manifest-path", manifest, "--environment", "dev"])
+
+    parsed = tomllib.loads(manifest.read_text())
+    # Only the inline dependency of the environment is upgraded.
+    assert parsed["dependencies"]["package"] == "==0.1.0"
+    assert parsed["environments"]["dev"]["dependencies"]["package2"] != "==0.1.0"
+
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest, "--environment", "nonexistent"],
+        ExitCode.FAILURE,
+        stderr_contains="could not find an environment",
+    )
+
+
+def test_upgrade_with_environment_flag_requires_inline_content(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(multiple_versions_channel_1)
+        + """
+    [feature.pinned.dependencies]
+    package = "==0.1.0"
+
+    [environments]
+    dev = ["pinned"]
+    """
+    )
+    manifest.write_text(toml)
+
+    # The environment only consists of features; there is nothing inline to
+    # upgrade. The feature itself is addressed with `--feature`.
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest, "--environment", "dev"],
+        ExitCode.FAILURE,
+        stderr_contains="does not define any content inline",
+    )
+
+
 def test_workspace_environment_list_hides_inline_feature(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -982,6 +982,123 @@ def test_remove_with_environment_flag(
     )
 
 
+def test_task_add_and_remove_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    manifest.write_text(workspace_header(dummy_channel_1))
+
+    verify_cli_command(
+        [
+            pixi,
+            "task",
+            "add",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "greet",
+            "echo hello-from-dev",
+        ],
+    )
+
+    # The task is written inline on the environment, not to a feature.
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["tasks"]["greet"] == "echo hello-from-dev"
+    assert "feature" not in parsed
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "dev", "greet"],
+        stdout_contains="hello-from-dev",
+    )
+
+    verify_cli_command(
+        [
+            pixi,
+            "task",
+            "remove",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "greet",
+        ],
+    )
+    # The task was the environment's only content, so the whole implicit
+    # entry disappears from the manifest.
+    parsed = tomllib.loads(manifest.read_text())
+    assert "dev" not in parsed.get("environments", {})
+
+
+def test_task_remove_with_environment_flag_requires_inline_task(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [tasks]
+    greet = "echo hello"
+
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    # The task lives in the default feature, not inline on the environment,
+    # so nothing is removed.
+    verify_cli_command(
+        [
+            pixi,
+            "task",
+            "remove",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "greet",
+        ],
+        stderr_contains="does not exist for environment 'dev'",
+    )
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["tasks"]["greet"] == "echo hello"
+
+
+def test_task_alias_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.tasks]
+    greet = "echo hello-from-dev"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [
+            pixi,
+            "task",
+            "alias",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "hi",
+            "greet",
+        ],
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["tasks"]["hi"] == [{"task": "greet"}]
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "dev", "hi"],
+        stdout_contains="hello-from-dev",
+    )
+
+
 def test_inline_channel_priority_and_solve_strategy(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str, dummy_channel_2: str
 ) -> None:

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -1,4 +1,11 @@
+import json
+import os
+import sys
+import time
+import tomllib
 from pathlib import Path
+
+import pytest
 
 from .common import CURRENT_PLATFORM, ExitCode, verify_cli_command
 
@@ -91,4 +98,708 @@ def test_reserved_env_feature_name_rejected(
         [pixi, "install", "--manifest-path", manifest, "--environment", "other"],
         ExitCode.FAILURE,
         stderr_contains="cannot be referenced",
+    )
+
+
+def workspace_header(channel: str) -> str:
+    return f"""
+    [workspace]
+    name = "test"
+    channels = ["{channel}"]
+    platforms = ["{CURRENT_PLATFORM}"]
+    """
+
+
+def test_inline_task_runs_without_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.tasks]
+    greet = "echo hello-from-dev"
+    """
+    )
+    manifest.write_text(toml)
+
+    # The task is only defined in the inline environment, so pixi should pick
+    # that environment without an explicit `--environment`.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "greet"],
+        stdout_contains="hello-from-dev",
+    )
+
+
+def test_inline_task_listed(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.tasks]
+    greet = "echo hello-from-dev"
+    """
+    )
+    manifest.write_text(toml)
+
+    # `pixi task list` prints the task names to stderr.
+    verify_cli_command(
+        [pixi, "task", "list", "--manifest-path", manifest],
+        stderr_contains="greet",
+    )
+
+
+def test_inline_activation_env(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.activation.env]
+    INLINE_VAR = "inline-var-value"
+
+    [environments.dev.tasks]
+    show = "echo $INLINE_VAR"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "dev", "show"],
+        stdout_contains="inline-var-value",
+    )
+
+
+def test_inline_channels(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str, dummy_channel_2: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + f"""
+    [environments.dev]
+    channels = ["{dummy_channel_2}"]
+    dependencies = {{ dummy-x = "*" }}
+    """
+    )
+    manifest.write_text(toml)
+
+    # dummy-x only exists in dummy_channel_2, which is added inline.
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-x",
+    )
+
+
+def test_inline_platforms(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+    other_platform = "osx-64" if CURRENT_PLATFORM != "osx-64" else "linux-64"
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+    [workspace]
+    name = "test"
+    channels = ["{dummy_channel_1}"]
+    platforms = ["{CURRENT_PLATFORM}", "{other_platform}"]
+
+    [environments.dev]
+    platforms = ["{CURRENT_PLATFORM}"]
+    dependencies = {{ dummy-a = "*" }}
+    """
+    manifest.write_text(toml)
+
+    verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
+
+    # The lock file should only contain the restricted platform for dev.
+    info = verify_cli_command([pixi, "info", "--json", "--manifest-path", manifest])
+    data = json.loads(info.stdout)
+    dev = next(env for env in data["environments_info"] if env["name"] == "dev")
+    assert [platform["name"] for platform in dev["platforms"]] == [CURRENT_PLATFORM]
+
+
+def test_inline_target_dependencies(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + f"""
+    [environments.dev.target.{CURRENT_PLATFORM}.dependencies]
+    dummy-b = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-b",
+    )
+
+
+def test_inline_constraints(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(multiple_versions_channel_1)
+        + """
+    [environments.dev]
+    dependencies = { package3 = "*" }
+    constraints = { package3 = "<0.3.0" }
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="0.2.0",
+        stdout_excludes="0.3.0",
+    )
+
+
+def test_inline_solve_group(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(multiple_versions_channel_1)
+        + """
+    [environments.dev]
+    dependencies = { package = "==0.1.0" }
+    solve-group = "group"
+
+    [environments.test]
+    dependencies = { package = "*" }
+    solve-group = "group"
+    """
+    )
+    manifest.write_text(toml)
+
+    # Because both environments are in the same solve group, the unpinned
+    # environment should also get the pinned version.
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "test"],
+        stdout_contains="0.1.0",
+        stdout_excludes="0.2.0",
+    )
+
+
+def test_inline_no_default_feature(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [dependencies]
+    dummy-a = "*"
+
+    [environments.dev]
+    dependencies = { dummy-b = "*" }
+    no-default-feature = true
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-b",
+        stdout_excludes="dummy-a",
+    )
+
+
+def test_pyproject_inline_environment(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pyproject.toml")
+    toml = f"""
+    [project]
+    name = "test"
+    version = "0.1.0"
+
+    [tool.pixi.workspace]
+    channels = ["{dummy_channel_1}"]
+    platforms = ["{CURRENT_PLATFORM}"]
+
+    # The default feature of a pyproject manifest implicitly depends on
+    # python, which the dummy channel does not provide, so avoid solving.
+    [tool.pixi.environments.dev]
+    dependencies = {{ dummy-a = "*" }}
+    no-default-feature = true
+    """
+    manifest.write_text(toml)
+
+    info = verify_cli_command([pixi, "info", "--json", "--manifest-path", manifest])
+    data = json.loads(info.stdout)
+    dev = next(env for env in data["environments_info"] if env["name"] == "dev")
+    assert dev["features"] == ["env:dev"]
+    assert dev["dependencies"] == ["dummy-a"]
+
+
+def test_task_add_to_env_feature_rejected(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [
+            pixi,
+            "task",
+            "add",
+            "--manifest-path",
+            manifest,
+            "--feature",
+            "env:dev",
+            "greet",
+            "echo hi",
+        ],
+        ExitCode.INCORRECT_USAGE,
+        stderr_contains="reserved",
+    )
+
+
+@pytest.mark.xfail(
+    reason="pixi upgrade writes the upgraded spec of an inline environment to a"
+    " dangling [feature.<env>.dependencies] table instead of the environment",
+    strict=True,
+)
+def test_upgrade_keeps_inline_environment(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(multiple_versions_channel_1)
+        + """
+    [dependencies]
+    package = "==0.1.0"
+
+    [environments.dev.dependencies]
+    package2 = "==0.1.0"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command([pixi, "upgrade", "--manifest-path", manifest])
+
+    parsed = tomllib.loads(manifest.read_text())
+    # The default dependency is upgraded ...
+    assert parsed["dependencies"]["package"] != "==0.1.0"
+    # ... while the inline environment dependency is left untouched and no
+    # reserved feature table is written to the manifest.
+    assert parsed["environments"]["dev"]["dependencies"]["package2"] == "==0.1.0"
+    assert "feature" not in parsed
+
+    # Upgrading the reserved feature directly is rejected.
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest, "--feature", "env:dev"],
+        ExitCode.INCORRECT_USAGE,
+        stderr_contains="reserved",
+    )
+
+
+def test_workspace_environment_list_shows_inline(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "workspace", "environment", "list", "--manifest-path", manifest],
+        stdout_contains="dev",
+    )
+
+
+def test_workspace_environment_remove_inline(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "workspace", "environment", "remove", "--manifest-path", manifest, "dev"],
+    )
+
+    # The environment is gone and the manifest is still valid.
+    output = verify_cli_command(
+        [pixi, "workspace", "environment", "list", "--manifest-path", manifest],
+    )
+    assert "dev" not in output.stdout
+    verify_cli_command([pixi, "install", "--manifest-path", manifest])
+
+
+def test_workspace_environment_add_existing_inline(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    # Without --force the existing environment must not be clobbered.
+    verify_cli_command(
+        [pixi, "workspace", "environment", "add", "--manifest-path", manifest, "dev"],
+        ExitCode.FAILURE,
+        stderr_contains="already exists",
+    )
+
+    # With --force the environment is replaced; the manifest must stay valid.
+    verify_cli_command(
+        [pixi, "workspace", "environment", "add", "--manifest-path", manifest, "dev", "--force"],
+    )
+    verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
+
+
+def test_info_shows_env_feature(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    info = verify_cli_command([pixi, "info", "--json", "--manifest-path", manifest])
+    data = json.loads(info.stdout)
+    dev = next(env for env in data["environments_info"] if env["name"] == "dev")
+    assert "env:dev" in dev["features"]
+
+
+def test_lockfile_contains_inline_env(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest])
+    lockfile = tmp_pixi_workspace.joinpath("pixi.lock").read_text()
+    assert "dummy-a" in lockfile
+
+    # A second lock is a no-op.
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest],
+        stderr_excludes="Updated lockfile",
+    )
+
+
+def test_feature_and_environment_same_name(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [feature.dev.dependencies]
+    dummy-b = "*"
+
+    [environments.dev]
+    features = ["dev"]
+    dependencies = { dummy-a = "*" }
+    """
+    )
+    manifest.write_text(toml)
+
+    # The named feature `dev` and the implicit feature `env:dev` coexist.
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains=["dummy-a", "dummy-b"],
+    )
+
+
+def test_add_default_dependency_preserves_inline_env(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command([pixi, "add", "--manifest-path", manifest, "dummy-b"])
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["dependencies"]["dummy-a"] == "*"
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains=["dummy-a", "dummy-b"],
+    )
+
+
+def test_ambiguous_inline_task(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.tasks]
+    greet = "echo hello-from-dev"
+
+    [environments.test.tasks]
+    greet = "echo hello-from-test"
+    """
+    )
+    manifest.write_text(toml)
+
+    # Running without an environment cannot disambiguate; with an explicit
+    # environment it works.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "greet"],
+        ExitCode.FAILURE,
+    )
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "--environment", "test", "greet"],
+        stdout_contains="hello-from-test",
+    )
+
+
+def test_tree_inline_env(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "tree", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-a",
+    )
+
+
+def test_export_conda_environment_inline(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "export",
+            "conda-environment",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+        ],
+        stdout_contains="dummy-a",
+    )
+
+
+@pytest.mark.xfail(
+    reason="pixi workspace environment add accepts env: features and writes a"
+    " manifest that no longer parses",
+    strict=True,
+)
+def test_workspace_environment_add_referencing_env_feature_rejected(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    # Adding an environment that references the reserved feature must fail
+    # instead of writing a manifest that no longer parses.
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "environment",
+            "add",
+            "--manifest-path",
+            manifest,
+            "other",
+            "--feature",
+            "env:dev",
+        ],
+        ExitCode.FAILURE,
+    )
+    verify_cli_command([pixi, "install", "--manifest-path", manifest, "--environment", "dev"])
+
+
+def test_inline_solve_strategy(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(multiple_versions_channel_1)
+        + """
+    [environments.dev]
+    dependencies = { package = "*" }
+    solve-strategy = "lowest"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="0.1.0",
+        stdout_excludes="0.2.0",
+    )
+
+
+@pytest.mark.xfail(
+    reason="pixi remove suggests `pixi remove --feature env:<name>`, which the"
+    " CLI rejects as a reserved feature name",
+    strict=True,
+)
+def test_remove_suggestion_is_actionable(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [dependencies]
+    dummy-b = "*"
+
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    # The dependency only exists inline on the environment. The error must not
+    # suggest `--feature env:dev`, because that flag value is rejected as
+    # reserved by the CLI.
+    verify_cli_command(
+        [pixi, "remove", "--manifest-path", manifest, "dummy-a"],
+        ExitCode.FAILURE,
+        stderr_excludes="--feature env:dev",
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="drives a confirmation prompt through a pty")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.xfail(
+    reason="pixi workspace feature remove rewrites environments that use the"
+    " feature, deleting inline content and referencing the synthesized feature"
+    " by its bare name",
+    strict=True,
+)
+def test_remove_feature_keeps_inline_content(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    import pty
+
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [feature.shared.dependencies]
+    dummy-b = "*"
+
+    [environments.dev]
+    features = ["shared"]
+    dependencies = { dummy-a = "*" }
+    """
+    )
+    manifest.write_text(toml)
+
+    # `pixi workspace feature remove` asks for confirmation when the feature
+    # is used by an environment, so answer "y" through a pty.
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execv(
+            str(pixi),
+            [
+                str(pixi),
+                "workspace",
+                "feature",
+                "remove",
+                "--manifest-path",
+                str(manifest),
+                "shared",
+            ],
+        )
+    time.sleep(2)
+    os.write(fd, b"y\n")
+    while True:
+        try:
+            if not os.read(fd, 4096):
+                break
+        except OSError:
+            break
+    _, status = os.waitpid(pid, 0)
+    assert os.waitstatus_to_exitcode(status) == 0
+
+    # The inline dependencies must survive the rewrite of the environment
+    # entry and the manifest must still be valid.
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-a",
+        stdout_excludes="dummy-b",
+    )
+
+
+def test_inline_channel_priority_and_solve_strategy(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str, dummy_channel_2: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + f"""
+    [environments.dev]
+    channels = ["{dummy_channel_2}"]
+    channel-priority = "disabled"
+    dependencies = {{ dummy-b = "*" }}
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-b",
     )

--- a/tests/integration_python/test_inline_environments.py
+++ b/tests/integration_python/test_inline_environments.py
@@ -671,12 +671,12 @@ def test_remove_suggestion_is_actionable(
     manifest.write_text(toml)
 
     # The dependency only exists inline on the environment. The error must
-    # point at the manifest table, because inline content is not addressable
-    # with `--feature`.
+    # point at the `--environment` flag, because inline content is not
+    # addressable with `--feature`.
     verify_cli_command(
         [pixi, "remove", "--manifest-path", manifest, "dummy-a"],
         ExitCode.FAILURE,
-        stderr_contains="[environments.dev.dependencies]",
+        stderr_contains="pixi remove --environment dev dummy-a",
         stderr_excludes="--feature",
     )
 
@@ -781,6 +781,149 @@ def test_import_into_inline_environment_keeps_content(
     verify_cli_command(
         [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
         stdout_contains=["dummy-a", "dummy-b"],
+    )
+
+
+def test_add_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest, "--environment", "dev", "dummy-b"],
+        stderr_contains="environment: dev",
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["dependencies"]["dummy-a"] == "*"
+    assert "dummy-b" in parsed["environments"]["dev"]["dependencies"]
+    assert "feature" not in parsed
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains=["dummy-a", "dummy-b"],
+    )
+
+
+def test_add_with_environment_flag_creates_environment(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    manifest.write_text(workspace_header(dummy_channel_1))
+
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest, "--environment", "dev", "dummy-a"],
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert "dummy-a" in parsed["environments"]["dev"]["dependencies"]
+    assert "feature" not in parsed
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-a",
+    )
+
+
+def test_add_with_environment_flag_converts_list_form(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [feature.lint.dependencies]
+    dummy-b = "*"
+
+    [environments]
+    dev = ["lint"]
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest, "--environment", "dev", "dummy-a"],
+    )
+
+    # The shorthand list form is converted to a table that keeps the feature
+    # list next to the new inline dependency.
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["features"] == ["lint"]
+    assert "dummy-a" in parsed["environments"]["dev"]["dependencies"]
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains=["dummy-a", "dummy-b"],
+    )
+
+
+def test_add_with_environment_flag_rejects_default(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    manifest.write_text(workspace_header(dummy_channel_1))
+
+    # Content of the default environment lives in the top-level tables.
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest, "--environment", "default", "dummy-a"],
+        ExitCode.INCORRECT_USAGE,
+        stderr_contains="cannot define its content inline",
+    )
+
+
+def test_add_environment_flag_conflicts_with_feature(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    manifest.write_text(workspace_header(dummy_channel_1))
+
+    verify_cli_command(
+        [
+            pixi,
+            "add",
+            "--manifest-path",
+            manifest,
+            "--environment",
+            "dev",
+            "--feature",
+            "lint",
+            "dummy-a",
+        ],
+        ExitCode.INCORRECT_USAGE,
+        stderr_contains="cannot be used with",
+    )
+
+
+def test_remove_with_environment_flag(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = (
+        workspace_header(dummy_channel_1)
+        + """
+    [environments.dev.dependencies]
+    dummy-a = "*"
+    dummy-b = "*"
+    """
+    )
+    manifest.write_text(toml)
+
+    verify_cli_command(
+        [pixi, "remove", "--manifest-path", manifest, "--environment", "dev", "dummy-b"],
+    )
+
+    parsed = tomllib.loads(manifest.read_text())
+    assert parsed["environments"]["dev"]["dependencies"]["dummy-a"] == "*"
+    assert "dummy-b" not in parsed["environments"]["dev"]["dependencies"]
+    verify_cli_command(
+        [pixi, "list", "--manifest-path", manifest, "--environment", "dev"],
+        stdout_contains="dummy-a",
+        stdout_excludes="dummy-b",
     )
 
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1092,6 +1092,7 @@ def test_pixi_task_list_json(pixi: Path, tmp_pixi_workspace: Path) -> None:
         [
             {
                 "environment": "default",
+                "tasks": [],
                 "features": [
                     {
                         "name": "default",


### PR DESCRIPTION
### Description

Not to be confused with inline packages, this PR implements the ability to do this:

```toml
[environments.dev.dependencies]
git = "*"

[environments.test.dependencies]
pytest = "*"
pytest-xdist = "*"

# features can still be added
[feature.python.dependencies]
python = "3.14.*"

[environments]
dev = { features = ["python"] }
test = { features = ["python"] }
```

Fixes prefix-dev/pixi#5317

### How Has This Been Tested?

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.