### PR TITLE
fix(pixi-build-r): provide R packages under their r-prefixed conda name

### DIFF
--- a/crates/pixi_build_r/src/main.rs
+++ b/crates/pixi_build_r/src/main.rs
@@ -647,6 +647,51 @@ Imports:
     }
 
     #[tokio::test]
+    async fn test_package_name_derived_from_description_is_r_prefixed() {
+        // When the model carries no name (the inline source-dependency flow),
+        // the recipe name comes from the DESCRIPTION via the metadata provider.
+        // It must be r-prefixed and lowercased so that a dependent's `Imports`
+        // (which maps through r_package_to_conda) resolves against it.
+        let temp_dir = TempDir::new().unwrap();
+
+        fs::write(
+            temp_dir.path().join("DESCRIPTION"),
+            "Package: Rhdf5lib\nVersion: 1.0.0\nTitle: Test Package\n",
+        )
+        .await
+        .unwrap();
+
+        let project_model = project_fixture!({
+            "version": "1.0.0",
+            "targets": {
+                "defaultTarget": {}
+            }
+        });
+
+        let generated_recipe = RGenerator::default()
+            .generate_recipe(
+                &project_model,
+                &RBackendConfig::default(),
+                temp_dir.path().to_path_buf(),
+                Platform::Linux64,
+                None,
+                &HashSet::new(),
+                vec![],
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to generate recipe");
+
+        assert_eq!(
+            generated_recipe.recipe.package.name.to_string(),
+            "r-rhdf5lib"
+        );
+    }
+
+    #[tokio::test]
     async fn test_explicit_compilers_override() {
         let temp_dir = TempDir::new().unwrap();
 

--- a/crates/pixi_build_r/src/metadata.rs
+++ b/crates/pixi_build_r/src/metadata.rs
@@ -373,7 +373,11 @@ impl MetadataProvider for DescriptionMetadataProvider {
     type Error = MetadataError;
 
     fn name(&mut self) -> Result<Option<String>, Self::Error> {
-        Ok(self.ensure_data()?.package.clone())
+        Ok(self
+            .ensure_data()?
+            .package
+            .as_deref()
+            .map(r_package_to_conda))
     }
 
     fn version(&mut self) -> Result<Option<Version>, Self::Error> {
@@ -460,7 +464,7 @@ License: GPL-3
         let temp_dir = create_test_description(content);
         let mut provider = DescriptionMetadataProvider::new(temp_dir.path());
 
-        assert_eq!(provider.name().unwrap(), Some("testpkg".to_string()));
+        assert_eq!(provider.name().unwrap(), Some("r-testpkg".to_string()));
         assert_eq!(provider.version().unwrap().unwrap().to_string(), "1.0.0");
         assert_eq!(
             provider.license().unwrap(),
@@ -473,6 +477,25 @@ License: GPL-3
         assert_eq!(
             provider.description().unwrap(),
             Some("A test package for testing".to_string())
+        );
+    }
+
+    #[test]
+    fn test_name_is_conda_normalized() {
+        // The provided name must match what dependents require: a mixed-case
+        // DESCRIPTION `Package:` such as `Rhdf5lib` becomes `r-rhdf5lib`, the
+        // same value `r_package_to_conda` produces for a dependency on it. This
+        // is what makes source->source R dependencies resolvable.
+        let content = r#"Package: Rhdf5lib
+Version: 1.0.0
+"#;
+        let temp_dir = create_test_description(content);
+        let mut provider = DescriptionMetadataProvider::new(temp_dir.path());
+
+        assert_eq!(provider.name().unwrap(), Some("r-rhdf5lib".to_string()));
+        assert_eq!(
+            provider.name().unwrap(),
+            Some(r_package_to_conda("Rhdf5lib"))
         );
     }
 
@@ -512,7 +535,7 @@ Imports: ggplot2, tidyr
         let temp_dir = create_test_description(content);
         let mut provider = DescriptionMetadataProvider::new(temp_dir.path());
 
-        assert_eq!(provider.name().unwrap(), Some("fullpkg".to_string()));
+        assert_eq!(provider.name().unwrap(), Some("r-fullpkg".to_string()));
         assert_eq!(provider.version().unwrap().unwrap().to_string(), "2.1.3");
         assert_eq!(
             provider.summary().unwrap(),


### PR DESCRIPTION
### Description

The `pixi-build-r` backend named a package's own conda output straight from the DESCRIPTION `Package:` field (`Rhdf5lib` → `rhdf5lib`), but ran every *dependency* through `r_package_to_conda`, which adds the `r-` prefix (`Rhdf5lib` → `r-rhdf5lib`). 

So basically, what gets built can not be used as a dependency of other packages currently. Because the two sides disagreed, one source-built R package could never depend on another: the solver looked for `r-<name>`, but the dependency was only ever provided as `<name>`, giving `No candidates were found for r-<name>`.

This fix routes the provided name through `r_package_to_conda` too, so both sides land on `r-<name>` — matching the conda-forge/bioconda convention where all R packages are `r-*`.

Note this is a behaviour change: source-built R packages are now provided as `r-<name>`, so an inline-source dependency keyed by its raw DESCRIPTION name must switch to the `r-`-prefixed key.

Fixes #6506

### How Has This Been Tested?

Unit tests in `pixi_build_r`: updated the `name()` assertions and added two regression tests — one that `name()` returns `r-rhdf5lib` for `Package: Rhdf5lib`, and one that the generated recipe's package name comes out `r-`-prefixed when the model has no name (the inline source-dependency path). Recipe snapshots are unchanged, since they set the name explicitly on the model.

I haven't been able to run the test battery locally (the build stack was a bit of a mess to figure out), so waiting to see how it goes through CI.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code
