### PR TITLE
refactor(run): report the assumed platform per environment

### DIFF
--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -18,10 +18,10 @@ use miette::{Diagnostic, IntoDiagnostic};
 use pixi_config::{ConfigCli, ConfigCliActivation};
 use pixi_core::{
     Workspace, WorkspaceLocator,
-    environment::{PlatformData, sanity_check_workspace},
+    environment::sanity_check_workspace,
     lock_file::{ReinstallPackages, UpdateLockFileOptions, UpdateMode},
     workspace::{
-        Environment, HasWorkspaceRef, PlatformOverrides, PlatformSource,
+        Environment,
         errors::UnsupportedPlatformError,
         virtual_packages::{
             EnvironmentRunnability, classify_environment_runnability,
@@ -172,36 +172,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // `--platform`), falling back to the host-aware best match when the
     // environment isn't installed yet.
     let user_platform = resolve_install_platform(&workspace, args.platform.as_ref())?;
-    let installed_platform = environment.installed_resolved_platform_name();
-    let run_platform = user_platform.clone().or_else(|| installed_platform.clone());
+    let run_platform = user_platform
+        .clone()
+        .or_else(|| environment.installed_resolved_platform_name());
     let best_declared_platform = environment.named_or_best_declared_platform(run_platform.as_ref());
-
-    let (resolved_marker, minimum_marker) = environment.installed_platforms();
-    let format_marker = |marker: &Option<PlatformData>| {
-        marker
-            .as_ref()
-            .map_or_else(|| "<none>".to_string(), ToString::to_string)
-    };
-    tracing::debug!(
-        "Run-platform decision for environment '{}': --platform={:?}, auto-detected={}, installed resolved platform={:?}, marker resolved={}, marker minimum={}, chosen run platform={:?}",
-        environment.name(),
-        user_platform.as_ref().map(|p| p.as_str()),
-        PlatformData::from(&environment.workspace().host_platform(
-            PlatformSource::Defaults,
-            PlatformOverrides::EnvironmentVariableOverrides
-        )),
-        installed_platform.as_ref().map(|p| p.as_str()),
-        format_marker(&resolved_marker),
-        format_marker(&minimum_marker),
-        run_platform.as_ref().map(|p| p.as_str()),
-    );
-    if let Some(platform) = best_declared_platform {
-        tracing::info!(
-            "Running tasks in environment '{}' assuming platform '{}'",
-            environment.name().fancy_display(),
-            platform.name(),
-        );
-    }
 
     // A `--platform` the environment doesn't list is a membership error. With
     // no platform requested, defer to the install path's minimum fallback.
@@ -406,6 +380,24 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let task_env: &_ = match task_envs.entry(executable_task.run_environment.clone()) {
             Entry::Occupied(env) => env.into_mut(),
             Entry::Vacant(entry) => {
+                // Report the platform per environment: a bare `pixi run` may
+                // span environments that declare different platforms.
+                let assumed_platform = user_platform.clone().or_else(|| {
+                    executable_task
+                        .run_environment
+                        .installed_resolved_platform_name()
+                });
+                if let Some(platform) = executable_task
+                    .run_environment
+                    .named_or_best_declared_platform(assumed_platform.as_ref())
+                {
+                    tracing::info!(
+                        "Running tasks in environment '{}' assuming platform '{}'",
+                        executable_task.run_environment.name().fancy_display(),
+                        platform.name(),
+                    );
+                }
+
                 // Check if we allow installs
                 if args.lock_and_install_config.allow_installs() {
                     // No `--platform`: pin to the platform this environment was


### PR DESCRIPTION
The `pixi run` platform decision moved into the per-task loop (#6507), so the up-front base-environment logging no longer matched what actually ran: a bare `pixi run` would log "assuming platform linux-64" for the default environment while the task ran in a sibling at a richer platform.

Emit the "assuming platform" info per environment, keyed on the task's run environment and its resolved platform, and drop the verbose "Run-platform decision" debug line -- it only described the base environment's inputs and is no longer needed.

### How Has This Been Tested?

By checking the logging output

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
