### PR TITLE
fix(cli): suggest `pixi self-update --version` for requires-pixi errors

### DIFF
--- a/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
@@ -18,7 +18,10 @@ pub fn execute(result: Result<(), WorkspaceLocatorError>) -> miette::Result<()> 
             #[cfg(feature = "self_update")]
             {
                 eprintln!();
-                eprintln!("Try running:\n  pixi self-update");
+                eprintln!(
+                    "Install a version of pixi that satisfies '{}' with:\n  pixi self-update --version <version>\n(a plain `pixi self-update` installs the latest version, which may not satisfy this requirement)",
+                    e.requires_pixi
+                );
             }
 
             #[cfg(not(feature = "self_update"))]

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -203,7 +203,7 @@ pub enum WorkspaceDiscoveryError {
     consts::PIXI_VERSION
 )]
 #[diagnostic(help(
-    "update pixi to a version that satisfies '{requires_pixi}' with `pixi self-update`"
+    "install a version of pixi that satisfies '{requires_pixi}' with `pixi self-update --version <version>` (a plain `pixi self-update` installs the latest version, which may not satisfy this requirement)"
 ))]
 pub struct PixiVersionMismatchError {
     pub requires_pixi: VersionSpec,
@@ -252,7 +252,7 @@ fn check_requires_pixi_early(toml: &toml_span::Value<'_>, kind: ManifestKind) ->
     };
     let Some(spec_str) = value.as_str() else {
         // Non-string values (e.g. integers, bools) will be caught as schema
-        // errors during full deserialization — skip the version check here.
+        // errors during full deserialization -- skip the version check here.
         return RequiresPixiCheck::Satisfied;
     };
     let span = SourceSpan::new(value.span.start.into(), value.span.end - value.span.start);

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-pyproject.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi-pyproject.snap
@@ -10,4 +10,4 @@ expression: snapshot
    ·                    ╰── this version requirement is not satisfied
  8 │ some-future-field = true
    ╰────
-  help: update pixi to a version that satisfies '>=100' with `pixi self-update`
+  help: install a version of pixi that satisfies '>=100' with `pixi self-update --version <version>` (a plain `pixi self-update` installs the latest version, which may not satisfy this requirement)

--- a/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi.snap
+++ b/crates/pixi_manifest/src/snapshots/pixi_manifest__discovery__test__workspace_discoverer@requires-newer-pixi.snap
@@ -10,4 +10,4 @@ expression: snapshot
    ·                    ╰── this version requirement is not satisfied
  6 │ some-future-field = true
    ╰────
-  help: update pixi to a version that satisfies '>=100' with `pixi self-update`
+  help: install a version of pixi that satisfies '>=100' with `pixi self-update --version <version>` (a plain `pixi self-update` installs the latest version, which may not satisfy this requirement)


### PR DESCRIPTION
A plain `pixi self-update` installs the latest version, which may not satisfy the workspace's `requires-pixi` specifier. Point the version mismatch help texts at `pixi self-update --version <version>` instead.

Fixes #6488

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
