### PR TITLE
fix: don't drag rich platform variants into bare-subdir environments

### DIFF
--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -648,6 +648,56 @@ mod tests {
         );
     }
 
+    /// Regression for prefix-dev/pixi#6493: a workspace declaring both a bare
+    /// subdir platform and a custom rich variant of the same subdir
+    /// (`linux-64` plus `linux-64-cuda`) must not assign the cuda variant to
+    /// an environment whose feature pins the bare `linux-64`. The bare-subdir
+    /// shorthand in `PixiPlatform::matches_reference` otherwise drags every
+    /// same-subdir variant into the environment, producing spurious cuda
+    /// entries in the lock file for cpu-only environments.
+    #[test]
+    fn test_bare_subdir_feature_excludes_custom_rich_platform() {
+        let manifest = Workspace::from_str(
+            Path::new("pixi.toml"),
+            r#"
+        [workspace]
+        name = "repro"
+        channels = []
+        platforms = [
+            "linux-64",
+            { name = "linux-64-cuda", platform = "linux-64", cuda = "12" },
+        ]
+
+        [environments]
+        cpu = { features = ["cpu"] }
+        cuda = { features = ["cuda"] }
+
+        [feature.cpu]
+        platforms = ["linux-64"]
+
+        [feature.cuda]
+        platforms = ["linux-64-cuda"]
+        "#,
+        )
+        .unwrap();
+
+        let cpu = manifest.environment("cpu").unwrap();
+        assert_eq!(
+            cpu.platforms(),
+            HashSet::from_iter([pixi_manifest::PixiPlatformName::from(Platform::Linux64)]),
+            "cpu environment pinned to bare `linux-64` must not gain the cuda variant"
+        );
+
+        let cuda = manifest.environment("cuda").unwrap();
+        assert_eq!(
+            cuda.platforms(),
+            HashSet::from_iter([
+                pixi_manifest::PixiPlatformName::try_from("linux-64-cuda").unwrap()
+            ]),
+            "cuda environment must resolve to exactly the named variant"
+        );
+    }
+
     #[test]
     fn test_default_tasks() {
         let manifest = Workspace::from_str(

--- a/crates/pixi_manifest/src/features_ext.rs
+++ b/crates/pixi_manifest/src/features_ext.rs
@@ -170,7 +170,12 @@ pub trait FeaturesExt<'source>: HasWorkspaceManifest<'source> + HasFeaturesIter<
     /// up front during parsing).
     ///
     /// Otherwise a workspace platform is supported when every selected feature
-    /// supports it by name or bare subdir.
+    /// supports it by name or bare subdir. The bare-subdir shorthand only
+    /// widens: on subdirs where a feature pins a platform by exact name, only
+    /// the exactly pinned platforms remain, so a feature constrained to
+    /// `linux-64` does not drag a declared `linux-64-cuda` variant into the
+    /// environment (prefix-dev/pixi#6493) while a sibling feature pinning
+    /// that variant by name still selects it.
     fn platforms(&self) -> HashSet<PixiPlatformName> {
         let workspace = &self.workspace_manifest().workspace;
         if workspace.use_platform_composition {
@@ -197,12 +202,26 @@ pub trait FeaturesExt<'source>: HasWorkspaceManifest<'source> + HasFeaturesIter<
                 })
                 .collect();
         }
+        let exact_names: HashSet<&PixiPlatformName> = self
+            .features()
+            .filter_map(|feature| feature.platforms.as_ref())
+            .flatten()
+            .collect();
+        let exact_subdirs: HashSet<Platform> = workspace
+            .platforms
+            .iter()
+            .filter(|platform| exact_names.contains(platform.name()))
+            .map(PixiPlatform::subdir)
+            .collect();
         workspace
             .platforms
             .iter()
             .filter(|platform| {
                 self.features()
                     .all(|feature| feature.supports_platform(Some(platform)))
+            })
+            .filter(|platform| {
+                exact_names.contains(platform.name()) || !exact_subdirs.contains(&platform.subdir())
             })
             .map(|platform| platform.name().clone())
             .collect()


### PR DESCRIPTION
On the custom rich-platform path, the bare-subdir shorthand in PixiPlatform::matches_reference let a feature pinned to linux-64 match a declared linux-64-cuda variant, so cpu-only environments gained spurious cuda entries in the lock file.

Refine the environment platform intersection: on subdirs where any of the environment's features pins a platform by exact name, only exactly pinned platforms remain. The shorthand still widens a bare reference onto a variant that a sibling feature pins by name, which keeps the migrated [system-requirements] case working.

Fixes #6493, #6514

### How Has This Been Tested?

A new unit test

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
