### PR TITLE
fix(platforms): Do not fail when running tasks in an environment

### DIFF
--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -237,9 +237,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .0;
 
-    // Pin the run platform (explicit `--platform`, else the auto-upgraded
-    // resolved platform) so the on-demand prefix install below targets it.
-    lock_file.target_platform = run_platform.clone();
+    // Only an explicit `--platform` pins the global target; the implicit
+    // auto-upgrade is resolved per-environment in the loop below, since a
+    // global pin broke sibling environments with a different platform.
+    lock_file.target_platform = user_platform.clone();
 
     // Spawn a task that listens for ctrl+c and resets the cursor.
     tokio::spawn(async {
@@ -407,6 +408,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             Entry::Vacant(entry) => {
                 // Check if we allow installs
                 if args.lock_and_install_config.allow_installs() {
+                    // No `--platform`: pin to the platform this environment was
+                    // last installed for, not a sibling's bare subdir.
+                    if user_platform.is_none() {
+                        lock_file.target_platform = executable_task
+                            .run_environment
+                            .installed_resolved_platform_name();
+                    }
+
                     // Ensure there is a valid prefix
                     lock_file
                         .prefix(

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -115,6 +115,66 @@ cuda = "*"
     )
 
 
+@requires_cuda_channel
+def test_run_without_environment_flag_does_not_leak_base_platform(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """``pixi run <task>`` (no ``-e``) must install the task's own environment
+    for a platform that environment declares, not the base environment's.
+
+    Repro of the GPU-CI failure: once the base ``default`` environment is
+    installed, its ``conda-meta/pixi`` marker records the bare-subdir resolved
+    platform. Running a task that lives in a *different* environment then pinned
+    that bare subdir as the global target platform for every prefix install. The
+    ``gpu`` environment only declares the rich ``<subdir>-cuda-13`` platform, so
+    the bare subdir is not one of its platforms and the install aborted with
+    "no platform supported by it matches the current system" -- even though the
+    (cuda-capable) host can run it. Running the same task with ``-e gpu`` always
+    worked, because that resolves the platform for ``gpu`` directly.
+    """
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "target-platform-leak"
+channels = ["{virtual_packages_channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[dependencies]
+no-deps = "*"
+
+[feature.gpu.system-requirements]
+cuda = "13"
+
+[feature.gpu.dependencies]
+cuda = "*"
+
+[feature.gpu.tasks]
+gpu-task = "echo gpu_task_ran"
+
+[environments]
+gpu = {{ features = ["gpu"], no-default-feature = true }}
+""",
+    )
+
+    # Install the base `default` environment first so its marker records the
+    # bare-subdir resolved platform -- the state the leak needs to trigger.
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest, "--environment", "default"],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "13"},
+    )
+
+    # Without `-e`, running the gpu task must still install and run it via the
+    # gpu environment's own (rich) platform, not the leaked bare subdir.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "gpu-task"],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "13"},
+        stdout_contains="gpu_task_ran",
+    )
+
+
 @linux_only
 def test_task_runs_in_empty_environment(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """A task in an empty environment must always run, even when the declared


### PR DESCRIPTION
### Description

A user reported a case where his CI failed with new pixi versions. This was due to the CI installing the default environment first. When it then ran a task in another environment, it tried to use the platform used by the default environment. Since that is not compatible with the environments listed platforms, this failed with a surprising error message

### How Has This Been Tested?

An python integration test. The rust test harness steps around the issue. The reproducer of course fails when added before the fix, but I did not want to hurt bisect, so I switched the order around. I further validated the change against an CI instance that copied the users as closely as possible: I found the issue there, claude generated the reproducer from that data, I then reproduced the exact failure using pixi main branch and checked that this branch fixes the issue there.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
